### PR TITLE
feat(anthropic): add `include_response_headers` param to `ChatAnthropic`

### DIFF
--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -504,7 +505,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.63"
+version = "0.3.65"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -519,7 +520,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33,<2.0" },
-    { name = "langsmith", specifier = ">=0.1.126,<0.4" },
+    { name = "langsmith", specifier = ">=0.3.45,<0.4" },
     { name = "packaging", specifier = ">=23.2,<25" },
     { name = "pydantic", specifier = ">=2.7.4" },
     { name = "pyyaml", specifier = ">=5.3" },
@@ -607,7 +608,7 @@ typing = [
 
 [[package]]
 name = "langsmith"
-version = "0.3.37"
+version = "0.3.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -618,9 +619,9 @@ dependencies = [
     { name = "requests-toolbelt" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/d0/98daffe57c57c2f44c5d363df5004d8e530b8c9b15751f451d273fd1d4c8/langsmith-0.3.37.tar.gz", hash = "sha256:d49d9a12d24d3984d5b3e2b5915b525b4a29a4706ea9cadde43c980fba43fab0", size = 344645 }
+sdist = { url = "https://files.pythonhosted.org/packages/be/86/b941012013260f95af2e90a3d9415af4a76a003a28412033fc4b09f35731/langsmith-0.3.45.tar.gz", hash = "sha256:1df3c6820c73ed210b2c7bc5cdb7bfa19ddc9126cd03fdf0da54e2e171e6094d", size = 348201 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/f2/5700dbeec7dca0aa57a6ed2f472fa3a323b46c85ab2bc446b2c7c8fb599e/langsmith-0.3.37-py3-none-any.whl", hash = "sha256:bdecca4eb48ba1799e821a33dbdca318ab202faa71a5bfa7d2358be6c3fd7eeb", size = 359308 },
+    { url = "https://files.pythonhosted.org/packages/6a/f4/c206c0888f8a506404cb4f16ad89593bdc2f70cf00de26a1a0a7a76ad7a3/langsmith-0.3.45-py3-none-any.whl", hash = "sha256:5b55f0518601fa65f3bb6b1a3100379a96aa7b3ed5e9380581615ba9c65ed8ed", size = 363002 },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description:**
   This PR adds support for the `include_response_headers` parameter to the
  `ChatAnthropic` class, providing feature parity with the existing `ChatOpenAI`
  implementation. When set to `True`, HTTP response headers from the Anthropic
  API are included in the `response_metadata` of AI messages.

We (Intercom) felt this gap when trying to instrument the quota we have with Anthropic for different models.

  **Changes:**
  - Added `include_response_headers: bool = False` parameter to `ChatAnthropic` class
  - Implemented `_create_with_raw_response()` and `_acreate_with_raw_response()` methods using Anthropic SDK's `with_raw_response` feature
  - Updated all four core methods (`_generate`, `_agenerate`, `_stream`,
  `_astream`) to conditionally extract and include headers
  - Modified `_format_output()` method to handle headers in response metadata
  - Added comprehensive unit tests and integration tests
  - Maintains backward compatibility by only setting `response_metadata` when
  headers are present

  **Issue:** N/A (feature request for parity with OpenAI integration)

  **Dependencies:** None - uses existing anthropic SDK functionality

  **Twitter handle:** @_ketanbhatt