### PR TITLE
openai[patch]: fix dropping response headers while streaming / Azure

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -741,7 +741,8 @@ class BaseChatOpenAI(BaseChatModel):
         if len(choices) == 0:
             # logprobs is implicitly None
             generation_chunk = ChatGenerationChunk(
-                message=default_chunk_class(content="", usage_metadata=usage_metadata)
+                message=default_chunk_class(content="", usage_metadata=usage_metadata),
+                generation_info=base_generation_info,
             )
             return generation_chunk
 


### PR DESCRIPTION
- Currently, while streaming with OpenAI with `include_response_headers=True`, the response headers are set as `generation_info` in the first chunk [here](https://github.com/langchain-ai/langchain/blob/446a9d5647918f1dd6b979122bf6f08e50b8a79e/libs/partners/openai/langchain_openai/chat_models/base.py#L922).
- However, the `_convert_chunk_to_generation_chunk` drops `generation_info` because it returns early. This PR makes it so that the  info is preserved.
