### PR TITLE
langchain.smith.evaluation.progress.ProgressBarCallback: Add newline when counter = total

### DIFF
--- a/libs/langchain/langchain/smith/evaluation/progress.py
+++ b/libs/langchain/langchain/smith/evaluation/progress.py
@@ -37,7 +37,8 @@ class ProgressBarCallback(base_callbacks.BaseCallbackHandler):
         progress = self.counter / self.total
         arrow = "-" * int(round(progress * self.ncols) - 1) + ">"
         spaces = " " * (self.ncols - len(arrow))
-        print(f"\r[{arrow + spaces}] {self.counter}/{self.total}", end="")  # noqa: T201
+        end = "" if self.counter < self.total else "\n"
+        print(f"\r[{arrow + spaces}] {self.counter}/{self.total}", end=end)  # noqa: T201
 
     def on_chain_error(
         self,


### PR DESCRIPTION
## Changes

This PR implements a small change in `ProgressBarCallback._print_bar()`, where it invokes `print(..., end="")` when `self.counter < self.total`, and `print(..., end="\n")` otherwise.

## Motivation
As currently written, any print/logging statements that occur after the progress bar has reached 100% do not occur on a new line, because `ProgressBarCallback._print_bar()` always sets `end=""` in its `print` statement. 

For example, running the following:

```
start = time.time()

progress_bar = ProgressBarCallback(total=10, ncols=50)
runnable.batch_as_completed(
    inputs=...,
    config=RunnableConfig(callbacks=[progress_bar])
)

end = time.time()
print(f"Total processing time: {round(end - start)} secs")
```

Produces something that looks like:
```
[------------------------------------------------->] 10/10Total processing time: 35 secs  # 'Total ...' would ideally be on new line
```

Ideally, the output would look like the following:

```
[------------------------------------------------->] 10/10
Total processing time: 35 secs
```