### PR TITLE
langchain[patch]: smith.evaluation.progress.ProgressBarCallback: Make output after progress bar ends configurable

### DIFF
--- a/libs/langchain/langchain/smith/evaluation/progress.py
+++ b/libs/langchain/langchain/smith/evaluation/progress.py
@@ -13,7 +13,9 @@ from langchain_core.outputs import LLMResult
 class ProgressBarCallback(base_callbacks.BaseCallbackHandler):
     """A simple progress bar for the console."""
 
-    def __init__(self, total: int, ncols: int = 50, end_with: str = "\n", **kwargs: Any):
+    def __init__(
+        self, total: int, ncols: int = 50, end_with: str = "\n", **kwargs: Any
+    ):
         """Initialize the progress bar.
 
         Args:

--- a/libs/langchain/langchain/smith/evaluation/progress.py
+++ b/libs/langchain/langchain/smith/evaluation/progress.py
@@ -37,7 +37,8 @@ class ProgressBarCallback(base_callbacks.BaseCallbackHandler):
         progress = self.counter / self.total
         arrow = "-" * int(round(progress * self.ncols) - 1) + ">"
         spaces = " " * (self.ncols - len(arrow))
-        print(f"\r[{arrow + spaces}] {self.counter}/{self.total}", end="")  # noqa: T201
+        end = "" if self.counter < self.total else "\n"
+        print(f"\r[{arrow + spaces}] {self.counter}/{self.total}", end=end)  # noqa: T201
 
     def on_chain_error(
         self,

--- a/libs/langchain/langchain/smith/evaluation/progress.py
+++ b/libs/langchain/langchain/smith/evaluation/progress.py
@@ -13,15 +13,17 @@ from langchain_core.outputs import LLMResult
 class ProgressBarCallback(base_callbacks.BaseCallbackHandler):
     """A simple progress bar for the console."""
 
-    def __init__(self, total: int, ncols: int = 50, **kwargs: Any):
+    def __init__(self, total: int, ncols: int = 50, end_with: str = "\n", **kwargs: Any):
         """Initialize the progress bar.
 
         Args:
             total: int, the total number of items to be processed.
             ncols: int, the character width of the progress bar.
+            end_with: str, last string to print after progress bar reaches end.
         """
         self.total = total
         self.ncols = ncols
+        self.end_with = end_with
         self.counter = 0
         self.lock = threading.Lock()
         self._print_bar()
@@ -37,7 +39,7 @@ class ProgressBarCallback(base_callbacks.BaseCallbackHandler):
         progress = self.counter / self.total
         arrow = "-" * int(round(progress * self.ncols) - 1) + ">"
         spaces = " " * (self.ncols - len(arrow))
-        end = "" if self.counter < self.total else "\n"
+        end = "" if self.counter < self.total else self.end_with
         print(f"\r[{arrow + spaces}] {self.counter}/{self.total}", end=end)  # noqa: T201
 
     def on_chain_error(


### PR DESCRIPTION
## Description

As currently written, any print/logging statements that occur after the progress bar has reached 100% end up sandwiched against the progress bar output, because `ProgressBarCallback._print_bar()` always sets `end=""` in its `print` statement. To address the issue, This PR implements a small change in `ProgressBarCallback._print_bar()`, where it invokes `print(..., end="")` when `self.counter < self.total`, and `print(..., end=self.end_with)` otherwise, where `end_with` is a new `__init__` param (default = `"\n"`).

## Outcomes

### Current Behavior
Under the current behavior, running the following:

```
start = time.time()

progress_bar = ProgressBarCallback(total=10, ncols=50)
runnable.batch_as_completed(
    inputs=...,
    config=RunnableConfig(callbacks=[progress_bar])
)

end = time.time()
print(f"Total processing time: {round(end - start)} secs")
```

Produces something that looks like:
```
[------------------------------------------------->] 10/10Total processing time: 35 secs  # 'Total ...' would ideally be on new line
```

### New Behavior
With the change in this PR, the output from the previous example would look like the following:

```
[------------------------------------------------->] 10/10
Total processing time: 35 secs
```

Now, suppose the user wants to print "DONE." once the progress bar is complete, and have the "Total time ..." message to appear on the next line. They can now accomplish this via `progress_bar = ProgressBarCallback(total=10, ncols=50, end_with=" Done.\n"), which produces:

```
[------------------------------------------------->] 10/10 DONE.
Total processing time: 35 secs
```
