### PR TITLE
core: fix `get_buffer_string` output for structured message content

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -129,7 +129,7 @@ def get_buffer_string(
         else:
             msg = f"Got unsupported message type: {m}"
             raise ValueError(msg)  # noqa: TRY004
-        message = f"{role}: {m.content}"
+        message = f"{role}: {m.text()}"
         if isinstance(m, AIMessage) and "function_call" in m.additional_kwargs:
             message += f"{m.additional_kwargs['function_call']}"
         string_messages.append(message)

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -21,6 +21,7 @@ from langchain_core.messages.utils import (
     convert_to_openai_messages,
     count_tokens_approximately,
     filter_messages,
+    get_buffer_string,
     merge_message_runs,
     trim_messages,
 )
@@ -1395,3 +1396,63 @@ def test_count_tokens_approximately_mixed_content_types() -> None:
 
     # Ensure that count is consistent if we do one message at a time
     assert sum(count_tokens_approximately([m]) for m in messages) == token_count
+
+
+def test_get_buffer_string_with_structured_content() -> None:
+    """Test get_buffer_string with structured content in messages."""
+    messages = [
+        HumanMessage(content=[{"type": "text", "text": "Hello, world!"}]),
+        AIMessage(content=[{"type": "text", "text": "Hi there!"}]),
+        SystemMessage(content=[{"type": "text", "text": "System message"}]),
+    ]
+    expected = "Human: Hello, world!\nAI: Hi there!\nSystem: System message"
+    actual = get_buffer_string(messages)
+    assert actual == expected
+
+
+def test_get_buffer_string_with_mixed_content() -> None:
+    """Test get_buffer_string with mixed content types in messages."""
+    messages = [
+        HumanMessage(content="Simple text"),
+        AIMessage(content=[{"type": "text", "text": "Structured text"}]),
+        SystemMessage(content=[{"type": "text", "text": "Another structured text"}]),
+    ]
+    expected = (
+        "Human: Simple text\nAI: Structured text\nSystem: Another structured text"
+    )
+    actual = get_buffer_string(messages)
+    assert actual == expected
+
+
+def test_get_buffer_string_with_function_call() -> None:
+    """Test get_buffer_string with function call in additional_kwargs."""
+    messages = [
+        HumanMessage(content="Hello"),
+        AIMessage(
+            content="Hi",
+            additional_kwargs={
+                "function_call": {
+                    "name": "test_function",
+                    "arguments": '{"arg": "value"}',
+                }
+            },
+        ),
+    ]
+    expected = (
+        "Human: Hello\n"
+        "AI: Hi{'name': 'test_function', 'arguments': '{\"arg\": \"value\"}'}"
+    )
+    actual = get_buffer_string(messages)
+    assert actual == expected
+
+
+def test_get_buffer_string_with_empty_content() -> None:
+    """Test get_buffer_string with empty content in messages."""
+    messages = [
+        HumanMessage(content=[]),
+        AIMessage(content=""),
+        SystemMessage(content=[]),
+    ]
+    expected = "Human: \nAI: \nSystem: "
+    actual = get_buffer_string(messages)
+    assert actual == expected

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1438,6 +1438,7 @@ def test_get_buffer_string_with_function_call() -> None:
             },
         ),
     ]
+    # TODO: consider changing this
     expected = (
         "Human: Hello\n"
         "AI: Hi{'name': 'test_function', 'arguments': '{\"arg\": \"value\"}'}"


### PR DESCRIPTION
**Description**

- Update get_buffer_string to call m.text() instead of accessing m.content directly, ensuring proper extraction of text from structured message content (e.g., list of dicts).
- Add unit tests to verify get_buffer_string handles structured, mixed, and empty content, as well as function_call metadata.
- This resolves issues where ChatPromptValue.to_string() would not output only the text content for structured messages.

fixes #31599