### PR TITLE
core: fix document hash collisions across different vector store collections

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -96,7 +96,9 @@ class _HashedDocument(Document):
             )
             raise ValueError(msg) from e
 
-        collection_hash = str(_hash_string_to_uuid(collection_name)) if collection_name else ""
+        collection_hash = (
+            str(_hash_string_to_uuid(collection_name)) if collection_name else ""
+        )
 
         values["content_hash"] = content_hash
         values["metadata_hash"] = metadata_hash
@@ -384,7 +386,12 @@ def index(
     for doc_batch in _batch(batch_size, doc_iterator):
         hashed_docs = list(
             _deduplicate_in_order(
-                [_HashedDocument.from_document(doc, collection_name=collection_name or "") for doc in doc_batch]
+                [
+                    _HashedDocument.from_document(
+                        doc, collection_name=collection_name or ""
+                    )
+                    for doc in doc_batch
+                ]
             )
         )
 
@@ -703,7 +710,12 @@ async def aindex(
     async for doc_batch in _abatch(batch_size, async_doc_iterator):
         hashed_docs = list(
             _deduplicate_in_order(
-                [_HashedDocument.from_document(doc, collection_name=collection_name or "") for doc in doc_batch]
+                [
+                    _HashedDocument.from_document(
+                        doc, collection_name=collection_name or ""
+                    )
+                    for doc in doc_batch
+                ]
             )
         )
 

--- a/libs/core/tests/unit_tests/indexing/test_hashed_document.py
+++ b/libs/core/tests/unit_tests/indexing/test_hashed_document.py
@@ -50,7 +50,7 @@ def test_from_document() -> None:
     assert hashed_document.uid == hashed_document.hash_
 
 
-def test_collection_hash_isolation():
+def test_collection_hash_isolation() -> None:
     """
     Test that identical documents in different collections get different hashes.
     """
@@ -61,12 +61,8 @@ def test_collection_hash_isolation():
     )
 
     # Create hashed documents for different collections
-    hashed_doc_a = _HashedDocument.from_document(
-        doc, collection_name="collection_a"
-    )
-    hashed_doc_b = _HashedDocument.from_document(
-        doc, collection_name="collection_b"
-    )
+    hashed_doc_a = _HashedDocument.from_document(doc, collection_name="collection_a")
+    hashed_doc_b = _HashedDocument.from_document(doc, collection_name="collection_b")
 
     # Assert they have different hashes and UIDs
     assert hashed_doc_a.hash_ != hashed_doc_b.hash_
@@ -77,7 +73,7 @@ def test_collection_hash_isolation():
     assert hashed_doc_a.metadata == hashed_doc_b.metadata
 
 
-def test_collection_hash_same_collection():
+def test_collection_hash_same_collection() -> None:
     """Test that identical documents in the same collection get same hashes."""
     doc1 = Document(page_content="test", metadata={"id": "1"})
     doc2 = Document(page_content="test", metadata={"id": "1"})
@@ -90,7 +86,7 @@ def test_collection_hash_same_collection():
     assert hashed_doc1.uid == hashed_doc2.uid
 
 
-def test_collection_hash_backward_compatibility():
+def test_collection_hash_backward_compatibility() -> None:
     """Test that collection name defaults to empty string for backward compatibility."""
     doc = Document(page_content="test", metadata={"key": "value"})
 


### PR DESCRIPTION
**Description:** Fixes document hash collisions across different vector store collections by including collection context in the hash calculation. When indexing identical documents into different collections (e.g., PGVector with different `collection_name`), they would receive the same hash/ID, causing cross-collection data contamination and silent data loss.

**Root Cause:** The `_HashedDocument.calculate_hashes()` method only considered document content and metadata when generating hashes, completely ignoring which collection the document belonged to.

**Changes Made:**
- Add `collection_name` parameter to `_HashedDocument.from_document()` method
- Include collection context in hash calculation within `calculate_hashes()` validator  
- Update both `index()` and `aindex()` functions to extract and pass collection names from vector stores
- Add tests for collection isolation, same-collection deduplication, and backward compatibility

**Backward Compatibility:**
- Existing code continues to work exactly as before
- Default empty collection name preserves original hashing behavior
- Only affects vector stores with explicit `collection_name` attribute (PGVector, etc.)

**Testing:**
- All indexing tests pass
- New collection isolation tests added and passing
- Verified with `make format`, `make lint`, and `make test`

Fixes #31613 

**Dependencies:** None 
