### PR TITLE
docs: update deprecated .schema() to .model_json_schema() in tool_run…

### DIFF
--- a/docs/docs/how_to/tool_runtime.ipynb
+++ b/docs/docs/how_to/tool_runtime.ipynb
@@ -182,7 +182,7 @@
     }
    ],
    "source": [
-    "update_favorite_pets.get_input_schema().schema()"
+    "update_favorite_pets.get_input_schema().model_json_schema()"
    ]
   },
   {
@@ -223,7 +223,7 @@
     }
    ],
    "source": [
-    "update_favorite_pets.tool_call_schema.schema()"
+    "update_favorite_pets.tool_call_schema.model_json_schema()"
    ]
   },
   {
@@ -500,7 +500,7 @@
     "    user_to_pets[user_id] = pets\n",
     "\n",
     "\n",
-    "update_favorite_pets.get_input_schema().schema()"
+    "update_favorite_pets.get_input_schema().model_json_schema()"
    ]
   },
   {
@@ -534,7 +534,7 @@
     }
    ],
    "source": [
-    "update_favorite_pets.tool_call_schema.schema()"
+    "update_favorite_pets.tool_call_schema.model_json_schema()"
    ]
   },
   {
@@ -583,7 +583,7 @@
     "        user_to_pets[user_id] = pets\n",
     "\n",
     "\n",
-    "UpdateFavoritePets().get_input_schema().schema()"
+    "UpdateFavoritePets().get_input_schema().model_json_schema()"
    ]
   },
   {
@@ -617,7 +617,7 @@
     }
    ],
    "source": [
-    "UpdateFavoritePets().tool_call_schema.schema()"
+    "UpdateFavoritePets().tool_call_schema.model_json_schema()"
    ]
   },
   {
@@ -659,7 +659,7 @@
     "        user_to_pets[user_id] = pets\n",
     "\n",
     "\n",
-    "UpdateFavoritePets2().get_input_schema().schema()"
+    "UpdateFavoritePets2().get_input_schema().model_json_schema()"
    ]
   },
   {
@@ -692,7 +692,7 @@
     }
    ],
    "source": [
-    "UpdateFavoritePets2().tool_call_schema.schema()"
+    "UpdateFavoritePets2().tool_call_schema.model_json_schema()"
    ]
   }
  ],


### PR DESCRIPTION
This PR updates the tool runtime example notebook to replace the deprecated `.schema()` method with `.model_json_schema()`, aligning it with Pydantic V2.

### 🔧 Changes:
- Replaced:
```python
update_favorite_pets.get_input_schema().schema()

with 

update_favorite_pets.get_input_schema().model_json_schema()

```

Fixes #31609