### PR TITLE
mistralai[patch]: Fix Typos in Comments and Improve Compatibility Note

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -83,7 +83,7 @@ logger = logging.getLogger(__name__)
 TOOL_CALL_ID_PATTERN = re.compile(r"^[a-zA-Z0-9]{9}$")
 
 
-# This SSL context is equivelent to the default `verify=True`.
+# This SSL context is equivalent to the default `verify=True`.
 # https://www.python-httpx.org/advanced/ssl/#configuring-client-instances
 global_ssl_context = ssl.create_default_context(cafile=certifi.where())
 

--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -592,7 +592,7 @@ class ChatMistralAI(BaseChatModel):
         llm_output = {
             "token_usage": token_usage,
             "model_name": self.model,
-            "model": self.model,  # Backwards compatability
+            "model": self.model,  # Backwards compatibility
         }
         return ChatResult(generations=generations, llm_output=llm_output)
 


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling mistakes in the comments within the `chat_models.py` file of the MistralAI partner integration. Specifically, it fixes the spelling of "equivalent" and "compatibility" in two separate comments. These changes improve code readability and maintain professional documentation standards. No functional code changes are included.