### PR TITLE
[Docs] Update deprecated Pydantic .schema() method to .model_json_schema() in How to convert Runnables to Tools guide

### DIFF
--- a/docs/docs/how_to/convert_runnable_to_tool.ipynb
+++ b/docs/docs/how_to/convert_runnable_to_tool.ipynb
@@ -106,14 +106,14 @@
     {
      "data": {
       "text/plain": [
-       "{'title': 'My tool',\n",
-       " 'type': 'object',\n",
-       " 'properties': {'a': {'title': 'A', 'type': 'integer'},\n",
-       "  'b': {'title': 'B', 'type': 'array', 'items': {'type': 'integer'}}},\n",
-       " 'required': ['a', 'b']}"
+       "{'properties': {'a': {'title': 'A', 'type': 'integer'},\n",
+       "  'b': {'items': {'type': 'integer'}, 'title': 'B', 'type': 'array'}},\n",
+       " 'required': ['a', 'b'],\n",
+       " 'title': 'My tool',\n",
+       " 'type': 'object'}"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -121,12 +121,12 @@
    "source": [
     "print(as_tool.description)\n",
     "\n",
-    "as_tool.args_schema.schema()"
+    "as_tool.args_schema.model_json_schema()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 24,
    "id": "54ae7384-a03d-4fa4-8cdf-9604a4bc39ee",
    "metadata": {},
    "outputs": [
@@ -136,7 +136,7 @@
        "'6'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 26,
    "id": "169f733c-4936-497f-8577-ee769dc16b88",
    "metadata": {},
    "outputs": [],
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 27,
    "id": "eb102705-89b7-48dc-9158-d36d5f98ae8e",
    "metadata": {},
    "outputs": [],
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 28,
    "id": "c475282a-58d6-4c2b-af7d-99b73b7d8a13",
    "metadata": {},
    "outputs": [],
@@ -233,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "id": "ad6d8d96-3a87-40bd-a2ac-44a8acde0a8e",
    "metadata": {},
    "outputs": [
@@ -243,7 +243,7 @@
        "'baz'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 29,
    "id": "d06c9f2a-4475-450f-9106-54db1d99623b",
    "metadata": {},
    "outputs": [],
@@ -296,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 30,
    "id": "23d2a47e-6712-4294-81c8-2c1d76b4bb81",
    "metadata": {},
    "outputs": [],
@@ -449,19 +449,20 @@
     {
      "data": {
       "text/plain": [
-       "{'title': 'RunnableParallel<context,question,answer_style>Input',\n",
-       " 'type': 'object',\n",
-       " 'properties': {'question': {'title': 'Question'},\n",
-       "  'answer_style': {'title': 'Answer Style'}}}"
+       "{'properties': {'question': {'title': 'Question'},\n",
+       "  'answer_style': {'title': 'Answer Style'}},\n",
+       " 'required': ['question', 'answer_style'],\n",
+       " 'title': 'RunnableParallel<context,question,answer_style>Input',\n",
+       " 'type': 'object'}"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "rag_chain.input_schema.schema()"
+    "rag_chain.input_schema.model_json_schema()"
    ]
   },
   {
@@ -495,11 +496,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_17iLPWvOD23zqwd1QVQ00Y63', 'function': {'arguments': '{\"question\":\"What are dogs known for according to pirates?\",\"answer_style\":\"quote\"}', 'name': 'pet_expert'}, 'type': 'function'}]}, response_metadata={'token_usage': {'completion_tokens': 28, 'prompt_tokens': 59, 'total_tokens': 87}, 'model_name': 'gpt-4o-mini', 'system_fingerprint': None, 'finish_reason': 'tool_calls', 'logprobs': None}, id='run-7fef44f3-7bba-4e63-8c51-2ad9c5e65e2e-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for according to pirates?', 'answer_style': 'quote'}, 'id': 'call_17iLPWvOD23zqwd1QVQ00Y63'}], usage_metadata={'input_tokens': 59, 'output_tokens': 28, 'total_tokens': 87})]}}\n",
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_7aY4WLTtoBI1byKQRU2G0ETX', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 58, 'total_tokens': 84, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIAtPBal0oiknqWAgUwJYuEJaQe', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--63b1d3ac-5d7b-4cb6-a60d-f279440c392f-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_7aY4WLTtoBI1byKQRU2G0ETX', 'type': 'tool_call'}], usage_metadata={'input_tokens': 58, 'output_tokens': 26, 'total_tokens': 84, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
       "----\n",
-      "{'tools': {'messages': [ToolMessage(content='\"Dogs are known for their loyalty and friendliness, making them great companions for pirates on long sea voyages.\"', name='pet_expert', tool_call_id='call_17iLPWvOD23zqwd1QVQ00Y63')]}}\n",
+      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='416fb85d-d017-439f-90a8-8dbf7cea9f39', tool_call_id='call_7aY4WLTtoBI1byKQRU2G0ETX', status='error')]}}\n",
       "----\n",
-      "{'agent': {'messages': [AIMessage(content='According to pirates, dogs are known for their loyalty and friendliness, making them great companions for pirates on long sea voyages.', response_metadata={'token_usage': {'completion_tokens': 27, 'prompt_tokens': 119, 'total_tokens': 146}, 'model_name': 'gpt-4o-mini', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-5a30edc3-7be0-4743-b980-ca2f8cad9b8d-0', usage_metadata={'input_tokens': 119, 'output_tokens': 27, 'total_tokens': 146})]}}\n",
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_22kD7RkvQTYZ1fVXUuR905bB', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 122, 'total_tokens': 148, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiICblMIBEGHU5mZ2VAIiBojr7mi', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--b1ba4885-32d9-42e0-89e2-a1e3140386bc-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_22kD7RkvQTYZ1fVXUuR905bB', 'type': 'tool_call'}], usage_metadata={'input_tokens': 122, 'output_tokens': 26, 'total_tokens': 148, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
+      "----\n",
+      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='866bb4f5-189d-445f-8709-0b27fb07ca02', tool_call_id='call_22kD7RkvQTYZ1fVXUuR905bB', status='error')]}}\n",
+      "----\n",
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_sSVFRHtz9NBws15OUDaw2QH2', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 186, 'total_tokens': 212, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIDcab3dpVYngCdlzliaGBppoiv', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--0ad0161e-0fa2-4dd4-a0bd-32bd18ce1b6b-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_sSVFRHtz9NBws15OUDaw2QH2', 'type': 'tool_call'}], usage_metadata={'input_tokens': 186, 'output_tokens': 26, 'total_tokens': 212, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
+      "----\n",
+      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='542bf787-447f-4fb8-9eeb-6d7929425e70', tool_call_id='call_sSVFRHtz9NBws15OUDaw2QH2', status='error')]}}\n",
+      "----\n",
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_UXLXmHqL1T7EvyBjR2VgsUoh', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 250, 'total_tokens': 276, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIEVFjY2ue0V1aHJb5il3HCeQr5', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--9363be58-0d9c-49dd-ab27-cdf005d869c5-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_UXLXmHqL1T7EvyBjR2VgsUoh', 'type': 'tool_call'}], usage_metadata={'input_tokens': 250, 'output_tokens': 26, 'total_tokens': 276, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
+      "----\n",
+      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='3477f252-c179-417e-9ec8-b2f6433c7542', tool_call_id='call_UXLXmHqL1T7EvyBjR2VgsUoh', status='error')]}}\n",
+      "----\n",
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_unVBE1RRMcpEY8kxyNn5FslL', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 314, 'total_tokens': 340, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIGZKOPWpAyOX3A5dEuEe9qfWl7', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--b2016362-c35c-4501-bffa-330167386095-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_unVBE1RRMcpEY8kxyNn5FslL', 'type': 'tool_call'}], usage_metadata={'input_tokens': 314, 'output_tokens': 26, 'total_tokens': 340, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
+      "----\n",
+      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='48ab8a7f-190d-48b3-8f1a-a0a20319b1e2', tool_call_id='call_unVBE1RRMcpEY8kxyNn5FslL', status='error')]}}\n",
+      "----\n",
+      "{'agent': {'messages': [AIMessage(content='It seems there is a technical issue preventing me from retrieving the information in a pirate style. However, I can tell you that a pirate might say something like:\\n\\n\"Arrr, matey! Dogs be known fer their loyalty and courage, always ready to stand by their captain\\'s side! They be the finest companions on the high seas, sniffin\\' out treasure and guardin\\' the ship from scallywags!\" \\n\\nIf you have any other questions or need further assistance, feel free to ask!', additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 103, 'prompt_tokens': 378, 'total_tokens': 481, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIH1pjyCLsoI51dMhLJl6Es87Fn', 'service_tier': 'default', 'finish_reason': 'stop', 'logprobs': None}, id='run--3b1c65b4-6f30-4275-8855-6bcefdea3b57-0', usage_metadata={'input_tokens': 378, 'output_tokens': 103, 'total_tokens': 481, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
       "----\n"
      ]
     }

--- a/docs/docs/how_to/convert_runnable_to_tool.ipynb
+++ b/docs/docs/how_to/convert_runnable_to_tool.ipynb
@@ -113,7 +113,7 @@
        " 'type': 'object'}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 4,
    "id": "54ae7384-a03d-4fa4-8cdf-9604a4bc39ee",
    "metadata": {},
    "outputs": [
@@ -136,7 +136,7 @@
        "'6'"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -155,7 +155,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 5,
    "id": "169f733c-4936-497f-8577-ee769dc16b88",
    "metadata": {},
    "outputs": [],
@@ -185,7 +185,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 6,
    "id": "eb102705-89b7-48dc-9158-d36d5f98ae8e",
    "metadata": {},
    "outputs": [],
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 7,
    "id": "c475282a-58d6-4c2b-af7d-99b73b7d8a13",
    "metadata": {},
    "outputs": [],
@@ -233,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "id": "ad6d8d96-3a87-40bd-a2ac-44a8acde0a8e",
    "metadata": {},
    "outputs": [
@@ -243,7 +243,7 @@
        "'baz'"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 9,
    "id": "d06c9f2a-4475-450f-9106-54db1d99623b",
    "metadata": {},
    "outputs": [],
@@ -296,7 +296,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 10,
    "id": "23d2a47e-6712-4294-81c8-2c1d76b4bb81",
    "metadata": {},
    "outputs": [],
@@ -456,7 +456,7 @@
        " 'type': 'object'}"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "id": "a3f9cf5b-8c71-4b0f-902b-f92e028780c9",
    "metadata": {},
    "outputs": [],
@@ -496,27 +496,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_7aY4WLTtoBI1byKQRU2G0ETX', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 58, 'total_tokens': 84, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIAtPBal0oiknqWAgUwJYuEJaQe', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--63b1d3ac-5d7b-4cb6-a60d-f279440c392f-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_7aY4WLTtoBI1byKQRU2G0ETX', 'type': 'tool_call'}], usage_metadata={'input_tokens': 58, 'output_tokens': 26, 'total_tokens': 84, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
+      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_17iLPWvOD23zqwd1QVQ00Y63', 'function': {'arguments': '{\"question\":\"What are dogs known for according to pirates?\",\"answer_style\":\"quote\"}', 'name': 'pet_expert'}, 'type': 'function'}]}, response_metadata={'token_usage': {'completion_tokens': 28, 'prompt_tokens': 59, 'total_tokens': 87}, 'model_name': 'gpt-4o-mini', 'system_fingerprint': None, 'finish_reason': 'tool_calls', 'logprobs': None}, id='run-7fef44f3-7bba-4e63-8c51-2ad9c5e65e2e-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for according to pirates?', 'answer_style': 'quote'}, 'id': 'call_17iLPWvOD23zqwd1QVQ00Y63'}], usage_metadata={'input_tokens': 59, 'output_tokens': 28, 'total_tokens': 87})]}}\n",
       "----\n",
-      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='416fb85d-d017-439f-90a8-8dbf7cea9f39', tool_call_id='call_7aY4WLTtoBI1byKQRU2G0ETX', status='error')]}}\n",
+      "{'tools': {'messages': [ToolMessage(content='\"Dogs are known for their loyalty and friendliness, making them great companions for pirates on long sea voyages.\"', name='pet_expert', tool_call_id='call_17iLPWvOD23zqwd1QVQ00Y63')]}}\n",
       "----\n",
-      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_22kD7RkvQTYZ1fVXUuR905bB', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 122, 'total_tokens': 148, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiICblMIBEGHU5mZ2VAIiBojr7mi', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--b1ba4885-32d9-42e0-89e2-a1e3140386bc-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_22kD7RkvQTYZ1fVXUuR905bB', 'type': 'tool_call'}], usage_metadata={'input_tokens': 122, 'output_tokens': 26, 'total_tokens': 148, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
-      "----\n",
-      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='866bb4f5-189d-445f-8709-0b27fb07ca02', tool_call_id='call_22kD7RkvQTYZ1fVXUuR905bB', status='error')]}}\n",
-      "----\n",
-      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_sSVFRHtz9NBws15OUDaw2QH2', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 186, 'total_tokens': 212, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIDcab3dpVYngCdlzliaGBppoiv', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--0ad0161e-0fa2-4dd4-a0bd-32bd18ce1b6b-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_sSVFRHtz9NBws15OUDaw2QH2', 'type': 'tool_call'}], usage_metadata={'input_tokens': 186, 'output_tokens': 26, 'total_tokens': 212, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
-      "----\n",
-      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='542bf787-447f-4fb8-9eeb-6d7929425e70', tool_call_id='call_sSVFRHtz9NBws15OUDaw2QH2', status='error')]}}\n",
-      "----\n",
-      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_UXLXmHqL1T7EvyBjR2VgsUoh', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 250, 'total_tokens': 276, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIEVFjY2ue0V1aHJb5il3HCeQr5', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--9363be58-0d9c-49dd-ab27-cdf005d869c5-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_UXLXmHqL1T7EvyBjR2VgsUoh', 'type': 'tool_call'}], usage_metadata={'input_tokens': 250, 'output_tokens': 26, 'total_tokens': 276, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
-      "----\n",
-      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='3477f252-c179-417e-9ec8-b2f6433c7542', tool_call_id='call_UXLXmHqL1T7EvyBjR2VgsUoh', status='error')]}}\n",
-      "----\n",
-      "{'agent': {'messages': [AIMessage(content='', additional_kwargs={'tool_calls': [{'id': 'call_unVBE1RRMcpEY8kxyNn5FslL', 'function': {'arguments': '{\"question\":\"What are dogs known for?\",\"answer_style\":\"pirate\"}', 'name': 'pet_expert'}, 'type': 'function'}], 'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 26, 'prompt_tokens': 314, 'total_tokens': 340, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIGZKOPWpAyOX3A5dEuEe9qfWl7', 'service_tier': 'default', 'finish_reason': 'tool_calls', 'logprobs': None}, id='run--b2016362-c35c-4501-bffa-330167386095-0', tool_calls=[{'name': 'pet_expert', 'args': {'question': 'What are dogs known for?', 'answer_style': 'pirate'}, 'id': 'call_unVBE1RRMcpEY8kxyNn5FslL', 'type': 'tool_call'}], usage_metadata={'input_tokens': 314, 'output_tokens': 26, 'total_tokens': 340, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
-      "----\n",
-      "{'tools': {'messages': [ToolMessage(content=\"Error: ImportError('cosine_similarity requires numpy to be installed. Please install numpy with `pip install numpy`.')\\n Please fix your mistakes.\", name='pet_expert', id='48ab8a7f-190d-48b3-8f1a-a0a20319b1e2', tool_call_id='call_unVBE1RRMcpEY8kxyNn5FslL', status='error')]}}\n",
-      "----\n",
-      "{'agent': {'messages': [AIMessage(content='It seems there is a technical issue preventing me from retrieving the information in a pirate style. However, I can tell you that a pirate might say something like:\\n\\n\"Arrr, matey! Dogs be known fer their loyalty and courage, always ready to stand by their captain\\'s side! They be the finest companions on the high seas, sniffin\\' out treasure and guardin\\' the ship from scallywags!\" \\n\\nIf you have any other questions or need further assistance, feel free to ask!', additional_kwargs={'refusal': None}, response_metadata={'token_usage': {'completion_tokens': 103, 'prompt_tokens': 378, 'total_tokens': 481, 'completion_tokens_details': {'accepted_prediction_tokens': 0, 'audio_tokens': 0, 'reasoning_tokens': 0, 'rejected_prediction_tokens': 0}, 'prompt_tokens_details': {'audio_tokens': 0, 'cached_tokens': 0}}, 'model_name': 'gpt-4o-mini-2024-07-18', 'system_fingerprint': 'fp_34a54ae93c', 'id': 'chatcmpl-BiiIH1pjyCLsoI51dMhLJl6Es87Fn', 'service_tier': 'default', 'finish_reason': 'stop', 'logprobs': None}, id='run--3b1c65b4-6f30-4275-8855-6bcefdea3b57-0', usage_metadata={'input_tokens': 378, 'output_tokens': 103, 'total_tokens': 481, 'input_token_details': {'audio': 0, 'cache_read': 0}, 'output_token_details': {'audio': 0, 'reasoning': 0}})]}}\n",
+      "{'agent': {'messages': [AIMessage(content='According to pirates, dogs are known for their loyalty and friendliness, making them great companions for pirates on long sea voyages.', response_metadata={'token_usage': {'completion_tokens': 27, 'prompt_tokens': 119, 'total_tokens': 146}, 'model_name': 'gpt-4o-mini', 'system_fingerprint': None, 'finish_reason': 'stop', 'logprobs': None}, id='run-5a30edc3-7be0-4743-b980-ca2f8cad9b8d-0', usage_metadata={'input_tokens': 119, 'output_tokens': 27, 'total_tokens': 146})]}}\n",
       "----\n"
      ]
     }


### PR DESCRIPTION
**Description:** 
This PR replaces all instances of the deprecated Pydantic `.schema()` method with the new `model_json_schema()` method across LangChain documentation. The `.schema()` method was deprecated in Pydantic V2.0.

**Changes made:**
- Updated How to convert Runnables to Tools guide documentation
- Fixed deprecated method calls in other documentation files
- Ensures users don't encounter deprecation warnings when following official examples

**Issue:** #31617

**Dependencies:** None

Fixes #31617
