### PR TITLE
openai[patch]: include 'type' key internally when streaming reasoning blocks

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/_compat.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_compat.py
@@ -72,7 +72,7 @@ def _convert_to_v03_ai_message(
         new_content: list[Union[dict, str]] = []
         for block in message.content:
             if isinstance(block, dict):
-                if block.get("type") == "reasoning" or "summary" in block:
+                if block.get("type") == "reasoning":
                     # Store a reasoning item in additional_kwargs (overwriting as in
                     # v0.3)
                     _ = block.pop("index", None)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3756,6 +3756,7 @@ def _convert_responses_chunk_to_generation_chunk(
                     {"index": chunk.summary_index, "type": "summary_text", "text": ""}
                 ],
                 "index": current_index,
+                "type": "reasoning",
             }
         )
     elif chunk.type == "response.image_generation_call.partial_image":
@@ -3773,6 +3774,7 @@ def _convert_responses_chunk_to_generation_chunk(
                     }
                 ],
                 "index": current_index,
+                "type": "reasoning",
             }
         )
     else:


### PR DESCRIPTION
Covered by existing tests.

Will make it easier to process streamed reasoning blocks.