### PR TITLE
infra: temporarily drop OpenAI from core release test matrix

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        partner: [openai, anthropic]
+        partner: [anthropic]
       fail-fast: false  # Continue testing other partners if one fails
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
As part of core releases we run tests on the last released version of some packages (including langchain-openai) using the new version of langchain-core. We run langchain-openai's test suite as it was when it was last released.

Our test for computer use started raising 500 error at some point during the day today (test passed as part of scheduled test job in the morning):
> InternalServerError: Error code: 500 - {'error': {'message': 'An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists.

Will revert this change after we release langchain-core.