### PR TITLE
Revert "infra: temporarily drop OpenAI from core release test matrix"

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        partner: [anthropic]
+        partner: [openai, anthropic]
       fail-fast: false  # Continue testing other partners if one fails
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Reverts langchain-ai/langchain#31693