### PR TITLE
groq: release 0.3.4

### DIFF
--- a/libs/partners/groq/pyproject.toml
+++ b/libs/partners/groq/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "pdm.backend"
 authors = []
 license = { text = "MIT" }
 requires-python = ">=3.9"
-dependencies = ["langchain-core<1.0.0,>=0.3.66", "groq<1,>=0.4.1"]
+dependencies = ["langchain-core<1.0.0,>=0.3.66", "groq<1,>=0.28.0"]
 name = "langchain-groq"
-version = "0.3.3"
+version = "0.3.4"
 description = "An integration package connecting Groq and LangChain"
 readme = "README.md"
 

--- a/libs/partners/groq/uv.lock
+++ b/libs/partners/groq/uv.lock
@@ -226,7 +226,7 @@ wheels = [
 
 [[package]]
 name = "groq"
-version = "0.18.0"
+version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -236,9 +236,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/40/8c/e72c164474a88dfed6c7327ad53cb87ff11566b74b3a76d41dc7b94fc51c/groq-0.18.0.tar.gz", hash = "sha256:8e2ccfea406d68b3525af4b7c0e321fcb3d2a73fc60bb70b4156e6cd88c72f03", size = 117322, upload-time = "2025-02-05T01:30:14.551Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/7d/bb053ba75357bf5e8c33def63fb31c8b0bb86dce07759a0cd8e3232d2df9/groq-0.28.0.tar.gz", hash = "sha256:65e1cab9184cbb32380d62eca50d6162269c7ec0c77e4cc868069cfe93450f9f", size = 131730, upload-time = "2025-06-12T16:22:49.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/6c/5a53d632b44ef7655ac8d9b34432e13160917f9307c94b1467efd34e336e/groq-0.18.0-py3-none-any.whl", hash = "sha256:81d5ac00057a45d8ce559d23ab5d3b3893011d1f12c35187ab35a9182d826ea6", size = 121911, upload-time = "2025-02-05T01:30:12.504Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/24/20fc18d1b3e0883aeb24286ca8f26dc1970561b07d9c4412c84561bdf307/groq-0.28.0-py3-none-any.whl", hash = "sha256:c6f86638371c2cba2ca337232e76c8d412e75965ed7e3058d30c9aa5dfe84303", size = 130217, upload-time = "2025-06-12T16:22:47.97Z" },
 ]
 
 [[package]]
@@ -389,7 +389,7 @@ typing = [
 
 [[package]]
 name = "langchain-groq"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "groq" },
@@ -425,7 +425,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "groq", specifier = ">=0.4.1,<1" },
+    { name = "groq", specifier = ">=0.28.0,<1" },
     { name = "langchain-core", editable = "../../core" },
 ]
 


### PR DESCRIPTION
bump groq dependency to ensure reasoning is supported