### PR TITLE
ollama: update tests, docs

### DIFF
--- a/docs/docs/integrations/chat/ollama.ipynb
+++ b/docs/docs/integrations/chat/ollama.ipynb
@@ -39,9 +39,10 @@
     "\n",
     "## Setup\n",
     "\n",
-    "First, follow [these instructions](https://github.com/jmorganca/ollama) to set up and run a local Ollama instance:\n",
+    "First, follow [these instructions](https://github.com/ollama/ollama?tab=readme-ov-file#ollama) to set up and run a local Ollama instance:\n",
     "\n",
-    "* [Download](https://ollama.ai/download) and install Ollama onto the available supported platforms (including Windows Subsystem for Linux)\n",
+    "* [Download](https://ollama.ai/download) and install Ollama onto the available supported platforms (including Windows Subsystem for Linux aka WSL, macOS, and Linux)\n",
+    "    * macOS users can install via Homebrew with `brew install ollama` and start with `brew services start ollama`\n",
     "* Fetch available LLM model via `ollama pull <name-of-model>`\n",
     "    * View a list of available models via the [model library](https://ollama.ai/library)\n",
     "    * e.g., `ollama pull llama3`\n",
@@ -54,7 +55,7 @@
     "* Specify the exact version of the model of interest as such `ollama pull vicuna:13b-v1.5-16k-q4_0` (View the [various tags for the `Vicuna`](https://ollama.ai/library/vicuna/tags) model in this instance)\n",
     "* To view all pulled models, use `ollama list`\n",
     "* To chat directly with a model from the command line, use `ollama run <name-of-model>`\n",
-    "* View the [Ollama documentation](https://github.com/jmorganca/ollama) for more commands. Run `ollama help` in the terminal to see available commands too.\n"
+    "* View the [Ollama documentation](https://github.com/ollama/ollama/tree/main/docs) for more commands. You can run `ollama help` in the terminal to see available commands.\n"
    ]
   },
   {
@@ -72,8 +73,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# os.environ[\"LANGSMITH_API_KEY\"] = getpass.getpass(\"Enter your LangSmith API key: \")\n",
-    "# os.environ[\"LANGSMITH_TRACING\"] = \"true\""
+    "# os.environ[\"LANGSMITH_TRACING\"] = \"true\"\n",
+    "# os.environ[\"LANGSMITH_API_KEY\"] = getpass.getpass(\"Enter your LangSmith API key: \")"
    ]
   },
   {
@@ -159,17 +160,15 @@
     {
      "data": {
       "text/plain": [
-       "AIMessage(content='The translation of \"I love programming\" from English to French is:\\n\\n\"J\\'adore programmer.\"', response_metadata={'model': 'llama3.1', 'created_at': '2024-08-19T16:05:32.81965Z', 'message': {'role': 'assistant', 'content': ''}, 'done_reason': 'stop', 'done': True, 'total_duration': 2167842917, 'load_duration': 54222584, 'prompt_eval_count': 35, 'prompt_eval_duration': 893007000, 'eval_count': 22, 'eval_duration': 1218962000}, id='run-0863daa2-43bf-4a43-86cc-611b23eae466-0', usage_metadata={'input_tokens': 35, 'output_tokens': 22, 'total_tokens': 57})"
+       "AIMessage(content='The translation of \"I love programming\" in French is:\\n\\n\"J\\'adore le programmation.\"', additional_kwargs={}, response_metadata={'model': 'llama3.1', 'created_at': '2025-06-25T18:43:00.483666Z', 'done': True, 'done_reason': 'stop', 'total_duration': 619971208, 'load_duration': 27793125, 'prompt_eval_count': 35, 'prompt_eval_duration': 36354583, 'eval_count': 22, 'eval_duration': 555182667, 'model_name': 'llama3.1'}, id='run--348bb5ef-9dd9-4271-bc7e-a9ddb54c28c1-0', usage_metadata={'input_tokens': 35, 'output_tokens': 22, 'total_tokens': 57})"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from langchain_core.messages import AIMessage\n",
-    "\n",
     "messages = [\n",
     "    (\n",
     "        \"system\",\n",
@@ -191,9 +190,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The translation of \"I love programming\" from English to French is:\n",
+      "The translation of \"I love programming\" in French is:\n",
       "\n",
-      "\"J'adore programmer.\"\n"
+      "\"J'adore le programmation.\"\n"
      ]
     }
    ],
@@ -220,10 +219,10 @@
     {
      "data": {
       "text/plain": [
-       "AIMessage(content='Das Programmieren ist mir ein Leidenschaft! (That\\'s \"Programming is my passion!\" in German.) Would you like me to translate anything else?', response_metadata={'model': 'llama3.1', 'created_at': '2024-08-19T16:05:34.893548Z', 'message': {'role': 'assistant', 'content': ''}, 'done_reason': 'stop', 'done': True, 'total_duration': 2045997333, 'load_duration': 22584792, 'prompt_eval_count': 30, 'prompt_eval_duration': 213210000, 'eval_count': 32, 'eval_duration': 1808541000}, id='run-d18e1c6b-50e0-4b1d-b23a-973fa058edad-0', usage_metadata={'input_tokens': 30, 'output_tokens': 32, 'total_tokens': 62})"
+       "AIMessage(content='\"Programmieren ist meine Leidenschaft.\"\\n\\n(I translated \"programming\" to the German word \"Programmieren\", and added \"ist meine Leidenschaft\" which means \"is my passion\")', additional_kwargs={}, response_metadata={'model': 'llama3.1', 'created_at': '2025-06-25T18:43:29.350032Z', 'done': True, 'done_reason': 'stop', 'total_duration': 1194744459, 'load_duration': 26982500, 'prompt_eval_count': 30, 'prompt_eval_duration': 117043458, 'eval_count': 41, 'eval_duration': 1049892167, 'model_name': 'llama3.1'}, id='run--efc6436e-2346-43d9-8118-3c20b3cdf0d0-0', usage_metadata={'input_tokens': 30, 'output_tokens': 41, 'total_tokens': 71})"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -258,7 +257,7 @@
    "source": [
     "## Tool calling\n",
     "\n",
-    "We can use [tool calling](https://blog.langchain.dev/improving-core-tool-interfaces-and-docs-in-langchain/) with an LLM [that has been fine-tuned for tool use](https://ollama.com/search?&c=tools) such as `llama3.1`:\n",
+    "We can use [tool calling](/docs/concepts/tool_calling/) with an LLM [that has been fine-tuned for tool use](https://ollama.com/search?&c=tools) such as `llama3.1`:\n",
     "\n",
     "```\n",
     "ollama pull llama3.1\n",
@@ -274,23 +273,17 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "[{'name': 'validate_user',\n",
-       "  'args': {'addresses': '[\"123 Fake St, Boston, MA\", \"234 Pretend Boulevard, Houston, TX\"]',\n",
-       "   'user_id': '123'},\n",
-       "  'id': '40fe3de0-500c-4b91-9616-5932a929e640',\n",
-       "  'type': 'tool_call'}]"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[{'name': 'validate_user', 'args': {'addresses': ['123 Fake St, Boston, MA', '234 Pretend Boulevard, Houston, TX'], 'user_id': '123'}, 'id': 'aef33a32-a34b-4b37-b054-e0d85584772f', 'type': 'tool_call'}]\n"
+     ]
     }
    ],
    "source": [
     "from typing import List\n",
     "\n",
+    "from langchain_core.messages import AIMessage\n",
     "from langchain_core.tools import tool\n",
     "from langchain_ollama import ChatOllama\n",
     "\n",
@@ -316,7 +309,9 @@
     "    \"123 Fake St in Boston MA and 234 Pretend Boulevard in \"\n",
     "    \"Houston TX.\"\n",
     ")\n",
-    "result.tool_calls"
+    "\n",
+    "if isinstance(result, AIMessage) and result.tool_calls:\n",
+    "    print(result.tool_calls)"
    ]
   },
   {
@@ -331,6 +326,16 @@
     "    ollama pull bakllava\n",
     "\n",
     "Be sure to update Ollama so that you have the most recent version to support multi-modal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69920d39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install pillow"
    ]
   },
   {
@@ -467,14 +472,13 @@
      "output_type": "stream",
      "text": [
       "Here is my thought process:\n",
-      "This question is asking for the result of 3 raised to the power of 3, which is a basic mathematical operation. \n",
+      "The user is asking for the value of 3 raised to the power of 3, which is a basic exponentiation operation.\n",
       "\n",
       "Here is my response:\n",
-      "The expression 3^3 means 3 raised to the power of 3. To calculate this, you multiply the base number (3) by itself as many times as its exponent (3):\n",
       "\n",
-      "3 * 3 * 3 = 27\n",
+      "3^3 (read as \"3 to the power of 3\") equals 27. \n",
       "\n",
-      "So, 3^3 equals 27.\n"
+      "This calculation is performed by multiplying 3 by itself three times: 3*3*3 = 27.\n"
      ]
     }
    ],
@@ -508,7 +512,7 @@
    "source": [
     "## API reference\n",
     "\n",
-    "For detailed documentation of all ChatOllama features and configurations head to the API reference: https://python.langchain.com/api_reference/ollama/chat_models/langchain_ollama.chat_models.ChatOllama.html"
+    "For detailed documentation of all ChatOllama features and configurations head to the [API reference](https://python.langchain.com/api_reference/ollama/chat_models/langchain_ollama.chat_models.ChatOllama.html)."
    ]
   }
  ],

--- a/docs/docs/integrations/llms/ollama.ipynb
+++ b/docs/docs/integrations/llms/ollama.ipynb
@@ -46,29 +46,30 @@
    "source": [
     "## Setup\n",
     "\n",
-    "First, follow [these instructions](https://github.com/jmorganca/ollama) to set up and run a local Ollama instance:\n",
+    "First, follow [these instructions](https://github.com/ollama/ollama?tab=readme-ov-file#ollama) to set up and run a local Ollama instance:\n",
     "\n",
-    "* [Download](https://ollama.ai/download) and install Ollama onto the available supported platforms (including Windows Subsystem for Linux)\n",
+    "* [Download](https://ollama.ai/download) and install Ollama onto the available supported platforms (including Windows Subsystem for Linux aka WSL, macOS, and Linux)\n",
+    "    * macOS users can install via Homebrew with `brew install ollama` and start with `brew services start ollama`\n",
     "* Fetch available LLM model via `ollama pull <name-of-model>`\n",
     "    * View a list of available models via the [model library](https://ollama.ai/library)\n",
     "    * e.g., `ollama pull llama3`\n",
     "* This will download the default tagged version of the model. Typically, the default points to the latest, smallest sized-parameter model.\n",
     "\n",
     "> On Mac, the models will be download to `~/.ollama/models`\n",
-    "> \n",
+    ">\n",
     "> On Linux (or WSL), the models will be stored at `/usr/share/ollama/.ollama/models`\n",
     "\n",
     "* Specify the exact version of the model of interest as such `ollama pull vicuna:13b-v1.5-16k-q4_0` (View the [various tags for the `Vicuna`](https://ollama.ai/library/vicuna/tags) model in this instance)\n",
     "* To view all pulled models, use `ollama list`\n",
     "* To chat directly with a model from the command line, use `ollama run <name-of-model>`\n",
-    "* View the [Ollama documentation](https://github.com/jmorganca/ollama) for more commands. Run `ollama help` in the terminal to see available commands too.\n",
+    "* View the [Ollama documentation](https://github.com/ollama/ollama/tree/main/docs) for more commands. You can run `ollama help` in the terminal to see available commands.\n",
     "\n",
     "## Usage"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "035dea0f",
    "metadata": {
     "tags": []
@@ -77,10 +78,10 @@
     {
      "data": {
       "text/plain": [
-       "\"Sounds like a plan!\\n\\nTo answer what LangChain is, let's break it down step by step.\\n\\n**Step 1: Understand the Context**\\nLangChain seems to be related to language or programming, possibly in an AI context. This makes me wonder if it's a framework, library, or tool for building models or interacting with them.\\n\\n**Step 2: Research Possible Definitions**\\nAfter some quick searching, I found that LangChain is actually a Python library for building and composing conversational AI models. It seems to provide a way to create modular and reusable components for chatbots, voice assistants, and other conversational interfaces.\\n\\n**Step 3: Explore Key Features and Use Cases**\\nLangChain likely offers features such as:\\n\\n* Easy composition of conversational flows\\n* Support for various input/output formats (e.g., text, audio)\\n* Integration with popular AI frameworks and libraries\\n\\nUse cases might include building chatbots for customer service, creating voice assistants for smart homes, or developing interactive stories.\\n\\n**Step 4: Confirm the Definition**\\nAfter this step-by-step analysis, I'm fairly confident that LangChain is a Python library for building conversational AI models. If you'd like to verify or provide more context, feel free to do so!\""
+       "'To break down what LangChain is, let\\'s analyze it step by step:\\n\\n1. **Break down the name**: \"Lang\" likely stands for \"Language\", suggesting that LangChain has something to do with language processing or AI-related tasks involving human languages.\\n\\n2. **Understanding the term \"chain\" in this context**: In technology and computing, particularly in the realm of artificial intelligence (AI) and machine learning (ML), a \"chain\" often refers to a series of processes linked together. This can imply that LangChain involves executing multiple tasks or functions in sequence.\\n\\n3. **Connection to AI/ML technologies**: Given its name and context, it\\'s reasonable to infer that LangChain is involved in the field of natural language processing (NLP) or more broadly, artificial intelligence. NLP is an area within computer science concerned with the interaction between computers and humans in a human language.\\n\\n4. **Possible functions or services**: Considering the focus on languages and the potential for multiple linked processes, LangChain might offer various AI-driven functionalities such as:\\n    - Text analysis (like sentiment analysis or text classification).\\n    - Language translation.\\n    - Chatbots or conversational interfaces.\\n    - Content generation (e.g., articles, summaries).\\n    - Dialogue management systems.\\n\\n5. **Conclusion**: Based on the name and analysis of its components, LangChain is likely a tool or framework for developing applications that involve complex interactions with human languages through AI and ML technologies. It possibly enables creating custom chatbots, natural language interfaces, text generators, or other applications that require intricate language understanding and processing capabilities.\\n\\nThis step-by-step breakdown indicates that LangChain is focused on leveraging AI to understand, process, and interact with human languages in a sophisticated manner, likely through multiple linked processes (the \"chain\" part).'"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -114,6 +115,16 @@
     "    ollama pull bakllava\n",
     "\n",
     "Be sure to update Ollama so that you have the most recent version to support multi-modal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56f95afd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install pillow"
    ]
   },
   {
@@ -177,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "id": "79aaf863",
    "metadata": {},
    "outputs": [
@@ -199,6 +210,16 @@
     "\n",
     "llm_with_image_context = llm.bind(images=[image_b64])\n",
     "llm_with_image_context.invoke(\"What is the dollar based gross retention rate:\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afd9494f",
+   "metadata": {},
+   "source": [
+    "## API reference\n",
+    "\n",
+    "For detailed documentation of all ChatOllama features and configurations head to the [API reference](https://python.langchain.com/api_reference/ollama/llms/langchain_ollama.llms.OllamaLLM.html)."
    ]
   }
  ],

--- a/docs/docs/integrations/text_embedding/ollama.ipynb
+++ b/docs/docs/integrations/text_embedding/ollama.ipynb
@@ -28,9 +28,10 @@
         "\n",
         "## Setup\n",
         "\n",
-        "First, follow [these instructions](https://github.com/jmorganca/ollama) to set up and run a local Ollama instance:\n",
+        "First, follow [these instructions](https://github.com/ollama/ollama?tab=readme-ov-file#ollama) to set up and run a local Ollama instance:\n",
         "\n",
-        "* [Download](https://ollama.ai/download) and install Ollama onto the available supported platforms (including Windows Subsystem for Linux)\n",
+        "* [Download](https://ollama.ai/download) and install Ollama onto the available supported platforms (including Windows Subsystem for Linux aka WSL, macOS, and Linux)\n",
+        "    * macOS users can install via Homebrew with `brew install ollama` and start with `brew services start ollama`\n",
         "* Fetch available LLM model via `ollama pull <name-of-model>`\n",
         "    * View a list of available models via the [model library](https://ollama.ai/library)\n",
         "    * e.g., `ollama pull llama3`\n",
@@ -43,12 +44,7 @@
         "* Specify the exact version of the model of interest as such `ollama pull vicuna:13b-v1.5-16k-q4_0` (View the [various tags for the `Vicuna`](https://ollama.ai/library/vicuna/tags) model in this instance)\n",
         "* To view all pulled models, use `ollama list`\n",
         "* To chat directly with a model from the command line, use `ollama run <name-of-model>`\n",
-        "* View the [Ollama documentation](https://github.com/jmorganca/ollama) for more commands. Run `ollama help` in the terminal to see available commands too.\n",
-        "\n",
-        "\n",
-        "### Credentials\n",
-        "\n",
-        "There is no built-in auth mechanism for Ollama."
+        "* View the [Ollama documentation](https://github.com/ollama/ollama/tree/main/docs) for more commands. You can run `ollama help` in the terminal to see available commands."
       ]
     },
     {
@@ -195,7 +191,7 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "[-0.001288981, 0.006547121, 0.018376578, 0.025603496, 0.009599175, -0.0042578303, -0.023250086, -0.0\n"
+            "[-0.0039849705, 0.023019705, -0.001768838, -0.0058736936, 0.00040999008, 0.017861595, -0.011274585, \n"
           ]
         }
       ],
@@ -224,8 +220,8 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "[-0.0013138362, 0.006438795, 0.018304596, 0.025530428, 0.009717592, -0.004225636, -0.023363983, -0.0\n",
-            "[-0.010317663, 0.01632489, 0.0070348927, 0.017076202, 0.008924255, 0.007399284, -0.023064945, -0.003\n"
+            "[-0.0039849705, 0.023019705, -0.001768838, -0.0058736936, 0.00040999008, 0.017861595, -0.011274585, \n",
+            "[-0.0066985516, 0.009878328, 0.008019467, -0.009384944, -0.029560851, 0.025744654, 0.004872892, -0.0\n"
           ]
         }
       ],

--- a/libs/partners/ollama/README.md
+++ b/libs/partners/ollama/README.md
@@ -12,10 +12,7 @@ For the package to work, you will need to install and run the Ollama server loca
 
 To run integration tests (`make integration_tests`), you will need the following models installed in your Ollama server:
 
-- `llama3`
-- `llama3:latest`
-- `lamma3.1`
-- `gemma3:4b`
+- `llama3.1`
 - `deepseek-r1:1.5b`
 
 Install these models by running:
@@ -24,35 +21,35 @@ Install these models by running:
 ollama pull <name-of-model>
 ```
 
-## Chat Models
+## [Chat Models](https://python.langchain.com/api_reference/ollama/chat_models/langchain_ollama.chat_models.ChatOllama.html#chatollama)
 
 `ChatOllama` class exposes chat models from Ollama.
 
 ```python
 from langchain_ollama import ChatOllama
 
-llm = ChatOllama(model="llama3-groq-tool-use")
+llm = ChatOllama(model="llama3.1")
 llm.invoke("Sing a ballad of LangChain.")
 ```
 
-## Embeddings
+## [Embeddings](https://python.langchain.com/api_reference/ollama/embeddings/langchain_ollama.embeddings.OllamaEmbeddings.html#ollamaembeddings)
 
 `OllamaEmbeddings` class exposes embeddings from Ollama.
 
 ```python
 from langchain_ollama import OllamaEmbeddings
 
-embeddings = OllamaEmbeddings(model="llama3")
+embeddings = OllamaEmbeddings(model="llama3.1")
 embeddings.embed_query("What is the meaning of life?")
 ```
 
-## LLMs
+## [LLMs](https://python.langchain.com/api_reference/ollama/llms/langchain_ollama.llms.OllamaLLM.html#ollamallm)
 
-`OllamaLLM` class exposes LLMs from Ollama.
+`OllamaLLM` class exposes traditional LLMs from Ollama.
 
 ```python
 from langchain_ollama import OllamaLLM
 
-llm = OllamaLLM(model="llama3")
+llm = OllamaLLM(model="llama3.1")
 llm.invoke("The meaning of life is")
 ```

--- a/libs/partners/ollama/pyproject.toml
+++ b/libs/partners/ollama/pyproject.toml
@@ -7,11 +7,11 @@ authors = []
 license = { text = "MIT" }
 requires-python = ">=3.9"
 dependencies = [
-    "ollama>=0.4.8,<1.0.0",
-    "langchain-core<1.0.0,>=0.3.60",
+    "ollama>=0.5.1,<1.0.0",
+    "langchain-core<1.0.0,>=0.3.66",
 ]
 name = "langchain-ollama"
-version = "0.3.3"
+version = "0.3.4"
 description = "An integration package connecting Ollama and LangChain"
 readme = "README.md"
 

--- a/libs/partners/ollama/pyproject.toml
+++ b/libs/partners/ollama/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "langchain-core<1.0.0,>=0.3.66",
 ]
 name = "langchain-ollama"
-version = "0.3.4"
+version = "0.3.3"
 description = "An integration package connecting Ollama and LangChain"
 readme = "README.md"
 

--- a/libs/partners/ollama/tests/integration_tests/chat_models/test_chat_models.py
+++ b/libs/partners/ollama/tests/integration_tests/chat_models/test_chat_models.py
@@ -8,7 +8,7 @@ from typing_extensions import TypedDict
 
 from langchain_ollama import ChatOllama
 
-MODEL_NAME = "llama3.1"
+DEFAULT_MODEL_NAME = "llama3.1"
 
 
 @pytest.mark.parametrize(("method"), [("function_calling"), ("json_schema")])
@@ -21,7 +21,7 @@ def test_structured_output(method: str) -> None:
         setup: str = Field(description="question to set up a joke")
         punchline: str = Field(description="answer to resolve the joke")
 
-    llm = ChatOllama(model=MODEL_NAME, temperature=0)
+    llm = ChatOllama(model=DEFAULT_MODEL_NAME, temperature=0)
     query = "Tell me a joke about cats."
 
     # Pydantic
@@ -61,7 +61,7 @@ def test_structured_output(method: str) -> None:
     assert set(chunk.keys()) == {"setup", "punchline"}
 
 
-@pytest.mark.parametrize(("model"), [(MODEL_NAME)])
+@pytest.mark.parametrize(("model"), [(DEFAULT_MODEL_NAME)])
 def test_structured_output_deeply_nested(model: str) -> None:
     """Test to verify structured output with a nested objects."""
     llm = ChatOllama(model=model, temperature=0)

--- a/libs/partners/ollama/tests/integration_tests/chat_models/test_chat_models.py
+++ b/libs/partners/ollama/tests/integration_tests/chat_models/test_chat_models.py
@@ -8,6 +8,8 @@ from typing_extensions import TypedDict
 
 from langchain_ollama import ChatOllama
 
+MODEL_NAME = "llama3.1"
+
 
 @pytest.mark.parametrize(("method"), [("function_calling"), ("json_schema")])
 def test_structured_output(method: str) -> None:
@@ -19,7 +21,7 @@ def test_structured_output(method: str) -> None:
         setup: str = Field(description="question to set up a joke")
         punchline: str = Field(description="answer to resolve the joke")
 
-    llm = ChatOllama(model="llama3.1", temperature=0)
+    llm = ChatOllama(model=MODEL_NAME, temperature=0)
     query = "Tell me a joke about cats."
 
     # Pydantic
@@ -38,7 +40,7 @@ def test_structured_output(method: str) -> None:
 
     for chunk in structured_llm.stream(query):
         assert isinstance(chunk, dict)
-    assert isinstance(chunk, dict)  # for mypy
+    assert isinstance(chunk, dict)
     assert set(chunk.keys()) == {"setup", "punchline"}
 
     # Typed Dict
@@ -55,11 +57,11 @@ def test_structured_output(method: str) -> None:
 
     for chunk in structured_llm.stream(query):
         assert isinstance(chunk, dict)
-    assert isinstance(chunk, dict)  # for mypy
+    assert isinstance(chunk, dict)
     assert set(chunk.keys()) == {"setup", "punchline"}
 
 
-@pytest.mark.parametrize(("model"), [("llama3.1")])
+@pytest.mark.parametrize(("model"), [(MODEL_NAME)])
 def test_structured_output_deeply_nested(model: str) -> None:
     """Test to verify structured output with a nested objects."""
     llm = ChatOllama(model=model, temperature=0)
@@ -80,7 +82,7 @@ def test_structured_output_deeply_nested(model: str) -> None:
 
         people: list[Person]
 
-    chat = llm.with_structured_output(Data)  # type: ignore[arg-type]
+    chat = llm.with_structured_output(Data)
     text = (
         "Alan Smith is 6 feet tall and has blond hair."
         "Alan Poe is 3 feet tall and has grey hair."

--- a/libs/partners/ollama/tests/integration_tests/chat_models/test_chat_models_standard.py
+++ b/libs/partners/ollama/tests/integration_tests/chat_models/test_chat_models_standard.py
@@ -1,8 +1,12 @@
 """Test chat model integration using standard integration tests."""
 
+import pytest
+from langchain_core.language_models import BaseChatModel
 from langchain_tests.integration_tests import ChatModelIntegrationTests
 
 from langchain_ollama.chat_models import ChatOllama
+
+MODEL_NAME = "llama3.1"
 
 
 class TestChatOllama(ChatModelIntegrationTests):
@@ -12,7 +16,7 @@ class TestChatOllama(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "llama3.1"}
+        return {"model": MODEL_NAME}
 
     @property
     def supports_json_mode(self) -> bool:
@@ -20,23 +24,26 @@ class TestChatOllama(ChatModelIntegrationTests):
 
     @property
     def has_tool_choice(self) -> bool:
-        return False
+        return False  # TODO: update after Ollama implements
 
+    @property
+    def supports_image_inputs(self) -> bool:
+        return True
 
-def test_image_model() -> None:
-    class ImageModelTests(ChatModelIntegrationTests):
-        @property
-        def chat_model_class(self) -> type[ChatOllama]:
-            return ChatOllama
+    @pytest.mark.xfail(
+        reason=(
+            "Will sometime encounter AssertionErrors where tool responses are "
+            "`'3'` instead of `3`"
+        )
+    )
+    def test_tool_calling(self, model: BaseChatModel) -> None:
+        super().test_tool_calling(model)
 
-        @property
-        def chat_model_params(self) -> dict:
-            return {"model": "gemma3:4b"}
-
-        @property
-        def supports_image_inputs(self) -> bool:
-            return True
-
-    test_instance = ImageModelTests()
-    model = test_instance.chat_model_class(**test_instance.chat_model_params)
-    ImageModelTests().test_image_inputs(model)
+    @pytest.mark.xfail(
+        reason=(
+            "Will sometime encounter AssertionErrors where tool responses are "
+            "`'3'` instead of `3`"
+        )
+    )
+    async def test_tool_calling_async(self, model: BaseChatModel) -> None:
+        await super().test_tool_calling_async(model)

--- a/libs/partners/ollama/tests/integration_tests/chat_models/test_chat_models_standard.py
+++ b/libs/partners/ollama/tests/integration_tests/chat_models/test_chat_models_standard.py
@@ -6,7 +6,7 @@ from langchain_tests.integration_tests import ChatModelIntegrationTests
 
 from langchain_ollama.chat_models import ChatOllama
 
-MODEL_NAME = "llama3.1"
+DEFAULT_MODEL_NAME = "llama3.1"
 
 
 class TestChatOllama(ChatModelIntegrationTests):
@@ -16,7 +16,7 @@ class TestChatOllama(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": MODEL_NAME}
+        return {"model": DEFAULT_MODEL_NAME}
 
     @property
     def supports_json_mode(self) -> bool:

--- a/libs/partners/ollama/tests/integration_tests/test_embeddings.py
+++ b/libs/partners/ollama/tests/integration_tests/test_embeddings.py
@@ -4,6 +4,8 @@ from langchain_tests.integration_tests import EmbeddingsIntegrationTests
 
 from langchain_ollama.embeddings import OllamaEmbeddings
 
+MODEL_NAME = "llama3.1"
+
 
 class TestOllamaEmbeddings(EmbeddingsIntegrationTests):
     @property
@@ -12,4 +14,4 @@ class TestOllamaEmbeddings(EmbeddingsIntegrationTests):
 
     @property
     def embedding_model_params(self) -> dict:
-        return {"model": "llama3:latest"}
+        return {"model": MODEL_NAME}

--- a/libs/partners/ollama/tests/integration_tests/test_llms.py
+++ b/libs/partners/ollama/tests/integration_tests/test_llms.py
@@ -1,8 +1,10 @@
 """Test OllamaLLM llm."""
 
+from langchain_core.runnables import RunnableConfig
+
 from langchain_ollama.llms import OllamaLLM
 
-MODEL_NAME = "llama3"
+MODEL_NAME = "llama3.1"
 
 
 def test_stream() -> None:
@@ -54,13 +56,12 @@ async def test_ainvoke() -> None:
     """Test invoke tokens from OllamaLLM."""
     llm = OllamaLLM(model=MODEL_NAME)
 
-    result = await llm.ainvoke("I'm Pickle Rick", config={"tags": ["foo"]})
+    result = await llm.ainvoke("I'm Pickle Rick", config=RunnableConfig(tags=["foo"]))
     assert isinstance(result, str)
 
 
 def test_invoke() -> None:
     """Test invoke tokens from OllamaLLM."""
     llm = OllamaLLM(model=MODEL_NAME)
-
-    result = llm.invoke("I'm Pickle Rick", config=dict(tags=["foo"]))
+    result = llm.invoke("I'm Pickle Rick", config=RunnableConfig(tags=["foo"]))
     assert isinstance(result, str)

--- a/libs/partners/ollama/uv.lock
+++ b/libs/partners/ollama/uv.lock
@@ -363,7 +363,7 @@ typing = [
 
 [[package]]
 name = "langchain-ollama"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },
@@ -397,7 +397,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", editable = "../../core" },
-    { name = "ollama", specifier = ">=0.4.8,<1.0.0" },
+    { name = "ollama", specifier = ">=0.5.1,<1.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -795,15 +795,15 @@ wheels = [
 
 [[package]]
 name = "ollama"
-version = "0.4.8"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/64/709dc99030f8f46ec552f0a7da73bbdcc2da58666abfec4742ccdb2e800e/ollama-0.4.8.tar.gz", hash = "sha256:1121439d49b96fa8339842965d0616eba5deb9f8c790786cdf4c0b3df4833802", size = 12972, upload-time = "2025-04-16T21:55:14.101Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/96/c7fe0d2d1b3053be614822a7b722c7465161b3672ce90df71515137580a0/ollama-0.5.1.tar.gz", hash = "sha256:5a799e4dc4e7af638b11e3ae588ab17623ee019e496caaf4323efbaa8feeff93", size = 41112, upload-time = "2025-05-30T21:32:48.679Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/3f/164de150e983b3a16e8bf3d4355625e51a357e7b3b1deebe9cc1f7cb9af8/ollama-0.4.8-py3-none-any.whl", hash = "sha256:04312af2c5e72449aaebac4a2776f52ef010877c554103419d3f36066fe8af4c", size = 13325, upload-time = "2025-04-16T21:55:12.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/76/3f96c8cdbf3955d7a73ee94ce3e0db0755d6de1e0098a70275940d1aff2f/ollama-0.5.1-py3-none-any.whl", hash = "sha256:4c8839f35bc173c7057b1eb2cbe7f498c1a7e134eafc9192824c8aecb3617506", size = 13369, upload-time = "2025-05-30T21:32:47.429Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- docs: for the Ollama notebooks, improve the specificity of some links, add `homebrew` install info, update some wording
- tests: reduce number of local models needed to run in half from 4 → 2 (shedding 8gb of required installs)
- bump deps (non-breaking) in anticipation of upcoming "thinking" PR