### PR TITLE
openai: release 0.3.27

### DIFF
--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "tiktoken<1,>=0.7",
 ]
 name = "langchain-openai"
-version = "0.3.26"
+version = "0.3.27"
 description = "An integration package connecting OpenAI and LangChain"
 readme = "README.md"
 

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -537,7 +537,7 @@ typing = [
 
 [[package]]
 name = "langchain-openai"
-version = "0.3.26"
+version = "0.3.27"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
To pick up https://github.com/langchain-ai/langchain/pull/31756.