### PR TITLE
langchain-prompty[patch]: Add ruff bandit rules to linter

### DIFF
--- a/libs/partners/prompty/langchain_prompty/core.py
+++ b/libs/partners/prompty/langchain_prompty/core.py
@@ -319,7 +319,7 @@ class Frontmatter:
             fmatter = result.group(1)
             body = result.group(2)
         return {
-            "attributes": yaml.load(fmatter, Loader=yaml.FullLoader),
+            "attributes": yaml.safe_load(fmatter),
             "body": body,
             "frontmatter": fmatter,
         }

--- a/libs/partners/prompty/langchain_prompty/core.py
+++ b/libs/partners/prompty/langchain_prompty/core.py
@@ -55,7 +55,7 @@ class TemplateSettings(BaseModel):
 class Prompty(BaseModel):
     """Base Prompty model."""
 
-    # metadata
+    # Metadata
     name: str = Field(default="")
     description: str = Field(default="")
     authors: list[str] = Field(default=[])
@@ -63,17 +63,18 @@ class Prompty(BaseModel):
     version: str = Field(default="")
     base: str = Field(default="")
     basePrompty: Optional[Prompty] = Field(default=None)
-    # model
+
+    # Model
     model: ModelSettings = Field(default_factory=ModelSettings)
 
-    # sample
+    # Sample
     sample: dict = Field(default={})
 
-    # input / output
+    # Input / output
     inputs: dict[str, PropertySettings] = Field(default={})
     outputs: dict[str, PropertySettings] = Field(default={})
 
-    # template
+    # Template
     template: TemplateSettings
 
     file: FilePath = Field(default="")  # type: ignore[assignment]
@@ -96,14 +97,14 @@ class Prompty(BaseModel):
                         else self.file
                     )
                 elif k == "basePrompty":
-                    # no need to serialize basePrompty
+                    # No need to serialize basePrompty
                     continue
 
                 else:
                     d[k] = v
         return d
 
-    # generate json representation of the prompty
+    # Generate json representation of the prompty
     def to_safe_json(self) -> str:
         d = self.to_safe_dict()
         return json.dumps(d)
@@ -307,9 +308,9 @@ class Frontmatter:
         """Returns dict with separated frontmatter from string.
 
         Returned dict keys:
-        attributes -- extracted YAML attributes in dict form.
-        body -- string contents below the YAML separators
-        frontmatter -- string representation of YAML
+        - attributes: extracted YAML attributes in dict form.
+        - body: string contents below the YAML separators
+        - frontmatter: string representation of YAML
         """
         fmatter = ""
         body = ""

--- a/libs/partners/prompty/langchain_prompty/parsers.py
+++ b/libs/partners/prompty/langchain_prompty/parsers.py
@@ -102,7 +102,8 @@ class PromptyChatParser(Invoker):
             return content
 
     def invoke(self, data: BaseModel) -> BaseModel:
-        assert isinstance(data, SimpleModel)
+        if not isinstance(data, SimpleModel):
+            raise ValueError("data must be an instance of SimpleModel")
         messages = []
         separator = r"(?i)^\s*#?\s*(" + "|".join(self.roles) + r")\s*:\s*\n"
 

--- a/libs/partners/prompty/langchain_prompty/renderers.py
+++ b/libs/partners/prompty/langchain_prompty/renderers.py
@@ -11,6 +11,7 @@ class MustacheRenderer(Invoker):
         self.prompty = prompty
 
     def invoke(self, data: BaseModel) -> BaseModel:
-        assert isinstance(data, SimpleModel)
+        if not isinstance(data, SimpleModel):
+            raise ValueError("Expected data to be an instance of SimpleModel")
         generated = mustache.render(self.prompty.content, data.item)
         return SimpleModel[str](item=generated)

--- a/libs/partners/prompty/pyproject.toml
+++ b/libs/partners/prompty/pyproject.toml
@@ -49,7 +49,7 @@ langchain = { path = "../../langchain", editable = true }
 target-version = "py39"
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "T201", "UP"]
+select = ["E", "F", "I", "T201", "UP", "S"]
 ignore = [ "UP007", ]
 
 [tool.mypy]
@@ -65,3 +65,9 @@ markers = [
     "compile: mark placeholder test used to compile integration tests without running them",
 ]
 asyncio_mode = "auto"
+
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/**/*.py" = [
+    "S101", # Tests need assertions
+    "S311", # Standard pseudo-random generators are not suitable for cryptographic purposes
+]


### PR DESCRIPTION
- Add ruff bandit rules
- Address some s101 assertion warnings
- Address s506 by using `yaml.safe_load()`