### PR TITLE
fix(core): Pydantic nested model field descriptions in tool schema generation

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -13,6 +13,7 @@ from typing import (
     Annotated,
     Any,
     Literal,
+    Optional,
     Union,
     cast,
     get_args,

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -176,13 +176,14 @@ def _get_schema_from_model(
         and "$defs" in schema
     ):
         for field_name, field_info in model.model_fields.items():
-            # Only replace if field is a direct model reference (not List[Model], etc.)
-            # Check that annotation is not a generic type (has no origin).
+            # Only replace if field is a direct BaseModel reference.
+            # Skip generic types (List[Model], etc.) and non-BaseModel types.
             if (
                 field_info.annotation
                 and hasattr(field_info.annotation, "__name__")
                 and field_info.annotation.__name__ in schema["$defs"]
                 and get_origin(field_info.annotation) is None
+                and is_basemodel_subclass(field_info.annotation)
             ):
                 # Recurse, passing the description from the parent field.
                 schema["properties"][field_name] = _get_schema_from_model(

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -161,7 +161,8 @@ def _get_schema_from_model(
             # Only process if field is a direct model reference (not List[Model], etc.)
             # In Pydantic v1, outer_type_ == type_ for direct references.
             if (
-                field.type_.__name__ in schema["definitions"]
+                hasattr(field.type_, "__name__")
+                and field.type_.__name__ in schema["definitions"]
                 and field.outer_type_ == field.type_
                 and is_basemodel_subclass(field.type_)
             ):
@@ -170,7 +171,11 @@ def _get_schema_from_model(
                     field.type_, field_description=field.field_info.description
                 )
                 # Only update description, preserve existing property schema.
-                if nested_schema.get("description"):
+                if (
+                    nested_schema.get("description")
+                    and "properties" in schema
+                    and field_name in schema["properties"]
+                ):
                     schema["properties"][field_name]["description"] = nested_schema[
                         "description"
                     ]
@@ -196,7 +201,11 @@ def _get_schema_from_model(
                     field_info.annotation, field_description=field_info.description
                 )
                 # Only update description, preserve existing property schema.
-                if nested_schema.get("description"):
+                if (
+                    nested_schema.get("description")
+                    and "properties" in schema
+                    and field_name in schema["properties"]
+                ):
                     schema["properties"][field_name]["description"] = nested_schema[
                         "description"
                     ]

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -121,7 +121,7 @@ def _rm_titles(kv: dict, prev_key: str = "") -> dict:
 
 def _get_schema_from_model(
     model: type, *, field_description: str | None = None
-) -> dict:
+) -> dict[str, Any]:
     """Gets the JSON schema for a Pydantic model, handling nested model descriptions.
 
     This function recursively generates a JSON schema for a Pydantic model.
@@ -136,6 +136,7 @@ def _get_schema_from_model(
     Returns:
         A dictionary representing the JSON schema of the model.
     """
+    schema: dict[str, Any]
     if hasattr(model, "model_json_schema"):
         schema = model.model_json_schema()
     elif hasattr(model, "schema"):

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -13,7 +13,6 @@ from typing import (
     Annotated,
     Any,
     Literal,
-    Optional,
     Union,
     cast,
     get_args,
@@ -121,7 +120,7 @@ def _rm_titles(kv: dict, prev_key: str = "") -> dict:
 
 
 def _get_schema_from_model(
-    model: type, *, field_description: Optional[str] = None
+    model: type, *, field_description: str | None = None
 ) -> dict:
     """Gets the JSON schema for a Pydantic model, handling nested model descriptions.
 


### PR DESCRIPTION
## Description
This Pull Request fixes a bug in LangChain's tool schema generation logic where descriptions for fields containing nested Pydantic models were not correctly handled. This issue, reported in #31808, led to inconsistent or missing descriptions in the tool specifications provided to Large Language Models (LLMs).

### Problem Statement (from #31808):
When a Pydantic model is used to define the arguments for a LangChain tool, the description provided for a field containing a nested Pydantic model is not handled correctly.
The behavior was inconsistent:
- If the nested Pydantic model had a `__doc__` string, that docstring was used as the description, overwriting the description from the parent field.
- If the nested Pydantic model did not have a `__doc__` string, the description from the parent field was completely ignored, and the field ended up with no description at all in the final tool schema.
The desired behavior is that if a nested model does not have a docstring, the system should fall back to using the description provided in the parent model's `Field`.

## Changes Made
The core of the fix is in the `_get_schema_from_model` utility function within `libs/core/langchain_core/utils/function_calling.py`. This function has been modified to implement the desired fallback logic:
1.  **Prioritize Nested Model Docstring:** If a nested Pydantic model has a `__doc__` string, its content is used as the description for that field in the schema. This maintains existing behavior where a docstring explicitly defines the model's purpose.
2.  **Fallback to Parent Field Description:** If a nested Pydantic model does *not* have a `__doc__` string, the `description` provided in the parent `Field` definition is now correctly used as a fallback. This ensures that descriptions are not lost when nested models do not have their own docstrings.
3.  **Recursive Handling:** The logic for resolving nested model definitions (`$defs` for Pydantic v2 and `definitions` for Pydantic v1) has been updated to correctly pass the parent `Field`'s description during recursion. This ensures the fallback mechanism works for arbitrarily deep nesting of Pydantic models.

This PR directly addresses and resolves the issue described in #31808, ensuring accurate and consistent tool schema generation for Pydantic models with nested fields.