### PR TITLE
ci: set explicit workflow permissions

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -12,6 +12,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
 

--- a/.github/workflows/_integration_test.yml
+++ b/.github/workflows/_integration_test.yml
@@ -12,6 +12,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
 

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -12,6 +12,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -12,6 +12,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
   UV_NO_SYNC: "true"

--- a/.github/workflows/_test_doc_imports.yml
+++ b/.github/workflows/_test_doc_imports.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "Python version to use"
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
 

--- a/.github/workflows/_test_pydantic.yml
+++ b/.github/workflows/_test_pydantic.yml
@@ -17,6 +17,9 @@ on:
         type: string
         description: "Pydantic version to test."
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
   UV_NO_SYNC: "true"

--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron:  '0 13 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   check-links:
     if: github.repository_owner == 'langchain-ai' || github.event_name != 'schedule'

--- a/.github/workflows/check_core_versions.yml
+++ b/.github/workflows/check_core_versions.yml
@@ -6,6 +6,9 @@ on:
       - 'libs/core/pyproject.toml'
       - 'libs/core/langchain_core/version.py'
 
+permissions:
+  contents: read
+
 jobs:
   check_version_equality:
     runs-on: ubuntu-latest

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
   UV_NO_SYNC: "true"

--- a/.github/workflows/check_new_docs.yml
+++ b/.github/workflows/check_new_docs.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: foo
   AZURE_OPENAI_LEGACY_CHAT_DEPLOYMENT_NAME: foo

--- a/.github/workflows/people.yml
+++ b/.github/workflows/people.yml
@@ -11,7 +11,8 @@ jobs:
   langchain-people:
     if: github.repository_owner == 'langchain-ai' || github.event_name != 'schedule'
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write
     steps:
       - name: Dump GitHub context
         env:

--- a/.github/workflows/run_notebooks.yml
+++ b/.github/workflows/run_notebooks.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 13 * * *'
 
+permissions:
+  contents: read
+
 env:
   UV_FROZEN: "true"
 

--- a/.github/workflows/scheduled_test.yml
+++ b/.github/workflows/scheduled_test.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron:  '0 13 * * *'
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "1.8.4"
   UV_FROZEN: "true"


### PR DESCRIPTION
* Set explicit workflow permissions
* Should be a no-op since we're using restricted GITHUB_TOKENs by default