### PR TITLE
core: make ruff rule PLW1510 unfixable

### DIFF
--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -103,6 +103,8 @@ ignore = [
     "ERA",
     "PLR2004",
 ]
+unfixable = ["PLW1510",]
+
 flake8-type-checking.runtime-evaluated-base-classes = ["pydantic.BaseModel","langchain_core.load.serializable.Serializable","langchain_core.runnables.base.RunnableSerializable"]
 flake8-annotations.allow-star-arg-any = true
 flake8-annotations.mypy-init-return = true

--- a/libs/core/tests/benchmarks/test_imports.py
+++ b/libs/core/tests/benchmarks/test_imports.py
@@ -51,4 +51,4 @@ from pytest_benchmark.fixture import BenchmarkFixture  # type: ignore[import-unt
 def test_import_time(benchmark: BenchmarkFixture, import_path: str) -> None:
     @benchmark  # type: ignore[misc]
     def import_in_subprocess() -> None:
-        subprocess.run([sys.executable, "-c", import_path], check=False)
+        subprocess.run([sys.executable, "-c", import_path], check=True)


### PR DESCRIPTION
See https://github.com/astral-sh/ruff/discussions/17087#discussioncomment-12675815

Tha autofix is misleading: it chooses to add `check=False` to keep the runtime behavior but in reality it hides the fact that most probably the user would prefer `check=True`.
