### PR TITLE
langchain[patch]: fix a bug where `now.replace(day=now.day - 1)` would raise a `ValueError` when `now.day` is equal to 1

### DIFF
--- a/libs/langchain/langchain/output_parsers/datetime.py
+++ b/libs/langchain/langchain/output_parsers/datetime.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers import BaseOutputParser
@@ -31,7 +31,7 @@ class DatetimeOutputParser(BaseOutputParser[datetime]):
                     [
                         now.strftime(self.format),
                         (now.replace(year=now.year - 1)).strftime(self.format),
-                        (now.replace(day=now.day - 1)).strftime(self.format),
+                        (now - timedelta(days=1)).strftime(self.format),
                     ]
                 )
             except ValueError:


### PR DESCRIPTION
### PR Message

#### **Description**  
This PR addresses a bug where `now.replace(day=now.day - 1)` would raise a `ValueError` when `now.day` is equal to 1. The issue is resolved by replacing the problematic line with `now - timedelta(days=1)`, ensuring proper handling of date calculations without errors.

#### **Dependencies**  
No additional dependencies are required for this change.