### PR TITLE
core: docs: clarify where the kwargs in on_tool_start and on_tool_end go

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1066,7 +1066,7 @@ class CallbackManagerForToolRun(ParentRunManager, ToolManagerMixin):
 
         Args:
             output (Any): The output of the tool.
-            **kwargs (Any): Additional keyword arguments.
+            **kwargs (Any): The keyword arguments to pass to the event handler
         """
         if not self.handlers:
             return
@@ -1470,7 +1470,7 @@ class CallbackManager(BaseCallbackManager):
                 input is needed.
                 If provided, the inputs are expected to be formatted as a dict.
                 The keys will correspond to the named-arguments in the tool.
-            **kwargs (Any): Additional keyword arguments.
+            **kwargs (Any): The keyword arguments to pass to the event handler
 
         Returns:
             CallbackManagerForToolRun: The callback manager for the tool run.

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -803,7 +803,7 @@ class ChildTool(BaseTool):
             run_id: The id of the run. Defaults to None.
             config: The configuration for the tool. Defaults to None.
             tool_call_id: The id of the tool call. Defaults to None.
-            kwargs: Keyword arguments to be passed to tool callbacks
+            kwargs: Keyword arguments to be passed to tool callbacks (event handler)
 
         Returns:
             The output of the tool.


### PR DESCRIPTION
**Description:**  
I traced the kwargs starting at `.invoke()` and it was not clear where they go. it was clarified to two layers down. so I changed it to make it more documented for the next person.  


**Issue:**  
No related issue.

**Dependencies:**  
No dependency changes.

**Twitter handle:**  
Nah. We're good.

If no one reviews your PR within a few days, please @-mention one of baskaryan, eyurtsev, ccurme, vbarda, hwchase17.
