### PR TITLE
ollama[patch]: fix model validation, ensure per-call reasoning can be set, tests

### DIFF
--- a/libs/partners/ollama/langchain_ollama/_utils.py
+++ b/libs/partners/ollama/langchain_ollama/_utils.py
@@ -16,7 +16,9 @@ def validate_model(client: Client, model_name: str) -> None:
     """
     try:
         response = client.list()
-        model_names: list[str] = [model["name"] for model in response["models"]]
+
+        model_names: list[str] = [model["model"] for model in response["models"]]
+
         if not any(
             model_name == m or m.startswith(f"{model_name}:") for m in model_names
         ):
@@ -27,10 +29,7 @@ def validate_model(client: Client, model_name: str) -> None:
             )
             raise ValueError(msg)
     except ConnectError as e:
-        msg = (
-            "Connection to Ollama failed. Please make sure Ollama is running "
-            f"and accessible at {client._client.base_url}. "
-        )
+        msg = "Failed to connect to Ollama. Please check that Ollama is downloaded, running and accessible. https://ollama.com/download"  # noqa: E501
         raise ValueError(msg) from e
     except ResponseError as e:
         msg = (

--- a/libs/partners/ollama/langchain_ollama/llms.py
+++ b/libs/partners/ollama/langchain_ollama/llms.py
@@ -38,7 +38,7 @@ class OllamaLLM(BaseLLM):
     model: str
     """Model name to use."""
 
-    reasoning: Optional[bool] = True
+    reasoning: Optional[bool] = None
     """Controls the reasoning/thinking mode for
     `supported models <https://ollama.com/search?c=thinking>`__.
 

--- a/libs/partners/ollama/langchain_ollama/llms.py
+++ b/libs/partners/ollama/langchain_ollama/llms.py
@@ -272,8 +272,11 @@ class OllamaLLM(BaseLLM):
         **kwargs: Any,
     ) -> GenerationChunk:
         final_chunk = None
+        thinking_content = ""
         async for stream_resp in self._acreate_generate_stream(prompt, stop, **kwargs):
             if not isinstance(stream_resp, str):
+                if stream_resp.get("thinking"):
+                    thinking_content += stream_resp["thinking"]
                 chunk = GenerationChunk(
                     text=stream_resp.get("response", ""),
                     generation_info=(
@@ -294,6 +297,12 @@ class OllamaLLM(BaseLLM):
             msg = "No data received from Ollama stream."
             raise ValueError(msg)
 
+        if thinking_content:
+            if final_chunk.generation_info:
+                final_chunk.generation_info["thinking"] = thinking_content
+            else:
+                final_chunk.generation_info = {"thinking": thinking_content}
+
         return final_chunk
 
     def _stream_with_aggregation(
@@ -305,8 +314,11 @@ class OllamaLLM(BaseLLM):
         **kwargs: Any,
     ) -> GenerationChunk:
         final_chunk = None
+        thinking_content = ""
         for stream_resp in self._create_generate_stream(prompt, stop, **kwargs):
             if not isinstance(stream_resp, str):
+                if stream_resp.get("thinking"):
+                    thinking_content += stream_resp["thinking"]
                 chunk = GenerationChunk(
                     text=stream_resp.get("response", ""),
                     generation_info=(
@@ -326,6 +338,12 @@ class OllamaLLM(BaseLLM):
         if final_chunk is None:
             msg = "No data received from Ollama stream."
             raise ValueError(msg)
+
+        if thinking_content:
+            if final_chunk.generation_info:
+                final_chunk.generation_info["thinking"] = thinking_content
+            else:
+                final_chunk.generation_info = {"thinking": thinking_content}
 
         return final_chunk
 
@@ -374,10 +392,11 @@ class OllamaLLM(BaseLLM):
         run_manager: Optional[CallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> Iterator[GenerationChunk]:
+        reasoning = kwargs.get("reasoning", self.reasoning)
         for stream_resp in self._create_generate_stream(prompt, stop, **kwargs):
             if not isinstance(stream_resp, str):
                 additional_kwargs = {}
-                if thinking_content := stream_resp.get("thinking"):
+                if reasoning and (thinking_content := stream_resp.get("thinking")):
                     additional_kwargs["reasoning_content"] = thinking_content
 
                 chunk = GenerationChunk(
@@ -404,10 +423,11 @@ class OllamaLLM(BaseLLM):
         run_manager: Optional[AsyncCallbackManagerForLLMRun] = None,
         **kwargs: Any,
     ) -> AsyncIterator[GenerationChunk]:
+        reasoning = kwargs.get("reasoning", self.reasoning)
         async for stream_resp in self._acreate_generate_stream(prompt, stop, **kwargs):
             if not isinstance(stream_resp, str):
                 additional_kwargs = {}
-                if thinking_content := stream_resp.get("thinking"):
+                if reasoning and (thinking_content := stream_resp.get("thinking")):
                     additional_kwargs["reasoning_content"] = thinking_content
 
                 chunk = GenerationChunk(

--- a/libs/partners/ollama/tests/integration_tests/test_llms.py
+++ b/libs/partners/ollama/tests/integration_tests/test_llms.py
@@ -1,18 +1,17 @@
 """Test OllamaLLM llm."""
 
 import pytest
-from langchain_core.messages import AIMessageChunk, BaseMessageChunk
+from langchain_core.outputs import GenerationChunk
 from langchain_core.runnables import RunnableConfig
 
 from langchain_ollama.llms import OllamaLLM
 
 MODEL_NAME = "llama3.1"
-
 SAMPLE = "What is 3^3?"
 
 
-def test_stream() -> None:
-    """Test streaming tokens from OpenAI."""
+def test_stream_text_tokens() -> None:
+    """Test streaming raw string tokens from OllamaLLM."""
     llm = OllamaLLM(model=MODEL_NAME)
 
     for token in llm.stream("I'm Pickle Rick"):
@@ -20,60 +19,52 @@ def test_stream() -> None:
 
 
 @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
-def test_stream_no_reasoning(model: str) -> None:
-    """Test streaming with `reasoning=False`"""
+def test__stream_no_reasoning(model: str) -> None:
+    """Test low-level chunk streaming of a simple prompt with `reasoning=False`."""
     llm = OllamaLLM(model=model, num_ctx=2**12)
-    messages = [
-        {
-            "role": "user",
-            "content": SAMPLE,
-        }
-    ]
-    result = None
-    for chunk in llm.stream(messages):
-        assert isinstance(chunk, BaseMessageChunk)
-        if result is None:
-            result = chunk
-            continue
-        result += chunk
-    assert isinstance(result, AIMessageChunk)
-    assert result.content
-    assert "reasoning_content" not in result.additional_kwargs
 
-    # Sanity check the old behavior isn't present
-    assert "<think>" not in result.content and "</think>" not in result.content
+    result_chunk = None
+    for chunk in llm._stream(SAMPLE):
+        # Should be a GenerationChunk
+        assert isinstance(chunk, GenerationChunk)
+        if result_chunk is None:
+            result_chunk = chunk
+        else:
+            result_chunk += chunk
+
+    # The final result must be a GenerationChunk with visible content
+    assert isinstance(result_chunk, GenerationChunk)
+    assert result_chunk.text
+    # No separate reasoning_content
+    assert "reasoning_content" not in result_chunk.generation_info
 
 
 @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
-def test_reasoning_stream(model: str) -> None:
-    """Test streaming with `reasoning=True`"""
+def test__stream_with_reasoning(model: str) -> None:
+    """Test low-level chunk streaming with `reasoning=True`."""
     llm = OllamaLLM(model=model, num_ctx=2**12, reasoning=True)
-    messages = [
-        {
-            "role": "user",
-            "content": SAMPLE,
-        }
-    ]
-    result = None
-    for chunk in llm.stream(messages):
-        assert isinstance(chunk, BaseMessageChunk)
-        if result is None:
-            result = chunk
-            continue
-        result += chunk
-    assert isinstance(result, AIMessageChunk)
-    assert result.content
-    assert "reasoning_content" in result.additional_kwargs
-    assert len(result.additional_kwargs["reasoning_content"]) > 0
 
-    # Sanity check the old behavior isn't present
-    assert "<think>" not in result.content and "</think>" not in result.content
-    assert "<think>" not in result.additional_kwargs["reasoning_content"]
-    assert "</think>" not in result.additional_kwargs["reasoning_content"]
+    result_chunk = None
+    for chunk in llm._stream(SAMPLE):
+        assert isinstance(chunk, GenerationChunk)
+        if result_chunk is None:
+            result_chunk = chunk
+        else:
+            result_chunk += chunk
+
+    assert isinstance(result_chunk, GenerationChunk)
+    assert result_chunk.text
+    # Should have extracted reasoning into generation_info
+    assert "reasoning_content" in result_chunk.generation_info
+    assert len(result_chunk.generation_info["reasoning_content"]) > 0
+    # And neither the visible nor the hidden portion contains <think> tags
+    assert "<think>" not in result_chunk.text and "</think>" not in result_chunk.text
+    assert "<think>" not in result_chunk.generation_info["reasoning_content"]
+    assert "</think>" not in result_chunk.generation_info["reasoning_content"]
 
 
-async def test_astream() -> None:
-    """Test streaming tokens from OpenAI."""
+async def test_astream_text_tokens() -> None:
+    """Test async streaming raw string tokens from OllamaLLM."""
     llm = OllamaLLM(model=MODEL_NAME)
 
     async for token in llm.astream("I'm Pickle Rick"):
@@ -81,60 +72,44 @@ async def test_astream() -> None:
 
 
 @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
-async def test_astream_no_reasoning(model: str) -> None:
-    """Test async streaming with `reasoning=False`"""
+async def test__astream_no_reasoning(model: str) -> None:
+    """Test low-level async chunk streaming with `reasoning=False`."""
     llm = OllamaLLM(model=model, num_ctx=2**12)
-    messages = [
-        {
-            "role": "user",
-            "content": SAMPLE,
-        }
-    ]
-    result = None
-    async for chunk in llm.astream(messages):
-        assert isinstance(chunk, BaseMessageChunk)
-        if result is None:
-            result = chunk
-            continue
-        result += chunk
-    assert isinstance(result, AIMessageChunk)
-    assert result.content
-    assert "reasoning_content" not in result.additional_kwargs
 
-    # Sanity check the old behavior isn't present
-    assert "<think>" not in result.content and "</think>" not in result.content
+    result_chunk = None
+    async for chunk in llm._astream(SAMPLE):
+        assert isinstance(chunk, GenerationChunk)
+        if result_chunk is None:
+            result_chunk = chunk
+        else:
+            result_chunk += chunk
+
+    assert isinstance(result_chunk, GenerationChunk)
+    assert result_chunk.text
+    assert "reasoning_content" not in result_chunk.generation_info
 
 
 @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
-async def test_reasoning_astream(model: str) -> None:
-    """Test async streaming with `reasoning=True`"""
+async def test__astream_with_reasoning(model: str) -> None:
+    """Test low-level async chunk streaming with `reasoning=True`."""
     llm = OllamaLLM(model=model, num_ctx=2**12, reasoning=True)
-    messages = [
-        {
-            "role": "user",
-            "content": SAMPLE,
-        }
-    ]
-    result = None
-    async for chunk in llm.astream(messages):
-        assert isinstance(chunk, BaseMessageChunk)
-        if result is None:
-            result = chunk
-            continue
-        result += chunk
-    assert isinstance(result, AIMessageChunk)
-    assert result.content
-    assert "reasoning_content" in result.additional_kwargs
-    assert len(result.additional_kwargs["reasoning_content"]) > 0
 
-    # Sanity check the old behavior isn't present
-    assert "<think>" not in result.content and "</think>" not in result.content
-    assert "<think>" not in result.additional_kwargs["reasoning_content"]
-    assert "</think>" not in result.additional_kwargs["reasoning_content"]
+    result_chunk = None
+    async for chunk in llm._astream(SAMPLE):
+        assert isinstance(chunk, GenerationChunk)
+        if result_chunk is None:
+            result_chunk = chunk
+        else:
+            result_chunk += chunk
+
+    assert isinstance(result_chunk, GenerationChunk)
+    assert result_chunk.text
+    assert "reasoning_content" in result_chunk.generation_info
+    assert len(result_chunk.generation_info["reasoning_content"]) > 0
 
 
 async def test_abatch() -> None:
-    """Test streaming tokens from OllamaLLM."""
+    """Test batch sync token generation from OllamaLLM."""
     llm = OllamaLLM(model=MODEL_NAME)
 
     result = await llm.abatch(["I'm Pickle Rick", "I'm not Pickle Rick"])
@@ -143,7 +118,7 @@ async def test_abatch() -> None:
 
 
 async def test_abatch_tags() -> None:
-    """Test batch tokens from OllamaLLM."""
+    """Test batch sync token generation with tags."""
     llm = OllamaLLM(model=MODEL_NAME)
 
     result = await llm.abatch(
@@ -154,7 +129,7 @@ async def test_abatch_tags() -> None:
 
 
 def test_batch() -> None:
-    """Test batch tokens from OllamaLLM."""
+    """Test batch token generation from OllamaLLM."""
     llm = OllamaLLM(model=MODEL_NAME)
 
     result = llm.batch(["I'm Pickle Rick", "I'm not Pickle Rick"])
@@ -163,75 +138,15 @@ def test_batch() -> None:
 
 
 async def test_ainvoke() -> None:
-    """Test invoke tokens from OllamaLLM."""
+    """Test async invoke returning a string."""
     llm = OllamaLLM(model=MODEL_NAME)
 
     result = await llm.ainvoke("I'm Pickle Rick", config=RunnableConfig(tags=["foo"]))
     assert isinstance(result, str)
 
 
-# TODO
-# @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
-# async def test_ainvoke_no_reasoning(model: str) -> None:
-#     """Test using async invoke with `reasoning=False`"""
-#     llm = OllamaLLM(model=model, num_ctx=2**12)
-#     message = SAMPLE
-#     result = await llm.ainvoke(message)
-#     assert result.content
-#     assert "reasoning_content" not in result.additional_kwargs
-
-#     # Sanity check the old behavior isn't present
-#     assert "<think>" not in result.content and "</think>" not in result.content
-
-
-# @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
-# async def test_reasoning_ainvoke(model: str) -> None:
-#     """Test invoke with `reasoning=True`"""
-#     llm = OllamaLLM(model=model, num_ctx=2**12, reasoning=True)
-#     message = SAMPLE
-#     result = await llm.ainvoke(message)
-#     assert result.content
-#     assert "reasoning_content" in result.additional_kwargs
-#     assert len(result.additional_kwargs["reasoning_content"]) > 0
-
-#     # Sanity check the old behavior isn't present
-#     assert "<think>" not in result.content and "</think>" not in result.content
-#     assert "<think>" not in result.additional_kwargs["reasoning_content"]
-#     assert "</think>" not in result.additional_kwargs["reasoning_content"]
-
-
 def test_invoke() -> None:
-    """Test invoke tokens from OllamaLLM."""
+    """Test sync invoke returning a string."""
     llm = OllamaLLM(model=MODEL_NAME)
     result = llm.invoke("I'm Pickle Rick", config=RunnableConfig(tags=["foo"]))
     assert isinstance(result, str)
-
-
-# TODO
-# @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
-# def test_invoke_no_reasoning(model: str) -> None:
-#     """Test using invoke with `reasoning=False`"""
-#     llm = OllamaLLM(model=model, num_ctx=2**12)
-#     message = SAMPLE
-#     result = llm.invoke(message)
-#     assert result.content
-#     assert "reasoning_content" not in result.additional_kwargs
-
-#     # Sanity check the old behavior isn't present
-#     assert "<think>" not in result.content and "</think>" not in result.content
-
-
-# @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
-# def test_reasoning_invoke(model: str) -> None:
-#     """Test invoke with `reasoning=True`"""
-#     llm = OllamaLLM(model=model, num_ctx=2**12, reasoning=True)
-#     message = SAMPLE
-#     result = llm.invoke(message)
-#     assert result.content
-#     assert "reasoning_content" in result.additional_kwargs
-#     assert len(result.additional_kwargs["reasoning_content"]) > 0
-
-#     # Sanity check the old behavior isn't present
-#     assert "<think>" not in result.content and "</think>" not in result.content
-#     assert "<think>" not in result.additional_kwargs["reasoning_content"]
-#     assert "</think>" not in result.additional_kwargs["reasoning_content"]

--- a/libs/partners/ollama/tests/integration_tests/test_llms.py
+++ b/libs/partners/ollama/tests/integration_tests/test_llms.py
@@ -36,7 +36,7 @@ def test__stream_no_reasoning(model: str) -> None:
     assert isinstance(result_chunk, GenerationChunk)
     assert result_chunk.text
     # No separate reasoning_content
-    assert "reasoning_content" not in result_chunk.generation_info
+    assert "reasoning_content" not in result_chunk.generation_info  # type: ignore[operator]
 
 
 @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
@@ -55,12 +55,12 @@ def test__stream_with_reasoning(model: str) -> None:
     assert isinstance(result_chunk, GenerationChunk)
     assert result_chunk.text
     # Should have extracted reasoning into generation_info
-    assert "reasoning_content" in result_chunk.generation_info
-    assert len(result_chunk.generation_info["reasoning_content"]) > 0
+    assert "reasoning_content" in result_chunk.generation_info  # type: ignore[operator]
+    assert len(result_chunk.generation_info["reasoning_content"]) > 0  # type: ignore[index]
     # And neither the visible nor the hidden portion contains <think> tags
     assert "<think>" not in result_chunk.text and "</think>" not in result_chunk.text
-    assert "<think>" not in result_chunk.generation_info["reasoning_content"]
-    assert "</think>" not in result_chunk.generation_info["reasoning_content"]
+    assert "<think>" not in result_chunk.generation_info["reasoning_content"]  # type: ignore[index]
+    assert "</think>" not in result_chunk.generation_info["reasoning_content"]  # type: ignore[index]
 
 
 async def test_astream_text_tokens() -> None:
@@ -86,7 +86,7 @@ async def test__astream_no_reasoning(model: str) -> None:
 
     assert isinstance(result_chunk, GenerationChunk)
     assert result_chunk.text
-    assert "reasoning_content" not in result_chunk.generation_info
+    assert "reasoning_content" not in result_chunk.generation_info  # type: ignore[operator]
 
 
 @pytest.mark.parametrize(("model"), [("deepseek-r1:1.5b")])
@@ -104,8 +104,8 @@ async def test__astream_with_reasoning(model: str) -> None:
 
     assert isinstance(result_chunk, GenerationChunk)
     assert result_chunk.text
-    assert "reasoning_content" in result_chunk.generation_info
-    assert len(result_chunk.generation_info["reasoning_content"]) > 0
+    assert "reasoning_content" in result_chunk.generation_info  # type: ignore[operator]
+    assert len(result_chunk.generation_info["reasoning_content"]) > 0  # type: ignore[index]
 
 
 async def test_abatch() -> None:

--- a/libs/partners/ollama/tests/unit_tests/test_llms.py
+++ b/libs/partners/ollama/tests/unit_tests/test_llms.py
@@ -48,3 +48,24 @@ def test_validate_model_on_init(mock_validate_model: Any) -> None:
     # Test that validate_model is NOT called by default
     OllamaLLM(model=MODEL_NAME)
     mock_validate_model.assert_not_called()
+
+
+def test_reasoning_aggregation() -> None:
+    """Test that reasoning chunks are aggregated into final response."""
+    llm = OllamaLLM(model=MODEL_NAME, reasoning=True)
+    prompts = ["some prompt"]
+    mock_stream = [
+        {"thinking": "I am thinking.", "done": False},
+        {"thinking": " Still thinking.", "done": False},
+        {"response": "Final Answer.", "done": True},
+    ]
+
+    with patch.object(llm, "_create_generate_stream") as mock_stream_method:
+        mock_stream_method.return_value = iter(mock_stream)
+        result = llm.generate(prompts)
+
+    assert result.generations[0][0].generation_info is not None
+    assert (
+        result.generations[0][0].generation_info["thinking"]
+        == "I am thinking. Still thinking."
+    )


### PR DESCRIPTION
* update model validation due to change in [Ollama client](https://github.com/ollama/ollama) - ensure you are running the latest version (0.9.6) to use `validate_model_on_init`
* add code example and fix formatting for ChatOllama reasoning
* ensure that setting `reasoning` in invocation kwargs overrides class-level setting
* tests