### PR TITLE
docs: add Google-style docstrings to tools and llms modules (zapier, …

### DIFF
--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -11,12 +11,10 @@ Exports:
 """
 
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.language_models.llms import BaseLLM, LLM
-
+from langchain_core.language_models.llms import LLM, BaseLLM
 
 __all__ = [
     "LLM",
     "BaseLLM",
     "BaseLanguageModel",
 ]
-

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -16,8 +16,10 @@ from langchain_core.language_models.llms import (
     BaseLLM,
 )
 
+
 __all__ = [
     "LLM",
     "BaseLLM",
     "BaseLanguageModel",
 ]
+

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -10,8 +10,8 @@ Exports:
     - BaseLanguageModel: Base class for core language model implementations
 """
 
-# Backwards compatibility.
 from langchain_core.language_models import BaseLanguageModel
+
 from langchain_core.language_models.llms import (
     LLM,
     BaseLLM,

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -11,8 +11,10 @@ Exports:
 """
 
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.language_models.llms import BaseLLM, LLM
-
+from langchain_core.language_models.llms import (
+    LLM,
+    BaseLLM,
+)
 
 __all__ = [
     "LLM",

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -11,10 +11,8 @@ Exports:
 """
 
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.language_models.llms import (
-    LLM,
-    BaseLLM,
-)
+
+from langchain_core.language_models.llms import LLM, BaseLLM
 
 
 __all__ = [

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -9,8 +9,10 @@ Exports:
     - BaseLLM: Deprecated or foundational class for legacy LLMs
     - BaseLanguageModel: Base class for core language model implementations
 """
+
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.language_models.llms import BaseLLM, LLM
+
 
 __all__ = [
     "LLM",

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -1,3 +1,15 @@
+"""
+This module provides backward-compatible exports of core language model classes.
+
+These classes are re-exported for compatibility with older versions of LangChain
+and allow users to import language model interfaces from a stable path.
+
+Exports:
+    - LLM: Abstract base class for all LLMs
+    - BaseLLM: Deprecated or foundational class for legacy LLMs
+    - BaseLanguageModel: Base class for core language model implementations
+"""
+
 # Backwards compatibility.
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.language_models.llms import (

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -11,7 +11,7 @@ Exports:
 """
 
 from langchain_core.language_models import BaseLanguageModel
-from langchain_core.language_models.llms import LLM, BaseLLM
+from langchain_core.language_models.llms import BaseLLM, LLM
 
 
 __all__ = [

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -9,13 +9,8 @@ Exports:
     - BaseLLM: Deprecated or foundational class for legacy LLMs
     - BaseLanguageModel: Base class for core language model implementations
 """
-
 from langchain_core.language_models import BaseLanguageModel
-
-from langchain_core.language_models.llms import (
-    LLM,
-    BaseLLM,
-)
+from langchain_core.language_models.llms import BaseLLM, LLM
 
 __all__ = [
     "LLM",

--- a/libs/langchain/langchain/llms/base.py
+++ b/libs/langchain/langchain/llms/base.py
@@ -11,7 +11,6 @@ Exports:
 """
 
 from langchain_core.language_models import BaseLanguageModel
-
 from langchain_core.language_models.llms import LLM, BaseLLM
 
 

--- a/libs/langchain/langchain/tools/jira/tool.py
+++ b/libs/langchain/langchain/tools/jira/tool.py
@@ -1,23 +1,38 @@
-from typing import TYPE_CHECKING, Any
+"""
+This module provides dynamic access to deprecated Jira tools.
 
+When attributes like `JiraAction` are accessed, they are redirected to their new
+locations in `langchain_community.tools`. This ensures backward compatibility
+while warning developers about deprecation.
+
+Attributes:
+    JiraAction (deprecated): Dynamically loaded from langchain_community.tools.
+"""
+
+from typing import TYPE_CHECKING, Any
 from langchain._api import create_importer
 
 if TYPE_CHECKING:
     from langchain_community.tools import JiraAction
 
-# Create a way to dynamically look up deprecated imports.
-# Used to consolidate logic for raising deprecation warnings and
-# handling optional imports.
-DEPRECATED_LOOKUP = {"JiraAction": "langchain_community.tools"}
+DEPRECATED_LOOKUP = {
+    "JiraAction": "langchain_community.tools",
+}
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
 
 
 def __getattr__(name: str) -> Any:
-    """Look up attributes dynamically."""
+    """
+    Dynamically retrieve attributes from the updated module path.
+
+    Args:
+        name (str): The name of the attribute to import.
+
+    Returns:
+        Any: The resolved attribute from the updated path.
+    """
     return _import_attribute(name)
 
 
-__all__ = [
-    "JiraAction",
-]
+__all__ = ["JiraAction"]

--- a/libs/langchain/langchain/tools/jira/tool.py
+++ b/libs/langchain/langchain/tools/jira/tool.py
@@ -8,9 +8,7 @@ while warning developers about deprecation.
 Attributes:
     JiraAction (deprecated): Dynamically loaded from langchain_community.tools.
 """
-
 from typing import TYPE_CHECKING, Any
-
 from langchain._api import create_importer
 
 if TYPE_CHECKING:
@@ -21,7 +19,6 @@ DEPRECATED_LOOKUP = {
 }
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
-
 
 def __getattr__(name: str) -> Any:
     """
@@ -34,6 +31,5 @@ def __getattr__(name: str) -> Any:
         Any: The resolved attribute from the updated path.
     """
     return _import_attribute(name)
-
 
 __all__ = ["JiraAction"]

--- a/libs/langchain/langchain/tools/jira/tool.py
+++ b/libs/langchain/langchain/tools/jira/tool.py
@@ -39,3 +39,4 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "JiraAction",
 ]
+

--- a/libs/langchain/langchain/tools/jira/tool.py
+++ b/libs/langchain/langchain/tools/jira/tool.py
@@ -8,7 +8,9 @@ while warning developers about deprecation.
 Attributes:
     JiraAction (deprecated): Dynamically loaded from langchain_community.tools.
 """
+
 from typing import TYPE_CHECKING, Any
+
 from langchain._api import create_importer
 
 if TYPE_CHECKING:
@@ -19,6 +21,7 @@ DEPRECATED_LOOKUP = {
 }
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
+
 
 def __getattr__(name: str) -> Any:
     """
@@ -31,5 +34,6 @@ def __getattr__(name: str) -> Any:
         Any: The resolved attribute from the updated path.
     """
     return _import_attribute(name)
+
 
 __all__ = ["JiraAction"]

--- a/libs/langchain/langchain/tools/jira/tool.py
+++ b/libs/langchain/langchain/tools/jira/tool.py
@@ -39,4 +39,3 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "JiraAction",
 ]
-

--- a/libs/langchain/langchain/tools/jira/tool.py
+++ b/libs/langchain/langchain/tools/jira/tool.py
@@ -10,6 +10,7 @@ Attributes:
 """
 
 from typing import TYPE_CHECKING, Any
+
 from langchain._api import create_importer
 
 if TYPE_CHECKING:

--- a/libs/langchain/langchain/tools/jira/tool.py
+++ b/libs/langchain/langchain/tools/jira/tool.py
@@ -8,6 +8,7 @@ while warning developers about deprecation.
 Attributes:
     JiraAction (deprecated): Dynamically loaded from langchain_community.tools.
 """
+
 from typing import TYPE_CHECKING, Any
 
 from langchain._api import create_importer

--- a/libs/langchain/langchain/tools/jira/tool.py
+++ b/libs/langchain/langchain/tools/jira/tool.py
@@ -8,7 +8,6 @@ while warning developers about deprecation.
 Attributes:
     JiraAction (deprecated): Dynamically loaded from langchain_community.tools.
 """
-
 from typing import TYPE_CHECKING, Any
 
 from langchain._api import create_importer
@@ -16,9 +15,10 @@ from langchain._api import create_importer
 if TYPE_CHECKING:
     from langchain_community.tools import JiraAction
 
-DEPRECATED_LOOKUP = {
-    "JiraAction": "langchain_community.tools",
-}
+# Create a way to dynamically look up deprecated imports.
+# Used to consolidate logic for raising deprecation warnings and
+# handling optional imports.
+DEPRECATED_LOOKUP = {"JiraAction": "langchain_community.tools"}
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
 
@@ -36,4 +36,6 @@ def __getattr__(name: str) -> Any:
     return _import_attribute(name)
 
 
-__all__ = ["JiraAction"]
+__all__ = [
+    "JiraAction",
+]

--- a/libs/langchain/langchain/tools/json/tool.py
+++ b/libs/langchain/langchain/tools/json/tool.py
@@ -1,25 +1,45 @@
-from typing import TYPE_CHECKING, Any
+"""
+This module provides dynamic access to deprecated JSON tools in LangChain.
 
+It ensures backward compatibility by forwarding references such as
+`JsonGetValueTool`, `JsonListKeysTool`, and `JsonSpec` to their updated
+locations within the `langchain_community.tools` namespace.
+
+This setup allows legacy code to continue working while guiding developers
+toward using the updated module paths.
+"""
+
+from typing import TYPE_CHECKING, Any
 from langchain._api import create_importer
 
 if TYPE_CHECKING:
     from langchain_community.tools import JsonGetValueTool, JsonListKeysTool
     from langchain_community.tools.json.tool import JsonSpec
 
-# Create a way to dynamically look up deprecated imports.
-# Used to consolidate logic for raising deprecation warnings and
-# handling optional imports.
+# Mapping of deprecated imports to their updated module paths.
 DEPRECATED_LOOKUP = {
     "JsonSpec": "langchain_community.tools.json.tool",
     "JsonListKeysTool": "langchain_community.tools",
     "JsonGetValueTool": "langchain_community.tools",
 }
 
+# Create a dynamic importer for resolving deprecated attributes.
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
 
 
 def __getattr__(name: str) -> Any:
-    """Look up attributes dynamically."""
+    """
+    Dynamically retrieve attributes from the updated module path.
+
+    This method is used to resolve deprecated attribute imports
+    at runtime and forward them to their new locations.
+
+    Args:
+        name (str): The name of the attribute to import.
+
+    Returns:
+        Any: The resolved attribute from the appropriate updated module.
+    """
     return _import_attribute(name)
 
 

--- a/libs/langchain/langchain/tools/json/tool.py
+++ b/libs/langchain/langchain/tools/json/tool.py
@@ -8,7 +8,9 @@ locations within the `langchain_community.tools` namespace.
 This setup allows legacy code to continue working while guiding developers
 toward using the updated module paths.
 """
+
 from typing import TYPE_CHECKING, Any
+
 from langchain._api import create_importer
 
 if TYPE_CHECKING:
@@ -22,6 +24,7 @@ DEPRECATED_LOOKUP = {
 }
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
+
 
 def __getattr__(name: str) -> Any:
     """
@@ -37,6 +40,7 @@ def __getattr__(name: str) -> Any:
         Any: The resolved attribute from the appropriate updated module.
     """
     return _import_attribute(name)
+
 
 __all__ = [
     "JsonGetValueTool",

--- a/libs/langchain/langchain/tools/json/tool.py
+++ b/libs/langchain/langchain/tools/json/tool.py
@@ -49,4 +49,3 @@ __all__ = [
     "JsonListKeysTool",
     "JsonSpec",
 ]
-

--- a/libs/langchain/langchain/tools/json/tool.py
+++ b/libs/langchain/langchain/tools/json/tool.py
@@ -49,3 +49,4 @@ __all__ = [
     "JsonListKeysTool",
     "JsonSpec",
 ]
+

--- a/libs/langchain/langchain/tools/json/tool.py
+++ b/libs/langchain/langchain/tools/json/tool.py
@@ -8,11 +8,8 @@ locations within the `langchain_community.tools` namespace.
 This setup allows legacy code to continue working while guiding developers
 toward using the updated module paths.
 """
-
 from typing import TYPE_CHECKING, Any
-
 from langchain._api import create_importer
-
 
 if TYPE_CHECKING:
     from langchain_community.tools import JsonGetValueTool, JsonListKeysTool
@@ -25,7 +22,6 @@ DEPRECATED_LOOKUP = {
 }
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
-
 
 def __getattr__(name: str) -> Any:
     """
@@ -41,7 +37,6 @@ def __getattr__(name: str) -> Any:
         Any: The resolved attribute from the appropriate updated module.
     """
     return _import_attribute(name)
-
 
 __all__ = [
     "JsonGetValueTool",

--- a/libs/langchain/langchain/tools/json/tool.py
+++ b/libs/langchain/langchain/tools/json/tool.py
@@ -8,6 +8,7 @@ locations within the `langchain_community.tools` namespace.
 This setup allows legacy code to continue working while guiding developers
 toward using the updated module paths.
 """
+
 from typing import TYPE_CHECKING, Any
 
 from langchain._api import create_importer

--- a/libs/langchain/langchain/tools/json/tool.py
+++ b/libs/langchain/langchain/tools/json/tool.py
@@ -10,20 +10,20 @@ toward using the updated module paths.
 """
 
 from typing import TYPE_CHECKING, Any
+
 from langchain._api import create_importer
+
 
 if TYPE_CHECKING:
     from langchain_community.tools import JsonGetValueTool, JsonListKeysTool
     from langchain_community.tools.json.tool import JsonSpec
 
-# Mapping of deprecated imports to their updated module paths.
 DEPRECATED_LOOKUP = {
     "JsonSpec": "langchain_community.tools.json.tool",
     "JsonListKeysTool": "langchain_community.tools",
     "JsonGetValueTool": "langchain_community.tools",
 }
 
-# Create a dynamic importer for resolving deprecated attributes.
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
 
 

--- a/libs/langchain/langchain/tools/json/tool.py
+++ b/libs/langchain/langchain/tools/json/tool.py
@@ -8,7 +8,6 @@ locations within the `langchain_community.tools` namespace.
 This setup allows legacy code to continue working while guiding developers
 toward using the updated module paths.
 """
-
 from typing import TYPE_CHECKING, Any
 
 from langchain._api import create_importer
@@ -17,6 +16,9 @@ if TYPE_CHECKING:
     from langchain_community.tools import JsonGetValueTool, JsonListKeysTool
     from langchain_community.tools.json.tool import JsonSpec
 
+# Create a way to dynamically look up deprecated imports.
+# Used to consolidate logic for raising deprecation warnings and
+# handling optional imports.
 DEPRECATED_LOOKUP = {
     "JsonSpec": "langchain_community.tools.json.tool",
     "JsonListKeysTool": "langchain_community.tools",

--- a/libs/langchain/langchain/tools/zapier/tool.py
+++ b/libs/langchain/langchain/tools/zapier/tool.py
@@ -8,11 +8,8 @@ in the `langchain_community.tools` package.
 Developers using older import paths will continue to function, while LangChain
 internally redirects access to the newer, supported module structure.
 """
-
 from typing import TYPE_CHECKING, Any
-
 from langchain._api import create_importer
-
 
 if TYPE_CHECKING:
     from langchain_community.tools import ZapierNLAListActions, ZapierNLARunAction
@@ -23,7 +20,6 @@ DEPRECATED_LOOKUP = {
 }
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
-
 
 def __getattr__(name: str) -> Any:
     """
@@ -39,7 +35,6 @@ def __getattr__(name: str) -> Any:
         Any: The resolved attribute from the appropriate updated module.
     """
     return _import_attribute(name)
-
 
 __all__ = [
     "ZapierNLAListActions",

--- a/libs/langchain/langchain/tools/zapier/tool.py
+++ b/libs/langchain/langchain/tools/zapier/tool.py
@@ -8,7 +8,6 @@ in the `langchain_community.tools` package.
 Developers using older import paths will continue to function, while LangChain
 internally redirects access to the newer, supported module structure.
 """
-
 from typing import TYPE_CHECKING, Any
 
 from langchain._api import create_importer
@@ -16,6 +15,9 @@ from langchain._api import create_importer
 if TYPE_CHECKING:
     from langchain_community.tools import ZapierNLAListActions, ZapierNLARunAction
 
+# Create a way to dynamically look up deprecated imports.
+# Used to consolidate logic for raising deprecation warnings and
+# handling optional imports.
 DEPRECATED_LOOKUP = {
     "ZapierNLARunAction": "langchain_community.tools",
     "ZapierNLAListActions": "langchain_community.tools",

--- a/libs/langchain/langchain/tools/zapier/tool.py
+++ b/libs/langchain/langchain/tools/zapier/tool.py
@@ -46,3 +46,4 @@ __all__ = [
     "ZapierNLAListActions",
     "ZapierNLARunAction",
 ]
+

--- a/libs/langchain/langchain/tools/zapier/tool.py
+++ b/libs/langchain/langchain/tools/zapier/tool.py
@@ -10,18 +10,18 @@ internally redirects access to the newer, supported module structure.
 """
 
 from typing import TYPE_CHECKING, Any
+
 from langchain._api import create_importer
+
 
 if TYPE_CHECKING:
     from langchain_community.tools import ZapierNLAListActions, ZapierNLARunAction
 
-# Mapping of deprecated imports to their updated module paths.
 DEPRECATED_LOOKUP = {
     "ZapierNLARunAction": "langchain_community.tools",
     "ZapierNLAListActions": "langchain_community.tools",
 }
 
-# Create a dynamic importer for resolving deprecated attributes.
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
 
 

--- a/libs/langchain/langchain/tools/zapier/tool.py
+++ b/libs/langchain/langchain/tools/zapier/tool.py
@@ -8,7 +8,9 @@ in the `langchain_community.tools` package.
 Developers using older import paths will continue to function, while LangChain
 internally redirects access to the newer, supported module structure.
 """
+
 from typing import TYPE_CHECKING, Any
+
 from langchain._api import create_importer
 
 if TYPE_CHECKING:
@@ -20,6 +22,7 @@ DEPRECATED_LOOKUP = {
 }
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
+
 
 def __getattr__(name: str) -> Any:
     """
@@ -35,6 +38,7 @@ def __getattr__(name: str) -> Any:
         Any: The resolved attribute from the appropriate updated module.
     """
     return _import_attribute(name)
+
 
 __all__ = [
     "ZapierNLAListActions",

--- a/libs/langchain/langchain/tools/zapier/tool.py
+++ b/libs/langchain/langchain/tools/zapier/tool.py
@@ -46,4 +46,3 @@ __all__ = [
     "ZapierNLAListActions",
     "ZapierNLARunAction",
 ]
-

--- a/libs/langchain/langchain/tools/zapier/tool.py
+++ b/libs/langchain/langchain/tools/zapier/tool.py
@@ -8,6 +8,7 @@ in the `langchain_community.tools` package.
 Developers using older import paths will continue to function, while LangChain
 internally redirects access to the newer, supported module structure.
 """
+
 from typing import TYPE_CHECKING, Any
 
 from langchain._api import create_importer

--- a/libs/langchain/langchain/tools/zapier/tool.py
+++ b/libs/langchain/langchain/tools/zapier/tool.py
@@ -1,23 +1,43 @@
-from typing import TYPE_CHECKING, Any
+"""
+This module provides dynamic access to deprecated Zapier tools in LangChain.
 
+It supports backward compatibility by forwarding references such as
+`ZapierNLAListActions` and `ZapierNLARunAction` to their updated locations
+in the `langchain_community.tools` package.
+
+Developers using older import paths will continue to function, while LangChain
+internally redirects access to the newer, supported module structure.
+"""
+
+from typing import TYPE_CHECKING, Any
 from langchain._api import create_importer
 
 if TYPE_CHECKING:
     from langchain_community.tools import ZapierNLAListActions, ZapierNLARunAction
 
-# Create a way to dynamically look up deprecated imports.
-# Used to consolidate logic for raising deprecation warnings and
-# handling optional imports.
+# Mapping of deprecated imports to their updated module paths.
 DEPRECATED_LOOKUP = {
     "ZapierNLARunAction": "langchain_community.tools",
     "ZapierNLAListActions": "langchain_community.tools",
 }
 
+# Create a dynamic importer for resolving deprecated attributes.
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
 
 
 def __getattr__(name: str) -> Any:
-    """Look up attributes dynamically."""
+    """
+    Dynamically retrieve attributes from the updated module path.
+
+    This method is used to resolve deprecated attribute imports
+    at runtime and forward them to their new locations.
+
+    Args:
+        name (str): The name of the attribute to import.
+
+    Returns:
+        Any: The resolved attribute from the appropriate updated module.
+    """
     return _import_attribute(name)
 
 


### PR DESCRIPTION
**Description:**
Added standardized Google-style docstrings to improve documentation consistency across key modules.

Updated files:
- `tools/zapier/tool.py`
- `tools/jira/tool.py`
- `tools/json/tool.py`
- `llms/base.py`

These changes enhance readability and maintain consistency with LangChain’s documentation style guide.

**Issue:**
Fixes #21983

**Dependencies:**
None

**Twitter handle :**
@Akshara_p_
