### PR TITLE
docs: add deprecation notice for PipelinePromptTemplate

### DIFF
--- a/docs/docs/how_to/prompts_composition.ipynb
+++ b/docs/docs/how_to/prompts_composition.ipynb
@@ -180,6 +180,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8ccadbae",
+   "metadata": {},
+   "source": [
+    ":::warning Deprecated\n",
+    "\n",
+    "PipelinePromptTemplate is deprecated; for more information, please refer to [PipelinePromptTemplate](https://python.langchain.com/api_reference/core/prompts/langchain_core.prompts.pipeline.PipelinePromptTemplate.html).\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0a5892f9-e4d8-4b7c-b6a5-4651539b9734",
    "metadata": {},
    "source": [
@@ -276,62 +288,6 @@
     "        input=\"What's your favorite social media site?\",\n",
     "    )\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4f4f0e8e",
-   "metadata": {},
-   "source": [
-    "### Deprecated"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8ccadbae",
-   "metadata": {},
-   "source": [
-    "PipelinePromptTemplate is deprecated; for more information, please refer to [PipelinePromptTemplate](https://python.langchain.com/api_reference/core/prompts/langchain_core.prompts.pipeline.PipelinePromptTemplate.html).\n",
-    "\n",
-    "This has been deprecated in favor of chaining individual prompts together in your code. E.g. using a for loop, you could do:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "id": "ce85582a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "You are impersonating Elon Musk.\n",
-      "\n",
-      "Here's an example of an interaction:\n",
-      "\n",
-      "Q: What's your favorite car?\n",
-      "A: Tesla\n",
-      "\n",
-      "Now, do this for real!\n",
-      "\n",
-      "Q: What's your favorite social media site?\n",
-      "A:\n"
-     ]
-    }
-   ],
-   "source": [
-    "my_input = {\n",
-    "    \"person\": \"Elon Musk\",\n",
-    "    \"example_q\": \"What's your favorite car?\",\n",
-    "    \"example_a\": \"Tesla\",\n",
-    "    \"input\": \"What's your favorite social media site?\",\n",
-    "}\n",
-    "\n",
-    "for name, prompt in input_prompts:\n",
-    "    my_input[name] = prompt.invoke(my_input).to_string()\n",
-    "\n",
-    "print(full_prompt.invoke(my_input).to_string())"
    ]
   },
   {

--- a/docs/docs/how_to/prompts_composition.ipynb
+++ b/docs/docs/how_to/prompts_composition.ipynb
@@ -280,6 +280,62 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4f4f0e8e",
+   "metadata": {},
+   "source": [
+    "### Deprecated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ccadbae",
+   "metadata": {},
+   "source": [
+    "PipelinePromptTemplate is deprecated; for more information, please refer to [PipelinePromptTemplate](https://python.langchain.com/api_reference/core/prompts/langchain_core.prompts.pipeline.PipelinePromptTemplate.html).\n",
+    "\n",
+    "This has been deprecated in favor of chaining individual prompts together in your code. E.g. using a for loop, you could do:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "ce85582a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You are impersonating Elon Musk.\n",
+      "\n",
+      "Here's an example of an interaction:\n",
+      "\n",
+      "Q: What's your favorite car?\n",
+      "A: Tesla\n",
+      "\n",
+      "Now, do this for real!\n",
+      "\n",
+      "Q: What's your favorite social media site?\n",
+      "A:\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_input = {\n",
+    "    \"person\": \"Elon Musk\",\n",
+    "    \"example_q\": \"What's your favorite car?\",\n",
+    "    \"example_a\": \"Tesla\",\n",
+    "    \"input\": \"What's your favorite social media site?\",\n",
+    "}\n",
+    "\n",
+    "for name, prompt in input_prompts:\n",
+    "    my_input[name] = prompt.invoke(my_input).to_string()\n",
+    "\n",
+    "print(full_prompt.invoke(my_input).to_string())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "96922030",
    "metadata": {},
    "source": [

--- a/libs/core/langchain_core/prompts/pipeline.py
+++ b/libs/core/langchain_core/prompts/pipeline.py
@@ -18,16 +18,14 @@ def _get_inputs(inputs: dict, input_variables: list[str]) -> dict:
     since="0.3.22",
     removal="1.0",
     message=(
-        "This class is deprecated. Please see the docstring below or at the link"
-        " for a replacement option: "
-        "https://python.langchain.com/api_reference/core/prompts/langchain_core.prompts.pipeline.PipelinePromptTemplate.html"
+        "This class is deprecated in favor of chaining individual prompts together."
     ),
 )
 class PipelinePromptTemplate(BasePromptTemplate):
-    """[DEPRECATED] Pipeline prompt template.
+    """Pipeline prompt template.
 
     This has been deprecated in favor of chaining individual prompts together in your
-    code. E.g. using a for loop, you could do:
+    code; e.g. using a for loop, you could do:
 
     .. code-block:: python
 


### PR DESCRIPTION
**PR title**: 
add deprecation notice for PipelinePromptTemplate

**PR message**: 
In the API documentation, PipelinePromptTemplate is marked as deprecated, but this is not mentioned in the docs.

I'm submitting this PR to add a deprecation notice to the docs.

**Tests**:
N/A (documentation only)