### PR TITLE
fix(core): correct return type hints in BaseChatPromptTemplate

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -35,7 +35,7 @@ from langchain_core.messages import (
     convert_to_messages,
 )
 from langchain_core.messages.base import get_msg_title_repr
-from langchain_core.prompt_values import ChatPromptValue, ImageURL, PromptValue
+from langchain_core.prompt_values import ChatPromptValue, ImageURL
 from langchain_core.prompts.base import BasePromptTemplate
 from langchain_core.prompts.dict import DictPromptTemplate
 from langchain_core.prompts.image import ImagePromptTemplate
@@ -734,7 +734,7 @@ class BaseChatPromptTemplate(BasePromptTemplate, ABC):
             **kwargs: Keyword arguments to use for formatting.
 
         Returns:
-            ChatPromptValue.
+            PromptValue.
         """
         messages = await self.aformat_messages(**kwargs)
         return ChatPromptValue(messages=messages)

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -715,26 +715,26 @@ class BaseChatPromptTemplate(BasePromptTemplate, ABC):
         """
         return (await self.aformat_prompt(**kwargs)).to_string()
 
-    def format_prompt(self, **kwargs: Any) -> PromptValue:
-        """Format prompt. Should return a PromptValue.
+    def format_prompt(self, **kwargs: Any) -> ChatPromptValue:
+        """Format prompt. Should return a ChatPromptValue.
 
         Args:
             **kwargs: Keyword arguments to use for formatting.
 
         Returns:
-            PromptValue.
+            ChatPromptValue.
         """
         messages = self.format_messages(**kwargs)
         return ChatPromptValue(messages=messages)
 
-    async def aformat_prompt(self, **kwargs: Any) -> PromptValue:
-        """Async format prompt. Should return a PromptValue.
+    async def aformat_prompt(self, **kwargs: Any) -> ChatPromptValue:
+        """Async format prompt. Should return a ChatPromptValue.
 
         Args:
             **kwargs: Keyword arguments to use for formatting.
 
         Returns:
-            PromptValue.
+            ChatPromptValue.
         """
         messages = await self.aformat_messages(**kwargs)
         return ChatPromptValue(messages=messages)


### PR DESCRIPTION
This PR changes the return type hints of the `format_prompt` and `aformat_prompt` methods in `BaseChatPromptTemplate` from  `PromptValue` to `ChatPromptValue`. Since both methods always return a `ChatPromptValue`.
