### PR TITLE
Fix issue #32028: `BaseCallbackManager.merge()` mixes `handlers` and `inheritable_handlers` in a confusing  way

### DIFF
--- a/path/to/BaseCallbackManager.py
+++ b/path/to/BaseCallbackManager.py
@@ -1,0 +1,13 @@
+# File changes (if any)
+class BaseCallbackManager:
+def __init__(self, handlers=None, inheritable_handlers=None):
+self.handlers = handlers if handlers is not None else []
+self.inheritable_handlers = inheritable_handlers if inheritable_handlers is not None else []
+
+def merge(self, other):
+# Create new lists for merged handlers and inheritable_handlers
+merged_handlers = list(set(self.handlers + other.handlers))
+merged_inheritable_handlers = list(set(self.inheritable_handlers + other.inheritable_handlers))
+
+# Return a new instance of BaseCallbackManager with the merged lists
+return BaseCallbackManager(handlers=merged_handlers, inheritable_handlers=merged_inheritable_handlers)

--- a/path/to/test_base_callback_manager.py
+++ b/path/to/test_base_callback_manager.py
@@ -1,0 +1,25 @@
+# New test file or add to existing test file
+import unittest
+from path.to.BaseCallbackManager import BaseCallbackManager
+
+class TestBaseCallbackManager(unittest.TestCase):
+def test_merge_handlers(self):
+manager1 = BaseCallbackManager(handlers=['handler1'], inheritable_handlers=['inheritable1'])
+manager2 = BaseCallbackManager(handlers=['handler2'], inheritable_handlers=['inheritable2'])
+
+merged_manager = manager1.merge(manager2)
+
+self.assertEqual(merged_manager.handlers, ['handler1', 'handler2'])
+self.assertEqual(merged_manager.inheritable_handlers, ['inheritable1', 'inheritable2'])
+
+def test_merge_duplicate_handlers(self):
+manager1 = BaseCallbackManager(handlers=['handler1'], inheritable_handlers=['inheritable1'])
+manager2 = BaseCallbackManager(handlers=['handler1'], inheritable_handlers=['inheritable1'])
+
+merged_manager = manager1.merge(manager2)
+
+self.assertEqual(merged_manager.handlers, ['handler1'])
+self.assertEqual(merged_manager.inheritable_handlers, ['inheritable1'])
+
+if __name__ == '__main__':
+unittest.main()


### PR DESCRIPTION
This PR addresses issue #32028

Automatic fix generated by GDev.