### PR TITLE
feat(core): add an option to make deserialization more permissive

### DIFF
--- a/libs/core/langchain_core/load/load.py
+++ b/libs/core/langchain_core/load/load.py
@@ -56,6 +56,7 @@ class Reviver:
         additional_import_mappings: Optional[
             dict[tuple[str, ...], tuple[str, ...]]
         ] = None,
+        *,
         ignore_unserializable_fields: bool = False,
     ) -> None:
         """Initialize the reviver.
@@ -196,6 +197,7 @@ def loads(
             Defaults to None.
         ignore_unserializable_fields: Whether to ignore unserializable fields.
             Defaults to False.
+
     Returns:
         Revived LangChain objects.
     """
@@ -206,7 +208,7 @@ def loads(
             valid_namespaces,
             secrets_from_env,
             additional_import_mappings,
-            ignore_unserializable_fields,
+            ignore_unserializable_fields=ignore_unserializable_fields,
         ),
     )
 
@@ -240,6 +242,7 @@ def load(
             Defaults to None.
         ignore_unserializable_fields: Whether to ignore unserializable fields.
             Defaults to False.
+
     Returns:
         Revived LangChain objects.
     """
@@ -248,7 +251,7 @@ def load(
         valid_namespaces,
         secrets_from_env,
         additional_import_mappings,
-        ignore_unserializable_fields,
+        ignore_unserializable_fields=ignore_unserializable_fields,
     )
 
     def _load(obj: Any) -> Any:

--- a/libs/core/langchain_core/load/load.py
+++ b/libs/core/langchain_core/load/load.py
@@ -113,12 +113,12 @@ class Reviver:
             and value.get("type") == "not_implemented"
             and value.get("id") is not None
         ):
+            if self.ignore_unserializable_fields:
+                return None
             msg = (
                 "Trying to load an object that doesn't implement "
                 f"serialization: {value}"
             )
-            if self.ignore_unserializable_fields:
-                return None
             raise NotImplementedError(msg)
 
         if (


### PR DESCRIPTION
## Description

Currently when deserializing objects that contain non-deserializable values, we throw an error. However, there are cases (e.g. proxies that return response fields containing extra fields like Python datetimes), where these values are not important and we just want to drop them.

Twitter handle: @hacubu