### PR TITLE
docs: add missing js providers to table

### DIFF
--- a/docs/scripts/partner_pkg_table.py
+++ b/docs/scripts/partner_pkg_table.py
@@ -127,8 +127,6 @@ If you'd like to contribute an integration, see [Contributing integrations](/doc
 
 :::
 
-LangChain integrates with many providers.
-
 ## Integration Packages
 
 These providers have standalone `langchain-{{provider}}` packages for improved versioning, dependency management and testing.

--- a/libs/packages.yml
+++ b/libs/packages.yml
@@ -253,6 +253,7 @@ packages:
 - name: langchain-cerebras
   path: libs/cerebras
   repo: langchain-ai/langchain-cerebras
+  js: '@langchain/cerebras'
   downloads: 30056
   downloads_updated_at: '2025-06-25T19:50:54.884652+00:00'
 - name: langchain-snowflake
@@ -434,6 +435,7 @@ packages:
 - name: langchain-xai
   path: libs/partners/xai
   repo: langchain-ai/langchain
+  js: '@langchain/xai'
   downloads: 47996
   downloads_updated_at: '2025-06-25T19:51:13.393705+00:00'
 - name: langchain-salesforce
@@ -621,6 +623,7 @@ packages:
 - name: langchain-cloudflare
   path: libs/langchain-cloudflare
   repo: cloudflare/langchain-cloudflare
+  js: '@langchain/cloudflare'
   downloads: 381
   downloads_updated_at: '2025-06-25T19:52:06.942587+00:00'
 - name: langchain-ydb


### PR DESCRIPTION
Update to show that Cerebras, xAI, and Cloudflare now have JS/TS equivalents