### PR TITLE
docs(docs): fix product name in Google SQL for MySQL description

### DIFF
--- a/docs/docs/integrations/memory/google_sql_mysql.ipynb
+++ b/docs/docs/integrations/memory/google_sql_mysql.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "# Google SQL for MySQL\n",
     "\n",
-    "> [Cloud Cloud SQL](https://cloud.google.com/sql) is a fully managed relational database service that offers high performance, seamless integration, and impressive scalability. It offers `MySQL`, `PostgreSQL`, and `SQL Server` database engines. Extend your database application to build AI-powered experiences leveraging Cloud SQL's Langchain integrations.\n",
+    "> [Google Cloud SQL](https://cloud.google.com/sql) is a fully managed relational database service that offers high performance, seamless integration, and impressive scalability. It offers `MySQL`, `PostgreSQL`, and `SQL Server` database engines. Extend your database application to build AI-powered experiences leveraging Cloud SQL's Langchain integrations.\n",
     "\n",
     "This notebook goes over how to use `Google Cloud SQL for MySQL` to store chat message history with the `MySQLChatMessageHistory` class.\n",
     "\n",


### PR DESCRIPTION
  - **Description:** Corrected the service name from "Cloud Cloud SQL" to "Google Cloud SQL" to accurately reflect the official product branding.
  - **Issue:** N/A
  - **Dependencies:** None
  - **Twitter handle:** N/A
