### PR TITLE
refactor(langchain): remove useless model_rebuild

### DIFF
--- a/libs/langchain/langchain/chains/natbot/base.py
+++ b/libs/langchain/langchain/chains/natbot/base.py
@@ -6,9 +6,7 @@ import warnings
 from typing import Any, Optional
 
 from langchain_core._api import deprecated
-from langchain_core.caches import BaseCache as BaseCache
 from langchain_core.callbacks import CallbackManagerForChainRun
-from langchain_core.callbacks import Callbacks as Callbacks
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.runnables import Runnable
@@ -163,6 +161,3 @@ class NatBotChain(Chain):
     @property
     def _chain_type(self) -> str:
         return "nat_bot_chain"
-
-
-NatBotChain.model_rebuild()

--- a/libs/langchain/langchain/memory/summary.py
+++ b/libs/langchain/langchain/memory/summary.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 from langchain_core._api import deprecated
-from langchain_core.caches import BaseCache as BaseCache  # For model_rebuild
-from langchain_core.callbacks import Callbacks as Callbacks  # For model_rebuild
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.language_models import BaseLanguageModel
 from langchain_core.messages import BaseMessage, SystemMessage, get_buffer_string
@@ -140,6 +138,3 @@ class ConversationSummaryMemory(BaseChatMemory, SummarizerMixin):
         """Clear memory contents."""
         super().clear()
         self.buffer = ""
-
-
-ConversationSummaryMemory.model_rebuild()


### PR DESCRIPTION
Since #29963 BaseCache and Callbacks are imported in BaseLanguageModel so there's no need to import them and rebuild the models.
Note: fix is available since `langchain-core==0.3.39` and the current langchain dependency on core is `>=0.3.66` so the fix will always be there.
