### PR TITLE
docs(docs): fix broken link in Google Gemini text embedding integration

### DIFF
--- a/docs/src/theme/FeatureTables.js
+++ b/docs/src/theme/FeatureTables.js
@@ -368,7 +368,7 @@ const FEATURE_TABLES = {
             },
             {
                 name: "Google Gemini",
-                link: "/docs/integrations/text_embedding/google-generative-ai",
+                link: "/docs/integrations/text_embedding/google_generative_ai",
                 package: "langchain-google-genai",
                 apiLink: "https://python.langchain.com/api_reference/google_genai/embeddings/langchain_google_genai.embeddings.GoogleGenerativeAIEmbeddings.html"
             },


### PR DESCRIPTION
  - **Description:** Corrected the `link` path in the Google Gemini integration entry from `/docs/integrations/text_embedding/google-generative-ai` to `/docs/integrations/text_embedding/google_generative_ai` to align with actual directory structure and prevent broken documentation links.
  - **Issue:** N/A
  - **Dependencies:** None
  - **Twitter handle:** N/A
