### PR TITLE
fix(docs): correct package name from `langchain-google_vertexai` to `langchain-google-vertexai` for VertexAILLM

### DIFF
--- a/docs/src/theme/FeatureTables.js
+++ b/docs/src/theme/FeatureTables.js
@@ -322,7 +322,7 @@ const FEATURE_TABLES = {
             {
                 name: "VertexAILLM",
                 link: "google_vertexai",
-                package: "langchain-google_vertexai",
+                package: "langchain-google-vertexai",
                 apiLink: "https://python.langchain.com/api_reference/google_vertexai/llms/langchain_google_vertexai.llms.VertexAI.html"
             },
             {


### PR DESCRIPTION
  - **Description:** This PR updates the `package` field for the VertexAI integration in the documentation metadata. The original value was `langchain-google_vertexai`, which has been corrected to `langchain-google-vertexai` to reflect the actual package name used in PyPI and LangChain integrations. 
  - **Issue:** N/A
  - **Dependencies:** None
  - **Twitter handle:** N/A