### PR TITLE
fix(docs): fix broken link in VertexAILLM and NVIDIA LLM integrations

### DIFF
--- a/docs/src/theme/FeatureTables.js
+++ b/docs/src/theme/FeatureTables.js
@@ -321,13 +321,13 @@ const FEATURE_TABLES = {
             },
             {
                 name: "VertexAILLM",
-                link: "google_vertexai",
+                link: "google_vertex_ai_palm",
                 package: "langchain-google_vertexai",
                 apiLink: "https://python.langchain.com/api_reference/google_vertexai/llms/langchain_google_vertexai.llms.VertexAI.html"
             },
             {
                 name: "NVIDIA",
-                link: "NVIDIA",
+                link: "nvidia_ai_endpoints",
                 package: "langchain-nvidia",
                 apiLink: "https://python.langchain.com/api_reference/nvidia_ai_endpoints/llm/langchain_nvidia_ai_endpoints.llm.NVIDIA.html"
             },


### PR DESCRIPTION
## **Description:**   
This PR updates the `link` values for the following integration metadata entries:

1. **VertexAILLM**  
   - Changed from: `google_vertexai`  
   - To: `google_vertex_ai_palm`  
2. **NVIDIA**  
   - Changed from: `NVIDIA`  
   - To: `nvidia_ai_endpoints`  

These changes ensure that the documentation links correspond to the correct integration paths, improving documentation navigation and consistency with the integration structure.

## **Issue:** N/A
## **Dependencies:** None
## **Twitter handle:** N/A