### PR TITLE
fix(core): fix docstrings and add sleep to FakeListChatModel._call

### DIFF
--- a/libs/core/langchain_core/language_models/fake_chat_models.py
+++ b/libs/core/langchain_core/language_models/fake_chat_models.py
@@ -63,9 +63,9 @@ class FakeListChatModel(SimpleChatModel):
     """List of responses to **cycle** through in order."""
     sleep: Optional[float] = None
     i: int = 0
-    """List of responses to **cycle** through in order."""
-    error_on_chunk_number: Optional[int] = None
     """Internally incremented after every model invocation."""
+    error_on_chunk_number: Optional[int] = None
+    """If set, raise an error on the specified chunk number during streaming."""
 
     @property
     @override
@@ -81,6 +81,8 @@ class FakeListChatModel(SimpleChatModel):
         **kwargs: Any,
     ) -> str:
         """First try to lookup in queries, else return 'foo' or 'bar'."""
+        if self.sleep is not None:
+            time.sleep(self.sleep)
         response = self.responses[self.i]
         if self.i < len(self.responses) - 1:
             self.i += 1


### PR DESCRIPTION
- **Description**:
Fix incorrect docstrings and implement missing sleep functionality in FakeListChatModel. The docstrings for responses and I attributes were swapped, causing confusion. Additionally, the sleep parameter was defined but not actually used in the _call method, which has been fixed to properly delay responses when configured.

- **Issue**: N/A

- **Dependencies**: None
