### PR TITLE
docs(core): move incorrect arg limitation in rate limiter's docstring

### DIFF
--- a/libs/core/langchain_core/rate_limiters.py
+++ b/libs/core/langchain_core/rate_limiters.py
@@ -146,13 +146,12 @@ class InMemoryRateLimiter(BaseRateLimiter):
 
         Args:
             requests_per_second: The number of tokens to add per second to the bucket.
-                Must be at least 1. The tokens represent "credit" that can be used
-                to make requests.
+                The tokens represent "credit" that can be used to make requests.
             check_every_n_seconds: check whether the tokens are available
                 every this many seconds. Can be a float to represent
                 fractions of a second.
             max_bucket_size: The maximum number of tokens that can be in the bucket.
-                This is used to prevent bursts of requests.
+                Must be at least 1. Used to prevent bursts of requests.
         """
         # Number of requests that we can make per second.
         self.requests_per_second = requests_per_second


### PR DESCRIPTION
"Must be at least 1" limitation is incorrect for requests_per_second argument and contradicts a use case example for InMemoryRateLimiter class mentioned in its docstring. I verified manually that values of requests_per_second below 1 (such as 0.1, 0.5) don't produce any errors or unexpected behavior. 

However, this limitation is true for max_bucket_size because self.available_tokens need to reach 1 in order for the request to be sent. The limitation is moved there.