### PR TITLE
docs(langchain): Added missing double brackets around parameter

### DIFF
--- a/docs/docs/tutorials/chatbot.ipynb
+++ b/docs/docs/tutorials/chatbot.ipynb
@@ -568,7 +568,7 @@
     "    [\n",
     "        (\n",
     "            \"system\",\n",
-    "            \"You are a helpful assistant. Answer all questions to the best of your ability in {language}.\",\n",
+    "            \"You are a helpful assistant. Answer all questions to the best of your ability in {{language}}.\",\n",
     "        ),\n",
     "        MessagesPlaceholder(variable_name=\"messages\"),\n",
     "    ]\n",


### PR DESCRIPTION
Description: 
Double brackets missing around "language" parameter in Prompt Template

Note:
Full error when run as copy & pasted - 
`KeyError: "Input to ChatPromptTemplate is missing variables {'language'}.  Expected: ['language', 'messages'] Received: ['messages']\nNote: if you intended {language} to be part of the string and not a variable, please escape it with double curly braces like: '{{language}}'.\nFor troubleshooting, visit: https://python.langchain.com/docs/troubleshooting/errors/INVALID_PROMPT_INPUT "`
