### PR TITLE
docs(docs): update RAG tutorials link to point to correct path in OpenAIEmbeddings

### DIFF
--- a/docs/docs/integrations/text_embedding/openai.ipynb
+++ b/docs/docs/integrations/text_embedding/openai.ipynb
@@ -123,7 +123,7 @@
       "source": [
         "## Indexing and Retrieval\n",
         "\n",
-        "Embedding models are often used in retrieval-augmented generation (RAG) flows, both as part of indexing data as well as later retrieving it. For more detailed instructions, please see our [RAG tutorials](/docs/tutorials/).\n",
+        "Embedding models are often used in retrieval-augmented generation (RAG) flows, both as part of indexing data as well as later retrieving it. For more detailed instructions, please see our [RAG tutorials](/docs/tutorials/rag).\n",
         "\n",
         "Below, see how to index and retrieve data using the `embeddings` object we initialized above. In this example, we will index and retrieve a sample document in the `InMemoryVectorStore`."
       ]


### PR DESCRIPTION
  - **Description:** This PR updates the internal documentation link for the RAG tutorials to reflect the updated path. Previously, the link pointed to the root `/docs/tutorials/`, which was generic. It now correctly routes to the RAG-specific tutorial page.  
  - **Issue:** N/A
  - **Dependencies:** None
  - **Twitter handle:** N/A