### PR TITLE
docs(core): fix grammar from 'as an bonus' to 'as a bonus

### DIFF
--- a/docs/docs/how_to/custom_chat_model.ipynb
+++ b/docs/docs/how_to/custom_chat_model.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "Wrapping your LLM with the standard [`BaseChatModel`](https://python.langchain.com/api_reference/core/language_models/langchain_core.language_models.chat_models.BaseChatModel.html) interface allow you to use your LLM in existing LangChain programs with minimal code modifications!\n",
     "\n",
-    "As an bonus, your LLM will automatically become a LangChain [Runnable](/docs/concepts/runnables/) and will benefit from some optimizations out of the box (e.g., batch via a threadpool), async support, the `astream_events` API, etc.\n",
+    "As a bonus, your LLM will automatically become a LangChain [Runnable](/docs/concepts/runnables/) and will benefit from some optimizations out of the box (e.g., batch via a threadpool), async support, the `astream_events` API, etc.\n",
     "\n",
     "## Inputs and outputs\n",
     "\n",


### PR DESCRIPTION
This PR corrects a minor grammar error in the documentation where “as an bonus” was used instead of “as a bonus.”

Issue: N/A

Dependencies: None

Twitter handle: @ziafatmajeed5 (please tag if this PR is announced 🙌)