### PR TITLE
chore(infra): drop anthropic from core test matrix

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        partner: [openai, anthropic]
+        partner: [openai]
       fail-fast: false  # Continue testing other partners if one fails
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Stricter JSON schema validation broke a test. Test was fixed in https://github.com/langchain-ai/langchain/pull/32145. Core release runs old tests (i.e., last released version of langchain-anthropic) against new core. So we bypass anthropic for release. Will revert after.