### PR TITLE
fix(deepseek): release openai version

### DIFF
--- a/libs/partners/deepseek/pyproject.toml
+++ b/libs/partners/deepseek/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 requires-python = ">=3.9"
 dependencies = [
     "langchain-core<1.0.0,>=0.3.70",
-    "langchain-openai<1.0.0,>=1.97.1",
+    "langchain-openai<1.0.0,>=0.3.28",
 ]
 name = "langchain-deepseek"
 version = "0.1.4"


### PR DESCRIPTION
used sdk version instead of langchain by accident