### PR TITLE
fix(core): exclude api_key from tracing metadata

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -230,6 +230,7 @@ def ensure_config(config: Optional[RunnableConfig] = None) -> RunnableConfig:
             not key.startswith("__")
             and isinstance(value, (str, int, float, bool))
             and key not in empty["metadata"]
+            and key != "api_key"
         ):
             empty["metadata"][key] = value
     return empty


### PR DESCRIPTION
This is a standard param.