### PR TITLE
chore(infra): drop anthropic from core test matrix

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -340,7 +340,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        partner: [openai, anthropic]
+        partner: [openai]
       fail-fast: false  # Continue testing other partners if one fails
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Some tests use models that were just retired, specifically `claude-3-sonnet-20240229` and `claude-2.1`.

Core release tests langchain-anthropic as of its last release. Will update Anthropic tests in a separate PR.