### PR TITLE
fix: dereference_refs Object might have keys other than $ref which was not catered

### DIFF
--- a/libs/core/langchain_core/utils/json_schema.py
+++ b/libs/core/langchain_core/utils/json_schema.py
@@ -55,7 +55,7 @@ def _dereference_refs_helper(
         processed_refs = set()
 
     # 1) Pure $ref node?
-    if isinstance(obj, dict) and set(obj.keys()) == {"$ref"}:
+    if isinstance(obj, dict) and "$ref" in obj.keys():
         ref_path = obj["$ref"]
         # cycle?
         if ref_path in processed_refs:


### PR DESCRIPTION
**[fix] dereference_refs Object might have keys other than $ref which was not catered**: 
- The `dereference_refs` function has a strict quality check against `{"$ref"}` assuming that it will always contain only this key.

  - **Issue:** Solves #32170 
