### PR TITLE
fix(anthropic): update integration test models

### DIFF
--- a/libs/partners/anthropic/tests/integration_tests/test_experimental.py
+++ b/libs/partners/anthropic/tests/integration_tests/test_experimental.py
@@ -9,8 +9,8 @@ from pydantic import BaseModel, Field
 
 from langchain_anthropic.experimental import ChatAnthropicTools
 
-MODEL_NAME = "claude-3-sonnet-20240229"
-BIG_MODEL_NAME = "claude-3-opus-20240229"
+MODEL_NAME = "claude-3-5-haiku-latest"
+BIG_MODEL_NAME = "claude-opus-4-20250514"
 
 #####################################
 ### Test Basic features, no tools ###


### PR DESCRIPTION
Multiple models were [retired](https://docs.anthropic.com/en/docs/about-claude/model-deprecations#model-status) yesterday.

Tests remain broken until we figure out what to do with the legacy Anthropic LLM integration— currently uses their (legacy) text completions API, for which there appear to be no remaining supported models.