### PR TITLE
fix(perplexity): temp xfail int tests

### DIFF
--- a/libs/partners/perplexity/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/partners/perplexity/tests/integration_tests/test_chat_models_standard.py
@@ -23,3 +23,23 @@ class TestPerplexityStandard(ChatModelIntegrationTests):
     @pytest.mark.xfail(reason="Raises 400: Custom stop words not supported.")
     def test_stop_sequence(self, model: BaseChatModel) -> None:
         super().test_stop_sequence(model)
+
+    @pytest.mark.xfail(reason="TODO, this regressed for some reason after 2025-04-15")
+    @pytest.mark.parametrize("schema_type", ["pydantic", "typeddict", "json_schema"])
+    def test_structured_output(self, model: BaseChatModel, schema_type: str) -> None:
+        super().test_structured_output(model, schema_type)
+
+    @pytest.mark.xfail(reason="TODO, this regressed for some reason after 2025-04-15")
+    @pytest.mark.parametrize("schema_type", ["pydantic", "typeddict", "json_schema"])
+    async def test_structured_output_async(
+        self, model: BaseChatModel, schema_type: str
+    ) -> None:
+        await super().test_structured_output_async(model, schema_type)
+
+    @pytest.mark.xfail(reason="TODO, this regressed for some reason after 2025-04-15")
+    def test_structured_output_pydantic_2_v1(self, model: BaseChatModel) -> None:
+        super().test_structured_output_pydantic_2_v1(model)
+
+    @pytest.mark.xfail(reason="TODO, this regressed for some reason after 2025-04-15")
+    def test_structured_output_optional_param(self, model: BaseChatModel) -> None:
+        super().test_structured_output_optional_param(model)


### PR DESCRIPTION
It appears the API has changes since the 2025-04-15 release, leading to failed integration tests.