### PR TITLE
fix(core): Dereference Refs for pydantic schema fails in tool schema generation

### DIFF
--- a/libs/core/langchain_core/utils/json_schema.py
+++ b/libs/core/langchain_core/utils/json_schema.py
@@ -55,7 +55,7 @@ def _dereference_refs_helper(
         processed_refs = set()
 
     # 1) Pure $ref node?
-    if isinstance(obj, dict) and set(obj.keys()) == {"$ref"}:
+    if isinstance(obj, dict) and "$ref" in set(obj.keys()):
         ref_path = obj["$ref"]
         # cycle?
         if ref_path in processed_refs:


### PR DESCRIPTION
The `_dereference_refs_helper` in `langchain_core.utils.json_schema` incorrectly handled objects with a reference and other fields.

**Issue**: #32170

# Description

We change the check so that it accepts other keys in the object.