### PR TITLE
fix(langchain): class HTMLSemanticPreservingSplitter ignores the text inside the div tag

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -842,6 +842,12 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
                         preserved_elements,
                         placeholder_count,
                     )
+                    
+                    content = " ".join(elem.find_all(string=True, recursive=False))
+                    if content:
+                        content = self._normalize_and_clean_text(content)
+                        current_content.append(content)
+                        
                     continue
 
                 if elem.name in [h[0] for h in self._headers_to_split_on]:

--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -842,12 +842,10 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
                         preserved_elements,
                         placeholder_count,
                     )
-                    
                     content = " ".join(elem.find_all(string=True, recursive=False))
                     if content:
                         content = self._normalize_and_clean_text(content)
                         current_content.append(content)
-                        
                     continue
 
                 if elem.name in [h[0] for h in self._headers_to_split_on]:


### PR DESCRIPTION
**Description:** We collect the text from the "html", "body", "div", and "main" nodes, if they have any.

**Issue:** Fixes #32206.
