### PR TITLE
feat(core): support for adding `PromptTemplate`s with formats other than `f-string`

### DIFF
--- a/libs/core/langchain_core/prompts/prompt.py
+++ b/libs/core/langchain_core/prompts/prompt.py
@@ -153,8 +153,8 @@ class PromptTemplate(StringPromptTemplate):
         # Allow for easy combining
         if isinstance(other, PromptTemplate):
             if self.template_format != other.template_format:
-                msg = "Cannot add two templates of different formats"
-                raise ValueError(msg) 
+                msg = "Cannot add templates of different formats"
+                raise ValueError(msg)
             input_variables = list(
                 set(self.input_variables) | set(other.input_variables)
             )
@@ -175,7 +175,10 @@ class PromptTemplate(StringPromptTemplate):
                 validate_template=validate_template,
             )
         if isinstance(other, str):
-            prompt = PromptTemplate.from_template(other, template_format=self.template_format)
+            prompt = PromptTemplate.from_template(
+                other,
+                template_format=self.template_format,
+            )
             return self + prompt
         msg = f"Unsupported operand type for +: {type(other)}"
         raise NotImplementedError(msg)

--- a/libs/core/langchain_core/prompts/prompt.py
+++ b/libs/core/langchain_core/prompts/prompt.py
@@ -152,12 +152,9 @@ class PromptTemplate(StringPromptTemplate):
         """
         # Allow for easy combining
         if isinstance(other, PromptTemplate):
-            if self.template_format != "f-string":
-                msg = "Adding prompt templates only supported for f-strings."
-                raise ValueError(msg)
-            if other.template_format != "f-string":
-                msg = "Adding prompt templates only supported for f-strings."
-                raise ValueError(msg)
+            if self.template_format != other.template_format:
+                msg = "Cannot add two templates of different formats"
+                raise ValueError(msg) 
             input_variables = list(
                 set(self.input_variables) | set(other.input_variables)
             )
@@ -174,11 +171,11 @@ class PromptTemplate(StringPromptTemplate):
                 template=template,
                 input_variables=input_variables,
                 partial_variables=partial_variables,
-                template_format="f-string",
+                template_format=self.template_format,
                 validate_template=validate_template,
             )
         if isinstance(other, str):
-            prompt = PromptTemplate.from_template(other)
+            prompt = PromptTemplate.from_template(other, template_format=self.template_format)
             return self + prompt
         msg = f"Unsupported operand type for +: {type(other)}"
         raise NotImplementedError(msg)

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -682,7 +682,10 @@ def test_prompt_with_template_variable_name_jinja2() -> None:
 
 def test_prompt_template_add_with_with_another_format() -> None:
     with pytest.raises(ValueError, match=r"Cannot add templates"):
-        PromptTemplate.from_template("This is a {template}") + PromptTemplate.from_template("So {{this}} is", template_format="mustache")
+        (
+            PromptTemplate.from_template("This is a {template}") +
+            PromptTemplate.from_template("So {{this}} is", template_format="mustache")
+        )
 
 
 @pytest.mark.parametrize(

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -680,28 +680,48 @@ def test_prompt_with_template_variable_name_jinja2() -> None:
     assert prompt.invoke({"template": "bar"}).to_string() == "This is a bar test."
 
 
-def test_prompt_template_add_with_with_another_format():
-    with pytest.raises(match=r"Cannot add templates"):
+def test_prompt_template_add_with_with_another_format() -> None:
+    with pytest.raises(ValueError, match=r"Cannot add templates"):
         PromptTemplate.from_template("This is a {template}") + PromptTemplate.from_template("So {{this}} is", template_format="mustache")
 
 
 @pytest.mark.parametrize(
-        "template_format, prompt1, prompt2",
-        [
-            ("f-string", "This is a {variable}", ". This is {another_variable}"),
-            pytest.param("jinja2", "This is a {{variable}}", ". This is {{another_variable}}", marks=[pytest.mark.requires("jinja2")]),
-            ("mustache", "This is a {{variable}}", ". This is {{another_variable}}"),
-        ]
+    ("template_format", "prompt1", "prompt2"),
+    [
+        ("f-string", "This is a {variable}", ". This is {another_variable}"),
+        pytest.param(
+            "jinja2",
+            "This is a {{variable}}",
+            ". This is {{another_variable}}",
+            marks=[pytest.mark.requires("jinja2")]
+        ),
+        ("mustache", "This is a {{variable}}", ". This is {{another_variable}}"),
+    ]
 )
 def test_prompt_template_add(template_format: str, prompt1: str, prompt2: str) -> None:
-    first_prompt = PromptTemplate.from_template(prompt1, template_format=template_format)
-    second_prompt = PromptTemplate.from_template(prompt2, template_format=template_format)
+    first_prompt = PromptTemplate.from_template(
+        prompt1,
+        template_format=template_format,
+    )
+    second_prompt = PromptTemplate.from_template(
+        prompt2,
+        template_format=template_format,
+    )
 
     concated_prompt = first_prompt + second_prompt
-    prompt_of_concated = PromptTemplate.from_template(prompt1 + prompt2, template_format=template_format)
+    prompt_of_concated = PromptTemplate.from_template(
+        prompt1 + prompt2,
+        template_format=template_format,
+    )
 
     assert concated_prompt.input_variables == prompt_of_concated.input_variables
     assert (
-        concated_prompt.format(variable="template", another_variable="other_template") == 
-        prompt_of_concated.format(variable="template", another_variable="other_template")
+        concated_prompt.format(
+            variable="template",
+            another_variable="other_template",
+        ) ==
+        prompt_of_concated.format(
+            variable="template",
+            another_variable="other_template",
+        )
     )

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -681,7 +681,7 @@ def test_prompt_with_template_variable_name_jinja2() -> None:
 
 
 def test_prompt_template_add_with_with_another_format():
-    with pytest.raises(match=r"Cannot add two templates"):
+    with pytest.raises(match=r"Cannot add templates"):
         PromptTemplate.from_template("This is a {template}") + PromptTemplate.from_template("So {{this}} is", template_format="mustache")
 
 

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -2,7 +2,7 @@
 
 import re
 from tempfile import NamedTemporaryFile
-from typing import Any, Union
+from typing import Any, Literal, Union
 from unittest import mock
 
 import pytest
@@ -683,8 +683,8 @@ def test_prompt_with_template_variable_name_jinja2() -> None:
 def test_prompt_template_add_with_with_another_format() -> None:
     with pytest.raises(ValueError, match=r"Cannot add templates"):
         (
-            PromptTemplate.from_template("This is a {template}") +
-            PromptTemplate.from_template("So {{this}} is", template_format="mustache")
+            PromptTemplate.from_template("This is a {template}")
+            + PromptTemplate.from_template("So {{this}} is", template_format="mustache")
         )
 
 
@@ -696,12 +696,16 @@ def test_prompt_template_add_with_with_another_format() -> None:
             "jinja2",
             "This is a {{variable}}",
             ". This is {{another_variable}}",
-            marks=[pytest.mark.requires("jinja2")]
+            marks=[pytest.mark.requires("jinja2")],
         ),
         ("mustache", "This is a {{variable}}", ". This is {{another_variable}}"),
-    ]
+    ],
 )
-def test_prompt_template_add(template_format: str, prompt1: str, prompt2: str) -> None:
+def test_prompt_template_add(
+    template_format: Literal["f-string", "mustache", "jinja2"],
+    prompt1: str,
+    prompt2: str,
+) -> None:
     first_prompt = PromptTemplate.from_template(
         prompt1,
         template_format=template_format,
@@ -718,13 +722,10 @@ def test_prompt_template_add(template_format: str, prompt1: str, prompt2: str) -
     )
 
     assert concated_prompt.input_variables == prompt_of_concated.input_variables
-    assert (
-        concated_prompt.format(
-            variable="template",
-            another_variable="other_template",
-        ) ==
-        prompt_of_concated.format(
-            variable="template",
-            another_variable="other_template",
-        )
+    assert concated_prompt.format(
+        variable="template",
+        another_variable="other_template",
+    ) == prompt_of_concated.format(
+        variable="template",
+        another_variable="other_template",
     )

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -678,3 +678,30 @@ def test_prompt_with_template_variable_name_jinja2() -> None:
     template = "This is a {{template}} test."
     prompt = PromptTemplate.from_template(template, template_format="jinja2")
     assert prompt.invoke({"template": "bar"}).to_string() == "This is a bar test."
+
+
+def test_prompt_template_add_with_with_another_format():
+    with pytest.raises(match=r"Cannot add two templates"):
+        PromptTemplate.from_template("This is a {template}") + PromptTemplate.from_template("So {{this}} is", template_format="mustache")
+
+
+@pytest.mark.parametrize(
+        "template_format, prompt1, prompt2",
+        [
+            ("f-string", "This is a {variable}", ". This is {another_variable}"),
+            pytest.param("jinja2", "This is a {{variable}}", ". This is {{another_variable}}", marks=[pytest.mark.requires("jinja2")]),
+            ("mustache", "This is a {{variable}}", ". This is {{another_variable}}"),
+        ]
+)
+def test_prompt_template_add(template_format: str, prompt1: str, prompt2: str) -> None:
+    first_prompt = PromptTemplate.from_template(prompt1, template_format=template_format)
+    second_prompt = PromptTemplate.from_template(prompt2, template_format=template_format)
+
+    concated_prompt = first_prompt + second_prompt
+    prompt_of_concated = PromptTemplate.from_template(prompt1 + prompt2, template_format=template_format)
+
+    assert concated_prompt.input_variables == prompt_of_concated.input_variables
+    assert (
+        concated_prompt.format(variable="template", another_variable="other_template") == 
+        prompt_of_concated.format(variable="template", another_variable="other_template")
+    )


### PR DESCRIPTION
Allow adding`PromptTemplate`s with formats other than `f-string`. Fixes #32151 