### PR TITLE
docs(docs): update RAG tutorials link to point to correct path

### DIFF
--- a/docs/docs/integrations/vectorstores/chroma.ipynb
+++ b/docs/docs/integrations/vectorstores/chroma.ipynb
@@ -638,7 +638,7 @@
     "\n",
     "For guides on how to use this vector store for retrieval-augmented generation (RAG), see the following sections:\n",
     "\n",
-    "- [Tutorials](/docs/tutorials/)\n",
+    "- [Tutorials](/docs/tutorials/rag)\n",
     "- [How-to: Question and answer with RAG](https://python.langchain.com/docs/how_to/#qa-with-rag)\n",
     "- [Retrieval conceptual docs](https://python.langchain.com/docs/concepts/retrieval)"
    ]


### PR DESCRIPTION
  - **Description:** This PR updates the internal documentation link for the RAG tutorials to reflect the updated path. Previously, the link pointed to the root `/docs/tutorials/`, which was generic. It now correctly routes to the RAG-specific tutorial page.  
  - **Issue:** N/A
  - **Dependencies:** None
  - **Twitter handle:** N/A