### PR TITLE
fix(openai): add `max_retries` parameter to ChatOpenAI for handling 503 capacity errors

### DIFF
--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -221,6 +221,7 @@ def test_openai_invoke() -> None:
     llm = ChatOpenAI(
         model="o4-mini",
         service_tier="flex",  # Also test service_tier
+        max_retries=3,  # Add retries for 503 capacity errors
     )
 
     result = llm.invoke("Hello", config=dict(tags=["foo"]))


### PR DESCRIPTION
Some integration tests were failing