### PR TITLE
docs: fixed link to docs of unstructured

### DIFF
--- a/docs/docs/how_to/document_loader_directory.ipynb
+++ b/docs/docs/how_to/document_loader_directory.ipynb
@@ -30,7 +30,7 @@
    "id": "e3cdb7bb-1f58-4a7a-af83-599443127834",
    "metadata": {},
    "source": [
-    "`DirectoryLoader` accepts a `loader_cls` kwarg, which defaults to [UnstructuredLoader](/docs/integrations/document_loaders/unstructured_file). [Unstructured](https://unstructured-io.github.io/unstructured/) supports parsing for a number of formats, such as PDF and HTML. Here we use it to read in a markdown (.md) file.\n",
+    "`DirectoryLoader` accepts a `loader_cls` kwarg, which defaults to [UnstructuredLoader](/docs/integrations/document_loaders/unstructured_file). [Unstructured](https://docs.unstructured.io/) supports parsing for a number of formats, such as PDF and HTML. Here we use it to read in a markdown (.md) file.\n",
     "\n",
     "We can use the `glob` parameter to control which files to load. Note that here it doesn't load the `.rst` file or the `.html` files."
    ]


### PR DESCRIPTION
In the section [How to load documents from a directory](https://python.langchain.com/docs/how_to/document_loader_directory/) there is a link to the docs of *unstructured*. When you click this link, it tells you that it has moved. Accordingly this PR fixes this link in LangChain docs directly

from: `https://unstructured-io.github.io/unstructured/#`
to: `https://docs.unstructured.io/`