### PR TITLE
refactor(docs): resolve a variable mismatch error

### DIFF
--- a/docs/docs/tutorials/sql_qa.ipynb
+++ b/docs/docs/tutorials/sql_qa.ipynb
@@ -289,7 +289,7 @@
     "        }\n",
     "    )\n",
     "    structured_llm = llm.with_structured_output(QueryOutput)\n",
-    "    result = structured_llm.invoke(prompt)\n",
+    "    result = structured_llm.invoke(user_prompt)\n",
     "    return {\"query\": result[\"query\"]}"
    ]
   },


### PR DESCRIPTION
# Description:

In line 292 we have a variable mismatch(**prompt** in place of **user_prompt**) which throws an error while running.

- [x] **Add tests and docs**: If you're adding a new integration, you must include:
  1. A test for the integration, preferably unit tests that do not rely on network access,
  2. An example notebook showing its use. It lives in `docs/docs/integrations` directory.

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. **We will not consider a PR unless these three are passing in CI.** See [contribution guidelines](https://python.langchain.com/docs/contributing/) for more.

