### PR TITLE
docs(ollama): update `ollama.mdx` with note about basic auth support

### DIFF
--- a/docs/docs/integrations/providers/ollama.mdx
+++ b/docs/docs/integrations/providers/ollama.mdx
@@ -55,6 +55,8 @@ See the notebook example [here](/docs/integrations/llms/ollama).
 from langchain_ollama.chat_models import ChatOllama
 ```
 
+Note: ChatOllama does not support basic auth via the URL-only strategy. If you keep the Ollama server behind basic auth (such as by using a proxy) then you'll need to manually set authentication headers to access it.
+
 See the notebook example [here](/docs/integrations/chat/ollama).
 
 ### Ollama tool calling

--- a/docs/docs/integrations/providers/ollama.mdx
+++ b/docs/docs/integrations/providers/ollama.mdx
@@ -55,7 +55,8 @@ See the notebook example [here](/docs/integrations/llms/ollama).
 from langchain_ollama.chat_models import ChatOllama
 ```
 
-Note: ChatOllama does not support basic auth via the URL-only strategy. If you keep the Ollama server behind basic auth (such as by using a proxy) then you'll need to manually set authentication headers to access it.
+.. note::
+    ChatOllama does not support basic auth via the URL-only strategy. If you keep the Ollama server behind basic auth (such as by using a proxy) then you'll need to manually set authentication headers to access it.
 
 See the notebook example [here](/docs/integrations/chat/ollama).
 


### PR DESCRIPTION
This is related to https://github.com/langchain-ai/langchain/issues/25055

Although langchain now allows users to specify headers, the client itself does not gracefully handle a standard URL of the form https://user:password@ollama.mysite.com:11343


