### PR TITLE
docs: clarify `SystemMessage` usage in LangGraph agent notebook (#32320)

### DIFF
--- a/cookbook/langgraph_agentic_rag.ipynb
+++ b/cookbook/langgraph_agentic_rag.ipynb
@@ -81,6 +81,17 @@
   },
   {
    "cell_type": "markdown",
+   "id": "168152fc",
+   "metadata": {},
+   "source": [
+    "📘 **Note on `SystemMessage` usage with LangGraph-based agents**\n",
+    "\n",
+    "When constructing the `messages` list for an agent, you *must* manually include any `SystemMessage`s.\n",
+    "Unlike some agent executors in LangChain that inject it automatically, LangGraph requires explicit inclusion."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fe6e8f78-1ef7-42ad-b2bf-835ed5850553",
    "metadata": {},
    "source": [

--- a/cookbook/langgraph_agentic_rag.ipynb
+++ b/cookbook/langgraph_agentic_rag.ipynb
@@ -87,7 +87,7 @@
     "📘 **Note on `SystemMessage` usage with LangGraph-based agents**\n",
     "\n",
     "When constructing the `messages` list for an agent, you *must* manually include any `SystemMessage`s.\n",
-    "Unlike some agent executors in LangChain that inject it automatically, LangGraph requires explicit inclusion."
+    "Unlike some agent executors in LangChain that set a default, LangGraph requires explicit inclusion."
    ]
   },
   {


### PR DESCRIPTION
Closes #32320

This PR updates the `langgraph_agentic_rag.ipynb` notebook to clarify that LangGraph does not automatically prepend a `SystemMessage`. A markdown note and an inline Python comment have been added to guide users to explicitly include a `SystemMessage` when needed.

This improves documentation for developers working with LangGraph-based agents and avoids confusion about system-level behavior not being applied.
