### PR TITLE
fix(docs): update package names, class links and package links across kv_store_feat_table.py

### DIFF
--- a/docs/scripts/kv_store_feat_table.py
+++ b/docs/scripts/kv_store_feat_table.py
@@ -32,19 +32,19 @@ KV_STORE_FEAT_TABLE = {
     "AstraDBByteStore": {
         "class": "[AstraDBByteStore](https://python.langchain.com/api_reference/astradb/storage/langchain_astradb.storage.AstraDBByteStore.html)",
         "local": False,
-        "package": "[langchain_astradb](https://python.langchain.com/api_reference/astradb/)",
+        "package": "[langchain-astradb](https://python.langchain.com/api_reference/astradb/)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_astradb?style=flat-square&label=%20)",
     },
     "CassandraByteStore": {
         "class": "[CassandraByteStore](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.cassandra.CassandraByteStore.html)",
         "local": False,
-        "package": "[langchain_community](https://python.langchain.com/api_reference/community/)",
+        "package": "[langchain-community](https://python.langchain.com/api_reference/community/)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_community?style=flat-square&label=%20)",
     },
     "ElasticsearchEmbeddingsCache": {
         "class": "[ElasticsearchEmbeddingsCache](https://python.langchain.com/api_reference/elasticsearch/cache/langchain_elasticsearch.cache.ElasticsearchEmbeddingsCache.html)",
         "local": True,
-        "package": "[langchain_elasticsearch](https://python.langchain.com/api_reference/elasticsearch/)",
+        "package": "[langchain-elasticsearch](https://python.langchain.com/api_reference/elasticsearch/)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_elasticsearch?style=flat-square&label=%20)",
     },
     "LocalFileStore": {
@@ -56,19 +56,19 @@ KV_STORE_FEAT_TABLE = {
     "InMemoryByteStore": {
         "class": "[InMemoryByteStore](https://python.langchain.com/api_reference/core/stores/langchain_core.stores.InMemoryByteStore.html)",
         "local": True,
-        "package": "[langchain_core](https://python.langchain.com/api_reference/core/)",
+        "package": "[langchain-core](https://python.langchain.com/api_reference/core/)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_core?style=flat-square&label=%20)",
     },
     "RedisStore": {
         "class": "[RedisStore](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.redis.RedisStore.html)",
         "local": True,
-        "package": "[langchain_community](https://python.langchain.com/api_reference/community/)",
+        "package": "[langchain-community](https://python.langchain.com/api_reference/community/)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_community?style=flat-square&label=%20)",
     },
     "UpstashRedisByteStore": {
         "class": "[UpstashRedisByteStore](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.upstash_redis.UpstashRedisByteStore.html)",
         "local": False,
-        "package": "[langchain_community](https://python.langchain.com/api_reference/community/)",
+        "package": "[langchain-community](https://python.langchain.com/api_reference/community/)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_community?style=flat-square&label=%20)",
     },
 }

--- a/docs/scripts/kv_store_feat_table.py
+++ b/docs/scripts/kv_store_feat_table.py
@@ -30,48 +30,49 @@ The following table shows information on all available key-value stores.
 
 KV_STORE_FEAT_TABLE = {
     "AstraDBByteStore": {
-        "class": "[AstraDBByteStore](https://python.langchain.com/api_reference/astradb/storage/langchain_astradb.storage.AstraDBByteStore.html)",
+        "class": "[AstraDBByteStore](https://python.langchain.com/docs/integrations/stores/astradb/)",
         "local": False,
-        "package": "[langchain-astradb](https://python.langchain.com/api_reference/astradb/)",
+        "package": "[langchain-astradb](https://python.langchain.com/api_reference/astradb/storage/langchain_astradb.storage.AstraDBByteStore.html)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_astradb?style=flat-square&label=%20)",
     },
     "CassandraByteStore": {
-        "class": "[CassandraByteStore](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.cassandra.CassandraByteStore.html)",
+        "class": "[CassandraByteStore](https://python.langchain.com/docs/integrations/stores/cassandra/)",
         "local": False,
-        "package": "[langchain-community](https://python.langchain.com/api_reference/community/)",
+        "package": "[langchain-community](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.cassandra.CassandraByteStore.html)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_community?style=flat-square&label=%20)",
     },
     "ElasticsearchEmbeddingsCache": {
-        "class": "[ElasticsearchEmbeddingsCache](https://python.langchain.com/api_reference/elasticsearch/cache/langchain_elasticsearch.cache.ElasticsearchEmbeddingsCache.html)",
+        "class": "[ElasticsearchEmbeddingsCache](https://python.langchain.com/docs/integrations/stores/elasticsearch/)",
         "local": True,
-        "package": "[langchain-elasticsearch](https://python.langchain.com/api_reference/elasticsearch/)",
+        "package": "[langchain-elasticsearch](https://python.langchain.com/api_reference/elasticsearch/cache/langchain_elasticsearch.cache.ElasticsearchEmbeddingsCache.html)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_elasticsearch?style=flat-square&label=%20)",
     },
     "LocalFileStore": {
-        "class": "[LocalFileStore](https://python.langchain.com/api_reference/storage/langchain.storage.file_system.LocalFileStore.html)",
+        "class": "[LocalFileStore](https://python.langchain.com/docs/integrations/stores/file_system/)",
         "local": True,
-        "package": "[langchain](https://python.langchain.com/api_reference/langchain/)",
+        "package": "[langchain](https://python.langchain.com/api_reference/storage/langchain.storage.file_system.LocalFileStore.html)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain?style=flat-square&label=%20)",
     },
     "InMemoryByteStore": {
-        "class": "[InMemoryByteStore](https://python.langchain.com/api_reference/core/stores/langchain_core.stores.InMemoryByteStore.html)",
+        "class": "[InMemoryByteStore](https://python.langchain.com/docs/integrations/stores/in_memory/)",
         "local": True,
-        "package": "[langchain-core](https://python.langchain.com/api_reference/core/)",
+        "package": "[langchain-core](https://python.langchain.com/api_reference/core/stores/langchain_core.stores.InMemoryByteStore.html)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_core?style=flat-square&label=%20)",
     },
     "RedisStore": {
-        "class": "[RedisStore](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.redis.RedisStore.html)",
+        "class": "[RedisStore](https://python.langchain.com/docs/integrations/stores/redis/)",
         "local": True,
-        "package": "[langchain-community](https://python.langchain.com/api_reference/community/)",
+        "package": "[langchain-community](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.redis.RedisStore.html)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_community?style=flat-square&label=%20)",
     },
     "UpstashRedisByteStore": {
-        "class": "[UpstashRedisByteStore](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.upstash_redis.UpstashRedisByteStore.html)",
+        "class": "[UpstashRedisByteStore](https://python.langchain.com/docs/integrations/stores/upstash_redis/)",
         "local": False,
-        "package": "[langchain-community](https://python.langchain.com/api_reference/community/)",
+        "package": "[langchain-community](https://python.langchain.com/api_reference/community/storage/langchain_community.storage.upstash_redis.UpstashRedisByteStore.html)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_community?style=flat-square&label=%20)",
     },
 }
+
 
 DEPRECATED = []
 

--- a/docs/scripts/kv_store_feat_table.py
+++ b/docs/scripts/kv_store_feat_table.py
@@ -50,7 +50,7 @@ KV_STORE_FEAT_TABLE = {
     "LocalFileStore": {
         "class": "[LocalFileStore](https://python.langchain.com/docs/integrations/stores/file_system/)",
         "local": True,
-        "package": "[langchain](https://python.langchain.com/api_reference/storage/langchain.storage.file_system.LocalFileStore.html)",
+        "package": "[langchain](https://python.langchain.com/api_reference/langchain/storage/langchain.storage.file_system.LocalFileStore.html)",
         "downloads": "![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain?style=flat-square&label=%20)",
     },
     "InMemoryByteStore": {


### PR DESCRIPTION
## **Description:** 
Refactored multiple entries in `kv_store_feat_table.py` to ensure that all vector store metadata is accurate, consistent, and aligned with LangChain's latest documentation structure and PyPI naming standards.

**Key improvements across all updated entries:**
- Updated `class` links to point to their respective **docs-based integration pages** (e.g., `/docs/integrations/stores/...`) instead of raw API reference URLs.
- Corrected `package` display names to use **hyphenated PyPI-compliant names** (e.g., `langchain-astradb` instead of `langchain_astradb`).
- Updated `package` links to point to the **specific class-level API references** (e.g., `/api_reference/.../storage/...ClassName.html`) for precision.

These improvements enhance:
- Navigation experience for users
- Alignment with PyPI and docs naming conventions
- Clarity across LangChain’s integrations documentation


 
## **Issue:** N/A
## **Dependencies:** None
## **Twitter handle:** N/A