### PR TITLE
docs(docs): add link for ALPHAVANTAGE_API_KEY generation in integration notebook

### DIFF
--- a/docs/docs/integrations/tools/alpha_vantage.ipynb
+++ b/docs/docs/integrations/tools/alpha_vantage.ipynb
@@ -9,9 +9,9 @@
    "source": [
     "# Alpha Vantage\n",
     "\n",
-    ">[Alpha Vantage](https://www.alphavantage.co) Alpha Vantage provides realtime and historical financial market data through a set of powerful and developer-friendly data APIs and spreadsheets. \n",
+    ">[Alpha Vantage](https://www.alphavantage.co) Alpha Vantage provides realtime and historical financial market data through a set of powerful and developer-friendly data APIs and spreadsheets.\n",
     "\n",
-    "Generate the `ALPHAVANTAGE_API_KEY` over here [Get API Key](https://www.alphavantage.co/support/#api-key) \n",
+    "Generate the `ALPHAVANTAGE_API_KEY` [at their website](https://www.alphavantage.co/support/#api-key)\n.",
     "\n",
     "Use the ``AlphaVantageAPIWrapper`` to get currency exchange rates."
    ]

--- a/docs/docs/integrations/tools/alpha_vantage.ipynb
+++ b/docs/docs/integrations/tools/alpha_vantage.ipynb
@@ -11,6 +11,8 @@
     "\n",
     ">[Alpha Vantage](https://www.alphavantage.co) Alpha Vantage provides realtime and historical financial market data through a set of powerful and developer-friendly data APIs and spreadsheets. \n",
     "\n",
+    "Generate the `ALPHAVANTAGE_API_KEY` over here [Get API Key](https://www.alphavantage.co/support/#api-key) \n",
+    "\n",
     "Use the ``AlphaVantageAPIWrapper`` to get currency exchange rates."
    ]
   },


### PR DESCRIPTION
docs(alpha_vantage): add link for ALPHAVANTAGE_API_KEY generation in integration notebook

**Description:**

This PR updates the `docs/docs/integrations/tools/alpha_vantage.ipynb` integration notebook to help users locate the API key registration page for Alpha Vantage. The following markdown line was added:
