### PR TITLE
fix(docs): inconsistent docs for Google Vertex AI

### DIFF
--- a/docs/docs/integrations/chat/google_vertex_ai_palm.ipynb
+++ b/docs/docs/integrations/chat/google_vertex_ai_palm.ipynb
@@ -45,7 +45,7 @@
     "\n",
     "### Credentials\n",
     "\n",
-    "To use the integration you must:\n",
+    "To use the integration you must either:\n",
     "- Have credentials configured for your environment (gcloud, workload identity, etc...)\n",
     "- Store the path to a service account JSON file as the GOOGLE_APPLICATION_CREDENTIALS environment variable\n",
     "\n",


### PR DESCRIPTION
Description: Documentation is inconsistent with API docs.

Current documentation implies that to use the integration you must have credentials configured AND store the path to a service account JSON file.

API docs explain that you must only complete EITHER of the steps regarding credentials.

I have updated the docs to make them consistent with the API wording.