### PR TITLE
fix(core): ensure `RunnablePick` always returns `dict`

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3204,7 +3204,9 @@ def test_map_stream() -> None:
     # Final value should be complete dict
     assert final_value == {"llm": "i'm a textbot"}
 
-    chain_pick_two = chain.assign(hello=RunnablePick("llm").pipe(itemgetter("llm")).pipe(llm)).pick(
+    chain_pick_two = chain.assign(
+        hello=RunnablePick("llm").pipe(itemgetter("llm")).pipe(llm)
+    ).pick(
         [
             "llm",
             "hello",
@@ -3233,9 +3235,13 @@ def test_map_stream() -> None:
             final_value += chunk
 
     # Find first non-empty chunk for chain_pick_two
-    first_content_chunk_two = next((chunk for chunk in streamed_chunks if chunk), {})
-    assert first_content_chunk_two.get("llm") == "i" or "chat" in first_content_chunk_two
-    
+    first_content_chunk_two: dict[str, Any] = next(
+        (chunk for chunk in streamed_chunks if chunk), {}
+    )
+    assert (
+        first_content_chunk_two.get("llm") == "i" or "chat" in first_content_chunk_two
+    )
+
     # Just check that final result is correct instead of chunk count
     assert final_value.get("llm") == "i'm a textbot"
     assert final_value.get("hello") == "i'm a textbot"


### PR DESCRIPTION
### Description: ###
Fixed RunnablePick to always return a dictionary, even when picking a single key by string. Previously, RunnablePick("key") would return the raw value instead of {"key": value}, which was inconsistent with the class's type signature and documentation that promised to always return a dict.

 #### Issue: Fixes #31309 ####

 #### Dependencies: None ####

### Changes made: ###
  - Modified RunnablePick._pick() method to always return AddableDict for consistency
  - Updated type signature behavior to match actual implementation
  - Fixed existing tests in test_runnable.py to expect dict output format
  - Updated docstring with clear examples showing both single and multiple key usage

Breaking Change Note: This is intentionally a breaking change as requested in the issue. Code that previously relied on RunnablePick("key") returning a raw value will need to be updated to handle dict output (e.g., result["key"] instead of result).
