### PR TITLE
docs: add Windows-specific setup instructions

### DIFF
--- a/docs/docs/contributing/how_to/code/setup.mdx
+++ b/docs/docs/contributing/how_to/code/setup.mdx
@@ -56,10 +56,10 @@ uv sync
 Then verify dependency installation:
 
 ```bash
-# If you have make installed:
+# If you have `make` installed:
 make test
 
-# If you don't have make (Windows alternative):
+# If you don't have `make` (Windows alternative):
 uv run --group test pytest -n auto --disable-socket --allow-unix-socket tests/unit_tests
 ```
 
@@ -73,7 +73,7 @@ If you add new logic, please add a unit test.
 To run unit tests:
 
 ```bash
-# If you have make installed:
+# If you have `make` installed:
 make test
 
 # If you don't have make (Windows alternative):
@@ -89,10 +89,10 @@ If you are only developing `langchain_core`, you can simply install the dependen
 ```bash
 cd libs/core
 
-# If you have make installed:
+# If you have `make` installed:
 make test
 
-# If you don't have make (Windows alternative):
+# If you don't have `make` (Windows alternative):
 uv run --group test pytest -n auto --disable-socket --allow-unix-socket tests/unit_tests
 ```
 
@@ -107,7 +107,7 @@ Formatting for this project is done via [ruff](https://docs.astral.sh/ruff/rules
 To run formatting for docs, cookbook and templates:
 
 ```bash
-# If you have make installed:
+# If you have `make` installed:
 make format
 
 # If you don't have make (Windows alternative):
@@ -120,7 +120,7 @@ To run formatting for a library, run the same command from the relevant library 
 ```bash
 cd libs/{LIBRARY}
 
-# If you have make installed:
+# If you have `make` installed:
 make format
 
 # If you don't have make (Windows alternative):
@@ -131,10 +131,10 @@ uv run --all-groups ruff check --fix .
 Additionally, you can run the formatter only on the files that have been modified in your current branch as compared to the master branch using the format_diff command:
 
 ```bash
-# If you have make installed:
+# If you have `make` installed:
 make format_diff
 
-# If you don't have make (Windows alternative):
+# If you don't have `make` (Windows alternative):
 # First, get the list of modified files:
 git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$' | xargs uv run --all-groups ruff format
 git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$' | xargs uv run --all-groups ruff check --fix
@@ -149,10 +149,10 @@ Linting for this project is done via a combination of [ruff](https://docs.astral
 To run linting for docs, cookbook and templates:
 
 ```bash
-# If you have make installed:
+# If you have `make` installed:
 make lint
 
-# If you don't have make (Windows alternative):
+# If you don't have `make` (Windows alternative):
 uv run --all-groups ruff check .
 uv run --all-groups ruff format . --diff
 uv run --all-groups mypy . --cache-dir .mypy_cache
@@ -163,10 +163,10 @@ To run linting for a library, run the same command from the relevant library dir
 ```bash
 cd libs/{LIBRARY}
 
-# If you have make installed:
+# If you have `make` installed:
 make lint
 
-# If you don't have make (Windows alternative):
+# If you don't have `make` (Windows alternative):
 uv run --all-groups ruff check .
 uv run --all-groups ruff format . --diff
 uv run --all-groups mypy . --cache-dir .mypy_cache
@@ -175,10 +175,10 @@ uv run --all-groups mypy . --cache-dir .mypy_cache
 In addition, you can run the linter only on the files that have been modified in your current branch as compared to the master branch using the lint_diff command:
 
 ```bash
-# If you have make installed:
+# If you have `make` installed:
 make lint_diff
 
-# If you don't have make (Windows alternative):
+# If you don't have `make` (Windows alternative):
 # First, get the list of modified files:
 git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$' | xargs uv run --all-groups ruff check
 git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$' | xargs uv run --all-groups ruff format --diff
@@ -197,20 +197,20 @@ Note that `codespell` finds common typos, so it could have false-positive (corre
 To check spelling for this project:
 
 ```bash
-# If you have make installed:
+# If you have `make` installed:
 make spell_check
 
-# If you don't have make (Windows alternative):
+# If you don't have `make` (Windows alternative):
 uv run --all-groups codespell --toml pyproject.toml
 ```
 
 To fix spelling in place:
 
 ```bash
-# If you have make installed:
+# If you have `make` installed:
 make spell_fix
 
-# If you don't have make (Windows alternative):
+# If you don't have `make` (Windows alternative):
 uv run --all-groups codespell --toml pyproject.toml -w
 ```
 

--- a/docs/docs/contributing/how_to/code/setup.mdx
+++ b/docs/docs/contributing/how_to/code/setup.mdx
@@ -9,6 +9,14 @@ This project utilizes [uv](https://docs.astral.sh/uv/) v0.5+ as a dependency man
 
 Install `uv`: **[documentation on how to install it](https://docs.astral.sh/uv/getting-started/installation/)**.
 
+### Windows Users
+
+If you're on Windows and don't have `make` installed, you can install it via:
+- **Option 1**: Install via [Chocolatey](https://chocolatey.org/): `choco install make`
+- **Option 2**: Install via [Scoop](https://scoop.sh/): `scoop install make`
+- **Option 3**: Use [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/)
+- **Option 4**: Use the direct `uv` commands shown in the sections below
+
 ## Different packages
 
 This repository contains multiple packages:
@@ -48,7 +56,11 @@ uv sync
 Then verify dependency installation:
 
 ```bash
+# If you have make installed:
 make test
+
+# If you don't have make (Windows alternative):
+uv run --group test pytest -n auto --disable-socket --allow-unix-socket tests/unit_tests
 ```
 
 ## Testing
@@ -61,7 +73,11 @@ If you add new logic, please add a unit test.
 To run unit tests:
 
 ```bash
+# If you have make installed:
 make test
+
+# If you don't have make (Windows alternative):
+uv run --group test pytest -n auto --disable-socket --allow-unix-socket tests/unit_tests
 ```
 
 There are also [integration tests and code-coverage](../testing.mdx) available.
@@ -72,7 +88,12 @@ If you are only developing `langchain_core`, you can simply install the dependen
 
 ```bash
 cd libs/core
+
+# If you have make installed:
 make test
+
+# If you don't have make (Windows alternative):
+uv run --group test pytest -n auto --disable-socket --allow-unix-socket tests/unit_tests
 ```
 
 ## Formatting and linting
@@ -86,20 +107,37 @@ Formatting for this project is done via [ruff](https://docs.astral.sh/ruff/rules
 To run formatting for docs, cookbook and templates:
 
 ```bash
+# If you have make installed:
 make format
+
+# If you don't have make (Windows alternative):
+uv run --all-groups ruff format .
+uv run --all-groups ruff check --fix .
 ```
 
 To run formatting for a library, run the same command from the relevant library directory:
 
 ```bash
 cd libs/{LIBRARY}
+
+# If you have make installed:
 make format
+
+# If you don't have make (Windows alternative):
+uv run --all-groups ruff format .
+uv run --all-groups ruff check --fix .
 ```
 
 Additionally, you can run the formatter only on the files that have been modified in your current branch as compared to the master branch using the format_diff command:
 
 ```bash
+# If you have make installed:
 make format_diff
+
+# If you don't have make (Windows alternative):
+# First, get the list of modified files:
+git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$' | xargs uv run --all-groups ruff format
+git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$' | xargs uv run --all-groups ruff check --fix
 ```
 
 This is especially useful when you have made changes to a subset of the project and want to ensure your changes are properly formatted without affecting the rest of the codebase.
@@ -111,20 +149,40 @@ Linting for this project is done via a combination of [ruff](https://docs.astral
 To run linting for docs, cookbook and templates:
 
 ```bash
+# If you have make installed:
 make lint
+
+# If you don't have make (Windows alternative):
+uv run --all-groups ruff check .
+uv run --all-groups ruff format . --diff
+uv run --all-groups mypy . --cache-dir .mypy_cache
 ```
 
 To run linting for a library, run the same command from the relevant library directory:
 
 ```bash
 cd libs/{LIBRARY}
+
+# If you have make installed:
 make lint
+
+# If you don't have make (Windows alternative):
+uv run --all-groups ruff check .
+uv run --all-groups ruff format . --diff
+uv run --all-groups mypy . --cache-dir .mypy_cache
 ```
 
 In addition, you can run the linter only on the files that have been modified in your current branch as compared to the master branch using the lint_diff command:
 
 ```bash
+# If you have make installed:
 make lint_diff
+
+# If you don't have make (Windows alternative):
+# First, get the list of modified files:
+git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$' | xargs uv run --all-groups ruff check
+git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$' | xargs uv run --all-groups ruff format --diff
+git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$' | xargs uv run --all-groups mypy --cache-dir .mypy_cache
 ```
 
 This can be very helpful when you've made changes to only certain parts of the project and want to ensure your changes meet the linting standards without having to check the entire codebase.
@@ -139,13 +197,21 @@ Note that `codespell` finds common typos, so it could have false-positive (corre
 To check spelling for this project:
 
 ```bash
+# If you have make installed:
 make spell_check
+
+# If you don't have make (Windows alternative):
+uv run --all-groups codespell --toml pyproject.toml
 ```
 
 To fix spelling in place:
 
 ```bash
+# If you have make installed:
 make spell_fix
+
+# If you don't have make (Windows alternative):
+uv run --all-groups codespell --toml pyproject.toml -w
 ```
 
 If codespell is incorrectly flagging a word, you can skip spellcheck for that word by adding it to the codespell config in the `pyproject.toml` file.


### PR DESCRIPTION
**Description:** This PR improves the contribution setup guide by adding comprehensive Windows-specific instructions. The changes address a common pain point for Windows contributors who don't have `make` installed by default, making the LangChain contribution process more accessible across different operating systems.
The main improvements include:

- Added a dedicated "Windows Users" section with multiple installation options for `make` (Chocolatey, Scoop, WSL)
- Provided direct `uv` commands as alternatives to all `make` commands throughout the setup guide
- Included Windows-specific instructions for testing, formatting, linting, and spellchecking
- Enhanced the documentation to be more inclusive for Windows developers

This change makes it easier for Windows users to contribute to LangChain without requiring additional tool installation, while maintaining the existing workflow for users who already have `make` available.

**Issue:** This addresses the common barrier Windows users face when trying to contribute to LangChain due to missing `make` commands.

**Dependencies:** None required - this is purely a documentation improvement.