### PR TITLE
fix(standard-tests): Add possibility to skip retriever tests that use the k arg

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/retrievers.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/retrievers.py
@@ -11,6 +11,16 @@ class RetrieversIntegrationTests(BaseStandardTests):
     """Base class for retrievers integration tests."""
 
     @property
+    def has_k_init_arg(self) -> bool:
+        """Whether the retriever supports a `k` parameter in its constructor."""
+        return True
+
+    @property
+    def has_k_invoke_kwarg(self) -> bool:
+        """Whether the retriever supports a `k` parameter in its `invoke` method."""
+        return True
+
+    @property
     @abstractmethod
     def retriever_constructor(self) -> type[BaseRetriever]:
         """A BaseRetriever subclass to be tested."""
@@ -41,6 +51,7 @@ class RetrieversIntegrationTests(BaseStandardTests):
             If this test fails, either the retriever constructor does not accept a k
             parameter, or the retriever does not return the correct number of documents
             (`k`) when it is set.
+            The test can be skipped by setting the `has_k_init_arg` property to False.
 
             For example, a retriever like
 
@@ -51,6 +62,8 @@ class RetrieversIntegrationTests(BaseStandardTests):
             should return 3 documents when invoked with a query.
 
         """
+        if not self.has_k_init_arg:
+            pytest.skip("Retriever does not support k init arg")
         params = {
             k: v for k, v in self.retriever_constructor_params.items() if k != "k"
         }
@@ -75,6 +88,8 @@ class RetrieversIntegrationTests(BaseStandardTests):
             If this test fails, the retriever's invoke method does not accept a k
             parameter, or the retriever does not return the correct number of documents
             (`k`) when it is set.
+            The test can be skipped by setting the `has_k_invoke_kwarg` property to
+            False.
 
             For example, a retriever like
 
@@ -85,6 +100,8 @@ class RetrieversIntegrationTests(BaseStandardTests):
             should return 3 documents when invoked with a query.
 
         """
+        if not self.has_k_invoke_kwarg:
+            pytest.skip("Retriever does not support k invoke arg")
         result_1 = retriever.invoke(self.retriever_query_example, k=1)
         assert len(result_1) == 1
         assert all(isinstance(doc, Document) for doc in result_1)

--- a/libs/standard-tests/tests/unit_tests/test_basic_retriever.py
+++ b/libs/standard-tests/tests/unit_tests/test_basic_retriever.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
@@ -10,15 +10,47 @@ class ParrotRetriever(BaseRetriever):
     parrot_name: str
     k: int = 3
 
-    def _get_relevant_documents(self, query: str, **kwargs: Any) -> list[Document]:
-        k = kwargs.get("k", self.k)
-        return [Document(page_content=f"{self.parrot_name} says: {query}")] * k
+    def _get_relevant_documents(
+        self, query: str, k: Optional[int] = None, **_: Any
+    ) -> list[Document]:
+        return [Document(page_content=f"{self.parrot_name} says: {query}")] * (
+            k or self.k
+        )
 
 
 class TestParrotRetrieverIntegration(RetrieversIntegrationTests):
     @property
     def retriever_constructor(self) -> type[ParrotRetriever]:
         return ParrotRetriever
+
+    @property
+    def retriever_constructor_params(self) -> dict:
+        return {"parrot_name": "Polly"}
+
+    @property
+    def retriever_query_example(self) -> str:
+        return "parrot"
+
+
+class ParrotRetrieverWithoutK(BaseRetriever):
+    parrot_name: str
+
+    def _get_relevant_documents(self, query: str, **_: Any) -> list[Document]:
+        return [Document(page_content=f"{self.parrot_name} says: {query}")] * 3
+
+
+class TestParrotRetrieverIntegrationWithoutK(RetrieversIntegrationTests):
+    @property
+    def has_k_init_arg(self) -> bool:
+        return False
+
+    @property
+    def has_k_invoke_kwarg(self) -> bool:
+        return False
+
+    @property
+    def retriever_constructor(self) -> type[ParrotRetrieverWithoutK]:
+        return ParrotRetrieverWithoutK
 
     @property
     def retriever_constructor_params(self) -> dict:


### PR DESCRIPTION
It's usual for retrievers to support a `k` arg in their constructor or in their `invoke` method but it is not a requirement as per the API, the usage of retrievers in  the code, and the docs.
So the tests in `RetrieversIntegrationTests` that relate to the `k` arg should be optional.
