### PR TITLE
fix(core): fix index checking when merging lists

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -97,7 +97,7 @@ def merge_lists(left: Optional[list], *others: Optional[list]) -> Optional[list]
                     to_merge = [
                         i
                         for i, e_left in enumerate(merged)
-                        if e_left["index"] == e["index"]
+                        if "index" in e_left and e_left["index"] == e["index"]
                     ]
                     if to_merge:
                         # TODO: Remove this once merge_dict is updated with special

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1019,6 +1019,11 @@ def test_tool_message_str() -> None:
         ("foo", [["bar"]], ["foo", "bar"]),
         (["foo"], ["bar"], ["foobar"]),
         (["foo"], [["bar"]], ["foo", "bar"]),
+        (
+            [{"text": "foo"}],
+            [[{"index": 0, "text": "bar"}]],
+            [{"text": "foo"}, {"index": 0, "text": "bar"}],
+        ),
     ],
 )
 def test_merge_content(


### PR DESCRIPTION
**Description:** fix an issue I discovered when attempting to merge messages in which one message has an `index` key in its content dictionary and another does not.
