### PR TITLE
fix(openai): tests to content blocks

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -222,7 +222,7 @@ def test_configurable_with_default() -> None:
             config={"configurable": {"my_model_model": "claude-3-sonnet-20240229"}}
         )
 
-    """
+    """  # noqa: E501
     model = init_chat_model("gpt-4o", configurable_fields="any", config_prefix="bar")
     for method in (
         "invoke",


### PR DESCRIPTION
Updates failing integration tests to use `output_version="responses/v1"` and correctly access tool outputs from message content blocks instead of additional_kwargs["tool_outputs"].

With `output_version="responses/v1"`, OpenAI's responses API stores tool outputs directly in the message content array as structured blocks rather than in `additional_kwargs["tool_outputs"]`. 

The tests now:
1. Filter content blocks by type using `isinstance(block, dict)` and `block.get("type") == "tool_type"`
2. Extract tool outputs from the filtered content blocks
3. Maintain the same assertion logic for validating tool output structure