### PR TITLE
fix(anthropic): incorrect `input_tokens` counting while streaming

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2065,20 +2065,12 @@ def _make_message_chunk_from_anthropic_event(
     message_chunk: Optional[AIMessageChunk] = None
     # See https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/streaming/_messages.py  # noqa: E501
     if event.type == "message_start" and stream_usage:
-        usage_metadata = _create_usage_metadata(event.message.usage)
-        # We pick up a cumulative count of output_tokens at the end of the stream,
-        # so here we zero out to avoid double counting.
-        usage_metadata["total_tokens"] = (
-            usage_metadata["total_tokens"] - usage_metadata["output_tokens"]
-        )
-        usage_metadata["output_tokens"] = 0
         if hasattr(event.message, "model"):
             response_metadata = {"model_name": event.message.model}
         else:
             response_metadata = {}
         message_chunk = AIMessageChunk(
             content="" if coerce_content_to_string else [],
-            usage_metadata=usage_metadata,
             response_metadata=response_metadata,
         )
     elif (
@@ -2159,14 +2151,9 @@ def _make_message_chunk_from_anthropic_event(
                 tool_call_chunks=tool_call_chunks,
             )
     elif event.type == "message_delta" and stream_usage:
-        usage_metadata = UsageMetadata(
-            input_tokens=0,
-            output_tokens=event.usage.output_tokens,
-            total_tokens=event.usage.output_tokens,
-        )
         message_chunk = AIMessageChunk(
             content="",
-            usage_metadata=usage_metadata,
+            usage_metadata=_create_usage_metadata(event.usage),
             response_metadata={
                 "stop_reason": event.delta.stop_reason,
                 "stop_sequence": event.delta.stop_sequence,


### PR DESCRIPTION
TLDR: The lanchain_anthropic client is reporting incorrect input_tokens usage when used with any tools/mcp-servers while streaming, it also doesn't report any input_cache_read/input_cache_creation token usage at all. This PR fixes it.

## Details

Currently the input_tokens are counted in the `message_start` event, which is inaccurate. 

We can never count input tokens accurately at the start of the anthropic response. This is true when we use any tools/mcp, which increases the input_tokens count right after a tool call.

Additionally, we should only emit token usage at the end of the streaming anyway, because Anthropic doesn't charge for failed requests. So, streaming user input's token usage at the start of message doesn't make sense.

From Anthropic docs: https://support.anthropic.com/en/articles/8977456-how-do-i-pay-for-my-api-usage
> Failed requests are not charged, and you will only be billed for successful API calls and completed tasks.

---

Therefore, this PR, fixes the logic, and only emit the input_tokens details with "message_delta" events. 
I have also modified it to use the existing `_create_usage_metadata` method (it is a well tested function, [test case here](https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/tests/unit_tests/test_chat_models.py#L983)), which will also emit the input cached read/write tokens correctly (they were not being emitted at all before)

