### PR TITLE
fix(langchain): add gpt-5 to _attempt_infer_model_provider‎

### DIFF
--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -484,10 +484,8 @@ _SUPPORTED_PROVIDERS = {
 
 
 def _attempt_infer_model_provider(model_name: str) -> Optional[str]:
-    if any(
-        model_name.startswith(pre)
-        for pre in ("gpt-3", "gpt-4", "gpt-5", "o1", "o3")
-    ):
+    openai_prefixes = ("gpt-3", "gpt-4", "gpt-5", "o1", "o3")
+    if any(model_name.startswith(pre) for pre in openai_prefixes):
         return "openai"
     if model_name.startswith("claude"):
         return "anthropic"
@@ -508,6 +506,7 @@ def _attempt_infer_model_provider(model_name: str) -> Optional[str]:
     if model_name.startswith("sonar"):
         return "perplexity"
     return None
+
 
 
 def _parse_model(model: str, model_provider: Optional[str]) -> tuple[str, str]:

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -486,7 +486,7 @@ _SUPPORTED_PROVIDERS = {
 def _attempt_infer_model_provider(model_name: str) -> Optional[str]:
     if any(
         model_name.startswith(pre)
-        for pre in ("gpt-3", "gpt-4", "o1", "o3")
+        for pre in ("gpt-3", "gpt-4", "gpt-5", "o1", "o3")
     ):
         return "openai"
     if model_name.startswith("claude"):

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -484,7 +484,10 @@ _SUPPORTED_PROVIDERS = {
 
 
 def _attempt_infer_model_provider(model_name: str) -> Optional[str]:
-    if any(model_name.startswith(pre) for pre in ("gpt-3", "gpt-4", "gpt-5", "o1", "o3")):
+    if any(
+        model_name.startswith(pre)
+        for pre in ("gpt-3", "gpt-4", "o1", "o3")
+    ):
         return "openai"
     if model_name.startswith("claude"):
         return "anthropic"

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -484,7 +484,7 @@ _SUPPORTED_PROVIDERS = {
 
 
 def _attempt_infer_model_provider(model_name: str) -> Optional[str]:
-    if any(model_name.startswith(pre) for pre in ("gpt-3", "gpt-4", "o1", "o3")):
+    if any(model_name.startswith(pre) for pre in ("gpt-3", "gpt-4", "gpt-5", "o1", "o3")):
         return "openai"
     if model_name.startswith("claude"):
         return "anthropic"


### PR DESCRIPTION
Just add the string "gpt-5" to the _attempt_infer_model_provider‎ method so we can still infer the correct provider for these models.