### PR TITLE
docs(docs): add missing name to AIMessage in example

### DIFF
--- a/docs/docs/how_to/structured_output.ipynb
+++ b/docs/docs/how_to/structured_output.ipynb
@@ -614,6 +614,7 @@
     "    HumanMessage(\"Now about caterpillars\", name=\"example_user\"),\n",
     "    AIMessage(\n",
     "        \"\",\n",
+    "        name=\"example_assistant\",\n",
     "        tool_calls=[\n",
     "            {\n",
     "                \"name\": \"joke\",\n",


### PR DESCRIPTION
**Description:**

In the `docs/docs/how_to/structured_output.ipynb` notebook, an `AIMessage` within the tool-calling few-shot example was missing the `name="example_assistant"` parameter. This was inconsistent with the other `AIMessage` instances in the same list.

This change adds the missing `name` parameter to ensure all examples in the section are consistent, improving the clarity and correctness of the documentation.

**Issue:** N/A

**Dependencies:** N/A
