### PR TITLE
fix(deepseek): correct ls_provider in ChatDeepSeek._get_ls_params

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -16,7 +16,7 @@ from langchain_core.messages import AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGenerationChunk, ChatResult
 from langchain_core.runnables import Runnable
 from langchain_core.utils import from_env, secret_from_env
-from langchain_core.utils.pydantic import LangSmithParams
+from langchain_core.language_models.chat_models import LangSmithParams
 from langchain_openai.chat_models.base import BaseChatOpenAI
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self

--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -16,6 +16,7 @@ from langchain_core.messages import AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGenerationChunk, ChatResult
 from langchain_core.runnables import Runnable
 from langchain_core.utils import from_env, secret_from_env
+from langchain_core.utils.pydantic import LangSmithParams
 from langchain_openai.chat_models.base import BaseChatOpenAI
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self

--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -218,6 +218,14 @@ class ChatDeepSeek(BaseChatOpenAI):
             )
             self.async_client = self.root_async_client.chat.completions
         return self
+        
+    def _get_ls_params(
+        self, stop: Optional[list[str]] = None, **kwargs: Any
+    ) -> LangSmithParams:
+        """Get standard params for tracing."""
+        ls_params = super()._get_ls_params(stop=stop, **kwargs)
+        ls_params["ls_provider"] = "deepseek"
+        return ls_params
 
     def _get_request_payload(
         self,


### PR DESCRIPTION
**Description:** Fix issue where ChatDeepSeek class incorrectly reports ls_provider="openai" instead of "deepseek" when using LangSmith tracing. This is a minimal fix that overrides the _get_ls_params method to set the correct provider name.

**Issue:** Fixes #32484

**Dependencies:** None