### PR TITLE
docs(docs): fix grammar in "How to deal with high-cardinality categoricals" guide title

### DIFF
--- a/docs/docs/how_to/query_high_cardinality.ipynb
+++ b/docs/docs/how_to/query_high_cardinality.ipynb
@@ -15,7 +15,7 @@
    "id": "f2195672-0cab-4967-ba8a-c6544635547d",
    "metadata": {},
    "source": [
-    "# How deal with high cardinality categoricals when doing query analysis\n",
+    "# How to deal with high-cardinality categoricals when doing query analysis\n",
     "\n",
     "You may want to do query analysis to create a filter on a categorical column. One of the difficulties here is that you usually need to specify the EXACT categorical value. The issue is you need to make sure the LLM generates that categorical value exactly. This can be done relatively easy with prompting when there are only a few values that are valid. When there are a high number of valid values then it becomes more difficult, as those values may not fit in the LLM context, or (if they do) there may be too many for the LLM to properly attend to.\n",
     "\n",


### PR DESCRIPTION
Description:
Corrected the guide title from "How deal with high cardinality categoricals" to "How to deal with high-cardinality categoricals".
- Added missing "to" for grammatical correctness.
- Hyphenated "high-cardinality" for standard compound adjective usage.

Issue:
N/A

Dependencies:
None

Twitter handle:
https://x.com/mishraravibhush
