### PR TITLE
docs(docs): remove redundant integration details from ChatGradient page.

### DIFF
--- a/docs/docs/integrations/providers/gradientai.mdx
+++ b/docs/docs/integrations/providers/gradientai.mdx
@@ -2,17 +2,10 @@
 
 This will help you getting started with DigitalOcean Gradient [chat models](/docs/concepts/chat_models).
 
-## Overview
-### Integration details
-
-| Class | Package | Package downloads | Package latest |
-| :--- | :--- | :---: | :---: |
-| [ChatGradient](https://python.langchain.com/api_reference/langchain-gradient/chat_models/langchain_gradient.chat_models.ChatGradient.html) | [langchain-gradient](https://python.langchain.com/api_reference/langchain-gradient/) | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-gradient?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-gradient?style=flat-square&label=%20) |
-
 
 ## Setup
 
-langchain-gradient uses DigitalOcean Gradient Platform.
+langchain-gradient uses DigitalOcean's Gradient™ AI Platform.
 
 Create an account on DigitalOcean, acquire a `DIGITALOCEAN_INFERENCE_KEY` API key from the Gradient Platform, and install the `langchain-gradient` integration package.
 


### PR DESCRIPTION
This commit removes redundant integration info from details page, additionally, changing reference from "DigitalOcean GradientAI" to "DigitalOcean Gradient™ AI" and updating the setup instructions accordingly.