### PR TITLE
fix(anthropic): incorrect `input_tokens` counting while streaming

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2065,20 +2065,12 @@ def _make_message_chunk_from_anthropic_event(
     message_chunk: Optional[AIMessageChunk] = None
     # See https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/streaming/_messages.py  # noqa: E501
     if event.type == "message_start" and stream_usage:
-        usage_metadata = _create_usage_metadata(event.message.usage)
-        # We pick up a cumulative count of output_tokens at the end of the stream,
-        # so here we zero out to avoid double counting.
-        usage_metadata["total_tokens"] = (
-            usage_metadata["total_tokens"] - usage_metadata["output_tokens"]
-        )
-        usage_metadata["output_tokens"] = 0
         if hasattr(event.message, "model"):
             response_metadata = {"model_name": event.message.model}
         else:
             response_metadata = {}
         message_chunk = AIMessageChunk(
             content="" if coerce_content_to_string else [],
-            usage_metadata=usage_metadata,
             response_metadata=response_metadata,
         )
     elif (
@@ -2159,14 +2151,9 @@ def _make_message_chunk_from_anthropic_event(
                 tool_call_chunks=tool_call_chunks,
             )
     elif event.type == "message_delta" and stream_usage:
-        usage_metadata = UsageMetadata(
-            input_tokens=0,
-            output_tokens=event.usage.output_tokens,
-            total_tokens=event.usage.output_tokens,
-        )
         message_chunk = AIMessageChunk(
             content="",
-            usage_metadata=usage_metadata,
+            usage_metadata=_create_usage_metadata(event.usage),
             response_metadata={
                 "stop_reason": event.delta.stop_reason,
                 "stop_sequence": event.delta.stop_sequence,


### PR DESCRIPTION
Supersedes: https://github.com/langchain-ai/langchain/pull/32461

From docs: 

https://docs.anthropic.com/en/docs/build-with-claude/streaming#event-types
> The token counts shown in the usage field of the message_delta event are cumulative.

I realised my mistake in the previous PR, that the token counting is actually a cumulative sum. Therefore, langchain should emit the input_tokens count as is, if they exist in the event. 

And the responsibility can lie with the API consumer, to only pick up the max available value for any given token type. 

