### PR TITLE
docs: fixed additional grammar and style issues in how-to index

### DIFF
--- a/docs/docs/how_to/index.mdx
+++ b/docs/docs/how_to/index.mdx
@@ -47,7 +47,7 @@ See [supported integrations](/docs/integrations/chat/) for details on getting st
 - [How to: use chat model to call tools](/docs/how_to/tool_calling)
 - [How to: stream tool calls](/docs/how_to/tool_streaming)
 - [How to: handle rate limits](/docs/how_to/chat_model_rate_limiting)
-- [How to: few shot prompt tool behavior](/docs/how_to/tools_few_shot)
+- [How to: few-shot prompt tool behavior](/docs/how_to/tools_few_shot)
 - [How to: bind model-specific formatted tools](/docs/how_to/tools_model_specific)
 - [How to: force a specific tool call](/docs/how_to/tool_choice)
 - [How to: pass multimodal data directly to models](/docs/how_to/multimodal_inputs/)
@@ -64,8 +64,8 @@ See [supported integrations](/docs/integrations/chat/) for details on getting st
 
 [Prompt Templates](/docs/concepts/prompt_templates) are responsible for formatting user input into a format that can be passed to a language model.
 
-- [How to: use few shot examples](/docs/how_to/few_shot_examples)
-- [How to: use few shot examples in chat models](/docs/how_to/few_shot_examples_chat/)
+- [How to: use few-shot examples](/docs/how_to/few_shot_examples)
+- [How to: use few-shot examples in chat models](/docs/how_to/few_shot_examples_chat/)
 - [How to: partially format prompt templates](/docs/how_to/prompts_partial)
 - [How to: compose prompts together](/docs/how_to/prompts_composition)
 - [How to: use multimodal prompts](/docs/how_to/multimodal_prompts/)
@@ -168,7 +168,7 @@ See [supported integrations](/docs/integrations/vectorstores/) for details on ge
 
 Indexing is the process of keeping your vectorstore in-sync with the underlying data source.
 
-- [How to: reindex data to keep your vectorstore in-sync with the underlying data source](/docs/how_to/indexing)
+- [How to: reindex data to keep your vectorstore in sync with the underlying data source](/docs/how_to/indexing)
 
 ### Tools
 
@@ -178,7 +178,7 @@ LangChain [Tools](/docs/concepts/tools) contain a description of the tool (to pa
 - [How to: use built-in tools and toolkits](/docs/how_to/tools_builtin)
 - [How to: use chat models to call tools](/docs/how_to/tool_calling)
 - [How to: pass tool outputs to chat models](/docs/how_to/tool_results_pass_to_model)
-- [How to: pass run time values to tools](/docs/how_to/tool_runtime)
+- [How to: pass runtime values to tools](/docs/how_to/tool_runtime)
 - [How to: add a human-in-the-loop for tools](/docs/how_to/tools_human)
 - [How to: handle tool errors](/docs/how_to/tools_error)
 - [How to: force models to call a tool](/docs/how_to/tool_choice)
@@ -297,7 +297,7 @@ For a high-level tutorial, check out [this guide](/docs/tutorials/sql_qa/).
 You can use an LLM to do question answering over graph databases.
 For a high-level tutorial, check out [this guide](/docs/tutorials/graph/).
 
-- [How to: add a semantic layer over the database](/docs/how_to/graph_semantic)
+- [How to: add a semantic layer over a database](/docs/how_to/graph_semantic)
 - [How to: construct knowledge graphs](/docs/how_to/graph_constructing)
 
 ### Summarization


### PR DESCRIPTION
- Fix 'few shot' → 'few-shot' (add hyphen for consistency)
- Fix 'over the database' → 'over a database' (add missing article)
- Fix 'run time' → 'runtime' (more consistent terminology)
- Fix 'in-sync' → 'in sync' (remove unnecessary hyphen)