### PR TITLE
docs(ollama): update API usage examples

### DIFF
--- a/docs/docs/integrations/chat/ollama.ipynb
+++ b/docs/docs/integrations/chat/ollama.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# ChatOllama\n",
     "\n",
-    "[Ollama](https://ollama.com/) allows you to run open-source large language models, such as `got-oss`, locally.\n",
+    "[Ollama](https://ollama.com/) allows you to run open-source large language models, such as `gpt-oss`, locally.\n",
     "\n",
     "`ollama` bundles model weights, configuration, and data into a single package, defined by a Modelfile.\n",
     "\n",


### PR DESCRIPTION
**Description**  
Corrected a typo in the Ollama chatbot example output in  
`docs/docs/integrations/chat/ollama.ipynb` where `"got-oss"` was  
mistakenly used instead of `"gpt-oss"`.

No functional changes to code; documentation-only update.  
All notebook outputs were cleared to keep the diff minimal.

**Issue**  
N/A

**Dependencies**  
None

**Twitter handle**  
N/A