### PR TITLE
docs(docs): update broken link docs/docs/…

### DIFF
--- a/docs/docs/tutorials/index.mdx
+++ b/docs/docs/tutorials/index.mdx
@@ -10,27 +10,27 @@ New to LangChain or LLM app development in general? Read this material to quickl
 
 Familiarize yourself with LangChain's open-source components by building simple applications.
 
-If you're looking to get started with [chat models](/docs/integrations/chat/), [vector stores](/docs/integrations/vectorstores/),
-or other LangChain components from a specific provider, check out our supported [integrations](/docs/integrations/providers/).
+If you're looking to get started with [chat models](/docs/docs/integrations/chat/), [vector stores](/docs/docs/integrations/vectorstores/),
+or other LangChain components from a specific provider, check out our supported [integrations](/docs/docs/integrations/providers/).
 
-- [Chat models and prompts](/docs/tutorials/llm_chain): Build a simple LLM application with [prompt templates](/docs/concepts/prompt_templates) and [chat models](/docs/concepts/chat_models).
-- [Semantic search](/docs/tutorials/retrievers): Build a semantic search engine over a PDF with [document loaders](/docs/concepts/document_loaders), [embedding models](/docs/concepts/embedding_models/), and [vector stores](/docs/concepts/vectorstores/).
-- [Classification](/docs/tutorials/classification): Classify text into categories or labels using [chat models](/docs/concepts/chat_models) with [structured outputs](/docs/concepts/structured_outputs/).
-- [Extraction](/docs/tutorials/extraction): Extract structured data from text and other unstructured media using [chat models](/docs/concepts/chat_models) and [few-shot examples](/docs/concepts/few_shot_prompting/).
+- [Chat models and prompts](/docs/docs/tutorials/llm_chain): Build a simple LLM application with [prompt templates](/docs/docs/concepts/prompt_templates) and [chat models](/docs/docs/concepts/chat_models).
+- [Semantic search](/docs/docs/tutorials/retrievers): Build a semantic search engine over a PDF with [document loaders](/docs/docs/concepts/document_loaders), [embedding models](/docs/docs/concepts/embedding_models/), and [vector stores](/docs/docs/concepts/vectorstores/).
+- [Classification](/docs/docs/tutorials/classification): Classify text into categories or labels using [chat models](/docs/docs/concepts/chat_models) with [structured outputs](/docs/docs/concepts/structured_outputs/).
+- [Extraction](/docs/docs/tutorials/extraction): Extract structured data from text and other unstructured media using [chat models](/docs/docs/concepts/chat_models) and [few-shot examples](/docs/docs/concepts/few_shot_prompting/).
 
-Refer to the [how-to guides](/docs/how_to) for more detail on using all LangChain components.
+Refer to the [how-to guides](/docs/docs/how_to) for more detail on using all LangChain components.
 
 ## Orchestration
 
 Get started using [LangGraph](https://langchain-ai.github.io/langgraph/) to assemble LangChain components into full-featured applications.
 
-- [Chatbots](/docs/tutorials/chatbot): Build a chatbot that incorporates memory.
-- [Agents](/docs/tutorials/agents): Build an agent that interacts with external tools.
-- [Retrieval Augmented Generation (RAG) Part 1](/docs/tutorials/rag): Build an application that uses your own documents to inform its responses.
-- [Retrieval Augmented Generation (RAG) Part 2](/docs/tutorials/qa_chat_history): Build a RAG application that incorporates a memory of its user interactions and multi-step retrieval.
-- [Question-Answering with SQL](/docs/tutorials/sql_qa): Build a question-answering system that executes SQL queries to inform its responses.
-- [Summarization](/docs/tutorials/summarization): Generate summaries of (potentially long) texts.
-- [Question-Answering with Graph Databases](/docs/tutorials/graph): Build a question-answering system that queries a graph database to inform its responses.
+- [Chatbots](/docs/docs/tutorials/chatbot): Build a chatbot that incorporates memory.
+- [Agents](/docs/docs/tutorials/agents): Build an agent that interacts with external tools.
+- [Retrieval Augmented Generation (RAG) Part 1](/docs/docs/tutorials/rag): Build an application that uses your own documents to inform its responses.
+- [Retrieval Augmented Generation (RAG) Part 2](/docs/docs/tutorials/qa_chat_history): Build a RAG application that incorporates a memory of its user interactions and multi-step retrieval.
+- [Question-Answering with SQL](/docs/docs/tutorials/sql_qa): Build a question-answering system that executes SQL queries to inform its responses.
+- [Summarization](/docs/docs/tutorials/summarization): Generate summaries of (potentially long) texts.
+- [Question-Answering with Graph Databases](/docs/docs/tutorials/graph): Build a question-answering system that queries a graph database to inform its responses.
 
 ## LangSmith
 


### PR DESCRIPTION
Update all internal documentation links in [index.mdx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to reflect the new [docs](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) folder structure. This ensures that all references to concepts, integrations, tutorials, and how-to guides point to the correct locations after the folder reorganization, preventing broken links and improving navigation throughout the documentation.

Issue:
No related issue.

Dependencies:
No new dependencies required.

Twitter handle:
https://x.com/mishraravibhush