### PR TITLE
feat(text-splitters): add support for batched length function in `TextSplitter`

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/base.py
+++ b/libs/text-splitters/langchain_text_splitters/base.py
@@ -31,6 +31,7 @@ except ImportError:
 
 try:
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
+    from transformers.tokenization_utils_fast import PreTrainedTokenizerFast
 
     _HAS_TRANSFORMERS = True
 except ImportError:
@@ -50,6 +51,8 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         chunk_overlap: int = 200,
         length_function: Callable[[str], int] = len,
         keep_separator: bool | Literal["start", "end"] = False,  # noqa: FBT001,FBT002
+        batched_length_function: Literal[False]  # noqa: FBT002
+        | Callable[[list[str]], list[int]] = False,
         add_start_index: bool = False,  # noqa: FBT001,FBT002
         strip_whitespace: bool = True,  # noqa: FBT001,FBT002
     ) -> None:
@@ -59,6 +62,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
             chunk_size: Maximum size of chunks to return
             chunk_overlap: Overlap in characters between chunks
             length_function: Function that measures the length of given chunks
+            batched_length_function: Function that measures chunk lengths in batches
             keep_separator: Whether to keep the separator and where to place it
                 in each corresponding chunk `(True='start')`
             add_start_index: If `True`, includes chunk's start index in metadata
@@ -85,6 +89,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         self._chunk_size = chunk_size
         self._chunk_overlap = chunk_overlap
         self._length_function = length_function
+        self._batched_length_function = batched_length_function
         self._keep_separator = keep_separator
         self._add_start_index = add_start_index
         self._strip_whitespace = strip_whitespace
@@ -149,16 +154,32 @@ class TextSplitter(BaseDocumentTransformer, ABC):
             text = text.strip()
         return text or None
 
-    def _merge_splits(self, splits: Iterable[str], separator: str) -> list[str]:
+    def _iter_text_lengths(self, texts: Iterable[str]) -> Iterable[int]:
+        if self._batched_length_function is not False:
+            if not isinstance(texts, list):
+                texts = list(texts)
+            lengths = self._batched_length_function(texts)
+            yield from lengths
+        else:
+            for text in texts:
+                yield self._length_function(text)
+
+    def _merge_splits(
+        self,
+        splits: Iterable[str],
+        separator: str,
+        lengths: Literal[False] | Iterable[int] = False,  # noqa: FBT002
+    ) -> list[str]:
         # We now want to combine these smaller pieces into medium size
         # chunks to send to the LLM.
-        separator_len = self._length_function(separator)
+        separator_len = self._text_length(separator)
 
         docs = []
         current_doc: list[str] = []
+        current_doc_lengths: list[int] = []
         total = 0
-        for d in splits:
-            len_ = self._length_function(d)
+        split_lengths = lengths or self._iter_text_lengths(splits)
+        for d, len_ in zip(splits, split_lengths, strict=True):
             if (
                 total + len_ + (separator_len if len(current_doc) > 0 else 0)
                 > self._chunk_size
@@ -182,25 +203,36 @@ class TextSplitter(BaseDocumentTransformer, ABC):
                         > self._chunk_size
                         and total > 0
                     ):
-                        total -= self._length_function(current_doc[0]) + (
+                        total -= current_doc_lengths[0] + (
                             separator_len if len(current_doc) > 1 else 0
                         )
                         current_doc = current_doc[1:]
+                        current_doc_lengths = current_doc_lengths[1:]
             current_doc.append(d)
+            current_doc_lengths.append(len_)
             total += len_ + (separator_len if len(current_doc) > 1 else 0)
         doc = self._join_docs(current_doc, separator)
         if doc is not None:
             docs.append(doc)
         return docs
 
+    def _text_length(self, text: str) -> int:
+        if self._batched_length_function is not False:
+            return self._batched_length_function([text])[0]
+        return self._length_function(text)
+
     @classmethod
     def from_huggingface_tokenizer(
-        cls, tokenizer: PreTrainedTokenizerBase, **kwargs: Any
+        cls,
+        tokenizer: PreTrainedTokenizerBase,
+        batched: bool = False,  # noqa: FBT001,FBT002
+        **kwargs: Any,
     ) -> TextSplitter:
         """Text splitter that uses Hugging Face tokenizer to count length.
 
         Args:
             tokenizer: The Hugging Face tokenizer to use.
+            batched: Whether to use batched tokenization.
 
         Returns:
             An instance of `TextSplitter` using the Hugging Face tokenizer for length
@@ -217,10 +249,24 @@ class TextSplitter(BaseDocumentTransformer, ABC):
             msg = "Tokenizer received was not an instance of PreTrainedTokenizerBase"  # type: ignore[unreachable]
             raise ValueError(msg)  # noqa: TRY004
 
+        if batched is False and isinstance(tokenizer, PreTrainedTokenizerFast):
+            # Take advantage of huggingface's fast tokenizers
+            # by batching tokenization of splits
+            batched = True
+
         def _huggingface_tokenizer_length(text: str) -> int:
             return len(tokenizer.tokenize(text))
 
-        return cls(length_function=_huggingface_tokenizer_length, **kwargs)
+        def _huggingface_tokenizer_batched_length(texts: list[str]) -> list[int]:
+            return tokenizer(texts, truncation=False, return_length=True).length  # type: ignore[no-any-return]
+
+        return cls(
+            length_function=_huggingface_tokenizer_length,
+            batched_length_function=_huggingface_tokenizer_batched_length
+            if batched
+            else False,
+            **kwargs,
+        )
 
     @classmethod
     def from_tiktoken_encoder(

--- a/libs/text-splitters/langchain_text_splitters/base.py
+++ b/libs/text-splitters/langchain_text_splitters/base.py
@@ -51,8 +51,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         chunk_overlap: int = 200,
         length_function: Callable[[str], int] = len,
         keep_separator: bool | Literal["start", "end"] = False,  # noqa: FBT001,FBT002
-        batched_length_function: Literal[False]  # noqa: FBT002
-        | Callable[[list[str]], list[int]] = False,
+        batched_length_function: Callable[[list[str]], list[int]] | None = None,
         add_start_index: bool = False,  # noqa: FBT001,FBT002
         strip_whitespace: bool = True,  # noqa: FBT001,FBT002
     ) -> None:
@@ -155,7 +154,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         return text or None
 
     def _iter_text_lengths(self, texts: Iterable[str]) -> Iterable[int]:
-        if self._batched_length_function is not False:
+        if self._batched_length_function:
             if not isinstance(texts, list):
                 texts = list(texts)
             lengths = self._batched_length_function(texts)
@@ -168,7 +167,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         self,
         splits: Iterable[str],
         separator: str,
-        lengths: Literal[False] | Iterable[int] = False,  # noqa: FBT002
+        lengths: Iterable[int] | None = None,
     ) -> list[str]:
         # We now want to combine these smaller pieces into medium size
         # chunks to send to the LLM.
@@ -217,7 +216,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         return docs
 
     def _text_length(self, text: str) -> int:
-        if self._batched_length_function is not False:
+        if self._batched_length_function:
             return self._batched_length_function([text])[0]
         return self._length_function(text)
 
@@ -264,7 +263,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
             length_function=_huggingface_tokenizer_length,
             batched_length_function=_huggingface_tokenizer_batched_length
             if batched
-            else False,
+            else None,
             **kwargs,
         )
 

--- a/libs/text-splitters/tests/integration_tests/test_text_splitter.py
+++ b/libs/text-splitters/tests/integration_tests/test_text_splitter.py
@@ -2,6 +2,7 @@
 
 import pytest
 from transformers import GPT2TokenizerFast
+from transformers.models.gpt2 import GPT2Tokenizer
 
 from langchain_text_splitters import (
     TokenTextSplitter,
@@ -23,9 +24,19 @@ def test_huggingface_type_check() -> None:
 
 def test_huggingface_tokenizer() -> None:
     """Test text splitter that uses a HuggingFace tokenizer."""
-    tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
+    tokenizer = GPT2Tokenizer.from_pretrained("gpt2")
     text_splitter = CharacterTextSplitter.from_huggingface_tokenizer(
         tokenizer, separator=" ", chunk_size=1, chunk_overlap=0
+    )
+    output = text_splitter.split_text("foo bar")
+    assert output == ["foo", "bar"]
+
+
+def test_huggingface_tokenizer_fast() -> None:
+    """Test text splitter that uses a fast HuggingFace tokenizer with batched=True."""
+    tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
+    text_splitter = CharacterTextSplitter.from_huggingface_tokenizer(
+        tokenizer, batched=True, separator=" ", chunk_size=1, chunk_overlap=0
     )
     output = text_splitter.split_text("foo bar")
     assert output == ["foo", "bar"]

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -446,6 +446,43 @@ Bye!\n\n-H."""
     assert output == expected_output
 
 
+def test_batched_recursive_character_text_splitter() -> None:
+    """Test recursive text splitter with batched length."""
+    num_batched_length_calls = 0
+    num_unbatched_length_calls = 0
+
+    def _batched_length(texts: list[str]) -> list[int]:
+        nonlocal num_batched_length_calls
+        num_batched_length_calls += 1
+        return [len(text) for text in texts]
+
+    def _length(text: str) -> int:
+        nonlocal num_unbatched_length_calls
+        num_unbatched_length_calls += 1
+        return len(text)
+
+    kwargs: dict[str, Any] = {
+        "separators": ["\n", " "],
+        "keep_separator": False,
+        "chunk_size": 3,
+        "chunk_overlap": 0,
+    }
+    batched_text_splitter = RecursiveCharacterTextSplitter(
+        batched_length_function=_batched_length,
+        **kwargs,
+    )
+    text_splitter = RecursiveCharacterTextSplitter(
+        length_function=_length,
+        **kwargs,
+    )
+    input_text = "a b\nc d"
+    batched_output = batched_text_splitter.split_text(input_text)
+    unbatched_output = text_splitter.split_text(input_text)
+    assert batched_output == ["a b", "c d"]
+    assert batched_output == unbatched_output
+    assert num_batched_length_calls < num_unbatched_length_calls
+
+
 def test_split_documents() -> None:
     """Test split_documents."""
     splitter = CharacterTextSplitter(separator="", chunk_size=1, chunk_overlap=0)


### PR DESCRIPTION
PS: This PR is based on the work of @bhperry. Around 90% of the code comes from https://github.com/langchain-ai/langchain/pull/5583.
That PR was closed due to conflicts, and I found it easier to restart from an up to date branch.
All I did was make a few changes so it could pass the formatter and linter, updated the doc and integration tests.

If there’s a way to give him nearly full credit for this work within this PR, please let me know.

**Description**

Enable batching optimization when using token-based splitters.

Currently, each text split is tokenized individually, which makes the splitter very slow on large documents, especially compared to how fast HuggingFace tokenizers can be with batching.

**Tests**

Added a unit test (`test_batched_recursive_character_text_splitter`) verifying that `batched_length_functions` introduces no regressions and outperforms `simple_length_function`.

Changed the integration test `test_huggingface_tokenizer` so it uses a base tokenizer, verifying it still works as intended.

Added the integration test `test_huggingface_tokenizer_fast` to verify that the use of the fast tokenizer and batching works as intended.

**Dependencies**

No new dependencies added or changed.

