### PR TITLE
fix(docs): update LangGraph guides link and add JS how-to link

### DIFF
--- a/docs/docs/how_to/index.mdx
+++ b/docs/docs/how_to/index.mdx
@@ -345,7 +345,8 @@ LangGraph is an extension of LangChain aimed at
 building robust and stateful multi-actor applications with LLMs by modeling steps as edges and nodes in a graph.
 
 LangGraph documentation is currently hosted on a separate site.
-You can peruse [LangGraph how-to guides here](https://langchain-ai.github.io/langgraph/how-tos/).
+You can find the [LangGraph guides here](https://langchain-ai.github.io/langgraph/guides/).
+For LangGraph.js, see the [LangGraph.js how-to guides here](https://langchain-ai.github.io/langgraphjs/how-tos/).
 
 ## [LangSmith](https://docs.smith.langchain.com/)
 

--- a/docs/docs/how_to/index.mdx
+++ b/docs/docs/how_to/index.mdx
@@ -346,7 +346,6 @@ building robust and stateful multi-actor applications with LLMs by modeling step
 
 LangGraph documentation is currently hosted on a separate site.
 You can find the [LangGraph guides here](https://langchain-ai.github.io/langgraph/guides/).
-For LangGraph.js, see the [LangGraph.js how-to guides here](https://langchain-ai.github.io/langgraphjs/how-tos/).
 
 ## [LangSmith](https://docs.smith.langchain.com/)
 


### PR DESCRIPTION
**Description:**  
Corrected LangGraph documentation link (changed to “guides”), and added a link to LangGraph JS how-to guides for clarity.  

**Issue:**  
N/A  

**Dependencies:**  
None