### PR TITLE
fix(docs): Using appropriate argument name in ToolNode for error handling

### DIFF
--- a/docs/docs/how_to/custom_tools.ipynb
+++ b/docs/docs/how_to/custom_tools.ipynb
@@ -741,13 +741,13 @@
     "\n",
     "If you're using tools with agents, you will likely need an error handling strategy, so the agent can recover from the error and continue execution.\n",
     "\n",
-    "A simple strategy is to throw a `ToolException` from inside the tool and specify an error handler using `handle_tool_error`. \n",
+    "A simple strategy is to throw a `ToolException` from inside the tool and specify an error handler using `handle_tool_errors`. \n",
     "\n",
     "When the error handler is specified, the exception will be caught and the error handler will decide which output to return from the tool.\n",
     "\n",
-    "You can set `handle_tool_error` to `True`, a string value, or a function. If it's a function, the function should take a `ToolException` as a parameter and return a value.\n",
+    "You can set `handle_tool_errors` to `True`, a string value, or a function. If it's a function, the function should take a `ToolException` as a parameter and return a value.\n",
     "\n",
-    "Please note that only raising a `ToolException` won't be effective. You need to first set the `handle_tool_error` of the tool because its default value is `False`."
+    "Please note that only raising a `ToolException` won't be effective. You need to first set the `handle_tool_errors` of the tool because its default value is `False`."
    ]
   },
   {
@@ -777,7 +777,7 @@
    "id": "9d93b217-1d44-4d31-8956-db9ea680ff4f",
    "metadata": {},
    "source": [
-    "Here's an example with the default `handle_tool_error=True` behavior."
+    "Here's an example with the default `handle_tool_errors=True` behavior."
    ]
   },
   {
@@ -807,7 +807,7 @@
    "source": [
     "get_weather_tool = StructuredTool.from_function(\n",
     "    func=get_weather,\n",
-    "    handle_tool_error=True,\n",
+    "    handle_tool_errors=True,\n",
     ")\n",
     "\n",
     "get_weather_tool.invoke({\"city\": \"foobar\"})"
@@ -818,7 +818,7 @@
    "id": "f91d6dc0-3271-4adc-a155-21f2e62ffa56",
    "metadata": {},
    "source": [
-    "We can set `handle_tool_error` to a string that will always be returned."
+    "We can set `handle_tool_errors` to a string that will always be returned."
    ]
   },
   {
@@ -848,7 +848,7 @@
    "source": [
     "get_weather_tool = StructuredTool.from_function(\n",
     "    func=get_weather,\n",
-    "    handle_tool_error=\"There is no such city, but it's probably above 0K there!\",\n",
+    "    handle_tool_errors=\"There is no such city, but it's probably above 0K there!\",\n",
     ")\n",
     "\n",
     "get_weather_tool.invoke({\"city\": \"foobar\"})"
@@ -893,7 +893,7 @@
     "\n",
     "get_weather_tool = StructuredTool.from_function(\n",
     "    func=get_weather,\n",
-    "    handle_tool_error=_handle_error,\n",
+    "    handle_tool_errors=_handle_error,\n",
     ")\n",
     "\n",
     "get_weather_tool.invoke({\"city\": \"foobar\"})"


### PR DESCRIPTION
The appropriate `ToolNode` attribute for error handling is called `handle_tool_errors` instead of `handle_tool_error`.

For further info see [ToolNode source code in LangGraph](https://github.com/langchain-ai/langgraph/blob/main/libs/prebuilt/langgraph/prebuilt/tool_node.py#L255)

**Twitter handle:** gitaroktato

- [x] **Add tests and docs**: If you're adding a new integration, you must include:
  1. A test for the integration, preferably unit tests that do not rely on network access,
  2. An example notebook showing its use. It lives in `docs/docs/integrations` directory.

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. **We will not consider a PR unless these three are passing in CI.** See [contribution guidelines](https://python.langchain.com/docs/contributing/) for more.

Additional guidelines:

- Make sure optional dependencies are imported within a function.
- Please do not add dependencies to `pyproject.toml` files (even optional ones) unless they are **required** for unit tests.
- Most PRs should not touch more than one package.
- Changes should be backwards compatible.
