### PR TITLE
fix(anthropic): clean up null `file_id` fields in citations during message formatting

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -397,14 +397,23 @@ def _format_messages(
                         # accepted.
                         # https://github.com/anthropics/anthropic-sdk-python/issues/461
                         if text.strip():
-                            content.append(
-                                {
-                                    k: v
-                                    for k, v in block.items()
-                                    if k
-                                    in ("type", "text", "cache_control", "citations")
-                                },
-                            )
+                            formatted_block = {
+                                k: v
+                                for k, v in block.items()
+                                if k in ("type", "text", "cache_control", "citations")
+                            }
+                            # Clean up citations to remove null file_id fields
+                            if formatted_block.get("citations"):
+                                cleaned_citations = []
+                                for citation in formatted_block["citations"]:
+                                    cleaned_citation = {
+                                        k: v
+                                        for k, v in citation.items()
+                                        if not (k == "file_id" and v is None)
+                                    }
+                                    cleaned_citations.append(cleaned_citation)
+                                formatted_block["citations"] = cleaned_citations
+                            content.append(formatted_block)
                     elif block["type"] == "thinking":
                         content.append(
                             {


### PR DESCRIPTION
When citations are returned from streaming, they include a `file_id: null` field in their `content_block_location` structure.

When these citations are passed back to the API in subsequent messages, the API rejects them with "Extra inputs are not permitted" for the `file_id` field.