### PR TITLE
feat(infra): add skip-preview tag check in Vercel deployment script

### DIFF
--- a/docs/ignore-step.sh
+++ b/docs/ignore-step.sh
@@ -5,6 +5,17 @@ echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
 echo "VERCEL_GIT_REPO_OWNER: $VERCEL_GIT_REPO_OWNER"
 echo "VERCEL_GIT_REPO_SLUG: $VERCEL_GIT_REPO_SLUG"
 
+# Check for skip-preview tags in commit message or PR
+echo "Checking for skip-preview tags..."
+COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+echo "Commit message: $COMMIT_MESSAGE"
+
+# Check if commit message contains skip-preview tags
+if [[ "$COMMIT_MESSAGE" == *"[skip-preview]"* ]] || [[ "$COMMIT_MESSAGE" == *"[no-preview]"* ]] || [[ "$COMMIT_MESSAGE" == *"[skip-deploy]"* ]]; then
+    echo "🛑 Skip-preview tag found in commit message - skipping preview deployment"
+    exit 0
+fi
+
 
 if  { \
         [ "$VERCEL_ENV" == "production" ] || \

--- a/docs/ignore-step.sh
+++ b/docs/ignore-step.sh
@@ -5,12 +5,9 @@ echo "VERCEL_GIT_COMMIT_REF: $VERCEL_GIT_COMMIT_REF"
 echo "VERCEL_GIT_REPO_OWNER: $VERCEL_GIT_REPO_OWNER"
 echo "VERCEL_GIT_REPO_SLUG: $VERCEL_GIT_REPO_SLUG"
 
-# Check for skip-preview tags in commit message or PR
 echo "Checking for skip-preview tags..."
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)
 echo "Commit message: $COMMIT_MESSAGE"
-
-# Check if commit message contains skip-preview tags
 if [[ "$COMMIT_MESSAGE" == *"[skip-preview]"* ]] || [[ "$COMMIT_MESSAGE" == *"[no-preview]"* ]] || [[ "$COMMIT_MESSAGE" == *"[skip-deploy]"* ]]; then
     echo "🛑 Skip-preview tag found in commit message - skipping preview deployment"
     exit 0
@@ -24,10 +21,10 @@ if  { \
         [ "$VERCEL_GIT_COMMIT_REF" == "v0.2" ] || \
         [ "$VERCEL_GIT_COMMIT_REF" == "v0.3rc" ]; \
     } && [ "$VERCEL_GIT_REPO_OWNER" == "langchain-ai" ]
-then 
+then
      echo "✅ Production build - proceeding with build"
      exit 1
-fi 
+fi
 
 
 echo "Checking for changes in docs/"


### PR DESCRIPTION
Having vercel attempt to deploy on each commit (even if unrelated to docs) was getting annoying. Options:

- `[skip-preview]`
- `[no-preview]`
- `[skip-deploy]`

Full example: `fix(core): resolve memory leak [no-preview]`

This shouldn't be used when merging into master