### PR TITLE
fix(openai): Chat Message `Annotations` defaults to `[ ]` if not list or None

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3875,8 +3875,8 @@ def _construct_lc_result_from_responses_api(
                         "annotations": [
                             annotation.model_dump()
                             for annotation in content.annotations
-                        ] 
-                        if isinstance(content.annotations, list) 
+                        ]
+                        if isinstance(content.annotations, list)
                         else [],
                         "id": output.id,
                     }

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3875,7 +3875,7 @@ def _construct_lc_result_from_responses_api(
                         "annotations": [
                             annotation.model_dump()
                             for annotation in content.annotations
-                        ],
+                        ] if isinstance(content.annotations, list) else [] ,
                         "id": output.id,
                     }
                     content_blocks.append(block)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3875,7 +3875,9 @@ def _construct_lc_result_from_responses_api(
                         "annotations": [
                             annotation.model_dump()
                             for annotation in content.annotations
-                        ] if isinstance(content.annotations, list) else [] ,
+                        ] 
+                        if isinstance(content.annotations, list) 
+                        else [],
                         "id": output.id,
                     }
                     content_blocks.append(block)


### PR DESCRIPTION
 **Description:** if annotation is not present or None, it shall default to empty list [ ]. Similar to line https://github.com/shahrukh-shaik/langchain/blob/09e70a346013f08304af608e6f4a3d9ed60d9aa4/libs/partners/openai/langchain_openai/chat_models/base.py#L3703 

