### PR TITLE
feat(openai): preserve reasoning field in `AIMessage`

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -167,6 +167,13 @@ class AIMessage(BaseMessage):
     At the moment, this is ignored by most models. Usage is discouraged.
     """
 
+    reasoning: Optional[str] = None
+    """An optional reasoning field for the message.
+
+    For example, in the case of a chain of thought model, this would be the reasoning
+    behind the output.
+    """
+
     tool_calls: list[ToolCall] = []
     """If provided, tool calls associated with the message."""
     invalid_tool_calls: list[InvalidToolCall] = []

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -142,6 +142,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
     role = _dict.get("role")
     name = _dict.get("name")
     id_ = _dict.get("id")
+    reasoning = _dict.get("reasoning")
+
     if role == "user":
         return HumanMessage(content=_dict.get("content", ""), id=id_, name=name)
     elif role == "assistant":
@@ -166,6 +168,7 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
             additional_kwargs["audio"] = audio
         return AIMessage(
             content=content,
+            reasoning=reasoning,
             additional_kwargs=additional_kwargs,
             name=name,
             id=id_,

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2673,3 +2673,14 @@ def test_extra_body_with_model_kwargs() -> None:
     assert payload["extra_body"]["ttl"] == 600
     assert payload["custom_non_openai_param"] == "test_value"
     assert payload["temperature"] == 0.5
+
+def test_convert_dict_preserves_reasoning() -> None:
+    """Test that _convert_dict_to_message preserves the 'reasoning' field."""
+    raw = {
+        "role": "assistant",
+        "content": "Hello!",
+        "reasoning": "I thought about greeting the user.",
+    }
+    msg = _convert_dict_to_message(raw)
+    assert isinstance(msg, AIMessage)
+    assert msg.reasoning == "I thought about greeting the user."

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2674,6 +2674,7 @@ def test_extra_body_with_model_kwargs() -> None:
     assert payload["custom_non_openai_param"] == "test_value"
     assert payload["temperature"] == 0.5
 
+
 def test_convert_dict_preserves_reasoning() -> None:
     """Test that _convert_dict_to_message preserves the 'reasoning' field."""
     raw = {

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.60.0"
+version = "0.64.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -192,9 +192,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/03/3334921dc54ed822b3dd993ae72d823a7402588521bbba3e024b3333a1fd/anthropic-0.60.0.tar.gz", hash = "sha256:a22ba187c6f4fd5afecb2fc913b960feccf72bc0d25c1b7ce0345e87caede577", size = 425983, upload-time = "2025-07-28T19:53:47.685Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/4f/f2b880cba1a76f3acc7d5eb2ae217632eac1b8cef5ed3027493545c59eba/anthropic-0.64.0.tar.gz", hash = "sha256:3d496c91a63dff64f451b3e8e4b238a9640bf87b0c11d0b74ddc372ba5a3fe58", size = 427893, upload-time = "2025-08-13T17:09:49.915Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/bb/d84f287fb1c217b30c328af987cf8bbe3897edf0518dcc5fa39412f794ec/anthropic-0.60.0-py3-none-any.whl", hash = "sha256:65ad1f088a960217aaf82ba91ff743d6c89e9d811c6d64275b9a7c59ee9ac3c6", size = 293116, upload-time = "2025-07-28T19:53:45.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b2/2d268bcd5d6441df9dc0ebebc67107657edb8b0150d3fda1a5b81d1bec45/anthropic-0.64.0-py3-none-any.whl", hash = "sha256:6f5f7d913a6a95eb7f8e1bda4e75f76670e8acd8d4cd965e02e2a256b0429dd1", size = 297244, upload-time = "2025-08-13T17:09:47.908Z" },
 ]
 
 [[package]]
@@ -2349,7 +2349,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "0.3.18"
+version = "0.3.19"
 source = { editable = "libs/partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2359,7 +2359,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.60.0,<1" },
+    { name = "anthropic", specifier = ">=0.64.0,<1" },
     { name = "langchain-core", editable = "libs/core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2367,7 +2367,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 codespell = [{ name = "codespell", specifier = ">=2.2.0,<3.0.0" }]
 dev = [{ name = "langchain-core", editable = "libs/core" }]
-lint = [{ name = "ruff", specifier = ">=0.12.2,<0.13" }]
+lint = [{ name = "ruff", specifier = ">=0.12.9,<0.13" }]
 test = [
     { name = "defusedxml", specifier = ">=0.7.1,<1.0.0" },
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -2389,7 +2389,7 @@ test-integration = [
 ]
 typing = [
     { name = "langchain-core", editable = "libs/core" },
-    { name = "mypy", specifier = ">=1.10,<2.0" },
+    { name = "mypy", specifier = ">=1.17.1,<2.0" },
     { name = "types-requests", specifier = ">=2.31.0" },
 ]
 


### PR DESCRIPTION
## Description  
Some local servers (e.g. LM Studio / GPT-OSS) return an extra `reasoning` field in the chat response.  
This PR adds `AIMessage.reasoning: Optional[str]` and keeps the value during message conversion, ensuring downstream code can access it without breaking compatibility.

## Issue  
Fixes #32613

## Dependencies  
None – only uses existing LangChain-Core and OpenAI packages.

## Tests  
- Unit test: `test_convert_dict_preserves_reasoning` in `libs/partners/openai/tests/unit_tests/chat_models/test_base.py`  
- All existing tests still pass.

## Lint / Format  
```bash
cd libs/partners/openai
make format && make lint && make test
All green ✅
Backwards compatibility
Yes – the new field is optional and defaults to None; no public API changes.