### PR TITLE
docs: add unified LLM loader example for OpenAI, Groq, Ollama, OpenRouter

### DIFF
--- a/docs/docs/tutorials/llm_loader.ipynb
+++ b/docs/docs/tutorials/llm_loader.ipynb
@@ -1,0 +1,152 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "393f807b-1960-4b56-b2ab-de5636dc35b3",
+   "metadata": {},
+   "source": [
+    "# Tutorial: Loading different LLM providers with a unified helper function.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2d95705-6448-474c-87cf-c5770e001ea4",
+   "metadata": {},
+   "source": [
+    "This example demonstrates how to use the `load_llm` utility to easily switch \n",
+    "between multiple LLM providers (OpenAI, OpenRouter, Groq, Ollama) without \n",
+    "changing downstream code. The `load_llm` function abstracts away provider-specific \n",
+    "setup and returns a LangChain-compatible LLM instance.\n",
+    "\n",
+    "🔑 API Key Setup:\n",
+    "- Store your API keys in a `.env` file in the project root.\n",
+    "- The keys will be automatically loaded when `llm_loader` is imported.\n",
+    "\n",
+    "Example `.env` file:\n",
+    "\n",
+    "    OPENAI_API_KEY=your_openai_key_here\n",
+    "    OPENROUTER_API_KEY=your_openrouter_key_here\n",
+    "    GROQ_API_KEY=your_groq_key_here\n",
+    "\n",
+    "👉 For Ollama, no API key is required (runs locally).\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "79d91bf5-42d5-4d2b-8574-3587d63f3c8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from llm_loader import load_llm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6aa0c433-161d-42f4-a782-1bf7be688bca",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# --- OpenAI Example ---\n",
+    "# Loads an OpenAI model (here, GPT-4o-mini).\n",
+    "# Requires a valid OpenAI API key in your environment (.env or system variable).\n",
+    "llm = load_llm(\"openai\", \"gpt-4o-mini\")\n",
+    "print(llm.invoke(\"Hello from OpenAI!\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "68d5c174-0718-4048-bb16-362bad79e4ed",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "content='Hello! 👋 How can I help you today?' additional_kwargs={'refusal': None} response_metadata={'token_usage': {'completion_tokens': 90, 'prompt_tokens': 76, 'total_tokens': 166, 'completion_tokens_details': None, 'prompt_tokens_details': None}, 'model_name': 'openai/gpt-oss-20b:free', 'system_fingerprint': None, 'id': 'gen-1755707385-JsQdKdbu290XqI1iG22Q', 'service_tier': None, 'finish_reason': 'stop', 'logprobs': None} id='run--a0bc7ae6-fee2-45cc-bb41-9f5401b8fbc7-0' usage_metadata={'input_tokens': 76, 'output_tokens': 90, 'total_tokens': 166, 'input_token_details': {}, 'output_token_details': {}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- OpenRouter Example ---\n",
+    "# Loads a model via OpenRouter (a router service that provides access to multiple LLMs).\n",
+    "# In this case, it uses the open-source GPT-OSS-20B model (free tier).\n",
+    "# Requires OPENROUTER_API_KEY in your environment.\n",
+    "llm = load_llm(\"openrouter\", \"openai/gpt-oss-20b:free\")\n",
+    "print(llm.invoke(\"Hello from OpenRouter!\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "67bf4a67-7461-490c-814a-77af5afa7626",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "content='Hello from me as well. Groq is a company known for its high-performance AI computing hardware. They specialize in developing custom ASICs (Application-Specific Integrated Circuits) for AI workloads. Their technology is designed to accelerate AI inference and training, making it a key player in the AI hardware space. What brings you to this conversation today?' additional_kwargs={} response_metadata={'token_usage': {'completion_tokens': 71, 'prompt_tokens': 40, 'total_tokens': 111, 'completion_time': 0.165241813, 'prompt_time': 0.00627803, 'queue_time': 0.19492126, 'total_time': 0.171519843}, 'model_name': 'llama-3.1-8b-instant', 'system_fingerprint': 'fp_510c177af0', 'service_tier': 'on_demand', 'finish_reason': 'stop', 'logprobs': None} id='run--a022eb56-8131-4e33-82c6-151c775d5be1-0' usage_metadata={'input_tokens': 40, 'output_tokens': 71, 'total_tokens': 111}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Groq Example ---\n",
+    "# Loads a Groq-hosted model (here, Llama 3.1 8B Instant).\n",
+    "# Groq specializes in low-latency inference.\n",
+    "# Requires GROQ_API_KEY in your environment.\n",
+    "llm = load_llm(\"groq\", \"llama-3.1-8b-instant\")\n",
+    "print(llm.invoke(\"Hello from Groq!\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "8d76637f-ff20-48b8-b062-f5d4badfc81f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "content=\"Hello there, Ollama! It's great to meet you! What brings you here today? Do you have a question, or are you just looking for some friendly conversation? I'm all ears (or rather, all text)!\" additional_kwargs={} response_metadata={'model': 'llama3', 'created_at': '2025-08-20T16:28:02.392780314Z', 'done': True, 'done_reason': 'stop', 'total_duration': 18208991006, 'load_duration': 16401506467, 'prompt_eval_count': 16, 'prompt_eval_duration': 566493103, 'eval_count': 48, 'eval_duration': 1239875258, 'model_name': 'llama3'} id='run--c59ca93d-27ab-4d1b-9404-e7d70242b021-0' usage_metadata={'input_tokens': 16, 'output_tokens': 48, 'total_tokens': 64}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Ollama Example ---\n",
+    "# Loads a local Ollama model (here, Llama 3).\n",
+    "# Ollama runs models locally on your machine without requiring cloud APIs.\n",
+    "# Make sure Ollama is installed and running on your system.\n",
+    "llm = load_llm(\"ollama\", \"llama3\")\n",
+    "print(llm.invoke(\"Hello from Ollama!\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "genai_lab",
+   "language": "python",
+   "name": "genai_lab"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/docs/tutorials/llm_loader.py
+++ b/docs/docs/tutorials/llm_loader.py
@@ -1,0 +1,95 @@
+"""
+Unified LLM loader for LangChain (OpenAI, OpenRouter, Groq, Ollama).
+
+Example:
+    from llm_loader import load_llm
+
+    llm = load_llm("openai", "gpt-4o-mini")
+    print(llm.invoke("Hello"))
+"""
+
+import os
+from typing import Optional
+from dotenv import load_dotenv
+
+# Optional imports (avoid breaking if package not installed)
+try:
+    from langchain_openai import ChatOpenAI
+except ImportError:
+    ChatOpenAI = None
+
+try:
+    from langchain_groq import ChatGroq
+except ImportError:
+    ChatGroq = None
+
+try:
+    from langchain_ollama import ChatOllama
+except ImportError:
+    ChatOllama = None
+
+# Load environment variables from .env
+load_dotenv()
+
+
+def load_llm(
+    provider: str,
+    model: str,
+    temperature: float = 0,
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+):
+    """
+    Load an LLM wrapper from different providers.
+
+    Args:
+        provider: One of ["openai", "openrouter", "groq", "ollama"].
+        model: Model name (string).
+        temperature: Sampling temperature.
+        api_key: Optional API key (overrides .env values).
+        base_url: Custom API base URL (used for OpenRouter).
+
+    Returns:
+        A LangChain chat model instance.
+    """
+    provider = provider.lower()
+
+    if provider == "openai":
+        if ChatOpenAI is None:
+            raise ImportError("langchain_openai is not installed.")
+        return ChatOpenAI(
+            model=model,
+            temperature=temperature,
+            openai_api_key=api_key or os.getenv("OPENAI_API_KEY"),
+        )
+
+    elif provider == "openrouter":
+        if ChatOpenAI is None:
+            raise ImportError("langchain_openai is not installed.")
+        return ChatOpenAI(
+            model=model,
+            temperature=temperature,
+            openai_api_base=base_url or "https://openrouter.ai/api/v1",
+            openai_api_key=api_key or os.getenv("OPENROUTER_API_KEY"),
+        )
+
+    elif provider == "groq":
+        if ChatGroq is None:
+            raise ImportError("langchain_groq is not installed.")
+        return ChatGroq(
+            model=model,
+            temperature=temperature,
+            groq_api_key=api_key or os.getenv("GROQ_API_KEY"),
+        )
+
+    elif provider == "ollama":
+        if ChatOllama is None:
+            raise ImportError("langchain_ollama is not installed.")
+        return ChatOllama(
+            model=model,
+            temperature=temperature,
+            validate_model_on_init=True,  # ensures model exists locally
+        )
+
+    else:
+        raise ValueError(f"Unknown provider: {provider}")


### PR DESCRIPTION
**Description:**
Added a new tutorial `llm_loader.py` and `llm_loader.ipynb` in `docs/docs/tutorials/` that demonstrates how to load LLMs from different providers (OpenAI, OpenRouter, Groq, Ollama) with a unified function.

**Issue:**
N/A (tutorial contribution)

**Dependencies:**
No new dependencies. Uses existing optional integrations: `langchain_openai`, `langchain_groq`, `langchain_ollama`.

**Twitter handle:**
@shravankumar147
