### PR TITLE
docs: clarify system message behavior with checkpointers

### DIFF
--- a/docs/docs/concepts/chat_history.mdx
+++ b/docs/docs/concepts/chat_history.mdx
@@ -40,6 +40,23 @@ Understanding correct conversation structure is essential for being able to prop
 [memory](https://langchain-ai.github.io/langgraph/concepts/memory/) in chat models.
 :::
 
+### System messages and persistence
+
+When working with system messages in applications that maintain conversation state, it's important to understand how they behave with and without persistence mechanisms (like checkpointers):
+
+**Without a checkpointer/persistence:**
+- You need to include **all messages** (including system, user, and assistant messages) with each invocation
+- The system message must be re-sent with every request to maintain context
+- Each invocation is stateless - the model has no memory of previous interactions
+
+**With a checkpointer/persistence (e.g., using LangGraph with MemorySaver):**
+- The conversation state, including the system message, is automatically persisted
+- You only need to send the system message once at the beginning of the conversation
+- Subsequent invocations only require new user messages - the system message and conversation history are maintained automatically
+- Use the same `thread_id` to continue the conversation with preserved context
+
+This distinction is crucial for applications that need to maintain consistent behavior across multiple turns of conversation. See the [message history guide](/docs/how_to/message_history) for implementation examples with checkpointers.
+
 ## Related resources
 
 - [How to trim messages](/docs/how_to/trim_messages/)

--- a/docs/docs/how_to/message_history.ipynb
+++ b/docs/docs/how_to/message_history.ipynb
@@ -213,50 +213,73 @@
   {
    "cell_type": "markdown",
    "id": "t34kc06c18f",
-   "source": "## System messages with checkpointers\n\nWhen using system messages to set context or instructions for your chat model, it's important to understand how they behave with checkpointers.\n\nWith a checkpointer, the system message is part of the persisted state. You only need to include it once at the beginning of a conversation:",
-   "metadata": {}
+   "metadata": {},
+   "source": "## System messages with checkpointers\n\nWhen using system messages to set context or instructions for your chat model, it's important to understand how they behave with checkpointers.\n\nWith a checkpointer, the system message is part of the persisted state. You only need to include it once at the beginning of a conversation:"
   },
   {
    "cell_type": "code",
-   "id": "tqk5dvnwt",
-   "source": "from langchain_core.messages import SystemMessage\n\n# Create a new thread with a system message\nconfig = {\"configurable\": {\"thread_id\": \"abc456\"}}\n\n# First invocation includes the system message\ninput_messages = [\n    SystemMessage(\"You are a helpful assistant who speaks like a pirate.\"),\n    HumanMessage(\"Hi, what's the weather like?\")\n]\noutput = app.invoke({\"messages\": input_messages}, config)\noutput[\"messages\"][-1].pretty_print()",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "tqk5dvnwt",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.messages import SystemMessage\n",
+    "\n",
+    "# Create a new thread with a system message\n",
+    "config = {\"configurable\": {\"thread_id\": \"abc456\"}}\n",
+    "\n",
+    "# First invocation includes the system message\n",
+    "input_messages = [\n",
+    "    SystemMessage(\"You are a helpful assistant who speaks like a pirate.\"),\n",
+    "    HumanMessage(\"Hi, what's the weather like?\"),\n",
+    "]\n",
+    "output = app.invoke({\"messages\": input_messages}, config)\n",
+    "output[\"messages\"][-1].pretty_print()"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "8v5zn3hum34",
-   "source": "Now, in subsequent invocations with the same `thread_id`, we don't need to include the system message again - it's already part of the persisted state:",
-   "metadata": {}
+   "metadata": {},
+   "source": "Now, in subsequent invocations with the same `thread_id`, we don't need to include the system message again - it's already part of the persisted state:"
   },
   {
    "cell_type": "code",
-   "id": "b6k4gr5741q",
-   "source": "# Subsequent invocation - no need to include the system message\ninput_messages = [HumanMessage(\"What about tomorrow?\")]\noutput = app.invoke({\"messages\": input_messages}, config)\noutput[\"messages\"][-1].pretty_print()  # Still responds like a pirate!",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "b6k4gr5741q",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Subsequent invocation - no need to include the system message\n",
+    "input_messages = [HumanMessage(\"What about tomorrow?\")]\n",
+    "output = app.invoke({\"messages\": input_messages}, config)\n",
+    "output[\"messages\"][-1].pretty_print()  # Still responds like a pirate!"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "ifuuu8qw9id",
-   "source": "We can verify that the system message is preserved in the state:",
-   "metadata": {}
+   "metadata": {},
+   "source": "We can verify that the system message is preserved in the state:"
   },
   {
    "cell_type": "code",
-   "id": "lxlff11481",
-   "source": "# Check the persisted state\nstate = app.get_state(config).values\nfor message in state[\"messages\"]:\n    message.pretty_print()",
-   "metadata": {},
    "execution_count": null,
-   "outputs": []
+   "id": "lxlff11481",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check the persisted state\n",
+    "state = app.get_state(config).values\n",
+    "for message in state[\"messages\"]:\n",
+    "    message.pretty_print()"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "1nh2bbvshzc",
-   "source": ":::tip\n**Key takeaway**: With checkpointers, system messages are part of the persisted conversation state. You only need to include them once at the beginning of a conversation thread, and they will be automatically maintained for all subsequent interactions using the same `thread_id`.\n:::",
-   "metadata": {}
+   "metadata": {},
+   "source": ":::tip\n**Key takeaway**: With checkpointers, system messages are part of the persisted conversation state. You only need to include them once at the beginning of a conversation thread, and they will be automatically maintained for all subsequent interactions using the same `thread_id`.\n:::"
   },
   {
    "cell_type": "code",

--- a/docs/docs/how_to/message_history.ipynb
+++ b/docs/docs/how_to/message_history.ipynb
@@ -211,6 +211,54 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "t34kc06c18f",
+   "source": "## System messages with checkpointers\n\nWhen using system messages to set context or instructions for your chat model, it's important to understand how they behave with checkpointers.\n\nWith a checkpointer, the system message is part of the persisted state. You only need to include it once at the beginning of a conversation:",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "tqk5dvnwt",
+   "source": "from langchain_core.messages import SystemMessage\n\n# Create a new thread with a system message\nconfig = {\"configurable\": {\"thread_id\": \"abc456\"}}\n\n# First invocation includes the system message\ninput_messages = [\n    SystemMessage(\"You are a helpful assistant who speaks like a pirate.\"),\n    HumanMessage(\"Hi, what's the weather like?\")\n]\noutput = app.invoke({\"messages\": input_messages}, config)\noutput[\"messages\"][-1].pretty_print()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8v5zn3hum34",
+   "source": "Now, in subsequent invocations with the same `thread_id`, we don't need to include the system message again - it's already part of the persisted state:",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "b6k4gr5741q",
+   "source": "# Subsequent invocation - no need to include the system message\ninput_messages = [HumanMessage(\"What about tomorrow?\")]\noutput = app.invoke({\"messages\": input_messages}, config)\noutput[\"messages\"][-1].pretty_print()  # Still responds like a pirate!",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ifuuu8qw9id",
+   "source": "We can verify that the system message is preserved in the state:",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "lxlff11481",
+   "source": "# Check the persisted state\nstate = app.get_state(config).values\nfor message in state[\"messages\"]:\n    message.pretty_print()",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1nh2bbvshzc",
+   "source": ":::tip\n**Key takeaway**: With checkpointers, system messages are part of the persisted conversation state. You only need to include them once at the beginning of a conversation thread, and they will be automatically maintained for all subsequent interactions using the same `thread_id`.\n:::",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "6f12c26f-8913-4484-b2c5-b49eda2e6d7d",


### PR DESCRIPTION
## Summary

Fixes langchain-ai/docs#433

This PR adds documentation to clarify how system messages behave differently when using checkpointers vs. without persistence, addressing user confusion about whether system messages need to be re-sent in subsequent interactions.

## Changes

### Documentation Updates

1. **chat_history.mdx** - Added "System messages and persistence" section that explains:
   - Without checkpointer: All messages (including system messages) must be re-sent with each invocation
   - With checkpointer: System messages are persisted and only need to be sent once at the beginning of a conversation thread

2. **message_history.ipynb** - Added "System messages with checkpointers" example section with:
   - Code example showing how to use system messages with checkpointers
   - Demonstration that system messages persist across invocations with the same thread_id
   - Verification of the persisted state showing the system message is maintained

## Context

As noted in the issue, users were confused about whether system messages need to be included in every request when using checkpoint memory. The contributor @keenborder786 provided the answer in the issue comments, which this PR now documents formally:
- Without a checkpointer: You need to feed all messages again including system, user, and assistant messages
- With a checkpointer: You do not need to pass any messages again, just use the same thread_id

## Testing

- Documentation changes only - no code changes required
- Examples are consistent with existing patterns in the documentation