### PR TITLE
fix(openai): reuse HTTP clients in `AzureChatOpenAI`

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -676,7 +676,7 @@ class AzureChatOpenAI(BaseChatOpenAI):
                 }
             else:
                 sync_specific = {"http_client": self.http_client}
-            self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
+            self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[call-overload]
             self.client = self.root_client.chat.completions
         if not self.async_client:
             # Use cached async client if not explicitly provided
@@ -697,7 +697,7 @@ class AzureChatOpenAI(BaseChatOpenAI):
 
             self.root_async_client = openai.AsyncAzureOpenAI(
                 **client_params,
-                **async_specific,  # type: ignore[arg-type]
+                **async_specific,  # type: ignore[call-overload]
             )
             self.async_client = self.root_async_client.chat.completions
         return self

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -132,9 +132,9 @@ def test_http_client_reuse() -> None:
 
     # Verify that the HTTP clients are the same instance (cached)
     # Check if the underlying httpx client is the same object
-    assert llm1.root_client._client is llm2.root_client._client
-    assert llm2.root_client._client is llm3.root_client._client
+    assert llm1.root_client._client is llm2.root_client._client  # noqa: SLF001
+    assert llm2.root_client._client is llm3.root_client._client  # noqa: SLF001
 
     # Verify async clients are also cached
-    assert llm1.root_async_client._client is llm2.root_async_client._client
-    assert llm2.root_async_client._client is llm3.root_async_client._client
+    assert llm1.root_async_client._client is llm2.root_async_client._client  # noqa: SLF001
+    assert llm2.root_async_client._client is llm3.root_async_client._client  # noqa: SLF001

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -116,19 +116,19 @@ def test_http_client_reuse() -> None:
     initial_async_cache_info = _cached_async_httpx_client.cache_info()
 
     # Create multiple instances with the same configuration
-    llm1 = AzureChatOpenAI(  # type: ignore[call-arg]
+    llm1 = AzureChatOpenAI(  # type: ignore[call-arg]  # noqa: F841
         azure_deployment="35-turbo-dev",
         openai_api_version="2023-05-15",
         azure_endpoint="https://my-base-url.openai.azure.com",
     )
 
-    llm2 = AzureChatOpenAI(  # type: ignore[call-arg]
+    llm2 = AzureChatOpenAI(  # type: ignore[call-arg]  # noqa: F841
         azure_deployment="35-turbo-dev",
         openai_api_version="2023-05-15",
         azure_endpoint="https://my-base-url.openai.azure.com",
     )
 
-    llm3 = AzureChatOpenAI(  # type: ignore[call-arg]
+    llm3 = AzureChatOpenAI(  # type: ignore[call-arg]  # noqa: F841
         azure_deployment="35-turbo-dev",
         openai_api_version="2023-05-15",
         azure_endpoint="https://my-base-url.openai.azure.com",

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -115,22 +115,23 @@ def test_http_client_reuse() -> None:
     llm1 = AzureChatOpenAI(  # type: ignore[call-arg]
         azure_deployment="35-turbo-dev",
         openai_api_version="2023-05-15",
-        azure_endpoint="my-base-url",
+        azure_endpoint="https://my-base-url.openai.azure.com",
     )
 
     llm2 = AzureChatOpenAI(  # type: ignore[call-arg]
         azure_deployment="35-turbo-dev",
         openai_api_version="2023-05-15",
-        azure_endpoint="my-base-url",
+        azure_endpoint="https://my-base-url.openai.azure.com",
     )
 
     llm3 = AzureChatOpenAI(  # type: ignore[call-arg]
         azure_deployment="35-turbo-dev",
         openai_api_version="2023-05-15",
-        azure_endpoint="my-base-url",
+        azure_endpoint="https://my-base-url.openai.azure.com",
     )
 
     # Verify that the HTTP clients are the same instance (cached)
+    # Check if the underlying httpx client is the same object
     assert llm1.root_client._client is llm2.root_client._client
     assert llm2.root_client._client is llm3.root_client._client
 


### PR DESCRIPTION
Similar to #32531

## Summary

Fixes #32489

AzureChatOpenAI was creating new `httpx.AsyncClient/Client` instances on each instantiation instead of reusing cached clients like the base ChatOpenAI class does. This PR implements client caching to improve performance and reduce memory overhead.

## Problem

As reported in the issue, each `AzureChatOpenAI()` instantiation creates a new HTTP client even when configurations are identical, leading to:
- Unnecessary memory overhead
- Potential resource exhaustion with many instances
- Inconsistent behavior compared to base ChatOpenAI

## Solution

This PR modifies the Azure client initialization to use cached HTTP clients when not explicitly provided:
- Uses `_get_default_httpx_client()` for sync clients
- Uses `_get_default_async_httpx_client()` for async clients
- Only creates new clients when explicitly provided via `http_client` or `http_async_client` parameters

## Changes

1. **azure.py** - Updated client initialization logic:
   - Import cached client helper functions from `_client_utils`
   - Check if `http_client`/`http_async_client` are None before using cached versions
   - Maintain backward compatibility for explicitly provided clients

2. **test_azure.py** - Added unit test:
   - Verifies multiple AzureChatOpenAI instances share the same HTTP client
   - Tests both sync and async client caching

## Testing

- Added unit test `test_http_client_reuse()` to verify client caching works correctly
- Existing tests continue to pass, ensuring backward compatibility
- Manual testing shows reduced memory usage with multiple instances

## Impact

This is a performance improvement with no breaking changes. Users who explicitly provide HTTP clients will see no change in behavior.