### PR TITLE
feat(standard-tests): add a property to skip relevant tests if the vector store doesn't support `get_by_ids()`

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/vectorstores.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/vectorstores.py
@@ -118,6 +118,11 @@ class VectorStoreIntegrationTests(BaseStandardTests):
         """Configurable property to enable or disable async tests."""
         return True
 
+    @property
+    def has_get_by_ids(self) -> bool:
+        """Whether the vector store supports get_by_ids."""
+        return True
+
     @staticmethod
     def get_embeddings() -> Embeddings:
         """Get embeddings.
@@ -336,17 +341,21 @@ class VectorStoreIntegrationTests(BaseStandardTests):
             .. note::
                 ``get_by_ids`` was added to the ``VectorStore`` interface in
                 ``langchain-core`` version 0.2.11. If difficult to implement, this
-                test can be skipped using a pytest ``xfail`` on the test class:
+                test can be skipped by setting the ``has_get_by_ids`` property to
+                ``False``.
 
                 .. code-block:: python
 
-                    @pytest.mark.xfail(reason=("get_by_ids not implemented."))
-                    def test_get_by_ids(self, vectorstore: VectorStore) -> None:
-                        super().test_get_by_ids(vectorstore)
+                    @property
+                    def has_get_by_ids(self) -> bool:
+                        return False
 
         """
         if not self.has_sync:
             pytest.skip("Sync tests not supported.")
+
+        if not self.has_get_by_ids:
+            pytest.skip("get_by_ids not implemented.")
 
         documents = [
             Document(page_content="foo", metadata={"id": 1}),
@@ -372,17 +381,21 @@ class VectorStoreIntegrationTests(BaseStandardTests):
             .. note::
                 ``get_by_ids`` was added to the ``VectorStore`` interface in
                 ``langchain-core`` version 0.2.11. If difficult to implement, this
-                test can be skipped using a pytest ``xfail`` on the test class:
+                test can be skipped by setting the ``has_get_by_ids`` property to
+                ``False``.
 
                 .. code-block:: python
 
-                    @pytest.mark.xfail(reason=("get_by_ids not implemented."))
-                    def test_get_by_ids_missing(self, vectorstore: VectorStore) -> None:
-                        super().test_get_by_ids_missing(vectorstore)
+                    @property
+                    def has_get_by_ids(self) -> bool:
+                        return False
 
         """
         if not self.has_sync:
             pytest.skip("Sync tests not supported.")
+
+        if not self.has_get_by_ids:
+            pytest.skip("get_by_ids not implemented.")
 
         # This should not raise an exception
         documents = vectorstore.get_by_ids(["1", "2", "3"])
@@ -402,19 +415,21 @@ class VectorStoreIntegrationTests(BaseStandardTests):
             .. note::
                 ``get_by_ids`` was added to the ``VectorStore`` interface in
                 ``langchain-core`` version 0.2.11. If difficult to implement, this
-                test can be skipped using a pytest ``xfail`` on the test class:
+                test can be skipped by setting the ``has_get_by_ids`` property to
+                ``False``.
 
                 .. code-block:: python
 
-                    @pytest.mark.xfail(reason=("get_by_ids not implemented."))
-                    def test_add_documents_documents(
-                        self, vectorstore: VectorStore
-                    ) -> None:
-                        super().test_add_documents_documents(vectorstore)
+                    @property
+                    def has_get_by_ids(self) -> bool:
+                        return False
 
         """
         if not self.has_sync:
             pytest.skip("Sync tests not supported.")
+
+        if not self.has_get_by_ids:
+            pytest.skip("get_by_ids not implemented.")
 
         documents = [
             Document(page_content="foo", metadata={"id": 1}),
@@ -446,19 +461,21 @@ class VectorStoreIntegrationTests(BaseStandardTests):
             .. note::
                 ``get_by_ids`` was added to the ``VectorStore`` interface in
                 ``langchain-core`` version 0.2.11. If difficult to implement, this
-                test can be skipped using a pytest ``xfail`` on the test class:
+                test can be skipped by setting the ``has_get_by_ids`` property to
+                ``False``.
 
                 .. code-block:: python
 
-                    @pytest.mark.xfail(reason=("get_by_ids not implemented."))
-                    def test_add_documents_with_existing_ids(
-                        self, vectorstore: VectorStore
-                    ) -> None:
-                        super().test_add_documents_with_existing_ids(vectorstore)
+                    @property
+                    def has_get_by_ids(self) -> bool:
+                        return False
 
         """
         if not self.has_sync:
             pytest.skip("Sync tests not supported.")
+
+        if not self.has_get_by_ids:
+            pytest.skip("get_by_ids not implemented.")
 
         documents = [
             Document(id="foo", page_content="foo", metadata={"id": 1}),
@@ -683,17 +700,21 @@ class VectorStoreIntegrationTests(BaseStandardTests):
             .. note::
                 ``get_by_ids`` was added to the ``VectorStore`` interface in
                 ``langchain-core`` version 0.2.11. If difficult to implement, this
-                test can be skipped using a pytest ``xfail`` on the test class:
+                test can be skipped by setting the ``has_get_by_ids`` property to
+                ``False``.
 
                 .. code-block:: python
 
-                    @pytest.mark.xfail(reason=("get_by_ids not implemented."))
-                    async def test_get_by_ids(self, vectorstore: VectorStore) -> None:
-                        await super().test_get_by_ids(vectorstore)
+                    @property
+                    def has_get_by_ids(self) -> bool:
+                        return False
 
         """
         if not self.has_async:
             pytest.skip("Async tests not supported.")
+
+        if not self.has_get_by_ids:
+            pytest.skip("get_by_ids not implemented.")
 
         documents = [
             Document(page_content="foo", metadata={"id": 1}),
@@ -719,19 +740,21 @@ class VectorStoreIntegrationTests(BaseStandardTests):
             .. note::
                 ``get_by_ids`` was added to the ``VectorStore`` interface in
                 ``langchain-core`` version 0.2.11. If difficult to implement, this
-                test can be skipped using a pytest ``xfail`` on the test class:
+                test can be skipped by setting the ``has_get_by_ids`` property to
+                ``False``.
 
                 .. code-block:: python
 
-                    @pytest.mark.xfail(reason=("get_by_ids not implemented."))
-                    async def test_get_by_ids_missing(
-                        self, vectorstore: VectorStore
-                    ) -> None:
-                        await super().test_get_by_ids_missing(vectorstore)
+                    @property
+                    def has_get_by_ids(self) -> bool:
+                        return False
 
         """
         if not self.has_async:
             pytest.skip("Async tests not supported.")
+
+        if not self.has_get_by_ids:
+            pytest.skip("get_by_ids not implemented.")
 
         # This should not raise an exception
         assert await vectorstore.aget_by_ids(["1", "2", "3"]) == []
@@ -752,19 +775,21 @@ class VectorStoreIntegrationTests(BaseStandardTests):
             .. note::
                 ``get_by_ids`` was added to the ``VectorStore`` interface in
                 ``langchain-core`` version 0.2.11. If difficult to implement, this
-                test can be skipped using a pytest ``xfail`` on the test class:
+                test can be skipped by setting the ``has_get_by_ids`` property to
+                ``False``.
 
                 .. code-block:: python
 
-                    @pytest.mark.xfail(reason=("get_by_ids not implemented."))
-                    async def test_add_documents_documents(
-                        self, vectorstore: VectorStore
-                    ) -> None:
-                        await super().test_add_documents_documents(vectorstore)
+                    @property
+                    def has_get_by_ids(self) -> bool:
+                        return False
 
         """
         if not self.has_async:
             pytest.skip("Async tests not supported.")
+
+        if not self.has_get_by_ids:
+            pytest.skip("get_by_ids not implemented.")
 
         documents = [
             Document(page_content="foo", metadata={"id": 1}),
@@ -798,19 +823,21 @@ class VectorStoreIntegrationTests(BaseStandardTests):
             .. note::
                 ``get_by_ids`` was added to the ``VectorStore`` interface in
                 ``langchain-core`` version 0.2.11. If difficult to implement, this
-                test can be skipped using a pytest ``xfail`` on the test class:
+                test can be skipped by setting the ``has_get_by_ids`` property to
+                ``False``.
 
                 .. code-block:: python
 
-                    @pytest.mark.xfail(reason=("get_by_ids not implemented."))
-                    async def test_add_documents_with_existing_ids(
-                        self, vectorstore: VectorStore
-                    ) -> None:
-                        await super().test_add_documents_with_existing_ids(vectorstore)
+                    @property
+                    def has_get_by_ids(self) -> bool:
+                        return False
 
         """
         if not self.has_async:
             pytest.skip("Async tests not supported.")
+
+        if not self.has_get_by_ids:
+            pytest.skip("get_by_ids not implemented.")
 
         documents = [
             Document(id="foo", page_content="foo", metadata={"id": 1}),

--- a/libs/standard-tests/tests/unit_tests/test_in_memory_vectorstore.py
+++ b/libs/standard-tests/tests/unit_tests/test_in_memory_vectorstore.py
@@ -35,6 +35,6 @@ class TestWithoutGetByIdVectorStore(VectorStoreIntegrationTests):
     def test_get_by_ids_fails(self, vectorstore: VectorStore) -> None:
         with pytest.raises(
             NotImplementedError,
-            match="WithoutGetByIdVectorStore does not yet support get_by_ids.",
+            match="WithoutGetByIdsVectorStore does not yet support get_by_ids.",
         ):
             vectorstore.get_by_ids(["id1", "id2"])

--- a/libs/standard-tests/tests/unit_tests/test_in_memory_vectorstore.py
+++ b/libs/standard-tests/tests/unit_tests/test_in_memory_vectorstore.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from langchain_core.vectorstores import (
     InMemoryVectorStore,
@@ -12,3 +14,27 @@ class TestInMemoryVectorStore(VectorStoreIntegrationTests):
     def vectorstore(self) -> VectorStore:
         embeddings = self.get_embeddings()
         return InMemoryVectorStore(embedding=embeddings)
+
+
+class WithoutGetByIdsVectorStore(InMemoryVectorStore):
+    """InMemoryVectorStore that does not implement get_by_ids."""
+
+    get_by_ids = VectorStore.get_by_ids
+
+
+class TestWithoutGetByIdVectorStore(VectorStoreIntegrationTests):
+    @pytest.fixture
+    def vectorstore(self) -> VectorStore:
+        embeddings = self.get_embeddings()
+        return WithoutGetByIdsVectorStore(embedding=embeddings)
+
+    @property
+    def has_get_by_ids(self) -> bool:
+        return False
+
+    def test_get_by_ids_fails(self, vectorstore: VectorStore) -> None:
+        with pytest.raises(
+            NotImplementedError,
+            match="WithoutGetByIdVectorStore does not yet support get_by_ids.",
+        ):
+            vectorstore.get_by_ids(["id1", "id2"])


### PR DESCRIPTION
This PR introduces a configurable `has_get_by_ids` property to the vector store integration test framework, allowing vector stores that don't implement the `get_by_ids` method to gracefully skip related tests instead of requiring manual pytest `xfail` decorators.

- Adds a `has_get_by_ids` property (defaults to `True`) to the `VectorStoreIntegrationTests` base class
- Updates all `get_by_ids`-related test methods to check this property and skip tests when `False`
- Creates a test implementation demonstrating how to use this feature with a vector store that doesn't support `get_by_ids`