### PR TITLE
docs: Fix agents tutorials parameter missing

### DIFF
--- a/docs/docs/tutorials/agents.ipynb
+++ b/docs/docs/tutorials/agents.ipynb
@@ -649,7 +649,7 @@
    ],
    "source": [
     "for step, metadata in agent_executor.stream(\n",
-    "    {\"messages\": [input_message]}, stream_mode=\"messages\"\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"messages\"\n",
     "):\n",
     "    if metadata[\"langgraph_node\"] == \"agent\" and (text := step.text()):\n",
     "        print(text, end=\"|\")"


### PR DESCRIPTION
Fix a minor issue in the Agents Tutorials Notebook.
While a config parameter is missing.

Specifically, on page [Build an Agent#Streaming tokens](https://python.langchain.com/docs/tutorials/agents/#streaming-tokens)

These pieces of code can not be run without the config parameter, which seems to have been omitted by the author.
<img width="1318" height="691" alt="image" src="https://github.com/user-attachments/assets/54ce2833-9499-41bb-9de0-d5f9beba9ef9" />

