### PR TITLE
fix(openai): construct responses api input

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3701,7 +3701,7 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                             msg_id = block.get("id")
                             if block_type in ("text", "output_text"):
                                 new_block = {
-                                    "type": "output_text",
+                                    "type": "input_text",
                                     "text": block["text"],
                                     "annotations": block.get("annotations") or [],
                                 }
@@ -3752,13 +3752,7 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                     {
                         "type": "message",
                         "role": "assistant",
-                        "content": [
-                            {
-                                "type": "output_text",
-                                "text": msg["content"],
-                                "annotations": [],
-                            }
-                        ],
+                        "content": [{"type": "input_text", "text": msg["content"]}],
                     }
                 )
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1974,8 +1974,8 @@ def test__construct_responses_api_input_multiple_message_components() -> None:
             "type": "message",
             "role": "assistant",
             "content": [
-                {"type": "output_text", "text": "foo", "annotations": []},
-                {"type": "output_text", "text": "bar", "annotations": []},
+                {"type": "input_text", "text": "foo", "annotations": []},
+                {"type": "input_text", "text": "bar", "annotations": []},
             ],
             "id": "msg_123",
         }
@@ -1999,8 +1999,8 @@ def test__construct_responses_api_input_multiple_message_components() -> None:
             "type": "message",
             "role": "assistant",
             "content": [
-                {"type": "output_text", "text": "foo", "annotations": []},
-                {"type": "output_text", "text": "bar", "annotations": []},
+                {"type": "input_text", "text": "foo", "annotations": []},
+                {"type": "input_text", "text": "bar", "annotations": []},
                 {"type": "refusal", "refusal": "I refuse."},
             ],
             "id": "msg_123",
@@ -2008,7 +2008,7 @@ def test__construct_responses_api_input_multiple_message_components() -> None:
         {
             "type": "message",
             "role": "assistant",
-            "content": [{"type": "output_text", "text": "baz", "annotations": []}],
+            "content": [{"type": "input_text", "text": "baz", "annotations": []}],
             "id": "msg_234",
         },
     ]
@@ -2130,7 +2130,7 @@ def test__construct_responses_api_input_ai_message_with_tool_calls_and_content()
     assert result[0]["role"] == "assistant"
     assert result[0]["content"] == [
         {
-            "type": "output_text",
+            "type": "input_text",
             "text": "I'll check the weather for you.",
             "annotations": [],
         }
@@ -2154,9 +2154,8 @@ def test__construct_responses_api_input_ai_message_with_tool_calls_and_content()
     assert result[0]["role"] == "assistant"
     assert result[0]["content"] == [
         {
-            "type": "output_text",
+            "type": "input_text",
             "text": "I'll check the weather for you.",
-            "annotations": [],
         }
     ]
 
@@ -2257,16 +2256,15 @@ def test__construct_responses_api_input_multiple_message_types() -> None:
     assert result[6]["role"] == "assistant"
     assert result[6]["content"] == [
         {
-            "type": "output_text",
+            "type": "input_text",
             "text": "The weather in San Francisco is 72°F and sunny.",
-            "annotations": [],
         }
     ]
 
     assert result[7]["role"] == "assistant"
     assert result[7]["content"] == [
         {
-            "type": "output_text",
+            "type": "input_text",
             "text": "The weather in San Francisco is 72°F and sunny.",
             "annotations": [],
         }

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2153,10 +2153,7 @@ def test__construct_responses_api_input_ai_message_with_tool_calls_and_content()
 
     assert result[0]["role"] == "assistant"
     assert result[0]["content"] == [
-        {
-            "type": "input_text",
-            "text": "I'll check the weather for you.",
-        }
+        {"type": "input_text", "text": "I'll check the weather for you."}
     ]
 
     assert result[1]["type"] == "function_call"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
@@ -678,6 +678,8 @@ def test_responses_stream() -> None:
     for idx, item in enumerate(response.output):
         dumped = _strip_none(item.model_dump())
         _ = dumped.pop("status", None)
-        if dumped["type"] == "output_text":
-            dumped["type"] = "input_text"
+        if "content" in dumped and isinstance(dumped["content"], list):
+            for content in dumped["content"]:
+                if "type" in content and content["type"] == "output_text":
+                    content["type"] == "input_text"
         assert dumped == payload["input"][idx]

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
@@ -681,5 +681,5 @@ def test_responses_stream() -> None:
         if "content" in dumped and isinstance(dumped["content"], list):
             for content in dumped["content"]:
                 if "type" in content and content["type"] == "output_text":
-                    content["type"] == "input_text"
+                    content["type"] = "input_text"
         assert dumped == payload["input"][idx]

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
@@ -678,4 +678,6 @@ def test_responses_stream() -> None:
     for idx, item in enumerate(response.output):
         dumped = _strip_none(item.model_dump())
         _ = dumped.pop("status", None)
+        if dumped["type"] == "output_text":
+            dumped["type"] = "input_text"
         assert dumped == payload["input"][idx]


### PR DESCRIPTION
The previous PR https://github.com/langchain-ai/langchain/pull/32557 did not completely resolve the class validation issues, because the [ResponseOutputMessageParam](https://github.com/openai/openai-python/blob/v1.99.9/src/openai/types/responses/response_output_message_param.py) has required fields `id` and `status` which are also not generated by `_construct_responses_api_input`.
However, after carefully reading the [OpenAI Responses API reference](https://platform.openai.com/docs/api-reference/responses/create), I want to propose another solution that changes the `content[].type` from "output_text" to "input_text".
This change makes the generated input more compliant with the API reference, and also passes the class validations of [EasyInputMessageParam](https://github.com/openai/openai-python/blob/v1.99.9/src/openai/types/responses/easy_input_message_param.py) and [ResponseInputTextParam](https://github.com/openai/openai-python/blob/v1.99.9/src/openai/types/responses/response_input_text_param.py).