### PR TITLE
feat(core): trace response body on error

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -78,6 +78,11 @@ def _generate_response_from_error(error: BaseException) -> list[ChatGeneration]:
     if hasattr(error, "response"):
         response = error.response
         metadata: dict = {}
+        if hasattr(response, "json"):
+            try:
+                metadata["body"] = response.json()
+            except Exception:
+                metadata["body"] = getattr(response, "text", None)
         if hasattr(response, "headers"):
             try:
                 metadata["headers"] = dict(response.headers)


### PR DESCRIPTION
Following https://github.com/langchain-ai/langchain/pull/30626

Sample trace: https://smith.langchain.com/public/e2d52b8b-288d-4e61-84c5-703ed24a34c5/r
```python
from langchain.chat_models import init_chat_model

llm = init_chat_model("openai:gpt-5-nano")

llm.invoke("Hello", tools="bad")
```