### PR TITLE
Added docs for Notion integration

### DIFF
--- a/docs/docs/integrations/tools/notion.ipynb
+++ b/docs/docs/integrations/tools/notion.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "raw",
+   "source": [
+    "---\n",
+    "sidebar_label: LangchainNotionToolkit\n",
+    "---"
+   ],
+   "id": "front-matter-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# LangchainNotionToolkit\n",
+    "\n",
+    "This notebook provides a quick overview for getting started with **LangchainNotionToolkit**.\n",
+    "For detailed documentation of all LangchainNotionToolkit features and configurations head to the\n",
+    "[API reference](https://python.langchain.com/v0.2/api_reference/community/toolkits/langchain_community.toolkits.langchain_notion.LangchainNotionToolkit.html).\n",
+    "\n",
+    "You may also want to check the official [Notion API docs](https://developers.notion.com/docs)\n",
+    "for details on objects like pages, databases, and properties.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "### Integration details\n",
+    "\n",
+    "| Class | Package | Serializable | JS support | Package latest |\n",
+    "| :--- | :--- | :---: | :---: | :---: |\n",
+    "| `LangchainNotionToolkit` | [`langchain-notion`](https://pypi.org/project/langchain-notion/) | ❌ | ❌ | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-notion?style=flat-square&label=%20) |\n",
+    "\n",
+    "### Tool features\n",
+    "\n",
+    "The `LangchainNotionToolkit` bundles multiple tools for interacting with Notion through agents:\n",
+    "\n",
+    "| Tool | Description | Input Schema |\n",
+    "| :--- | :--- | :--- |\n",
+    "| Search Pages | Search for pages in Notion using keywords. | `{\"query\": str}` _or_ a plain string |\n",
+    "| Get Page | Retrieve a page’s title, URL, and properties by ID. | `{\"page_id\": str}` |\n",
+    "| Create Page | Create a new page in a database or under another page. | `{\"parent\": {...}, \"properties\": {...}}` |\n",
+    "| Update Page | Update properties of an existing page. | `{\"page_id\": str, \"properties\": {...}}` |\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "Install dependencies:\n",
+    "\n",
+    "```bash\n",
+    "pip install langchain-notion\n",
+    "```"
+   ],
+   "id": "intro-md-1"
+  },
+  {
+   "cell_type": "code",
+   "id": "pip-cell-1",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
+   "source": [
+    "%pip install --quiet -U langchain-notion"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "markdown",
+   "id": "creds-md-1",
+   "metadata": {},
+   "source": [
+    "### Credentials\n",
+    "\n",
+    "This integration requires a **Notion API key** (integration token).\n",
+    "\n",
+    "1. Create an integration at the [Notion Developer Portal](https://www.notion.so/my-integrations) and copy the token (`secret_...`).\n",
+    "2. Share your target pages or databases with this integration (Notion → **Share** → invite your integration).\n",
+    "3. Provide credentials to this notebook via environment variables or directly to the wrapper.\n",
+    "\n",
+    "**Environment variables (recommended):**\n",
+    "\n",
+    "```bash\n",
+    "export NOTION_API_KEY=\"secret_abc...\"\n",
+    "export NOTION_DATABASE_ID=\"your_database_id\"   # optional (for create)\n",
+    "```"
+   ]
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "import getpass, os\n",
+    "\n",
+    "if not os.environ.get(\"NOTION_API_KEY\"):\n",
+    "    os.environ[\"NOTION_API_KEY\"] = getpass.getpass(\"Enter your Notion API key (secret_...):\\n\")"
+   ],
+   "id": "creds-code-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "It's also helpful (but not required) to set up [LangSmith](https://smith.langchain.com/) for observability:",
+   "id": "langsmith-md-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# os.environ[\"LANGSMITH_TRACING\"] = \"true\"\n",
+    "# os.environ[\"LANGSMITH_API_KEY\"] = getpass.getpass(\"LangSmith API key:\\n\")"
+   ],
+   "id": "langsmith-code-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## Instantiation\n",
+    "\n",
+    "Instantiate the toolkit with a `NotionWrapper`:"
+   ],
+   "id": "instantiation-md-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "from langchain_notion.notion_wrapper import NotionWrapper\n",
+    "from langchain_notion.toolkits import LangchainNotionToolkit\n",
+    "\n",
+    "api = NotionWrapper(api_key=os.environ[\"NOTION_API_KEY\"])  # will also read NOTION_DATABASE_ID if set\n",
+    "toolkit = LangchainNotionToolkit.from_notion_wrapper(api, include_write_tools=True)\n",
+    "tools = toolkit.get_tools()\n",
+    "tools"
+   ],
+   "id": "instantiation-code-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## Invocation\n",
+    "\n",
+    "### Invoke directly with args\n",
+    "\n",
+    "Each tool can be retrieved from the toolkit and invoked directly."
+   ],
+   "id": "invocation-md-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "**Search for pages:**"
+   ],
+   "id": "search-md-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "search = next(t for t in tools if t.name == \"Search Pages\")\n",
+    "print(search.invoke(\"roadmap\"))  # plain string is supported\n",
+    "# print(search.invoke({\"query\": \"roadmap\"}))  # dict form also supported"
+   ],
+   "id": "search-code-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "**Get a page:**"
+   ],
+   "id": "get-md-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "get_page = next(t for t in tools if t.name == \"Get Page\")\n",
+    "print(get_page.invoke({\"page_id\": \"YOUR_PAGE_ID\"}))  # replace with a real page ID shared with the integration"
+   ],
+   "id": "get-code-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "**Create a page:**"
+   ],
+   "id": "create-md-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "create_page = next(t for t in tools if t.name == \"Create Page\")\n",
+    "print(create_page.invoke({\n",
+    "    \"parent\": {\"database_id\": os.environ.get(\"NOTION_DATABASE_ID\", \"YOUR_DATABASE_ID\")},\n",
+    "    \"properties\": {\n",
+    "        \"title\": {\"title\": [{\"type\": \"text\", \"text\": {\"content\": \"Demo Page\"}}]}\n",
+    "    }\n",
+    "}))"
+   ],
+   "id": "create-code-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "**Update a page:**"
+   ],
+   "id": "update-md-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "update_page = next(t for t in tools if t.name == \"Update Page\")\n",
+    "print(update_page.invoke({\n",
+    "    \"page_id\": \"YOUR_PAGE_ID\",\n",
+    "    \"properties\": {\n",
+    "        \"title\": {\"title\": [{\"type\": \"text\", \"text\": {\"content\": \"Updated Title\"}}]}\n",
+    "    }\n",
+    "}))"
+   ],
+   "id": "update-code-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## Chaining\n",
+    "\n",
+    "You can also bind these tools to a chat model that supports tool calling.\n",
+    "Below is a minimal example using `init_chat_model` (you will need valid model credentials):"
+   ],
+   "id": "chain-md-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": [
+    "# !pip install -qU langchain langchain-openai\n",
+    "from langchain.chat_models import init_chat_model\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "\n",
+    "llm = init_chat_model(model=\"gpt-4o\", model_provider=\"openai\")\n",
+    "llm_with_tools = llm.bind_tools(tools)\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_messages([\n",
+    "    (\"system\", \"You are a helpful Notion assistant.\"),\n",
+    "    (\"human\", \"Search for pages about the project roadmap\")\n",
+    "])\n",
+    "\n",
+    "chain = prompt | llm_with_tools\n",
+    "result = chain.invoke({})\n",
+    "print(result)"
+   ],
+   "id": "chain-code-1"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## API reference\n",
+    "\n",
+    "For detailed documentation of all LangchainNotionToolkit features and configurations, see the\n",
+    "[API reference](https://python.langchain.com/v0.2/api_reference/community/toolkits/langchain_community.toolkits.langchain_notion.LangchainNotionToolkit.html)."
+   ],
+   "id": "api-md-1"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}
+

--- a/libs/packages.yml
+++ b/libs/packages.yml
@@ -733,4 +733,6 @@ packages:
 - name: langchain-scrapeless
   repo: scrapeless-ai/langchain-scrapeless
   path: .
-
+- name: langchain-notion
+  repo: rujeetjahagirdar/langchain-notion
+  path: .


### PR DESCRIPTION

### Description
This PR introduces a new **Notion integration** for LangChain.  
It adds a `LangchainNotionToolkit` that bundles multiple tools to enable agents to interact with Notion pages.  

The toolkit supports the following operations:
-  **Search Pages** – search for Notion pages by keyword  
-  **Get Page** – retrieve a page’s title, URL, and properties by ID  
-  **Create Page** – create a new page in a database or under another page  
-  **Update Page** – update properties of an existing page  

The integration is structured into three layers:
1. **`NotionWrapper`** – lightweight wrapper around the official Notion SDK  
2. **`LangchainNotionTool`** – individual tools (search, get, create, update)  
3. **`LangchainNotionToolkit`** – groups the tools for agent use  

---

###  Dependencies
- `notion-client` (official Notion SDK)  
- `langchain-core`  

---

###  Documentation
- Added an **example notebook**: `docs/docs/integrations/toolkits/langchain_notion.ipynb`  
  Includes setup, authentication, and usage examples.  

---
