### PR TITLE
docs(docs): update Docker to ClickHouse 25.7 with vector_similarity support

### DIFF
--- a/docs/docs/integrations/vectorstores/clickhouse.ipynb
+++ b/docs/docs/integrations/vectorstores/clickhouse.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! docker run -d -p 8123:8123 -p9000:9000 --name langchain-clickhouse-server --ulimit nofile=262144:262144 clickhouse/clickhouse-server:24.7.6.8"
+    "! docker run -d -p 8123:8123 -p 9000:9000 --name langchain-clickhouse-server --ulimit nofile=262144:262144 -e CLICKHOUSE_SKIP_USER_SETUP=1 clickhouse/clickhouse-server:25.7"
    ]
   },
   {
@@ -310,7 +310,8 @@
     "    where_str=f\"{meta}.source = 'tweet'\",\n",
     ")\n",
     "for res in results:\n",
-    "    print(f\"* {res.page_content} [{res.metadata}]\")"
+    "    page_content, metadata = res\n",
+    "    print(f\"* {page_content} [{metadata}]\")"
    ]
   },
   {


### PR DESCRIPTION
- **Description:** Updated Docker command to use ClickHouse 25.7 (has `vector_similarity` index support). Added `CLICKHOUSE_SKIP_USER_SETUP=1` env param to [bypass default user setup](https://clickhouse.com/docs/install/docker#managing-default-user) and allow external network access. There was also a bug where if you try to access results using `similarity_search_with_relevance_scores`, they need to unpacked first.

- **Issue:** Fixes #32094 if someone following tutorial with default Clickhouse configurations.