### PR TITLE
feat(core): (v1) restore separate type for `AIMessage.tool_calls`

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -255,9 +255,9 @@ class AIMessage(BaseMessage):
                         "args": tool_call["args"],
                     }
                     if "index" in tool_call:
-                        tool_call_block["index"] = tool_call["index"]
+                        tool_call_block["index"] = tool_call["index"]  # type: ignore[typeddict-item]
                     if "extras" in tool_call:
-                        tool_call_block["extras"] = tool_call["extras"]
+                        tool_call_block["extras"] = tool_call["extras"]  # type: ignore[typeddict-item]
                     blocks.append(tool_call_block)
 
         return blocks

--- a/libs/core/langchain_core/messages/block_translators/anthropic.py
+++ b/libs/core/langchain_core/messages/block_translators/anthropic.py
@@ -237,7 +237,12 @@ def _convert_to_v1_from_anthropic(message: AIMessage) -> list[types.ContentBlock
                     not isinstance(message, AIMessageChunk)
                     and len(message.tool_calls) == 1
                 ):
-                    tool_call_block = message.tool_calls[0]
+                    tool_call_block: types.ToolCall = {
+                        "type": "tool_call",
+                        "name": message.tool_calls[0]["name"],
+                        "args": message.tool_calls[0]["args"],
+                        "id": message.tool_calls[0].get("id"),
+                    }
                     if "index" in block:
                         tool_call_block["index"] = block["index"]
                     yield tool_call_block

--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -30,7 +30,14 @@ def _convert_to_v1_from_chat_completions(
             content_blocks = []
 
     for tool_call in message.tool_calls:
-        content_blocks.append(tool_call)
+        content_blocks.append(
+            {
+                "type": "tool_call",
+                "name": tool_call["name"],
+                "args": tool_call["args"],
+                "id": tool_call.get("id"),
+            }
+        )
 
     return content_blocks
 
@@ -287,7 +294,12 @@ def _convert_to_v1_from_responses(message: AIMessage) -> list[types.ContentBlock
                 elif call_id:
                     for tool_call in message.tool_calls or []:
                         if tool_call.get("id") == call_id:
-                            tool_call_block = tool_call.copy()
+                            tool_call_block = {
+                                "type": "tool_call",
+                                "name": tool_call["name"],
+                                "args": tool_call["args"],
+                                "id": tool_call.get("id"),
+                            }
                             break
                     else:
                         for invalid_tool_call in message.invalid_tool_calls or []:

--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -10,7 +10,6 @@ from typing_extensions import NotRequired, TypedDict, override
 from langchain_core.messages import content as types
 from langchain_core.messages.base import BaseMessage, BaseMessageChunk, merge_content
 from langchain_core.messages.content import InvalidToolCall as InvalidToolCall
-from langchain_core.messages.content import ToolCall as ToolCall
 from langchain_core.utils._merge import merge_dicts, merge_obj
 
 
@@ -197,6 +196,37 @@ class ToolMessageChunk(ToolMessage, BaseMessageChunk):
             )
 
         return super().__add__(other)
+
+
+class ToolCall(TypedDict):
+    """Represents a request to call a tool.
+
+    Example:
+
+        .. code-block:: python
+
+            {
+                "name": "foo",
+                "args": {"a": 1},
+                "id": "123"
+            }
+
+        This represents a request to call the tool named "foo" with arguments {"a": 1}
+        and an identifier of "123".
+
+    """
+
+    name: str
+    """The name of the tool to be called."""
+    args: dict[str, Any]
+    """The arguments to the tool call."""
+    id: Optional[str]
+    """An identifier associated with the tool call.
+
+    An identifier is needed to associate a tool call request with a tool
+    call result in events when multiple concurrent tool calls are made.
+    """
+    type: NotRequired[Literal["tool_call"]]
 
 
 def tool_call(

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -203,6 +203,16 @@ def test_add_ai_message_chunks_usage() -> None:
     )
 
 
+def test_init_tool_calls() -> None:
+    # Test we add "type" key on init
+    msg = AIMessage("", tool_calls=[{"name": "foo", "args": {"a": "b"}, "id": "abc"}])
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0]["type"] == "tool_call"
+
+    # Test we can assign without adding type key
+    msg.tool_calls = [{"name": "bar", "args": {"c": "d"}, "id": "def"}]
+
+
 def test_content_blocks() -> None:
     message = AIMessage(
         "",

--- a/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
+++ b/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
@@ -1014,21 +1014,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -1042,17 +1031,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -1064,10 +1042,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',
@@ -2485,21 +2462,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -2513,17 +2479,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -2535,10 +2490,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -1417,21 +1417,10 @@
                 
                     This represents a request to call the tool named "foo" with arguments {"a": 1}
                     and an identifier of "123".
-                
-                .. note::
-                    ``create_tool_call`` may also be used as a factory to create a
-                    ``ToolCall``. Benefits include:
-                
-                    * Automatic ID generation (when not provided)
-                    * Required arguments strictly validated at creation time
               ''',
               'properties': dict({
                 'args': dict({
                   'title': 'Args',
-                  'type': 'object',
-                }),
-                'extras': dict({
-                  'title': 'Extras',
                   'type': 'object',
                 }),
                 'id': dict({
@@ -1445,17 +1434,6 @@
                   ]),
                   'title': 'Id',
                 }),
-                'index': dict({
-                  'anyOf': list([
-                    dict({
-                      'type': 'integer',
-                    }),
-                    dict({
-                      'type': 'string',
-                    }),
-                  ]),
-                  'title': 'Index',
-                }),
                 'name': dict({
                   'title': 'Name',
                   'type': 'string',
@@ -1467,10 +1445,9 @@
                 }),
               }),
               'required': list([
-                'type',
-                'id',
                 'name',
                 'args',
+                'id',
               ]),
               'title': 'ToolCall',
               'type': 'object',

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
@@ -2959,21 +2959,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -2987,17 +2976,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -3008,10 +2986,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',
@@ -4493,21 +4470,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -4521,17 +4487,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -4542,10 +4497,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',
@@ -6039,21 +5993,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -6067,17 +6010,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -6088,10 +6020,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',
@@ -7441,21 +7372,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -7469,17 +7389,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -7490,10 +7399,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',
@@ -9017,21 +8925,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -9045,17 +8942,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -9066,10 +8952,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',
@@ -10464,21 +10349,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -10492,17 +10366,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -10513,10 +10376,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',
@@ -11959,21 +11821,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -11987,17 +11838,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -12008,10 +11848,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',
@@ -13455,21 +13294,10 @@
           
               This represents a request to call the tool named "foo" with arguments {"a": 1}
               and an identifier of "123".
-          
-          .. note::
-              ``create_tool_call`` may also be used as a factory to create a
-              ``ToolCall``. Benefits include:
-          
-              * Automatic ID generation (when not provided)
-              * Required arguments strictly validated at creation time
         ''',
         'properties': dict({
           'args': dict({
             'title': 'Args',
-            'type': 'object',
-          }),
-          'extras': dict({
-            'title': 'Extras',
             'type': 'object',
           }),
           'id': dict({
@@ -13483,17 +13311,6 @@
             ]),
             'title': 'Id',
           }),
-          'index': dict({
-            'anyOf': list([
-              dict({
-                'type': 'integer',
-              }),
-              dict({
-                'type': 'string',
-              }),
-            ]),
-            'title': 'Index',
-          }),
           'name': dict({
             'title': 'Name',
             'type': 'string',
@@ -13504,10 +13321,9 @@
           }),
         }),
         'required': list([
-          'type',
-          'id',
           'name',
           'args',
+          'id',
         ]),
         'title': 'ToolCall',
         'type': 'object',

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1501,11 +1501,20 @@ class ChatAnthropic(BaseChatModel):
                 isinstance(message, AIMessage)
                 and message.response_metadata.get("output_version") == "v1"
             ):
+                tcs: list[types.ToolCall] = [
+                    {
+                        "type": "tool_call",
+                        "name": tool_call["name"],
+                        "args": tool_call["args"],
+                        "id": tool_call.get("id"),
+                    }
+                    for tool_call in message.tool_calls
+                ]
                 messages[idx] = message.model_copy(
                     update={
                         "content": _convert_from_v1_to_anthropic(
                             cast(list[types.ContentBlock], message.content),
-                            message.tool_calls,
+                            tcs,
                             message.response_metadata.get("model_provider"),
                         )
                     }

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -64,6 +64,7 @@ from langchain_core.messages import (
     convert_to_openai_data_block,
     is_data_content_block,
 )
+from langchain_core.messages import content as types
 from langchain_core.messages.ai import (
     InputTokenDetails,
     OutputTokenDetails,
@@ -3748,9 +3749,16 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
             if isinstance(msg.get("content"), list) and all(
                 isinstance(block, dict) for block in msg["content"]
             ):
-                msg["content"] = _convert_from_v1_to_responses(
-                    msg["content"], lc_msg.tool_calls
-                )
+                tcs: list[types.ToolCall] = [
+                    {
+                        "type": "tool_call",
+                        "name": tool_call["name"],
+                        "args": tool_call["args"],
+                        "id": tool_call.get("id"),
+                    }
+                    for tool_call in lc_msg.tool_calls
+                ]
+                msg["content"] = _convert_from_v1_to_responses(msg["content"], tcs)
         else:
             msg = _convert_message_to_dict(lc_msg)
             # Get content from non-standard content blocks

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -20,6 +20,7 @@ from langchain_core.messages import (
     ToolCall,
     ToolMessage,
 )
+from langchain_core.messages import content as types
 from langchain_core.messages.ai import UsageMetadata
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.runnables import RunnableLambda
@@ -2575,9 +2576,16 @@ def test_convert_from_v1_to_chat_completions(
 def test_convert_from_v1_to_responses(
     message_v1: AIMessage, expected: list[dict[str, Any]]
 ) -> None:
-    result = _convert_from_v1_to_responses(
-        message_v1.content_blocks, message_v1.tool_calls
-    )
+    tcs: list[types.ToolCall] = [
+        {
+            "type": "tool_call",
+            "name": tool_call["name"],
+            "args": tool_call["args"],
+            "id": tool_call.get("id"),
+        }
+        for tool_call in message_v1.tool_calls
+    ]
+    result = _convert_from_v1_to_responses(message_v1.content_blocks, tcs)
     assert result == expected
 
     # Check no mutation


### PR DESCRIPTION
`"type"` needs to be a required key for content blocks, including tool calls in content blocks, for type discrimination.

This has not a required key for the tool calls in `AIMessage.tool_calls`. If we require that content ToolCall and `.tool_calls` ToolCall both require `"type"`, we introduce type errors in user code:
```python
msg.tool_calls = [{"name": "foo", "args": {"a": "b"}, "id": "abc-123"}]
```
Any pydantic classes expecting tool calls would also raise validation errors if `"type"` is not provided— I realized this issue when this happened to some test classes in langgraph.

For now, we restore the old type, so that for both AIMessage.tool_calls and AIMessage.tool_call_chunks we have separate types that do not require the `"type"` key.