### PR TITLE
chore(infra): drop anthropic from core test matrix

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -347,7 +347,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        partner: [openai, anthropic]
+        partner: [openai]
       fail-fast: false  # Continue testing other partners if one fails
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Will restore after we have an anthropic release that's compatible with langchain-core 1.0.

After normalization, we get 1.0 multimodal blocks, so Anthropic keying on `source_type` will fail until we release langchain-anthropic.