### PR TITLE
docs: replace smart quotes with straight quotes on How-to guides landing page

### DIFF
--- a/docs/docs/how_to/index.mdx
+++ b/docs/docs/how_to/index.mdx
@@ -5,7 +5,7 @@ sidebar_class_name: hidden
 
 # How-to guides
 
-Here you’ll find answers to “How do I….?” types of questions.
+Here you’ll find answers to "How do I….?" types of questions.
 These guides are *goal-oriented* and *concrete*; they're meant to help you complete a specific task.
 For conceptual explanations see the [Conceptual guide](/docs/concepts/).
 For end-to-end walkthroughs see [Tutorials](/docs/tutorials).


### PR DESCRIPTION
### Summary

This PR updates the sentence on the "How-to guides" landing page to replace smart (curly) quotes with straight quotes in the phrase:

> "How do I...?"

### Why This Change?

- Ensures formatting consistency across documentation
- Avoids encoding or rendering issues with smart quotes
- Matches standard Markdown and inline code formatting

This is a small change, but improves clarity and polish on a key landing page.
