### PR TITLE
docs(docs): added `content=` keyword when creating `SystemMessage` and `HumanMessage`

### DIFF
--- a/docs/docs/tutorials/llm_chain.ipynb
+++ b/docs/docs/tutorials/llm_chain.ipynb
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "1b2481f0",
    "metadata": {},
    "outputs": [
@@ -178,8 +178,8 @@
     "from langchain_core.messages import HumanMessage, SystemMessage\n",
     "\n",
     "messages = [\n",
-    "    SystemMessage(\"Translate the following from English into Italian\"),\n",
-    "    HumanMessage(\"hi!\"),\n",
+    "    SystemMessage(content=\"Translate the following from English into Italian\"),\n",
+    "    HumanMessage(content=\"hi!\"),\n",
     "]\n",
     "\n",
     "model.invoke(messages)"


### PR DESCRIPTION
Description: 
Added the content= keyword when creating SystemMessage and HumanMessage in the messages list, making it consistent with the API reference.


