### PR TITLE
chore(langchain): improve PostgreSQL Manager upsert SQLAlchemy API calls.

### DIFF
--- a/libs/langchain/langchain/indexes/_sql_record_manager.py
+++ b/libs/langchain/langchain/indexes/_sql_record_manager.py
@@ -30,6 +30,7 @@ from sqlalchemy import (
     and_,
     create_engine,
     delete,
+    func,
     select,
     text,
 )
@@ -326,10 +327,13 @@ class SQLRecordManager(RecordManager):
                     records_to_upsert,
                 )
                 stmt = pg_insert_stmt.on_conflict_do_update(  # type: ignore[assignment]
-                    "uix_key_namespace",  # Name of constraint
+                    constraint="uix_key_namespace",  # Name of constraint
                     set_={
                         "updated_at": pg_insert_stmt.excluded.updated_at,
-                        "group_id": pg_insert_stmt.excluded.group_id,
+                        "group_id": func.coalesce(
+                            pg_insert_stmt.excluded.group_id,
+                            UpsertionRecord.group_id,
+                        ),
                     },
                 )
             else:
@@ -408,10 +412,13 @@ class SQLRecordManager(RecordManager):
                     records_to_upsert,
                 )
                 stmt = pg_insert_stmt.on_conflict_do_update(  # type: ignore[assignment]
-                    "uix_key_namespace",  # Name of constraint
+                    constraint="uix_key_namespace",  # Name of constraint
                     set_={
                         "updated_at": pg_insert_stmt.excluded.updated_at,
-                        "group_id": pg_insert_stmt.excluded.group_id,
+                        "group_id": func.coalesce(
+                            pg_insert_stmt.excluded.group_id,
+                            UpsertionRecord.group_id,
+                        ),
                     },
                 )
             else:

--- a/libs/langchain/langchain/indexes/_sql_record_manager.py
+++ b/libs/langchain/langchain/indexes/_sql_record_manager.py
@@ -30,7 +30,6 @@ from sqlalchemy import (
     and_,
     create_engine,
     delete,
-    func,
     select,
     text,
 )
@@ -330,10 +329,7 @@ class SQLRecordManager(RecordManager):
                     constraint="uix_key_namespace",  # Name of constraint
                     set_={
                         "updated_at": pg_insert_stmt.excluded.updated_at,
-                        "group_id": func.coalesce(
-                            pg_insert_stmt.excluded.group_id,
-                            UpsertionRecord.group_id,
-                        ),
+                        "group_id": pg_insert_stmt.excluded.group_id,
                     },
                 )
             else:
@@ -415,10 +411,7 @@ class SQLRecordManager(RecordManager):
                     constraint="uix_key_namespace",  # Name of constraint
                     set_={
                         "updated_at": pg_insert_stmt.excluded.updated_at,
-                        "group_id": func.coalesce(
-                            pg_insert_stmt.excluded.group_id,
-                            UpsertionRecord.group_id,
-                        ),
+                        "group_id": pg_insert_stmt.excluded.group_id,
                     },
                 )
             else:


### PR DESCRIPTION
- Make explicit the `constraint` parameter name to avoid mixing it with `index_elements` [[Documentation](https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#sqlalchemy.dialects.postgresql.Insert.on_conflict_do_update)]
- ~Fallback on the existing `group_id` row value, to avoid setting it to `None`.~
