### PR TITLE
chore(standard-tests): bump to 0.3.21 (relax langchain-core bounds)

### DIFF
--- a/libs/standard-tests/pyproject.toml
+++ b/libs/standard-tests/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Erick Friis", email = "erick@langchain.dev" }]
 license = { text = "MIT" }
 requires-python = ">=3.9"
 dependencies = [
-    "langchain-core<1.0.0,>=0.3.63",
+    "langchain-core<2.0.0,>=0.3.63",
     "pytest<9,>=7",
     "pytest-asyncio<2,>=0.20",
     "httpx<1,>=0.28.1",
@@ -21,7 +21,7 @@ dependencies = [
     "numpy>=2.1.0; python_version>='3.13'",
 ]
 name = "langchain-tests"
-version = "0.3.20"
+version = "0.3.21"
 description = "Standard tests for LangChain implementations"
 readme = "README.md"
 

--- a/libs/standard-tests/uv.lock
+++ b/libs/standard-tests/uv.lock
@@ -363,7 +363,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "0.3.20"
+version = "0.3.21"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
### Overview
Patch release: bump `langchain-tests` to be compatible with `langchain-core` version `1.0.0a1`.

### Changes
- Bump package version to `0.3.21`
- Relax `langchain-core` requirement from `<1.0.0,>=0.3.63` to `<2.0.0,>=0.3.63`

### Motivation
All main LangChain packages are now publishing `1.0.0a` prereleases.  
`langchain-tests` needs a bump so downstreams can install tests alongside the 1.0 series without conflicts.

### Tests
- Verified installation and tests against `langchain-tests` versions `0.3.75` and `1.0.0a1`.
