### PR TITLE
chore(standard-tests): bump `langchain-core` minimum to 0.3.75

### DIFF
--- a/libs/standard-tests/pyproject.toml
+++ b/libs/standard-tests/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Erick Friis", email = "erick@langchain.dev" }]
 license = { text = "MIT" }
 requires-python = ">=3.9"
 dependencies = [
-    "langchain-core<2.0.0,>=0.3.63",
+    "langchain-core<2.0.0,>=0.3.75",
     "pytest<9,>=7",
     "pytest-asyncio<2,>=0.20",
     "httpx<1,>=0.28.1",


### PR DESCRIPTION
Update `langchain-core` dependency min from `>=0.3.63` to `>=0.3.75`.

### Motivation
- We located the `langchain-core` package locally in the monorepo and need to align `langchain-tests` with the new minimum version.
