### PR TITLE
fix(qdrant): allow `as_retriever` to work without embeddings in SPARSE mode

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -240,17 +240,47 @@ class QdrantVectorStore(VectorStore):
     def embeddings(self) -> Optional[Embeddings]:
         """Get the dense embeddings instance that is being used.
 
-        Raises:
-            ValueError: If embeddings are ``None`` and retrieval mode is not SPARSE.
-
         Returns:
             Embeddings: An instance of ``Embeddings``, or None for SPARSE mode.
 
         """
-        if self._embeddings is None and self.retrieval_mode != RetrievalMode.SPARSE:
-            msg = "Embeddings are `None`. Please set using the `embedding` parameter."
-            raise ValueError(msg)
         return self._embeddings
+
+    def _get_retriever_tags(self) -> list[str]:
+        """Get tags for retriever.
+
+        Override the base class method to handle SPARSE mode where embeddings can be None.
+        In SPARSE mode, embeddings is None, so we don't include embeddings class name in tags.
+        In DENSE/HYBRID modes, embeddings is not None, so we include embeddings class name.
+        """
+        tags = [self.__class__.__name__]
+
+        # Handle different retrieval modes
+        if self.retrieval_mode == RetrievalMode.SPARSE:
+            # SPARSE mode: no dense embeddings, so no embeddings class name in tags
+            pass
+        else:
+            # DENSE/HYBRID modes: include embeddings class name if available
+            if self.embeddings is not None:
+                tags.append(self.embeddings.__class__.__name__)
+
+        return tags
+
+    def _require_embeddings(self, operation: str) -> Embeddings:
+        """Require embeddings for operations that need them.
+
+        Args:
+            operation: Description of the operation requiring embeddings.
+
+        Returns:
+            The embeddings instance.
+
+        Raises:
+            ValueError: If embeddings are None and required for the operation.
+        """
+        if self.embeddings is None:
+            raise ValueError(f"Embeddings are required for {operation}")
+        return self.embeddings
 
     @property
     def sparse_embeddings(self) -> SparseEmbeddings:
@@ -517,7 +547,7 @@ class QdrantVectorStore(VectorStore):
             **kwargs,
         }
         if self.retrieval_mode == RetrievalMode.DENSE:
-            query_dense_embedding = self.embeddings.embed_query(query)
+            query_dense_embedding = self._require_embeddings("DENSE mode").embed_query(query)
             results = self.client.query_points(
                 query=query_dense_embedding,
                 using=self.vector_name,
@@ -536,7 +566,7 @@ class QdrantVectorStore(VectorStore):
             ).points
 
         elif self.retrieval_mode == RetrievalMode.HYBRID:
-            query_dense_embedding = self.embeddings.embed_query(query)
+            query_dense_embedding = self._require_embeddings("HYBRID mode").embed_query(query)
             query_sparse_embedding = self.sparse_embeddings.embed_query(query)
             results = self.client.query_points(
                 prefetch=[
@@ -690,7 +720,7 @@ class QdrantVectorStore(VectorStore):
             self.embeddings,
         )
 
-        query_embedding = self.embeddings.embed_query(query)
+        query_embedding = self._require_embeddings("max_marginal_relevance_search").embed_query(query)
         return self.max_marginal_relevance_search_by_vector(
             query_embedding,
             k=k,
@@ -1041,7 +1071,7 @@ class QdrantVectorStore(VectorStore):
         texts: Iterable[str],
     ) -> list[models.VectorStruct]:
         if self.retrieval_mode == RetrievalMode.DENSE:
-            batch_embeddings = self.embeddings.embed_documents(list(texts))
+            batch_embeddings = self._require_embeddings("DENSE mode").embed_documents(list(texts))
             return [
                 {
                     self.vector_name: vector,
@@ -1063,7 +1093,7 @@ class QdrantVectorStore(VectorStore):
             ]
 
         if self.retrieval_mode == RetrievalMode.HYBRID:
-            dense_embeddings = self.embeddings.embed_documents(list(texts))
+            dense_embeddings = self._require_embeddings("HYBRID mode").embed_documents(list(texts))
             sparse_embeddings = self.sparse_embeddings.embed_documents(list(texts))
 
             if len(dense_embeddings) != len(sparse_embeddings):

--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -237,17 +237,17 @@ class QdrantVectorStore(VectorStore):
         return self._client
 
     @property
-    def embeddings(self) -> Embeddings:
+    def embeddings(self) -> Optional[Embeddings]:
         """Get the dense embeddings instance that is being used.
 
         Raises:
-            ValueError: If embeddings are ``None``.
+            ValueError: If embeddings are ``None`` and retrieval mode is not SPARSE.
 
         Returns:
-            Embeddings: An instance of ``Embeddings``.
+            Embeddings: An instance of ``Embeddings``, or None for SPARSE mode.
 
         """
-        if self._embeddings is None:
+        if self._embeddings is None and self.retrieval_mode != RetrievalMode.SPARSE:
             msg = "Embeddings are `None`. Please set using the `embedding` parameter."
             raise ValueError(msg)
         return self._embeddings

--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -249,9 +249,10 @@ class QdrantVectorStore(VectorStore):
     def _get_retriever_tags(self) -> list[str]:
         """Get tags for retriever.
 
-        Override the base class method to handle SPARSE mode where embeddings can be None.
-        In SPARSE mode, embeddings is None, so we don't include embeddings class name in tags.
-        In DENSE/HYBRID modes, embeddings is not None, so we include embeddings class name.
+        Override the base class method to handle SPARSE mode where embeddings can be
+        None. In SPARSE mode, embeddings is None, so we don't include embeddings class
+        name in tags. In DENSE/HYBRID modes, embeddings is not None, so we include
+        embeddings class name.
         """
         tags = [self.__class__.__name__]
 
@@ -279,7 +280,8 @@ class QdrantVectorStore(VectorStore):
             ValueError: If embeddings are None and required for the operation.
         """
         if self.embeddings is None:
-            raise ValueError(f"Embeddings are required for {operation}")
+            msg = f"Embeddings are required for {operation}"
+            raise ValueError(msg)
         return self.embeddings
 
     @property
@@ -547,7 +549,8 @@ class QdrantVectorStore(VectorStore):
             **kwargs,
         }
         if self.retrieval_mode == RetrievalMode.DENSE:
-            query_dense_embedding = self._require_embeddings("DENSE mode").embed_query(query)
+            embeddings = self._require_embeddings("DENSE mode")
+            query_dense_embedding = embeddings.embed_query(query)
             results = self.client.query_points(
                 query=query_dense_embedding,
                 using=self.vector_name,
@@ -566,7 +569,8 @@ class QdrantVectorStore(VectorStore):
             ).points
 
         elif self.retrieval_mode == RetrievalMode.HYBRID:
-            query_dense_embedding = self._require_embeddings("HYBRID mode").embed_query(query)
+            embeddings = self._require_embeddings("HYBRID mode")
+            query_dense_embedding = embeddings.embed_query(query)
             query_sparse_embedding = self.sparse_embeddings.embed_query(query)
             results = self.client.query_points(
                 prefetch=[
@@ -720,7 +724,8 @@ class QdrantVectorStore(VectorStore):
             self.embeddings,
         )
 
-        query_embedding = self._require_embeddings("max_marginal_relevance_search").embed_query(query)
+        embeddings = self._require_embeddings("max_marginal_relevance_search")
+        query_embedding = embeddings.embed_query(query)
         return self.max_marginal_relevance_search_by_vector(
             query_embedding,
             k=k,
@@ -1071,7 +1076,8 @@ class QdrantVectorStore(VectorStore):
         texts: Iterable[str],
     ) -> list[models.VectorStruct]:
         if self.retrieval_mode == RetrievalMode.DENSE:
-            batch_embeddings = self._require_embeddings("DENSE mode").embed_documents(list(texts))
+            embeddings = self._require_embeddings("DENSE mode")
+            batch_embeddings = embeddings.embed_documents(list(texts))
             return [
                 {
                     self.vector_name: vector,
@@ -1093,7 +1099,8 @@ class QdrantVectorStore(VectorStore):
             ]
 
         if self.retrieval_mode == RetrievalMode.HYBRID:
-            dense_embeddings = self._require_embeddings("HYBRID mode").embed_documents(list(texts))
+            embeddings = self._require_embeddings("HYBRID mode")
+            dense_embeddings = embeddings.embed_documents(list(texts))
             sparse_embeddings = self.sparse_embeddings.embed_documents(list(texts))
 
             if len(dense_embeddings) != len(sparse_embeddings):

--- a/libs/partners/qdrant/tests/integration_tests/qdrant_vector_store/test_search.py
+++ b/libs/partners/qdrant/tests/integration_tests/qdrant_vector_store/test_search.py
@@ -1,8 +1,6 @@
 import pytest
 from langchain_core.documents import Document
 from qdrant_client import models
-from qdrant_client import QdrantClient
-from qdrant_client.http.models import SparseVectorParams
 
 from langchain_qdrant import QdrantVectorStore, RetrievalMode
 from tests.integration_tests.common import (
@@ -316,15 +314,12 @@ def test_similarity_search_filters_with_qdrant_filters(
 @pytest.mark.parametrize("location", qdrant_locations())
 def test_embeddings_property_sparse_mode(location: str) -> None:
     """Test that embeddings property returns None in SPARSE mode."""
-    qdrant = QdrantClient(location)
-    qdrant.create_collection(
-        collection_name="test_sparse_embeddings",
-        sparse_vectors_config={"sparse": SparseVectorParams(modifier=models.Modifier.IDF)},
-    )
-
-    vectorstore = QdrantVectorStore(
-        client=qdrant,
-        collection_name="test_sparse_embeddings",
+    # Use from_texts to create the vectorstore, which handles collection creation
+    texts = ["test document"]
+    vectorstore = QdrantVectorStore.from_texts(
+        texts,
+        embedding=None,  # No dense embedding for SPARSE mode
+        location=location,
         retrieval_mode=RetrievalMode.SPARSE,
         sparse_embedding=ConsistentFakeSparseEmbeddings(),
         sparse_vector_name="sparse",
@@ -337,18 +332,14 @@ def test_embeddings_property_sparse_mode(location: str) -> None:
 @pytest.mark.parametrize("location", qdrant_locations())
 def test_embeddings_property_dense_mode(location: str) -> None:
     """Test that embeddings property returns embedding object in DENSE mode."""
-    qdrant = QdrantClient(location)
-    qdrant.create_collection(
-        collection_name="test_dense_embeddings",
-        vectors_config=models.VectorParams(size=1536, distance=models.Distance.COSINE),
-    )
-
+    # Use from_texts to create the vectorstore, which handles collection creation
+    texts = ["test document"]
     embedding = ConsistentFakeEmbeddings()
-    vectorstore = QdrantVectorStore(
-        client=qdrant,
-        collection_name="test_dense_embeddings",
-        retrieval_mode=RetrievalMode.DENSE,
+    vectorstore = QdrantVectorStore.from_texts(
+        texts,
         embedding=embedding,
+        location=location,
+        retrieval_mode=RetrievalMode.DENSE,
     )
 
     # In DENSE mode, embeddings should return the embedding object
@@ -358,15 +349,12 @@ def test_embeddings_property_dense_mode(location: str) -> None:
 @pytest.mark.parametrize("location", qdrant_locations())
 def test_as_retriever_sparse_mode(location: str) -> None:
     """Test that as_retriever() works in SPARSE mode."""
-    qdrant = QdrantClient(location)
-    qdrant.create_collection(
-        collection_name="test_sparse_retriever",
-        sparse_vectors_config={"sparse": SparseVectorParams(modifier=models.Modifier.IDF)},
-    )
-
-    vectorstore = QdrantVectorStore(
-        client=qdrant,
-        collection_name="test_sparse_retriever",
+    # Use from_texts to create the vectorstore, which handles collection creation
+    texts = ["test document"]
+    vectorstore = QdrantVectorStore.from_texts(
+        texts,
+        embedding=None,  # No dense embedding for SPARSE mode
+        location=location,
         retrieval_mode=RetrievalMode.SPARSE,
         sparse_embedding=ConsistentFakeSparseEmbeddings(),
         sparse_vector_name="sparse",
@@ -389,7 +377,7 @@ def test_as_retriever_sparse_mode(location: str) -> None:
     assert all(isinstance(doc, Document) for doc in results)
 
     # Test that retriever has tags
-    assert hasattr(retriever, 'tags')
+    assert hasattr(retriever, "tags")
     assert isinstance(retriever.tags, list)
     assert "QdrantVectorStore" in retriever.tags
 
@@ -397,15 +385,12 @@ def test_as_retriever_sparse_mode(location: str) -> None:
 @pytest.mark.parametrize("location", qdrant_locations())
 def test_as_retriever_sparse_mode_with_search_kwargs(location: str) -> None:
     """Test as_retriever() with custom search_kwargs in SPARSE mode."""
-    qdrant = QdrantClient(location)
-    qdrant.create_collection(
-        collection_name="test_sparse_retriever_kwargs",
-        sparse_vectors_config={"sparse": SparseVectorParams(modifier=models.Modifier.IDF)},
-    )
-
-    vectorstore = QdrantVectorStore(
-        client=qdrant,
-        collection_name="test_sparse_retriever_kwargs",
+    # Use from_texts to create the vectorstore, which handles collection creation
+    texts = ["test document"]
+    vectorstore = QdrantVectorStore.from_texts(
+        texts,
+        embedding=None,  # No dense embedding for SPARSE mode
+        location=location,
         retrieval_mode=RetrievalMode.SPARSE,
         sparse_embedding=ConsistentFakeSparseEmbeddings(),
         sparse_vector_name="sparse",


### PR DESCRIPTION
Description:
Fixes a bug where QdrantVectorStore.as_retriever() raised a ValueError if embedding=None, even when retrieval_mode=RetrievalMode.SPARSE. This fix relaxes the check in the .embeddings property to allow sparse-only configurations.

Fixes #32751
Dependencies: None