### PR TITLE
fix(core): ensure `InjectedToolCallId` always overrides LLM-generated values

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -655,10 +655,7 @@ class ChildTool(BaseTool):
                 return tool_input
             if issubclass(input_args, BaseModel):
                 for k, v in get_all_basemodel_annotations(input_args).items():
-                    if (
-                        _is_injected_arg_type(v, injected_type=InjectedToolCallId)
-                        and k not in tool_input
-                    ):
+                    if _is_injected_arg_type(v, injected_type=InjectedToolCallId):
                         if tool_call_id is None:
                             msg = (
                                 "When tool includes an InjectedToolCallId "
@@ -673,10 +670,7 @@ class ChildTool(BaseTool):
                 result_dict = result.model_dump()
             elif issubclass(input_args, BaseModelV1):
                 for k, v in get_all_basemodel_annotations(input_args).items():
-                    if (
-                        _is_injected_arg_type(v, injected_type=InjectedToolCallId)
-                        and k not in tool_input
-                    ):
+                    if _is_injected_arg_type(v, injected_type=InjectedToolCallId):
                         if tool_call_id is None:
                             msg = (
                                 "When tool includes an InjectedToolCallId "

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2316,6 +2316,7 @@ def test_tool_injected_tool_call_id() -> None:
 
 def test_tool_injected_tool_call_id_override_llm_generated() -> None:
     """Test that InjectedToolCallId overrides LLM-generated values."""
+
     @tool
     def foo(x: int, tool_call_id: Annotated[str, InjectedToolCallId]) -> ToolMessage:
         """Foo."""

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2314,6 +2314,27 @@ def test_tool_injected_tool_call_id() -> None:
     ) == ToolMessage(0, tool_call_id="bar")  # type: ignore[arg-type]
 
 
+def test_tool_injected_tool_call_id_override_llm_generated() -> None:
+    """Test that InjectedToolCallId overrides LLM-generated values."""
+    @tool
+    def foo(x: int, tool_call_id: Annotated[str, InjectedToolCallId]) -> ToolMessage:
+        """Foo."""
+        return ToolMessage(x, tool_call_id=tool_call_id)  # type: ignore[arg-type]
+
+    # Test that when LLM generates the tool_call_id, it gets overridden
+    result = foo.invoke(
+        {
+            "type": "tool_call",
+            "args": {"x": 0, "tool_call_id": "fake_llm_id"},  # LLM generated this
+            "name": "foo",
+            "id": "real_tool_call_id",  # This should be used instead
+        }
+    )
+
+    # The tool should receive the real tool call ID, not the LLM-generated one
+    assert result == ToolMessage(0, tool_call_id="real_tool_call_id")  # type: ignore[arg-type]
+
+
 def test_tool_uninjected_tool_call_id() -> None:
     @tool
     def foo(x: int, tool_call_id: str) -> ToolMessage:


### PR DESCRIPTION
**Description:** This PR fixes a bug where InjectedToolCallId injection would fail when an LLM generates the parameter that should be automatically injected. Previously, the injection logic would skip injection if the parameter was already present in the tool input, causing tools to receive LLM-generated fake IDs instead of the real tool call ID.

The fix removes the `k not in tool_input` condition check, ensuring that InjectedToolCallId parameters are always injected regardless of whether the LLM has already provided them. This maintains the intended behavior where injected parameters should always override any user-provided values.

**Issue:** Fixes #32729

**Dependencies:** None