### PR TITLE
chore(core): add utf-8 encoding to `Path` `read_text`/`write_text`

### DIFF
--- a/libs/cli/scripts/generate_migrations.py
+++ b/libs/cli/scripts/generate_migrations.py
@@ -72,7 +72,7 @@ def generic(
     else:
         dumped = dump_migrations_as_grit(name, migrations)
 
-    Path(output).write_text(dumped)
+    Path(output).write_text(dumped, encoding="utf-8")
 
 
 def handle_partner(pkg: str, output: str | None = None) -> None:
@@ -83,7 +83,7 @@ def handle_partner(pkg: str, output: str | None = None) -> None:
     data = dump_migrations_as_grit(name, migrations)
     output_name = f"{name}.grit" if output is None else output
     if migrations:
-        Path(output_name).write_text(data)
+        Path(output_name).write_text(data, encoding="utf-8")
         click.secho(f"LangChain migration script saved to {output_name}")
     else:
         click.secho(f"No migrations found for {pkg}", fg="yellow")
@@ -108,7 +108,7 @@ def json_to_grit(json_file: str) -> None:
     name = file.stem
     data = dump_migrations_as_grit(name, migrations)
     output_name = f"{name}.grit"
-    Path(output_name).write_text(data)
+    Path(output_name).write_text(data, encoding="utf-8")
     click.secho(f"GritQL migration script saved to {output_name}")
 
 

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -1430,10 +1430,10 @@ class BaseLLM(BaseLanguageModel[str], ABC):
         prompt_dict = self.dict()
 
         if save_path.suffix == ".json":
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 json.dump(prompt_dict, f, indent=4)
         elif save_path.suffix.endswith((".yaml", ".yml")):
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 yaml.dump(prompt_dict, f, default_flow_style=False)
         else:
             msg = f"{save_path} must be json or yaml"

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -384,10 +384,10 @@ class BasePromptTemplate(
         directory_path.mkdir(parents=True, exist_ok=True)
 
         if save_path.suffix == ".json":
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 json.dump(prompt_dict, f, indent=4)
         elif save_path.suffix.endswith((".yaml", ".yml")):
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 yaml.dump(prompt_dict, f, default_flow_style=False)
         else:
             msg = f"{save_path} must be json or yaml"

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -543,8 +543,7 @@ class _StringImageMessagePromptTemplate(BaseMessagePromptTemplate):
         Returns:
             A new instance of this class.
         """
-        template = Path(template_file).read_text()
-        # TODO: .read_text(encoding="utf-8") for v0.4
+        template = Path(template_file).read_text(encoding="utf-8")
         return cls.from_template(template, input_variables=input_variables, **kwargs)
 
     def format_messages(self, **kwargs: Any) -> list[BaseMessage]:

--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -53,7 +53,7 @@ def _load_template(var_name: str, config: dict) -> dict:
         template_path = Path(config.pop(f"{var_name}_path"))
         # Load the template.
         if template_path.suffix == ".txt":
-            template = template_path.read_text()
+            template = template_path.read_text(encoding="utf-8")
         else:
             raise ValueError
         # Set the template variable to the extracted variable.
@@ -67,7 +67,7 @@ def _load_examples(config: dict) -> dict:
         pass
     elif isinstance(config["examples"], str):
         path = Path(config["examples"])
-        with path.open() as f:
+        with path.open(encoding="utf-8") as f:
             if path.suffix == ".json":
                 examples = json.load(f)
             elif path.suffix in {".yaml", ".yml"}:

--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -597,7 +597,7 @@ class InMemoryVectorStore(VectorStore):
             A VectorStore object.
         """
         path_: Path = Path(path)
-        with path_.open("r") as f:
+        with path_.open("r", encoding="utf-8") as f:
             store = load(json.load(f))
         vectorstore = cls(embedding=embedding, **kwargs)
         vectorstore.store = store
@@ -611,5 +611,5 @@ class InMemoryVectorStore(VectorStore):
         """
         path_: Path = Path(path)
         path_.parent.mkdir(exist_ok=True, parents=True)
-        with path_.open("w") as f:
+        with path_.open("w", encoding="utf-8") as f:
             json.dump(dumpd(self.store), f, indent=2)

--- a/libs/langchain/tests/unit_tests/test_imports.py
+++ b/libs/langchain/tests/unit_tests/test_imports.py
@@ -118,7 +118,7 @@ def extract_deprecated_lookup(file_path: str) -> Optional[dict[str, Any]]:
     Returns:
         dict or None: The value of DEPRECATED_LOOKUP if it exists, None otherwise.
     """
-    tree = ast.parse(Path(file_path).read_text(), filename=file_path)
+    tree = ast.parse(Path(file_path).read_text(encoding="utf-8"), filename=file_path)
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):


### PR DESCRIPTION
## Summary

This PR standardizes all text file I/O to use `UTF-8`. This eliminates OS-specific defaults (e.g. Windows `cp1252`) and ensures consistent, Unicode-safe behavior across platforms.

## Breaking changes

Users on systems with a default encoding which is not utf-8 may see decoding errors from the following code paths:

* langchain_core.vectorstores.in_memroy.InMemoryVectorStore.load
* langchain_core.prompts.loading.load_prompt
* `from_template` in AIMessagePromptTemplate, HumanMessagePromptTemplate, SystemMessagePromptTemplate

## Migration

Change the encoding of files that are encoded with a non utf-8 encoding to utf-8.