### PR TITLE
refactor(core): refactors for python 3.10+

### DIFF
--- a/libs/core/langchain_core/_api/deprecation.py
+++ b/libs/core/langchain_core/_api/deprecation.py
@@ -18,6 +18,7 @@ from collections.abc import Generator
 from typing import (
     Any,
     Callable,
+    ParamSpec,
     TypeVar,
     Union,
     cast,
@@ -25,7 +26,6 @@ from typing import (
 
 from pydantic.fields import FieldInfo
 from pydantic.v1.fields import FieldInfo as FieldInfoV1
-from typing_extensions import ParamSpec
 
 from langchain_core._api.internal import is_caller_internal
 

--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -12,12 +12,13 @@ from typing import (
     Callable,
     Literal,
     Optional,
+    TypeAlias,
     TypeVar,
     Union,
 )
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-from typing_extensions import TypeAlias, TypedDict, override
+from typing_extensions import TypedDict, override
 
 from langchain_core._api import deprecated
 from langchain_core.caches import BaseCache

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -4,10 +4,10 @@ import json
 import logging
 import operator
 from collections.abc import Sequence
-from typing import Any, Literal, Optional, Union, cast
+from typing import Any, Literal, Optional, Union, cast, overload
 
 from pydantic import model_validator
-from typing_extensions import NotRequired, Self, TypedDict, overload, override
+from typing_extensions import NotRequired, Self, TypedDict, override
 
 from langchain_core.messages import content as types
 from langchain_core.messages.base import (

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -28,17 +28,19 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Literal,
     Optional,
     Protocol,
     TypeVar,
     Union,
     cast,
+    get_args,
     get_type_hints,
     overload,
 )
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
-from typing_extensions import Literal, get_args, override
+from typing_extensions import override
 
 from langchain_core._api import beta_decorator
 from langchain_core.load.serializable import (

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -10,9 +10,18 @@ from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from contextvars import Context, ContextVar, Token, copy_context
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypeVar, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Optional,
+    ParamSpec,
+    TypeVar,
+    Union,
+    cast,
+)
 
-from typing_extensions import ParamSpec, TypedDict
+from typing_extensions import TypedDict
 
 from langchain_core.runnables.utils import (
     Input,

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -18,11 +18,12 @@ from typing import (
     NamedTuple,
     Optional,
     Protocol,
+    TypeGuard,
     TypeVar,
     Union,
 )
 
-from typing_extensions import TypeGuard, override
+from typing_extensions import override
 
 # Re-export create-model for backwards compatibility
 from langchain_core.utils.pydantic import create_model  # noqa: F401

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1265,7 +1265,7 @@ class InjectedToolCallId(InjectedToolArg):
 
     .. code-block:: python
 
-        from typing_extensions import Annotated
+        from typing import Annotated
         from langchain_core.messages import ToolMessage
         from langchain_core.tools import tool, InjectedToolCallId
 

--- a/libs/core/langchain_core/tracers/core.py
+++ b/libs/core/langchain_core/tracers/core.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import sys
 import traceback
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
@@ -98,12 +97,7 @@ class _TracerCore(ABC):
         """Get the stacktrace of the parent error."""
         msg = repr(error)
         try:
-            if sys.version_info < (3, 10):
-                tb = traceback.format_exception(
-                    error.__class__, error, error.__traceback__
-                )
-            else:
-                tb = traceback.format_exception(error)
+            tb = traceback.format_exception(error)
             return (msg + "\n\n".join(tb)).strip()
         except:  # noqa: E722
             return msg

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -17,11 +17,13 @@ from typing import (
     Optional,
     Union,
     cast,
+    get_args,
+    get_origin,
 )
 
 from pydantic import BaseModel
 from pydantic.v1 import BaseModel as BaseModelV1
-from typing_extensions import TypedDict, get_args, get_origin, is_typeddict
+from typing_extensions import TypedDict, is_typeddict
 
 from langchain_core._api import beta, deprecated
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage

--- a/libs/core/langchain_core/utils/iter.py
+++ b/libs/core/langchain_core/utils/iter.py
@@ -8,13 +8,12 @@ from types import TracebackType
 from typing import (
     Any,
     Generic,
+    Literal,
     Optional,
     TypeVar,
     Union,
     overload,
 )
-
-from typing_extensions import Literal
 
 T = TypeVar("T")
 

--- a/libs/core/langchain_core/utils/mustache.py
+++ b/libs/core/langchain_core/utils/mustache.py
@@ -18,7 +18,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 logger = logging.getLogger(__name__)
 

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -537,9 +537,6 @@ def test_passthrough_assign_schema() -> None:
     }
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Requires python version >= 3.9 to run."
-)
 def test_lambda_schemas(snapshot: SnapshotAssertion) -> None:
     first_lambda = lambda x: x["hello"]  # noqa: E731
     assert RunnableLambda(first_lambda).get_input_jsonschema() == {
@@ -4742,9 +4739,6 @@ async def test_runnable_branch_astream_with_callbacks() -> None:
     assert tracer.runs[2].outputs == {"output": "bye"}
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Requires python version >= 3.9 to run."
-)
 def test_representation_of_runnables() -> None:
     """Test representation of runnables."""
     runnable = RunnableLambda(lambda x: x * 2)

--- a/libs/core/tests/unit_tests/runnables/test_tracing_interops.py
+++ b/libs/core/tests/unit_tests/runnables/test_tracing_interops.py
@@ -5,7 +5,7 @@ import sys
 import uuid
 from collections.abc import AsyncGenerator, Coroutine, Generator
 from inspect import isasyncgenfunction
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Literal, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,7 +13,6 @@ from langsmith import Client, get_current_run_tree, traceable
 from langsmith.run_helpers import tracing_context
 from langsmith.run_trees import RunTree
 from langsmith.utils import get_env_var
-from typing_extensions import Literal
 
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.runnables.base import RunnableLambda, RunnableParallel

--- a/libs/core/tests/unit_tests/runnables/test_utils.py
+++ b/libs/core/tests/unit_tests/runnables/test_utils.py
@@ -1,4 +1,3 @@
-import sys
 from typing import Callable
 
 import pytest
@@ -11,9 +10,6 @@ from langchain_core.runnables.utils import (
 )
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 9), reason="Requires python version >= 3.9 to run."
-)
 @pytest.mark.parametrize(
     ("func", "expected_source"),
     [

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1,9 +1,8 @@
 import unittest
 import uuid
-from typing import Optional, Union
+from typing import Optional, Union, get_args
 
 import pytest
-from typing_extensions import get_args
 
 from langchain_core.documents import Document
 from langchain_core.load import dumpd, load
@@ -211,7 +210,7 @@ def test_chat_message_chunks() -> None:
     ):
         ChatMessageChunk(role="User", content="I am") + ChatMessageChunk(
             role="Assistant", content=" indeed."
-        )  # type: ignore[reportUnusedExpression, unused-ignore]
+        )
 
     assert ChatMessageChunk(role="User", content="I am") + AIMessageChunk(
         content=" indeed."
@@ -320,7 +319,7 @@ def test_function_message_chunks() -> None:
     ):
         FunctionMessageChunk(name="hello", content="I am") + FunctionMessageChunk(
             name="bye", content=" indeed."
-        )  # type: ignore[reportUnusedExpression, unused-ignore]
+        )
 
 
 def test_ai_message_chunks() -> None:
@@ -336,7 +335,7 @@ def test_ai_message_chunks() -> None:
     ):
         AIMessageChunk(example=True, content="I am") + AIMessageChunk(
             example=False, content=" indeed."
-        )  # type: ignore[reportUnusedExpression, unused-ignore]
+        )
 
 
 class TestGetBufferString(unittest.TestCase):

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1,28 +1,22 @@
-import sys
 import typing
 from collections.abc import Iterable, Mapping, MutableMapping, Sequence
-from typing import Annotated as ExtensionsAnnotated
+from typing import Annotated as TypingAnnotated
 from typing import (
     Any,
     Callable,
     Literal,
     Optional,
+    TypeAlias,
     Union,
 )
 from typing import TypedDict as TypingTypedDict
 
 import pytest
+from pydantic import BaseModel, Field
 from pydantic import BaseModel as BaseModelV2Maybe  # pydantic: ignore
 from pydantic import Field as FieldV2Maybe  # pydantic: ignore
-from typing_extensions import TypeAlias
+from typing_extensions import Annotated as ExtensionsAnnotated  # noqa: UP035
 from typing_extensions import TypedDict as ExtensionsTypedDict
-
-try:
-    from typing import Annotated as TypingAnnotated
-except ImportError:
-    TypingAnnotated = ExtensionsAnnotated
-
-from pydantic import BaseModel, Field
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import Runnable, RunnableLambda
@@ -177,8 +171,8 @@ def dummy_typing_typed_dict() -> type:
     class dummy_function(TypingTypedDict):  # noqa: N801
         """Dummy function."""
 
-        arg1: TypingAnnotated[int, ..., "foo"]  # noqa: F821
-        arg2: TypingAnnotated[Literal["bar", "baz"], ..., "one of 'bar', 'baz'"]  # noqa: F722
+        arg1: TypingAnnotated[int, ..., "foo"]
+        arg2: TypingAnnotated[Literal["bar", "baz"], ..., "one of 'bar', 'baz'"]
 
     return dummy_function
 
@@ -1047,12 +1041,9 @@ def test__convert_typed_dict_to_openai_function_fail(typed_dict: type) -> None:
         _convert_typed_dict_to_openai_function(Tool)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 10), reason="Requires python version >= 3.10 to run."
-)
-def test_convert_union_type_py_39() -> None:
+def test_convert_union_type() -> None:
     @tool
-    def magic_function(value: int | str) -> str:  # type: ignore[syntax,unused-ignore] # noqa: ARG001,FA102
+    def magic_function(value: int | str) -> str:  # noqa: ARG001,FA102
         """Compute a magic function."""
         return ""
 


### PR DESCRIPTION
* Remove `sys.version_info` checks no longer needed
* Use `typing` instead of `typing_extensions` where applicable (NB: keep using `TypedDict` from `typing_extensions` as [Pydantic requires it](https://docs.pydantic.dev/2.3/usage/types/dicts_mapping/#typeddict))