### PR TITLE
docs: update evaluation tutorial link

### DIFF
--- a/docs/docs/tutorials/index.mdx
+++ b/docs/docs/tutorials/index.mdx
@@ -44,4 +44,4 @@ You can peruse [LangSmith tutorials here](https://docs.smith.langchain.com/).
 
 LangSmith helps you evaluate the performance of your LLM applications. The tutorial below is a great way to get started:
 
-- [Evaluate your LLM application](https://docs.smith.langchain.com/tutorials/Developers/evaluation)
+- [Evaluate your LLM application](https://docs.langchain.com/langsmith/evaluate-llm-application)


### PR DESCRIPTION
**Description**
This PR updates the evaluation tutorial link for LangSmith to the new official docs location.

**Issue**
N/A

**Dependencies**
None