### PR TITLE
feat(core): support AWS Bedrock `document` content blocks in msg_content_output

### DIFF
--- a/docs/docs/concepts/tracing.mdx
+++ b/docs/docs/concepts/tracing.mdx
@@ -7,4 +7,4 @@ Traces contain individual steps called `runs`. These can be individual calls fro
 tool, or sub-chains.
 Tracing gives you observability inside your chains and agents, and is vital in diagnosing issues.
 
-For a deeper dive, check out [this LangSmith conceptual guide](https://python.langchain.com/docs/concepts/).
+For a deeper dive, check out [this LangSmith conceptual guide](https://docs.langchain.com/langsmith/observability-quickstart).

--- a/docs/docs/concepts/tracing.mdx
+++ b/docs/docs/concepts/tracing.mdx
@@ -7,4 +7,4 @@ Traces contain individual steps called `runs`. These can be individual calls fro
 tool, or sub-chains.
 Tracing gives you observability inside your chains and agents, and is vital in diagnosing issues.
 
-For a deeper dive, check out [this LangSmith conceptual guide](https://docs.smith.langchain.com/concepts/tracing).
+For a deeper dive, check out [this LangSmith conceptual guide](https://python.langchain.com/docs/concepts/).

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -80,7 +80,9 @@ TOOL_MESSAGE_BLOCK_TYPES = (
     "image",
     "json",
     "search_result",
-    "custom_tool_call_output",
+    "custom_tool_call_output"
+    "document",
+
 )
 
 

--- a/libs/core/tests/unit_tests/test_msg_content_output_preserves_document_block.py
+++ b/libs/core/tests/unit_tests/test_msg_content_output_preserves_document_block.py
@@ -1,0 +1,16 @@
+def test_msg_content_output_preserves_document_block():
+    """Document blocks should pass through unchanged when recognized."""
+    from langgraph.schema.message import msg_content_output
+    doc_block = [{"type": "document", "content": [{"text": "Hello"}]}]
+    result = msg_content_output(doc_block)
+    assert result == doc_block
+
+
+def test_msg_content_output_falls_back_to_json_for_unknown_block():
+    """Unknown block types should be JSON serialized for backward compatibility."""
+    from langgraph.schema.message import msg_content_output
+    unknown_block = [{"type": "foo_block", "content": [{"text": "bar"}]}]
+    result = msg_content_output(unknown_block)
+    # Should be serialized to a JSON string
+    import json
+    assert result == json.dumps(unknown_block, ensure_ascii=False)


### PR DESCRIPTION
**Description:**
This PR adds support for AWS Bedrock `document` content blocks in `msg_content_output`.  
Currently, any tool output containing a `document` block gets serialized into a JSON string because `document` is not included in `TOOL_MESSAGE_BLOCK_TYPES`. This prevents Bedrock from recognizing structured document responses and generating citations.

With this change, `"document"` is added to `TOOL_MESSAGE_BLOCK_TYPES`, allowing document blocks to pass through unchanged.

**Issue:** Fixes #32781 
