### PR TITLE
feat(core): support AWS Bedrock `document` content blocks in msg_content_output

### DIFF
--- a/docs/docs/concepts/tracing.mdx
+++ b/docs/docs/concepts/tracing.mdx
@@ -7,4 +7,4 @@ Traces contain individual steps called `runs`. These can be individual calls fro
 tool, or sub-chains.
 Tracing gives you observability inside your chains and agents, and is vital in diagnosing issues.
 
-For a deeper dive, check out [this LangSmith conceptual guide](https://python.langchain.com/docs/concepts/).
+For a deeper dive, check out [this LangSmith conceptual guide](https://docs.langchain.com/langsmith/observability-quickstart).

--- a/docs/docs/concepts/tracing.mdx
+++ b/docs/docs/concepts/tracing.mdx
@@ -7,4 +7,4 @@ Traces contain individual steps called `runs`. These can be individual calls fro
 tool, or sub-chains.
 Tracing gives you observability inside your chains and agents, and is vital in diagnosing issues.
 
-For a deeper dive, check out [this LangSmith conceptual guide](https://docs.smith.langchain.com/concepts/tracing).
+For a deeper dive, check out [this LangSmith conceptual guide](https://python.langchain.com/docs/concepts/).

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -80,7 +80,9 @@ TOOL_MESSAGE_BLOCK_TYPES = (
     "image",
     "json",
     "search_result",
-    "custom_tool_call_output",
+    "custom_tool_call_output"
+    "document",
+
 )
 
 

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -80,9 +80,8 @@ TOOL_MESSAGE_BLOCK_TYPES = (
     "image",
     "json",
     "search_result",
-    "custom_tool_call_output"
+    "custom_tool_call_output",
     "document",
-
 )
 
 

--- a/libs/core/tests/unit_tests/test_msg_content_output_preserves_document_block.py
+++ b/libs/core/tests/unit_tests/test_msg_content_output_preserves_document_block.py
@@ -1,0 +1,16 @@
+def test_msg_content_output_preserves_document_block():
+    """Document blocks should pass through unchanged when recognized."""
+    from langgraph.schema.message import msg_content_output
+    doc_block = [{"type": "document", "content": [{"text": "Hello"}]}]
+    result = msg_content_output(doc_block)
+    assert result == doc_block
+
+
+def test_msg_content_output_falls_back_to_json_for_unknown_block():
+    """Unknown block types should be JSON serialized for backward compatibility."""
+    from langgraph.schema.message import msg_content_output
+    unknown_block = [{"type": "foo_block", "content": [{"text": "bar"}]}]
+    result = msg_content_output(unknown_block)
+    # Should be serialized to a JSON string
+    import json
+    assert result == json.dumps(unknown_block, ensure_ascii=False)

--- a/libs/core/tests/unit_tests/test_msg_content_output_preserves_document_block.py
+++ b/libs/core/tests/unit_tests/test_msg_content_output_preserves_document_block.py
@@ -1,4 +1,4 @@
-def test_msg_content_output_preserves_document_block():
+def test_msg_content_output_preserves_document_block() -> None:
     """Document blocks should pass through unchanged when recognized."""
     from langgraph.schema.message import msg_content_output
     doc_block = [{"type": "document", "content": [{"text": "Hello"}]}]
@@ -6,7 +6,7 @@ def test_msg_content_output_preserves_document_block():
     assert result == doc_block
 
 
-def test_msg_content_output_falls_back_to_json_for_unknown_block():
+def test_msg_content_output_falls_back_to_json_for_unknown_block() -> None:
     """Unknown block types should be JSON serialized for backward compatibility."""
     from langgraph.schema.message import msg_content_output
     unknown_block = [{"type": "foo_block", "content": [{"text": "bar"}]}]

--- a/libs/core/tests/unit_tests/test_msg_content_output_preserves_document_block.py
+++ b/libs/core/tests/unit_tests/test_msg_content_output_preserves_document_block.py
@@ -1,6 +1,10 @@
+import json
+
+from langgraph.schema.message import msg_content_output
+
+
 def test_msg_content_output_preserves_document_block() -> None:
     """Document blocks should pass through unchanged when recognized."""
-    from langgraph.schema.message import msg_content_output
     doc_block = [{"type": "document", "content": [{"text": "Hello"}]}]
     result = msg_content_output(doc_block)
     assert result == doc_block
@@ -8,9 +12,7 @@ def test_msg_content_output_preserves_document_block() -> None:
 
 def test_msg_content_output_falls_back_to_json_for_unknown_block() -> None:
     """Unknown block types should be JSON serialized for backward compatibility."""
-    from langgraph.schema.message import msg_content_output
     unknown_block = [{"type": "foo_block", "content": [{"text": "bar"}]}]
     result = msg_content_output(unknown_block)
     # Should be serialized to a JSON string
-    import json
     assert result == json.dumps(unknown_block, ensure_ascii=False)


### PR DESCRIPTION
**Description:**
This PR adds support for AWS Bedrock `document` content blocks in `msg_content_output`.  

Currently, when tools return `document` blocks (used by AWS Bedrock for citations and structured document responses), LangGraph serializes them into JSON strings because `document` is not included in `TOOL_MESSAGE_BLOCK_TYPES`. This prevents Bedrock from recognizing them and generating proper citations.  

This change adds `"document"` to `TOOL_MESSAGE_BLOCK_TYPES`, allowing these blocks to pass through unmodified.  

**Issue:** Fixes #32781 

**Dependencies:** None

**Tests:**
- ✅ `test_msg_content_output_preserves_document_block`: ensures `document` blocks are preserved.  
- ✅ `test_msg_content_output_falls_back_to_json_for_unknown_block`: ensures unknown block types still fallback to JSON serialization for backward compatibility.  
