### PR TITLE
fix(docs): update Anthropic model name and add version warnings

### DIFF
--- a/docs/src/theme/ChatModelTabs.js
+++ b/docs/src/theme/ChatModelTabs.js
@@ -118,7 +118,8 @@ export default function ChatModelTabs(props) {
     {
       value: "anthropic",
       label: "Anthropic",
-      model: "claude-3-5-sonnet-latest",
+      model: "claude-3-7-sonnet-20250219",
+      comment: "# Note: Model versions may become outdated. Check https://docs.anthropic.com/en/docs/models-overview for latest versions",
       apiKeyName: "ANTHROPIC_API_KEY",
       packageName: "langchain[anthropic]",
     },
@@ -269,6 +270,9 @@ if not os.environ.get("${selectedTabItem.apiKeyName}"):
 
 ${llmVarName} = init_chat_model("${selectedTabItem.model}", model_provider="${selectedTabItem.value}"${selectedTabItem?.kwargs ? `, ${selectedTabItem.kwargs}` : ""})`;
 
+  // Add comment if available
+  const commentText = selectedTabItem?.comment ? selectedTabItem.comment + "\n\n" : "";
+
   return (
     <div>
       <CustomDropdown
@@ -282,7 +286,7 @@ ${llmVarName} = init_chat_model("${selectedTabItem.model}", model_provider="${se
         {`pip install -qU "${selectedTabItem.packageName}"`}
       </CodeBlock>
       <CodeBlock language="python">
-        {apiKeyText ? apiKeyText + "\n\n" + initModelText : initModelText}
+        {apiKeyText ? apiKeyText + "\n\n" + commentText + initModelText : commentText + initModelText}
       </CodeBlock>
     </div>
   );


### PR DESCRIPTION
**Description:** This PR fixes the broken Anthropic model example in the documentation introduction page and adds a comment field to display model version warnings in code blocks. The changes ensure that users can successfully run the example code and are reminded to check for the latest model versions.

**Issue:** https://github.com/langchain-ai/langchain/issues/32806

**Changes made:**
- Update Anthropic model from broken "claude-3-5-sonnet-latest" to working "claude-3-7-sonnet-20250219"
- Add comment field to display model version warnings in code blocks
- Improve user experience by providing working examples and version guidance

**Dependencies:** None required