### PR TITLE
fix(core): fix `BaseMessage` `.text()` filtering out blocks with text

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -98,11 +98,13 @@ class BaseMessage(Serializable):
             return self.content
 
         # must be a list
+        # if a block is a dict, it could be a merged type block
+        # check only if the text prop exists
         blocks = [
             block
             for block in self.content
             if isinstance(block, str)
-            or (block.get("type") == "text" and isinstance(block.get("text"), str))
+            or isinstance(block.get("text"), str)
         ]
         return "".join(
             block if isinstance(block, str) else block["text"] for block in blocks

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -103,8 +103,7 @@ class BaseMessage(Serializable):
         blocks = [
             block
             for block in self.content
-            if isinstance(block, str)
-            or isinstance(block.get("text"), str)
+            if isinstance(block, str) or isinstance(block.get("text"), str)
         ]
         return "".join(
             block if isinstance(block, str) else block["text"] for block in blocks


### PR DESCRIPTION
- **Description:** BaseMessage .text() filters for blocks of type "text" when content is a list of dict. Concatenated messages can result in type != "text" but containing a text prop. This results in calling .text() on the message but receiving "". To address this, only consider if a text prop is present and a str.
