### PR TITLE
chore(core): replace Optional[T] with T | None

### DIFF
--- a/libs/core/langchain_core/globals.py
+++ b/libs/core/langchain_core/globals.py
@@ -1,7 +1,9 @@
 """Global values and configuration that apply to all of LangChain."""
 
+from __future__ import annotations
+
 import warnings
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from langchain_core.caches import BaseCache
@@ -20,7 +22,7 @@ except ImportError:
 # https://github.com/langchain-ai/langchain/pull/11311#issuecomment-1743780004
 _verbose: bool = False
 _debug: bool = False
-_llm_cache: Optional["BaseCache"] = None
+_llm_cache: BaseCache | None = None
 
 
 def set_verbose(value: bool) -> None:  # noqa: FBT001
@@ -152,7 +154,7 @@ def get_debug() -> bool:
     return _debug or old_debug
 
 
-def set_llm_cache(value: Optional["BaseCache"]) -> None:
+def set_llm_cache(value: BaseCache | None) -> None:
     """Set a new LLM cache, overwriting the previous value, if any.
 
     Args:
@@ -182,7 +184,7 @@ def set_llm_cache(value: Optional["BaseCache"]) -> None:
     _llm_cache = value
 
 
-def get_llm_cache() -> Optional["BaseCache"]:
+def get_llm_cache() -> BaseCache | None:
     """Get the value of the `llm_cache` global setting.
 
     Returns:

--- a/libs/core/langchain_core/outputs/chat_result.py
+++ b/libs/core/langchain_core/outputs/chat_result.py
@@ -1,6 +1,6 @@
 """Chat result schema."""
 
-from typing import Optional
+from __future__ import annotations
 
 from pydantic import BaseModel
 
@@ -26,7 +26,7 @@ class ChatResult(BaseModel):
     Generations is a list to allow for multiple candidate generations for a single
     input prompt.
     """
-    llm_output: Optional[dict] = None
+    llm_output: dict | None = None
     """For arbitrary LLM provider specific output.
 
     This dictionary is a free-form dictionary that can contain any information that the

--- a/libs/core/langchain_core/rate_limiters.py
+++ b/libs/core/langchain_core/rate_limiters.py
@@ -6,7 +6,6 @@ import abc
 import asyncio
 import threading
 import time
-from typing import Optional
 
 
 class BaseRateLimiter(abc.ABC):
@@ -163,7 +162,7 @@ class InMemoryRateLimiter(BaseRateLimiter):
         # at a given time.
         self._consume_lock = threading.Lock()
         # The last time we tried to consume tokens.
-        self.last: Optional[float] = None
+        self.last: float | None = None
         self.check_every_n_seconds = check_every_n_seconds
 
     def _consume(self) -> bool:


### PR DESCRIPTION
Modernize type hints to use Python 3.10+ union syntax.

- `rate_limiters.py`: `Optional[float]` → `float | None`
- `globals.py`: `Optional["BaseCache"]` → `"BaseCache | None"`  
- `outputs/chat_result.py`: `Optional[dict]` → `dict | None`