### PR TITLE
fix(core): force overwrite additionalProperties to False in strict mode

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -834,9 +834,11 @@ def _recursive_set_additional_properties_false(
         # Check if 'required' is a key at the current level or if the schema is empty,
         # in which case additionalProperties still needs to be specified.
         # If additionalProperties already be set to True, we need override it to False
-        if "required" in schema or (
-            "properties" in schema and not schema["properties"]
-        ) or "additionalProperties" in schema:
+        if (
+            "required" in schema
+            or ("properties" in schema and not schema["properties"])
+            or "additionalProperties" in schema
+        ):
             schema["additionalProperties"] = False
 
         # Recursively check 'properties' and 'items' if they exist

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -833,13 +833,10 @@ def _recursive_set_additional_properties_false(
     if isinstance(schema, dict):
         # Check if 'required' is a key at the current level or if the schema is empty,
         # in which case additionalProperties still needs to be specified.
+        # If additionalProperties already be set to True, we need override it to False
         if "required" in schema or (
             "properties" in schema and not schema["properties"]
-        ):
-            schema["additionalProperties"] = False
-
-        # if additionalProperties already be set to True, we override it to False
-        if "additionalProperties" in schema:
+        ) or "additionalProperties" in schema:
             schema["additionalProperties"] = False
 
         # Recursively check 'properties' and 'items' if they exist

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -838,6 +838,10 @@ def _recursive_set_additional_properties_false(
         ):
             schema["additionalProperties"] = False
 
+        # if additionalProperties already be set to True, we override it to False
+        if "additionalProperties" in schema:
+            schema["additionalProperties"] = False
+
         # Recursively check 'properties' and 'items' if they exist
         if "anyOf" in schema:
             for sub_schema in schema["anyOf"]:

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -833,10 +833,13 @@ def _recursive_set_additional_properties_false(
     if isinstance(schema, dict):
         # Check if 'required' is a key at the current level or if the schema is empty,
         # in which case additionalProperties still needs to be specified.
-        # If additionalProperties already be set to True, we need override it to False
         if (
             "required" in schema
             or ("properties" in schema and not schema["properties"])
+            # Since Pydantic 2.11, it will always add `additionalProperties: True`
+            # for arbitrary dictionary schemas
+            # See: https://pydantic.dev/articles/pydantic-v2-11-release#changes
+            # If it is already set to True, we need override it to False
             or "additionalProperties" in schema
         ):
             schema["additionalProperties"] = False

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -25,6 +25,7 @@ except ImportError:
 
 from importlib.metadata import version
 
+from packaging.version import parse
 from pydantic import BaseModel, Field
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -1155,7 +1156,7 @@ def test_convert_to_openai_function_nested_strict_2() -> None:
     }
 
     # there will be no extra `"additionalProperties": False` when Pydantic < 2.11
-    if version("pydantic") < "2.11":
+    if parse(version("pydantic")) < parse("2.11"):
         del expected["parameters"]["properties"]["arg1"]["additionalProperties"]
         del expected["parameters"]["properties"]["arg2"]["anyOf"][0][
             "additionalProperties"

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1146,9 +1146,9 @@ def test_convert_to_openai_function_nested_strict_2() -> None:
                 },
             },
             "required": ["arg1", "arg2"],
-            'additionalProperties': False,
+            "additionalProperties": False,
         },
-        'strict': True,
+        "strict": True,
     }
 
     actual = convert_to_openai_function(my_function, strict=True)

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -12,6 +12,7 @@ from typing import (
 from typing import TypedDict as TypingTypedDict
 
 import pytest
+from aiofiles import stderr
 from pydantic import BaseModel as BaseModelV2Maybe  # pydantic: ignore
 from pydantic import Field as FieldV2Maybe  # pydantic: ignore
 from typing_extensions import TypeAlias
@@ -1122,3 +1123,36 @@ def test_convert_to_json_schema(
     ):
         actual = convert_to_json_schema(fn)
         assert actual == expected
+
+
+def test_convert_to_openai_function_nested_strict_2() -> None:
+    def my_function(arg1: dict, arg2: Union[dict, None]) -> None:
+        """Dummy function."""
+
+    expected = {
+        "name": "my_function",
+        "description": "Dummy function.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                'arg1': {
+                    'additionalProperties': False,
+                    'type': 'object',
+                },
+                "arg2": {
+                    'anyOf': [
+                        {
+                            'additionalProperties': False,
+                            'type': 'object'
+                        }, {
+                            'type': 'null'
+                        }
+                    ],
+                },
+            },
+            "required": ["arg1", "arg2"],
+        },
+    }
+
+    actual = convert_to_openai_function(my_function)
+    assert actual == expected

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -12,7 +12,6 @@ from typing import (
 from typing import TypedDict as TypingTypedDict
 
 import pytest
-from aiofiles import stderr
 from pydantic import BaseModel as BaseModelV2Maybe  # pydantic: ignore
 from pydantic import Field as FieldV2Maybe  # pydantic: ignore
 from typing_extensions import TypeAlias

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1149,5 +1149,5 @@ def test_convert_to_openai_function_nested_strict_2() -> None:
         },
     }
 
-    actual = convert_to_openai_function(my_function)
+    actual = convert_to_openai_function(my_function, strict=True)
     assert actual == expected

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1146,7 +1146,9 @@ def test_convert_to_openai_function_nested_strict_2() -> None:
                 },
             },
             "required": ["arg1", "arg2"],
+            'additionalProperties': False,
         },
+        'strict': True,
     }
 
     actual = convert_to_openai_function(my_function, strict=True)

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -22,6 +22,9 @@ try:
 except ImportError:
     TypingAnnotated = ExtensionsAnnotated
 
+
+from importlib.metadata import version
+
 from pydantic import BaseModel, Field
 
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -1128,7 +1131,7 @@ def test_convert_to_openai_function_nested_strict_2() -> None:
     def my_function(arg1: dict, arg2: Union[dict, None]) -> None:
         """Dummy function."""
 
-    expected = {
+    expected: dict = {
         "name": "my_function",
         "description": "Dummy function.",
         "parameters": {
@@ -1150,6 +1153,13 @@ def test_convert_to_openai_function_nested_strict_2() -> None:
         },
         "strict": True,
     }
+
+    # there will be no extra `"additionalProperties": False` when Pydantic < 2.11
+    if version("pydantic") < "2.11":
+        del expected["parameters"]["properties"]["arg1"]["additionalProperties"]
+        del expected["parameters"]["properties"]["arg2"]["anyOf"][0][
+            "additionalProperties"
+        ]
 
     actual = convert_to_openai_function(my_function, strict=True)
     assert actual == expected

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1134,18 +1134,14 @@ def test_convert_to_openai_function_nested_strict_2() -> None:
         "parameters": {
             "type": "object",
             "properties": {
-                'arg1': {
-                    'additionalProperties': False,
-                    'type': 'object',
+                "arg1": {
+                    "additionalProperties": False,
+                    "type": "object",
                 },
                 "arg2": {
-                    'anyOf': [
-                        {
-                            'additionalProperties': False,
-                            'type': 'object'
-                        }, {
-                            'type': 'null'
-                        }
+                    "anyOf": [
+                        {"additionalProperties": False, "type": "object"},
+                        {"type": "null"},
                     ],
                 },
             },


### PR DESCRIPTION
# Description
This PR fixes a bug in _recursive_set_additional_properties_false used in function_calling.convert_to_openai_function.

Previously, schemas with "additionalProperties=True" were not correctly overridden when strict validation was expected, which could lead to invalid OpenAI function schemas.

The updated implementation ensures that:
- Any schema with "additionalProperties" already set will now be forced to False under strict mode.
- Recursive traversal of properties, items, and anyOf is preserved.
- Function signature remains unchanged for backward compatibility.

# Issue
When using tool calling in OpenAI structured output strict mode (strict=True), 400: "Invalid schema for response_format XXXXX 'additionalProperties' is required to be supplied and to be false" error raises for the parameter that contains dict type. OpenAI requires additionalProperties to be set to False.
Some PRs try to resolved the issue.
- PR #25169 introduced _recursive_set_additional_properties_false to recursively set additionalProperties=False.
- PR #26287 fixed handling of empty parameter tools for OpenAI function generation.
- PR #30971 added support for Union type arguments in strict mode of OpenAI function calling / structured output.

Despite these improvements, since Pydantic 2.11, it will always add `additionalProperties: True` for arbitrary dictionary schemas dict or Any (https://pydantic.dev/articles/pydantic-v2-11-release#changes). Schemas that already had additionalProperties=True in such cases were not being overridden, which this PR addresses to ensure strict mode behaves correctly in all cases.

# Dependencies
No Changes
