### PR TITLE
chore: remove ruff target-version

### DIFF
--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -39,9 +39,6 @@ test_integration = []
 langchain-core = { path = "../core", editable = true }
 langchain = { path = "../langchain", editable = true }
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.format]
 docstring-code-format = true
 

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -73,9 +73,6 @@ disallow_any_generics = false
 warn_return_any = false
 
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.format]
 docstring-code-format = true
 

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -120,7 +120,6 @@ langchain-text-splitters = { path = "../text-splitters", editable = true }
 langchain-openai = { path = "../partners/openai", editable = true }
 
 [tool.ruff]
-target-version = "py39"
 exclude = ["tests/integration_tests/examples/non-utf8-encoding.py"]
 
 [tool.mypy]

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -83,7 +83,6 @@ langchain-text-splitters = { path = "../text-splitters", editable = true }
 langchain-openai = { path = "../partners/openai", editable = true }
 
 [tool.ruff]
-target-version = "py310"
 exclude = ["tests/integration_tests/examples/non-utf8-encoding.py"]
 line-length = 100
 

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -56,9 +56,6 @@ langchain-tests = { path = "../../standard-tests", editable = true }
 disallow_untyped_defs = "True"
 plugins = ['pydantic.mypy']
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/chroma/pyproject.toml
+++ b/libs/partners/chroma/pyproject.toml
@@ -58,9 +58,6 @@ langchain-tests = { path = "../../standard-tests", editable = true }
 [tool.mypy]
 disallow_untyped_defs = true
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/deepseek/pyproject.toml
+++ b/libs/partners/deepseek/pyproject.toml
@@ -45,9 +45,6 @@ langchain-tests = { path = "../../standard-tests", editable = true }
 [tool.mypy]
 disallow_untyped_defs = "True"
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/exa/pyproject.toml
+++ b/libs/partners/exa/pyproject.toml
@@ -44,9 +44,6 @@ langchain-core = { path = "../../core", editable = true }
 [tool.mypy]
 disallow_untyped_defs = "True"
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/fireworks/pyproject.toml
+++ b/libs/partners/fireworks/pyproject.toml
@@ -48,9 +48,6 @@ langchain-tests = { path = "../../standard-tests", editable = true }
 [tool.mypy]
 disallow_untyped_defs = "True"
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/groq/pyproject.toml
+++ b/libs/partners/groq/pyproject.toml
@@ -40,9 +40,6 @@ langchain-tests = { path = "../../standard-tests", editable = true }
 [tool.mypy]
 disallow_untyped_defs = "True"
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/huggingface/pyproject.toml
+++ b/libs/partners/huggingface/pyproject.toml
@@ -54,9 +54,6 @@ langchain-tests = { path = "../../standard-tests", editable = true }
 [tool.mypy]
 disallow_untyped_defs = "True"
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/mistralai/pyproject.toml
+++ b/libs/partners/mistralai/pyproject.toml
@@ -44,9 +44,6 @@ langchain-tests = { path = "../../standard-tests", editable = true }
 [tool.mypy]
 disallow_untyped_defs = "True"
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/nomic/pyproject.toml
+++ b/libs/partners/nomic/pyproject.toml
@@ -40,9 +40,6 @@ dev = ["langchain-core"]
 [tool.uv.sources]
 langchain-core = { path = "../../core", editable = true }
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/ollama/pyproject.toml
+++ b/libs/partners/ollama/pyproject.toml
@@ -42,9 +42,6 @@ langchain-tests = { path = "../../standard-tests", editable = true }
 [tool.mypy]
 disallow_untyped_defs = "True"
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -60,9 +60,6 @@ disallow_untyped_defs = "True"
 module = "transformers"
 ignore_missing_imports = true
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201", "UP", "S"]
 ignore = [ "UP007", "UP045" ]

--- a/libs/partners/perplexity/pyproject.toml
+++ b/libs/partners/perplexity/pyproject.toml
@@ -55,9 +55,6 @@ plugins = ['pydantic.mypy']
 module = "transformers"
 ignore_missing_imports = true
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201", "UP", "S"]
 ignore = [ "UP007", "UP045"]

--- a/libs/partners/prompty/pyproject.toml
+++ b/libs/partners/prompty/pyproject.toml
@@ -45,9 +45,6 @@ langchain-core = { path = "../../core", editable = true }
 langchain-text-splitters = { path = "../../text-splitters", editable = true }
 langchain = { path = "../../langchain", editable = true }
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201", "UP", "S"]
 ignore = [ "UP007", "UP045" ]

--- a/libs/partners/qdrant/pyproject.toml
+++ b/libs/partners/qdrant/pyproject.toml
@@ -47,9 +47,6 @@ typing = ["mypy<2.0,>=1.10", "simsimd<7.0.0,>=6.0.0", "langchain-core"]
 [tool.uv.sources]
 langchain-core = { path = "../../core", editable = true }
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/partners/xai/pyproject.toml
+++ b/libs/partners/xai/pyproject.toml
@@ -50,9 +50,6 @@ langchain-openai = { path = "../openai", editable = true }
 [tool.mypy]
 disallow_untyped_defs = "True"
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 select = [
     "A",      # flake8-builtins

--- a/libs/standard-tests/pyproject.toml
+++ b/libs/standard-tests/pyproject.toml
@@ -55,9 +55,6 @@ disallow_any_generics = false
 module = ["vcr.*",]
 ignore_missing_imports = true
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.format]
 docstring-code-format = true
 

--- a/libs/text-splitters/pyproject.toml
+++ b/libs/text-splitters/pyproject.toml
@@ -63,9 +63,6 @@ warn_unreachable = true
 module = ["konlpy", "nltk",]
 ignore_missing_imports = true
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.format]
 docstring-code-format = true
 


### PR DESCRIPTION
This is not needed anymore since `requires-python` was added when moving to `uv`.