### PR TITLE
fix(ollama): Fix handling message content lists

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -661,8 +661,10 @@ class ChatOllama(BaseChatModel):
             if isinstance(message.content, str):
                 content = message.content
             else:
-                for content_part in cast(list[dict], message.content):
-                    if content_part.get("type") == "text":
+                for content_part in message.content:
+                    if isinstance(content_part, str):
+                        content += f"\n{content_part}"
+                    elif content_part.get("type") == "text":
                         content += f"\n{content_part['text']}"
                     elif content_part.get("type") == "tool_use":
                         continue


### PR DESCRIPTION
The Ollama chat model adapter does not support all of the possible message content formats. That leads to Ollama model adapter crashing on some messages from different models (e.g. Gemini 2.5 Flash).

These changes should fix one known scenario - when `content` is a list containing a string.
