### PR TITLE
test(core): reactivate commented tests in `test_indexing`

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1362,8 +1362,8 @@ def get_all_basemodel_annotations(
                 continue
 
             # if class = FooBar inherits from Baz[str]:
-            # parent = Baz[str],
-            # parent_origin = Baz,
+            # parent = class Baz[str],
+            # parent_origin = class Baz,
             # generic_type_vars = (type vars in Baz)
             # generic_map = {type var in Baz: str}
             generic_type_vars: tuple = getattr(parent_origin, "__parameters__", ())

--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -315,7 +315,7 @@ def tool(
 
     if runnable is not None:
         # tool is used as a function
-        # tool_from_runnable = tool("name", runnable)
+        # for instance tool_from_runnable = tool("name", runnable)
         if not name_or_callable:
             msg = "Runnable without name for tool constructor"
             raise ValueError(msg)

--- a/libs/core/tests/unit_tests/indexing/test_indexing.py
+++ b/libs/core/tests/unit_tests/indexing/test_indexing.py
@@ -2421,14 +2421,12 @@ def test_index_into_document_index(record_manager: InMemoryRecordManager) -> Non
         "num_updated": 2,
     }
 
-    # TODO: This test is failing due to an existing bug with DocumentIndex deletion
-    # when indexing an empty list. Skipping this assertion for now.
-    # assert index([], record_manager, document_index, cleanup="full") == {
-    #     "num_added": 0,
-    #     "num_deleted": 2,
-    #     "num_skipped": 0,
-    #     "num_updated": 0,
-    # }
+    assert index([], record_manager, document_index, cleanup="full") == {
+        "num_added": 0,
+        "num_deleted": 2,
+        "num_skipped": 0,
+        "num_updated": 0,
+    }
 
 
 async def test_aindex_into_document_index(
@@ -2460,6 +2458,7 @@ async def test_aindex_into_document_index(
         "num_skipped": 2,
         "num_updated": 0,
     }
+
     assert await aindex(
         docs, arecord_manager, document_index, cleanup="full", force_update=True
     ) == {
@@ -2469,14 +2468,12 @@ async def test_aindex_into_document_index(
         "num_updated": 2,
     }
 
-    # TODO: This test is failing due to an existing bug with DocumentIndex deletion
-    # when indexing an empty list. Skipping this assertion for now.
-    # assert await aindex([], arecord_manager, document_index, cleanup="full") == {
-    #     "num_added": 0,
-    #     "num_deleted": 2,
-    #     "num_skipped": 0,
-    #     "num_updated": 0,
-    # }
+    assert await aindex([], arecord_manager, document_index, cleanup="full") == {
+        "num_added": 0,
+        "num_deleted": 2,
+        "num_skipped": 0,
+        "num_updated": 0,
+    }
 
 
 def test_index_with_upsert_kwargs(


### PR DESCRIPTION
* These tests now pass
* Commenting them is a [ruff ERA](https://docs.astral.sh/ruff/rules/commented-out-code/) violation