### PR TITLE
fix(infra): exclude pre-releases from latest version checks in core release workflow

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -393,7 +393,7 @@ jobs:
             git ls-remote --tags origin "langchain-${{ matrix.partner }}*" \
             | awk '{print $2}' \
             | sed 's|refs/tags/||' \
-            | grep -Ev '==[^=]*(\.?dev[0-9]*|\.?rc[0-9]*)$' \
+            | grep -E '[0-9]+\.[0-9]+\.[0-9]+$' \
             | sort -Vr \
             | head -n 1
           )"


### PR DESCRIPTION
Regex wasn't catching releases of the form `1.0.0aX`