### PR TITLE
fix(groq): update docs due to model deprecation

### DIFF
--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -895,7 +895,7 @@ class ChatGroq(BaseChatModel):
                 - ``'json_schema'``:
                     Uses Groq's `Structured Output API <https://console.groq.com/docs/structured-outputs>`__.
                     Supported for a subset of models, including ``openai/gpt-oss``,
-                    ``moonshotai/kimi-k2-instruct``, and some ``meta-llama/llama-4``
+                    ``moonshotai/kimi-k2-instruct-0905``, and some ``meta-llama/llama-4``
                     models. See `docs <https://console.groq.com/docs/structured-outputs>`__
                     for details.
                 - ``'json_mode'``:


### PR DESCRIPTION
On Friday, October 10th, the moonshotai/kimi-k2-instruct model will be decommissioned in favor of the latest version, moonshotai/kimi-k2-instruct-0905.
 
Until then, requests to moonshotai/kimi-k2-instruct will automatically be routed to moonshotai/kimi-k2-instruct-0905.
