### PR TITLE
fix(langchain): use messages from model request

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -714,10 +714,6 @@ def test_summarization_middleware_full_workflow() -> None:
 
 
 def test_modify_model_request() -> None:
-    @tool
-    def my_tool(input: str) -> str:
-        """A great tool"""
-        return input.upper()
 
     class ModifyMiddleware(AgentMiddleware):
         def modify_model_request(self, request: ModelRequest, state: AgentState) -> ModelRequest:

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -19,7 +19,8 @@ from langchain.agents.middleware_agent import create_agent
 from langchain.agents.middleware.human_in_the_loop import HumanInTheLoopMiddleware
 from langchain.agents.middleware.prompt_caching import AnthropicPromptCachingMiddleware
 from langchain.agents.middleware.summarization import SummarizationMiddleware
-from langchain.agents.middleware.types import AgentMiddleware, ModelRequest
+from langchain.agents.middleware.types import AgentMiddleware, ModelRequest, AgentState
+from langchain_core.tools import BaseTool
 
 from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.checkpoint.memory import InMemorySaver
@@ -710,3 +711,30 @@ def test_summarization_middleware_full_workflow() -> None:
 
     assert summary_message is not None
     assert "Generated summary" in summary_message.content
+
+
+def test_modify_model_request() -> None:
+    @tool
+    def my_tool(input: str) -> str:
+        """A great tool"""
+        return input.upper()
+
+    class ModifyMiddleware(AgentMiddleware):
+        def modify_model_request(self, request: ModelRequest, state: AgentState) -> ModelRequest:
+            request.messages.append(HumanMessage("remember to be nice!"))
+            return request
+
+    builder = create_agent(
+        model=FakeToolCallingModel(),
+        tools=[],
+        system_prompt="You are a helpful assistant.",
+        middleware=[ModifyMiddleware()],
+    )
+
+    agent = builder.compile()
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert result["messages"][0].content == "Hello"
+    assert result["messages"][1].content == "remember to be nice!"
+    assert (
+        result["messages"][2].content == "You are a helpful assistant.-Hello-remember to be nice!"
+    )

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -714,7 +714,6 @@ def test_summarization_middleware_full_workflow() -> None:
 
 
 def test_modify_model_request() -> None:
-
     class ModifyMiddleware(AgentMiddleware):
         def modify_model_request(self, request: ModelRequest, state: AgentState) -> ModelRequest:
             request.messages.append(HumanMessage("remember to be nice!"))


### PR DESCRIPTION
Oversight when moving back to basic function call for `modify_model_request` rather than implementation as its own node.

Basic test right now failing on main, passing on this branch

Revealed a gap in testing. Will write up a more robust test suite for basic middleware features.