### PR TITLE
feat(core): ChatPromptTemplate.to_messages

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -1243,6 +1243,16 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
                 raise ValueError(msg)  # noqa:TRY004
         return result
 
+    def to_messages(self) -> list[BaseMessage]:
+        """Convert template into a list of messages.
+
+        This method fills in the template variables with placeholder values.
+
+        Returns:
+            List of messages.
+        """
+        return self.format_messages(**{k: "{" + k + "}" for k in self.input_variables})
+
     def partial(self, **kwargs: Any) -> ChatPromptTemplate:
         """Get a new ChatPromptTemplate with some input variables already filled in.
 

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -1236,3 +1236,46 @@ def test_dict_message_prompt_template_errors_on_jinja2() -> None:
         _ = ChatPromptTemplate.from_messages(
             [("human", [prompt])], template_format="jinja2"
         )
+
+
+def test_to_messages() -> None:
+    prompt = ChatPromptTemplate(
+        [
+            {"role": "system", "content": "{foo} and {bar}"},
+            {"role": "user", "content": "{baz} qux"},
+        ]
+    )
+    result = prompt.to_messages()
+    expected = [SystemMessage("{foo} and {bar}"), HumanMessage("{baz} qux")]
+    assert result == expected
+
+    prompt = ChatPromptTemplate(
+        [
+            {
+                "role": "system",
+                "content": "Describe the image provided.",
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "url": "{url}",
+                    },
+                ],
+            },
+        ]
+    )
+    result = prompt.to_messages()
+    expected = [
+        SystemMessage("Describe the image provided."),
+        HumanMessage(
+            content=[
+                {
+                    "type": "image",
+                    "url": "{url}",
+                }
+            ]
+        ),
+    ]
+    assert result == expected


### PR DESCRIPTION
For convenience when working with prompt hub but not using langchain chat models.