### PR TITLE
fix(core)!: fix `BaseTool` when `args_schema` has pydantic validators that change the input keys

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -694,9 +694,7 @@ class ChildTool(BaseTool):
                     f"args_schema must be a Pydantic BaseModel, got {self.args_schema}"
                 )
                 raise NotImplementedError(msg)
-            return {
-                k: getattr(result, k) for k, v in result_dict.items() if k in tool_input
-            }
+            return {k: getattr(result, k) for k, v in result_dict.items()}
         return tool_input
 
     @model_validator(mode="before")


### PR DESCRIPTION
**Description:**

We encountered a bug where we used a pydantic validator to patch broken llm inputs to our tools. The validator would fix the input dict, but the BaseTool would return an empty dict to the tool because our validator changed the dictionary keys. This PR changes one line of code to fix the issue and adds a test to improve the test coverage.

- **Issue:**

Concretely, the following code would fail before the PR:
```
from pydantic import BaseModel, model_validator
from langchain_core.tools import tool


class B(BaseModel):
    b: int


class A(BaseModel):
    a: B

    @model_validator(mode="before")
    def a_wrapper(cls, data):
        if "a" not in data:
            return {"a": data}
        return data


if __name__ == "__main__":
    # Valid input passes
    print(A.model_validate({"a": {"b": 1}}))
    # Invalid input also passes because validator patches it
    print(A.model_validate({"b": 1}))


@tool(args_schema=A, infer_schema=False)
def answer(
    **kwargs,
):
    """Use this function to provide your final answer to the request."""
    return kwargs


if __name__ == "__main__":
    # Valid input passes
    assert answer.invoke({"a": {"b": 1}}) == {"a": B(b=1)}
    # Invalid input should pass, but throws assertion error
    res = answer.invoke({"b": 1})
    assert res == {"a": B(b=1)}, f"Failure: {res} of type {type(res)}"
    # AssertionError: Failure: {} of type <class 'dict'>
```

**Add tests and docs**:
I added a test for the above use case.

**Comments**:

Please note that I had to remove `*args: Any` from one of the tests. The previous code would filter out the `args` keyword. I don't see any realistic use case where one would have `*args` in their tool as this gives no meaningful instruction to the LLM on how to use the `*args`. Please let me know if you see any issues here. I don't see a clean and robust method that would have the new test passing while still filtering out the `*args` argument. Let me know if you see a better solution.


This PR is a port of https://github.com/langchain-ai/langchain/pull/30004 courtesy of @VMinB12 