### PR TITLE
fix(openai): Missing 'prompt_cache_key' added to ChatOpenAI

### DIFF
--- a/libs/langchain/tests/unit_tests/chat_models/test_base.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_base.py
@@ -149,6 +149,7 @@ def test_configurable() -> None:
             "request_timeout": None,
             "max_retries": None,
             "presence_penalty": None,
+            'prompt_cache_key': None,
             "reasoning": None,
             "reasoning_effort": None,
             "verbosity": None,

--- a/libs/langchain/tests/unit_tests/chat_models/test_base.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_base.py
@@ -149,7 +149,7 @@ def test_configurable() -> None:
             "request_timeout": None,
             "max_retries": None,
             "presence_penalty": None,
-            'prompt_cache_key': None,
+            "prompt_cache_key": None,
             "reasoning": None,
             "reasoning_effort": None,
             "verbosity": None,

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -149,6 +149,7 @@ def test_configurable() -> None:
             "request_timeout": None,
             "max_retries": None,
             "presence_penalty": None,
+            'prompt_cache_key': None,
             "reasoning": None,
             "reasoning_effort": None,
             "verbosity": None,

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -149,7 +149,7 @@ def test_configurable() -> None:
             "request_timeout": None,
             "max_retries": None,
             "presence_penalty": None,
-            'prompt_cache_key': None,
+            "prompt_cache_key": None,
             "reasoning": None,
             "reasoning_effort": None,
             "verbosity": None,

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -701,6 +701,9 @@ class BaseChatOpenAI(BaseChatModel):
 
     """
 
+    prompt_cache_key: Optional[str] = None
+    """Prompt cache key for the improving the cache hit rate """
+
     model_config = ConfigDict(populate_by_name=True)
 
     @model_validator(mode="before")
@@ -840,6 +843,7 @@ class BaseChatOpenAI(BaseChatModel):
             "service_tier": self.service_tier,
             "truncation": self.truncation,
             "store": self.store,
+            "prompt_cache_key": self.prompt_cache_key,
         }
 
         params = {


### PR DESCRIPTION

  - **Description:** Added the missing attribute `prompt_cache_key` to ChatOpenAI
  - **Issue:** #32939