### PR TITLE
docs: update SerpApi free searches amount  in tool feature table

### DIFF
--- a/docs/scripts/tool_feat_table.py
+++ b/docs/scripts/tool_feat_table.py
@@ -57,8 +57,8 @@ SEARCH_TOOL_FEAT_TABLE = {
         "available_data": "URL, Snippet, Title, Search Rank, Site Links, Authors",
         "link": "/docs/integrations/tools/searchapi",
     },
-    "SerpAPI": {
-        "pricing": "100 Free Searches/Month",
+    "SerpApi": {
+        "pricing": "250 Free Searches/Month",
         "available_data": "Answer",
         "link": "/docs/integrations/tools/serpapi",
     },


### PR DESCRIPTION
**Description:** 
This PR updates the free searches per month from **100** to **250** and renames SerpAPI to [SerpApi](https://serpapi.com/) to prevent confusion.
Add import API keys and enhance usage instructions in the Jupyter notebook

**Issue:** N/A

**Dependencies:** N/A

- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. **We will not consider a PR unless these three are passing in CI.** See [contribution guidelines](https://python.langchain.com/docs/contributing/) for more.

