### PR TITLE
fix(cli): warnings & tests

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -134,6 +134,8 @@ def _get_configs_for_single_dir(job: str, dir_: str) -> List[Dict[str, str]]:
         py_versions = ["3.9", "3.13"]
     elif dir_ == "libs/langchain_v1":
         py_versions = ["3.10", "3.13"]
+    elif dir_ in {"libs/cli"}:
+        py_versions = ["3.10", "3.13"]
 
     elif dir_ == ".":
         # unable to install with 3.13 because tokenizers doesn't support 3.13 yet

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -38,7 +38,7 @@ _e2e_test:
 	mkdir .integration_test
 	cd .integration_test && \
 		python3 -m venv .venv && \
-		pip install --upgrade poetry && \
+		$(PYTHON) -m pip install --upgrade poetry && \
 		$(PYTHON) -m pip install -e .. && \
 		$(PYTHON) -m langchain_cli.cli integration new --name parrot-link --name-class ParrotLink && \
 		$(PYTHON) -m langchain_cli.cli integration new --name parrot-link --name-class ParrotLinkB --src=integration_template/chat_models.py --dst=langchain-parrot-link/langchain_parrot_link/chat_models_b.py && \

--- a/libs/cli/Makefile
+++ b/libs/cli/Makefile
@@ -38,15 +38,14 @@ _e2e_test:
 	mkdir .integration_test
 	cd .integration_test && \
 		python3 -m venv .venv && \
-		$(PYTHON) -m pip install --upgrade poetry && \
+		$(PYTHON) -m pip install --upgrade uv && \
 		$(PYTHON) -m pip install -e .. && \
 		$(PYTHON) -m langchain_cli.cli integration new --name parrot-link --name-class ParrotLink && \
 		$(PYTHON) -m langchain_cli.cli integration new --name parrot-link --name-class ParrotLinkB --src=integration_template/chat_models.py --dst=langchain-parrot-link/langchain_parrot_link/chat_models_b.py && \
 		$(PYTHON) -m langchain_cli.cli integration create-doc --name parrot-link --name-class ParrotLinkB --component-type ChatModel --destination-dir langchain-parrot-link/docs && \
 		cd langchain-parrot-link && \
-			poetry install --with lint,typing,test && \
-			poetry run pip install -e ../../../standard-tests && \
+			uv sync && \
+			uv add -e ../../../standard-tests && \
 			make format lint tests && \
-			poetry install --with test_integration && \
-			poetry run pip install -e ../../../core && \
+			uv add -e ../../../core && \
 			make integration_test 

--- a/libs/cli/langchain_cli/integration_template/Makefile
+++ b/libs/cli/langchain_cli/integration_template/Makefile
@@ -10,14 +10,14 @@ integration_test integration_tests: TEST_FILE = tests/integration_tests/
 
 # unit tests are run with the --disable-socket flag to prevent network calls
 test tests:
-	poetry run pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test_watch:
-	poetry run ptw --snapshot-update --now . -- -vv $(TEST_FILE)
+	uv run ptw --snapshot-update --now . -- -vv $(TEST_FILE)
 
 # integration tests are run without the --disable-socket flag to allow network calls
 integration_test integration_tests:
-	poetry run pytest $(TEST_FILE)
+	uv run pytest $(TEST_FILE)
 
 ######################
 # LINTING AND FORMATTING
@@ -33,22 +33,22 @@ lint_tests: PYTHON_FILES=tests
 lint_tests: MYPY_CACHE=.mypy_cache_test
 
 lint lint_diff lint_package lint_tests:
-	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff check $(PYTHON_FILES)
-	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff format $(PYTHON_FILES) --diff
-	[ "$(PYTHON_FILES)" = "" ] || mkdir -p $(MYPY_CACHE) && poetry run mypy $(PYTHON_FILES) --cache-dir $(MYPY_CACHE)
+	[ "$(PYTHON_FILES)" = "" ] || uv run ruff check $(PYTHON_FILES)
+	[ "$(PYTHON_FILES)" = "" ] || uv run ruff format $(PYTHON_FILES) --diff
+	[ "$(PYTHON_FILES)" = "" ] || mkdir -p $(MYPY_CACHE) && uv run mypy $(PYTHON_FILES) --cache-dir $(MYPY_CACHE)
 
 format format_diff:
-	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff format $(PYTHON_FILES)
-	[ "$(PYTHON_FILES)" = "" ] || poetry run ruff check --fix $(PYTHON_FILES)
+	[ "$(PYTHON_FILES)" = "" ] || uv run ruff format $(PYTHON_FILES)
+	[ "$(PYTHON_FILES)" = "" ] || uv run ruff check --fix $(PYTHON_FILES)
 
 spell_check:
-	poetry run codespell --toml pyproject.toml
+	uv run codespell --toml pyproject.toml
 
 spell_fix:
-	poetry run codespell --toml pyproject.toml -w
+	uv run codespell --toml pyproject.toml -w
 
 check_imports: $(shell find __module_name__ -name '*.py')
-	poetry run python ./scripts/check_imports.py $^
+	uv run python ./scripts/check_imports.py $^
 
 ######################
 # HELP

--- a/libs/cli/langchain_cli/integration_template/pyproject.toml
+++ b/libs/cli/langchain_cli/integration_template/pyproject.toml
@@ -1,26 +1,38 @@
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
-[tool.poetry]
+[project]
 name = "__package_name__"
 version = "0.1.0"
 description = "An integration package connecting __ModuleName__ and LangChain"
 authors = []
 readme = "README.md"
-repository = "https://github.com/langchain-ai/langchain"
 license = "MIT"
+requires-python = ">=3.10"
+dependencies = [
+    "langchain-core>=0.3.15",
+]
+
+[project.urls]
+"Source Code" = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/__package_name_short__"
+"Release Notes" = "https://github.com/langchain-ai/langchain/releases?q=tag%3A%22__package_name_short__%3D%3D0%22&expanded=true"
+"Repository" = "https://github.com/langchain-ai/langchain"
 
 [tool.mypy]
 disallow_untyped_defs = "True"
 
-[tool.poetry.urls]
-"Source Code" = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/__package_name_short__"
-"Release Notes" = "https://github.com/langchain-ai/langchain/releases?q=tag%3A%22__package_name_short__%3D%3D0%22&expanded=true"
-
-[tool.poetry.dependencies]
-python = ">=3.9,<4.0"
-langchain-core = "^0.3.15"
+[tool.uv]
+dev-dependencies = [
+    "pytest>=7.4.3",
+    "pytest-asyncio>=0.23.2",
+    "pytest-socket>=0.7.0",
+    "pytest-watcher>=0.3.4",
+    "langchain-tests>=0.3.5",
+    "codespell>=2.2.6",
+    "ruff>=0.5",
+    "mypy>=1.10",
+]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]
@@ -37,38 +49,3 @@ markers = [
     "compile: mark placeholder test used to compile integration tests without running them",
 ]
 asyncio_mode = "auto"
-
-[tool.poetry.group.test]
-optional = true
-
-[tool.poetry.group.codespell]
-optional = true
-
-[tool.poetry.group.test_integration]
-optional = true
-
-[tool.poetry.group.lint]
-optional = true
-
-[tool.poetry.group.dev]
-optional = true
-
-[tool.poetry.group.dev.dependencies]
-
-[tool.poetry.group.test.dependencies]
-pytest = "^7.4.3"
-pytest-asyncio = "^0.23.2"
-pytest-socket = "^0.7.0"
-pytest-watcher = "^0.3.4"
-langchain-tests = "^0.3.5"
-
-[tool.poetry.group.codespell.dependencies]
-codespell = "^2.2.6"
-
-[tool.poetry.group.test_integration.dependencies]
-
-[tool.poetry.group.lint.dependencies]
-ruff = "^0.5"
-
-[tool.poetry.group.typing.dependencies]
-mypy = "^1.10"

--- a/libs/cli/langchain_cli/namespaces/app.py
+++ b/libs/cli/langchain_cli/namespaces/app.py
@@ -50,7 +50,6 @@ def new(
         typer.Option(
             "--pip/--no-pip",
             help="Pip install the template(s) as editable dependencies",
-            is_flag=True,
         ),
     ] = None,
     noninteractive: Annotated[
@@ -58,7 +57,6 @@ def new(
         typer.Option(
             "--non-interactive/--interactive",
             help="Don't prompt for any input",
-            is_flag=True,
         ),
     ] = False,
 ) -> None:
@@ -154,7 +152,6 @@ def add(
         typer.Option(
             "--pip/--no-pip",
             help="Pip install the template(s) as editable dependencies",
-            is_flag=True,
             prompt="Would you like to `pip install -e` the template(s)?",
         ),
     ],

--- a/libs/cli/langchain_cli/namespaces/integration.py
+++ b/libs/cli/langchain_cli/namespaces/integration.py
@@ -125,12 +125,18 @@ def new(
         # replacements in files
         replace_glob(destination_dir, "**/*", cast("dict[str, str]", replacements))
 
-        # poetry install
-        subprocess.run(
-            ["poetry", "install", "--with", "lint,test,typing,test_integration"],  # noqa: S607
-            cwd=destination_dir,
-            check=True,
-        )
+        # dependency install
+        try:
+            subprocess.run(
+                ["uv", "sync", "--dev"],  # noqa: S607
+                cwd=destination_dir,
+                check=True,
+            )
+        except FileNotFoundError:
+            typer.echo(
+                "uv is not installed. Skipping dependency installation; run "
+                "`uv sync --dev` manually if needed.",
+            )
     else:
         # confirm src and dst are the same length
         if not src:

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -80,6 +80,12 @@ pyupgrade.keep-runtime-typing = true
 "tests/**" = [ "D1", "DOC", "S", "SLF",]
 "scripts/**" = [ "INP", "S",]
 
+[tool.pytest.ini_options]
+addopts = "--strict-markers --strict-config --durations=5"
+markers = [
+    "compile: mark placeholder test used to compile integration tests without running them",
+]
+
 [tool.mypy]
 plugins = ["pydantic.mypy"]
 strict = true

--- a/libs/cli/pyproject.toml
+++ b/libs/cli/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Erick Friis", email = "erick@langchain.dev" }]
 license = { text = "MIT" }
 requires-python = ">=3.10"
 dependencies = [
-    "typer<1.0.0,>=0.9.0",
+    "typer<1.0.0,>=0.17",
     "gitpython<4,>=3",
     "langserve[all]>=0.0.51",
     "uvicorn<1.0,>=0.23",

--- a/libs/cli/uv.lock
+++ b/libs/cli/uv.lock
@@ -468,7 +468,7 @@ requires-dist = [
     { name = "gritql", specifier = ">=0.2.0,<1.0.0" },
     { name = "langserve", extras = ["all"], specifier = ">=0.0.51" },
     { name = "tomlkit", specifier = ">=0.12" },
-    { name = "typer", specifier = ">=0.9.0,<1.0.0" },
+    { name = "typer", specifier = ">=0.17,<1.0.0" },
     { name = "uvicorn", specifier = ">=0.23,<1.0" },
 ]
 


### PR DESCRIPTION
- drop deprecated `is_flag` param usage (it's inferred)
- drop 3.9 from testing matrix for cli
- correct python env usage for pip install
- register `compile` pytest marker
- migrate to uv in template