### PR TITLE
docs: add cross-links between summarization how-to pages

### DIFF
--- a/docs/docs/how_to/summarize_stuff.ipynb
+++ b/docs/docs/how_to/summarize_stuff.ipynb
@@ -40,6 +40,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ecc06359",
+   "metadata": {},
+   "source": [
+    "See also: [How to summarize through parallelization](/docs/how_to/summarize_map_reduce/) and\n",
+    "[How to summarize through iterative refinement](/docs/how_to/summarize_refine/).\n",
+    "\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "e5f426fc-cea6-4351-8931-1e422d3c8b69",


### PR DESCRIPTION
This PR improves navigation in the summarization how-to section by adding
cross-links from the single-call guide to the related map-reduce and refine
guides. This mirrors the docs style guide’s emphasis on clear cross-references
and should help readers discover the appropriate pattern for longer texts.

- Source edited: docs/docs/how_to/summarize_stuff.ipynb
- Links added:
  - /docs/how_to/summarize_map_reduce/
  - /docs/how_to/summarize_refine/

Type: docs-only (no code changes)

