### PR TITLE
docs: fix memory for agents

### DIFF
--- a/docs/docs/tutorials/agents.ipynb
+++ b/docs/docs/tutorials/agents.ipynb
@@ -691,7 +691,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "id": "a13462d0-2d02-4474-921e-15a1ba1fa274",
    "metadata": {},
    "outputs": [
@@ -709,16 +709,15 @@
     }
    ],
    "source": [
-    "input_message = {\"role\": \"user\", \"content\": \"Hi, I'm Bob!\"}\n",
     "for step in agent_executor.stream(\n",
-    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "    {\"messages\": [(\"user\", \"Hi, I'm Bob!\")]}, config, stream_mode=\"values\"\n",
     "):\n",
     "    step[\"messages\"][-1].pretty_print()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "id": "56d8028b-5dbc-40b2-86f5-ed60631d86a3",
    "metadata": {},
    "outputs": [
@@ -736,9 +735,8 @@
     }
    ],
    "source": [
-    "input_message = {\"role\": \"user\", \"content\": \"What's my name?\"}\n",
     "for step in agent_executor.stream(\n",
-    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "    {\"messages\": [(\"user\", \"What is my name?\")]}, config, stream_mode=\"values\"\n",
     "):\n",
     "    step[\"messages\"][-1].pretty_print()"
    ]
@@ -761,7 +759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "24460239",
    "metadata": {},
    "outputs": [
@@ -782,9 +780,8 @@
     "# highlight-next-line\n",
     "config = {\"configurable\": {\"thread_id\": \"xyz123\"}}\n",
     "\n",
-    "input_message = {\"role\": \"user\", \"content\": \"What's my name?\"}\n",
     "for step in agent_executor.stream(\n",
-    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "    {\"messages\": [(\"user\", \"What is my name?\")]}, config, stream_mode=\"values\"\n",
     "):\n",
     "    step[\"messages\"][-1].pretty_print()"
    ]


### PR DESCRIPTION
Replaced `input_message` parameter with a directly called tuple, e.g. `{"messages": [("user", "What is my name?")]}`

Before, the memory function wasn't working with the agent, using the format of the input_message parameter.

Specifically, on page [Build an Agent#adding-in-memory](https://python.langchain.com/docs/tutorials/agents/#adding-in-memory)

In the previous code, the query "What's my name?" wasn't working, as the agent could not recall memory correctly.

<img width="860" height="679" alt="image" src="https://github.com/user-attachments/assets/dfbca21e-ffe9-4645-a810-3be7a46d81d5" />

