### PR TITLE
fix(openai): add support for reasoning content in OpenAI chat responses from OpenRouter

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -934,6 +934,7 @@ class BaseChatOpenAI(BaseChatModel):
             if (reasoning_content := delta.get("reasoning_content")) is not None:
                 message_chunk.additional_kwargs["reasoning_content"] = reasoning_content
             elif (reasoning := delta.get("reasoning")) is not None:
+                # Handle use via OpenRouter
                 message_chunk.additional_kwargs["reasoning_content"] = reasoning
 
         generation_chunk = ChatGenerationChunk(
@@ -1309,7 +1310,9 @@ class BaseChatOpenAI(BaseChatModel):
                     "reasoning_content"
                 ] = message.reasoning
             elif hasattr(message, "reasoning_content"):
-                generations[0].message.additional_kwargs["reasoning_content"] = message.reasoning_content
+                generations[0].message.additional_kwargs[
+                    "reasoning_content"
+                ] = message.reasoning_content
 
         return ChatResult(generations=generations, llm_output=llm_output)
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1247,7 +1247,6 @@ class BaseChatOpenAI(BaseChatModel):
         # separately below).
         if response_dict.get("error"):
             raise ValueError(response_dict.get("error"))
-
         # Raise informative error messages for non-OpenAI chat completions APIs
         # that return malformed responses.
         try:
@@ -1294,6 +1293,8 @@ class BaseChatOpenAI(BaseChatModel):
                 generations[0].message.additional_kwargs["parsed"] = message.parsed
             if hasattr(message, "refusal"):
                 generations[0].message.additional_kwargs["refusal"] = message.refusal
+            if hasattr(message, "reasoning"):  # e.g. parsing from openrouter
+                generations[0].message.additional_kwargs["reasoning_content"] = message.reasoning
 
         return ChatResult(generations=generations, llm_output=llm_output)
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1295,7 +1295,9 @@ class BaseChatOpenAI(BaseChatModel):
             if hasattr(message, "refusal"):
                 generations[0].message.additional_kwargs["refusal"] = message.refusal
             if hasattr(message, "reasoning"):  # e.g. parsing from openrouter
-                generations[0].message.additional_kwargs["reasoning_content"] = message.reasoning
+                generations[0].message.additional_kwargs[
+                    "reasoning_content"
+                ] = message.reasoning
 
         return ChatResult(generations=generations, llm_output=llm_output)
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1247,6 +1247,7 @@ class BaseChatOpenAI(BaseChatModel):
         # separately below).
         if response_dict.get("error"):
             raise ValueError(response_dict.get("error"))
+
         # Raise informative error messages for non-OpenAI chat completions APIs
         # that return malformed responses.
         try:


### PR DESCRIPTION
Description: I added `reasoning_content` to `additional_kwargs` when the reasoning field is present in the response message. This enables support for reasoning content from providers like OpenRouter that include this field in their responses.
Issue: #32981 
Dependencies: N/A

P.S. this is my first time ever attempting to contribute to an open source package so feel free to rip me to shreds.