### PR TITLE
fix(standard-tests): add filename to PDF file block

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -2376,6 +2376,7 @@ class ChatModelIntegrationTests(ChatModelTests):
                     "type": "file",
                     "mime_type": "application/pdf",
                     "base64": pdf_data,
+                    "filename": "dummy.pdf",
                 },
             ]
         )


### PR DESCRIPTION
The standard PDF input test was creating file content blocks without a filename field.

This caused a warning when the OpenAI block translator processed the message for LangSmith tracing, since OpenAI requires filenames for file inputs.