### PR TITLE
fix(docs): update dead link to docling github and docs

### DIFF
--- a/docs/docs/integrations/providers/docling.mdx
+++ b/docs/docs/integrations/providers/docling.mdx
@@ -36,7 +36,7 @@ For end-to-end usage check out
 
 ## Additional Resources
 
-- [LangChain Docling integration GitHub](https://github.com/DS4SD/docling-langchain)
+- [LangChain Docling integration GitHub](https://github.com/docling-project/docling-langchain)
 - [LangChain Docling integration PyPI package](https://pypi.org/project/langchain-docling/)
-- [Docling GitHub](https://github.com/DS4SD/docling)
-- [Docling docs](https://ds4sd.github.io/docling/)
+- [Docling GitHub](https://github.com/docling-project/docling)
+- [Docling docs](https://docling-project.github.io/docling/)


### PR DESCRIPTION

  - **Description:** Updated the dead/unreachable links to Docling from the additional resources section of the langchain-docling docs
  - **Issue:** Fixes langchain-ai/docs/issues/574
  - **Dependencies:** None

