### PR TITLE
revert: fix(standard-tests): add filename to PDF file block

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -2376,7 +2376,6 @@ class ChatModelIntegrationTests(ChatModelTests):
                     "type": "file",
                     "mime_type": "application/pdf",
                     "base64": pdf_data,
-                    "filename": "dummy.pdf",
                 },
             ]
         )


### PR DESCRIPTION
Reverts langchain-ai/langchain#32989 in favor of https://github.com/langchain-ai/langchain/pull/33009.