### PR TITLE
fix(langchain): use state schema as input schema to middleware nodes

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -528,8 +528,8 @@ def _fetch_last_ai_and_tool_messages(
 
 def _make_model_to_tools_edge(
     first_node: str, structured_output_tools: dict[str, OutputToolBinding], tool_node: ToolNode
-) -> Callable[[dict[str, Any]], str | list[Send] | None]:
-    def model_to_tools(state: dict[str, Any]) -> str | list[Send] | None:
+) -> Callable[[AgentState], str | list[Send] | None]:
+    def model_to_tools(state: AgentState) -> str | list[Send] | None:
         if jump_to := state.get("jump_to"):
             return _resolve_jump(jump_to, first_node)
 
@@ -548,7 +548,8 @@ def _make_model_to_tools_edge(
             # of using Send w/ tool calls directly which allows more intuitive interrupt behavior
             # largely internal so can be fixed later
             pending_tool_calls = [
-                tool_node.inject_tool_args(call, state, None) for call in pending_tool_calls
+                tool_node.inject_tool_args(call, state, None)  # type: ignore[arg-type]
+                for call in pending_tool_calls
             ]
             return [Send("tools", [tool_call]) for tool_call in pending_tool_calls]
 


### PR DESCRIPTION
We want state schema as the input schema to middleware nodes because the conditional edges after these nodes need access to the full state.

Interestingly, if the node before a conditional edge takes a subset of state, the conditional edge func gets that subset. We have conditional edges to the tool node which obviously need to be able to inject full state!

Also, we just generally want all state passed to middleware nodes, so we should be specifying this explicitly. If we don't, the state annotations used by users in their node signatures are used (so they might be missing fields).