### PR TITLE
refactor(langchain): replace `dict()` with `model_dump()` in agent classes and tests

### DIFF
--- a/libs/langchain/langchain/agents/agent.py
+++ b/libs/langchain/langchain/agents/agent.py
@@ -174,7 +174,7 @@ class BaseSingleActionAgent(BaseModel):
         Returns:
             Dict: Dictionary representation of agent.
         """
-        _dict = super().model_dump()
+        _dict = super().model_dump(**kwargs)
         try:
             _type = self._agent_type
         except NotImplementedError:
@@ -205,7 +205,7 @@ class BaseSingleActionAgent(BaseModel):
         directory_path.mkdir(parents=True, exist_ok=True)
 
         # Fetch dictionary to save
-        agent_dict = self.dict()
+        agent_dict = self.model_dump()
         if "_type" not in agent_dict:
             msg = f"Agent {self} does not support saving"
             raise NotImplementedError(msg)
@@ -320,7 +320,7 @@ class BaseMultiActionAgent(BaseModel):
     @override
     def dict(self, **kwargs: Any) -> builtins.dict:
         """Return dictionary representation of agent."""
-        _dict = super().model_dump()
+        _dict = super().model_dump(**kwargs)
         with contextlib.suppress(NotImplementedError):
             _dict["_type"] = str(self._agent_type)
         return _dict
@@ -346,7 +346,7 @@ class BaseMultiActionAgent(BaseModel):
         save_path = Path(file_path) if isinstance(file_path, str) else file_path
 
         # Fetch dictionary to save
-        agent_dict = self.dict()
+        agent_dict = self.model_dump()
         if "_type" not in agent_dict:
             msg = f"Agent {self} does not support saving."
             raise NotImplementedError(msg)
@@ -655,8 +655,8 @@ class LLMSingleActionAgent(BaseSingleActionAgent):
     @override
     def dict(self, **kwargs: Any) -> builtins.dict:
         """Return dictionary representation of agent."""
-        _dict = super().dict()
-        del _dict["output_parser"]
+        _dict = super().model_dump(**kwargs)
+        _dict.pop("output_parser", None)
         return _dict
 
     def plan(
@@ -740,8 +740,8 @@ class Agent(BaseSingleActionAgent):
     @override
     def dict(self, **kwargs: Any) -> builtins.dict:
         """Return dictionary representation of agent."""
-        _dict = super().dict()
-        del _dict["output_parser"]
+        _dict = super().model_dump(**kwargs)
+        _dict.pop("output_parser", None)
         return _dict
 
     def get_allowed_tools(self) -> Optional[list[str]]:

--- a/libs/langchain/tests/unit_tests/chat_models/test_base.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_base.py
@@ -48,7 +48,7 @@ def test_init_chat_model(model_name: str, model_provider: Optional[str]) -> None
         f"{model_provider}:{model_name}",
         api_key="foo",
     )
-    assert llm1.dict() == llm2.dict()
+    assert llm1.model_dump() == llm2.model_dump()
 
 
 def test_init_missing_dep() -> None:

--- a/libs/langchain/tests/unit_tests/llms/test_base.py
+++ b/libs/langchain/tests/unit_tests/llms/test_base.py
@@ -22,7 +22,7 @@ def test_caching() -> None:
     """Test caching behavior."""
     set_llm_cache(InMemoryCache())
     llm = FakeLLM()
-    params = llm.dict()
+    params = llm.model_dump()
     params["stop"] = None
     llm_string = str(sorted([(k, v) for k, v in params.items()]))
     get_llm_cache().update("foo", llm_string, [Generation(text="fizz")])

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any, Literal, Union
 from unittest.mock import MagicMock
 
-import pydantic
 from langchain_core.messages import AIMessageChunk, ToolMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
 from openai import BaseModel
@@ -13,10 +12,6 @@ from openai.types.chat import ChatCompletionMessage
 from pydantic import SecretStr
 
 from langchain_deepseek.chat_models import ChatDeepSeek
-
-# patch validation to ignore leading underscores due to OpenAI client issue
-# TODO: remove when fixed in OpenAI client
-pydantic._internal._model_construction.is_valid_field_name = lambda name: True
 
 
 class MockOpenAIResponse(BaseModel):

--- a/libs/partners/xai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/xai/tests/unit_tests/test_chat_models.py
@@ -1,6 +1,5 @@
 import json
 
-import pydantic
 import pytest  # type: ignore[import-not-found]
 from langchain_core.messages import (
     AIMessage,
@@ -15,10 +14,6 @@ from langchain_openai.chat_models.base import (
 )
 
 from langchain_xai import ChatXAI
-
-# patch validation to ignore leading underscores due to OpenAI client issue
-# TODO: remove when fixed in OpenAI client
-pydantic._internal._model_construction.is_valid_field_name = lambda name: True
 
 MODEL_NAME = "grok-4"
 


### PR DESCRIPTION
Fixed Pydantic compatibility issues causing test failures with Pydantic 2.7.0+ (`Fields must not use names with leading underscores;`)