### PR TITLE
fix(infra): prevent labeler workflow from adding/removing same labels

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -19,4 +19,4 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler.yml
-        sync-labels: true
+        sync-labels: false


### PR DESCRIPTION
The file-based and title-based labeler workflows were conflicting, causing the bot to add and remove identical labels in the same operation. Hopefully this fixes