### PR TITLE
docs: fix stripe toolkit import in the guide

### DIFF
--- a/docs/docs/integrations/tools/stripe.ipynb
+++ b/docs/docs/integrations/tools/stripe.ipynb
@@ -118,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from stripe_agent_toolkit.crewai.toolkit import StripeAgentToolkit\n",
+    "from stripe_agent_toolkit.langchain.toolkit import StripeAgentToolkit\n",
     "\n",
     "stripe_agent_toolkit = StripeAgentToolkit(\n",
     "    secret_key=os.getenv(\"STRIPE_SECRET_KEY\"),\n",


### PR DESCRIPTION
**Description:**
Stripe tools integration guide incorrectly referenced the `crewai` toolkit. Updated the import to use the correct `langchain` toolkit.

Stripe docs reference: https://docs.stripe.com/agents?framework=langchain&lang=python
