### PR TITLE
chore(infra): fix ping pong pr labeler config

### DIFF
--- a/.github/pr-title-labeler.yml
+++ b/.github/pr-title-labeler.yml
@@ -3,6 +3,7 @@
 # Format: type(scope): description or type!: description (breaking)
 
 add-missing-labels: true
+clear-prexisting: false
 include-commits: false
 include-title: true
 label-for-breaking-changes: breaking
@@ -21,7 +22,24 @@ label-mapping:
   infra: ["chore", "ci", "build", "infra"]
 
   # Integration partners - detected by scope
-  integration: ["anthropic", "chroma", "deepseek", "exa", "fireworks", "groq", "huggingface", "mistralai", "nomic", "ollama", "openai", "perplexity", "prompty", "qdrant", "xai"]
+  integration:
+    [
+      "anthropic",
+      "chroma",
+      "deepseek",
+      "exa",
+      "fireworks",
+      "groq",
+      "huggingface",
+      "mistralai",
+      "nomic",
+      "ollama",
+      "openai",
+      "perplexity",
+      "prompty",
+      "qdrant",
+      "xai",
+    ]
 
   # Releases
   release: ["release"]


### PR DESCRIPTION
The title-based labeler was clearing all pre-existing labels (including the file-based ones) before adding its semantic labels.