### PR TITLE
feat(langchain): improvements to anthropic prompt caching

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/prompt_caching.py
+++ b/libs/langchain_v1/langchain/agents/middleware/prompt_caching.py
@@ -1,6 +1,7 @@
 """Anthropic prompt caching middleware."""
 
 from typing import Literal
+from warnings import warn
 
 from langchain.agents.middleware.types import AgentMiddleware, ModelRequest
 
@@ -19,6 +20,7 @@ class AnthropicPromptCachingMiddleware(AgentMiddleware):
         type: Literal["ephemeral"] = "ephemeral",
         ttl: Literal["5m", "1h"] = "5m",
         min_messages_to_cache: int = 0,
+        unsupported_model_behavior: Literal["ignore", "warn", "raise"] = "warn",
     ) -> None:
         """Initialize the middleware with cache control settings.
 
@@ -27,10 +29,15 @@ class AnthropicPromptCachingMiddleware(AgentMiddleware):
             ttl: The time to live for the cache, only "5m" and "1h" are supported.
             min_messages_to_cache: The minimum number of messages until the cache is used,
                 default is 0.
+            unsupported_model_behavior: The behavior to take when an unsupported model is used.
+                "ignore" will ignore the unsupported model and continue without caching.
+                "warn" will warn the user and continue without caching.
+                "raise" will raise an error and stop the agent.
         """
         self.type = type
         self.ttl = ttl
         self.min_messages_to_cache = min_messages_to_cache
+        self.unsupported_model_behavior = unsupported_model_behavior
 
     def modify_model_request(  # type: ignore[override]
         self,
@@ -40,19 +47,29 @@ class AnthropicPromptCachingMiddleware(AgentMiddleware):
         try:
             from langchain_anthropic import ChatAnthropic
         except ImportError:
+            ChatAnthropic = None  # noqa: N806
+
+        msg: str | None = None
+
+        if ChatAnthropic is None:
             msg = (
                 "AnthropicPromptCachingMiddleware caching middleware only supports "
-                "Anthropic models."
+                "Anthropic models. "
                 "Please install langchain-anthropic."
             )
-            raise ValueError(msg)
-
-        if not isinstance(request.model, ChatAnthropic):
+        elif not isinstance(request.model, ChatAnthropic):
             msg = (
                 "AnthropicPromptCachingMiddleware caching middleware only supports "
                 f"Anthropic models, not instances of {type(request.model)}"
             )
-            raise ValueError(msg)
+
+        if msg is not None:
+            if self.unsupported_model_behavior == "raise":
+                raise ValueError(msg)
+            if self.unsupported_model_behavior == "warn":
+                warn(msg, stacklevel=3)
+            else:
+                return request
 
         messages_count = (
             len(request.messages) + 1 if request.system_prompt else len(request.messages)


### PR DESCRIPTION
Adding an `unsupported_model_behavior` arg that can be `'ignore'`, `'warn'`, or `'raise'`. Defaults to `'warn'`.