### PR TITLE
chore(langchain_v1): remove union return type in init_embeddings

### DIFF
--- a/libs/langchain_v1/langchain/embeddings/base.py
+++ b/libs/langchain_v1/langchain/embeddings/base.py
@@ -5,7 +5,6 @@ from importlib import util
 from typing import Any
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.runnables import Runnable
 
 _SUPPORTED_PROVIDERS = {
     "azure_openai": "langchain_openai",
@@ -126,7 +125,7 @@ def init_embeddings(
     *,
     provider: str | None = None,
     **kwargs: Any,
-) -> Embeddings | Runnable[Any, list[float]]:
+) -> Embeddings:
     """Initialize an embeddings model from a model name and optional provider.
 
     **Note:** Must have the integration package corresponding to the model provider


### PR DESCRIPTION
Fix the return type of init_embeddings