### PR TITLE
fix(langchain_v1): only interrupt if at least one ToolConfig value is True

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -138,13 +138,14 @@ class HumanInTheLoopMiddleware(AgentMiddleware):
                         allow_edit=True,
                         allow_respond=True,
                     )
-            else:
-                if any([
+            elif any(
+                [
                     tool_config.get("allow_accept", False),
                     tool_config.get("allow_edit", False),
-                    tool_config.get("allow_respond", False)
-                ]):
-                    resolved_tool_configs[tool_name] = tool_config
+                    tool_config.get("allow_respond", False),
+                ]
+            ):
+                resolved_tool_configs[tool_name] = tool_config
         self.tool_configs = resolved_tool_configs
         self.description_prefix = description_prefix
 

--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -139,7 +139,12 @@ class HumanInTheLoopMiddleware(AgentMiddleware):
                         allow_respond=True,
                     )
             else:
-                resolved_tool_configs[tool_name] = tool_config
+                if any([
+                    tool_config.get("allow_accept", False),
+                    tool_config.get("allow_edit", False),
+                    tool_config.get("allow_respond", False)
+                ]):
+                    resolved_tool_configs[tool_name] = tool_config
         self.tool_configs = resolved_tool_configs
         self.description_prefix = description_prefix
 


### PR DESCRIPTION
**Description:** Right now, we interrupt even if the provided ToolConfig has all false values. We should ignore ToolConfigs which do not have at least one value marked as true (just as we would if tool_name: False was passed into the dict).
