### PR TITLE
chore: delete erroneous `poetry.toml` configuration file

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[virtualenvs]
-in-project = true


### PR DESCRIPTION
- Not used by the current build system
- Potentially confusing for new contributors
- A leftover artifact from the Poetry to uv migration