### PR TITLE
chore: update `pull_request_target` types, harden

### DIFF
--- a/.github/workflows/pr_labeler_file.yml
+++ b/.github/workflows/pr_labeler_file.yml
@@ -5,8 +5,10 @@
 name: "🏷️ Pull Request Labeler"
 
 on:
+  # Safe since we're not checking out or running the PR's code
+  # Never check out the PR's head in a pull_request_target job
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   labeler:

--- a/.github/workflows/pr_labeler_title.yml
+++ b/.github/workflows/pr_labeler_title.yml
@@ -5,7 +5,9 @@
 name: "🏷️ PR Title Labeler"
 
 on:
-  pull_request:
+  # Safe since we're not checking out or running the PR's code
+  # Never check out the PR's head in a pull_request_target job
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 jobs:
@@ -19,7 +21,8 @@ jobs:
 
     steps:
     - name: Label PR based on title
-      uses: grafana/pr-labeler-action@v0.1.0
+      # Archived repo; latest commit (v0.1.0)
+      uses: grafana/pr-labeler-action@f19222d3ef883d2ca5f04420fdfe8148003763f0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         configuration-path: .github/pr-title-labeler.yml


### PR DESCRIPTION
Enhance the pull request workflows by updating the `pull_request_target` types and ensuring safety by avoiding checkout of the PR's head. Update the action to use a specific commit from the archived repository.