### PR TITLE
test(core): enhance stringify_value test coverage for nested structures

### DIFF
--- a/libs/core/tests/unit_tests/utils/test_strings.py
+++ b/libs/core/tests/unit_tests/utils/test_strings.py
@@ -47,3 +47,37 @@ def test_existing_string_functions() -> None:
     result = stringify_dict(data)
     assert "key: value" in result
     assert "number: 123" in result
+
+def test_stringify_value_nested_structures() -> None:
+    """Test stringifying nested structures."""
+    # Test nested dict in list
+    nested_data = {
+        "users": [
+            {"name": "Alice", "age": 25},
+            {"name": "Bob", "age": 30},
+        ],
+        "metadata": {
+            "total_users": 2,
+            "active": True
+        }
+    }
+
+    result = stringify_value(nested_data)
+
+    # Shoudl contain all the nested values
+    assert "users:" in result
+    assert "name: Alice" in result
+    assert "name: Bob" in result
+    assert "metadata:" in result
+    assert "total_users: 2" in result
+    assert "active: True" in result
+
+    # Test list of mixed types
+    mixed_list = ["string", 42, {"key": "value"}, ["nested", "list"]]
+    result = stringify_value(mixed_list)
+
+    assert "string" in result
+    assert "42" in result
+    assert "key: value" in result
+    assert "nested" in result
+    assert "list" in result

--- a/libs/core/tests/unit_tests/utils/test_strings.py
+++ b/libs/core/tests/unit_tests/utils/test_strings.py
@@ -48,6 +48,7 @@ def test_existing_string_functions() -> None:
     assert "key: value" in result
     assert "number: 123" in result
 
+
 def test_stringify_value_nested_structures() -> None:
     """Test stringifying nested structures."""
     # Test nested dict in list
@@ -56,10 +57,7 @@ def test_stringify_value_nested_structures() -> None:
             {"name": "Alice", "age": 25},
             {"name": "Bob", "age": 30},
         ],
-        "metadata": {
-            "total_users": 2,
-            "active": True
-        }
+        "metadata": {"total_users": 2, "active": True},
     }
 
     result = stringify_value(nested_data)


### PR DESCRIPTION
## Summary
Adds test coverage for the `stringify_value` utility function to handle complex nested data structures that weren't previously tested.

## Changes
- Added `test_stringify_value_nested_structures()` to `test_strings.py`
- Tests nested dictionaries within lists
- Tests mixed-type lists with various data types
- Verifies proper stringification of complex nested structures

## Why This Matters
- Fills a gap in test coverage for edge cases
- Ensures `stringify_value` handles complex data structures correctly  
- Improves confidence in string utility functions used throughout the codebase
- Low risk addition that strengthens existing test suite

## Testing
```bash
uv run --group test pytest libs/core/tests/unit_tests/utils/test_strings.py::test_stringify_value_nested_structures -v
```

This test addition follows the project's testing patterns and adds meaningful coverage without introducing any breaking changes.