### PR TITLE
test(core): suppress deprecation warnings in `PipelinePromptTemplate`

### DIFF
--- a/libs/core/tests/unit_tests/prompts/test_pipeline_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_pipeline_prompt.py
@@ -1,8 +1,17 @@
+import pytest
+
 from langchain_core.prompts.chat import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.prompts.pipeline import PipelinePromptTemplate
 from langchain_core.prompts.prompt import PromptTemplate
 
+# Suppress deprecation warnings for PipelinePromptTemplate since we're testing the
+# deprecated functionality intentionally to ensure it still works correctly
 
+
+@pytest.mark.filterwarnings(
+    "ignore:This class is deprecated"
+    ":langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
 def test_get_input_variables() -> None:
     prompt_a = PromptTemplate.from_template("{foo}")
     prompt_b = PromptTemplate.from_template("{bar}")
@@ -12,6 +21,10 @@ def test_get_input_variables() -> None:
     assert pipeline_prompt.input_variables == ["foo"]
 
 
+@pytest.mark.filterwarnings(
+    "ignore:This class is deprecated"
+    ":langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
 def test_simple_pipeline() -> None:
     prompt_a = PromptTemplate.from_template("{foo}")
     prompt_b = PromptTemplate.from_template("{bar}")
@@ -22,6 +35,10 @@ def test_simple_pipeline() -> None:
     assert output == "jim"
 
 
+@pytest.mark.filterwarnings(
+    "ignore:This class is deprecated"
+    ":langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
 def test_multi_variable_pipeline() -> None:
     prompt_a = PromptTemplate.from_template("{foo}")
     prompt_b = PromptTemplate.from_template("okay {bar} {baz}")
@@ -32,6 +49,10 @@ def test_multi_variable_pipeline() -> None:
     assert output == "okay jim deep"
 
 
+@pytest.mark.filterwarnings(
+    "ignore:This class is deprecated"
+    ":langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
 async def test_partial_with_chat_prompts() -> None:
     prompt_a = ChatPromptTemplate(
         input_variables=["foo"], messages=[MessagesPlaceholder(variable_name="foo")]


### PR DESCRIPTION
We're intentionally testing this still so as not to regress. Reduce warning noise.