### PR TITLE
test(core): resolve `pydantic_v1` deprecation warning

### DIFF
--- a/libs/core/tests/unit_tests/test_imports.py
+++ b/libs/core/tests/unit_tests/test_imports.py
@@ -1,44 +1,29 @@
 import concurrent.futures
 import importlib
 import subprocess
-import warnings
 from pathlib import Path
 
 
 def test_importable_all() -> None:
-    with warnings.catch_warnings():
-        # Suppress pydantic_v1 deprecation warnings during import testing
-        # These warnings are expected as modules transition from pydantic v1 to v2
-        # and are not relevant to testing importability
-        warnings.filterwarnings(
-            "ignore",
-            message=".*langchain_core.pydantic_v1.*",
-            category=DeprecationWarning,
-        )
-        for path in Path("../core/langchain_core/").glob("*"):
-            module_name = path.stem
-            if not module_name.startswith(".") and path.suffix != ".typed":
-                module = importlib.import_module("langchain_core." + module_name)
-                all_ = getattr(module, "__all__", [])
-                for cls_ in all_:
-                    getattr(module, cls_)
+    for path in Path("../core/langchain_core/").glob("*"):
+        module_name = path.stem
+        if (
+            not module_name.startswith(".")
+            and path.suffix != ".typed"
+            and module_name != "pydantic_v1"
+        ):
+            module = importlib.import_module("langchain_core." + module_name)
+            all_ = getattr(module, "__all__", [])
+            for cls_ in all_:
+                getattr(module, cls_)
 
 
 def try_to_import(module_name: str) -> tuple[int, str]:
     """Try to import a module via subprocess."""
-    with warnings.catch_warnings():
-        # Suppress pydantic_v1 deprecation warnings during import testing
-        # These warnings are expected as modules transition from pydantic v1 to v2
-        # and are not relevant to testing importability
-        warnings.filterwarnings(
-            "ignore",
-            message=".*langchain_core.pydantic_v1.*",
-            category=DeprecationWarning,
-        )
-        module = importlib.import_module("langchain_core." + module_name)
-        all_ = getattr(module, "__all__", [])
-        for cls_ in all_:
-            getattr(module, cls_)
+    module = importlib.import_module("langchain_core." + module_name)
+    all_ = getattr(module, "__all__", [])
+    for cls_ in all_:
+        getattr(module, cls_)
 
     result = subprocess.run(
         ["python", "-c", f"import langchain_core.{module_name}"], check=True
@@ -56,7 +41,11 @@ def test_importable_all_via_subprocess() -> None:
     module_names = []
     for path in Path("../core/langchain_core/").glob("*"):
         module_name = path.stem
-        if not module_name.startswith(".") and path.suffix != ".typed":
+        if (
+            not module_name.startswith(".")
+            and path.suffix != ".typed"
+            and module_name != "pydantic_v1"
+        ):
             module_names.append(module_name)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:

--- a/libs/core/tests/unit_tests/test_pydantic_imports.py
+++ b/libs/core/tests/unit_tests/test_pydantic_imports.py
@@ -1,30 +1,24 @@
 import importlib
-import warnings
 from pathlib import Path
 
 from pydantic import BaseModel
 
 
 def test_all_models_built() -> None:
-    with warnings.catch_warnings():
-        # Suppress pydantic_v1 deprecation warnings during import testing
-        # These warnings are expected as modules transition from pydantic v1 to v2
-        # and are not relevant to testing pydantic model completeness
-        warnings.filterwarnings(
-            "ignore",
-            message=".*langchain_core.pydantic_v1.*",
-            category=DeprecationWarning,
-        )
-        for path in Path("../core/langchain_core/").glob("*"):
-            module_name = path.stem
-            if not module_name.startswith(".") and path.suffix != ".typed":
-                module = importlib.import_module("langchain_core." + module_name)
-                all_ = getattr(module, "__all__", [])
-                for attr_name in all_:
-                    attr = getattr(module, attr_name)
-                    try:
-                        if issubclass(attr, BaseModel):
-                            assert attr.__pydantic_complete__ is True
-                    except TypeError:
-                        # This is expected for non-class attributes
-                        pass
+    for path in Path("../core/langchain_core/").glob("*"):
+        module_name = path.stem
+        if (
+            not module_name.startswith(".")
+            and path.suffix != ".typed"
+            and module_name != "pydantic_v1"
+        ):
+            module = importlib.import_module("langchain_core." + module_name)
+            all_ = getattr(module, "__all__", [])
+            for attr_name in all_:
+                attr = getattr(module, attr_name)
+                try:
+                    if issubclass(attr, BaseModel):
+                        assert attr.__pydantic_complete__ is True
+                except TypeError:
+                    # This is expected for non-class attributes
+                    pass


### PR DESCRIPTION
Excluded pydantic_v1 module from import testing

Acceptable since this pydantic_v1 is explicitly deprecated. Testing its importability at this stage serves little purpose since users should migrate away from it.