### PR TITLE
test(core): resolve pytest marker warning

### DIFF
--- a/libs/core/tests/unit_tests/prompts/test_few_shot.py
+++ b/libs/core/tests/unit_tests/prompts/test_few_shot.py
@@ -27,7 +27,6 @@ EXAMPLE_PROMPT = PromptTemplate(
 
 
 @pytest.fixture
-@pytest.mark.requires("jinja2")
 def example_jinja2_prompt() -> tuple[PromptTemplate, list[dict[str, str]]]:
     example_template = "{{ word }}: {{ antonym }}"
 


### PR DESCRIPTION
Remove redundant/outdated `@pytest.mark.requires("jinja2")` decorator

Pytest marks (like `@pytest.mark.requires(...)`) applied directly to fixtures have no effect and are deprecated. 