### PR TITLE
feat(langchain): Using Structured Response as Key in Output Schema for Middleware Agent

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -90,7 +90,7 @@ class AgentState(TypedDict, Generic[ResponseT]):
 
     messages: Required[Annotated[list[AnyMessage], add_messages]]
     jump_to: NotRequired[Annotated[JumpTo | None, EphemeralValue, PrivateStateAttr]]
-    response: NotRequired[ResponseT]
+    structured_response: NotRequired[ResponseT]
 
 
 class PublicAgentState(TypedDict, Generic[ResponseT]):
@@ -100,7 +100,7 @@ class PublicAgentState(TypedDict, Generic[ResponseT]):
     """
 
     messages: Required[Annotated[list[AnyMessage], add_messages]]
-    response: NotRequired[ResponseT]
+    structured_response: NotRequired[ResponseT]
 
 
 StateT = TypeVar("StateT", bound=AgentState, default=AgentState)

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -246,7 +246,7 @@ def create_agent(  # noqa: PLR0915
         if isinstance(response_format, ProviderStrategy):
             if not output.tool_calls and native_output_binding:
                 structured_response = native_output_binding.parse(output)
-                return {"messages": [output], "response": structured_response}
+                return {"messages": [output], "structured_response": structured_response}
             return {"messages": [output]}
 
         # Handle structured output with tools strategy
@@ -303,7 +303,7 @@ def create_agent(  # noqa: PLR0915
                                 name=tool_call["name"],
                             ),
                         ],
-                        "response": structured_response,
+                        "structured_response": structured_response,
                     }
                 except Exception as exc:  # noqa: BLE001
                     exception = StructuredOutputValidationError(tool_call["name"], exc)

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -1292,11 +1292,11 @@ def test_tools_to_model_edge_with_structured_and_regular_tool_calls():
     assert "Regular tool result for: test query" in regular_tool_message.content
 
     # Verify that the structured response is available in the result
-    assert "response" in result
-    assert result["response"] is not None
-    assert hasattr(result["response"], "temperature")
-    assert result["response"].temperature == 72.0
-    assert result["response"].condition == "sunny"
+    assert "structured_response" in result
+    assert result["structured_response"] is not None
+    assert hasattr(result["structured_response"], "temperature")
+    assert result["structured_response"].temperature == 72.0
+    assert result["structured_response"].condition == "sunny"
 
 
 def test_public_private_state_for_custom_middleware() -> None:


### PR DESCRIPTION
- **Description:** Changing the key from `response` to `structured_response` for middleware agent to keep it sync with agent without middleware. This a breaking change.
 - **Issue:** #33154
  