### PR TITLE
fix(infra): temporarily skip pre-release checks for alpha branch

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -404,12 +404,9 @@ jobs:
       # We implement this conditional as Github Actions does not have good support
       # for conditionally needing steps. https://github.com/actions/runner/issues/491
       # TODO: this seems to be resolved upstream, so we can probably remove this workaround
-      - name: Check if libs/core
+      - name: Deliberately skip (temporary)
         run: |
-          if [ "${{ startsWith(inputs.working-directory, 'libs/core') }}" != "true" ]; then
-            echo "Not in libs/core. Exiting successfully."
-            exit 0
-          fi
+          exit 0
 
       - name: Set up Python + uv
         if: startsWith(inputs.working-directory, 'libs/core')


### PR DESCRIPTION
We have deliberately introduced a breaking change in https://github.com/langchain-ai/langchain/pull/33021.

Will revert when we have compatible pre-releases for tested packages.