### PR TITLE
feat(langchain): async support for `create_agent`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -355,13 +355,14 @@ def create_agent(  # noqa: PLR0915
 
     # Build signatures for modify_model_request middleware with async support
     model_request_signatures: list[
-        tuple[bool, bool, AgentMiddleware[AgentState[ResponseT], ContextT]]
+        tuple[bool, bool, bool, AgentMiddleware[AgentState[ResponseT], ContextT]]
     ] = []
     for m in middleware_w_modify_model_request:
         uses_runtime = "runtime" in signature(m.modify_model_request).parameters
         # Check if async version is implemented (not the default)
+        has_sync = m.__class__.modify_model_request is not AgentMiddleware.modify_model_request
         has_async = m.__class__.amodify_model_request is not AgentMiddleware.amodify_model_request
-        model_request_signatures.append((uses_runtime, has_async, m))
+        model_request_signatures.append((uses_runtime, has_sync, has_async, m))
 
     def model_request(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
@@ -375,14 +376,20 @@ def create_agent(  # noqa: PLR0915
         )
 
         # Apply modify_model_request middleware in sequence
-        for use_runtime, has_async, m in model_request_signatures:
+        for use_runtime, has_sync, has_async, m in model_request_signatures:
             if has_async:
-                # Skip async middleware in sync context
-                continue
-            if use_runtime:
-                m.modify_model_request(request, state, runtime)
-            else:
-                m.modify_model_request(request, state)  # type: ignore[call-arg]
+                if use_runtime:
+                    m.modify_model_request(request, state, runtime)
+                else:
+                    m.modify_model_request(request, state)  # type: ignore[call-arg]
+            elif has_sync:
+                msg = (
+                    f"No synchronous function provided for "
+                    f'{m.__class__.__name__}.amodify_model_request".'
+                    "\nEither initialize with a synchronous function or invoke"
+                    " via the async API (ainvoke, astream, etc.)"
+                )
+                raise TypeError(msg)
 
         # Get the final model and messages
         model_ = _get_bound_model(request)
@@ -406,9 +413,8 @@ def create_agent(  # noqa: PLR0915
         )
 
         # Apply modify_model_request middleware in sequence
-        for use_runtime, has_async, m in model_request_signatures:
+        for use_runtime, _has_sync, has_async, m in model_request_signatures:
             if has_async:
-                # Use async version
                 if use_runtime:
                     await m.amodify_model_request(request, state, runtime)
                 else:

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -212,15 +212,22 @@ def create_agent(  # noqa: PLR0915
         "Please remove duplicate middleware instances."
     )
     middleware_w_before = [
-        m for m in middleware if m.__class__.before_model is not AgentMiddleware.before_model
+        m
+        for m in middleware
+        if m.__class__.before_model is not AgentMiddleware.before_model
+        or m.__class__.abefore_model is not AgentMiddleware.abefore_model
     ]
     middleware_w_modify_model_request = [
         m
         for m in middleware
         if m.__class__.modify_model_request is not AgentMiddleware.modify_model_request
+        or m.__class__.amodify_model_request is not AgentMiddleware.amodify_model_request
     ]
     middleware_w_after = [
-        m for m in middleware if m.__class__.after_model is not AgentMiddleware.after_model
+        m
+        for m in middleware
+        if m.__class__.after_model is not AgentMiddleware.after_model
+        or m.__class__.aafter_model is not AgentMiddleware.aafter_model
     ]
 
     state_schemas = {m.state_schema for m in middleware}


### PR DESCRIPTION
First pass w/ claude (tests too), including some manual edits and refactoring.

One unfortunate consequence here is that w/ Python we're seeing 4 branches:
sync vs async
w/ runtime vs w/o runtime

One easy way to control this would be to require `runtime` in signatures. But I think we **don't** want to do that. Happy to be corrected here.