### PR TITLE
feat(langchain_v1): add `async` support for `create_agent`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -146,7 +146,7 @@ class HumanInTheLoopMiddleware(AgentMiddleware):
         self.interrupt_on = resolved_tool_configs
         self.description_prefix = description_prefix
 
-    def after_model(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
+    def after_model(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:  # noqa: ARG002
         """Trigger interrupt flows for relevant tool calls after an AIMessage."""
         messages = state["messages"]
         if not messages:

--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -3,6 +3,7 @@
 from typing import Any, Literal
 
 from langchain_core.messages import AIMessage, ToolCall, ToolMessage
+from langgraph.runtime import Runtime
 from langgraph.types import interrupt
 from typing_extensions import NotRequired, TypedDict
 
@@ -145,7 +146,7 @@ class HumanInTheLoopMiddleware(AgentMiddleware):
         self.interrupt_on = resolved_tool_configs
         self.description_prefix = description_prefix
 
-    def after_model(self, state: AgentState) -> dict[str, Any] | None:  # type: ignore[override]
+    def after_model(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
         """Trigger interrupt flows for relevant tool calls after an AIMessage."""
         messages = state["messages"]
         if not messages:

--- a/libs/langchain_v1/langchain/agents/middleware/planning.py
+++ b/libs/langchain_v1/langchain/agents/middleware/planning.py
@@ -189,8 +189,8 @@ class PlanningMiddleware(AgentMiddleware):
     def modify_model_request(
         self,
         request: ModelRequest,
-        state: AgentState,
-        runtime: Runtime,
+        state: AgentState,  # noqa: ARG002
+        runtime: Runtime,  # noqa: ARG002
     ) -> ModelRequest:
         """Update the system prompt to include the todo system prompt."""
         request.system_prompt = (

--- a/libs/langchain_v1/langchain/agents/middleware/planning.py
+++ b/libs/langchain_v1/langchain/agents/middleware/planning.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool
@@ -12,6 +12,9 @@ from typing_extensions import NotRequired, TypedDict
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ModelRequest
 from langchain.tools import InjectedToolCallId
+
+if TYPE_CHECKING:
+    from langgraph.runtime import Runtime
 
 
 class Todo(TypedDict):
@@ -183,10 +186,11 @@ class PlanningMiddleware(AgentMiddleware):
 
         self.tools = [write_todos]
 
-    def modify_model_request(  # type: ignore[override]
+    def modify_model_request(
         self,
         request: ModelRequest,
-        state: PlanningState,  # noqa: ARG002
+        state: AgentState,
+        runtime: Runtime,
     ) -> ModelRequest:
         """Update the system prompt to include the todo system prompt."""
         request.system_prompt = (

--- a/libs/langchain_v1/langchain/agents/middleware/prompt_caching.py
+++ b/libs/langchain_v1/langchain/agents/middleware/prompt_caching.py
@@ -1,9 +1,11 @@
 """Anthropic prompt caching middleware."""
 
-from typing import Any, Literal
+from typing import Literal
 from warnings import warn
 
-from langchain.agents.middleware.types import AgentMiddleware, ModelRequest
+from langgraph.runtime import Runtime
+
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, ModelRequest
 
 
 class AnthropicPromptCachingMiddleware(AgentMiddleware):
@@ -39,12 +41,14 @@ class AnthropicPromptCachingMiddleware(AgentMiddleware):
         self.min_messages_to_cache = min_messages_to_cache
         self.unsupported_model_behavior = unsupported_model_behavior
 
-    def modify_model_request(  # type: ignore[override]
+    def modify_model_request(
         self,
         request: ModelRequest,
-        state: dict[str, Any],  # noqa: ARG002
+        state: AgentState,
+        runtime: Runtime,
     ) -> ModelRequest:
         """Modify the model request to add cache control blocks."""
+        del state, runtime  # unused
         try:
             from langchain_anthropic import ChatAnthropic
         except ImportError:

--- a/libs/langchain_v1/langchain/agents/middleware/prompt_caching.py
+++ b/libs/langchain_v1/langchain/agents/middleware/prompt_caching.py
@@ -44,11 +44,10 @@ class AnthropicPromptCachingMiddleware(AgentMiddleware):
     def modify_model_request(
         self,
         request: ModelRequest,
-        state: AgentState,
-        runtime: Runtime,
+        state: AgentState,  # noqa: ARG002
+        runtime: Runtime,  # noqa: ARG002
     ) -> ModelRequest:
         """Modify the model request to add cache control blocks."""
-        del state, runtime  # unused
         try:
             from langchain_anthropic import ChatAnthropic
         except ImportError:

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -99,7 +99,7 @@ class SummarizationMiddleware(AgentMiddleware):
         self.summary_prompt = summary_prompt
         self.summary_prefix = summary_prefix
 
-    def before_model(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
+    def before_model(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:  # noqa: ARG002
         """Process messages before model invocation, potentially triggering summarization."""
         messages = state["messages"]
         self._ensure_message_ids(messages)

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -16,6 +16,7 @@ from langchain_core.messages.utils import count_tokens_approximately, trim_messa
 from langgraph.graph.message import (
     REMOVE_ALL_MESSAGES,
 )
+from langgraph.runtime import Runtime
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState
 from langchain.chat_models import BaseChatModel, init_chat_model
@@ -98,7 +99,7 @@ class SummarizationMiddleware(AgentMiddleware):
         self.summary_prompt = summary_prompt
         self.summary_prefix = summary_prefix
 
-    def before_model(self, state: AgentState) -> dict[str, Any] | None:  # type: ignore[override]
+    def before_model(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
         """Process messages before model invocation, potentially triggering summarization."""
         messages = state["messages"]
         self._ensure_message_ids(messages)

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -355,13 +355,14 @@ def create_agent(  # noqa: PLR0915
 
     # Build signatures for modify_model_request middleware with async support
     model_request_signatures: list[
-        tuple[bool, bool, AgentMiddleware[AgentState[ResponseT], ContextT]]
+        tuple[bool, bool, bool, AgentMiddleware[AgentState[ResponseT], ContextT]]
     ] = []
     for m in middleware_w_modify_model_request:
         uses_runtime = "runtime" in signature(m.modify_model_request).parameters
         # Check if async version is implemented (not the default)
+        has_sync = m.__class__.modify_model_request is not AgentMiddleware.modify_model_request
         has_async = m.__class__.amodify_model_request is not AgentMiddleware.amodify_model_request
-        model_request_signatures.append((uses_runtime, has_async, m))
+        model_request_signatures.append((uses_runtime, has_sync, has_async, m))
 
     def model_request(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
@@ -375,14 +376,20 @@ def create_agent(  # noqa: PLR0915
         )
 
         # Apply modify_model_request middleware in sequence
-        for use_runtime, has_async, m in model_request_signatures:
+        for use_runtime, has_sync, has_async, m in model_request_signatures:
             if has_async:
-                # Skip async middleware in sync context
-                continue
-            if use_runtime:
-                m.modify_model_request(request, state, runtime)
-            else:
-                m.modify_model_request(request, state)  # type: ignore[call-arg]
+                if use_runtime:
+                    m.modify_model_request(request, state, runtime)
+                else:
+                    m.modify_model_request(request, state)  # type: ignore[call-arg]
+            elif has_sync:
+                msg = (
+                    f"No synchronous function provided for "
+                    f'{m.__class__.__name__}.amodify_model_request".'
+                    "\nEither initialize with a synchronous function or invoke"
+                    " via the async API (ainvoke, astream, etc.)"
+                )
+                raise TypeError(msg)
 
         # Get the final model and messages
         model_ = _get_bound_model(request)
@@ -406,9 +413,8 @@ def create_agent(  # noqa: PLR0915
         )
 
         # Apply modify_model_request middleware in sequence
-        for use_runtime, has_async, m in model_request_signatures:
+        for use_runtime, _has_sync, has_async, m in model_request_signatures:
             if has_async:
-                # Use async version
                 if use_runtime:
                     await m.amodify_model_request(request, state, runtime)
                 else:

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -212,15 +212,22 @@ def create_agent(  # noqa: PLR0915
         "Please remove duplicate middleware instances."
     )
     middleware_w_before = [
-        m for m in middleware if m.__class__.before_model is not AgentMiddleware.before_model
+        m
+        for m in middleware
+        if m.__class__.before_model is not AgentMiddleware.before_model
+        or m.__class__.abefore_model is not AgentMiddleware.abefore_model
     ]
     middleware_w_modify_model_request = [
         m
         for m in middleware
         if m.__class__.modify_model_request is not AgentMiddleware.modify_model_request
+        or m.__class__.amodify_model_request is not AgentMiddleware.amodify_model_request
     ]
     middleware_w_after = [
-        m for m in middleware if m.__class__.after_model is not AgentMiddleware.after_model
+        m
+        for m in middleware
+        if m.__class__.after_model is not AgentMiddleware.after_model
+        or m.__class__.aafter_model is not AgentMiddleware.aafter_model
     ]
 
     state_schemas = {m.state_schema for m in middleware}

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -2,9 +2,7 @@
 
 import itertools
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
-from inspect import signature
-from typing import Annotated, Any, Generic, cast, get_args, get_origin, get_type_hints
+from typing import Annotated, Any, cast, get_args, get_origin, get_type_hints
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, AnyMessage, SystemMessage, ToolMessage
@@ -40,25 +38,6 @@ from langchain.tools import ToolNode
 STRUCTURED_OUTPUT_ERROR_TEMPLATE = "Error: {error}\n Please fix your mistakes."
 
 ResponseT = TypeVar("ResponseT")
-
-
-@dataclass
-class MiddlewareSignature(Generic[ResponseT, ContextT]):
-    """Structured metadata for a middleware's hook implementations.
-
-    Attributes:
-        middleware: The middleware instance.
-        has_sync: Whether the middleware implements a sync version of the hook.
-        has_async: Whether the middleware implements an async version of the hook.
-        sync_uses_runtime: Whether the sync hook accepts a runtime argument.
-        async_uses_runtime: Whether the async hook accepts a runtime argument.
-    """
-
-    middleware: AgentMiddleware[AgentState[ResponseT], ContextT]
-    has_sync: bool
-    has_async: bool
-    sync_uses_runtime: bool
-    async_uses_runtime: bool
 
 
 def _resolve_schema(schemas: set[type], schema_name: str, omit_flag: str | None = None) -> type:
@@ -372,33 +351,6 @@ def create_agent(  # noqa: PLR0915
             )
         return request.model.bind(**request.model_settings)
 
-    # Build signatures for modify_model_request middleware with async support
-    model_request_signatures: list[MiddlewareSignature[ResponseT, ContextT]] = []
-    for m in middleware_w_modify_model_request:
-        # Check if async version is implemented (not the default)
-        has_sync = m.__class__.modify_model_request is not AgentMiddleware.modify_model_request
-        has_async = m.__class__.amodify_model_request is not AgentMiddleware.amodify_model_request
-
-        # Check runtime usage for each implementation
-        sync_uses_runtime = (
-            "runtime" in signature(m.modify_model_request).parameters if has_sync else False
-        )
-        # If async is implemented, check its signature; otherwise default is True
-        # (the default async implementation always expects runtime)
-        async_uses_runtime = (
-            "runtime" in signature(m.amodify_model_request).parameters if has_async else True
-        )
-
-        model_request_signatures.append(
-            MiddlewareSignature(
-                middleware=m,
-                has_sync=has_sync,
-                has_async=has_async,
-                sync_uses_runtime=sync_uses_runtime,
-                async_uses_runtime=async_uses_runtime,
-            )
-        )
-
     def model_request(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
         request = ModelRequest(
@@ -411,20 +363,8 @@ def create_agent(  # noqa: PLR0915
         )
 
         # Apply modify_model_request middleware in sequence
-        for sig in model_request_signatures:
-            if sig.has_sync:
-                if sig.sync_uses_runtime:
-                    sig.middleware.modify_model_request(request, state, runtime)
-                else:
-                    sig.middleware.modify_model_request(request, state)  # type: ignore[call-arg]
-            elif sig.has_async:
-                msg = (
-                    f"No synchronous function provided for "
-                    f'{sig.middleware.__class__.__name__}.amodify_model_request".'
-                    "\nEither initialize with a synchronous function or invoke"
-                    " via the async API (ainvoke, astream, etc.)"
-                )
-                raise TypeError(msg)
+        for m in middleware_w_modify_model_request:
+            m.modify_model_request(request, state, runtime)
 
         # Get the final model and messages
         model_ = _get_bound_model(request)
@@ -437,7 +377,6 @@ def create_agent(  # noqa: PLR0915
 
     async def amodel_request(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Async model request handler with sequential middleware processing."""
-        # Start with the base model request
         request = ModelRequest(
             model=model,
             tools=default_tools,
@@ -448,13 +387,8 @@ def create_agent(  # noqa: PLR0915
         )
 
         # Apply modify_model_request middleware in sequence
-        for sig in model_request_signatures:
-            # If async is overridden and doesn't use runtime, call without it
-            if sig.has_async and not sig.async_uses_runtime:
-                await sig.middleware.amodify_model_request(request, state)  # type: ignore[call-arg]
-            # Otherwise call async with runtime (default implementation handles sync delegation)
-            else:
-                await sig.middleware.amodify_model_request(request, state, runtime)
+        for m in middleware_w_modify_model_request:
+            await m.amodify_model_request(request, state, runtime)
 
         # Get the final model and messages
         model_ = _get_bound_model(request)

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -364,7 +364,16 @@ def create_agent(  # noqa: PLR0915
 
         # Apply modify_model_request middleware in sequence
         for m in middleware_w_modify_model_request:
-            m.modify_model_request(request, state, runtime)
+            if m.__class__.modify_model_request is not AgentMiddleware.modify_model_request:
+                m.modify_model_request(request, state, runtime)
+            else:
+                msg = (
+                    f"No synchronous function provided for "
+                    f'{m.__class__.__name__}.amodify_model_request".'
+                    "\nEither initialize with a synchronous function or invoke"
+                    " via the async API (ainvoke, astream, etc.)"
+                )
+                raise TypeError(msg)
 
         # Get the final model and messages
         model_ = _get_bound_model(request)

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -58,68 +58,68 @@ def test_create_agent_diagram(
     snapshot: SnapshotAssertion,
 ):
     class NoopOne(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             pass
 
     class NoopTwo(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             pass
 
     class NoopThree(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             pass
 
     class NoopFour(AgentMiddleware):
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             pass
 
     class NoopFive(AgentMiddleware):
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             pass
 
     class NoopSix(AgentMiddleware):
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             pass
 
     class NoopSeven(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             pass
 
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             pass
 
     class NoopEight(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             pass
 
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             pass
 
     class NoopNine(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             pass
 
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             pass
 
     class NoopTen(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             pass
 
-        def modify_model_request(self, request, state):
+        def modify_model_request(self, request, state, runtime):
             pass
 
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             pass
 
     class NoopEleven(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             pass
 
-        def modify_model_request(self, request, state):
+        def modify_model_request(self, request, state, runtime):
             pass
 
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             pass
 
     agent_zero = create_agent(
@@ -237,25 +237,25 @@ def test_create_agent_invoke(
     calls = []
 
     class NoopSeven(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             calls.append("NoopSeven.before_model")
 
-        def modify_model_request(self, request, state):
+        def modify_model_request(self, request, state, runtime):
             calls.append("NoopSeven.modify_model_request")
             return request
 
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             calls.append("NoopSeven.after_model")
 
     class NoopEight(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             calls.append("NoopEight.before_model")
 
-        def modify_model_request(self, request, state):
+        def modify_model_request(self, request, state, runtime):
             calls.append("NoopEight.modify_model_request")
             return request
 
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             calls.append("NoopEight.after_model")
 
     @tool
@@ -329,28 +329,28 @@ def test_create_agent_jump(
     calls = []
 
     class NoopSeven(AgentMiddleware):
-        def before_model(self, state):
+        def before_model(self, state, runtime):
             calls.append("NoopSeven.before_model")
 
-        def modify_model_request(self, request, state):
+        def modify_model_request(self, request, state, runtime):
             calls.append("NoopSeven.modify_model_request")
             return request
 
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             calls.append("NoopSeven.after_model")
 
     class NoopEight(AgentMiddleware):
         before_model_jump_to = ["end"]
 
-        def before_model(self, state) -> dict[str, Any]:
+        def before_model(self, state, runtime) -> dict[str, Any]:
             calls.append("NoopEight.before_model")
             return {"jump_to": "end"}
 
-        def modify_model_request(self, request, state) -> ModelRequest:
+        def modify_model_request(self, request, state, runtime) -> ModelRequest:
             calls.append("NoopEight.modify_model_request")
             return request
 
-        def after_model(self, state):
+        def after_model(self, state, runtime):
             calls.append("NoopEight.after_model")
 
     @tool
@@ -404,12 +404,12 @@ def test_human_in_the_loop_middleware_no_interrupts_needed() -> None:
 
     # Test with no messages
     state: dict[str, Any] = {"messages": []}
-    result = middleware.after_model(state)
+    result = middleware.after_model(state, None)
     assert result is None
 
     # Test with message but no tool calls
     state = {"messages": [HumanMessage(content="Hello"), AIMessage(content="Hi there")]}
-    result = middleware.after_model(state)
+    result = middleware.after_model(state, None)
     assert result is None
 
     # Test with tool calls that don't require interrupts
@@ -418,7 +418,7 @@ def test_human_in_the_loop_middleware_no_interrupts_needed() -> None:
         tool_calls=[{"name": "other_tool", "args": {"input": "test"}, "id": "1"}],
     )
     state = {"messages": [HumanMessage(content="Hello"), ai_message]}
-    result = middleware.after_model(state)
+    result = middleware.after_model(state, None)
     assert result is None
 
 
@@ -441,7 +441,7 @@ def test_human_in_the_loop_middleware_single_tool_accept() -> None:
         return [{"type": "accept", "args": None}]
 
     with patch("langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=mock_accept):
-        result = middleware.after_model(state)
+        result = middleware.after_model(state, None)
         assert result is not None
         assert "messages" in result
         assert len(result["messages"]) == 1
@@ -453,7 +453,7 @@ def test_human_in_the_loop_middleware_single_tool_accept() -> None:
     )
     state["messages"].append(AIMessage(content="test_tool called with result: Tool message"))
 
-    result = middleware.after_model(state)
+    result = middleware.after_model(state, None)
     # No interrupts needed
     assert result is None
 
@@ -484,7 +484,7 @@ def test_human_in_the_loop_middleware_single_tool_edit() -> None:
         ]
 
     with patch("langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=mock_edit):
-        result = middleware.after_model(state)
+        result = middleware.after_model(state, None)
         assert result is not None
         assert "messages" in result
         assert len(result["messages"]) == 1
@@ -513,7 +513,7 @@ def test_human_in_the_loop_middleware_single_tool_response() -> None:
     with patch(
         "langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=mock_response
     ):
-        result = middleware.after_model(state)
+        result = middleware.after_model(state, None)
         assert result is not None
         assert "messages" in result
         assert len(result["messages"]) == 2
@@ -552,7 +552,7 @@ def test_human_in_the_loop_middleware_multiple_tools_mixed_responses() -> None:
     with patch(
         "langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=mock_mixed_responses
     ):
-        result = middleware.after_model(state)
+        result = middleware.after_model(state, None)
         assert result is not None
         assert "messages" in result
         assert (
@@ -612,7 +612,7 @@ def test_human_in_the_loop_middleware_multiple_tools_edit_responses() -> None:
     with patch(
         "langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=mock_edit_responses
     ):
-        result = middleware.after_model(state)
+        result = middleware.after_model(state, None)
         assert result is not None
         assert "messages" in result
         assert len(result["messages"]) == 1
@@ -654,7 +654,7 @@ def test_human_in_the_loop_middleware_edit_with_modified_args() -> None:
         "langchain.agents.middleware.human_in_the_loop.interrupt",
         side_effect=mock_edit_with_args,
     ):
-        result = middleware.after_model(state)
+        result = middleware.after_model(state, None)
         assert result is not None
         assert "messages" in result
         assert len(result["messages"]) == 1
@@ -687,7 +687,7 @@ def test_human_in_the_loop_middleware_unknown_response_type() -> None:
             ValueError,
             match=r"Unexpected human response: {'type': 'unknown', 'args': None}. Response action 'unknown' is not allowed for tool 'test_tool'. Expected one of \['accept', 'edit', 'response'\] based on the tool's configuration.",
         ):
-            middleware.after_model(state)
+            middleware.after_model(state, None)
 
 
 def test_human_in_the_loop_middleware_disallowed_action() -> None:
@@ -725,7 +725,7 @@ def test_human_in_the_loop_middleware_disallowed_action() -> None:
             ValueError,
             match=r"Unexpected human response: {'type': 'edit', 'args': {'action': 'test_tool', 'args': {'input': 'modified'}}}. Response action 'edit' is not allowed for tool 'test_tool'. Expected one of \['accept', 'response'\] based on the tool's configuration.",
         ):
-            middleware.after_model(state)
+            middleware.after_model(state, None)
 
 
 def test_human_in_the_loop_middleware_mixed_auto_approved_and_interrupt() -> None:
@@ -750,7 +750,7 @@ def test_human_in_the_loop_middleware_mixed_auto_approved_and_interrupt() -> Non
         return [{"type": "accept", "args": None}]
 
     with patch("langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=mock_accept):
-        result = middleware.after_model(state)
+        result = middleware.after_model(state, None)
         assert result is not None
         assert "messages" in result
         assert len(result["messages"]) == 1
@@ -787,7 +787,7 @@ def test_human_in_the_loop_middleware_interrupt_request_structure() -> None:
     with patch(
         "langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=mock_capture_requests
     ):
-        middleware.after_model(state)
+        middleware.after_model(state, None)
 
         assert len(captured_requests) == 1
         request = captured_requests[0]
@@ -820,7 +820,7 @@ def test_human_in_the_loop_middleware_boolean_configs() -> None:
         "langchain.agents.middleware.human_in_the_loop.interrupt",
         return_value=[{"type": "accept", "args": None}],
     ):
-        result = middleware.after_model(state)
+        result = middleware.after_model(state, None)
         assert result is not None
         assert "messages" in result
         assert len(result["messages"]) == 1
@@ -839,7 +839,7 @@ def test_human_in_the_loop_middleware_boolean_configs() -> None:
             }
         ],
     ):
-        result = middleware.after_model(state)
+        result = middleware.after_model(state, None)
         assert result is not None
         assert "messages" in result
         assert len(result["messages"]) == 1
@@ -847,7 +847,7 @@ def test_human_in_the_loop_middleware_boolean_configs() -> None:
 
     middleware = HumanInTheLoopMiddleware(interrupt_on={"test_tool": False})
 
-    result = middleware.after_model(state)
+    result = middleware.after_model(state, None)
     # No interruption should occur
     assert result is None
 
@@ -871,7 +871,7 @@ def test_human_in_the_loop_middleware_sequence_mismatch() -> None:
             ValueError,
             match=r"Number of human responses \(0\) does not match number of hanging tool calls \(1\)\.",
         ):
-            middleware.after_model(state)
+            middleware.after_model(state, None)
 
     # Test with too many responses
     with patch(
@@ -885,7 +885,7 @@ def test_human_in_the_loop_middleware_sequence_mismatch() -> None:
             ValueError,
             match=r"Number of human responses \(2\) does not match number of hanging tool calls \(1\)\.",
         ):
-            middleware.after_model(state)
+            middleware.after_model(state, None)
 
 
 # Tests for AnthropicPromptCachingMiddleware
@@ -915,7 +915,7 @@ def test_anthropic_prompt_caching_middleware_initialization() -> None:
         model_settings={},
     )
 
-    assert middleware.modify_model_request(fake_request, {}).model_settings == {
+    assert middleware.modify_model_request(fake_request, {}, None).model_settings == {
         "cache_control": {"type": "ephemeral", "ttl": "5m"}
     }
 
@@ -938,7 +938,7 @@ def test_anthropic_prompt_caching_middleware_unsupported_model() -> None:
         ValueError,
         match="AnthropicPromptCachingMiddleware caching middleware only supports Anthropic models. Please install langchain-anthropic.",
     ):
-        middleware.modify_model_request(fake_request, {})
+        middleware.modify_model_request(fake_request, {}, None)
 
     langchain_anthropic = ModuleType("langchain_anthropic")
 
@@ -952,12 +952,12 @@ def test_anthropic_prompt_caching_middleware_unsupported_model() -> None:
             ValueError,
             match="AnthropicPromptCachingMiddleware caching middleware only supports Anthropic models, not instances of",
         ):
-            middleware.modify_model_request(fake_request, {})
+            middleware.modify_model_request(fake_request, {}, None)
 
     middleware = AnthropicPromptCachingMiddleware(unsupported_model_behavior="warn")
 
     with warnings.catch_warnings(record=True) as w:
-        result = middleware.modify_model_request(fake_request, {})
+        result = middleware.modify_model_request(fake_request, {}, None)
         assert len(w) == 1
         assert (
             "AnthropicPromptCachingMiddleware caching middleware only supports Anthropic models. Please install langchain-anthropic."
@@ -967,7 +967,7 @@ def test_anthropic_prompt_caching_middleware_unsupported_model() -> None:
 
     with warnings.catch_warnings(record=True) as w:
         with patch.dict("sys.modules", {"langchain_anthropic": langchain_anthropic}):
-            result = middleware.modify_model_request(fake_request, {})
+            result = middleware.modify_model_request(fake_request, {}, None)
             assert result is fake_request
             assert len(w) == 1
             assert (
@@ -977,11 +977,11 @@ def test_anthropic_prompt_caching_middleware_unsupported_model() -> None:
 
     middleware = AnthropicPromptCachingMiddleware(unsupported_model_behavior="ignore")
 
-    result = middleware.modify_model_request(fake_request, {})
+    result = middleware.modify_model_request(fake_request, {}, None)
     assert result is fake_request
 
     with patch.dict("sys.modules", {"langchain_anthropic": {"ChatAnthropic": object()}}):
-        result = middleware.modify_model_request(fake_request, {})
+        result = middleware.modify_model_request(fake_request, {}, None)
         assert result is fake_request
 
 
@@ -1020,7 +1020,7 @@ def test_summarization_middleware_no_summarization_cases() -> None:
     # Test when summarization is disabled
     middleware_disabled = SummarizationMiddleware(model=model, max_tokens_before_summary=None)
     state = {"messages": [HumanMessage(content="Hello"), AIMessage(content="Hi")]}
-    result = middleware_disabled.before_model(state)
+    result = middleware_disabled.before_model(state, None)
     assert result is None
 
     # Test when token count is below threshold
@@ -1028,7 +1028,7 @@ def test_summarization_middleware_no_summarization_cases() -> None:
         return 500  # Below threshold
 
     middleware.token_counter = mock_token_counter
-    result = middleware.before_model(state)
+    result = middleware.before_model(state, None)
     assert result is None
 
 
@@ -1181,7 +1181,7 @@ def test_summarization_middleware_full_workflow() -> None:
     ]
 
     state = {"messages": messages}
-    result = middleware.before_model(state)
+    result = middleware.before_model(state, None)
 
     assert result is not None
     assert "messages" in result
@@ -1204,7 +1204,9 @@ def test_summarization_middleware_full_workflow() -> None:
 
 def test_modify_model_request() -> None:
     class ModifyMiddleware(AgentMiddleware):
-        def modify_model_request(self, request: ModelRequest, state: AgentState) -> ModelRequest:
+        def modify_model_request(
+            self, request: ModelRequest, state: AgentState, runtime: Runtime
+        ) -> ModelRequest:
             request.messages.append(HumanMessage("remember to be nice!"))
             return request
 
@@ -1450,7 +1452,7 @@ def test_planning_middleware_modify_model_request(original_prompt, expected_prom
     )
 
     state: PlanningState = {"messages": [HumanMessage(content="Hello")]}
-    modified_request = middleware.modify_model_request(request, state)
+    modified_request = middleware.modify_model_request(request, state, None)
     assert modified_request.system_prompt.startswith(expected_prompt_prefix)
 
 
@@ -1577,7 +1579,7 @@ def test_planning_middleware_custom_system_prompt() -> None:
     )
 
     state: PlanningState = {"messages": [HumanMessage(content="Hello")]}
-    modified_request = middleware.modify_model_request(request, state)
+    modified_request = middleware.modify_model_request(request, state, None)
     assert modified_request.system_prompt == f"Original prompt\n\n{custom_system_prompt}"
 
 
@@ -1613,7 +1615,7 @@ def test_planning_middleware_custom_system_prompt_and_tool_description() -> None
     )
 
     state: PlanningState = {"messages": [HumanMessage(content="Hello")]}
-    modified_request = middleware.modify_model_request(request, state)
+    modified_request = middleware.modify_model_request(request, state, None)
     assert modified_request.system_prompt == custom_system_prompt
 
     # Verify tool description
@@ -1669,15 +1671,15 @@ async def test_create_agent_async_invoke() -> None:
     calls = []
 
     class AsyncMiddleware(AgentMiddleware):
-        async def abefore_model(self, state) -> None:
+        async def abefore_model(self, state, runtime) -> None:
             calls.append("AsyncMiddleware.abefore_model")
 
-        async def amodify_model_request(self, request, state) -> ModelRequest:
+        async def amodify_model_request(self, request, state, runtime) -> ModelRequest:
             calls.append("AsyncMiddleware.amodify_model_request")
             request.messages.append(HumanMessage("async middleware message"))
             return request
 
-        async def aafter_model(self, state) -> None:
+        async def aafter_model(self, state, runtime) -> None:
             calls.append("AsyncMiddleware.aafter_model")
 
     @tool
@@ -1726,25 +1728,25 @@ async def test_create_agent_async_invoke_multiple_middleware() -> None:
     calls = []
 
     class AsyncMiddlewareOne(AgentMiddleware):
-        async def abefore_model(self, state) -> None:
+        async def abefore_model(self, state, runtime) -> None:
             calls.append("AsyncMiddlewareOne.abefore_model")
 
-        async def amodify_model_request(self, request, state) -> ModelRequest:
+        async def amodify_model_request(self, request, state, runtime) -> ModelRequest:
             calls.append("AsyncMiddlewareOne.amodify_model_request")
             return request
 
-        async def aafter_model(self, state) -> None:
+        async def aafter_model(self, state, runtime) -> None:
             calls.append("AsyncMiddlewareOne.aafter_model")
 
     class AsyncMiddlewareTwo(AgentMiddleware):
-        async def abefore_model(self, state) -> None:
+        async def abefore_model(self, state, runtime) -> None:
             calls.append("AsyncMiddlewareTwo.abefore_model")
 
-        async def amodify_model_request(self, request, state) -> ModelRequest:
+        async def amodify_model_request(self, request, state, runtime) -> ModelRequest:
             calls.append("AsyncMiddlewareTwo.amodify_model_request")
             return request
 
-        async def aafter_model(self, state) -> None:
+        async def aafter_model(self, state, runtime) -> None:
             calls.append("AsyncMiddlewareTwo.aafter_model")
 
     agent = create_agent(
@@ -1771,13 +1773,13 @@ async def test_create_agent_async_jump() -> None:
     calls = []
 
     class AsyncMiddlewareOne(AgentMiddleware):
-        async def abefore_model(self, state) -> None:
+        async def abefore_model(self, state, runtime) -> None:
             calls.append("AsyncMiddlewareOne.abefore_model")
 
     class AsyncMiddlewareTwo(AgentMiddleware):
         before_model_jump_to = ["end"]
 
-        async def abefore_model(self, state) -> dict[str, Any]:
+        async def abefore_model(self, state, runtime) -> dict[str, Any]:
             calls.append("AsyncMiddlewareTwo.abefore_model")
             return {"jump_to": "end"}
 
@@ -1799,25 +1801,25 @@ async def test_create_agent_mixed_sync_async_middleware() -> None:
     calls = []
 
     class SyncMiddleware(AgentMiddleware):
-        def before_model(self, state) -> None:
+        def before_model(self, state, runtime) -> None:
             calls.append("SyncMiddleware.before_model")
 
-        def modify_model_request(self, request, state) -> ModelRequest:
+        def modify_model_request(self, request, state, runtime) -> ModelRequest:
             calls.append("SyncMiddleware.modify_model_request")
             return request
 
-        def after_model(self, state) -> None:
+        def after_model(self, state, runtime) -> None:
             calls.append("SyncMiddleware.after_model")
 
     class AsyncMiddleware(AgentMiddleware):
-        async def abefore_model(self, state) -> None:
+        async def abefore_model(self, state, runtime) -> None:
             calls.append("AsyncMiddleware.abefore_model")
 
-        async def amodify_model_request(self, request, state) -> ModelRequest:
+        async def amodify_model_request(self, request, state, runtime) -> ModelRequest:
             calls.append("AsyncMiddleware.amodify_model_request")
             return request
 
-        async def aafter_model(self, state) -> None:
+        async def aafter_model(self, state, runtime) -> None:
             calls.append("AsyncMiddleware.aafter_model")
 
     agent = create_agent(
@@ -1841,10 +1843,10 @@ async def test_create_agent_mixed_sync_async_middleware() -> None:
 
 
 def test_create_agent_sync_invoke_with_only_async_middleware_raises_error() -> None:
-    """Test that sync invoke with only async middleware raises TypeError."""
+    """Test that sync invoke with only async middleware works via run_in_executor."""
 
     class AsyncOnlyMiddleware(AgentMiddleware):
-        async def amodify_model_request(self, request, state) -> ModelRequest:
+        async def amodify_model_request(self, request, state, runtime) -> ModelRequest:
             return request
 
     agent = create_agent(
@@ -1854,11 +1856,9 @@ def test_create_agent_sync_invoke_with_only_async_middleware_raises_error() -> N
         middleware=[AsyncOnlyMiddleware()],
     ).compile()
 
-    with pytest.raises(
-        TypeError,
-        match=r"No synchronous function provided for AsyncOnlyMiddleware\.amodify_model_request",
-    ):
-        agent.invoke({"messages": [HumanMessage("hello")]})
+    # Should work now - default implementation uses run_in_executor
+    result = agent.invoke({"messages": [HumanMessage("hello")]})
+    assert result["messages"]
 
 
 def test_create_agent_sync_invoke_with_mixed_middleware() -> None:
@@ -1866,17 +1866,17 @@ def test_create_agent_sync_invoke_with_mixed_middleware() -> None:
     calls = []
 
     class MixedMiddleware(AgentMiddleware):
-        def before_model(self, state) -> None:
+        def before_model(self, state, runtime) -> None:
             calls.append("MixedMiddleware.before_model")
 
-        async def abefore_model(self, state) -> None:
+        async def abefore_model(self, state, runtime) -> None:
             calls.append("MixedMiddleware.abefore_model")
 
-        def modify_model_request(self, request, state) -> ModelRequest:
+        def modify_model_request(self, request, state, runtime) -> ModelRequest:
             calls.append("MixedMiddleware.modify_model_request")
             return request
 
-        async def amodify_model_request(self, request, state) -> ModelRequest:
+        async def amodify_model_request(self, request, state, runtime) -> ModelRequest:
             calls.append("MixedMiddleware.amodify_model_request")
             return request
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -1856,9 +1856,11 @@ def test_create_agent_sync_invoke_with_only_async_middleware_raises_error() -> N
         middleware=[AsyncOnlyMiddleware()],
     ).compile()
 
-    # Should work now - default implementation uses run_in_executor
-    result = agent.invoke({"messages": [HumanMessage("hello")]})
-    assert result["messages"]
+    with pytest.raises(
+        TypeError,
+        match="No synchronous function provided for AsyncOnlyMiddleware.amodify_model_request",
+    ):
+        agent.invoke({"messages": [HumanMessage("hello")]})
 
 
 def test_create_agent_sync_invoke_with_mixed_middleware() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_decorators.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_decorators.py
@@ -48,8 +48,8 @@ def test_before_model_decorator() -> None:
     assert custom_before_model.before_model_jump_to == ["__end__"]
     assert custom_before_model.__class__.__name__ == "CustomBeforeModel"
 
-    # Note: We can't easily test calling the method directly without a real runtime
-    # The integration tests below will test the actual execution
+    result = custom_before_model.before_model({"messages": [HumanMessage("Hello")]}, None)
+    assert result == {"jump_to": "__end__"}
 
 
 def test_after_model_decorator() -> None:
@@ -71,6 +71,12 @@ def test_after_model_decorator() -> None:
     assert custom_after_model.after_model_jump_to == ["model", "__end__"]
     assert custom_after_model.__class__.__name__ == "CustomAfterModel"
 
+    # Verify it works
+    result = custom_after_model.after_model(
+        {"messages": [HumanMessage("Hello"), AIMessage("Hi!")]}, None
+    )
+    assert result == {"jump_to": "model"}
+
 
 def test_modify_model_request_decorator() -> None:
     """Test modify_model_request decorator with all configuration options."""
@@ -87,6 +93,20 @@ def test_modify_model_request_decorator() -> None:
     assert custom_modify_request.state_schema == CustomState
     assert custom_modify_request.tools == [test_tool]
     assert custom_modify_request.__class__.__name__ == "CustomModifyRequest"
+
+    # Verify it works
+    original_request = ModelRequest(
+        model="test-model",
+        system_prompt="Original",
+        messages=[HumanMessage("Hello")],
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+    )
+    result = custom_modify_request.modify_model_request(
+        original_request, {"messages": [HumanMessage("Hello")]}, None
+    )
+    assert result.system_prompt == "Modified"
 
 
 def test_all_decorators_integration() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_decorators.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_decorators.py
@@ -6,6 +6,7 @@ from typing_extensions import NotRequired
 
 from langchain_core.messages import HumanMessage, AIMessage
 from langchain_core.tools import tool
+from langgraph.runtime import Runtime
 from langgraph.types import Command
 
 from langchain.agents.middleware.types import (
@@ -38,7 +39,7 @@ def test_before_model_decorator() -> None:
     @before_model(
         state_schema=CustomState, tools=[test_tool], jump_to=["__end__"], name="CustomBeforeModel"
     )
-    def custom_before_model(state: CustomState) -> dict[str, Any]:
+    def custom_before_model(state: CustomState, runtime: Runtime) -> dict[str, Any]:
         return {"jump_to": "__end__"}
 
     assert isinstance(custom_before_model, AgentMiddleware)
@@ -47,8 +48,8 @@ def test_before_model_decorator() -> None:
     assert custom_before_model.before_model_jump_to == ["__end__"]
     assert custom_before_model.__class__.__name__ == "CustomBeforeModel"
 
-    result = custom_before_model.before_model({"messages": [HumanMessage("Hello")]})
-    assert result == {"jump_to": "__end__"}
+    # Note: We can't easily test calling the method directly without a real runtime
+    # The integration tests below will test the actual execution
 
 
 def test_after_model_decorator() -> None:
@@ -60,7 +61,7 @@ def test_after_model_decorator() -> None:
         jump_to=["model", "__end__"],
         name="CustomAfterModel",
     )
-    def custom_after_model(state: CustomState) -> dict[str, Any]:
+    def custom_after_model(state: CustomState, runtime: Runtime) -> dict[str, Any]:
         return {"jump_to": "model"}
 
     # Verify all options were applied
@@ -70,16 +71,14 @@ def test_after_model_decorator() -> None:
     assert custom_after_model.after_model_jump_to == ["model", "__end__"]
     assert custom_after_model.__class__.__name__ == "CustomAfterModel"
 
-    # Verify it works
-    result = custom_after_model.after_model({"messages": [HumanMessage("Hello"), AIMessage("Hi!")]})
-    assert result == {"jump_to": "model"}
-
 
 def test_modify_model_request_decorator() -> None:
     """Test modify_model_request decorator with all configuration options."""
 
     @modify_model_request(state_schema=CustomState, tools=[test_tool], name="CustomModifyRequest")
-    def custom_modify_request(request: ModelRequest, state: CustomState) -> ModelRequest:
+    def custom_modify_request(
+        request: ModelRequest, state: CustomState, runtime: Runtime
+    ) -> ModelRequest:
         request.system_prompt = "Modified"
         return request
 
@@ -89,37 +88,23 @@ def test_modify_model_request_decorator() -> None:
     assert custom_modify_request.tools == [test_tool]
     assert custom_modify_request.__class__.__name__ == "CustomModifyRequest"
 
-    # Verify it works
-    original_request = ModelRequest(
-        model="test-model",
-        system_prompt="Original",
-        messages=[HumanMessage("Hello")],
-        tool_choice=None,
-        tools=[],
-        response_format=None,
-    )
-    result = custom_modify_request.modify_model_request(
-        original_request, {"messages": [HumanMessage("Hello")]}
-    )
-    assert result.system_prompt == "Modified"
-
 
 def test_all_decorators_integration() -> None:
     """Test all three decorators working together in an agent."""
     call_order = []
 
     @before_model
-    def track_before(state: AgentState) -> None:
+    def track_before(state: AgentState, runtime: Runtime) -> None:
         call_order.append("before")
         return None
 
     @modify_model_request
-    def track_modify(request: ModelRequest, state: AgentState) -> ModelRequest:
+    def track_modify(request: ModelRequest, state: AgentState, runtime: Runtime) -> ModelRequest:
         call_order.append("modify")
         return request
 
     @after_model
-    def track_after(state: AgentState) -> None:
+    def track_after(state: AgentState, runtime: Runtime) -> None:
         call_order.append("after")
         return None
 
@@ -136,15 +121,15 @@ def test_decorators_use_function_names_as_default() -> None:
     """Test that decorators use function names as default middleware names."""
 
     @before_model
-    def my_before_hook(state: AgentState) -> None:
+    def my_before_hook(state: AgentState, runtime: Runtime) -> None:
         return None
 
     @modify_model_request
-    def my_modify_hook(request: ModelRequest, state: AgentState) -> ModelRequest:
+    def my_modify_hook(request: ModelRequest, state: AgentState, runtime: Runtime) -> ModelRequest:
         return request
 
     @after_model
-    def my_after_hook(state: AgentState) -> None:
+    def my_after_hook(state: AgentState, runtime: Runtime) -> None:
         return None
 
     # Verify that function names are used as middleware class names
@@ -160,7 +145,7 @@ def test_async_before_model_decorator() -> None:
     """Test before_model decorator with async function."""
 
     @before_model(state_schema=CustomState, tools=[test_tool], name="AsyncBeforeModel")
-    async def async_before_model(state: CustomState) -> dict[str, Any]:
+    async def async_before_model(state: CustomState, runtime: Runtime) -> dict[str, Any]:
         return {"custom_field": "async_value"}
 
     assert isinstance(async_before_model, AgentMiddleware)
@@ -173,7 +158,7 @@ def test_async_after_model_decorator() -> None:
     """Test after_model decorator with async function."""
 
     @after_model(state_schema=CustomState, tools=[test_tool], name="AsyncAfterModel")
-    async def async_after_model(state: CustomState) -> dict[str, Any]:
+    async def async_after_model(state: CustomState, runtime: Runtime) -> dict[str, Any]:
         return {"custom_field": "async_value"}
 
     assert isinstance(async_after_model, AgentMiddleware)
@@ -186,7 +171,9 @@ def test_async_modify_model_request_decorator() -> None:
     """Test modify_model_request decorator with async function."""
 
     @modify_model_request(state_schema=CustomState, tools=[test_tool], name="AsyncModifyRequest")
-    async def async_modify_request(request: ModelRequest, state: CustomState) -> ModelRequest:
+    async def async_modify_request(
+        request: ModelRequest, state: CustomState, runtime: Runtime
+    ) -> ModelRequest:
         request.system_prompt = "Modified async"
         return request
 
@@ -200,19 +187,21 @@ def test_mixed_sync_async_decorators() -> None:
     """Test decorators with both sync and async functions."""
 
     @before_model(name="MixedBeforeModel")
-    def sync_before(state: AgentState) -> None:
+    def sync_before(state: AgentState, runtime: Runtime) -> None:
         return None
 
     @before_model(name="MixedBeforeModel")
-    async def async_before(state: AgentState) -> None:
+    async def async_before(state: AgentState, runtime: Runtime) -> None:
         return None
 
     @modify_model_request(name="MixedModifyRequest")
-    def sync_modify(request: ModelRequest, state: AgentState) -> ModelRequest:
+    def sync_modify(request: ModelRequest, state: AgentState, runtime: Runtime) -> ModelRequest:
         return request
 
     @modify_model_request(name="MixedModifyRequest")
-    async def async_modify(request: ModelRequest, state: AgentState) -> ModelRequest:
+    async def async_modify(
+        request: ModelRequest, state: AgentState, runtime: Runtime
+    ) -> ModelRequest:
         return request
 
     # Both should create valid middleware instances
@@ -228,17 +217,19 @@ async def test_async_decorators_integration() -> None:
     call_order = []
 
     @before_model
-    async def track_async_before(state: AgentState) -> None:
+    async def track_async_before(state: AgentState, runtime: Runtime) -> None:
         call_order.append("async_before")
         return None
 
     @modify_model_request
-    async def track_async_modify(request: ModelRequest, state: AgentState) -> ModelRequest:
+    async def track_async_modify(
+        request: ModelRequest, state: AgentState, runtime: Runtime
+    ) -> ModelRequest:
         call_order.append("async_modify")
         return request
 
     @after_model
-    async def track_async_after(state: AgentState) -> None:
+    async def track_async_after(state: AgentState, runtime: Runtime) -> None:
         call_order.append("async_after")
         return None
 
@@ -258,32 +249,36 @@ async def test_mixed_sync_async_decorators_integration() -> None:
     call_order = []
 
     @before_model
-    def track_sync_before(state: AgentState) -> None:
+    def track_sync_before(state: AgentState, runtime: Runtime) -> None:
         call_order.append("sync_before")
         return None
 
     @before_model
-    async def track_async_before(state: AgentState) -> None:
+    async def track_async_before(state: AgentState, runtime: Runtime) -> None:
         call_order.append("async_before")
         return None
 
     @modify_model_request
-    def track_sync_modify(request: ModelRequest, state: AgentState) -> ModelRequest:
+    def track_sync_modify(
+        request: ModelRequest, state: AgentState, runtime: Runtime
+    ) -> ModelRequest:
         call_order.append("sync_modify")
         return request
 
     @modify_model_request
-    async def track_async_modify(request: ModelRequest, state: AgentState) -> ModelRequest:
+    async def track_async_modify(
+        request: ModelRequest, state: AgentState, runtime: Runtime
+    ) -> ModelRequest:
         call_order.append("async_modify")
         return request
 
     @after_model
-    async def track_async_after(state: AgentState) -> None:
+    async def track_async_after(state: AgentState, runtime: Runtime) -> None:
         call_order.append("async_after")
         return None
 
     @after_model
-    def track_sync_after(state: AgentState) -> None:
+    def track_sync_after(state: AgentState, runtime: Runtime) -> None:
         call_order.append("sync_after")
         return None
 


### PR DESCRIPTION
This makes branching **much** more simple internally and helps greatly w/ type safety for users. It just allows for one signature on hooks instead of multiple.

Opened after https://github.com/langchain-ai/langchain/pull/33164 ballooned more than expected, w/ branching for:
* sync vs async
* runtime vs no runtime (this is self imposed)

**This also removes support for nodes w/o `runtime` in the signature.** We can always go back and add support for nodes w/o `runtime`.

I think @christian-bromann's idea to re-export `runtime` from langchain's agents might make sense due to the abundance of imports here.

Check out the value of the change based on this diff: https://github.com/langchain-ai/langchain/pull/33176