### PR TITLE
feat(langchain): use decorators for jumps instead

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -10,7 +10,7 @@ from .types import (
     ModelRequest,
     after_model,
     before_model,
-    jump_to,
+    hook_config,
     modify_model_request,
 )
 
@@ -25,6 +25,6 @@ __all__ = [
     "SummarizationMiddleware",
     "after_model",
     "before_model",
-    "jump_to",
+    "hook_config",
     "modify_model_request",
 ]

--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -10,6 +10,7 @@ from .types import (
     ModelRequest,
     after_model,
     before_model,
+    jump_to,
     modify_model_request,
 )
 
@@ -24,5 +25,6 @@ __all__ = [
     "SummarizationMiddleware",
     "after_model",
     "before_model",
+    "jump_to",
     "modify_model_request",
 ]

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -323,6 +323,10 @@ def before_model(
             ) -> dict[str, Any] | Command | None:
                 return await func(state, runtime)  # type: ignore[misc]
 
+            # Preserve can_jump_to metadata on the wrapped function
+            if func_can_jump_to:
+                async_wrapped.__can_jump_to__ = func_can_jump_to  # type: ignore[attr-defined]
+
             middleware_name = name or cast(
                 "str", getattr(func, "__name__", "BeforeModelMiddleware")
             )
@@ -588,6 +592,10 @@ def after_model(
                 runtime: Runtime[ContextT],
             ) -> dict[str, Any] | Command | None:
                 return await func(state, runtime)  # type: ignore[misc]
+
+            # Preserve can_jump_to metadata on the wrapped function
+            if func_can_jump_to:
+                async_wrapped.__can_jump_to__ = func_can_jump_to  # type: ignore[attr-defined]
 
             middleware_name = name or cast("str", getattr(func, "__name__", "AfterModelMiddleware"))
 

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -227,6 +227,7 @@ def hook_config(
 
     return decorator
 
+
 @overload
 def before_model(
     func: _CallableWithStateAndRuntime[StateT, ContextT],
@@ -332,7 +333,6 @@ def before_model(
                 {
                     "state_schema": state_schema or AgentState,
                     "tools": tools or [],
-                    "before_model_jump_to": jump_to or [],
                     "abefore_model": async_wrapped,
                 },
             )()
@@ -597,7 +597,6 @@ def after_model(
                 {
                     "state_schema": state_schema or AgentState,
                     "tools": tools or [],
-                    "after_model_jump_to": jump_to or [],
                     "aafter_model": async_wrapped,
                 },
             )()

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -464,7 +464,7 @@ def create_agent(  # noqa: PLR0915
             f"{middleware_w_after[0].__class__.__name__}.after_model",
             END,
             first_node,
-            jump_to=middleware_w_after[0].after_model_jump_to,
+            jump_to=getattr(middleware_w_after[0].__class__.after_model, "__jump_to__", []),
         )
 
     # Add middleware edges (same as before)
@@ -475,7 +475,7 @@ def create_agent(  # noqa: PLR0915
                 f"{m1.__class__.__name__}.before_model",
                 f"{m2.__class__.__name__}.before_model",
                 first_node,
-                jump_to=m1.before_model_jump_to,
+                jump_to=getattr(m1.__class__.before_model, "__jump_to__", []),
             )
         # Go directly to model_request after the last before_model
         _add_middleware_edge(
@@ -483,7 +483,7 @@ def create_agent(  # noqa: PLR0915
             f"{middleware_w_before[-1].__class__.__name__}.before_model",
             "model_request",
             first_node,
-            jump_to=middleware_w_before[-1].before_model_jump_to,
+            jump_to=getattr(middleware_w_before[-1].__class__.before_model, "__jump_to__", []),
         )
 
     if middleware_w_after:
@@ -496,7 +496,7 @@ def create_agent(  # noqa: PLR0915
                 f"{m1.__class__.__name__}.after_model",
                 f"{m2.__class__.__name__}.after_model",
                 first_node,
-                jump_to=m1.after_model_jump_to,
+                jump_to=getattr(m1.__class__.after_model, "__jump_to__", []),
             )
 
     return graph

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -95,14 +95,26 @@ def _get_can_jump_to(middleware: AgentMiddleware[Any, Any], hook_name: str) -> l
     Returns:
         List of jump destinations, or empty list if not configured.
     """
-    # Try sync method first
+    # Get the base class method for comparison
+    base_sync_method = getattr(AgentMiddleware, hook_name, None)
+    base_async_method = getattr(AgentMiddleware, f"a{hook_name}", None)
+
+    # Try sync method first - only if it's overridden from base class
     sync_method = getattr(middleware.__class__, hook_name, None)
-    if sync_method and hasattr(sync_method, "__can_jump_to__"):
+    if (
+        sync_method
+        and sync_method is not base_sync_method
+        and hasattr(sync_method, "__can_jump_to__")
+    ):
         return sync_method.__can_jump_to__
 
-    # Try async method
+    # Try async method - only if it's overridden from base class
     async_method = getattr(middleware.__class__, f"a{hook_name}", None)
-    if async_method and hasattr(async_method, "__can_jump_to__"):
+    if (
+        async_method
+        and async_method is not base_async_method
+        and hasattr(async_method, "__can_jump_to__")
+    ):
         return async_method.__can_jump_to__
 
     return []

--- a/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_middleware_decorators.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_middleware_decorators.ambr
@@ -1,0 +1,95 @@
+# serializer version: 1
+# name: test_async_middleware_with_can_jump_to_graph_snapshot
+  '''
+  ---
+  config:
+    flowchart:
+      curve: linear
+  ---
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	model_request(model_request)
+  	async_before_with_jump\2ebefore_model(async_before_with_jump.before_model)
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> async_before_with_jump\2ebefore_model;
+  	async_before_with_jump\2ebefore_model -.-> __end__;
+  	async_before_with_jump\2ebefore_model -.-> model_request;
+  	model_request --> __end__;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_async_middleware_with_can_jump_to_graph_snapshot.1
+  '''
+  ---
+  config:
+    flowchart:
+      curve: linear
+  ---
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	model_request(model_request)
+  	async_after_with_jump\2eafter_model(async_after_with_jump.after_model)
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> model_request;
+  	async_after_with_jump\2eafter_model -.-> __end__;
+  	async_after_with_jump\2eafter_model -.-> model_request;
+  	model_request --> async_after_with_jump\2eafter_model;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_async_middleware_with_can_jump_to_graph_snapshot.2
+  '''
+  ---
+  config:
+    flowchart:
+      curve: linear
+  ---
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	model_request(model_request)
+  	async_before_early_exit\2ebefore_model(async_before_early_exit.before_model)
+  	async_after_retry\2eafter_model(async_after_retry.after_model)
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> async_before_early_exit\2ebefore_model;
+  	async_after_retry\2eafter_model -.-> __end__;
+  	async_after_retry\2eafter_model -.-> async_before_early_exit\2ebefore_model;
+  	async_before_early_exit\2ebefore_model -.-> __end__;
+  	async_before_early_exit\2ebefore_model -.-> model_request;
+  	model_request --> async_after_retry\2eafter_model;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
+# name: test_async_middleware_with_can_jump_to_graph_snapshot.3
+  '''
+  ---
+  config:
+    flowchart:
+      curve: linear
+  ---
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	model_request(model_request)
+  	sync_before_with_jump\2ebefore_model(sync_before_with_jump.before_model)
+  	async_after_with_jumps\2eafter_model(async_after_with_jumps.after_model)
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> sync_before_with_jump\2ebefore_model;
+  	async_after_with_jumps\2eafter_model -.-> __end__;
+  	async_after_with_jumps\2eafter_model -.-> sync_before_with_jump\2ebefore_model;
+  	model_request --> async_after_with_jumps\2eafter_model;
+  	sync_before_with_jump\2ebefore_model -.-> __end__;
+  	sync_before_with_jump\2ebefore_model -.-> model_request;
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -24,6 +24,7 @@ from langgraph.types import Command
 from pydantic import BaseModel, Field
 from syrupy.assertion import SnapshotAssertion
 from typing_extensions import Annotated
+from langchain.agents.middleware.types import jump_to
 
 from langchain.agents.middleware.human_in_the_loop import (
     ActionRequest,
@@ -41,6 +42,7 @@ from langchain.agents.middleware.summarization import SummarizationMiddleware
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
+    jump_to,
     ModelRequest,
     OmitFromInput,
     OmitFromOutput,
@@ -338,8 +340,6 @@ def test_create_agent_jump(
 
         def after_model(self, state):
             calls.append("NoopSeven.after_model")
-
-    from langchain.agents.middleware.types import jump_to
 
     class NoopEight(AgentMiddleware):
         @jump_to("end")

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -24,7 +24,6 @@ from langgraph.types import Command
 from pydantic import BaseModel, Field
 from syrupy.assertion import SnapshotAssertion
 from typing_extensions import Annotated
-from langchain.agents.middleware.types import jump_to
 
 from langchain.agents.middleware.human_in_the_loop import (
     ActionRequest,
@@ -42,7 +41,7 @@ from langchain.agents.middleware.summarization import SummarizationMiddleware
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
-    jump_to,
+    hook_config,
     ModelRequest,
     OmitFromInput,
     OmitFromOutput,
@@ -342,7 +341,7 @@ def test_create_agent_jump(
             calls.append("NoopSeven.after_model")
 
     class NoopEight(AgentMiddleware):
-        @jump_to("end")
+        @hook_config(can_jump_to=["end"])
         def before_model(self, state) -> dict[str, Any]:
             calls.append("NoopEight.before_model")
             return {"jump_to": "end"}

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -339,9 +339,10 @@ def test_create_agent_jump(
         def after_model(self, state):
             calls.append("NoopSeven.after_model")
 
-    class NoopEight(AgentMiddleware):
-        before_model_jump_to = ["end"]
+    from langchain.agents.middleware.types import jump_to
 
+    class NoopEight(AgentMiddleware):
+        @jump_to("end")
         def before_model(self, state) -> dict[str, Any]:
             calls.append("NoopEight.before_model")
             return {"jump_to": "end"}

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2261,7 +2261,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "0.3.33"
+version = "0.3.34"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },
@@ -2272,7 +2272,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", editable = "../core" },
-    { name = "openai", specifier = ">=1.104.2,<2.0.0" },
+    { name = "openai", specifier = ">=1.104.2,<3.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
 ]
 


### PR DESCRIPTION
The old `before_model_jump_to` classvar approach was quite clunky, this is nicer imo and easier to document. Also moving from `jump_to` to `can_jump_to` which is more idiomatic.

Before:

```py
class MyMiddleware(AgentMiddleware):
    before_model_jump_to: ClassVar[list[JumpTo]] = ["end"]

    def before_model(state, runtime) -> dict[str, Any]:
        return {"jump_to": "end"}
```

After

```py
class MyMiddleware(AgentMiddleware):

    @hook_config(can_jump_to=["end"])
    def before_model(state, runtime) -> dict[str, Any]:
        return {"jump_to": "end"}
```