### PR TITLE
feat(openai): support for including reasoning_content from model responses

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -152,6 +152,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         additional_kwargs: dict = {}
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = _dict["reasoning_content"]
         tool_calls = []
         invalid_tool_calls = []
         if raw_tool_calls := _dict.get("tool_calls"):


### PR DESCRIPTION
support for including reasoning_content from model responses in AIMessage

it's simliar with pr : https://github.com/langchain-ai/langchain/pull/32982 , 
same as https://github.com/langchain-ai/langchain/pull/32859

I use GPT_OSS_20B with llama-cpp with local server like
```sh
llama-server -m "$llm_model_path" \
    --host "localhost" \
    --port "$llm_port" \
    --n-cpu-moe 9 \
    --n-gpu-layers 999 \
    -c 0 \
    -n -1 \
    -fa on \
    --jinja \
    --chat-template-kwargs '{"reasoning_effort": "high"}'
```
and make llm and agent like
```python
from langchain.chat_models import init_chat_model
from langgraph.prebuilt import create_react_agent

llm= init_chat_model(
                model = model_path,
                model_provider = "openai",
                base_url = f"http://{host}:{port}/v1",
                api_key = "EMPTY", # no auth
            )
agent = create_react_agent(
                llm, 
                tools = self.available_tools,
            )
```

It could be open_ai right?

@ccurme 
