### PR TITLE
fix(openai): bump min core version

### DIFF
--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -7,7 +7,7 @@ authors = []
 license = { text = "MIT" }
 requires-python = ">=3.9.0,<4.0.0"
 dependencies = [
-    "langchain-core>=0.3.76,<2.0.0",
+    "langchain-core>=0.3.77,<2.0.0",
     "openai>=1.104.2,<3.0.0",
     "tiktoken>=0.7.0,<1.0.0",
 ]

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "0.3.76"
+version = "0.3.77"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Required for new tests added in https://github.com/langchain-ai/langchain/pull/32541 and https://github.com/langchain-ai/langchain/pull/33183.