### PR TITLE
refactor: simplify length checks and normalize docstring spacing

### DIFF
--- a/libs/core/langchain_core/_api/__init__.py
+++ b/libs/core/langchain_core/_api/__init__.py
@@ -4,8 +4,8 @@ This module is only relevant for LangChain developers, not for users.
 
 !!! warning
 
-    This module and its submodules are for internal use only.  Do not use them
-    in your own code.  We may change the API at any time with no warning.
+    This module and its submodules are for internal use only. Do not use them
+    in your own code. We may change the API at any time with no warning.
 
 """
 

--- a/libs/core/langchain_core/_api/beta_decorator.py
+++ b/libs/core/langchain_core/_api/beta_decorator.py
@@ -6,7 +6,7 @@ https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/_api/deprecati
 
 !!! warning
 
-    This module is for internal use only.  Do not use it in your own code.
+    This module is for internal use only. Do not use it in your own code.
     We may change the API at any time with no warning.
 """
 

--- a/libs/core/langchain_core/_api/deprecation.py
+++ b/libs/core/langchain_core/_api/deprecation.py
@@ -6,7 +6,7 @@ https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/_api/deprecati
 
 !!! warning
 
-    This module is for internal use only.  Do not use it in your own code.
+    This module is for internal use only. Do not use it in your own code.
     We may change the API at any time with no warning.
 """
 
@@ -540,7 +540,7 @@ def rename_parameter(
 ) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
     """Decorator indicating that parameter *old* of *func* is renamed to *new*.
 
-    The actual implementation of *func* should use *new*, not *old*.  If *old*
+    The actual implementation of *func* should use *new*, not *old*. If *old*
     is passed to *func*, a DeprecationWarning is emitted, and its value is
     used, even if *new* is also passed by keyword.
 

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1567,7 +1567,7 @@ def _last_max_tokens(
 
     # Handle system message preservation
     system_message = None
-    if include_system and len(messages) > 0 and isinstance(messages[0], SystemMessage):
+    if include_system and messages and isinstance(messages[0], SystemMessage):
         system_message = messages[0]
         messages = messages[1:]
 

--- a/libs/core/langchain_core/output_parsers/base.py
+++ b/libs/core/langchain_core/output_parsers/base.py
@@ -180,7 +180,7 @@ class BaseOutputParser(
         for base in self.__class__.mro():
             if hasattr(base, "__pydantic_generic_metadata__"):
                 metadata = base.__pydantic_generic_metadata__
-                if "args" in metadata and len(metadata["args"]) > 0:
+                if "args" in metadata and metadata["args"]:
                     return metadata["args"][0]
 
         msg = (

--- a/libs/core/langchain_core/prompts/__init__.py
+++ b/libs/core/langchain_core/prompts/__init__.py
@@ -14,8 +14,6 @@ from multiple components and prompt values. Prompt classes and functions make co
                            BaseChatPromptTemplate --> AutoGPTPrompt
                                                       ChatPromptTemplate --> AgentScratchPadChatPromptTemplate
 
-
-
     BaseMessagePromptTemplate --> MessagesPlaceholder
                                   BaseStringMessagePromptTemplate --> ChatMessagePromptTemplate
                                                                       HumanMessagePromptTemplate

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -392,7 +392,7 @@ class BasePromptTemplate(
 def _get_document_info(doc: Document, prompt: BasePromptTemplate[str]) -> dict:
     base_info = {"page_content": doc.page_content, **doc.metadata}
     missing_metadata = set(prompt.input_variables).difference(base_info)
-    if len(missing_metadata) > 0:
+    if missing_metadata:
         required_metadata = [
             iv for iv in prompt.input_variables if iv != "page_content"
         ]

--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -436,7 +436,7 @@ class _StringImageMessagePromptTemplate(BaseMessagePromptTemplate):
             )
             return cls(prompt=prompt, **kwargs)
         if isinstance(template, list):
-            if (partial_variables is not None) and len(partial_variables) > 0:
+            if partial_variables:
                 msg = "Partial variables are not supported for list of templates."
                 raise ValueError(msg)
             prompt = []

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1792,17 +1792,17 @@ class Runnable(ABC, Generic[Input, Output]):
             def format_t(timestamp: float) -> str:
                 return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat()
 
-            async def test_runnable(time_to_sleep : int):
+            async def test_runnable(time_to_sleep: int):
                 print(f"Runnable[{time_to_sleep}s]: starts at {format_t(time.time())}")
                 await asyncio.sleep(time_to_sleep)
                 print(f"Runnable[{time_to_sleep}s]: ends at {format_t(time.time())}")
 
-            async def fn_start(run_obj : Runnable):
+            async def fn_start(run_obj: Runnable):
                 print(f"on start callback starts at {format_t(time.time())}")
                 await asyncio.sleep(3)
                 print(f"on start callback ends at {format_t(time.time())}")
 
-            async def fn_end(run_obj : Runnable):
+            async def fn_end(run_obj: Runnable):
                 print(f"on end callback starts at {format_t(time.time())}")
                 await asyncio.sleep(2)
                 print(f"on end callback ends at {format_t(time.time())}")

--- a/libs/core/langchain_core/utils/formatting.py
+++ b/libs/core/langchain_core/utils/formatting.py
@@ -24,7 +24,7 @@ class StrictFormatter(Formatter):
         Raises:
             ValueError: If any arguments are provided.
         """
-        if len(args) > 0:
+        if args:
             msg = (
                 "No arguments should be provided, "
                 "everything should be passed as keyword arguments."


### PR DESCRIPTION
**Description:**
This PR applies style and refactor improvements across multiple core modules:
- Replaced `len(x) > 0` with more pythonic `if x` checks.
- Normalized sentence spacing in docstrings.
- Removed excessive blank lines for better PEP 8 compliance.
- Fixed minor spacing issues in type annotations.

**Issue:**
N/A (no related issue)

**Dependencies:**
None
