### PR TITLE
fix(langchain_v1): handle switching resposne format strategy based on model identity

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -427,7 +427,7 @@ def create_agent(  # noqa: PLR0915
         requested_tools = [tools_by_name[name] for name in request.tools]
 
         # Determine effective response format (auto-detect if needed)
-        effective_response_format = request.response_format
+        effective_response_format: ResponseFormat | None = request.response_format
         if (
             # User provided raw schema - auto-detect best strategy based on model
             is_auto_detect
@@ -436,7 +436,7 @@ def create_agent(  # noqa: PLR0915
             # Model supports provider strategy - use it instead
             _supports_provider_strategy(request.model)
         ):
-            effective_response_format = ProviderStrategy(schema=response_format)
+            effective_response_format = ProviderStrategy(schema=response_format)  # type: ignore[arg-type]
             # else: keep ToolStrategy from initial conversion
 
         # Bind model based on effective response format

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -328,7 +328,8 @@ def create_agent(  # noqa: PLR0915
 
         Args:
             output: The AI message output from the model.
-            effective_response_format: The resolved strategy (may differ from response_format if auto-detected).
+            effective_response_format: The resolved strategy (may differ
+                from response_format if auto-detected).
         """
         # Handle structured output with provider strategy
         if isinstance(effective_response_format, ProviderStrategy):
@@ -432,7 +433,8 @@ def create_agent(  # noqa: PLR0915
 
         Returns:
             Tuple of (bound_model, effective_response_format).
-            ``effective_response_format`` is the resolved strategy (may differ from original if auto-detected).
+            ``effective_response_format`` is the resolved strategy
+                (may differ from original if auto-detected).
         """
         # Validate requested tools are available
         tools_by_name = {t.name: t for t in default_tools}

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -164,16 +164,15 @@ def _resolve_response_format_strategy(
     if response_format is None:
         return None, {}
 
-    # Already a concrete strategy - return as-is
-    if isinstance(response_format, (ToolStrategy, ProviderStrategy)):
-        # Extract tools if it's a ToolStrategy
-        if isinstance(response_format, ToolStrategy):
-            tools = {
-                info.tool.name: info
-                for response_schema in response_format.schema_specs
-                for info in [OutputToolBinding.from_schema_spec(response_schema)]
-            }
-            return response_format, tools
+    # Extract tools if it's a ToolStrategy
+    if isinstance(response_format, ToolStrategy):
+        tools = {
+            info.tool.name: info
+            for response_schema in response_format.schema_specs
+            for info in [OutputToolBinding.from_schema_spec(response_schema)]
+        }
+        return response_format, tools
+    if isinstance(response_format, ProviderStrategy):
         return response_format, {}
 
     # Auto-detect strategy based on model capabilities

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -1,9 +1,11 @@
 """Test suite for create_agent with structured output response_format permutations."""
 
+import json
+
 import pytest
 
 from dataclasses import dataclass
-from typing import Union
+from typing import Union, Sequence, Any, Callable
 
 from langchain_core.messages import HumanMessage
 from langchain.agents import create_agent
@@ -13,10 +15,16 @@ from langchain.agents.structured_output import (
     StructuredOutputValidationError,
     ToolStrategy,
 )
+from langchain.tools import tool
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
+from langchain.messages import AIMessage
+from langchain_core.messages import BaseMessage
+from langchain_core.language_models import LanguageModelInput
+from langchain_core.runnables import Runnable
 from tests.unit_tests.agents.model import FakeToolCallingModel
+from langchain.tools import BaseTool
 
 
 # Test data models
@@ -674,6 +682,89 @@ class TestResponseFormatAsProviderStrategy:
 
         assert response["structured_response"] == EXPECTED_WEATHER_DICT
         assert len(response["messages"]) == 4
+
+
+class TestDynamicModelWithResponseFormat:
+    """Test response_format with middleware that modifies the model."""
+
+    def test_middleware_model_swap_provider_to_tool_strategy(self) -> None:
+        """Test that strategy resolution is deferred until after middleware modifies the model.
+
+        Verifies that when a raw schema is provided, ``_supports_provider_strategy`` is called
+        on the middleware-modified model (not the original), ensuring the correct strategy is
+        selected based on the final model's capabilities.
+        """
+        from unittest.mock import patch
+        from langchain.agents.middleware.types import AgentMiddleware, ModelRequest
+        from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+
+        # Custom model that we'll use to test whether the tool strategy is applied
+        # correctly at runtime.
+        class CustomModel(GenericFakeChatModel):
+            tool_bindings: list[Any] = []
+
+            def bind_tools(
+                self,
+                tools: Sequence[Union[dict[str, Any], type[BaseModel], Callable, BaseTool]],
+                **kwargs: Any,
+            ) -> Runnable[LanguageModelInput, BaseMessage]:
+                # Record every tool binding event.
+                self.tool_bindings.append(tools)
+                return self
+
+        model = CustomModel(
+            messages=iter(
+                [
+                    # Simulate model returning structured output directly
+                    # (this is what provider strategy would do)
+                    json.dumps(WEATHER_DATA),
+                ]
+            )
+        )
+
+        # Create middleware that swaps the model in the request
+        class ModelSwappingMiddleware(AgentMiddleware):
+            def modify_model_request(self, request: ModelRequest, state, runtime) -> ModelRequest:
+                # Replace the model with our custom test model
+                request.model = model
+                return request
+
+        # Track which model is checked for provider strategy support
+        calls = []
+
+        def mock_supports_provider_strategy(model) -> bool:
+            """Track which model is checked and return True for ProviderStrategy."""
+            calls.append(model)
+            return True
+
+        # Use raw Pydantic model (not wrapped in ToolStrategy or ProviderStrategy)
+        # This should auto-detect strategy based on model capabilities
+        agent = create_agent(
+            model=model,
+            tools=[],
+            # Raw schema - should auto-detect strategy
+            response_format=WeatherBaseModel,
+            middleware=[ModelSwappingMiddleware()],
+        )
+
+        with patch(
+            "langchain.agents.middleware_agent._supports_provider_strategy",
+            side_effect=mock_supports_provider_strategy,
+        ):
+            response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        # Verify strategy resolution was deferred: check was called once during _get_bound_model
+        assert len(calls) == 1
+
+        # Verify successful parsing of JSON as structured output via ProviderStrategy
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+        # Two messages: Human input message and AI response with JSON content
+        assert len(response["messages"]) == 2
+        ai_message = response["messages"][1]
+        assert isinstance(ai_message, AIMessage)
+        # ProviderStrategy doesn't use tool calls - it parses content directly
+        assert ai_message.tool_calls == []
+        assert ai_message.content == json.dumps(WEATHER_DATA)
 
 
 def test_union_of_types() -> None:


### PR DESCRIPTION
Change response format strategy dynamically based on model.

After this PR there are two remaining issues:

- [ ] Review binding of tools used for output to ToolNode (shouldn't be required)
- [ ] Update ModelRequest to also support the original schema provided by the user (to correctly support auto mode)