### PR TITLE
feat(langchain_v1): on_tool_call interceptor (wip)

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -7,6 +7,10 @@ from .planning import PlanningMiddleware
 from .prompt_caching import AnthropicPromptCachingMiddleware
 from .summarization import SummarizationMiddleware
 from .tool_call_limit import ToolCallLimitMiddleware
+from .tool_error_handling import (
+    ErrorToMessageMiddleware,
+    RetryMiddleware,
+)
 from .tool_selection import LLMToolSelectorMiddleware
 from .types import (
     AgentMiddleware,
@@ -24,6 +28,7 @@ __all__ = [
     "AgentState",
     # should move to langchain-anthropic if we decide to keep it
     "AnthropicPromptCachingMiddleware",
+    "ErrorToMessageMiddleware",
     "HumanInTheLoopMiddleware",
     "LLMToolSelectorMiddleware",
     "ModelFallbackMiddleware",
@@ -31,6 +36,7 @@ __all__ = [
     "PIIDetectionError",
     "PIIMiddleware",
     "PlanningMiddleware",
+    "RetryMiddleware",
     "SummarizationMiddleware",
     "ToolCallLimitMiddleware",
     "after_model",

--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -9,7 +9,7 @@ from .summarization import SummarizationMiddleware
 from .tool_call_limit import ToolCallLimitMiddleware
 from .tool_error_handling import (
     ErrorToMessageMiddleware,
-    RetryMiddleware,
+    ToolRetryMiddleware,
 )
 from .tool_selection import LLMToolSelectorMiddleware
 from .types import (
@@ -36,7 +36,7 @@ __all__ = [
     "PIIDetectionError",
     "PIIMiddleware",
     "PlanningMiddleware",
-    "RetryMiddleware",
+    "ToolRetryMiddleware",
     "SummarizationMiddleware",
     "ToolCallLimitMiddleware",
     "after_model",

--- a/libs/langchain_v1/langchain/agents/middleware/tool_error_handling.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_error_handling.py
@@ -1,0 +1,409 @@
+"""Middleware for handling tool execution errors in agents.
+
+This module provides composable middleware for error handling, retries,
+and error-to-message conversion in tool execution workflows.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Union, get_args, get_origin, get_type_hints
+
+from langchain_core.messages import ToolMessage
+
+from langchain.agents.middleware.types import AgentMiddleware
+
+# Import ToolResponse locally to avoid circular import
+from langchain.tools.tool_node import ToolResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from types import UnionType
+
+    from langchain.tools.tool_node import ToolRequest, ToolResponse
+
+logger = logging.getLogger(__name__)
+
+
+# Default retriable exception types - transient errors that may succeed on retry
+DEFAULT_RETRIABLE_EXCEPTIONS = (
+    # Network and connection errors
+    ConnectionError,
+    TimeoutError,
+    # HTTP client errors are typically not retriable, but these are exceptions:
+    # - 429: Rate limit (temporary)
+    # - 503: Service unavailable (temporary)
+    # Note: Specific HTTP libraries may define their own exception types
+)
+
+
+def _infer_retriable_types(
+    predicate: Callable[[Exception], bool],
+) -> tuple[type[Exception], ...]:
+    """Infer exception types from a retry predicate function's type annotations.
+
+    Analyzes the type annotations of a predicate function to determine which
+    exception types it's designed to handle for retry decisions.
+
+    Args:
+        predicate: A callable that takes an exception and returns whether to retry.
+            The first parameter should be type-annotated with exception type(s).
+
+    Returns:
+        Tuple of exception types that the predicate handles. Returns (Exception,)
+        if no specific type information is available.
+
+    Raises:
+        ValueError: If the predicate's annotation contains non-Exception types.
+    """
+    sig = inspect.signature(predicate)
+    params = list(sig.parameters.values())
+    if params:
+        # Skip self/cls if it's a method
+        if params[0].name in ["self", "cls"] and len(params) == 2:
+            first_param = params[1]
+        else:
+            first_param = params[0]
+
+        type_hints = get_type_hints(predicate)
+        if first_param.name in type_hints:
+            origin = get_origin(first_param.annotation)
+            # Handle Union types
+            if origin in [Union, UnionType]:  # type: ignore[has-type]
+                args = get_args(first_param.annotation)
+                if all(isinstance(arg, type) and issubclass(arg, Exception) for arg in args):
+                    return tuple(args)
+                msg = (
+                    "All types in retry predicate annotation must be Exception types. "
+                    "For example, `def should_retry(e: Union[TimeoutError, ConnectionError]) -> bool`. "
+                    f"Got '{first_param.annotation}' instead."
+                )
+                raise ValueError(msg)
+
+            # Handle single exception type
+            exception_type = type_hints[first_param.name]
+            if isinstance(exception_type, type) and issubclass(exception_type, Exception):
+                return (exception_type,)
+            msg = (
+                "Retry predicate must be annotated with Exception type(s). "
+                "For example, `def should_retry(e: TimeoutError) -> bool` or "
+                "`def should_retry(e: Union[TimeoutError, ConnectionError]) -> bool`. "
+                f"Got '{exception_type}' instead."
+            )
+            raise ValueError(msg)
+
+    # No type information - return Exception for backward compatibility
+    return (Exception,)
+
+
+class RetryMiddleware(AgentMiddleware):
+    """Retry failed tool calls with constant delay.
+
+    This middleware catches tool execution errors and retries them up to a maximum
+    number of attempts with a constant delay between retries. It operates at the
+    outermost layer of middleware composition to catch all errors.
+
+    Examples:
+        Retry only network errors:
+
+        ```python
+        from langchain.agents.middleware import RetryMiddleware
+
+        middleware = RetryMiddleware(
+            max_retries=3,
+            delay=2.0,
+            retry_on=(TimeoutError, ConnectionError),
+        )
+
+        agent = create_agent(
+            model="openai:gpt-4o",
+            tools=[my_tool],
+            middleware=[middleware],
+        )
+        ```
+
+        Use predicate function for custom retry logic:
+
+        ```python
+        from langchain.tools.tool_node import ToolInvocationError
+
+
+        def should_retry(e: Exception) -> bool:
+            # Don't retry validation errors from LLM
+            if isinstance(e, ToolInvocationError):
+                return False
+            # Retry network errors
+            if isinstance(e, (TimeoutError, ConnectionError)):
+                return True
+            return False
+
+
+        middleware = RetryMiddleware(
+            max_retries=3,
+            retry_on=should_retry,
+        )
+        ```
+
+        Compose with error conversion:
+
+        ```python
+        from langchain.agents.middleware import (
+            RetryMiddleware,
+            ErrorToMessageMiddleware,
+        )
+
+        agent = create_agent(
+            model="openai:gpt-4o",
+            tools=[my_tool],
+            middleware=[
+                # Outer: retry network errors
+                RetryMiddleware(
+                    max_retries=3,
+                    delay=2.0,
+                    retry_on=(TimeoutError, ConnectionError),
+                ),
+                # Inner: convert validation errors to messages
+                ErrorToMessageMiddleware(
+                    exception_types=(ValidationError,),
+                ),
+            ],
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        max_retries: int = 3,
+        delay: float = 1.0,
+        retry_on: type[Exception]
+        | tuple[type[Exception], ...]
+        | Callable[[Exception], bool] = DEFAULT_RETRIABLE_EXCEPTIONS,
+    ) -> None:
+        """Initialize retry middleware.
+
+        Args:
+            max_retries: Maximum number of retry attempts. Total attempts will be
+                max_retries + 1 (initial attempt plus retries).
+            delay: Constant delay in seconds between retry attempts.
+            retry_on: Specifies which exceptions should be retried. Can be:
+                - **type[Exception]**: Retry only this exception type
+                - **tuple[type[Exception], ...]**: Retry these exception types
+                - **Callable[[Exception], bool]**: Predicate function that returns
+                  True if the exception should be retried. Type annotations on the
+                  callable are used to filter which exceptions are passed to it.
+                Defaults to ``DEFAULT_RETRIABLE_EXCEPTIONS`` (ConnectionError, TimeoutError).
+        """
+        super().__init__()
+        if max_retries < 0:
+            msg = "max_retries must be non-negative"
+            raise ValueError(msg)
+        if delay < 0:
+            msg = "delay must be non-negative"
+            raise ValueError(msg)
+
+        self.max_retries = max_retries
+        self.delay = delay
+        self._retry_on = retry_on
+
+        # Determine which exception types to check
+        if isinstance(retry_on, type) and issubclass(retry_on, Exception):
+            self._retriable_types = (retry_on,)
+            self._retry_predicate = None
+        elif isinstance(retry_on, tuple):
+            if not retry_on:
+                msg = "retry_on tuple must not be empty"
+                raise ValueError(msg)
+            if not all(isinstance(t, type) and issubclass(t, Exception) for t in retry_on):
+                msg = "All elements in retry_on tuple must be Exception types"
+                raise ValueError(msg)
+            self._retriable_types = retry_on
+            self._retry_predicate = None
+        elif callable(retry_on):
+            self._retriable_types = _infer_retriable_types(retry_on)
+            self._retry_predicate = retry_on
+        else:
+            msg = (
+                "retry_on must be an Exception type, tuple of Exception types, "
+                f"or callable. Got {type(retry_on)}"
+            )
+            raise ValueError(msg)
+
+    def on_tool_call(
+        self, request: ToolRequest
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Retry tool execution on failures."""
+        for attempt in range(1, self.max_retries + 2):  # +1 for initial, +1 for inclusive
+            response = yield request
+
+            # Success - return immediately
+            if response.action == "return":
+                return response
+
+            # Error - check if we should retry
+            if response.action == "raise":
+                exception = response.exception
+                if exception is None:
+                    msg = "ToolResponse with action='raise' must have an exception"
+                    raise ValueError(msg)
+
+                # Check if this exception type is retriable
+                if not isinstance(exception, self._retriable_types):
+                    logger.debug(
+                        "Exception %s is not retriable for tool %s",
+                        type(exception).__name__,
+                        request.tool_call["name"],
+                    )
+                    return response
+
+                # If predicate is provided, check if we should retry
+                if self._retry_predicate is not None:
+                    if not self._retry_predicate(exception):
+                        logger.debug(
+                            "Retry predicate returned False for %s in tool %s",
+                            type(exception).__name__,
+                            request.tool_call["name"],
+                        )
+                        return response
+
+                # Last attempt - return error
+                if attempt > self.max_retries:
+                    logger.debug(
+                        "Max retries (%d) reached for tool %s",
+                        self.max_retries,
+                        request.tool_call["name"],
+                    )
+                    return response
+
+                # Retry - log and delay
+                logger.debug(
+                    "Retrying tool %s (attempt %d/%d) after error: %s",
+                    request.tool_call["name"],
+                    attempt,
+                    self.max_retries + 1,
+                    type(exception).__name__,
+                )
+                time.sleep(self.delay)
+                continue
+
+        # Should never reach here
+        msg = f"Unexpected control flow in RetryMiddleware for tool {request.tool_call['name']}"
+        raise RuntimeError(msg)
+
+
+class ErrorToMessageMiddleware(AgentMiddleware):
+    """Convert specific exception types to ToolMessages.
+
+    This middleware intercepts errors and converts them into ToolMessages that
+    can be sent back to the model as feedback. This is useful for errors caused
+    by invalid model inputs where the model needs feedback to correct its behavior.
+
+    Examples:
+        Convert validation errors to messages:
+
+        ```python
+        from langchain.agents.middleware import ErrorToMessageMiddleware
+        from langchain.tools.tool_node import ToolInvocationError
+
+        middleware = ErrorToMessageMiddleware(
+            exception_types=(ToolInvocationError,),
+            message_template="Invalid arguments: {error}. Please fix and try again.",
+        )
+
+        agent = create_agent(
+            model="openai:gpt-4o",
+            tools=[my_tool],
+            middleware=[middleware],
+        )
+        ```
+
+        Compose with retry for network errors:
+
+        ```python
+        from langchain.agents.middleware import (
+            RetryMiddleware,
+            ErrorToMessageMiddleware,
+        )
+
+        agent = create_agent(
+            model="openai:gpt-4o",
+            tools=[my_tool],
+            middleware=[
+                # Outer: retry all errors
+                RetryMiddleware(max_retries=3),
+                # Inner: convert validation errors to messages
+                ErrorToMessageMiddleware(
+                    exception_types=(ValidationError,),
+                ),
+            ],
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        exception_types: tuple[type[Exception], ...],
+        message_template: str = "Error: {error}",
+    ) -> None:
+        """Initialize error conversion middleware.
+
+        Args:
+            exception_types: Tuple of exception types to convert to messages.
+            message_template: Template string for error messages. Can use ``{error}``
+                placeholder for the exception string representation.
+        """
+        super().__init__()
+        if not exception_types:
+            msg = "exception_types must not be empty"
+            raise ValueError(msg)
+
+        self.exception_types = exception_types
+        self.message_template = message_template
+
+    def on_tool_call(
+        self, request: ToolRequest
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Convert matching errors to ToolMessages."""
+        response = yield request
+
+        # Success - pass through
+        if response.action == "return":
+            return response
+
+        # Error - check if we should convert
+        if response.action == "raise":
+            exception = response.exception
+            if exception is None:
+                msg = "ToolResponse with action='raise' must have an exception"
+                raise ValueError(msg)
+
+            # Check if exception type matches
+            if not isinstance(exception, self.exception_types):
+                return response
+
+            # Convert to ToolMessage
+            logger.debug(
+                "Converting %s to ToolMessage for tool %s",
+                type(exception).__name__,
+                request.tool_call["name"],
+            )
+
+            error_message = self.message_template.format(error=str(exception))
+            tool_message = ToolMessage(
+                content=error_message,
+                name=request.tool_call["name"],
+                tool_call_id=request.tool_call["id"],
+                status="error",
+            )
+
+            return ToolResponse(
+                action="return",
+                result=tool_message,
+                exception=exception,  # Preserve for logging/debugging
+            )
+
+        return response

--- a/libs/langchain_v1/langchain/agents/middleware/tool_error_handling.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_error_handling.py
@@ -238,7 +238,7 @@ class RetryMiddleware(AgentMiddleware):
             response = yield request
 
             # Success - return immediately
-            if response.action == "return":
+            if response.action == "continue":
                 return response
 
             # Error - check if we should retry
@@ -368,7 +368,7 @@ class ErrorToMessageMiddleware(AgentMiddleware):
         response = yield request
 
         # Success - pass through
-        if response.action == "return":
+        if response.action == "continue":
             return response
 
         # Error - check if we should convert
@@ -398,7 +398,7 @@ class ErrorToMessageMiddleware(AgentMiddleware):
             )
 
             return ToolCallResponse(
-                action="return",
+                action="continue",
                 result=tool_message,
                 exception=exception,  # Preserve for logging/debugging
             )

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -249,7 +249,7 @@ class AgentMiddleware(Generic[StateT, ContextT]):
             def on_tool_call(self, request, state, runtime):
                 for attempt in range(3):
                     response = yield request
-                    if response.action == "return":
+                    if response.action == "continue":
                         return response
                     if "rate limit" in str(response.exception):
                         time.sleep(2**attempt)

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
     from langgraph.types import Command
 
     from langchain.agents.structured_output import ResponseFormat
-    from langchain.tools.tool_node import ToolRequest, ToolResponse
+    from langchain.tools.tool_node import ToolCallRequest, ToolCallResponse
 
 __all__ = [
     "AgentMiddleware",
@@ -218,8 +218,8 @@ class AgentMiddleware(Generic[StateT, ContextT]):
 
     def on_tool_call(
         self,
-        request: ToolRequest,
-    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        request: ToolCallRequest,
+    ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Intercept tool execution to implement retry logic, monitoring, or request modification.
 
         Provides generator-based control over the complete tool execution lifecycle.
@@ -227,10 +227,10 @@ class AgentMiddleware(Generic[StateT, ContextT]):
         outer middleware wrapping inner middleware (first defined = outermost layer).
 
         Generator Protocol:
-            1. Yield a ToolRequest (potentially modified from the input)
-            2. Receive a ToolResponse via .send()
+            1. Yield a ToolCallRequest (potentially modified from the input)
+            2. Receive a ToolCallResponse via .send()
             3. Optionally yield again to retry
-            4. Return the final ToolResponse to propagate
+            4. Return the final ToolCallResponse to propagate
 
         Args:
             request: Tool invocation details including tool_call, tool instance, and config.

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -219,6 +219,8 @@ class AgentMiddleware(Generic[StateT, ContextT]):
     def on_tool_call(
         self,
         request: ToolCallRequest,
+        state: StateT,
+        runtime: Runtime[ContextT],
     ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Intercept tool execution to implement retry logic, monitoring, or request modification.
 
@@ -234,6 +236,8 @@ class AgentMiddleware(Generic[StateT, ContextT]):
 
         Args:
             request: Tool invocation details including tool_call, tool instance, and config.
+            state: Current agent state (readonly context).
+            runtime: LangGraph runtime for accessing user context (readonly context).
 
         Returns:
             Generator for request/response interception.
@@ -242,7 +246,7 @@ class AgentMiddleware(Generic[StateT, ContextT]):
             Retry on rate limit with exponential backoff:
 
             ```python
-            def on_tool_call(self, request):
+            def on_tool_call(self, request, state, runtime):
                 for attempt in range(3):
                     response = yield request
                     if response.action == "return":

--- a/libs/langchain_v1/langchain/agents/middleware_agent.py
+++ b/libs/langchain_v1/langchain/agents/middleware_agent.py
@@ -35,7 +35,7 @@ from langchain.agents.structured_output import (
 )
 from langchain.chat_models import init_chat_model
 from langchain.tools import ToolNode
-from langchain.tools.tool_node import ToolCallHandler, ToolRequest, ToolResponse
+from langchain.tools.tool_node import ToolCallHandler, ToolCallRequest, ToolCallResponse
 
 STRUCTURED_OUTPUT_ERROR_TEMPLATE = "Error: {error}\n Please fix your mistakes."
 
@@ -84,10 +84,10 @@ def _chain_tool_call_handlers(
     if len(handlers) == 1:
         return handlers[0]
 
-    def _extract_return_value(stop_iteration: StopIteration) -> ToolResponse:
-        """Extract ToolResponse from StopIteration, validating protocol compliance."""
+    def _extract_return_value(stop_iteration: StopIteration) -> ToolCallResponse:
+        """Extract ToolCallResponse from StopIteration, validating protocol compliance."""
         if stop_iteration.value is None:
-            msg = "on_tool_call handler must explicitly return a ToolResponse"
+            msg = "on_tool_call handler must explicitly return a ToolCallResponse"
             raise ValueError(msg)
         return stop_iteration.value
 
@@ -95,8 +95,8 @@ def _chain_tool_call_handlers(
         """Compose two handlers where outer wraps inner."""
 
         def composed(
-            request: ToolRequest,
-        ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+            request: ToolCallRequest,
+        ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             outer_gen = outer(request)
 
             # Initialize outer generator

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -53,6 +53,7 @@ from typing import (
     get_origin,
     get_type_hints,
 )
+from typing import Optional as Optional
 
 from langchain_core.messages import (
     AIMessage,
@@ -512,7 +513,9 @@ class ToolNode(RunnableCallable):
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
         *,
-        store: Optional[BaseStore],
+        # Optional[BaseStore] should not change to BaseStore | None
+        # until we support injection of store using `BaseStore | None` annotation
+        store: Optional[BaseStore],  # noqa: UP045
     ) -> Any:
         try:
             runtime = get_runtime()
@@ -536,7 +539,9 @@ class ToolNode(RunnableCallable):
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
         *,
-        store: BaseStore | None,
+        # Optional[BaseStore] should not change to BaseStore | None
+        # until we support injection of store using `BaseStore | None` annotation
+        store: Optional[BaseStore],  # noqa: UP045
     ) -> Any:
         try:
             runtime = get_runtime()

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -512,7 +512,7 @@ class ToolNode(RunnableCallable):
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
         *,
-        store: BaseStore | None,
+        store: Optional[BaseStore],
     ) -> Any:
         try:
             runtime = get_runtime()

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -152,7 +152,8 @@ ToolCallHandler = Callable[
 """Generator-based handler that intercepts tool execution.
 
 Receives a ToolCallRequest, state, and runtime; yields modified ToolCallRequests;
-receives ToolCallResponses; and returns a final ToolCallResponse. Supports multiple yields for retry logic.
+receives ToolCallResponses; and returns a final ToolCallResponse. Supports multiple
+yields for retry logic.
 """
 
 
@@ -511,7 +512,7 @@ class ToolNode(RunnableCallable):
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
         *,
-        store: Optional[BaseStore],
+        store: BaseStore | None,
     ) -> Any:
         try:
             runtime = get_runtime()
@@ -535,7 +536,7 @@ class ToolNode(RunnableCallable):
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
         *,
-        store: Optional[BaseStore],
+        store: BaseStore | None,
     ) -> Any:
         try:
             runtime = get_runtime()

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -209,7 +209,7 @@ class ToolInvocationError(Exception):
         super().__init__(self.message)
 
 
-def _default_handle_tool_errors(e: Exception) -> str:
+def _default_handle_tool_errors(e: ToolInvocationError) -> str:
     """Default error handler for tool errors.
 
     If the tool is a tool invocation error, return its message.

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call.py
@@ -1,0 +1,402 @@
+"""Unit tests for on_tool_call middleware hook."""
+
+from collections.abc import Generator
+from typing import Any, Literal, Union
+import typing
+
+from pydantic import BaseModel
+import pytest
+from langchain_core.language_models import LanguageModelInput
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool, tool
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain.agents.middleware_agent import create_agent
+from langchain.tools.tool_node import ToolRequest, ToolResponse
+
+
+class FakeModel(GenericFakeChatModel):
+    """Fake chat model for testing."""
+
+    tool_style: Literal["openai", "anthropic"] = "openai"
+
+    def bind_tools(
+        self,
+        tools: typing.Sequence[Union[dict[str, Any], type[BaseModel], typing.Callable, BaseTool]],
+        **kwargs: Any,
+    ) -> Runnable[LanguageModelInput, BaseMessage]:
+        if len(tools) == 0:
+            msg = "Must provide at least one tool"
+            raise ValueError(msg)
+
+        tool_dicts = []
+        for tool in tools:
+            if isinstance(tool, dict):
+                tool_dicts.append(tool)
+                continue
+            if not isinstance(tool, BaseTool):
+                msg = "Only BaseTool and dict is supported by FakeModel.bind_tools"
+                raise TypeError(msg)
+
+            # NOTE: this is a simplified tool spec for testing purposes only
+            if self.tool_style == "openai":
+                tool_dicts.append(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": tool.name,
+                        },
+                    }
+                )
+            elif self.tool_style == "anthropic":
+                tool_dicts.append(
+                    {
+                        "name": tool.name,
+                    }
+                )
+
+        return self.bind(tools=tool_dicts)
+
+
+@tool
+def add_tool(x: int, y: int) -> int:
+    """Add two numbers."""
+    return x + y
+
+
+@tool
+def failing_tool(x: int) -> int:
+    """Tool that raises an error."""
+    msg = "Intentional failure"
+    raise ValueError(msg)
+
+
+def test_single_middleware_on_tool_call():
+    """Test that a single middleware can intercept tool calls."""
+    call_log = []
+
+    class LoggingMiddleware(AgentMiddleware):
+        """Middleware that logs tool calls."""
+
+        def on_tool_call(
+            self, request: ToolRequest
+        ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+            call_log.append(f"before_{request.tool.name}")
+            response = yield request
+            call_log.append(f"after_{request.tool.name}")
+            return response
+
+    model = FakeModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "add_tool", "args": {"x": 2, "y": 3}, "id": "1"}],
+                ),
+                AIMessage(content="Done"),
+            ]
+        )
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[add_tool],
+        middleware=[LoggingMiddleware()],
+    )
+
+    result = agent.compile().invoke({"messages": [HumanMessage("Add 2 and 3")]})
+
+    assert "before_add_tool" in call_log
+    assert "after_add_tool" in call_log
+    assert call_log.index("before_add_tool") < call_log.index("after_add_tool")
+
+    # Check that tool executed successfully
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "5"
+
+
+def test_multiple_middleware_chaining():
+    """Test that multiple middleware chain correctly (outer wraps inner)."""
+    call_order = []
+
+    class OuterMiddleware(AgentMiddleware):
+        """Outer middleware in the chain."""
+
+        def on_tool_call(
+            self, request: ToolRequest
+        ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+            call_order.append("outer_start")
+            response = yield request
+            call_order.append("outer_end")
+            return response
+
+    class InnerMiddleware(AgentMiddleware):
+        """Inner middleware in the chain."""
+
+        def on_tool_call(
+            self, request: ToolRequest
+        ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+            call_order.append("inner_start")
+            response = yield request
+            call_order.append("inner_end")
+            return response
+
+    model = FakeModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "add_tool", "args": {"x": 1, "y": 1}, "id": "1"}],
+                ),
+                AIMessage(content="Done"),
+            ]
+        )
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[add_tool],
+        middleware=[OuterMiddleware(), InnerMiddleware()],
+    )
+
+    agent.compile().invoke({"messages": [HumanMessage("Add 1 and 1")]})
+
+    # Verify order: outer_start -> inner_start -> tool -> inner_end -> outer_end
+    assert call_order == ["outer_start", "inner_start", "inner_end", "outer_end"]
+
+
+def test_middleware_retry_logic():
+    """Test that middleware can retry tool calls."""
+    attempt_count = 0
+
+    class RetryMiddleware(AgentMiddleware):
+        """Middleware that retries on failure."""
+
+        def on_tool_call(
+            self, request: ToolRequest
+        ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+            nonlocal attempt_count
+            max_retries = 2
+
+            for attempt in range(max_retries):
+                attempt_count += 1
+                response = yield request
+
+                if response.action == "return":
+                    return response
+
+                if response.action == "raise" and attempt < max_retries - 1:
+                    # Retry
+                    continue
+
+                # Convert error to success message
+                return ToolResponse(
+                    action="return",
+                    result=ToolMessage(
+                        content=f"Failed after {max_retries} attempts",
+                        name=request.tool_call["name"],
+                        tool_call_id=request.tool_call["id"],
+                        status="error",
+                    ),
+                )
+
+            # Should never reach here
+            return response
+
+    model = FakeModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "failing_tool", "args": {"x": 1}, "id": "1"}],
+                ),
+                AIMessage(content="Done"),
+            ]
+        )
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[failing_tool],
+        middleware=[RetryMiddleware()],
+    )
+
+    result = agent.compile().invoke({"messages": [HumanMessage("Test retry")]})
+
+    # Should have attempted twice
+    assert attempt_count == 2
+
+    # Check that we got an error message
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert "Failed after 2 attempts" in tool_messages[0].content
+
+
+def test_middleware_request_modification():
+    """Test that middleware can modify tool requests."""
+
+    class RequestModifierMiddleware(AgentMiddleware):
+        """Middleware that doubles the input."""
+
+        def on_tool_call(
+            self, request: ToolRequest
+        ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+            # Modify the arguments
+            modified_tool_call = {
+                **request.tool_call,
+                "args": {
+                    "x": request.tool_call["args"]["x"] * 2,
+                    "y": request.tool_call["args"]["y"] * 2,
+                },
+            }
+            modified_request = ToolRequest(
+                tool_call=modified_tool_call,
+                tool=request.tool,
+                config=request.config,
+            )
+            response = yield modified_request
+            return response
+
+    model = FakeModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "add_tool", "args": {"x": 1, "y": 2}, "id": "1"}],
+                ),
+                AIMessage(content="Done"),
+            ]
+        )
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[add_tool],
+        middleware=[RequestModifierMiddleware()],
+    )
+
+    result = agent.compile().invoke({"messages": [HumanMessage("Add 1 and 2")]})
+
+    # Original: 1 + 2 = 3, Modified: 2 + 4 = 6
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "6"
+
+
+def test_multiple_middleware_with_retry():
+    """Test complex scenario with multiple middleware and retry logic."""
+    call_log = []
+
+    class MonitoringMiddleware(AgentMiddleware):
+        """Outer middleware for monitoring."""
+
+        def on_tool_call(
+            self, request: ToolRequest
+        ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+            call_log.append("monitoring_start")
+            response = yield request
+            call_log.append("monitoring_end")
+            return response
+
+    class RetryMiddleware(AgentMiddleware):
+        """Inner middleware for retries."""
+
+        def on_tool_call(
+            self, request: ToolRequest
+        ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+            call_log.append("retry_start")
+            for attempt in range(2):
+                call_log.append(f"retry_attempt_{attempt + 1}")
+                response = yield request
+
+                if response.action == "return":
+                    call_log.append("retry_success")
+                    return response
+
+                if attempt == 0:  # Retry once
+                    call_log.append("retry_retry")
+                    continue
+
+            call_log.append("retry_failed")
+            return response
+
+    model = FakeModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "add_tool", "args": {"x": 5, "y": 7}, "id": "1"}],
+                ),
+                AIMessage(content="Done"),
+            ]
+        )
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[add_tool],
+        middleware=[MonitoringMiddleware(), RetryMiddleware()],
+    )
+
+    agent.compile().invoke({"messages": [HumanMessage("Add 5 and 7")]})
+
+    # Verify the call sequence
+    assert call_log[0] == "monitoring_start"
+    assert call_log[1] == "retry_start"
+    assert "retry_attempt_1" in call_log
+    assert "retry_success" in call_log
+    assert call_log[-1] == "monitoring_end"
+
+
+def test_mixed_middleware():
+    """Test middleware with both before_model and on_tool_call hooks."""
+    call_log = []
+
+    class MixedMiddleware(AgentMiddleware):
+        """Middleware with multiple hooks."""
+
+        def before_model(self, state, runtime):
+            call_log.append("before_model")
+            return None
+
+        def on_tool_call(
+            self, request: ToolRequest
+        ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+            call_log.append("on_tool_call_start")
+            response = yield request
+            call_log.append("on_tool_call_end")
+            return response
+
+    model = FakeModel(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "add_tool", "args": {"x": 10, "y": 20}, "id": "1"}],
+                ),
+                AIMessage(content="Done"),
+            ]
+        )
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[add_tool],
+        middleware=[MixedMiddleware()],
+    )
+
+    agent.compile().invoke({"messages": [HumanMessage("Add 10 and 20")]})
+
+    # Both hooks should have been called
+    assert "before_model" in call_log
+    assert "on_tool_call_start" in call_log
+    assert "on_tool_call_end" in call_log
+    # before_model runs before on_tool_call
+    assert call_log.index("before_model") < call_log.index("on_tool_call_start")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call_middleware.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call_middleware.py
@@ -254,7 +254,6 @@ def test_middleware_request_modification():
             modified_request = ToolCallRequest(
                 tool_call=modified_tool_call,
                 tool=request.tool,
-                config=request.config,
             )
             response = yield modified_request
             return response

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call_middleware.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call_middleware.py
@@ -395,7 +395,3 @@ def test_mixed_middleware():
     assert "on_tool_call_end" in call_log
     # before_model runs before on_tool_call
     assert call_log.index("before_model") < call_log.index("on_tool_call_start")
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call_middleware.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call_middleware.py
@@ -356,15 +356,15 @@ def test_mixed_middleware():
     class MixedMiddleware(AgentMiddleware):
         """Middleware with multiple hooks."""
 
+        def before_model(self, state, runtime):
+            call_log.append("before_model")
+            return None
+
         def on_tool_call(
             self, request: ToolCallRequest, state, runtime
         ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             call_log.append("on_tool_call_start")
-            for _ in range(3):
-                response = yield request
-                if response.action == "continue":
-                    break
-            # response = yield request
+            response = yield request
             call_log.append("on_tool_call_end")
             return response
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call_middleware.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_on_tool_call_middleware.py
@@ -81,7 +81,7 @@ def test_single_middleware_on_tool_call():
         """Middleware that logs tool calls."""
 
         def on_tool_call(
-            self, request: ToolCallRequest
+            self, request: ToolCallRequest, state, runtime
         ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             call_log.append(f"before_{request.tool.name}")
             response = yield request
@@ -126,7 +126,7 @@ def test_multiple_middleware_chaining():
         """Outer middleware in the chain."""
 
         def on_tool_call(
-            self, request: ToolCallRequest
+            self, request: ToolCallRequest, state, runtime
         ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             call_order.append("outer_start")
             response = yield request
@@ -137,7 +137,7 @@ def test_multiple_middleware_chaining():
         """Inner middleware in the chain."""
 
         def on_tool_call(
-            self, request: ToolCallRequest
+            self, request: ToolCallRequest, state, runtime
         ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             call_order.append("inner_start")
             response = yield request
@@ -174,8 +174,9 @@ def test_middleware_retry_logic():
 
     class RetryMiddleware(AgentMiddleware):
         """Middleware that retries on failure."""
+
         def on_tool_call(
-            self, request: ToolCallRequest
+            self, request: ToolCallRequest, state, runtime
         ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             nonlocal attempt_count
             max_retries = 2
@@ -240,7 +241,7 @@ def test_middleware_request_modification():
         """Middleware that doubles the input."""
 
         def on_tool_call(
-            self, request: ToolCallRequest
+            self, request: ToolCallRequest, state, runtime
         ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             # Modify the arguments
             modified_tool_call = {
@@ -292,7 +293,7 @@ def test_multiple_middleware_with_retry():
         """Outer middleware for monitoring."""
 
         def on_tool_call(
-            self, request: ToolCallRequest
+            self, request: ToolCallRequest, state, runtime
         ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             call_log.append("monitoring_start")
             response = yield request
@@ -303,7 +304,7 @@ def test_multiple_middleware_with_retry():
         """Inner middleware for retries."""
 
         def on_tool_call(
-            self, request: ToolCallRequest
+            self, request: ToolCallRequest, state, runtime
         ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             call_log.append("retry_start")
             for attempt in range(2):
@@ -361,7 +362,7 @@ def test_mixed_middleware():
             return None
 
         def on_tool_call(
-            self, request: ToolCallRequest
+            self, request: ToolCallRequest, state, runtime
         ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
             call_log.append("on_tool_call_start")
             response = yield request

--- a/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
+++ b/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
@@ -261,7 +261,6 @@ def test_on_tool_call_request_modification() -> None:
         modified_request = ToolCallRequest(
             tool_call=modified_tool_call,
             tool=request.tool,
-            config=request.config,
         )
         response = yield modified_request
         return response

--- a/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
+++ b/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
@@ -1,0 +1,389 @@
+"""Tests for on_tool_call handler functionality."""
+
+from collections.abc import Generator
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.tools import tool
+
+from langchain.tools import ToolNode
+from langchain.tools.tool_node import ToolRequest, ToolResponse
+
+
+# Test tools
+@tool
+def success_tool(x: int) -> int:
+    """A tool that always succeeds."""
+    return x * 2
+
+
+@tool
+def error_tool(x: int) -> int:
+    """A tool that always raises ValueError."""
+    msg = f"Error with value: {x}"
+    raise ValueError(msg)
+
+
+@tool
+def rate_limit_tool(x: int) -> int:
+    """A tool that simulates rate limit errors."""
+    if not hasattr(rate_limit_tool, "_call_count"):
+        rate_limit_tool._call_count = 0
+    rate_limit_tool._call_count += 1
+
+    if rate_limit_tool._call_count < 3:  # Fail first 2 times
+        msg = "Rate limit exceeded"
+        raise ValueError(msg)
+    return x * 2
+
+
+def test_on_tool_call_passthrough() -> None:
+    """Test that a simple passthrough handler works."""
+
+    def passthrough_handler(
+        request: ToolRequest,
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Simply pass through without modification."""
+        response = yield request
+        return response
+
+    tool_node = ToolNode([success_tool], on_tool_call=passthrough_handler)
+    result = tool_node.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[{"name": "success_tool", "args": {"x": 5}, "id": "1"}],
+                )
+            ]
+        }
+    )
+
+    assert len(result["messages"]) == 1
+    tool_message: ToolMessage = result["messages"][0]
+    assert tool_message.content == "10"
+    assert tool_message.status != "error"
+
+
+def test_on_tool_call_retry_success():
+    """Test that retry handler can recover from transient errors."""
+    # Reset counter
+    if hasattr(rate_limit_tool, "_call_count"):
+        rate_limit_tool._call_count = 0
+
+    def retry_handler(
+        request: ToolRequest,
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Retry up to 3 times."""
+        max_retries = 3
+
+        for attempt in range(max_retries):
+            response = yield request
+
+            if response.action == "return":
+                return response
+
+            # Retry on error
+            if attempt < max_retries - 1:
+                continue
+
+            # Final attempt failed - convert to error message
+            return ToolResponse(
+                action="return",
+                result=ToolMessage(
+                    content=f"Failed after {max_retries} attempts",
+                    name=request.tool_call["name"],
+                    tool_call_id=request.tool_call["id"],
+                    status="error",
+                ),
+            )
+
+        return response  # Should never reach here
+
+    tool_node = ToolNode([rate_limit_tool], on_tool_call=retry_handler, handle_tool_errors=False)
+    result = tool_node.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[{"name": "rate_limit_tool", "args": {"x": 5}, "id": "1"}],
+                )
+            ]
+        }
+    )
+
+    assert len(result["messages"]) == 1
+    tool_message: ToolMessage = result["messages"][0]
+    assert tool_message.content == "10"  # Should succeed on 3rd attempt
+    assert tool_message.status != "error"
+
+
+def test_on_tool_call_convert_error_to_message():
+    """Test that handler can convert raised errors to error messages."""
+
+    def error_to_message_handler(
+        request: ToolRequest,
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Convert any error to a user-friendly message."""
+        response = yield request
+
+        if response.action == "raise":
+            return ToolResponse(
+                action="return",
+                result=ToolMessage(
+                    content=f"Tool failed: {response.exception}",
+                    name=request.tool_call["name"],
+                    tool_call_id=request.tool_call["id"],
+                    status="error",
+                ),
+                exception=response.exception,
+            )
+
+        return response
+
+    tool_node = ToolNode(
+        [error_tool], on_tool_call=error_to_message_handler, handle_tool_errors=False
+    )
+    result = tool_node.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[{"name": "error_tool", "args": {"x": 5}, "id": "1"}],
+                )
+            ]
+        }
+    )
+
+    assert len(result["messages"]) == 1
+    tool_message: ToolMessage = result["messages"][0]
+    assert "Tool failed" in tool_message.content
+    assert "Error with value: 5" in tool_message.content
+    assert tool_message.status == "error"
+
+
+def test_on_tool_call_let_error_raise():
+    """Test that handler can let errors propagate."""
+
+    def let_raise_handler(
+        request: ToolRequest,
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Just return the response as-is, letting errors raise."""
+        response = yield request
+        return response
+
+    tool_node = ToolNode([error_tool], on_tool_call=let_raise_handler, handle_tool_errors=False)
+
+    with pytest.raises(ValueError) as exc_info:
+        tool_node.invoke(
+            {
+                "messages": [
+                    AIMessage(
+                        "",
+                        tool_calls=[{"name": "error_tool", "args": {"x": 5}, "id": "1"}],
+                    )
+                ]
+            }
+        )
+
+    assert "Error with value: 5" in str(exc_info.value)
+
+
+def test_on_tool_call_with_handled_errors():
+    """Test interaction between on_tool_call and handle_tool_errors."""
+    call_count = {"count": 0}
+
+    def counting_handler(
+        request: ToolRequest,
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Count how many times we're called."""
+        call_count["count"] += 1
+        response = yield request
+        return response
+
+    # When handle_tool_errors=True, errors are converted to ToolMessages
+    # so handler sees action="return"
+    tool_node = ToolNode([error_tool], on_tool_call=counting_handler, handle_tool_errors=True)
+    result = tool_node.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[{"name": "error_tool", "args": {"x": 5}, "id": "1"}],
+                )
+            ]
+        }
+    )
+
+    assert call_count["count"] == 1
+    assert len(result["messages"]) == 1
+    tool_message: ToolMessage = result["messages"][0]
+    assert tool_message.status == "error"
+    assert "Please fix your mistakes" in tool_message.content
+
+
+def test_on_tool_call_must_return_value():
+    """Test that handler must return a ToolResponse."""
+
+    def no_return_handler(
+        request: ToolRequest,
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Handler that doesn't return anything."""
+        response = yield request
+        # Implicit return None
+
+    tool_node = ToolNode([success_tool], on_tool_call=no_return_handler)
+
+    with pytest.raises(ValueError) as exc_info:
+        tool_node.invoke(
+            {
+                "messages": [
+                    AIMessage(
+                        "",
+                        tool_calls=[{"name": "success_tool", "args": {"x": 5}, "id": "1"}],
+                    )
+                ]
+            }
+        )
+
+    assert "must explicitly return a ToolResponse" in str(exc_info.value)
+
+
+def test_on_tool_call_request_modification():
+    """Test that handler can modify the request before execution."""
+
+    def double_input_handler(
+        request: ToolRequest,
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Double the input value."""
+        # Modify the tool call args
+        modified_tool_call = {
+            **request.tool_call,
+            "args": {**request.tool_call["args"], "x": request.tool_call["args"]["x"] * 2},
+        }
+        modified_request = ToolRequest(
+            tool_call=modified_tool_call,
+            tool=request.tool,
+            config=request.config,
+        )
+        response = yield modified_request
+        return response
+
+    tool_node = ToolNode([success_tool], on_tool_call=double_input_handler)
+    result = tool_node.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[{"name": "success_tool", "args": {"x": 5}, "id": "1"}],
+                )
+            ]
+        }
+    )
+
+    assert len(result["messages"]) == 1
+    tool_message: ToolMessage = result["messages"][0]
+    # Input was 5, doubled to 10, then tool multiplies by 2 = 20
+    assert tool_message.content == "20"
+
+
+def test_on_tool_call_response_validation():
+    """Test that ToolResponse validates action and required fields."""
+    # Test action="return" requires result
+    with pytest.raises(ValueError) as exc_info:
+        ToolResponse(action="return")
+    assert "action='return' requires a result" in str(exc_info.value)
+
+    # Test action="raise" requires exception
+    with pytest.raises(ValueError) as exc_info:
+        ToolResponse(action="raise")
+    assert "action='raise' requires an exception" in str(exc_info.value)
+
+    # Valid responses should work
+    ToolResponse(
+        action="return",
+        result=ToolMessage(content="test", tool_call_id="1", name="test"),
+    )
+    ToolResponse(action="raise", exception=ValueError("test"))
+
+
+def test_on_tool_call_without_handler_backward_compat():
+    """Test that tools work without on_tool_call handler (backward compatibility)."""
+    # Success case
+    tool_node = ToolNode([success_tool])
+    result = tool_node.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[{"name": "success_tool", "args": {"x": 5}, "id": "1"}],
+                )
+            ]
+        }
+    )
+    assert result["messages"][0].content == "10"
+
+    # Error case with handle_tool_errors=False
+    tool_node_error = ToolNode([error_tool], handle_tool_errors=False)
+    with pytest.raises(ValueError):
+        tool_node_error.invoke(
+            {
+                "messages": [
+                    AIMessage(
+                        "",
+                        tool_calls=[{"name": "error_tool", "args": {"x": 5}, "id": "1"}],
+                    )
+                ]
+            }
+        )
+
+    # Error case with handle_tool_errors=True
+    tool_node_handled = ToolNode([error_tool], handle_tool_errors=True)
+    result = tool_node_handled.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "",
+                    tool_calls=[{"name": "error_tool", "args": {"x": 5}, "id": "1"}],
+                )
+            ]
+        }
+    )
+    assert result["messages"][0].status == "error"
+
+
+def test_on_tool_call_multiple_yields():
+    """Test that handler can yield multiple times for retries."""
+    attempts = {"count": 0}
+
+    def multi_yield_handler(
+        request: ToolRequest,
+    ) -> Generator[ToolRequest, ToolResponse, ToolResponse]:
+        """Yield multiple times to track attempts."""
+        max_attempts = 3
+
+        for _ in range(max_attempts):
+            attempts["count"] += 1
+            response = yield request
+
+            if response.action == "return":
+                return response
+
+        # All attempts failed
+        return response
+
+    tool_node = ToolNode([error_tool], on_tool_call=multi_yield_handler, handle_tool_errors=False)
+
+    with pytest.raises(ValueError):
+        tool_node.invoke(
+            {
+                "messages": [
+                    AIMessage(
+                        "",
+                        tool_calls=[{"name": "error_tool", "args": {"x": 5}, "id": "1"}],
+                    )
+                ]
+            }
+        )
+
+    assert attempts["count"] == 3

--- a/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
+++ b/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
@@ -41,7 +41,7 @@ def test_on_tool_call_passthrough() -> None:
     """Test that a simple passthrough handler works."""
 
     def passthrough_handler(
-        request: ToolCallRequest,
+        request: ToolCallRequest, state, runtime
     ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Simply pass through without modification."""
         response = yield request
@@ -72,7 +72,7 @@ def test_on_tool_call_retry_success():
         rate_limit_tool._call_count = 0
 
     def retry_handler(
-        request: ToolCallRequest,
+        request: ToolCallRequest, state, runtime
     ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Retry up to 3 times."""
         max_retries = 3
@@ -121,7 +121,7 @@ def test_on_tool_call_convert_error_to_message():
     """Test that handler can convert raised errors to error messages."""
 
     def error_to_message_handler(
-        request: ToolCallRequest,
+        request: ToolCallRequest, state, runtime
     ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Convert any error to a user-friendly message."""
         response = yield request
@@ -165,7 +165,7 @@ def test_on_tool_call_let_error_raise():
     """Test that handler can let errors propagate."""
 
     def let_raise_handler(
-        request: ToolCallRequest,
+        request: ToolCallRequest, state, runtime
     ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Just return the response as-is, letting errors raise."""
         response = yield request
@@ -193,7 +193,7 @@ def test_on_tool_call_with_handled_errors():
     call_count = {"count": 0}
 
     def counting_handler(
-        request: ToolCallRequest,
+        request: ToolCallRequest, state, runtime
     ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Count how many times we're called."""
         call_count["count"] += 1
@@ -225,7 +225,7 @@ def test_on_tool_call_must_return_value():
     """Test that handler must return a ToolCallResponse."""
 
     def no_return_handler(
-        request: ToolCallRequest,
+        request: ToolCallRequest, state, runtime
     ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Handler that doesn't return anything."""
         response = yield request
@@ -252,7 +252,7 @@ def test_on_tool_call_request_modification():
     """Test that handler can modify the request before execution."""
 
     def double_input_handler(
-        request: ToolCallRequest,
+        request: ToolCallRequest, state, runtime
     ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Double the input value."""
         # Modify the tool call args
@@ -356,7 +356,7 @@ def test_on_tool_call_multiple_yields():
     attempts = {"count": 0}
 
     def multi_yield_handler(
-        request: ToolCallRequest,
+        request: ToolCallRequest, state, runtime
     ) -> Generator[ToolCallRequest, ToolCallResponse, ToolCallResponse]:
         """Yield multiple times to track attempts."""
         max_attempts = 3


### PR DESCRIPTION
Still WIP:

* Need to update the API in the middleware


Changes:

* Goal is to remove ToolNode from accepted types in create_agent, but re-introduce support for tool handling. (Removing ToolNode as it's not obvious how it should interact with tools brought by middleware).
* Adds an interceptor ToolNode
* Adds an middleware on_tool_call
* Allows composing middlewares for handling tool calls.


```python
from langchain.agents.middleware import RetryMiddleware

# Retry network errors up to 3 times with 1 second delay
retry = RetryMiddleware(
    max_retries=3,
    delay=1.0,
    retry_on=(TimeoutError, ConnectionError),
)

agent = create_agent(
    model="openai:gpt-4o",
    tools=[my_tool],
    middleware=[retry],
)
```

```python
class SimpleRetryMiddleware(AgentMiddleware):
    def __init__(self, max_retries=3, delay=1.0):
        super().__init__()
        self.max_retries = max_retries
        self.delay = delay

    def on_tool_call(self, request):
        for attempt in range(self.max_retries + 1):
            response = yield request

            if response.action == "return":
                return response

            if response.action == "raise":
                if attempt < self.max_retries:
                    time.sleep(self.delay)
                    continue
                return response
```
