### PR TITLE
chore(langchain_v1): remove support for `ToolNode` in `create_agent`

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -219,7 +219,7 @@ def create_agent(  # noqa: PLR0915
         model: The language model for the agent. Can be a string identifier
             (e.g., ``"openai:gpt-4"``), a chat model instance (e.g., ``ChatOpenAI()``).
         tools: A list of tools, dicts, or callables. If ``None`` or an empty list,
-            the agent will consist of a single LLM node without tool calling.
+            the agent will consist of a model_request node without a tool calling loop.
         system_prompt: An optional system prompt for the LLM. If provided as a string,
             it will be converted to a SystemMessage and added to the beginning
             of the message list.

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -194,7 +194,7 @@ def _handle_structured_output_error(
 
 def create_agent(  # noqa: PLR0915
     model: str | BaseChatModel,
-    tools: Sequence[BaseTool | Callable | dict[str, Any]] | ToolNode | None = None,
+    tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
     *,
     system_prompt: str | None = None,
     middleware: Sequence[AgentMiddleware[AgentState[ResponseT], ContextT]] = (),
@@ -218,7 +218,7 @@ def create_agent(  # noqa: PLR0915
     Args:
         model: The language model for the agent. Can be a string identifier
             (e.g., ``"openai:gpt-4"``), a chat model instance (e.g., ``ChatOpenAI()``).
-        tools: A list of tools or a ToolNode instance. If ``None`` or an empty list,
+        tools: A list of tools, dicts, or callables. If ``None`` or an empty list,
             the agent will consist of a single LLM node without tool calling.
         system_prompt: An optional system prompt for the LLM. If provided as a string,
             it will be converted to a SystemMessage and added to the beginning
@@ -321,42 +321,24 @@ def create_agent(  # noqa: PLR0915
 
     # Setup tools
     tool_node: ToolNode | None = None
-    if isinstance(tools, list):
-        # Extract built-in provider tools (dict format) and regular tools (BaseTool/callables)
-        built_in_tools = [t for t in tools if isinstance(t, dict)]
-        regular_tools = [t for t in tools if not isinstance(t, dict)]
+    # Extract built-in provider tools (dict format) and regular tools (BaseTool/callables)
+    built_in_tools = [t for t in tools if isinstance(t, dict)]
+    regular_tools = [t for t in tools if not isinstance(t, dict)]
 
-        # Tools that require client-side execution (must be in ToolNode)
-        available_tools = middleware_tools + regular_tools
+    # Tools that require client-side execution (must be in ToolNode)
+    available_tools = middleware_tools + regular_tools
 
-        # Only create ToolNode if we have client-side tools
-        tool_node = ToolNode(tools=available_tools) if available_tools else None
+    # Only create ToolNode if we have client-side tools
+    tool_node = ToolNode(tools=available_tools) if available_tools else None
 
-        # Default tools for ModelRequest initialization
-        # Use converted BaseTool instances from ToolNode (not raw callables)
-        # Include built-ins and converted tools (can be changed dynamically by middleware)
-        # Structured tools are NOT included - they're added dynamically based on response_format
-        if tool_node:
-            default_tools = list(tool_node.tools_by_name.values()) + built_in_tools
-        else:
-            default_tools = list(built_in_tools)
-    elif isinstance(tools, ToolNode):
-        tool_node = tools
-        if tool_node:
-            # Add middleware tools to existing ToolNode
-            available_tools = list(tool_node.tools_by_name.values()) + middleware_tools
-            tool_node = ToolNode(available_tools)
-
-            # default_tools includes all client-side tools (no built-ins or structured tools)
-            default_tools = list(tool_node.tools_by_name.values())
-        else:
-            default_tools = []
-    # No tools provided, only middleware_tools available
-    elif middleware_tools:
-        tool_node = ToolNode(middleware_tools)
-        default_tools = list(tool_node.tools_by_name.values())
+    # Default tools for ModelRequest initialization
+    # Use converted BaseTool instances from ToolNode (not raw callables)
+    # Include built-ins and converted tools (can be changed dynamically by middleware)
+    # Structured tools are NOT included - they're added dynamically based on response_format
+    if tool_node:
+        default_tools = list(tool_node.tools_by_name.values()) + built_in_tools
     else:
-        default_tools = []
+        default_tools = list(built_in_tools)
 
     # validate middleware
     assert len({m.name for m in middleware}) == len(middleware), (  # noqa: S101

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_tools.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_tools.py
@@ -4,6 +4,7 @@ import pytest
 
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ModelRequest
 from langchain.agents.factory import create_agent
+from langchain.tools import ToolNode
 from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.tools import tool
 from .model import FakeToolCallingModel
@@ -301,3 +302,21 @@ def test_middleware_with_additional_tools() -> None:
     assert len(tool_messages) == 1
     assert tool_messages[0].name == "middleware_tool"
     assert "middleware" in tool_messages[0].content.lower()
+
+
+def test_tool_node_not_accepted() -> None:
+    """Test that passing a ToolNode instance to create_agent raises an error."""
+
+    @tool
+    def some_tool(input: str) -> str:
+        """Some tool."""
+        return "result"
+
+    tool_node = ToolNode([some_tool])
+
+    with pytest.raises(TypeError, match="'ToolNode' object is not iterable"):
+        create_agent(
+            model=FakeToolCallingModel(),
+            tools=tool_node,  # type: ignore[arg-type]
+            system_prompt="You are a helpful assistant.",
+        )


### PR DESCRIPTION
Let's add a note to help w/ migration once we add the tool call retry middleware.