### PR TITLE
chore(infra): use different pr title labeler

### DIFF
--- a/.github/workflows/pr_labeler_title.yml
+++ b/.github/workflows/pr_labeler_title.yml
@@ -1,6 +1,7 @@
 # Label PRs based on their titles.
 #
-# See `.github/pr-title-labeler.yml` to see rules for each label/title pattern.
+# Uses conventional commit types from PR titles to apply labels.
+# Note: Scope-based labeling (e.g., integration labels) is handled by pr_labeler_file.yml
 
 name: "🏷️ PR Title Labeler"
 
@@ -8,7 +9,7 @@ on:
   # Safe since we're not checking out or running the PR's code
   # Never check out the PR's head in a pull_request_target job
   pull_request_target:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, edited]
 
 jobs:
   pr-title-labeler:
@@ -20,14 +21,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-
       - name: Label PR based on title
-        # Archived repo; latest commit (v0.1.0)
-        uses: grafana/pr-labeler-action@f19222d3ef883d2ca5f04420fdfe8148003763f0
+        uses: bcoe/conventional-release-labels@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          configuration-path: .github/pr-title-labeler.yml
+          type_labels: >-
+            {
+              "feat": "feature",
+              "fix": "fix",
+              "docs": "documentation",
+              "style": "linting",
+              "refactor": "refactor",
+              "perf": "performance",
+              "test": "tests",
+              "build": "infra",
+              "ci": "infra",
+              "chore": "infra",
+              "revert": "revert",
+              "release": "release",
+              "breaking": "breaking"
+            }
+          ignored_types: '[]'


### PR DESCRIPTION
The previous (from Grafana) is archived and doesn't work for community PRs.