### PR TITLE
chore(infra): only build 0.3 ref docs from `v0.3` branches

### DIFF
--- a/.github/workflows/api_doc_build.yml
+++ b/.github/workflows/api_doc_build.yml
@@ -78,7 +78,7 @@ jobs:
               exit 1
             fi
             echo "Checking out $repo to $REPO_NAME"
-            git clone --depth 1 https://github.com/$repo.git $REPO_NAME
+            git clone --depth 1 --branch v0.3 https://github.com/$repo.git $REPO_NAME
           done
 
       - name: "🐍 Setup Python ${{ env.PYTHON_VERSION }}"


### PR DESCRIPTION
Using the `api_doc_build.yml` workflow will now only pull from the `v0.3` branch for each `langchain-ai` repo used during the build process. This ensures that upcoming updates to the `master`/`main` branch for each repo won't affect the v0.3 reference docs if/when they are re-built or updated.