### PR TITLE
feat(core): Migrating ContextualCompressionRetriever to Core

### DIFF
--- a/libs/core/langchain_core/vectorstores/__init__.py
+++ b/libs/core/langchain_core/vectorstores/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from langchain_core._import_utils import import_attr
 
 if TYPE_CHECKING:
-    from langchain_core.vectorstores.base import VST, VectorStore, VectorStoreRetriever
+    from langchain_core.vectorstores.base import VST, VectorStore, VectorStoreRetriever, ContextualCompressionRetriever
     from langchain_core.vectorstores.in_memory import InMemoryVectorStore
 
 __all__ = (
@@ -13,6 +13,7 @@ __all__ = (
     "InMemoryVectorStore",
     "VectorStore",
     "VectorStoreRetriever",
+    "ContextualCompressionRetriever",
 )
 
 _dynamic_imports = {
@@ -20,6 +21,7 @@ _dynamic_imports = {
     "VST": "base",
     "VectorStoreRetriever": "base",
     "InMemoryVectorStore": "in_memory",
+    "ContextualCompressionRetriever": "base",
 }
 
 

--- a/libs/core/langchain_core/vectorstores/__init__.py
+++ b/libs/core/langchain_core/vectorstores/__init__.py
@@ -5,15 +5,20 @@ from typing import TYPE_CHECKING
 from langchain_core._import_utils import import_attr
 
 if TYPE_CHECKING:
-    from langchain_core.vectorstores.base import VST, VectorStore, VectorStoreRetriever, ContextualCompressionRetriever
+    from langchain_core.vectorstores.base import (
+        VST,
+        ContextualCompressionRetriever,
+        VectorStore,
+        VectorStoreRetriever,
+    )
     from langchain_core.vectorstores.in_memory import InMemoryVectorStore
 
 __all__ = (
     "VST",
+    "ContextualCompressionRetriever",
     "InMemoryVectorStore",
     "VectorStore",
     "VectorStoreRetriever",
-    "ContextualCompressionRetriever",
 )
 
 _dynamic_imports = {

--- a/libs/langchain/langchain_classic/retrievers/contextual_compression.py
+++ b/libs/langchain/langchain_classic/retrievers/contextual_compression.py
@@ -8,7 +8,9 @@ if TYPE_CHECKING:
 # Create a way to dynamically look up deprecated imports.
 # Used to consolidate logic for raising deprecation warnings and
 # handling optional imports.
-DEPRECATED_LOOKUP = {"ContextualCompressionRetriever": "langchain_core.vectorstores.base"}
+DEPRECATED_LOOKUP = {
+    "ContextualCompressionRetriever": "langchain_core.vectorstores.base"
+}
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)
 


### PR DESCRIPTION
- **Description:** Migrated `ContextualCompressionRetriever` to core, as it logically makes more sense to keep it there rather than in `langchain_classic`, similar to `VectorStoreRetriever`.
- **Issue:** While not the primary issue addressed, this change was inspired by documentation issue #33292.

Related PR on Langchain Docs: https://github.com/langchain-ai/docs/pull/762
