### PR TITLE
revert: chore(infra): temporarily skip tests of previous alpha versions on core release

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -385,7 +385,6 @@ jobs:
   test-prior-published-packages-against-new-core:
     # Installs the new core with old partners: Installs the new unreleased core
     # alongside the previously published partner packages and runs integration tests
-    if: false # temporarily skip
     needs:
       - build
       - release-notes
@@ -476,6 +475,7 @@ jobs:
       - release-notes
       - test-pypi-publish
       - pre-release-checks
+      - test-prior-published-packages-against-new-core
     runs-on: ubuntu-latest
     permissions:
       # This permission is used for trusted publishing:


### PR DESCRIPTION
Reverts langchain-ai/langchain#33312