### PR TITLE
fix(core): handle parent/child mustache vars

### DIFF
--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -174,9 +174,9 @@ def mustache_schema(template: str) -> type[BaseModel]:
         elif type_ in {"variable", "no escape"}:
             fields[prefix + tuple(key.split("."))] = True
 
-    for key, val in fields.items():
-        fields[key] = val and not any(
-            is_subsequence(key, k) for k in fields if k != key
+    for fkey, fval in fields.items():
+        fields[fkey] = fval and not any(
+            is_subsequence(fkey, k) for k in fields if k != fkey
         )
     defs: Defs = {}  # None means leaf node
     while fields:

--- a/libs/core/tests/unit_tests/prompts/test_string.py
+++ b/libs/core/tests/unit_tests/prompts/test_string.py
@@ -1,6 +1,19 @@
+import pytest
+from packaging import version
+
 from langchain_core.prompts.string import mustache_schema
+from langchain_core.utils.pydantic import PYDANTIC_VERSION
+
+PYDANTIC_VERSION_AT_LEAST_210 = version.parse("2.10") <= PYDANTIC_VERSION
 
 
+@pytest.mark.skipif(
+    PYDANTIC_VERSION_AT_LEAST_210,
+    reason=(
+        "Only test with most recent version of pydantic. "
+        "Pydantic introduced small fixes to generated JSONSchema on minor versions."
+    ),
+)
 def test_mustache_schema_parent_child() -> None:
     template = "{{x.y}} {{x}}"
     expected = {

--- a/libs/core/tests/unit_tests/prompts/test_string.py
+++ b/libs/core/tests/unit_tests/prompts/test_string.py
@@ -8,7 +8,7 @@ PYDANTIC_VERSION_AT_LEAST_29 = version.parse("2.9") <= PYDANTIC_VERSION
 
 
 @pytest.mark.skipif(
-    PYDANTIC_VERSION_AT_LEAST_29,
+    not PYDANTIC_VERSION_AT_LEAST_29,
     reason=(
         "Only test with most recent version of pydantic. "
         "Pydantic introduced small fixes to generated JSONSchema on minor versions."

--- a/libs/core/tests/unit_tests/prompts/test_string.py
+++ b/libs/core/tests/unit_tests/prompts/test_string.py
@@ -1,0 +1,19 @@
+from langchain_core.prompts.string import mustache_schema
+
+
+def test_mustache_schema_parent_child() -> None:
+    template = "{{x.y}} {{x}}"
+    expected = {
+        "$defs": {
+            "x": {
+                "properties": {"y": {"default": None, "title": "Y", "type": "string"}},
+                "title": "x",
+                "type": "object",
+            }
+        },
+        "properties": {"x": {"$ref": "#/$defs/x", "default": None}},
+        "title": "PromptInput",
+        "type": "object",
+    }
+    actual = mustache_schema(template).model_json_schema()
+    assert expected == actual

--- a/libs/core/tests/unit_tests/prompts/test_string.py
+++ b/libs/core/tests/unit_tests/prompts/test_string.py
@@ -4,11 +4,11 @@ from packaging import version
 from langchain_core.prompts.string import mustache_schema
 from langchain_core.utils.pydantic import PYDANTIC_VERSION
 
-PYDANTIC_VERSION_AT_LEAST_210 = version.parse("2.10") <= PYDANTIC_VERSION
+PYDANTIC_VERSION_AT_LEAST_29 = version.parse("2.9") <= PYDANTIC_VERSION
 
 
 @pytest.mark.skipif(
-    PYDANTIC_VERSION_AT_LEAST_210,
+    PYDANTIC_VERSION_AT_LEAST_29,
     reason=(
         "Only test with most recent version of pydantic. "
         "Pydantic introduced small fixes to generated JSONSchema on minor versions."


### PR DESCRIPTION
**Description:**

currently `mustache_schema("{{x.y}} {{x}}")` will error. pr fixes

**Issue:** na
**Dependencies:**na
