### PR TITLE
fix(core): override streaming callback if streaming attribute is set

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -471,8 +471,10 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         if "stream" in kwargs:
             return kwargs["stream"]
 
-        if getattr(self, "streaming", False):
-            return True
+        if "streaming" in self.model_fields_set:
+            streaming_value = getattr(self, "streaming", None)
+            if isinstance(streaming_value, bool):
+                return streaming_value
 
         # Check if any streaming callback handlers have been passed in.
         handlers = run_manager.handlers if run_manager else []

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -364,6 +364,8 @@ class NoStreamingModel(BaseChatModel):
 
 
 class StreamingModel(NoStreamingModel):
+    streaming: bool = False
+
     @override
     def _stream(
         self,
@@ -425,6 +427,13 @@ async def test_disable_streaming_async(
             [], config={"callbacks": [_AstreamEventsCallbackHandler()]}, tools=[{}]
         )
     ).content == expected
+
+
+async def test_streaming_attribute_overrides_streaming_callback() -> None:
+    model = StreamingModel(streaming=False)
+    assert (
+        await model.ainvoke([], config={"callbacks": [_AstreamEventsCallbackHandler()]})
+    ).content == "invoke"
 
 
 @pytest.mark.parametrize("disable_streaming", [True, False, "tool_calling"])


### PR DESCRIPTION
Currently the presence of a streaming callback handler enables streaming, even when a chat model has a `streaming` attribute that is explicitly set to False:
```python
llm = MyChatModel(streaming=False)

await model.ainvoke(..., config={"callbacks": [_AstreamEventsCallbackHandler()]})  # streams
```
The `streaming` attribute is not on BaseChatModel but it is on most major chat models, including OpenAI, Anthropic, and Google GenAI. Its intended purpose is to enable streaming under the hood when calling `.invoke`.

OpenAI and Anthropic implement `streaming` as a boolean attribute with no sentinel value, so here we disable streaming if that attribute is explicitly set to False.

N.B. BaseChatModel does implement `disable_streaming` for the complementary case, and this currently works:
```python
llm = MyChatModel(disable_streaming=True)

await model.ainvoke(..., config={"callbacks": [_AstreamEventsCallbackHandler()]})  # does not stream
```
but the behavior with `streaming` is unintuitive, so we update it here.

Ideally we would have a single `bool | None = None` attribute instead of these two booleans.