### PR TITLE
chore(langchain_v1): simplify on model call logic 

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -966,10 +966,10 @@ def create_agent(  # noqa: PLR0915
 
         # Define base handler that executes the model
         def base_handler(req: ModelRequest) -> AIMessage:
+            nonlocal effective_response_format
             internal_response = _execute_model_sync(req)
             if internal_response.exception is not None:
                 raise internal_response.exception
-            nonlocal effective_response_format
             effective_response_format = internal_response.effective_response_format
             assert internal_response.result is not None  # noqa: S101
             return internal_response.result
@@ -1032,10 +1032,10 @@ def create_agent(  # noqa: PLR0915
 
         # Define base async handler that executes the model
         async def base_handler(req: ModelRequest) -> AIMessage:
+            nonlocal effective_response_format
             internal_response = await _execute_model_async(req)
             if internal_response.exception is not None:
                 raise internal_response.exception
-            nonlocal effective_response_format
             effective_response_format = internal_response.effective_response_format
             assert internal_response.result is not None  # noqa: S101
             return internal_response.result

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -14,6 +14,9 @@ from typing import (
     get_type_hints,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, AnyMessage, SystemMessage, ToolMessage
 from langchain_core.tools import BaseTool

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -970,8 +970,10 @@ def create_agent(  # noqa: PLR0915
             internal_response = _execute_model_sync(req)
             if internal_response.exception is not None:
                 raise internal_response.exception
+            if internal_response.result is None:
+                msg = "Model execution succeeded but returned no result"
+                raise RuntimeError(msg)
             effective_response_format = internal_response.effective_response_format
-            assert internal_response.result is not None  # noqa: S101
             return internal_response.result
 
         if on_model_call_handler is None:
@@ -1036,8 +1038,10 @@ def create_agent(  # noqa: PLR0915
             internal_response = await _execute_model_async(req)
             if internal_response.exception is not None:
                 raise internal_response.exception
+            if internal_response.result is None:
+                msg = "Model execution succeeded but returned no result"
+                raise RuntimeError(msg)
             effective_response_format = internal_response.effective_response_format
-            assert internal_response.result is not None  # noqa: S101
             return internal_response.result
 
         if aon_model_call_handler is None:

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -81,24 +81,24 @@ class _InternalModelResponse:
     """Cached response format after auto-detection."""
 
 
-def _chain_model_call_handlers(  # noqa: PLR0915
+def _chain_model_call_handlers(
     handlers: Sequence[
         Callable[
-            [ModelRequest, Any, Any],
-            Generator[ModelRequest | AIMessage, AIMessage, None],
+            [ModelRequest, Any, Any, Callable[[ModelRequest], AIMessage]],
+            AIMessage,
         ]
     ],
 ) -> (
     Callable[
-        [ModelRequest, Any, Any],
-        Generator[ModelRequest | AIMessage, AIMessage, None],
+        [ModelRequest, Any, Any, Callable[[ModelRequest], AIMessage]],
+        AIMessage,
     ]
     | None
 ):
     """Compose multiple on_model_call handlers into single middleware stack.
 
     Composes handlers so first in list becomes outermost layer. Each handler
-    can intercept and modify both requests (going down) and responses (coming up).
+    receives a handler callback to execute inner layers.
 
     Args:
         handlers: List of handlers. First handler wraps all others.
@@ -109,26 +109,22 @@ def _chain_model_call_handlers(  # noqa: PLR0915
     Example:
         ```python
         # handlers=[auth, retry] means: auth wraps retry
-        # Flow: auth-before -> retry-before -> model -> retry-after -> auth-after
-        def auth(req, state, runtime):
+        # Flow: auth calls retry, retry calls base handler
+        def auth(req, state, runtime, handler):
             try:
-                result = yield req
-                return result
+                return handler(req)
             except UnauthorizedError:
                 refresh_token()
-                result = yield req
-                return result
+                return handler(req)
 
 
-        def retry(req, state, runtime):
+        def retry(req, state, runtime, handler):
             for attempt in range(3):
                 try:
-                    result = yield req
-                    return result
+                    return handler(req)
                 except Exception:
                     if attempt == 2:
                         raise
-            return result
 
 
         handler = _chain_model_call_handlers([auth, retry])
@@ -140,138 +136,103 @@ def _chain_model_call_handlers(  # noqa: PLR0915
     if len(handlers) == 1:
         return handlers[0]
 
-    def compose_two(  # noqa: PLR0915
+    def compose_two(
         outer: Callable[
-            [ModelRequest, Any, Any],
-            Generator[ModelRequest | AIMessage, AIMessage, None],
+            [ModelRequest, Any, Any, Callable[[ModelRequest], AIMessage]],
+            AIMessage,
         ],
         inner: Callable[
-            [ModelRequest, Any, Any],
-            Generator[ModelRequest | AIMessage, AIMessage, None],
+            [ModelRequest, Any, Any, Callable[[ModelRequest], AIMessage]],
+            AIMessage,
         ],
     ) -> Callable[
-        [ModelRequest, Any, Any],
-        Generator[ModelRequest | AIMessage, AIMessage, None],
+        [ModelRequest, Any, Any, Callable[[ModelRequest], AIMessage]],
+        AIMessage,
     ]:
-        """Compose two handlers where outer wraps inner.
+        """Compose two handlers where outer wraps inner."""
 
-        Yields ModelRequest for execution or AIMessage for short-circuit results.
-        Never uses return values - relies on last yield being tracked by caller.
-        """
-
-        def composed(  # noqa: PLR0915
+        def composed(
             request: ModelRequest,
             state: Any,
             runtime: Any,
-        ) -> Generator[ModelRequest | AIMessage, AIMessage, None]:
-            outer_gen = outer(request, state, runtime)
+            handler: Callable[[ModelRequest], AIMessage],
+        ) -> AIMessage:
+            # Create a wrapper that calls inner with the base handler
+            def inner_handler(req: ModelRequest) -> AIMessage:
+                return inner(req, state, runtime, handler)
 
-            # Initialize outer generator
-            try:
-                outer_request = next(outer_gen)
-            except StopIteration:
-                msg = "on_model_call handler must yield at least once"
-                raise ValueError(msg)
-
-            # Outer retry loop
-            while True:
-                # Check if outer yielded AIMessage (short-circuit)
-                if isinstance(outer_request, AIMessage):
-                    # Outer is short-circuiting, yield it to caller
-                    yield outer_request
-                    # Consume outer to completion
-                    try:
-                        next(outer_gen)
-                        msg = "on_model_call handler should not yield after yielding AIMessage"
-                        raise ValueError(msg)
-                    except StopIteration:
-                        pass
-                    return
-
-                # Outer yielded ModelRequest - pass to inner
-                inner_gen = inner(outer_request, state, runtime)
-
-                # Initialize inner generator
-                try:
-                    inner_request = next(inner_gen)
-                except StopIteration:
-                    msg = "on_model_call handler must yield at least once"
-                    raise ValueError(msg)
-
-                # Inner retry loop
-                inner_result: AIMessage | None = None
-                outer_is_retrying = False
-                while True:
-                    # Check if inner yielded AIMessage (short-circuit)
-                    if isinstance(inner_request, AIMessage):
-                        # Inner is short-circuiting, send to outer
-                        inner_result = inner_request
-                        # Consume inner to completion
-                        try:
-                            next(inner_gen)
-                            msg = "on_model_call handler should not yield after yielding AIMessage"
-                            raise ValueError(msg)
-                        except StopIteration:
-                            pass
-                        break  # Exit inner loop
-
-                    try:
-                        # Yield inner's request to caller for execution
-                        model_result = yield inner_request
-
-                        # Send result to inner
-                        try:
-                            inner_request = inner_gen.send(model_result)
-                            # Inner yielded again - check type in next iteration
-                        except StopIteration:
-                            # Inner finished, use the result we got
-                            inner_result = model_result
-                            break
-
-                    except Exception as exc:  # noqa: BLE001
-                        # Caller threw exception, route to inner
-                        try:
-                            inner_request = inner_gen.throw(exc)
-                            # Inner caught and yielded again
-                        except StopIteration:
-                            # Inner finished after handling exception
-                            inner_result = None
-                            break
-                        except Exception as inner_unhandled:  # noqa: BLE001
-                            # Inner didn't catch, propagate to outer
-                            try:
-                                outer_request = outer_gen.throw(inner_unhandled)
-                                # Outer caught and is retrying
-                                outer_is_retrying = True
-                                break
-                            except StopIteration:
-                                # Outer finished after handling exception
-                                return
-                            except Exception:
-                                # Outer didn't catch either
-                                raise
-
-                # If outer is retrying, continue outer loop with new request
-                if outer_is_retrying:
-                    continue
-
-                # Inner finished - send result to outer
-                if inner_result is None:
-                    # Inner failed without result
-                    return
-
-                try:
-                    outer_request = outer_gen.send(inner_result)
-                    # Outer yielded again - continue outer loop to check type
-                except StopIteration:
-                    # Outer finished - yield the inner result for caller to see
-                    if inner_result is not None:
-                        yield inner_result
-                    return
+            # Call outer with the wrapped inner as its handler
+            return outer(request, state, runtime, inner_handler)
 
         return composed
 
-    # Compose right-to-left: handlers[0](handlers[1](...(handlers[-1](model))))
+    # Compose right-to-left: outer(inner(innermost(handler)))
+    result = handlers[-1]
+    for handler in reversed(handlers[:-1]):
+        result = compose_two(handler, result)
+
+    return result
+
+
+def _chain_async_model_call_handlers(
+    handlers: Sequence[
+        Callable[
+            [ModelRequest, Any, Any, Callable[[ModelRequest], Awaitable[AIMessage]]],
+            Awaitable[AIMessage],
+        ]
+    ],
+) -> (
+    Callable[
+        [ModelRequest, Any, Any, Callable[[ModelRequest], Awaitable[AIMessage]]],
+        Awaitable[AIMessage],
+    ]
+    | None
+):
+    """Compose multiple async on_model_call handlers into single middleware stack.
+
+    Args:
+        handlers: List of async handlers. First handler wraps all others.
+
+    Returns:
+        Composed async handler, or None if handlers empty.
+    """
+    if not handlers:
+        return None
+
+    if len(handlers) == 1:
+        return handlers[0]
+
+    def compose_two(
+        outer: Callable[
+            [ModelRequest, Any, Any, Callable[[ModelRequest], Awaitable[AIMessage]]],
+            Awaitable[AIMessage],
+        ],
+        inner: Callable[
+            [ModelRequest, Any, Any, Callable[[ModelRequest], Awaitable[AIMessage]]],
+            Awaitable[AIMessage],
+        ],
+    ) -> Callable[
+        [ModelRequest, Any, Any, Callable[[ModelRequest], Awaitable[AIMessage]]],
+        Awaitable[AIMessage],
+    ]:
+        """Compose two async handlers where outer wraps inner."""
+
+        async def composed(
+            request: ModelRequest,
+            state: Any,
+            runtime: Any,
+            handler: Callable[[ModelRequest], Awaitable[AIMessage]],
+        ) -> AIMessage:
+            # Create a wrapper that calls inner with the base handler
+            async def inner_handler(req: ModelRequest) -> AIMessage:
+                return await inner(req, state, runtime, handler)
+
+            # Call outer with the wrapped inner as its handler
+            return await outer(request, state, runtime, inner_handler)
+
+        return composed
+
+    # Compose right-to-left: outer(inner(innermost(handler)))
     result = handlers[-1]
     for handler in reversed(handlers[:-1]):
         result = compose_two(handler, result)
@@ -704,12 +665,21 @@ def create_agent(  # noqa: PLR0915
     middleware_w_on_model_call = [
         m for m in middleware if m.__class__.on_model_call is not AgentMiddleware.on_model_call
     ]
+    middleware_w_aon_model_call = [
+        m for m in middleware if m.__class__.aon_model_call is not AgentMiddleware.aon_model_call
+    ]
 
-    # Compose on_model_call handlers into a single middleware stack
+    # Compose on_model_call handlers into a single middleware stack (sync)
     on_model_call_handler = None
     if middleware_w_on_model_call:
         sync_handlers = [m.on_model_call for m in middleware_w_on_model_call]
         on_model_call_handler = _chain_model_call_handlers(sync_handlers)
+
+    # Compose aon_model_call handlers into a single middleware stack (async)
+    aon_model_call_handler = None
+    if middleware_w_aon_model_call:
+        async_handlers = [m.aon_model_call for m in middleware_w_aon_model_call]
+        aon_model_call_handler = _chain_async_model_call_handlers(async_handlers)
 
     state_schemas = {m.state_schema for m in middleware}
     state_schemas.add(AgentState)
@@ -964,7 +934,7 @@ def create_agent(  # noqa: PLR0915
                 effective_response_format=None,
             )
 
-    def model_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:  # noqa: PLR0915
+    def model_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
         request = ModelRequest(
             model=model,
@@ -989,78 +959,24 @@ def create_agent(  # noqa: PLR0915
                 raise TypeError(msg)
 
         # Execute with or without handler
-        current_request: ModelRequest | AIMessage = request
-        internal_response: _InternalModelResponse
         effective_response_format: Any = None
+
+        # Define base handler that executes the model
+        def base_handler(req: ModelRequest) -> AIMessage:
+            internal_response = _execute_model_sync(req)
+            if internal_response.exception is not None:
+                raise internal_response.exception
+            nonlocal effective_response_format
+            effective_response_format = internal_response.effective_response_format
+            assert internal_response.result is not None  # noqa: S101
+            return internal_response.result
 
         if on_model_call_handler is None:
             # No handlers - execute directly
-            internal_response = _execute_model_sync(request)
-            if internal_response.exception is not None:
-                raise internal_response.exception
-            output = internal_response.result
-            effective_response_format = internal_response.effective_response_format
+            output = base_handler(request)
         else:
-            # Use composed handler with generator protocol
-            gen = on_model_call_handler(request, state, runtime)
-
-            try:
-                current_request = next(gen)
-            except StopIteration:
-                msg = "on_model_call handler must yield at least once to request model execution"
-                raise ValueError(msg)
-
-            # Execution loop - track last AIMessage seen
-            last_ai_message: AIMessage | None = None
-            while True:
-                # Check if handler yielded AIMessage (short-circuit result)
-                if isinstance(current_request, AIMessage):
-                    # Handler short-circuited with this result
-                    last_ai_message = current_request
-                    # Try to get next yield (should be done)
-                    try:
-                        current_request = next(gen)
-                        # Handler yielded again after AIMessage - continue loop
-                    except StopIteration:
-                        # Handler finished, use the AIMessage
-                        break
-                elif isinstance(current_request, ModelRequest):
-                    # Execute the model request
-                    internal_response = _execute_model_sync(current_request)
-                    effective_response_format = internal_response.effective_response_format
-
-                    try:
-                        if internal_response.exception is None:
-                            # Success - send AIMessage to handler
-                            assert internal_response.result is not None  # noqa: S101
-                            last_ai_message = internal_response.result
-                            current_request = gen.send(internal_response.result)
-                        else:
-                            # Error - throw exception to handler
-                            current_request = gen.throw(internal_response.exception)
-                        # Handler yielded again - check what it yielded in next iteration
-                    except StopIteration:
-                        # Handler finished
-                        break
-                    except Exception:
-                        # Handler didn't catch exception - propagate
-                        raise
-                else:
-                    msg = f"Handler yielded unexpected type: {type(current_request).__name__}"
-                    raise TypeError(msg)
-
-            output = last_ai_message
-
-            # Validate final result
-            if output is None:
-                msg = "on_model_call handler must complete with at least one successful model call"
-                raise ValueError(msg)
-            if not isinstance(output, AIMessage):
-                msg = f"on_model_call handler must end with AIMessage, got {type(output).__name__}"
-                raise TypeError(msg)
-
-        # output is guaranteed to be AIMessage at this point
-        assert isinstance(output, AIMessage)  # noqa: S101
+            # Call composed handler with base handler
+            output = on_model_call_handler(request, state, runtime, base_handler)
         return {
             "thread_model_call_count": state.get("thread_model_call_count", 0) + 1,
             "run_model_call_count": state.get("run_model_call_count", 0) + 1,
@@ -1093,7 +1009,7 @@ def create_agent(  # noqa: PLR0915
                 effective_response_format=None,
             )
 
-    async def amodel_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:  # noqa: PLR0915
+    async def amodel_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Async model request handler with sequential middleware processing."""
         request = ModelRequest(
             model=model,
@@ -1109,79 +1025,24 @@ def create_agent(  # noqa: PLR0915
             request = await m.amodify_model_request(request, state, runtime)
 
         # Execute with or without handler
-        # Note: handler is sync generator, but model execution is async
-        current_request: ModelRequest | AIMessage = request
-        internal_response: _InternalModelResponse
         effective_response_format: Any = None
 
-        if on_model_call_handler is None:
-            # No handlers - execute directly
-            internal_response = await _execute_model_async(request)
+        # Define base async handler that executes the model
+        async def base_handler(req: ModelRequest) -> AIMessage:
+            internal_response = await _execute_model_async(req)
             if internal_response.exception is not None:
                 raise internal_response.exception
-            output = internal_response.result
+            nonlocal effective_response_format
             effective_response_format = internal_response.effective_response_format
+            assert internal_response.result is not None  # noqa: S101
+            return internal_response.result
+
+        if aon_model_call_handler is None:
+            # No async handlers - execute directly
+            output = await base_handler(request)
         else:
-            # Use composed handler with generator protocol (sync generator, async execution)
-            gen = on_model_call_handler(request, state, runtime)
-
-            try:
-                current_request = next(gen)
-            except StopIteration:
-                msg = "on_model_call handler must yield at least once to request model execution"
-                raise ValueError(msg)
-
-            # Execution loop - track last AIMessage seen
-            last_ai_message: AIMessage | None = None
-            while True:
-                # Check if handler yielded AIMessage (short-circuit result)
-                if isinstance(current_request, AIMessage):
-                    # Handler short-circuited with this result
-                    last_ai_message = current_request
-                    # Try to get next yield (should be done)
-                    try:
-                        current_request = next(gen)
-                        # Handler yielded again after AIMessage - continue loop
-                    except StopIteration:
-                        # Handler finished, use the AIMessage
-                        break
-                elif isinstance(current_request, ModelRequest):
-                    # Execute the model request
-                    internal_response = await _execute_model_async(current_request)
-                    effective_response_format = internal_response.effective_response_format
-
-                    try:
-                        if internal_response.exception is None:
-                            # Success - send AIMessage to handler
-                            assert internal_response.result is not None  # noqa: S101
-                            last_ai_message = internal_response.result
-                            current_request = gen.send(internal_response.result)
-                        else:
-                            # Error - throw exception to handler
-                            current_request = gen.throw(internal_response.exception)
-                        # Handler yielded again - check what it yielded in next iteration
-                    except StopIteration:
-                        # Handler finished
-                        break
-                    except Exception:
-                        # Handler didn't catch exception - propagate
-                        raise
-                else:
-                    msg = f"Handler yielded unexpected type: {type(current_request).__name__}"
-                    raise TypeError(msg)
-
-            output = last_ai_message
-
-            # Validate final result
-            if output is None:
-                msg = "on_model_call handler must complete with at least one successful model call"
-                raise ValueError(msg)
-            if not isinstance(output, AIMessage):
-                msg = f"on_model_call handler must end with AIMessage, got {type(output).__name__}"
-                raise TypeError(msg)
-
-        # output is guaranteed to be AIMessage at this point
-        assert isinstance(output, AIMessage)  # noqa: S101
+            # Call composed async handler with base handler
+            output = await aon_model_call_handler(request, state, runtime, base_handler)
         return {
             "thread_model_call_count": state.get("thread_model_call_count", 0) + 1,
             "run_model_call_count": state.get("run_model_call_count", 0) + 1,

--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -89,10 +89,11 @@ class ModelFallbackMiddleware(AgentMiddleware):
             Exception: If all models fail, re-raises last exception.
         """
         # Try primary model first
+        last_exception: Exception
         try:
             return handler(request)
-        except Exception:  # noqa: BLE001
-            pass
+        except Exception as e:  # noqa: BLE001
+            last_exception = e
 
         # Try fallback models
         for fallback_model in self.models:

--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -11,7 +11,7 @@ from langchain.agents.middleware.types import (
 from langchain.chat_models import init_chat_model
 
 if TYPE_CHECKING:
-    from collections.abc import Generator
+    from collections.abc import Callable
 
     from langchain_core.language_models.chat_models import BaseChatModel
     from langchain_core.messages import AIMessage
@@ -72,36 +72,35 @@ class ModelFallbackMiddleware(AgentMiddleware):
         request: ModelRequest,
         state: Any,  # noqa: ARG002
         runtime: Runtime[ContextT],  # noqa: ARG002
-    ) -> Generator[ModelRequest | AIMessage, AIMessage, None]:
+        handler: Callable[[ModelRequest], AIMessage],
+    ) -> AIMessage:
         """Try fallback models in sequence on errors.
 
         Args:
             request: Initial model request.
             state: Current agent state.
             runtime: LangGraph runtime.
+            handler: Callback to execute the model.
 
-        Yields:
-            ModelRequest to execute.
+        Returns:
+            AIMessage from successful model call.
 
         Raises:
             Exception: If all models fail, re-raises last exception.
         """
-        last_exception = None
+        # Try primary model first
         try:
-            yield request
-        except Exception as e:  # noqa: BLE001
-            last_exception = e
-        else:
-            return
+            return handler(request)
+        except Exception:  # noqa: BLE001
+            pass
 
+        # Try fallback models
         for fallback_model in self.models:
             request.model = fallback_model
             try:
-                yield request
+                return handler(request)
             except Exception as e:  # noqa: BLE001
                 last_exception = e
                 continue
-            else:
-                return
 
         raise last_exception

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -278,7 +278,6 @@ class AgentMiddleware(Generic[StateT, ContextT]):
                             raise
             ```
         """
-        # Default: call sync version (will fail if handler is truly async)
         raise NotImplementedError
 
     def after_agent(self, state: StateT, runtime: Runtime[ContextT]) -> dict[str, Any] | None:

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -377,20 +377,6 @@ class _CallableReturningModelResponse(Protocol[StateT_contra, ContextT]):
         ...
 
 
-class _AsyncCallableReturningModelResponse(Protocol[StateT_contra, ContextT]):
-    """Async callable for model call interception with handler callback."""
-
-    def __call__(
-        self,
-        request: ModelRequest,
-        state: StateT_contra,
-        runtime: Runtime[ContextT],
-        handler: Callable[[ModelRequest], Awaitable[AIMessage]],
-    ) -> Awaitable[AIMessage]:
-        """Intercept model execution via async handler callback."""
-        ...
-
-
 CallableT = TypeVar("CallableT", bound=Callable[..., Any])
 
 
@@ -1347,7 +1333,7 @@ def on_model_call(
                 runtime: Runtime[ContextT],
                 handler: Callable[[ModelRequest], Awaitable[AIMessage]],
             ) -> AIMessage:
-                return await func(request, state, runtime, handler)  # type: ignore[misc]
+                return await func(request, state, runtime, handler)  # type: ignore[misc, arg-type]
 
             middleware_name = name or cast(
                 "str", getattr(func, "__name__", "OnModelCallMiddleware")
@@ -1370,7 +1356,7 @@ def on_model_call(
             runtime: Runtime[ContextT],
             handler: Callable[[ModelRequest], AIMessage],
         ) -> AIMessage:
-            return func(request, state, runtime, handler)  # type: ignore[return-value]
+            return func(request, state, runtime, handler)
 
         middleware_name = name or cast("str", getattr(func, "__name__", "OnModelCallMiddleware"))
 

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
+from collections.abc import Awaitable, Callable, Generator
 from dataclasses import dataclass, field
 from inspect import iscoroutinefunction
 from typing import (
@@ -188,39 +188,33 @@ class AgentMiddleware(Generic[StateT, ContextT]):
         request: ModelRequest,
         state: StateT,
         runtime: Runtime[ContextT],
-    ) -> Generator[ModelRequest | AIMessage, AIMessage, None]:
-        """Intercept and control model execution via generator protocol.
+        handler: Callable[[ModelRequest], AIMessage],
+    ) -> AIMessage:
+        """Intercept and control model execution via handler callback.
 
-        Protocol:
-        1. Yield ModelRequest to execute the model.
-        2. Receive AIMessage via .send() on success, or exception via .throw() on error.
-        3. Optionally yield again to retry.
-        4. Generator ends naturally - consumer uses last successful AIMessage.
-
-        Middleware can implement retry logic, error handling, response rewriting,
-        and request modification using standard try/except. Multiple middleware
+        The handler callback executes the model request and returns an AIMessage.
+        Middleware can call the handler multiple times for retry logic, skip calling
+        it to short-circuit, or modify the request/response. Multiple middleware
         compose with first in list as outermost layer.
 
         Args:
             request: Initial model request to execute.
             state: Current agent state.
             runtime: LangGraph runtime context.
+            handler: Callback that executes the model request and returns AIMessage.
+                     Call this to execute the model. Can be called multiple times
+                     for retry logic. Can skip calling it to short-circuit.
 
-        Yields:
-            ModelRequest to execute.
-
-        Receives:
-            AIMessage via .send() on success.
-            Exception via .throw() on error.
+        Returns:
+            Final AIMessage to use (from handler or custom).
 
         Examples:
             Retry on error:
             ```python
-            def on_model_call(self, request, state, runtime):
+            def on_model_call(self, request, state, runtime, handler):
                 for attempt in range(3):
                     try:
-                        yield request
-                        break  # Success
+                        return handler(request)
                     except Exception:
                         if attempt == 2:
                             raise
@@ -228,31 +222,63 @@ class AgentMiddleware(Generic[StateT, ContextT]):
 
             Rewrite response:
             ```python
-            def on_model_call(self, request, state, runtime):
-                result = yield request
-                modified = AIMessage(content=f"[{result.content}]")
-                yield modified
+            def on_model_call(self, request, state, runtime, handler):
+                result = handler(request)
+                return AIMessage(content=f"[{result.content}]")
             ```
 
             Error to fallback:
             ```python
-            def on_model_call(self, request, state, runtime):
+            def on_model_call(self, request, state, runtime, handler):
                 try:
-                    yield request
+                    return handler(request)
                 except Exception:
-                    fallback = AIMessage(content="Service unavailable")
-                    yield fallback
+                    return AIMessage(content="Service unavailable")
+            ```
 
             Cache/short-circuit:
             ```python
-            def on_model_call(self, request, state, runtime):
+            def on_model_call(self, request, state, runtime, handler):
                 if cached := get_cache(request):
-                    yield cached  # Short-circuit with cached result
-                else:
-                    result = yield request
-                    save_cache(request, result)
+                    return cached  # Short-circuit with cached result
+                result = handler(request)
+                save_cache(request, result)
+                return result
             ```
         """
+        raise NotImplementedError
+
+    async def aon_model_call(
+        self,
+        request: ModelRequest,
+        state: StateT,
+        runtime: Runtime[ContextT],
+        handler: Callable[[ModelRequest], Awaitable[AIMessage]],
+    ) -> AIMessage:
+        """Async version of on_model_call.
+
+        Args:
+            request: Initial model request to execute.
+            state: Current agent state.
+            runtime: LangGraph runtime context.
+            handler: Async callback that executes the model request.
+
+        Returns:
+            Final AIMessage to use (from handler or custom).
+
+        Examples:
+            Retry on error:
+            ```python
+            async def aon_model_call(self, request, state, runtime, handler):
+                for attempt in range(3):
+                    try:
+                        return await handler(request)
+                    except Exception:
+                        if attempt == 2:
+                            raise
+            ```
+        """
+        # Default: call sync version (will fail if handler is truly async)
         raise NotImplementedError
 
     def after_agent(self, state: StateT, runtime: Runtime[ContextT]) -> dict[str, Any] | None:
@@ -334,17 +360,34 @@ class _CallableReturningPromptString(Protocol[StateT_contra, ContextT]):
         ...
 
 
-class _CallableReturningModelResponseGenerator(Protocol[StateT_contra, ContextT]):
-    """Callable returning generator for model call interception.
+class _CallableReturningModelResponse(Protocol[StateT_contra, ContextT]):
+    """Callable for model call interception with handler callback.
 
-    Returns sync generator that works with both sync and async model execution.
-    Generator receives AIMessage via .send() or exception via .throw().
+    Receives handler callback to execute model and returns final AIMessage.
     """
 
     def __call__(
-        self, request: ModelRequest, state: StateT_contra, runtime: Runtime[ContextT]
-    ) -> Generator[ModelRequest, AIMessage, AIMessage]:
-        """Return generator to intercept model execution."""
+        self,
+        request: ModelRequest,
+        state: StateT_contra,
+        runtime: Runtime[ContextT],
+        handler: Callable[[ModelRequest], AIMessage],
+    ) -> AIMessage:
+        """Intercept model execution via handler callback."""
+        ...
+
+
+class _AsyncCallableReturningModelResponse(Protocol[StateT_contra, ContextT]):
+    """Async callable for model call interception with handler callback."""
+
+    def __call__(
+        self,
+        request: ModelRequest,
+        state: StateT_contra,
+        runtime: Runtime[ContextT],
+        handler: Callable[[ModelRequest], Awaitable[AIMessage]],
+    ) -> Awaitable[AIMessage]:
+        """Intercept model execution via async handler callback."""
         ...
 
 
@@ -1207,7 +1250,7 @@ def dynamic_prompt(
 
 @overload
 def on_model_call(
-    func: _CallableReturningModelResponseGenerator[StateT, ContextT],
+    func: _CallableReturningModelResponse[StateT, ContextT],
 ) -> AgentMiddleware[StateT, ContextT]: ...
 
 
@@ -1219,34 +1262,32 @@ def on_model_call(
     tools: list[BaseTool] | None = None,
     name: str | None = None,
 ) -> Callable[
-    [_CallableReturningModelResponseGenerator[StateT, ContextT]],
+    [_CallableReturningModelResponse[StateT, ContextT]],
     AgentMiddleware[StateT, ContextT],
 ]: ...
 
 
 def on_model_call(
-    func: _CallableReturningModelResponseGenerator[StateT, ContextT] | None = None,
+    func: _CallableReturningModelResponse[StateT, ContextT] | None = None,
     *,
     state_schema: type[StateT] | None = None,
     tools: list[BaseTool] | None = None,
     name: str | None = None,
 ) -> (
     Callable[
-        [_CallableReturningModelResponseGenerator[StateT, ContextT]],
+        [_CallableReturningModelResponse[StateT, ContextT]],
         AgentMiddleware[StateT, ContextT],
     ]
     | AgentMiddleware[StateT, ContextT]
 ):
-    """Create middleware with on_model_call hook from a generator function.
+    """Create middleware with on_model_call hook from a function.
 
-    Converts a generator function into middleware that can intercept model calls,
-    implement retry logic, handle errors, and rewrite responses using standard
-    Python exception handling.
+    Converts a function with handler callback into middleware that can intercept
+    model calls, implement retry logic, handle errors, and rewrite responses.
 
     Args:
-        func: Generator function accepting (request, state, runtime) that yields
-            ModelRequest, receives AIMessage via .send() on success or exception
-            via .throw() on error, and returns final AIMessage.
+        func: Function accepting (request, state, runtime, handler) that calls
+            handler(request) to execute the model and returns final AIMessage.
         state_schema: Custom state schema. Defaults to AgentState.
         tools: Additional tools to register with this middleware.
         name: Middleware class name. Defaults to function name.
@@ -1258,14 +1299,11 @@ def on_model_call(
         Basic retry logic:
         ```python
         @on_model_call
-        def retry_on_error(
-            request: ModelRequest, state: AgentState, runtime: Runtime
-        ) -> Generator[ModelRequest, AIMessage, AIMessage]:
+        def retry_on_error(request, state, runtime, handler):
             max_retries = 3
             for attempt in range(max_retries):
                 try:
-                    yield request
-                    break  # Success
+                    return handler(request)
                 except Exception:
                     if attempt == max_retries - 1:
                         raise
@@ -1274,43 +1312,65 @@ def on_model_call(
         Model fallback:
         ```python
         @on_model_call
-        def fallback_model(
-            request: ModelRequest, state: AgentState, runtime: Runtime
-        ) -> Generator[ModelRequest, AIMessage, AIMessage]:
+        def fallback_model(request, state, runtime, handler):
             # Try primary model
             try:
-                yield request
-                return  # Success
+                return handler(request)
             except Exception:
                 pass
 
             # Try fallback model
             request.model = fallback_model_instance
-            yield request
+            return handler(request)
         ```
 
         Rewrite response content:
         ```python
         @on_model_call
-        def uppercase_responses(
-            request: ModelRequest, state: AgentState, runtime: Runtime
-        ) -> Generator[ModelRequest, AIMessage, AIMessage]:
-            result = yield request
-            modified = AIMessage(content=result.content.upper())
-            yield modified
+        def uppercase_responses(request, state, runtime, handler):
+            result = handler(request)
+            return AIMessage(content=result.content.upper())
         ```
     """
 
     def decorator(
-        func: _CallableReturningModelResponseGenerator[StateT, ContextT],
+        func: _CallableReturningModelResponse[StateT, ContextT],
     ) -> AgentMiddleware[StateT, ContextT]:
+        is_async = iscoroutinefunction(func)
+
+        if is_async:
+
+            async def async_wrapped(
+                self: AgentMiddleware[StateT, ContextT],  # noqa: ARG001
+                request: ModelRequest,
+                state: StateT,
+                runtime: Runtime[ContextT],
+                handler: Callable[[ModelRequest], Awaitable[AIMessage]],
+            ) -> AIMessage:
+                return await func(request, state, runtime, handler)  # type: ignore[misc]
+
+            middleware_name = name or cast(
+                "str", getattr(func, "__name__", "OnModelCallMiddleware")
+            )
+
+            return type(
+                middleware_name,
+                (AgentMiddleware,),
+                {
+                    "state_schema": state_schema or AgentState,
+                    "tools": tools or [],
+                    "aon_model_call": async_wrapped,
+                },
+            )()
+
         def wrapped(
             self: AgentMiddleware[StateT, ContextT],  # noqa: ARG001
             request: ModelRequest,
             state: StateT,
             runtime: Runtime[ContextT],
-        ) -> Generator[ModelRequest, AIMessage, AIMessage]:
-            return func(request, state, runtime)
+            handler: Callable[[ModelRequest], AIMessage],
+        ) -> AIMessage:
+            return func(request, state, runtime, handler)  # type: ignore[return-value]
 
         middleware_name = name or cast("str", getattr(func, "__name__", "OnModelCallMiddleware"))
 


### PR DESCRIPTION
Moving from the generator pattern to the slightly less verbose (but explicit) handler pattern.

This will be more familiar to users

**Before (Generator Pattern):**
```python
def on_model_call(self, request, state, runtime):
    try:
        result = yield request
    except Exception:
        result = yield request  # Retry
```

**After (Handler Pattern):**
```python
def on_model_call(self, request, state, runtime, handler):
    try:
        return handler(request)
    except Exception:
        return handler(request)  # Retry
```
