### PR TITLE
fix(anthropic): handle empty AIMessage

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -549,6 +549,10 @@ def _format_messages(
                 _lc_tool_calls_to_anthropic_tool_use_blocks(missing_tool_calls),
             )
 
+        if not content and role == "assistant" and _i < len(merged_messages) - 1:
+            # anthropic.BadRequestError: Error code: 400: all messages must have
+            # non-empty content except for the optional final assistant message
+            continue
         formatted_messages.append({"role": role, "content": content})
     return system, formatted_messages
 

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -642,6 +642,38 @@ def test__format_messages_with_tool_calls() -> None:
     actual = _format_messages(messages)
     assert expected == actual
 
+    # Check handling of empty AIMessage
+    empty_contents: list[str | list[str | dict]] = ["", []]
+    for empty_content in empty_contents:
+        ## Permit message in final position
+        _, anthropic_messages = _format_messages([human, AIMessage(empty_content)])
+        expected_messages = [
+            {"role": "user", "content": "foo"},
+            {"role": "assistant", "content": empty_content},
+        ]
+        assert expected_messages == anthropic_messages
+
+        ## Remove message otherwise
+        _, anthropic_messages = _format_messages(
+            [human, AIMessage(empty_content), human]
+        )
+        expected_messages = [
+            {"role": "user", "content": "foo"},
+            {"role": "user", "content": "foo"},
+        ]
+        assert expected_messages == anthropic_messages
+
+        actual = _format_messages(
+            [system, human, ai, tool, AIMessage(empty_content), human]
+        )
+        assert actual[0] == "fuzz"
+        assert [message["role"] for message in actual[1]] == [
+            "user",
+            "assistant",
+            "user",
+            "user",
+        ]
+
 
 def test__format_tool_use_block() -> None:
     # Test we correctly format tool_use blocks when there is no corresponding tool_call.


### PR DESCRIPTION
Claude can generate AIMessages with no content (including no tool calls), but these aren't valid inputs unless they end the sequence of messages (e.g., to pre-fill a response).