### PR TITLE
fix(langchain_v1): can not import     "wrap_tool_call"  from agents.…

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -28,7 +28,7 @@ from .types import (
     dynamic_prompt,
     hook_config,
     wrap_model_call,
-    wrap_tool_call
+    wrap_tool_call,
 )
 
 __all__ = [

--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -28,6 +28,7 @@ from .types import (
     dynamic_prompt,
     hook_config,
     wrap_model_call,
+    wrap_tool_call
 )
 
 __all__ = [
@@ -55,4 +56,5 @@ __all__ = [
     "dynamic_prompt",
     "hook_config",
     "wrap_model_call",
+    "wrap_tool_call",
 ]


### PR DESCRIPTION
fix can not import `wrap_tool_call` from ` langchain.agents.middleware import `
```python

from langchain.agents import create_agent
from langchain.agents.middleware import wrap_tool_call # here !
from langchain_core.messages import ToolMessage

@wrap_tool_call
def handle_tool_errors(request, handler):
    """Handle tool execution errors with custom messages."""
    try:
        return handler(request)
    except Exception as e:
        # Return a custom error message to the model
        return ToolMessage(
            content=f"Tool error: Please check your input and try again. ({str(e)})",
            tool_call_id=request.tool_call["id"]
        )

agent = create_agent(
    model="openai:gpt-4o",
    tools=[search, calculate],
    middleware=[handle_tool_errors]
)
```
> example code from: https://docs.langchain.com/oss/python/langchain/agents#tool-error-handling