### PR TITLE
feat(standard-tests): parametrize tool calling test

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -113,6 +113,15 @@ def _validate_tool_call_message(message: BaseMessage) -> None:
     assert tool_call["id"] is not None
     assert tool_call.get("type") == "tool_call"
 
+    content_tool_calls = [
+        block for block in message.content_blocks if block["type"] == "tool_call"
+    ]
+    assert len(content_tool_calls) == 1
+    content_tool_call = content_tool_calls[0]
+    assert content_tool_call["name"] == "magic_function"
+    assert content_tool_call["args"] == {"input": 3}
+    assert content_tool_call["id"] is not None
+
 
 def _validate_tool_call_message_no_args(message: BaseMessage) -> None:
     assert isinstance(message, AIMessage)
@@ -1325,6 +1334,7 @@ class ChatModelIntegrationTests(ChatModelTests):
         result = custom_model.invoke("hi")
         assert isinstance(result, AIMessage)
 
+    @pytest.mark.parametrize("model", [{}, {"output_version": "v1"}], indirect=True)
     def test_tool_calling(self, model: BaseChatModel) -> None:
         """Test that the model generates tool calls.
 


### PR DESCRIPTION
Add check for streaming tool calls when `output_version="v1"`.