### PR TITLE
feat(langchain_v1): injected runtime

### DIFF
--- a/libs/langchain_v1/langchain/tools/__init__.py
+++ b/libs/langchain_v1/langchain/tools/__init__.py
@@ -8,7 +8,7 @@ from langchain_core.tools import (
     tool,
 )
 
-from langchain.tools.tool_node import InjectedState, InjectedStore
+from langchain.tools.tool_node import InjectedState, InjectedStore, ToolRuntime
 
 __all__ = [
     "BaseTool",
@@ -17,5 +17,6 @@ __all__ = [
     "InjectedToolArg",
     "InjectedToolCallId",
     "ToolException",
+    "ToolRuntime",
     "tool",
 ]

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -80,6 +80,7 @@ from langchain_core.tools.base import (
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.errors import GraphBubbleUp
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from langgraph.store.base import BaseStore  # noqa: TC002
 from langgraph.types import Command, Send, StreamWriter
 from pydantic import BaseModel, ValidationError
 from typing_extensions import Unpack
@@ -88,7 +89,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from langgraph.runtime import Runtime
-    from langgraph.store.base import BaseStore
 
 StateT = TypeVar("StateT")
 ContextT = TypeVar("ContextT")

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -80,7 +80,7 @@ from langchain_core.tools.base import (
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.errors import GraphBubbleUp
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
-from langgraph.types import Command, Send
+from langgraph.types import Command, Send, StreamWriter
 from pydantic import BaseModel, ValidationError
 from typing_extensions import Unpack
 
@@ -1371,9 +1371,9 @@ class ToolRuntime(InjectedToolArg, Generic[StateT, ContextT]):
     state: StateT
     config: RunnableConfig
     tool_call_id: str
+    stream_writer: StreamWriter
     context: ContextT = field(default=None)  # type: ignore[assignment]
-    store: Any = field(default=None)
-    stream_writer: Any = field(default=None)
+    store: BaseStore | None = field(default=None)
 
 
 class InjectedState(InjectedToolArg):

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -597,7 +597,7 @@ class _ToolNode(RunnableCallable):
 
         # Construct ToolRuntime instances at the top level for each tool call
         tool_runtimes = []
-        for call, cfg in zip(tool_calls, config_list, strict=False):
+        for call, cfg in zip(tool_calls, config_list):
             state = self._extract_state(input)
             runtime_store = runtime.store
             stream_writer = runtime.stream_writer
@@ -615,7 +615,7 @@ class _ToolNode(RunnableCallable):
 
         injected_tool_calls = []
         input_types = [input_type] * len(tool_calls)
-        for call, tool_runtime in zip(tool_calls, tool_runtimes, strict=False):
+        for call, tool_runtime in zip(tool_calls, tool_runtimes):
             injected_call = self._inject_tool_args(call, tool_runtime)
             injected_tool_calls.append(injected_call)
         with get_executor_for_config(config) as executor:
@@ -636,7 +636,7 @@ class _ToolNode(RunnableCallable):
 
         # Construct ToolRuntime instances at the top level for each tool call
         tool_runtimes = []
-        for call, cfg in zip(tool_calls, config_list, strict=False):
+        for call, cfg in zip(tool_calls, config_list):
             state = self._extract_state(input)
             runtime_store = runtime.store
             stream_writer = runtime.stream_writer
@@ -652,7 +652,7 @@ class _ToolNode(RunnableCallable):
 
         injected_tool_calls = []
         coros = []
-        for call, tool_runtime in zip(tool_calls, tool_runtimes, strict=False):
+        for call, tool_runtime in zip(tool_calls, tool_runtimes):
             injected_call = self._inject_tool_args(call, tool_runtime)
             injected_tool_calls.append(injected_call)
             coros.append(self._arun_one(injected_call, input_type, tool_runtime))

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -48,7 +48,6 @@ from typing import (
     Any,
     Generic,
     Literal,
-    Optional,
     TypedDict,
     TypeVar,
     Union,
@@ -108,10 +107,6 @@ TOOL_INVOCATION_ERROR_TEMPLATE = (
     " {error}\n"
     " Please fix the error and try again."
 )
-
-
-def _no_op_stream_writer(*args: Any, **kwargs: Any) -> None:
-    """No-op stream writer for when runtime is not available."""
 
 
 class _ToolCallRequestOverrides(TypedDict, total=False):
@@ -595,8 +590,6 @@ class _ToolNode(RunnableCallable):
         self,
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
-        *,
-        store: Optional[BaseStore],  # noqa: UP045
         runtime: Runtime,
     ) -> Any:
         tool_calls, input_type = self._parse_input(input)
@@ -606,8 +599,8 @@ class _ToolNode(RunnableCallable):
         tool_runtimes = []
         for call, cfg in zip(tool_calls, config_list, strict=False):
             state = self._extract_state(input)
-            runtime_store = runtime.store if runtime else store
-            stream_writer = runtime.stream_writer if runtime else _no_op_stream_writer
+            runtime_store = runtime.store
+            stream_writer = runtime.stream_writer
             tool_runtime = ToolRuntime(
                 state=state,
                 tool_call_id=call.get("id") or "",
@@ -638,8 +631,6 @@ class _ToolNode(RunnableCallable):
         self,
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
-        *,
-        store: Optional[BaseStore],  # noqa: UP045
         runtime: Runtime,
     ) -> Any:
         tool_calls, input_type = self._parse_input(input)
@@ -649,8 +640,8 @@ class _ToolNode(RunnableCallable):
         tool_runtimes = []
         for call, cfg in zip(tool_calls, config_list, strict=False):
             state = self._extract_state(input)
-            runtime_store = runtime.store if runtime else store
-            stream_writer = runtime.stream_writer if runtime else _no_op_stream_writer
+            runtime_store = runtime.store
+            stream_writer = runtime.stream_writer
             tool_runtime = ToolRuntime(
                 state=state,
                 tool_call_id=call.get("id") or "",

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -596,8 +596,8 @@ class _ToolNode(RunnableCallable):
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
         *,
-        store: Optional[BaseStore] = None,  # noqa: UP045
-        runtime: Optional[Runtime] = None,  # noqa: UP045
+        store: Optional[BaseStore],  # noqa: UP045
+        runtime: Runtime,
     ) -> Any:
         tool_calls, input_type = self._parse_input(input)
         config_list = get_config_list(config, len(tool_calls))
@@ -639,8 +639,8 @@ class _ToolNode(RunnableCallable):
         input: list[AnyMessage] | dict[str, Any] | BaseModel,
         config: RunnableConfig,
         *,
-        store: Optional[BaseStore] = None,  # noqa: UP045
-        runtime: Optional[Runtime] = None,  # noqa: UP045
+        store: Optional[BaseStore],  # noqa: UP045
+        runtime: Runtime,
     ) -> Any:
         tool_calls, input_type = self._parse_input(input)
         config_list = get_config_list(config, len(tool_calls))
@@ -1346,7 +1346,7 @@ def tools_condition(
 class ToolRuntime(InjectedToolArg, Generic[StateT, ContextT]):
     """Runtime context automatically injected into tools.
 
-    When a tool function has a parameter named 'runtime' with type hint
+    When a tool function has a parameter named 'tool_runtime' with type hint
     'ToolRuntime', the tool execution system will automatically inject
     an instance containing:
 
@@ -1357,7 +1357,7 @@ class ToolRuntime(InjectedToolArg, Generic[StateT, ContextT]):
     - store: BaseStore instance for persistent storage (from langgraph Runtime)
     - stream_writer: StreamWriter for streaming output (from langgraph Runtime)
 
-    No `Annotated` wrapper is needed - just use `runtime: ToolRuntime`
+    No `Annotated` wrapper is needed - just use `tool_runtime: ToolRuntime`
     as a parameter.
 
     Example:
@@ -1366,25 +1366,25 @@ class ToolRuntime(InjectedToolArg, Generic[StateT, ContextT]):
         from langchain.tools import ToolRuntime
 
         @tool
-        def my_tool(x: int, runtime: ToolRuntime) -> str:
+        def my_tool(x: int, tool_runtime: ToolRuntime) -> str:
             \"\"\"Tool that accesses runtime context.\"\"\"
             # Access state
-            messages = runtime.state["messages"]
+            messages = tool_runtime.state["messages"]
 
             # Access tool_call_id
-            print(f"Tool call ID: {runtime.tool_call_id}")
+            print(f"Tool call ID: {tool_runtime.tool_call_id}")
 
             # Access config
-            print(f"Run ID: {runtime.config.get('run_id')}")
+            print(f"Run ID: {tool_runtime.config.get('run_id')}")
 
             # Access runtime context
-            user_id = runtime.context.get("user_id")
+            user_id = tool_runtime.context.get("user_id")
 
             # Access store
-            runtime.store.put(("metrics",), "count", 1)
+            tool_runtime.store.put(("metrics",), "count", 1)
 
             # Stream output
-            runtime.stream_writer.write("Processing...")
+            tool_runtime.stream_writer.write("Processing...")
 
             return f"Processed {x}"
         ```

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_wrap_tool_call_decorator.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_wrap_tool_call_decorator.py
@@ -4,7 +4,6 @@ These tests verify the decorator-based approach for wrapping tool calls,
 focusing on the handler pattern (not generators).
 """
 
-import pytest
 from collections.abc import Callable
 
 from langchain_core.messages import HumanMessage, ToolCall, ToolMessage
@@ -210,7 +209,7 @@ def test_wrap_tool_call_access_runtime() -> None:
 
     # Middleware should have accessed runtime
     assert len(runtime_data) >= 1
-    assert runtime_data[0] == "Runtime"
+    assert runtime_data[0] == "ToolRuntime"
 
 
 def test_wrap_tool_call_retry_on_error() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
@@ -1,0 +1,544 @@
+"""Test ToolRuntime injection with create_agent.
+
+This module tests the injected runtime functionality when using tools
+with the create_agent factory. The ToolRuntime provides tools access to:
+- state: Current graph state
+- tool_call_id: ID of the current tool call
+- config: RunnableConfig for the execution
+- context: Runtime context from LangGraph
+- store: BaseStore for persistent storage
+- stream_writer: For streaming custom output
+
+These tests verify that runtime injection works correctly across both
+sync and async execution paths, with middleware, and in various agent
+configurations.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from langgraph.store.memory import InMemoryStore
+
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentState
+from langchain.tools import ToolRuntime
+
+from .model import FakeToolCallingModel
+
+
+def test_tool_runtime_basic_injection() -> None:
+    """Test basic ToolRuntime injection in tools with create_agent."""
+    # Track what was injected
+    injected_data = {}
+
+    @tool
+    def runtime_tool(x: int, runtime: ToolRuntime) -> str:
+        """Tool that accesses runtime context."""
+        injected_data["state"] = runtime.state
+        injected_data["tool_call_id"] = runtime.tool_call_id
+        injected_data["config"] = runtime.config
+        injected_data["context"] = runtime.context
+        injected_data["store"] = runtime.store
+        injected_data["stream_writer"] = runtime.stream_writer
+        return f"Processed {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 42}, "id": "call_123", "name": "runtime_tool"}],
+                [],
+            ]
+        ),
+        tools=[runtime_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test")]})
+
+    # Verify tool executed
+    assert len(result["messages"]) == 4
+    tool_message = result["messages"][2]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == "Processed 42"
+    assert tool_message.tool_call_id == "call_123"
+
+    # Verify runtime was injected
+    assert injected_data["state"] is not None
+    assert "messages" in injected_data["state"]
+    assert injected_data["tool_call_id"] == "call_123"
+    assert injected_data["config"] is not None
+    # Context, store, stream_writer may be None depending on graph setup
+    assert "context" in injected_data
+    assert "store" in injected_data
+    assert "stream_writer" in injected_data
+
+
+async def test_tool_runtime_async_injection() -> None:
+    """Test ToolRuntime injection works with async tools."""
+    injected_data = {}
+
+    @tool
+    async def async_runtime_tool(x: int, runtime: ToolRuntime) -> str:
+        """Async tool that accesses runtime context."""
+        injected_data["state"] = runtime.state
+        injected_data["tool_call_id"] = runtime.tool_call_id
+        injected_data["config"] = runtime.config
+        return f"Async processed {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 99}, "id": "async_call_456", "name": "async_runtime_tool"}],
+                [],
+            ]
+        ),
+        tools=[async_runtime_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("Test async")]})
+
+    # Verify tool executed
+    assert len(result["messages"]) == 4
+    tool_message = result["messages"][2]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == "Async processed 99"
+    assert tool_message.tool_call_id == "async_call_456"
+
+    # Verify runtime was injected
+    assert injected_data["state"] is not None
+    assert "messages" in injected_data["state"]
+    assert injected_data["tool_call_id"] == "async_call_456"
+    assert injected_data["config"] is not None
+
+
+def test_tool_runtime_state_access() -> None:
+    """Test that tools can access and use state via ToolRuntime."""
+
+    @tool
+    def state_aware_tool(query: str, runtime: ToolRuntime) -> str:
+        """Tool that uses state to provide context-aware responses."""
+        messages = runtime.state.get("messages", [])
+        msg_count = len(messages)
+        return f"Query: {query}, Message count: {msg_count}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"query": "test"}, "id": "state_call", "name": "state_aware_tool"}],
+                [],
+            ]
+        ),
+        tools=[state_aware_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Hello"), HumanMessage("World")]})
+
+    # Check that tool accessed state correctly
+    tool_message = result["messages"][3]
+    assert isinstance(tool_message, ToolMessage)
+    # Should have original 2 HumanMessages + 1 AIMessage before tool execution
+    assert "Message count: 3" in tool_message.content
+
+
+def test_tool_runtime_with_store() -> None:
+    """Test ToolRuntime provides access to store."""
+    # Note: create_agent doesn't currently expose a store parameter,
+    # so runtime.store will be None in this test.
+    # This test demonstrates the runtime injection works correctly.
+
+    @tool
+    def store_tool(key: str, value: str, runtime: ToolRuntime) -> str:
+        """Tool that uses store."""
+        if runtime.store is None:
+            return f"No store (key={key}, value={value})"
+        runtime.store.put(("test",), key, {"data": value})
+        return f"Stored {key}={value}"
+
+    @tool
+    def check_runtime_tool(runtime: ToolRuntime) -> str:
+        """Tool that checks runtime availability."""
+        has_store = runtime.store is not None
+        has_context = runtime.context is not None
+        return f"Runtime: store={has_store}, context={has_context}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"key": "foo", "value": "bar"}, "id": "call_1", "name": "store_tool"}],
+                [{"args": {}, "id": "call_2", "name": "check_runtime_tool"}],
+                [],
+            ]
+        ),
+        tools=[store_tool, check_runtime_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test store")]})
+
+    # Find the tool messages
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert len(tool_messages) == 2
+
+    # First tool indicates no store is available (expected since create_agent doesn't expose store)
+    assert "No store" in tool_messages[0].content
+
+    # Second tool confirms runtime was injected
+    assert "Runtime:" in tool_messages[1].content
+
+
+def test_tool_runtime_with_multiple_tools() -> None:
+    """Test multiple tools can all access ToolRuntime."""
+    call_log = []
+
+    @tool
+    def tool_a(x: int, runtime: ToolRuntime) -> str:
+        """First tool."""
+        call_log.append(("tool_a", runtime.tool_call_id, x))
+        return f"A: {x}"
+
+    @tool
+    def tool_b(y: str, runtime: ToolRuntime) -> str:
+        """Second tool."""
+        call_log.append(("tool_b", runtime.tool_call_id, y))
+        return f"B: {y}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [
+                    {"args": {"x": 1}, "id": "call_a", "name": "tool_a"},
+                    {"args": {"y": "test"}, "id": "call_b", "name": "tool_b"},
+                ],
+                [],
+            ]
+        ),
+        tools=[tool_a, tool_b],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Use both tools")]})
+
+    # Verify both tools were called with correct runtime
+    assert len(call_log) == 2
+    # Tools may execute in parallel, so check both calls are present
+    call_ids = {(name, call_id) for name, call_id, _ in call_log}
+    assert ("tool_a", "call_a") in call_ids
+    assert ("tool_b", "call_b") in call_ids
+
+    # Verify tool messages
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert len(tool_messages) == 2
+    contents = {msg.content for msg in tool_messages}
+    assert "A: 1" in contents
+    assert "B: test" in contents
+
+
+def test_tool_runtime_config_access() -> None:
+    """Test tools can access config through ToolRuntime."""
+    config_data = {}
+
+    @tool
+    def config_tool(x: int, runtime: ToolRuntime) -> str:
+        """Tool that accesses config."""
+        config_data["config_exists"] = runtime.config is not None
+        config_data["has_configurable"] = (
+            "configurable" in runtime.config if runtime.config else False
+        )
+        # Config may have run_id or other fields depending on execution context
+        if runtime.config:
+            config_data["config_keys"] = list(runtime.config.keys())
+        return f"Config accessed for {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 5}, "id": "config_call", "name": "config_tool"}],
+                [],
+            ]
+        ),
+        tools=[config_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test config")]})
+
+    # Verify config was accessible
+    assert config_data["config_exists"] is True
+    assert "config_keys" in config_data
+
+    # Verify tool executed
+    tool_message = result["messages"][2]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == "Config accessed for 5"
+
+
+def test_tool_runtime_with_custom_state() -> None:
+    """Test ToolRuntime works with custom state schemas."""
+    from typing_extensions import Annotated, TypedDict
+
+    from langchain.agents.middleware.types import AgentMiddleware
+
+    class CustomState(AgentState):
+        custom_field: str
+
+    runtime_state = {}
+
+    @tool
+    def custom_state_tool(x: int, runtime: ToolRuntime) -> str:
+        """Tool that accesses custom state."""
+        runtime_state["custom_field"] = runtime.state.get("custom_field", "not found")
+        return f"Custom: {x}"
+
+    class CustomMiddleware(AgentMiddleware):
+        state_schema = CustomState
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 10}, "id": "custom_call", "name": "custom_state_tool"}],
+                [],
+            ]
+        ),
+        tools=[custom_state_tool],
+        system_prompt="You are a helpful assistant.",
+        middleware=[CustomMiddleware()],
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Test custom state")], "custom_field": "custom_value"}
+    )
+
+    # Verify custom field was accessible
+    assert runtime_state["custom_field"] == "custom_value"
+
+    # Verify tool executed
+    tool_message = result["messages"][2]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == "Custom: 10"
+
+
+def test_tool_runtime_no_runtime_parameter() -> None:
+    """Test that tools without runtime parameter work normally."""
+
+    @tool
+    def regular_tool(x: int) -> str:
+        """Regular tool without runtime."""
+        return f"Regular: {x}"
+
+    @tool
+    def runtime_tool(y: int, runtime: ToolRuntime) -> str:
+        """Tool with runtime."""
+        return f"Runtime: {y}, call_id: {runtime.tool_call_id}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [
+                    {"args": {"x": 1}, "id": "regular_call", "name": "regular_tool"},
+                    {"args": {"y": 2}, "id": "runtime_call", "name": "runtime_tool"},
+                ],
+                [],
+            ]
+        ),
+        tools=[regular_tool, runtime_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test mixed tools")]})
+
+    # Verify both tools executed correctly
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert len(tool_messages) == 2
+    assert tool_messages[0].content == "Regular: 1"
+    assert "Runtime: 2, call_id: runtime_call" in tool_messages[1].content
+
+
+async def test_tool_runtime_parallel_execution() -> None:
+    """Test ToolRuntime injection works with parallel tool execution."""
+    execution_log = []
+
+    @tool
+    async def parallel_tool_1(x: int, runtime: ToolRuntime) -> str:
+        """First parallel tool."""
+        execution_log.append(("tool_1", runtime.tool_call_id, x))
+        return f"Tool1: {x}"
+
+    @tool
+    async def parallel_tool_2(y: int, runtime: ToolRuntime) -> str:
+        """Second parallel tool."""
+        execution_log.append(("tool_2", runtime.tool_call_id, y))
+        return f"Tool2: {y}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [
+                    {"args": {"x": 10}, "id": "parallel_1", "name": "parallel_tool_1"},
+                    {"args": {"y": 20}, "id": "parallel_2", "name": "parallel_tool_2"},
+                ],
+                [],
+            ]
+        ),
+        tools=[parallel_tool_1, parallel_tool_2],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("Run parallel")]})
+
+    # Verify both tools executed
+    assert len(execution_log) == 2
+
+    # Find the tool messages (order may vary due to parallel execution)
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert len(tool_messages) == 2
+
+    contents = {msg.content for msg in tool_messages}
+    assert "Tool1: 10" in contents
+    assert "Tool2: 20" in contents
+
+    call_ids = {msg.tool_call_id for msg in tool_messages}
+    assert "parallel_1" in call_ids
+    assert "parallel_2" in call_ids
+
+
+def test_tool_runtime_error_handling() -> None:
+    """Test error handling with ToolRuntime injection."""
+
+    @tool
+    def error_tool(x: int, runtime: ToolRuntime) -> str:
+        """Tool that may error."""
+        # Access runtime to ensure it's injected even during errors
+        _ = runtime.tool_call_id
+        if x == 0:
+            msg = "Cannot process zero"
+            raise ValueError(msg)
+        return f"Processed: {x}"
+
+    # create_agent uses default error handling which doesn't catch ValueError
+    # So we need to handle this differently
+    @tool
+    def safe_tool(x: int, runtime: ToolRuntime) -> str:
+        """Tool that handles errors safely."""
+        try:
+            if x == 0:
+                return "Error: Cannot process zero"
+            return f"Processed: {x}"
+        except Exception as e:
+            return f"Error: {e}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 0}, "id": "error_call", "name": "safe_tool"}],
+                [{"args": {"x": 5}, "id": "success_call", "name": "safe_tool"}],
+                [],
+            ]
+        ),
+        tools=[safe_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test error handling")]})
+
+    # Both tool calls should complete
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert len(tool_messages) == 2
+
+    # First call returned error message
+    assert "Error:" in tool_messages[0].content or "Cannot process zero" in tool_messages[0].content
+
+    # Second call succeeded
+    assert "Processed: 5" in tool_messages[1].content
+
+
+def test_tool_runtime_with_middleware() -> None:
+    """Test ToolRuntime injection works with agent middleware."""
+    from typing import Any
+
+    from langchain.agents.middleware.types import AgentMiddleware
+
+    middleware_calls = []
+    runtime_calls = []
+
+    class TestMiddleware(AgentMiddleware):
+        def before_model(self, state, runtime) -> dict[str, Any]:
+            middleware_calls.append("before_model")
+            return {}
+
+        def after_model(self, state, runtime) -> dict[str, Any]:
+            middleware_calls.append("after_model")
+            return {}
+
+    @tool
+    def middleware_tool(x: int, runtime: ToolRuntime) -> str:
+        """Tool with runtime in middleware agent."""
+        runtime_calls.append(("middleware_tool", runtime.tool_call_id))
+        return f"Middleware result: {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 7}, "id": "mw_call", "name": "middleware_tool"}],
+                [],
+            ]
+        ),
+        tools=[middleware_tool],
+        system_prompt="You are a helpful assistant.",
+        middleware=[TestMiddleware()],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test with middleware")]})
+
+    # Verify middleware ran
+    assert "before_model" in middleware_calls
+    assert "after_model" in middleware_calls
+
+    # Verify tool with runtime executed
+    assert len(runtime_calls) == 1
+    assert runtime_calls[0] == ("middleware_tool", "mw_call")
+
+    # Verify result
+    tool_message = result["messages"][2]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == "Middleware result: 7"
+
+
+def test_tool_runtime_type_hints() -> None:
+    """Test that ToolRuntime provides access to state fields."""
+    typed_runtime = {}
+
+    # Use ToolRuntime without generic type hints to avoid forward reference issues
+    @tool
+    def typed_runtime_tool(x: int, runtime: ToolRuntime) -> str:
+        """Tool with runtime access."""
+        # Access state dict - verify we can access standard state fields
+        if isinstance(runtime.state, dict):
+            # Count messages in state
+            typed_runtime["message_count"] = len(runtime.state.get("messages", []))
+        else:
+            typed_runtime["message_count"] = len(getattr(runtime.state, "messages", []))
+        return f"Typed: {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 3}, "id": "typed_call", "name": "typed_runtime_tool"}],
+                [],
+            ]
+        ),
+        tools=[typed_runtime_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test")]})
+
+    # Verify typed runtime worked - should see 2 messages (HumanMessage + AIMessage) before tool executes
+    assert typed_runtime["message_count"] == 2
+
+    tool_message = result["messages"][2]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == "Typed: 3"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
@@ -34,14 +34,14 @@ def test_tool_runtime_basic_injection() -> None:
     injected_data = {}
 
     @tool
-    def runtime_tool(x: int, runtime: ToolRuntime) -> str:
+    def runtime_tool(x: int, tool_runtime: ToolRuntime) -> str:
         """Tool that accesses runtime context."""
-        injected_data["state"] = runtime.state
-        injected_data["tool_call_id"] = runtime.tool_call_id
-        injected_data["config"] = runtime.config
-        injected_data["context"] = runtime.context
-        injected_data["store"] = runtime.store
-        injected_data["stream_writer"] = runtime.stream_writer
+        injected_data["state"] = tool_runtime.state
+        injected_data["tool_call_id"] = tool_runtime.tool_call_id
+        injected_data["config"] = tool_runtime.config
+        injected_data["context"] = tool_runtime.context
+        injected_data["store"] = tool_runtime.store
+        injected_data["stream_writer"] = tool_runtime.stream_writer
         return f"Processed {x}"
 
     agent = create_agent(
@@ -80,11 +80,11 @@ async def test_tool_runtime_async_injection() -> None:
     injected_data = {}
 
     @tool
-    async def async_runtime_tool(x: int, runtime: ToolRuntime) -> str:
+    async def async_runtime_tool(x: int, tool_runtime: ToolRuntime) -> str:
         """Async tool that accesses runtime context."""
-        injected_data["state"] = runtime.state
-        injected_data["tool_call_id"] = runtime.tool_call_id
-        injected_data["config"] = runtime.config
+        injected_data["state"] = tool_runtime.state
+        injected_data["tool_call_id"] = tool_runtime.tool_call_id
+        injected_data["config"] = tool_runtime.config
         return f"Async processed {x}"
 
     agent = create_agent(
@@ -118,9 +118,9 @@ def test_tool_runtime_state_access() -> None:
     """Test that tools can access and use state via ToolRuntime."""
 
     @tool
-    def state_aware_tool(query: str, runtime: ToolRuntime) -> str:
+    def state_aware_tool(query: str, tool_runtime: ToolRuntime) -> str:
         """Tool that uses state to provide context-aware responses."""
-        messages = runtime.state.get("messages", [])
+        messages = tool_runtime.state.get("messages", [])
         msg_count = len(messages)
         return f"Query: {query}, Message count: {msg_count}"
 
@@ -147,22 +147,22 @@ def test_tool_runtime_state_access() -> None:
 def test_tool_runtime_with_store() -> None:
     """Test ToolRuntime provides access to store."""
     # Note: create_agent doesn't currently expose a store parameter,
-    # so runtime.store will be None in this test.
+    # so tool_runtime.store will be None in this test.
     # This test demonstrates the runtime injection works correctly.
 
     @tool
-    def store_tool(key: str, value: str, runtime: ToolRuntime) -> str:
+    def store_tool(key: str, value: str, tool_runtime: ToolRuntime) -> str:
         """Tool that uses store."""
-        if runtime.store is None:
+        if tool_runtime.store is None:
             return f"No store (key={key}, value={value})"
-        runtime.store.put(("test",), key, {"data": value})
+        tool_runtime.store.put(("test",), key, {"data": value})
         return f"Stored {key}={value}"
 
     @tool
-    def check_runtime_tool(runtime: ToolRuntime) -> str:
+    def check_runtime_tool(tool_runtime: ToolRuntime) -> str:
         """Tool that checks runtime availability."""
-        has_store = runtime.store is not None
-        has_context = runtime.context is not None
+        has_store = tool_runtime.store is not None
+        has_context = tool_runtime.context is not None
         return f"Runtime: store={has_store}, context={has_context}"
 
     agent = create_agent(
@@ -195,15 +195,15 @@ def test_tool_runtime_with_multiple_tools() -> None:
     call_log = []
 
     @tool
-    def tool_a(x: int, runtime: ToolRuntime) -> str:
+    def tool_a(x: int, tool_runtime: ToolRuntime) -> str:
         """First tool."""
-        call_log.append(("tool_a", runtime.tool_call_id, x))
+        call_log.append(("tool_a", tool_runtime.tool_call_id, x))
         return f"A: {x}"
 
     @tool
-    def tool_b(y: str, runtime: ToolRuntime) -> str:
+    def tool_b(y: str, tool_runtime: ToolRuntime) -> str:
         """Second tool."""
-        call_log.append(("tool_b", runtime.tool_call_id, y))
+        call_log.append(("tool_b", tool_runtime.tool_call_id, y))
         return f"B: {y}"
 
     agent = create_agent(
@@ -242,15 +242,15 @@ def test_tool_runtime_config_access() -> None:
     config_data = {}
 
     @tool
-    def config_tool(x: int, runtime: ToolRuntime) -> str:
+    def config_tool(x: int, tool_runtime: ToolRuntime) -> str:
         """Tool that accesses config."""
-        config_data["config_exists"] = runtime.config is not None
+        config_data["config_exists"] = tool_runtime.config is not None
         config_data["has_configurable"] = (
-            "configurable" in runtime.config if runtime.config else False
+            "configurable" in tool_runtime.config if tool_runtime.config else False
         )
         # Config may have run_id or other fields depending on execution context
-        if runtime.config:
-            config_data["config_keys"] = list(runtime.config.keys())
+        if tool_runtime.config:
+            config_data["config_keys"] = list(tool_runtime.config.keys())
         return f"Config accessed for {x}"
 
     agent = create_agent(
@@ -288,9 +288,9 @@ def test_tool_runtime_with_custom_state() -> None:
     runtime_state = {}
 
     @tool
-    def custom_state_tool(x: int, runtime: ToolRuntime) -> str:
+    def custom_state_tool(x: int, tool_runtime: ToolRuntime) -> str:
         """Tool that accesses custom state."""
-        runtime_state["custom_field"] = runtime.state.get("custom_field", "not found")
+        runtime_state["custom_field"] = tool_runtime.state.get("custom_field", "not found")
         return f"Custom: {x}"
 
     class CustomMiddleware(AgentMiddleware):
@@ -330,9 +330,9 @@ def test_tool_runtime_no_runtime_parameter() -> None:
         return f"Regular: {x}"
 
     @tool
-    def runtime_tool(y: int, runtime: ToolRuntime) -> str:
+    def runtime_tool(y: int, tool_runtime: ToolRuntime) -> str:
         """Tool with runtime."""
-        return f"Runtime: {y}, call_id: {runtime.tool_call_id}"
+        return f"Runtime: {y}, call_id: {tool_runtime.tool_call_id}"
 
     agent = create_agent(
         model=FakeToolCallingModel(
@@ -362,15 +362,15 @@ async def test_tool_runtime_parallel_execution() -> None:
     execution_log = []
 
     @tool
-    async def parallel_tool_1(x: int, runtime: ToolRuntime) -> str:
+    async def parallel_tool_1(x: int, tool_runtime: ToolRuntime) -> str:
         """First parallel tool."""
-        execution_log.append(("tool_1", runtime.tool_call_id, x))
+        execution_log.append(("tool_1", tool_runtime.tool_call_id, x))
         return f"Tool1: {x}"
 
     @tool
-    async def parallel_tool_2(y: int, runtime: ToolRuntime) -> str:
+    async def parallel_tool_2(y: int, tool_runtime: ToolRuntime) -> str:
         """Second parallel tool."""
-        execution_log.append(("tool_2", runtime.tool_call_id, y))
+        execution_log.append(("tool_2", tool_runtime.tool_call_id, y))
         return f"Tool2: {y}"
 
     agent = create_agent(
@@ -409,10 +409,10 @@ def test_tool_runtime_error_handling() -> None:
     """Test error handling with ToolRuntime injection."""
 
     @tool
-    def error_tool(x: int, runtime: ToolRuntime) -> str:
+    def error_tool(x: int, tool_runtime: ToolRuntime) -> str:
         """Tool that may error."""
         # Access runtime to ensure it's injected even during errors
-        _ = runtime.tool_call_id
+        _ = tool_runtime.tool_call_id
         if x == 0:
             msg = "Cannot process zero"
             raise ValueError(msg)
@@ -421,7 +421,7 @@ def test_tool_runtime_error_handling() -> None:
     # create_agent uses default error handling which doesn't catch ValueError
     # So we need to handle this differently
     @tool
-    def safe_tool(x: int, runtime: ToolRuntime) -> str:
+    def safe_tool(x: int, tool_runtime: ToolRuntime) -> str:
         """Tool that handles errors safely."""
         try:
             if x == 0:
@@ -474,9 +474,9 @@ def test_tool_runtime_with_middleware() -> None:
             return {}
 
     @tool
-    def middleware_tool(x: int, runtime: ToolRuntime) -> str:
+    def middleware_tool(x: int, tool_runtime: ToolRuntime) -> str:
         """Tool with runtime in middleware agent."""
-        runtime_calls.append(("middleware_tool", runtime.tool_call_id))
+        runtime_calls.append(("middleware_tool", tool_runtime.tool_call_id))
         return f"Middleware result: {x}"
 
     agent = create_agent(
@@ -513,14 +513,14 @@ def test_tool_runtime_type_hints() -> None:
 
     # Use ToolRuntime without generic type hints to avoid forward reference issues
     @tool
-    def typed_runtime_tool(x: int, runtime: ToolRuntime) -> str:
+    def typed_runtime_tool(x: int, tool_runtime: ToolRuntime) -> str:
         """Tool with runtime access."""
         # Access state dict - verify we can access standard state fields
-        if isinstance(runtime.state, dict):
+        if isinstance(tool_runtime.state, dict):
             # Count messages in state
-            typed_runtime["message_count"] = len(runtime.state.get("messages", []))
+            typed_runtime["message_count"] = len(tool_runtime.state.get("messages", []))
         else:
-            typed_runtime["message_count"] = len(getattr(runtime.state, "messages", []))
+            typed_runtime["message_count"] = len(getattr(tool_runtime.state, "messages", []))
         return f"Typed: {x}"
 
     agent = create_agent(

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
@@ -8,6 +8,7 @@ from typing import (
     NoReturn,
     TypeVar,
 )
+from unittest.mock import Mock
 
 import pytest
 from langchain_core.messages import (
@@ -18,6 +19,7 @@ from langchain_core.messages import (
     ToolCall,
     ToolMessage,
 )
+from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import BaseTool, ToolException
 from langchain_core.tools import tool as dec_tool
 from langgraph.config import get_stream_writer
@@ -42,6 +44,29 @@ from .messages import _AnyIdHumanMessage, _AnyIdToolMessage
 from .model import FakeToolCallingModel
 
 pytestmark = pytest.mark.anyio
+
+
+def _create_mock_runtime(store: BaseStore | None = None) -> Mock:
+    """Create a mock Runtime object for testing ToolNode outside of graph context.
+
+    This helper is needed because ToolNode._func expects a Runtime parameter
+    which is injected by RunnableCallable from config["configurable"]["__pregel_runtime"].
+    When testing ToolNode directly (outside a graph), we need to provide this manually.
+    """
+    mock_runtime = Mock()
+    mock_runtime.store = store
+    mock_runtime.context = None
+    mock_runtime.stream_writer = lambda *args, **kwargs: None
+    return mock_runtime
+
+
+def _create_config_with_runtime(store: BaseStore | None = None) -> RunnableConfig:
+    """Create a RunnableConfig with mock Runtime for testing ToolNode.
+
+    Returns:
+        RunnableConfig with __pregel_runtime in configurable dict.
+    """
+    return {"configurable": {"__pregel_runtime": _create_mock_runtime(store)}}
 
 
 def tool1(some_val: int, some_other_val: str) -> str:
@@ -101,7 +126,8 @@ async def test_tool_node() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message: ToolMessage = result["messages"][-1]
@@ -123,7 +149,8 @@ async def test_tool_node() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message: ToolMessage = result2["messages"][-1]
@@ -145,7 +172,8 @@ async def test_tool_node() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
     tool_message: ToolMessage = result3["messages"][-1]
     assert tool_message.type == "tool"
@@ -169,7 +197,8 @@ async def test_tool_node() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
     tool_message: ToolMessage = result4["messages"][-1]
     assert tool_message.type == "tool"
@@ -185,7 +214,7 @@ async def test_tool_node_tool_call_input() -> None:
         "id": "some 0",
         "type": "tool_call",
     }
-    result = _ToolNode([tool1]).invoke([tool_call_1])
+    result = _ToolNode([tool1]).invoke([tool_call_1], config=_create_config_with_runtime())
     assert result["messages"] == [
         ToolMessage(content="1 - foo", tool_call_id="some 0", name="tool1"),
     ]
@@ -197,7 +226,9 @@ async def test_tool_node_tool_call_input() -> None:
         "id": "some 1",
         "type": "tool_call",
     }
-    result = _ToolNode([tool1]).invoke([tool_call_1, tool_call_2])
+    result = _ToolNode([tool1]).invoke(
+        [tool_call_1, tool_call_2], config=_create_config_with_runtime()
+    )
     assert result["messages"] == [
         ToolMessage(content="1 - foo", tool_call_id="some 0", name="tool1"),
         ToolMessage(content="2 - bar", tool_call_id="some 1", name="tool1"),
@@ -206,7 +237,9 @@ async def test_tool_node_tool_call_input() -> None:
     # Test with unknown tool
     tool_call_3 = tool_call_1.copy()
     tool_call_3["name"] = "tool2"
-    result = _ToolNode([tool1]).invoke([tool_call_1, tool_call_3])
+    result = _ToolNode([tool1]).invoke(
+        [tool_call_1, tool_call_3], config=_create_config_with_runtime()
+    )
     assert result["messages"] == [
         ToolMessage(content="1 - foo", tool_call_id="some 0", name="tool1"),
         ToolMessage(
@@ -234,7 +267,8 @@ def test_tool_node_error_handling_default_invocation() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     assert all(m.type == "tool" for m in result["messages"])
@@ -262,7 +296,8 @@ def test_tool_node_error_handling_default_exception() -> None:
                         ],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
 
 
@@ -305,7 +340,8 @@ async def test_tool_node_error_handling() -> None:
                         ],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
 
         assert all(m.type == "tool" for m in result_error["messages"])
@@ -350,7 +386,8 @@ async def test_tool_node_error_handling_callable() -> None:
                         ],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
         tool_message: ToolMessage = result_error["messages"][-1]
         assert tool_message.type == "tool"
@@ -381,7 +418,8 @@ async def test_tool_node_error_handling_callable() -> None:
                             ],
                         )
                     ]
-                }
+                },
+                config=_create_config_with_runtime(),
             )
         assert str(exc_info.value) == "Test error"
 
@@ -406,7 +444,8 @@ async def test_tool_node_error_handling_callable() -> None:
                             ],
                         )
                     ]
-                }
+                },
+                config=_create_config_with_runtime(),
             )
         assert str(exc_info.value) == "Test error"
 
@@ -427,7 +466,8 @@ async def test_tool_node_handle_tool_errors_false() -> None:
                         ],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
 
     assert str(exc_info.value) == "Test error"
@@ -447,7 +487,8 @@ async def test_tool_node_handle_tool_errors_false() -> None:
                         ],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
 
     assert str(exc_info.value) == "Test error"
@@ -468,7 +509,8 @@ async def test_tool_node_handle_tool_errors_false() -> None:
                         ],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
 
 
@@ -488,7 +530,8 @@ def test_tool_node_individual_tool_error_handling() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message: ToolMessage = result_individual_tool_error_handler["messages"][-1]
@@ -513,7 +556,8 @@ def test_tool_node_incorrect_tool_name() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message: ToolMessage = result_incorrect_name["messages"][-1]
@@ -549,7 +593,8 @@ def test_tool_node_node_interrupt() -> None:
                             ],
                         )
                     ]
-                }
+                },
+                config=_create_config_with_runtime(),
             )
             assert exc_info.value == "foo"
 
@@ -636,7 +681,7 @@ async def test_tool_node_command(input_type: str) -> None:
         input_ = {"messages": [AIMessage("", tool_calls=tool_calls)]}
     elif input_type == "tool_calls":
         input_ = tool_calls
-    result = _ToolNode([add, transfer_to_bob]).invoke(input_)
+    result = _ToolNode([add, transfer_to_bob]).invoke(input_, config=_create_config_with_runtime())
 
     assert result == [
         {
@@ -668,7 +713,8 @@ async def test_tool_node_command(input_type: str) -> None:
     # test sync tools
     for tool in [transfer_to_bob, custom_tool]:
         result = _ToolNode([tool]).invoke(
-            {"messages": [AIMessage("", tool_calls=[{"args": {}, "id": "1", "name": tool.name}])]}
+            {"messages": [AIMessage("", tool_calls=[{"args": {}, "id": "1", "name": tool.name}])]},
+            config=_create_config_with_runtime(),
         )
         assert result == [
             Command(
@@ -689,7 +735,8 @@ async def test_tool_node_command(input_type: str) -> None:
     # test async tools
     for tool in [async_transfer_to_bob, async_custom_tool]:
         result = await _ToolNode([tool]).ainvoke(
-            {"messages": [AIMessage("", tool_calls=[{"args": {}, "id": "1", "name": tool.name}])]}
+            {"messages": [AIMessage("", tool_calls=[{"args": {}, "id": "1", "name": tool.name}])]},
+            config=_create_config_with_runtime(),
         )
         assert result == [
             Command(
@@ -719,7 +766,8 @@ async def test_tool_node_command(input_type: str) -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
     assert result == [
         Command(
@@ -766,7 +814,8 @@ async def test_tool_node_command(input_type: str) -> None:
                         tool_calls=[{"args": {}, "id": "1", "name": "list_update_tool"}],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
 
     # test validation (missing tool message in the update for current graph)
@@ -785,7 +834,8 @@ async def test_tool_node_command(input_type: str) -> None:
                         tool_calls=[{"args": {}, "id": "1", "name": "no_update_tool"}],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
 
     # test validation (tool message with a wrong tool call ID)
@@ -810,7 +860,8 @@ async def test_tool_node_command(input_type: str) -> None:
                         ],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
 
     # test validation (missing tool message in the update for parent graph is OK)
@@ -827,7 +878,8 @@ async def test_tool_node_command(input_type: str) -> None:
                     tool_calls=[{"args": {}, "id": "1", "name": "node_update_parent_tool"}],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     ) == [Command(update={"messages": []}, graph=Command.PARENT)]
 
 
@@ -905,7 +957,8 @@ async def test_tool_node_command_list_input() -> None:
                     {"args": {}, "id": "2", "name": "transfer_to_bob"},
                 ],
             )
-        ]
+        ],
+        config=_create_config_with_runtime(),
     )
 
     assert result == [
@@ -934,7 +987,8 @@ async def test_tool_node_command_list_input() -> None:
     # test sync tools
     for tool in [transfer_to_bob, custom_tool]:
         result = _ToolNode([tool]).invoke(
-            [AIMessage("", tool_calls=[{"args": {}, "id": "1", "name": tool.name}])]
+            [AIMessage("", tool_calls=[{"args": {}, "id": "1", "name": tool.name}])],
+            config=_create_config_with_runtime(),
         )
         assert result == [
             Command(
@@ -953,7 +1007,8 @@ async def test_tool_node_command_list_input() -> None:
     # test async tools
     for tool in [async_transfer_to_bob, async_custom_tool]:
         result = await _ToolNode([tool]).ainvoke(
-            [AIMessage("", tool_calls=[{"args": {}, "id": "1", "name": tool.name}])]
+            [AIMessage("", tool_calls=[{"args": {}, "id": "1", "name": tool.name}])],
+            config=_create_config_with_runtime(),
         )
         assert result == [
             Command(
@@ -979,7 +1034,8 @@ async def test_tool_node_command_list_input() -> None:
                     {"args": {}, "id": "2", "name": "custom_transfer_to_bob"},
                 ],
             )
-        ]
+        ],
+        config=_create_config_with_runtime(),
     )
     assert result == [
         Command(
@@ -1022,7 +1078,8 @@ async def test_tool_node_command_list_input() -> None:
                     "",
                     tool_calls=[{"args": {}, "id": "1", "name": "list_update_tool"}],
                 )
-            ]
+            ],
+            config=_create_config_with_runtime(),
         )
 
     # test validation (missing tool message in the update for current graph)
@@ -1039,7 +1096,8 @@ async def test_tool_node_command_list_input() -> None:
                     "",
                     tool_calls=[{"args": {}, "id": "1", "name": "no_update_tool"}],
                 )
-            ]
+            ],
+            config=_create_config_with_runtime(),
         )
 
     # test validation (tool message with a wrong tool call ID)
@@ -1056,7 +1114,8 @@ async def test_tool_node_command_list_input() -> None:
                     "",
                     tool_calls=[{"args": {}, "id": "1", "name": "mismatching_tool_call_id_tool"}],
                 )
-            ]
+            ],
+            config=_create_config_with_runtime(),
         )
 
     # test validation (missing tool message in the update for parent graph is OK)
@@ -1071,7 +1130,8 @@ async def test_tool_node_command_list_input() -> None:
                 "",
                 tool_calls=[{"args": {}, "id": "1", "name": "node_update_parent_tool"}],
             )
-        ]
+        ],
+        config=_create_config_with_runtime(),
     ) == [Command(update=[], graph=Command.PARENT)]
 
 
@@ -1126,7 +1186,8 @@ def test_tool_node_parent_command_with_send() -> None:
     ]
 
     result = _ToolNode([transfer_to_alice, transfer_to_bob]).invoke(
-        [AIMessage("", tool_calls=tool_calls)]
+        [AIMessage("", tool_calls=tool_calls)],
+        config=_create_config_with_runtime(),
     )
 
     assert result == [
@@ -1176,7 +1237,10 @@ async def test_tool_node_command_remove_all_messages() -> None:
         "args": {},
         "id": "tool_call_123",
     }
-    result = await tool_node.ainvoke({"messages": [AIMessage(content="", tool_calls=[tool_call])]})
+    result = await tool_node.ainvoke(
+        {"messages": [AIMessage(content="", tool_calls=[tool_call])]},
+        config=_create_config_with_runtime(),
+    )
 
     assert isinstance(result, list)
     assert len(result) == 1
@@ -1252,7 +1316,9 @@ def test_tool_node_inject_state(schema_: type[T]) -> None:
             "type": "tool_call",
         }
         msg = AIMessage("hi?", tool_calls=[tool_call])
-        result = node.invoke(schema_(messages=[msg], foo="bar"))
+        result = node.invoke(
+            schema_(messages=[msg], foo="bar"), config=_create_config_with_runtime()
+        )
         tool_message = result["messages"][-1]
         assert tool_message.content == "bar", f"Failed for tool={tool_name}"
 
@@ -1262,10 +1328,10 @@ def test_tool_node_inject_state(schema_: type[T]) -> None:
                 failure_input = schema_(messages=[msg], notfoo="bar")
             if failure_input is not None:
                 with pytest.raises(KeyError):
-                    node.invoke(failure_input)
+                    node.invoke(failure_input, config=_create_config_with_runtime())
 
                 with pytest.raises(ValueError):
-                    node.invoke([msg])
+                    node.invoke([msg], config=_create_config_with_runtime())
         else:
             failure_input = None
             try:
@@ -1275,10 +1341,10 @@ def test_tool_node_inject_state(schema_: type[T]) -> None:
                 # anyway
                 pass
             if failure_input is not None:
-                messages_ = node.invoke(failure_input)
+                messages_ = node.invoke(failure_input, config=_create_config_with_runtime())
                 tool_message = messages_["messages"][-1]
                 assert "KeyError" in tool_message.content
-                tool_message = node.invoke([msg])[-1]
+                tool_message = node.invoke([msg], config=_create_config_with_runtime())[-1]
                 assert "KeyError" in tool_message.content
 
     tool_call = {
@@ -1288,11 +1354,11 @@ def test_tool_node_inject_state(schema_: type[T]) -> None:
         "type": "tool_call",
     }
     msg = AIMessage("hi?", tool_calls=[tool_call])
-    result = node.invoke(schema_(messages=[msg], foo=""))
+    result = node.invoke(schema_(messages=[msg], foo=""), config=_create_config_with_runtime())
     tool_message = result["messages"][-1]
     assert tool_message.content == "hi?"
 
-    result = node.invoke([msg])
+    result = node.invoke([msg], config=_create_config_with_runtime())
     tool_message = result[-1]
     assert tool_message.content == "hi?"
 
@@ -1339,7 +1405,9 @@ def test_tool_node_inject_store() -> None:
             "type": "tool_call",
         }
         msg = AIMessage("hi?", tool_calls=[tool_call])
-        node_result = node.invoke({"messages": [msg]}, store=store)
+        node_result = node.invoke(
+            {"messages": [msg]}, config=_create_config_with_runtime(store=store)
+        )
         graph_result = graph.invoke({"messages": [msg]})
         for result in (node_result, graph_result):
             result["messages"][-1]
@@ -1355,7 +1423,9 @@ def test_tool_node_inject_store() -> None:
         "type": "tool_call",
     }
     msg = AIMessage("hi?", tool_calls=[tool_call])
-    node_result = node.invoke({"messages": [msg], "bar": "baz"}, store=store)
+    node_result = node.invoke(
+        {"messages": [msg], "bar": "baz"}, config=_create_config_with_runtime(store=store)
+    )
     graph_result = graph.invoke({"messages": [msg], "bar": "baz"})
     for result in (node_result, graph_result):
         result["messages"][-1]
@@ -1380,7 +1450,8 @@ def test_tool_node_ensure_utf8() -> None:
     tools = [get_day_list]
     tool_calls = [ToolCall(name=get_day_list.name, args={"days": data}, id="test_id")]
     outputs: list[ToolMessage] = _ToolNode(tools).invoke(
-        [AIMessage(content="", tool_calls=tool_calls)]
+        [AIMessage(content="", tool_calls=tool_calls)],
+        config=_create_config_with_runtime(),
     )
     assert outputs[0].content == json.dumps(data, ensure_ascii=False)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
@@ -7,7 +7,6 @@ from typing import (
     Any,
     NoReturn,
     TypeVar,
-    Union,
 )
 
 import pytest

--- a/libs/langchain_v1/tests/unit_tests/tools/test_imports.py
+++ b/libs/langchain_v1/tests/unit_tests/tools/test_imports.py
@@ -7,6 +7,7 @@ EXPECTED_ALL = {
     "InjectedToolArg",
     "InjectedToolCallId",
     "ToolException",
+    "ToolRuntime",
     "tool",
 }
 

--- a/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
+++ b/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
@@ -1,10 +1,13 @@
 """Unit tests for tool call interceptor in ToolNode."""
 
 from collections.abc import Callable
+from unittest.mock import Mock
 
 import pytest
 from langchain_core.messages import AIMessage, ToolCall, ToolMessage
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
+from langgraph.store.base import BaseStore
 from langgraph.types import Command
 
 from langchain.tools.tool_node import (
@@ -13,6 +16,18 @@ from langchain.tools.tool_node import (
 )
 
 pytestmark = pytest.mark.anyio
+
+
+def _create_mock_runtime(store: BaseStore | None = None) -> Mock:
+    mock_runtime = Mock()
+    mock_runtime.store = store
+    mock_runtime.context = None
+    mock_runtime.stream_writer = lambda _: None
+    return mock_runtime
+
+
+def _create_config_with_runtime(store: BaseStore | None = None) -> RunnableConfig:
+    return {"configurable": {"__pregel_runtime": _create_mock_runtime(store)}}
 
 
 @tool
@@ -60,7 +75,8 @@ def test_passthrough_handler() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message = result["messages"][-1]
@@ -96,7 +112,8 @@ async def test_passthrough_handler_async() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message = result["messages"][-1]
@@ -135,7 +152,8 @@ def test_modify_arguments() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message = result["messages"][-1]
@@ -170,7 +188,8 @@ def test_handler_validation_no_return() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     assert isinstance(result, dict)
@@ -208,7 +227,8 @@ def test_handler_validation_no_yield() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Result contains None in messages (bad handler behavior)
@@ -248,7 +268,8 @@ def test_handler_with_handle_tool_errors_true() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message = result["messages"][-1]
@@ -295,7 +316,8 @@ def test_multiple_tool_calls_with_handler() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Handler should be called once for each tool call
@@ -359,7 +381,8 @@ async def test_handler_with_async_execution() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message = result["messages"][-1]
@@ -399,7 +422,8 @@ def test_short_circuit_with_tool_message() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message = result["messages"][-1]
@@ -439,7 +463,8 @@ async def test_short_circuit_with_tool_message_async() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message = result["messages"][-1]
@@ -487,7 +512,8 @@ def test_conditional_short_circuit() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message1 = result1["messages"][-1]
@@ -508,7 +534,8 @@ def test_conditional_short_circuit() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message2 = result2["messages"][-1]
@@ -546,7 +573,8 @@ def test_direct_return_tool_message() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message = result["messages"][-1]
@@ -586,7 +614,8 @@ async def test_direct_return_tool_message_async() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message = result["messages"][-1]
@@ -632,7 +661,8 @@ def test_conditional_direct_return() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message1 = result1["messages"][-1]
@@ -653,7 +683,8 @@ def test_conditional_direct_return() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     tool_message2 = result2["messages"][-1]
@@ -691,7 +722,8 @@ def test_handler_can_throw_exception() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Should get error message due to handle_tool_errors=True
@@ -731,7 +763,8 @@ def test_handler_throw_without_handle_errors() -> None:
                         ],
                     )
                 ]
-            }
+            },
+            config=_create_config_with_runtime(),
         )
 
 
@@ -775,7 +808,8 @@ def test_retry_middleware_with_exception() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Should succeed after 1 attempt
@@ -814,7 +848,8 @@ async def test_async_handler_can_throw_exception() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Should get error message due to handle_tool_errors=True
@@ -854,7 +889,8 @@ def test_handler_cannot_yield_multiple_tool_messages() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Should succeed - handlers can only return once
@@ -891,7 +927,8 @@ def test_handler_cannot_yield_request_after_tool_message() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Should succeed with cached result
@@ -926,7 +963,8 @@ def test_handler_can_short_circuit_with_command() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Should get Command in result list
@@ -964,7 +1002,8 @@ def test_handler_cannot_yield_multiple_commands() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Should succeed - handlers naturally return once
@@ -1002,7 +1041,8 @@ def test_handler_cannot_yield_request_after_command() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Should succeed with Command
@@ -1043,7 +1083,8 @@ def test_tool_returning_command_sent_to_handler() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Handler should have received the Command
@@ -1087,7 +1128,8 @@ def test_handler_can_modify_command_from_tool() -> None:
                     ],
                 )
             ]
-        }
+        },
+        config=_create_config_with_runtime(),
     )
 
     # Final result should be the modified Command in result list
@@ -1121,7 +1163,7 @@ def test_state_extraction_with_dict_input() -> None:
         "other_field": "value",
     }
 
-    tool_node.invoke(input_state)
+    tool_node.invoke(input_state, config=_create_config_with_runtime())
 
     # State should be the dict we passed in
     assert len(state_seen) == 1
@@ -1153,7 +1195,7 @@ def test_state_extraction_with_list_input() -> None:
         )
     ]
 
-    tool_node.invoke(input_state)
+    tool_node.invoke(input_state, config=_create_config_with_runtime())
 
     # State should be the list we passed in
     assert len(state_seen) == 1
@@ -1194,7 +1236,7 @@ def test_state_extraction_with_tool_call_with_context() -> None:
         "state": actual_state,
     }
 
-    tool_node.invoke(tool_call_with_context)
+    tool_node.invoke(tool_call_with_context, config=_create_config_with_runtime())
 
     # State should be the extracted state from ToolCallWithContext, not the wrapper
     assert len(state_seen) == 1
@@ -1236,7 +1278,7 @@ async def test_state_extraction_with_tool_call_with_context_async() -> None:
         "state": actual_state,
     }
 
-    await tool_node.ainvoke(tool_call_with_context)
+    await tool_node.ainvoke(tool_call_with_context, config=_create_config_with_runtime())
 
     # State should be the extracted state from ToolCallWithContext
     assert len(state_seen) == 1

--- a/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
+++ b/libs/langchain_v1/tests/unit_tests/tools/test_on_tool_call.py
@@ -338,7 +338,7 @@ def test_tool_call_request_dataclass() -> None:
     state: dict = {"messages": []}
     runtime = None
 
-    request = ToolCallRequest(tool_call=tool_call, tool=add, state=state, runtime=runtime)
+    request = ToolCallRequest(tool_call=tool_call, tool=add, state=state, runtime=runtime)  # type: ignore[arg-type]
 
     assert request.tool_call == tool_call
     assert request.tool == add

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1740,7 +1740,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.0.0a8"
+version = "1.0.0rc1"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1925,6 +1925,7 @@ dev = [{ name = "langchain-core", editable = "../core" }]
 lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
+    { name = "langchain", editable = "." },
     { name = "langchain-core", editable = "../core" },
     { name = "langchain-tests", editable = "../standard-tests" },
     { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },


### PR DESCRIPTION
Goal here is 2 fold

1. Improved devx for injecting args into tools
2. Support runtime injection for Python 3.10 async

One consequence of this PR is that `ToolNode` now expects `config` available with `runtime`, which only happens in LangGraph execution contexts. Hence the config patch for tests.

Are we ok reserving `tool_runtime`?

before, eek:
```py
from langchain.agents import create_agent
from langchain.tools import tool, InjectedState, InjectedStore
from langgraph.runtime import get_runtime
from typing_extensions import Annotated
from langgraph.store.base import BaseStore

@tool
def do_something(
    arg: int,
    state: Annotated[dict, InjectedState],
    store: Annotated[BaseStore, InjectedStore],
) -> None:
    """does something."""
    print(state)
    print(store)
    print(get_runtime().context)
    ...
```

after, woo!
```py
from langchain.agents import create_agent
from langchain.tools import tool, ToolRuntime

@tool
def do_something_better(
    arg: int,
    tool_runtime: ToolRuntime,
) -> None:
    """does something better."""
    print(tool_runtime.state)
    print(tool_runtime.store)
    print(tool_runtime.context)
    ...
```

```python
@dataclass
class ToolRuntime(InjectedToolArg, Generic[StateT, ContextT]):
    state: StateT
    context: ContextT
    config: RunnableConfig
    tool_call_id: str
    stream_writer: StreamWriter
    context: ContextT
    store: BaseStore | None