### PR TITLE
chore(langchain_v1): adding back `state_schema` to `create_agent`

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
@@ -34,14 +34,14 @@ def test_tool_runtime_basic_injection() -> None:
     injected_data = {}
 
     @tool
-    def runtime_tool(x: int, tool_runtime: ToolRuntime) -> str:
+    def runtime_tool(x: int, runtime: ToolRuntime) -> str:
         """Tool that accesses runtime context."""
-        injected_data["state"] = tool_runtime.state
-        injected_data["tool_call_id"] = tool_runtime.tool_call_id
-        injected_data["config"] = tool_runtime.config
-        injected_data["context"] = tool_runtime.context
-        injected_data["store"] = tool_runtime.store
-        injected_data["stream_writer"] = tool_runtime.stream_writer
+        injected_data["state"] = runtime.state
+        injected_data["tool_call_id"] = runtime.tool_call_id
+        injected_data["config"] = runtime.config
+        injected_data["context"] = runtime.context
+        injected_data["store"] = runtime.store
+        injected_data["stream_writer"] = runtime.stream_writer
         return f"Processed {x}"
 
     agent = create_agent(
@@ -80,11 +80,11 @@ async def test_tool_runtime_async_injection() -> None:
     injected_data = {}
 
     @tool
-    async def async_runtime_tool(x: int, tool_runtime: ToolRuntime) -> str:
+    async def async_runtime_tool(x: int, runtime: ToolRuntime) -> str:
         """Async tool that accesses runtime context."""
-        injected_data["state"] = tool_runtime.state
-        injected_data["tool_call_id"] = tool_runtime.tool_call_id
-        injected_data["config"] = tool_runtime.config
+        injected_data["state"] = runtime.state
+        injected_data["tool_call_id"] = runtime.tool_call_id
+        injected_data["config"] = runtime.config
         return f"Async processed {x}"
 
     agent = create_agent(
@@ -118,9 +118,9 @@ def test_tool_runtime_state_access() -> None:
     """Test that tools can access and use state via ToolRuntime."""
 
     @tool
-    def state_aware_tool(query: str, tool_runtime: ToolRuntime) -> str:
+    def state_aware_tool(query: str, runtime: ToolRuntime) -> str:
         """Tool that uses state to provide context-aware responses."""
-        messages = tool_runtime.state.get("messages", [])
+        messages = runtime.state.get("messages", [])
         msg_count = len(messages)
         return f"Query: {query}, Message count: {msg_count}"
 
@@ -147,22 +147,22 @@ def test_tool_runtime_state_access() -> None:
 def test_tool_runtime_with_store() -> None:
     """Test ToolRuntime provides access to store."""
     # Note: create_agent doesn't currently expose a store parameter,
-    # so tool_runtime.store will be None in this test.
+    # so runtime.store will be None in this test.
     # This test demonstrates the runtime injection works correctly.
 
     @tool
-    def store_tool(key: str, value: str, tool_runtime: ToolRuntime) -> str:
+    def store_tool(key: str, value: str, runtime: ToolRuntime) -> str:
         """Tool that uses store."""
-        if tool_runtime.store is None:
+        if runtime.store is None:
             return f"No store (key={key}, value={value})"
-        tool_runtime.store.put(("test",), key, {"data": value})
+        runtime.store.put(("test",), key, {"data": value})
         return f"Stored {key}={value}"
 
     @tool
-    def check_runtime_tool(tool_runtime: ToolRuntime) -> str:
+    def check_runtime_tool(runtime: ToolRuntime) -> str:
         """Tool that checks runtime availability."""
-        has_store = tool_runtime.store is not None
-        has_context = tool_runtime.context is not None
+        has_store = runtime.store is not None
+        has_context = runtime.context is not None
         return f"Runtime: store={has_store}, context={has_context}"
 
     agent = create_agent(
@@ -195,15 +195,15 @@ def test_tool_runtime_with_multiple_tools() -> None:
     call_log = []
 
     @tool
-    def tool_a(x: int, tool_runtime: ToolRuntime) -> str:
+    def tool_a(x: int, runtime: ToolRuntime) -> str:
         """First tool."""
-        call_log.append(("tool_a", tool_runtime.tool_call_id, x))
+        call_log.append(("tool_a", runtime.tool_call_id, x))
         return f"A: {x}"
 
     @tool
-    def tool_b(y: str, tool_runtime: ToolRuntime) -> str:
+    def tool_b(y: str, runtime: ToolRuntime) -> str:
         """Second tool."""
-        call_log.append(("tool_b", tool_runtime.tool_call_id, y))
+        call_log.append(("tool_b", runtime.tool_call_id, y))
         return f"B: {y}"
 
     agent = create_agent(
@@ -242,15 +242,15 @@ def test_tool_runtime_config_access() -> None:
     config_data = {}
 
     @tool
-    def config_tool(x: int, tool_runtime: ToolRuntime) -> str:
+    def config_tool(x: int, runtime: ToolRuntime) -> str:
         """Tool that accesses config."""
-        config_data["config_exists"] = tool_runtime.config is not None
+        config_data["config_exists"] = runtime.config is not None
         config_data["has_configurable"] = (
-            "configurable" in tool_runtime.config if tool_runtime.config else False
+            "configurable" in runtime.config if runtime.config else False
         )
         # Config may have run_id or other fields depending on execution context
-        if tool_runtime.config:
-            config_data["config_keys"] = list(tool_runtime.config.keys())
+        if runtime.config:
+            config_data["config_keys"] = list(runtime.config.keys())
         return f"Config accessed for {x}"
 
     agent = create_agent(
@@ -288,9 +288,9 @@ def test_tool_runtime_with_custom_state() -> None:
     runtime_state = {}
 
     @tool
-    def custom_state_tool(x: int, tool_runtime: ToolRuntime) -> str:
+    def custom_state_tool(x: int, runtime: ToolRuntime) -> str:
         """Tool that accesses custom state."""
-        runtime_state["custom_field"] = tool_runtime.state.get("custom_field", "not found")
+        runtime_state["custom_field"] = runtime.state.get("custom_field", "not found")
         return f"Custom: {x}"
 
     class CustomMiddleware(AgentMiddleware):
@@ -330,9 +330,9 @@ def test_tool_runtime_no_runtime_parameter() -> None:
         return f"Regular: {x}"
 
     @tool
-    def runtime_tool(y: int, tool_runtime: ToolRuntime) -> str:
+    def runtime_tool(y: int, runtime: ToolRuntime) -> str:
         """Tool with runtime."""
-        return f"Runtime: {y}, call_id: {tool_runtime.tool_call_id}"
+        return f"Runtime: {y}, call_id: {runtime.tool_call_id}"
 
     agent = create_agent(
         model=FakeToolCallingModel(
@@ -362,15 +362,15 @@ async def test_tool_runtime_parallel_execution() -> None:
     execution_log = []
 
     @tool
-    async def parallel_tool_1(x: int, tool_runtime: ToolRuntime) -> str:
+    async def parallel_tool_1(x: int, runtime: ToolRuntime) -> str:
         """First parallel tool."""
-        execution_log.append(("tool_1", tool_runtime.tool_call_id, x))
+        execution_log.append(("tool_1", runtime.tool_call_id, x))
         return f"Tool1: {x}"
 
     @tool
-    async def parallel_tool_2(y: int, tool_runtime: ToolRuntime) -> str:
+    async def parallel_tool_2(y: int, runtime: ToolRuntime) -> str:
         """Second parallel tool."""
-        execution_log.append(("tool_2", tool_runtime.tool_call_id, y))
+        execution_log.append(("tool_2", runtime.tool_call_id, y))
         return f"Tool2: {y}"
 
     agent = create_agent(
@@ -409,10 +409,10 @@ def test_tool_runtime_error_handling() -> None:
     """Test error handling with ToolRuntime injection."""
 
     @tool
-    def error_tool(x: int, tool_runtime: ToolRuntime) -> str:
+    def error_tool(x: int, runtime: ToolRuntime) -> str:
         """Tool that may error."""
         # Access runtime to ensure it's injected even during errors
-        _ = tool_runtime.tool_call_id
+        _ = runtime.tool_call_id
         if x == 0:
             msg = "Cannot process zero"
             raise ValueError(msg)
@@ -421,7 +421,7 @@ def test_tool_runtime_error_handling() -> None:
     # create_agent uses default error handling which doesn't catch ValueError
     # So we need to handle this differently
     @tool
-    def safe_tool(x: int, tool_runtime: ToolRuntime) -> str:
+    def safe_tool(x: int, runtime: ToolRuntime) -> str:
         """Tool that handles errors safely."""
         try:
             if x == 0:
@@ -474,9 +474,9 @@ def test_tool_runtime_with_middleware() -> None:
             return {}
 
     @tool
-    def middleware_tool(x: int, tool_runtime: ToolRuntime) -> str:
+    def middleware_tool(x: int, runtime: ToolRuntime) -> str:
         """Tool with runtime in middleware agent."""
-        runtime_calls.append(("middleware_tool", tool_runtime.tool_call_id))
+        runtime_calls.append(("middleware_tool", runtime.tool_call_id))
         return f"Middleware result: {x}"
 
     agent = create_agent(
@@ -513,14 +513,14 @@ def test_tool_runtime_type_hints() -> None:
 
     # Use ToolRuntime without generic type hints to avoid forward reference issues
     @tool
-    def typed_runtime_tool(x: int, tool_runtime: ToolRuntime) -> str:
+    def typed_runtime_tool(x: int, runtime: ToolRuntime) -> str:
         """Tool with runtime access."""
         # Access state dict - verify we can access standard state fields
-        if isinstance(tool_runtime.state, dict):
+        if isinstance(runtime.state, dict):
             # Count messages in state
-            typed_runtime["message_count"] = len(tool_runtime.state.get("messages", []))
+            typed_runtime["message_count"] = len(runtime.state.get("messages", []))
         else:
-            typed_runtime["message_count"] = len(getattr(tool_runtime.state, "messages", []))
+            typed_runtime["message_count"] = len(getattr(runtime.state, "messages", []))
         return f"Typed: {x}"
 
     agent = create_agent(

--- a/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
@@ -1,0 +1,262 @@
+"""Test state_schema parameter in create_agent.
+
+This module tests that the state_schema parameter allows users to extend
+AgentState without needing to create custom middleware.
+"""
+
+from __future__ import annotations
+
+from typing_extensions import TypedDict
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.tools import tool
+
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentState
+from langchain.tools import ToolRuntime
+
+from .model import FakeToolCallingModel
+
+
+def test_state_schema_basic() -> None:
+    """Test that state_schema parameter works with a simple extension of AgentState."""
+
+    class CustomState(AgentState):
+        custom_field: str
+
+    captured_state = {}
+
+    @tool
+    def custom_state_tool(x: int) -> str:
+        """Simple tool."""
+        return f"Processed {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 42}, "id": "call_123", "name": "custom_state_tool"}],
+                [],
+            ]
+        ),
+        tools=[custom_state_tool],
+        system_prompt="You are a helpful assistant.",
+        state_schema=CustomState,
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test")], "custom_field": "test_value"})
+
+    # Verify the custom field was preserved in the state
+    assert result["custom_field"] == "test_value"
+    assert len(result["messages"]) == 4
+
+
+def test_state_schema_with_tool_runtime() -> None:
+    """Test that state_schema works with ToolRuntime to access custom fields."""
+
+    class ExtendedState(AgentState):
+        counter: int
+
+    runtime_data = {}
+
+    @tool
+    def counter_tool(x: int, tool_runtime: ToolRuntime) -> str:
+        """Tool that accesses custom state field."""
+        runtime_data["counter"] = tool_runtime.state.get("counter", 0)
+        return f"Counter is {runtime_data['counter']}, x is {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 10}, "id": "call_1", "name": "counter_tool"}],
+                [],
+            ]
+        ),
+        tools=[counter_tool],
+        system_prompt="You are a helpful assistant.",
+        state_schema=ExtendedState,
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test")], "counter": 5})
+
+    # Verify custom field was accessible via ToolRuntime
+    assert runtime_data["counter"] == 5
+    assert "Counter is 5" in result["messages"][2].content
+
+
+def test_state_schema_multiple_custom_fields() -> None:
+    """Test state_schema with multiple custom fields."""
+
+    class MultiFieldState(AgentState):
+        user_id: str
+        session_id: str
+        context: str
+
+    @tool
+    def simple_tool(x: int) -> str:
+        """Simple tool."""
+        return f"Result: {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 1}, "id": "call_1", "name": "simple_tool"}],
+                [],
+            ]
+        ),
+        tools=[simple_tool],
+        state_schema=MultiFieldState,
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage("Test")],
+            "user_id": "user_123",
+            "session_id": "session_456",
+            "context": "test_context",
+        }
+    )
+
+    # Verify all custom fields are preserved
+    assert result["user_id"] == "user_123"
+    assert result["session_id"] == "session_456"
+    assert result["context"] == "test_context"
+
+
+def test_state_schema_with_middleware() -> None:
+    """Test that state_schema works alongside middleware state schemas."""
+    from typing import Any
+
+    from langchain.agents.middleware.types import AgentMiddleware
+
+    class UserState(AgentState):
+        user_name: str
+
+    class MiddlewareState(AgentState):
+        middleware_data: str
+
+    middleware_calls = []
+
+    class TestMiddleware(AgentMiddleware):
+        state_schema = MiddlewareState
+
+        def before_model(self, state, runtime) -> dict[str, Any]:
+            middleware_calls.append(state.get("middleware_data", ""))
+            return {}
+
+    @tool
+    def state_tool(x: int) -> str:
+        """Simple tool."""
+        return f"x={x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 5}, "id": "call_1", "name": "state_tool"}],
+                [],
+            ]
+        ),
+        tools=[state_tool],
+        state_schema=UserState,
+        middleware=[TestMiddleware()],
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage("Test")],
+            "user_name": "Alice",
+            "middleware_data": "test_data",
+        }
+    )
+
+    # Verify both state schemas were merged
+    assert result["user_name"] == "Alice"
+    assert result["middleware_data"] == "test_data"
+    assert "test_data" in middleware_calls
+
+
+def test_state_schema_none_uses_default() -> None:
+    """Test that when state_schema is None, the default AgentState is used."""
+
+    @tool
+    def basic_tool(x: int) -> str:
+        """Basic tool."""
+        return f"x={x}"
+
+    # Create agent without state_schema (should work as before)
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 1}, "id": "call_1", "name": "basic_tool"}],
+                [],
+            ]
+        ),
+        tools=[basic_tool],
+        state_schema=None,  # Explicitly pass None
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Test")]})
+
+    # Verify basic functionality works
+    assert len(result["messages"]) == 4
+    assert "x=1" in result["messages"][2].content
+
+
+async def test_state_schema_async() -> None:
+    """Test that state_schema works with async agents."""
+
+    class AsyncState(AgentState):
+        async_field: str
+
+    @tool
+    async def async_tool(x: int) -> str:
+        """Async tool."""
+        return f"Async: {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 99}, "id": "async_call", "name": "async_tool"}],
+                [],
+            ]
+        ),
+        tools=[async_tool],
+        state_schema=AsyncState,
+    )
+
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage("Test async")], "async_field": "async_value"}
+    )
+
+    # Verify custom field was preserved
+    assert result["async_field"] == "async_value"
+    assert "Async: 99" in result["messages"][2].content
+
+
+def test_state_schema_preserves_required_fields() -> None:
+    """Test that state_schema preserves all standard AgentState fields."""
+
+    class ExtendedAgentState(AgentState):
+        extra_data: str
+
+    @tool
+    def check_tool(x: int) -> str:
+        """Tool that returns a value."""
+        return f"Result: {x}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {"x": 1}, "id": "call_1", "name": "check_tool"}],
+                [],
+            ]
+        ),
+        tools=[check_tool],
+        state_schema=ExtendedAgentState,
+    )
+
+    # Input should have messages (required) and extra_data
+    result = agent.invoke({"messages": [HumanMessage("Test")], "extra_data": "extra_value"})
+
+    # Output should have messages and extra_data preserved
+    assert len(result["messages"]) == 4
+    assert result["extra_data"] == "extra_value"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
@@ -6,52 +6,66 @@ AgentState without needing to create custom middleware.
 
 from __future__ import annotations
 
-from typing_extensions import TypedDict
+from typing import Any
 
-from langchain_core.messages import AIMessage, HumanMessage
+import pytest
+
+from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 
 from langchain.agents import create_agent
-from langchain.agents.middleware.types import AgentState
+from langchain.agents.middleware.types import AgentMiddleware, AgentState
 from langchain.tools import ToolRuntime
 
 from .model import FakeToolCallingModel
 
 
-def test_state_schema_basic() -> None:
-    """Test that state_schema parameter works with a simple extension of AgentState."""
+@tool
+def simple_tool(x: int) -> str:
+    """Simple tool for basic tests."""
+    return f"Result: {x}"
 
-    class CustomState(AgentState):
-        custom_field: str
 
-    captured_state = {}
-
-    @tool
-    def custom_state_tool(x: int) -> str:
-        """Simple tool."""
-        return f"Processed {x}"
+@pytest.mark.parametrize(
+    ("state_fields", "input_values", "expected_in_output"),
+    [
+        # Single custom field
+        ({"custom_field": str}, {"custom_field": "test_value"}, {"custom_field": "test_value"}),
+        # Multiple custom fields
+        (
+            {"user_id": str, "session_id": str, "context": str},
+            {"user_id": "user_123", "session_id": "session_456", "context": "test_ctx"},
+            {"user_id": "user_123", "session_id": "session_456", "context": "test_ctx"},
+        ),
+    ],
+)
+def test_state_schema_field_preservation(
+    state_fields: dict[str, type],
+    input_values: dict[str, Any],
+    expected_in_output: dict[str, Any],
+) -> None:
+    """Test that custom state fields are preserved through agent execution."""
+    # Create dynamic state class with specified fields
+    CustomState = type("CustomState", (AgentState,), {"__annotations__": state_fields})
 
     agent = create_agent(
         model=FakeToolCallingModel(
-            tool_calls=[
-                [{"args": {"x": 42}, "id": "call_123", "name": "custom_state_tool"}],
-                [],
-            ]
+            tool_calls=[[{"args": {"x": 1}, "id": "call_1", "name": "simple_tool"}], []]
         ),
-        tools=[custom_state_tool],
-        system_prompt="You are a helpful assistant.",
+        tools=[simple_tool],
         state_schema=CustomState,
     )
 
-    result = agent.invoke({"messages": [HumanMessage("Test")], "custom_field": "test_value"})
+    result = agent.invoke({"messages": [HumanMessage("Test")], **input_values})
 
-    # Verify the custom field was preserved in the state
-    assert result["custom_field"] == "test_value"
+    # Verify all expected fields are preserved and messages were added
+    for key, value in expected_in_output.items():
+        assert result[key] == value
     assert len(result["messages"]) == 4
 
 
 def test_state_schema_with_tool_runtime() -> None:
-    """Test that state_schema works with ToolRuntime to access custom fields."""
+    """Test that custom state fields are accessible via ToolRuntime."""
 
     class ExtendedState(AgentState):
         counter: int
@@ -61,72 +75,25 @@ def test_state_schema_with_tool_runtime() -> None:
     @tool
     def counter_tool(x: int, runtime: ToolRuntime) -> str:
         """Tool that accesses custom state field."""
-        runtime_data["counter"] = runtime.state.get("counter", 0)
+        runtime_data["counter"] = runtime.state["counter"]
         return f"Counter is {runtime_data['counter']}, x is {x}"
 
     agent = create_agent(
         model=FakeToolCallingModel(
-            tool_calls=[
-                [{"args": {"x": 10}, "id": "call_1", "name": "counter_tool"}],
-                [],
-            ]
+            tool_calls=[[{"args": {"x": 10}, "id": "call_1", "name": "counter_tool"}], []]
         ),
         tools=[counter_tool],
-        system_prompt="You are a helpful assistant.",
         state_schema=ExtendedState,
     )
 
     result = agent.invoke({"messages": [HumanMessage("Test")], "counter": 5})
 
-    # Verify custom field was accessible via ToolRuntime
     assert runtime_data["counter"] == 5
     assert "Counter is 5" in result["messages"][2].content
 
 
-def test_state_schema_multiple_custom_fields() -> None:
-    """Test state_schema with multiple custom fields."""
-
-    class MultiFieldState(AgentState):
-        user_id: str
-        session_id: str
-        context: str
-
-    @tool
-    def simple_tool(x: int) -> str:
-        """Simple tool."""
-        return f"Result: {x}"
-
-    agent = create_agent(
-        model=FakeToolCallingModel(
-            tool_calls=[
-                [{"args": {"x": 1}, "id": "call_1", "name": "simple_tool"}],
-                [],
-            ]
-        ),
-        tools=[simple_tool],
-        state_schema=MultiFieldState,
-    )
-
-    result = agent.invoke(
-        {
-            "messages": [HumanMessage("Test")],
-            "user_id": "user_123",
-            "session_id": "session_456",
-            "context": "test_context",
-        }
-    )
-
-    # Verify all custom fields are preserved
-    assert result["user_id"] == "user_123"
-    assert result["session_id"] == "session_456"
-    assert result["context"] == "test_context"
-
-
 def test_state_schema_with_middleware() -> None:
-    """Test that state_schema works alongside middleware state schemas."""
-    from typing import Any
-
-    from langchain.agents.middleware.types import AgentMiddleware
+    """Test that state_schema merges with middleware state schemas."""
 
     class UserState(AgentState):
         user_name: str
@@ -143,19 +110,11 @@ def test_state_schema_with_middleware() -> None:
             middleware_calls.append(state.get("middleware_data", ""))
             return {}
 
-    @tool
-    def state_tool(x: int) -> str:
-        """Simple tool."""
-        return f"x={x}"
-
     agent = create_agent(
         model=FakeToolCallingModel(
-            tool_calls=[
-                [{"args": {"x": 5}, "id": "call_1", "name": "state_tool"}],
-                [],
-            ]
+            tool_calls=[[{"args": {"x": 5}, "id": "call_1", "name": "simple_tool"}], []]
         ),
-        tools=[state_tool],
+        tools=[simple_tool],
         state_schema=UserState,
         middleware=[TestMiddleware()],
     )
@@ -168,37 +127,25 @@ def test_state_schema_with_middleware() -> None:
         }
     )
 
-    # Verify both state schemas were merged
     assert result["user_name"] == "Alice"
     assert result["middleware_data"] == "test_data"
     assert "test_data" in middleware_calls
 
 
 def test_state_schema_none_uses_default() -> None:
-    """Test that when state_schema is None, the default AgentState is used."""
-
-    @tool
-    def basic_tool(x: int) -> str:
-        """Basic tool."""
-        return f"x={x}"
-
-    # Create agent without state_schema (should work as before)
+    """Test that state_schema=None uses default AgentState."""
     agent = create_agent(
         model=FakeToolCallingModel(
-            tool_calls=[
-                [{"args": {"x": 1}, "id": "call_1", "name": "basic_tool"}],
-                [],
-            ]
+            tool_calls=[[{"args": {"x": 1}, "id": "call_1", "name": "simple_tool"}], []]
         ),
-        tools=[basic_tool],
-        state_schema=None,  # Explicitly pass None
+        tools=[simple_tool],
+        state_schema=None,
     )
 
     result = agent.invoke({"messages": [HumanMessage("Test")]})
 
-    # Verify basic functionality works
     assert len(result["messages"]) == 4
-    assert "x=1" in result["messages"][2].content
+    assert "Result: 1" in result["messages"][2].content
 
 
 async def test_state_schema_async() -> None:
@@ -214,10 +161,7 @@ async def test_state_schema_async() -> None:
 
     agent = create_agent(
         model=FakeToolCallingModel(
-            tool_calls=[
-                [{"args": {"x": 99}, "id": "async_call", "name": "async_tool"}],
-                [],
-            ]
+            tool_calls=[[{"args": {"x": 99}, "id": "call_1", "name": "async_tool"}], []]
         ),
         tools=[async_tool],
         state_schema=AsyncState,
@@ -227,36 +171,5 @@ async def test_state_schema_async() -> None:
         {"messages": [HumanMessage("Test async")], "async_field": "async_value"}
     )
 
-    # Verify custom field was preserved
     assert result["async_field"] == "async_value"
     assert "Async: 99" in result["messages"][2].content
-
-
-def test_state_schema_preserves_required_fields() -> None:
-    """Test that state_schema preserves all standard AgentState fields."""
-
-    class ExtendedAgentState(AgentState):
-        extra_data: str
-
-    @tool
-    def check_tool(x: int) -> str:
-        """Tool that returns a value."""
-        return f"Result: {x}"
-
-    agent = create_agent(
-        model=FakeToolCallingModel(
-            tool_calls=[
-                [{"args": {"x": 1}, "id": "call_1", "name": "check_tool"}],
-                [],
-            ]
-        ),
-        tools=[check_tool],
-        state_schema=ExtendedAgentState,
-    )
-
-    # Input should have messages (required) and extra_data
-    result = agent.invoke({"messages": [HumanMessage("Test")], "extra_data": "extra_value"})
-
-    # Output should have messages and extra_data preserved
-    assert len(result["messages"]) == 4
-    assert result["extra_data"] == "extra_value"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
@@ -59,9 +59,9 @@ def test_state_schema_with_tool_runtime() -> None:
     runtime_data = {}
 
     @tool
-    def counter_tool(x: int, tool_runtime: ToolRuntime) -> str:
+    def counter_tool(x: int, runtime: ToolRuntime) -> str:
         """Tool that accesses custom state field."""
-        runtime_data["counter"] = tool_runtime.state.get("counter", 0)
+        runtime_data["counter"] = runtime.state.get("counter", 0)
         return f"Counter is {runtime_data['counter']}, x is {x}"
 
     agent = create_agent(


### PR DESCRIPTION
To make migration easier, things are more backwards compat

Very minimal footprint here

Will need to upgrade migration guide and other docs w/ this change