### PR TITLE
refactor: replace deprecated type hints from List to built-in modern list for consistency

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -19,7 +19,7 @@ import os
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, List, Set
+from typing import Dict, Set
 
 import tomllib
 from get_min_versions import get_min_version_from_toml
@@ -112,7 +112,7 @@ def dependents_graph() -> dict:
     return dependents
 
 
-def add_dependents(dirs_to_eval: Set[str], dependents: dict) -> List[str]:
+def add_dependents(dirs_to_eval: Set[str], dependents: dict) -> list[str]:
     updated = set()
     for dir_ in dirs_to_eval:
         # handle core manually because it has so many dependents
@@ -125,7 +125,7 @@ def add_dependents(dirs_to_eval: Set[str], dependents: dict) -> List[str]:
     return list(updated)
 
 
-def _get_configs_for_single_dir(job: str, dir_: str) -> List[Dict[str, str]]:
+def _get_configs_for_single_dir(job: str, dir_: str) -> list[Dict[str, str]]:
     if job == "test-pydantic":
         return _get_pydantic_test_configs(dir_)
 
@@ -153,7 +153,7 @@ def _get_configs_for_single_dir(job: str, dir_: str) -> List[Dict[str, str]]:
 
 def _get_pydantic_test_configs(
     dir_: str, *, python_version: str = "3.11"
-) -> List[Dict[str, str]]:
+) -> list[Dict[str, str]]:
     with open("./libs/core/uv.lock", "rb") as f:
         core_uv_lock_data = tomllib.load(f)
     for package in core_uv_lock_data["package"]:
@@ -208,7 +208,7 @@ def _get_pydantic_test_configs(
 
 def _get_configs_for_multi_dirs(
     job: str, dirs_to_run: Dict[str, Set[str]], dependents: dict
-) -> List[Dict[str, str]]:
+) -> list[Dict[str, str]]:
     if job == "lint":
         dirs = add_dependents(
             dirs_to_run["lint"] | dirs_to_run["test"] | dirs_to_run["extended-test"],

--- a/.github/scripts/get_min_versions.py
+++ b/.github/scripts/get_min_versions.py
@@ -10,7 +10,6 @@ else:
     import tomli as tomllib
 
 import re
-from typing import List
 
 import requests
 from packaging.requirements import Requirement
@@ -34,7 +33,7 @@ SKIP_IF_PULL_REQUEST = [
 ]
 
 
-def get_pypi_versions(package_name: str) -> List[str]:
+def get_pypi_versions(package_name: str) -> list[str]:
     """Fetch all available versions for a package from PyPI.
 
     Args:

--- a/libs/cli/langchain_cli/integration_template/integration_template/chat_models.py
+++ b/libs/cli/langchain_cli/integration_template/integration_template/chat_models.py
@@ -1,6 +1,6 @@
 """__ModuleName__ chat models."""
 
-from typing import Any, Dict, Iterator, List
+from typing import Any, Dict, Iterator
 
 from langchain_core.callbacks import (
     CallbackManagerForLLMRun,
@@ -299,7 +299,7 @@ class Chat__ModuleName__(BaseChatModel):
 
     def _generate(
         self,
-        messages: List[BaseMessage],
+        messages: list[BaseMessage],
         stop: list[str] | None = None,
         run_manager: CallbackManagerForLLMRun | None = None,
         **kwargs: Any,
@@ -345,7 +345,7 @@ class Chat__ModuleName__(BaseChatModel):
 
     def _stream(
         self,
-        messages: List[BaseMessage],
+        messages: list[BaseMessage],
         stop: list[str] | None = None,
         run_manager: CallbackManagerForLLMRun | None = None,
         **kwargs: Any,
@@ -407,7 +407,7 @@ class Chat__ModuleName__(BaseChatModel):
     # TODO: Implement if Chat__ModuleName__ supports async streaming. Otherwise delete.
     # async def _astream(
     #     self,
-    #     messages: List[BaseMessage],
+    #     messages: list[BaseMessage],
     #     stop: list[str] | None = None,
     #     run_manager: AsyncCallbackManagerForLLMRun | None = None,
     #     **kwargs: Any,
@@ -416,7 +416,7 @@ class Chat__ModuleName__(BaseChatModel):
     # TODO: Implement if Chat__ModuleName__ supports async generation. Otherwise delete.
     # async def _agenerate(
     #     self,
-    #     messages: List[BaseMessage],
+    #     messages: list[BaseMessage],
     #     stop: list[str] | None = None,
     #     run_manager: AsyncCallbackManagerForLLMRun | None = None,
     #     **kwargs: Any,

--- a/libs/cli/langchain_cli/integration_template/integration_template/embeddings.py
+++ b/libs/cli/langchain_cli/integration_template/integration_template/embeddings.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from langchain_core.embeddings import Embeddings
 
 
@@ -74,11 +72,11 @@ class __ModuleName__Embeddings(Embeddings):
     def __init__(self, model: str):
         self.model = model
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
         """Embed search docs."""
         return [[0.5, 0.6, 0.7] for _ in texts]
 
-    def embed_query(self, text: str) -> List[float]:
+    def embed_query(self, text: str) -> list[float]:
         """Embed query text."""
         return self.embed_documents([text])[0]
 
@@ -87,10 +85,10 @@ class __ModuleName__Embeddings(Embeddings):
     # use the default implementation, which calls the sync
     # version in an async executor:
 
-    # async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+    # async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
     #     """Asynchronous Embed search docs."""
     #     ...
 
-    # async def aembed_query(self, text: str) -> List[float]:
+    # async def aembed_query(self, text: str) -> list[float]:
     #     """Asynchronous Embed query text."""
     #     ...

--- a/libs/cli/langchain_cli/integration_template/integration_template/retrievers.py
+++ b/libs/cli/langchain_cli/integration_template/integration_template/retrievers.py
@@ -1,6 +1,6 @@
 """__ModuleName__ retrievers."""
 
-from typing import Any, List
+from typing import Any
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
@@ -91,7 +91,7 @@ class __ModuleName__Retriever(BaseRetriever):
     # TODO: This method must be implemented to retrieve documents.
     def _get_relevant_documents(
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any
-    ) -> List[Document]:
+    ) -> list[Document]:
         k = kwargs.get("k", self.k)
         return [
             Document(page_content=f"Result {i} for query: {query}") for i in range(k)
@@ -104,4 +104,4 @@ class __ModuleName__Retriever(BaseRetriever):
     #     *,
     #     run_manager: AsyncCallbackManagerForRetrieverRun,
     #     **kwargs: Any,
-    # ) -> List[Document]: ...
+    # ) -> list[Document]: ...

--- a/libs/cli/langchain_cli/integration_template/integration_template/toolkits.py
+++ b/libs/cli/langchain_cli/integration_template/integration_template/toolkits.py
@@ -1,7 +1,5 @@
 """__ModuleName__ toolkits."""
 
-from typing import List
-
 from langchain_core.tools import BaseTool, BaseToolkit
 
 
@@ -69,5 +67,5 @@ class __ModuleName__Toolkit(BaseToolkit):
     """
 
     # TODO: This method must be implemented to list tools.
-    def get_tools(self) -> List[BaseTool]:
+    def get_tools(self) -> list[BaseTool]:
         raise NotImplementedError()

--- a/libs/cli/langchain_cli/integration_template/integration_template/vectorstores.py
+++ b/libs/cli/langchain_cli/integration_template/integration_template/vectorstores.py
@@ -7,7 +7,6 @@ from typing import (
     Any,
     Callable,
     Iterator,
-    List,
     Sequence,
     Tuple,
     Type,
@@ -169,7 +168,7 @@ class __ModuleName__VectorStore(VectorStore):
     @classmethod
     def from_texts(
         cls: Type[__ModuleName__VectorStore],
-        texts: List[str],
+        texts: list[str],
         embedding: Embeddings,
         metadatas: list[dict] | None = None,
         **kwargs: Any,
@@ -184,7 +183,7 @@ class __ModuleName__VectorStore(VectorStore):
     # @classmethod
     # async def afrom_texts(
     #     cls: Type[VST],
-    #     texts: List[str],
+    #     texts: list[str],
     #     embedding: Embeddings,
     #     metadatas: list[dict] | None = None,
     #     **kwargs: Any,
@@ -199,10 +198,10 @@ class __ModuleName__VectorStore(VectorStore):
 
     def add_documents(
         self,
-        documents: List[Document],
+        documents: list[Document],
         ids: list[str] | None = None,
         **kwargs: Any,
-    ) -> List[str]:
+    ) -> list[str]:
         """Add documents to the store."""
         texts = [doc.page_content for doc in documents]
         vectors = self.embedding.embed_documents(texts)
@@ -236,10 +235,10 @@ class __ModuleName__VectorStore(VectorStore):
     # optional: add custom async implementations
     # async def aadd_documents(
     #     self,
-    #     documents: List[Document],
+    #     documents: list[Document],
     #     ids: list[str] | None = None,
     #     **kwargs: Any,
-    # ) -> List[str]:
+    # ) -> list[str]:
     #     raise NotImplementedError
 
     def delete(self, ids: list[str] | None = None, **kwargs: Any) -> None:
@@ -284,11 +283,11 @@ class __ModuleName__VectorStore(VectorStore):
     # storage. It is optional and not a part of the vector store interface.
     def _similarity_search_with_score_by_vector(
         self,
-        embedding: List[float],
+        embedding: list[float],
         k: int = 4,
         filter: Callable[[Document], bool] | None = None,
         **kwargs: Any,
-    ) -> List[tuple[Document, float, List[float]]]:
+    ) -> list[tuple[Document, float, list[float]]]:
         # get all docs with fixed order in list
         docs = list(self._database.values())
 
@@ -327,7 +326,7 @@ class __ModuleName__VectorStore(VectorStore):
 
     def similarity_search(
         self, query: str, k: int = 4, **kwargs: Any
-    ) -> List[Document]:
+    ) -> list[Document]:
         embedding = self.embedding.embed_query(query)
         return [
             doc
@@ -339,7 +338,7 @@ class __ModuleName__VectorStore(VectorStore):
     # optional: add custom async implementations
     # async def asimilarity_search(
     #     self, query: str, k: int = 4, **kwargs: Any
-    # ) -> List[Document]:
+    # ) -> list[Document]:
     #     # This is a temporary workaround to make the similarity search
     #     # asynchronous. The proper solution is to make the similarity search
     #     # asynchronous in the vector store implementations.
@@ -348,7 +347,7 @@ class __ModuleName__VectorStore(VectorStore):
 
     def similarity_search_with_score(
         self, query: str, k: int = 4, **kwargs: Any
-    ) -> List[Tuple[Document, float]]:
+    ) -> list[Tuple[Document, float]]:
         embedding = self.embedding.embed_query(query)
         return [
             (doc, similarity)
@@ -360,7 +359,7 @@ class __ModuleName__VectorStore(VectorStore):
     # optional: add custom async implementations
     # async def asimilarity_search_with_score(
     #     self, *args: Any, **kwargs: Any
-    # ) -> List[Tuple[Document, float]]:
+    # ) -> list[Tuple[Document, float]]:
     #     # This is a temporary workaround to make the similarity search
     #     # asynchronous. The proper solution is to make the similarity search
     #     # asynchronous in the vector store implementations.
@@ -370,14 +369,14 @@ class __ModuleName__VectorStore(VectorStore):
     ### ADDITIONAL OPTIONAL SEARCH METHODS BELOW ###
 
     # def similarity_search_by_vector(
-    #     self, embedding: List[float], k: int = 4, **kwargs: Any
-    # ) -> List[Document]:
+    #     self, embedding: list[float], k: int = 4, **kwargs: Any
+    # ) -> list[Document]:
     #     raise NotImplementedError
 
     # optional: add custom async implementations
     # async def asimilarity_search_by_vector(
-    #     self, embedding: List[float], k: int = 4, **kwargs: Any
-    # ) -> List[Document]:
+    #     self, embedding: list[float], k: int = 4, **kwargs: Any
+    # ) -> list[Document]:
     #     # This is a temporary workaround to make the similarity search
     #     # asynchronous. The proper solution is to make the similarity search
     #     # asynchronous in the vector store implementations.
@@ -391,7 +390,7 @@ class __ModuleName__VectorStore(VectorStore):
     #     fetch_k: int = 20,
     #     lambda_mult: float = 0.5,
     #     **kwargs: Any,
-    # ) -> List[Document]:
+    # ) -> list[Document]:
     #     raise NotImplementedError
 
     # optional: add custom async implementations
@@ -402,7 +401,7 @@ class __ModuleName__VectorStore(VectorStore):
     #     fetch_k: int = 20,
     #     lambda_mult: float = 0.5,
     #     **kwargs: Any,
-    # ) -> List[Document]:
+    # ) -> list[Document]:
     #     # This is a temporary workaround to make the similarity search
     #     # asynchronous. The proper solution is to make the similarity search
     #     # asynchronous in the vector store implementations.
@@ -418,21 +417,21 @@ class __ModuleName__VectorStore(VectorStore):
 
     # def max_marginal_relevance_search_by_vector(
     #     self,
-    #     embedding: List[float],
+    #     embedding: list[float],
     #     k: int = 4,
     #     fetch_k: int = 20,
     #     lambda_mult: float = 0.5,
     #     **kwargs: Any,
-    # ) -> List[Document]:
+    # ) -> list[Document]:
     #     raise NotImplementedError
 
     # optional: add custom async implementations
     # async def amax_marginal_relevance_search_by_vector(
     #     self,
-    #     embedding: List[float],
+    #     embedding: list[float],
     #     k: int = 4,
     #     fetch_k: int = 20,
     #     lambda_mult: float = 0.5,
     #     **kwargs: Any,
-    # ) -> List[Document]:
+    # ) -> list[Document]:
     #     raise NotImplementedError

--- a/libs/langchain/langchain_classic/chains/constitutional_ai/base.py
+++ b/libs/langchain/langchain_classic/chains/constitutional_ai/base.py
@@ -45,7 +45,7 @@ class ConstitutionalChain(Chain):
         ```
 
         ```python
-        from typing import List, Optional, Tuple
+        from typing Optional, Tuple
 
         from langchain_classic.chains.constitutional_ai.prompts import (
             CRITIQUE_PROMPT,
@@ -93,9 +93,9 @@ class ConstitutionalChain(Chain):
 
         class State(TypedDict):
             query: str
-            constitutional_principles: List[ConstitutionalPrinciple]
+            constitutional_principles: list[ConstitutionalPrinciple]
             initial_response: str
-            critiques_and_revisions: List[Tuple[str, str]]
+            critiques_and_revisions: list[Tuple[str, str]]
             response: str
 
 

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -1407,7 +1407,6 @@ class InjectedState(InjectedToolArg):
 
     Example:
         ```python
-        from typing import List
         from typing_extensions import Annotated, TypedDict
 
         from langchain_core.messages import BaseMessage, AIMessage
@@ -1415,7 +1414,7 @@ class InjectedState(InjectedToolArg):
 
 
         class AgentState(TypedDict):
-            messages: List[BaseMessage]
+            messages: list[BaseMessage]
             foo: str
 
 


### PR DESCRIPTION
Description: This change updates type hints across multiple files to use the built-in `list` type instead of `List` from the `typing` module, aligning with modern Python and replacing the deprecated imports.