### PR TITLE
fix(exa)!: rename 'type' parameter to 'search_type' to avoid shadowing Python built-in

### DIFF
--- a/libs/partners/exa/langchain_exa/retrievers.py
+++ b/libs/partners/exa/langchain_exa/retrievers.py
@@ -55,7 +55,7 @@ class ExaSearchRetriever(BaseRetriever):
     """The end date for when the document was published (in YYYY-MM-DD format)."""
     use_autoprompt: bool | None = None
     """Whether to use autoprompt for the search."""
-    type: str = "neural"
+    search_type: str = "neural"
     """The type of search, 'keyword', 'neural', or 'auto'. Default: neural"""
     highlights: HighlightsContentsOptions | bool | None = None
     """Whether to set the page content to the highlights of the results."""
@@ -96,7 +96,7 @@ class ExaSearchRetriever(BaseRetriever):
             use_autoprompt=self.use_autoprompt,
             livecrawl=self.livecrawl,
             summary=self.summary,
-            type=self.type,
+            type=self.search_type,
         )  # type: ignore[call-overload, misc]
 
         results = response.results

--- a/libs/partners/exa/langchain_exa/tools.py
+++ b/libs/partners/exa/langchain_exa/tools.py
@@ -116,10 +116,9 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
         use_autoprompt: bool | None = None,  # noqa: FBT001
         livecrawl: Literal["always", "fallback", "never"] | None = None,
         summary: bool | dict[str, str] | None = None,  # noqa: FBT001
-        type: Literal["neural", "keyword", "auto"] | None = None,  # noqa: A002
+        search_type: Literal["neural", "keyword", "auto"] | None = None,
         run_manager: CallbackManagerForToolRun | None = None,
     ) -> list[dict] | str:
-        # TODO: rename `type` to something else, as it is a reserved keyword
         """Use the tool.
 
         Args:
@@ -136,7 +135,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
             use_autoprompt: Whether to use autoprompt for the search.
             livecrawl: Option to crawl live webpages if content is not in the index. Options: "always", "fallback", "never"
             summary: Whether to include a summary of the content. Can be a boolean or a dict with a custom query.
-            type: The type of search, 'keyword', 'neural', or 'auto'.
+            search_type: The type of search, 'keyword', 'neural', or 'auto'.
             run_manager: The run manager for callbacks.
 
         """  # noqa: E501
@@ -155,7 +154,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
                 use_autoprompt=use_autoprompt,
                 livecrawl=livecrawl,
                 summary=summary,
-                type=type,
+                type=search_type,
             )  # type: ignore[call-overload, misc]
         except Exception as e:
             return repr(e)

--- a/libs/partners/exa/tests/integration_tests/test_retriever.py
+++ b/libs/partners/exa/tests/integration_tests/test_retriever.py
@@ -35,7 +35,10 @@ def test_exa_retriever_highlights() -> None:
 def test_exa_retriever_advanced_features() -> None:
     """Test advanced features of the `ExaSearchRetriever`."""
     retriever = ExaSearchRetriever(
-        k=3, text_contents_options={"max_characters": 1000}, summary=True, type="auto"
+        k=3,
+        text_contents_options={"max_characters": 1000},
+        summary=True,
+        search_type="auto",
     )
     res = retriever.invoke("best time to visit japan")
     print(res)  # noqa: T201

--- a/libs/partners/exa/uv.lock
+++ b/libs/partners/exa/uv.lock
@@ -226,7 +226,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.0.0a6"
+version = "1.0.0rc2"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -514,7 +514,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.0.0a2"
+version = "1.0.0rc1"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/exa/uv.lock
+++ b/libs/partners/exa/uv.lock
@@ -226,7 +226,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -396,7 +396,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.0.0rc2"
+version = "1.0.0a6"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -514,7 +514,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.0.0rc1"
+version = "1.0.0a2"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
**Description:**
Fixes a code quality issue where the `type` parameter in Exa tools was shadowing Python's reserved `type` keyword. The parameter has been renamed to `search_type`.

**Changes:**
- Renamed `type` parameter to `search_type` in `ExaSearchResults._run()` method
- Updated `ExaSearchRetriever` class to use `search_type` attribute
- Updated integration test to use the new parameter name

**Issue:**
Addresses TODO comment in `libs/partners/exa/langchain_exa/tools.py:122`

**Dependencies:**
None

**Note:**
This is a breaking change for users directly passing `type=` to these methods. They will need to update to `search_type=`.