### PR TITLE
fix(core): allow injected tool args to be direct subclasses (not annotated metadata)

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1250,6 +1250,14 @@ def _is_injected_arg_type(
         `True` if the type is an injected argument, `False` otherwise.
     """
     injected_type = injected_type or InjectedToolArg
+
+    origin = get_origin(type_)
+    if origin is not None and isinstance(origin, type) and issubclass(origin, injected_type):
+        return True
+
+    if isinstance(type_, type) and issubclass(type_, injected_type):
+        return True
+
     return any(
         isinstance(arg, injected_type)
         or (isinstance(arg, type) and issubclass(arg, injected_type))

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1251,9 +1251,13 @@ def _is_injected_arg_type(
     """
     injected_type = injected_type or InjectedToolArg
 
-    # if the type is a generic alias, check if the origin is a subclass of the injected type
+    # if the type is a generic alias, check if the origin is a subclass of inj type
     origin = get_origin(type_)
-    if origin is not None and isinstance(origin, type) and issubclass(origin, injected_type):
+    if (
+        origin is not None
+        and isinstance(origin, type)
+        and issubclass(origin, injected_type)
+    ):
         return True
 
     # check if the type is a subclass of the injected type

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1251,13 +1251,17 @@ def _is_injected_arg_type(
     """
     injected_type = injected_type or InjectedToolArg
 
+    # if the type is a generic alias, check if the origin is a subclass of the injected type
     origin = get_origin(type_)
     if origin is not None and isinstance(origin, type) and issubclass(origin, injected_type):
         return True
 
+    # check if the type is a subclass of the injected type
     if isinstance(type_, type) and issubclass(type_, injected_type):
         return True
 
+    # if the type is an Annotated type, check if any of the annotations
+    # are a subclass of the injected type
     return any(
         isinstance(arg, injected_type)
         or (isinstance(arg, type) and issubclass(arg, injected_type))

--- a/libs/langchain_v1/langchain/__init__.py
+++ b/libs/langchain_v1/langchain/__init__.py
@@ -1,3 +1,3 @@
 """Main entrypoint into LangChain."""
 
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0rc2"

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 name = "langchain"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 description = "Building applications with LLMs through composability"
 readme = "README.md"
 

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1550,7 +1550,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Right now, these work:

```py
def tool(
    tool_call_id: Annotated[str, InjectedToolCallId],
    state: Annotated[dict, InjectedState],
    state_part: Annotated[str, InjectedState("foo")],
    store: Annotated[BaseStore, InjectedStore],
)
```

This would mean that the following would work:
```py
def tool(
    tool_call_id: InjectedToolCallId
    state: InjectedState
    state_part: InjectedState("foo"),
    store: InjectedStore,
    runtime: ToolRuntime
)
```

Maybe this is not ideal... but we've been trying to move away from the injected pattern, and this would pave the way for `ToolRuntime` injection...

The alternative is sticking to something like the following, which would also be ok, but feels clunky.
It's less breaking.

```py
def tool(
    runtime: Annotated[ToolRuntime, InjectedRuntime]
)
```