### PR TITLE
chore(langchain): allow injection of `ToolRuntime` and generic `ToolRuntime[ContextT, StateT]`

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1258,7 +1258,14 @@ class InjectedToolCallId(InjectedToolArg):
 
 
 def _is_directly_injected_arg_type(type_: Any) -> bool:
-    """Check if a type annotation indicates a reserved argument."""
+    """Check if a type annotation indicates a directly injected argument.
+
+    This is currently only used for ToolRuntime.
+    Checks if either the annotation itself is a subclass of _DirectlyInjectedToolArg
+    or the origin of the annotation is a subclass of _DirectlyInjectedToolArg.
+
+    Ex: ToolRuntime or ToolRuntime[ContextT, StateT] would both return True.
+    """
     return (
         isinstance(type_, type) and issubclass(type_, _DirectlyInjectedToolArg)
     ) or (

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1268,11 +1268,12 @@ def _is_injected_arg_type(
     Returns:
         `True` if the type is an injected argument, `False` otherwise.
     """
-    injected_type = injected_type or InjectedToolArg
-
-    # if the type is a directly injected argument, return True
-    if _is_directly_injected_arg_type(type_):
-        return True
+    if injected_type is None:
+        # if no injected type is specified,
+        # check if the type is a directly injected argument
+        if _is_directly_injected_arg_type(type_):
+            return True
+        injected_type = InjectedToolArg
 
     # if the type is an Annotated type, check if annotated metadata
     # is an intance or subclass of the injected type

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1214,6 +1214,18 @@ class _DirectlyInjectedToolArg:
     """Annotation for tool arguments that are injected at runtime.
 
     Injected via direct type annotation, rather than annotated metadata.
+
+    For example, ToolRuntime is a directly injected argument.
+    Note the direct annotation rather than the verbose alternative:
+    Annotated[ToolRuntime, InjectedRuntime]
+    ```python
+    from langchain_core.tools import tool, ToolRuntime
+
+
+    @tool
+    def foo(x: int, runtime: ToolRuntime) -> str:
+        # use runtime.state, runtime.context, runtime.store, etc.
+        ...
     ```
     """
 

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -75,6 +75,7 @@ from langchain_core.tools import tool as create_tool
 from langchain_core.tools.base import (
     TOOL_MESSAGE_BLOCK_TYPES,
     ToolException,
+    _DirectlyInjectedToolArg,
     get_all_basemodel_annotations,
 )
 from langgraph._internal._runnable import RunnableCallable
@@ -1349,7 +1350,7 @@ def tools_condition(
 
 
 @dataclass
-class ToolRuntime(InjectedToolArg, Generic[ContextT, StateT]):
+class ToolRuntime(_DirectlyInjectedToolArg, Generic[ContextT, StateT]):
     """Runtime context automatically injected into tools.
 
     When a tool function has a parameter named 'tool_runtime' with type hint


### PR DESCRIPTION
Adds special private helper to allow direct injection of `ToolRuntime` in tools, plus adding guards for generic annotations w/ `get_origin`.

Went w/ the private helper so that we didn't change behavior for other injected types.