### PR TITLE
chore(langchain_v1): relax typing on input state

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -31,7 +31,8 @@ from langchain.agents.middleware.types import (
     ModelRequest,
     ModelResponse,
     OmitFromSchema,
-    PublicAgentState,
+    _InputAgentState,
+    _OutputAgentState,
 )
 from langchain.agents.structured_output import (
     AutoStrategy,
@@ -527,7 +528,7 @@ def create_agent(  # noqa: PLR0915
     name: str | None = None,
     cache: BaseCache | None = None,
 ) -> CompiledStateGraph[
-    AgentState[ResponseT], ContextT, PublicAgentState[ResponseT], PublicAgentState[ResponseT]
+    AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]
 ]:
     """Creates an agent graph that calls tools in a loop until a stopping condition is met.
 
@@ -780,7 +781,7 @@ def create_agent(  # noqa: PLR0915
 
     # create graph, add nodes
     graph: StateGraph[
-        AgentState[ResponseT], ContextT, PublicAgentState[ResponseT], PublicAgentState[ResponseT]
+        AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]
     ] = StateGraph(
         state_schema=resolved_state_schema,
         input_schema=input_schema,
@@ -1518,7 +1519,7 @@ def _make_tools_to_model_edge(
 
 
 def _add_middleware_edge(
-    graph: StateGraph[AgentState, ContextT, PublicAgentState, PublicAgentState],
+    graph: StateGraph[AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]],
     *,
     name: str,
     default_destination: str,

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1519,7 +1519,9 @@ def _make_tools_to_model_edge(
 
 
 def _add_middleware_edge(
-    graph: StateGraph[AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]],
+    graph: StateGraph[
+        AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]
+    ],
     *,
     name: str,
     default_destination: str,

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -45,7 +45,6 @@ __all__ = [
     "ModelRequest",
     "ModelResponse",
     "OmitFromSchema",
-    "PublicAgentState",
     "after_agent",
     "after_model",
     "before_agent",
@@ -172,11 +171,14 @@ class AgentState(TypedDict, Generic[ResponseT]):
     structured_response: NotRequired[Annotated[ResponseT, OmitFromInput]]
 
 
-class PublicAgentState(TypedDict, Generic[ResponseT]):
-    """Public state schema for the agent.
+class _InputAgentState(TypedDict):
+    """Input state schema for the agent."""
 
-    Just used for typing purposes.
-    """
+    messages: Required[Annotated[list[AnyMessage | dict], add_messages]]
+
+
+class _OutputAgentState(TypedDict, Generic[ResponseT]):
+    """Output state schema for the agent."""
 
     messages: Required[Annotated[list[AnyMessage], add_messages]]
     structured_response: NotRequired[ResponseT]

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -171,13 +171,13 @@ class AgentState(TypedDict, Generic[ResponseT]):
     structured_response: NotRequired[Annotated[ResponseT, OmitFromInput]]
 
 
-class _InputAgentState(TypedDict):
+class _InputAgentState(TypedDict):  # noqa: PYI049
     """Input state schema for the agent."""
 
     messages: Required[Annotated[list[AnyMessage | dict], add_messages]]
 
 
-class _OutputAgentState(TypedDict, Generic[ResponseT]):
+class _OutputAgentState(TypedDict, Generic[ResponseT]):  # noqa: PYI049
     """Output state schema for the agent."""
 
     messages: Required[Annotated[list[AnyMessage], add_messages]]


### PR DESCRIPTION
so we don't get type errors when invoking w/ dict type (openai format) messages

would love to have types for these eventually so we can get proper checking

before
<img width="759" height="257" alt="Screenshot 2025-10-16 at 9 46 08 PM" src="https://github.com/user-attachments/assets/aabe716f-6d8f-429d-ae47-31dd8617752d" />

after
<img width="751" height="228" alt="Screenshot 2025-10-16 at 9 51 09 PM" src="https://github.com/user-attachments/assets/e74dcf12-874b-43ca-9d5b-5575ef8ced73" />