### PR TITLE
fix(langchain_v1): `ToolRuntime` default for args 

### DIFF
--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -49,7 +49,6 @@ from typing import (
     Generic,
     Literal,
     TypedDict,
-    TypeVar,
     Union,
     cast,
     get_args,
@@ -84,7 +83,7 @@ from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.store.base import BaseStore  # noqa: TC002
 from langgraph.types import Command, Send, StreamWriter
 from pydantic import BaseModel, ValidationError
-from typing_extensions import Unpack
+from typing_extensions import TypeVar, Unpack
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -95,7 +94,7 @@ if TYPE_CHECKING:
 # on if this lives in LangChain or LangGraph... ideally would have some typed
 # messages key
 StateT = TypeVar("StateT", default=dict)
-ContextT = TypeVar("ContextT")
+ContextT = TypeVar("ContextT", default=None)
 
 INVALID_TOOL_NAME_ERROR_TEMPLATE = (
     "Error: {requested_tool} is not a valid tool, try one of [{available_tools}]."

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -91,7 +91,10 @@ if TYPE_CHECKING:
 
     from langgraph.runtime import Runtime
 
-StateT = TypeVar("StateT")
+# right now we use a dict as the default, can change this to AgentState, but depends
+# on if this lives in LangChain or LangGraph... ideally would have some typed
+# messages key
+StateT = TypeVar("StateT", default=dict)
 ContextT = TypeVar("ContextT")
 
 INVALID_TOOL_NAME_ERROR_TEMPLATE = (

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -628,7 +628,7 @@ class _ToolNode(RunnableCallable):
         injected_tool_calls = []
         input_types = [input_type] * len(tool_calls)
         for call, tool_runtime in zip(tool_calls, tool_runtimes, strict=False):
-            injected_call = self._inject_tool_args(call, tool_runtime)
+            injected_call = self._inject_tool_args(call, tool_runtime)  # type: ignore[arg-type]
             injected_tool_calls.append(injected_call)
         with get_executor_for_config(config) as executor:
             outputs = list(
@@ -663,9 +663,9 @@ class _ToolNode(RunnableCallable):
         injected_tool_calls = []
         coros = []
         for call, tool_runtime in zip(tool_calls, tool_runtimes, strict=False):
-            injected_call = self._inject_tool_args(call, tool_runtime)
+            injected_call = self._inject_tool_args(call, tool_runtime)  # type: ignore[arg-type]
             injected_tool_calls.append(injected_call)
-            coros.append(self._arun_one(injected_call, input_type, tool_runtime))
+            coros.append(self._arun_one(injected_call, input_type, tool_runtime))  # type: ignore[arg-type]
         outputs = await asyncio.gather(*coros)
 
         return self._combine_tool_outputs(outputs, input_type)


### PR DESCRIPTION
added some noqas, this is a quick patch to support a bug uncovered in the quickstart, will resolve fully depending on where we centralize ToolNode stuff.