### PR TITLE
fix(core): applied secrets_map in load() to plain string values

### DIFF
--- a/libs/core/langchain_core/load/load.py
+++ b/libs/core/langchain_core/load/load.py
@@ -265,6 +265,8 @@ def load(
             return reviver(loaded_obj)
         if isinstance(obj, list):
             return [_load(o) for o in obj]
+        if isinstance(obj, str) and obj in reviver.secrets_map:
+            return reviver.secrets_map[obj]
         return obj
 
     return _load(obj)

--- a/libs/langchain/tests/unit_tests/load/test_load.py
+++ b/libs/langchain/tests/unit_tests/load/test_load.py
@@ -194,3 +194,11 @@ def test_loads_with_missing_secrets() -> None:
     # Should throw on instantiation, not deserialization
     with pytest.raises(openai.OpenAIError):
         loads(llm_string)
+
+def test_load_with_string_secrets() -> None:
+    obj = {"api_key": "__SECRET_API_KEY__"}
+    secret_key = "secret_key_1234"
+    secrets_map = {"__SECRET_API_KEY__": secret_key}
+    result = load(obj, secrets_map=secrets_map)
+
+    assert result["api_key"] == secret_key

--- a/libs/langchain/tests/unit_tests/load/test_load.py
+++ b/libs/langchain/tests/unit_tests/load/test_load.py
@@ -197,8 +197,7 @@ def test_loads_with_missing_secrets() -> None:
 
 def test_load_with_string_secrets() -> None:
     obj = {"api_key": "__SECRET_API_KEY__"}
-    secret_key = "secret_key_1234"
-    secrets_map = {"__SECRET_API_KEY__": secret_key}
+    secrets_map = {"__SECRET_API_KEY__": "hello"}
     result = load(obj, secrets_map=secrets_map)
 
-    assert result["api_key"] == secret_key
+    assert result["api_key"] == "hello"


### PR DESCRIPTION
**Description:** Fixes the bug in the `load()` function where secret placeholders in plain dicts were not replaced, even if they match a key in `secrets_map`, and adds a test case.

Example:
```py
obj = {"api_key": "__SECRET_API_KEY__"}
secret_key = "secret_key_1234"
secrets_map = {"__SECRET_API_KEY__": secret_key}
result = load(obj, secrets_map=secrets_map)
```
Before this change, printing `api_key` in `result` would output `"__SECRET_API_KEY__"`. Now, it will properly output `"secret_key_1234"`.

**Issue:** Fixes #31804 

**Dependencies:** None

`make format`, `make lint`, and `make test` have all passed on my machine.
