### PR TITLE
fix(langchain_v1): remove non llm controllable params from tool message on invocation failure

### DIFF
--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -471,15 +471,16 @@ def _filter_validation_errors(
     tool_to_store_arg: str | None,
     tool_to_runtime_arg: str | None,
 ) -> list[ErrorDetails]:
-    """Filter validation errors to only include model-controlled arguments.
+    """Filter validation errors to only include LLM-controlled arguments.
 
-    When a tool invocation fails validation, only errors for arguments that the model
-    controls should be included in error messages. Injected arguments (state, store,
-    runtime) are provided by the system, not the model, so validation errors for them
-    are filtered out.
+    When a tool invocation fails validation, only errors for arguments that the LLM
+    controls should be included in error messages. This ensures the LLM receives
+    focused, actionable feedback about parameters it can actually fix. System-injected
+    arguments (state, store, runtime) are filtered out since the LLM has no control
+    over them.
 
     This function also removes injected argument values from the `input` field in error
-    details, ensuring that only model-provided arguments appear in error messages.
+    details, ensuring that only LLM-provided arguments appear in error messages.
 
     Args:
         validation_error: The Pydantic ValidationError raised during tool invocation.
@@ -488,8 +489,8 @@ def _filter_validation_errors(
         tool_to_runtime_arg: Name of the runtime argument, if any.
 
     Returns:
-        List of ErrorDetails containing only errors for model-controlled arguments,
-        with injected argument values removed from the input field.
+        List of ErrorDetails containing only errors for LLM-controlled arguments,
+        with system-injected argument values removed from the input field.
     """
     injected_args = set(tool_to_state_args.keys())
     if tool_to_store_arg:

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -471,11 +471,15 @@ def _filter_validation_errors(
     tool_to_store_arg: str | None,
     tool_to_runtime_arg: str | None,
 ) -> list[ErrorDetails]:
-    """Filter validation errors to exclude injected arguments.
+    """Filter validation errors to only include model-controlled arguments.
 
-    When a tool is invoked with arguments that fail validation, we need to filter
-    out any errors associated with injected arguments (state, store, runtime) since
-    these are not provided by the model and should not be reported as invocation errors.
+    When a tool invocation fails validation, only errors for arguments that the model
+    controls should be included in error messages. Injected arguments (state, store,
+    runtime) are provided by the system, not the model, so validation errors for them
+    are filtered out.
+
+    This function also removes injected argument values from the `input` field in error
+    details, ensuring that only model-provided arguments appear in error messages.
 
     Args:
         validation_error: The Pydantic ValidationError raised during tool invocation.
@@ -484,8 +488,8 @@ def _filter_validation_errors(
         tool_to_runtime_arg: Name of the runtime argument, if any.
 
     Returns:
-        List of ErrorDetails with injected argument errors filtered out and
-        injected values removed from input_value fields.
+        List of ErrorDetails containing only errors for model-controlled arguments,
+        with injected argument values removed from the input field.
     """
     injected_args = set(tool_to_state_args.keys())
     if tool_to_store_arg:

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -321,15 +321,12 @@ class ToolInvocationError(ToolException):
         """
         # Format error display based on filtered errors if provided
         if filtered_errors is not None:
-            # Manually format the filtered errors
-            error_count = len(filtered_errors)
-            plural = "s" if error_count != 1 else ""
-            header = f"{error_count} validation error{plural} for {tool_name}"
-            error_str_parts = [header]
+            # Manually format the filtered errors without URLs or fancy formatting
+            error_str_parts = []
             for error in filtered_errors:
-                loc_str = " -> ".join(str(loc) for loc in error.get("loc", ()))
-                error_str_parts.append(f"{loc_str}")
-                error_str_parts.append(f"  {error.get('msg', 'Unknown error')}")
+                loc_str = ".".join(str(loc) for loc in error.get("loc", ()))
+                msg = error.get("msg", "Unknown error")
+                error_str_parts.append(f"{loc_str}: {msg}")
             error_display_str = "\n".join(error_str_parts)
         else:
             error_display_str = str(source)

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -89,6 +89,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from langgraph.runtime import Runtime
+    from pydantic_core import ErrorDetails
 
 # right now we use a dict as the default, can change this to AgentState, but depends
 # on if this lives in LangChain or LangGraph... ideally would have some typed
@@ -303,7 +304,11 @@ class ToolInvocationError(ToolException):
     """
 
     def __init__(
-        self, tool_name: str, source: ValidationError, tool_kwargs: dict[str, Any]
+        self,
+        tool_name: str,
+        source: ValidationError,
+        tool_kwargs: dict[str, Any],
+        filtered_errors: list[ErrorDetails] | None = None,
     ) -> None:
         """Initialize the ToolInvocationError.
 
@@ -311,13 +316,31 @@ class ToolInvocationError(ToolException):
             tool_name: The name of the tool that failed.
             source: The exception that occurred.
             tool_kwargs: The keyword arguments that were passed to the tool.
+            filtered_errors: Optional list of filtered validation errors excluding
+                injected arguments.
         """
+        # Format error display based on filtered errors if provided
+        if filtered_errors is not None:
+            # Manually format the filtered errors
+            error_count = len(filtered_errors)
+            plural = "s" if error_count != 1 else ""
+            header = f"{error_count} validation error{plural} for {tool_name}"
+            error_str_parts = [header]
+            for error in filtered_errors:
+                loc_str = " -> ".join(str(loc) for loc in error.get("loc", ()))
+                error_str_parts.append(f"{loc_str}")
+                error_str_parts.append(f"  {error.get('msg', 'Unknown error')}")
+            error_display_str = "\n".join(error_str_parts)
+        else:
+            error_display_str = str(source)
+
         self.message = TOOL_INVOCATION_ERROR_TEMPLATE.format(
-            tool_name=tool_name, tool_kwargs=tool_kwargs, error=source
+            tool_name=tool_name, tool_kwargs=tool_kwargs, error=error_display_str
         )
         self.tool_name = tool_name
         self.tool_kwargs = tool_kwargs
         self.source = source
+        self.filtered_errors = filtered_errors
         super().__init__(self.message)
 
 
@@ -440,6 +463,54 @@ def _infer_handled_types(handler: Callable[..., str]) -> tuple[type[Exception], 
     # If no type information is available, return (Exception,)
     # for backwards compatibility.
     return (Exception,)
+
+
+def _filter_validation_errors(
+    validation_error: ValidationError,
+    tool_to_state_args: dict[str, str | None],
+    tool_to_store_arg: str | None,
+    tool_to_runtime_arg: str | None,
+) -> list[ErrorDetails]:
+    """Filter validation errors to exclude injected arguments.
+
+    When a tool is invoked with arguments that fail validation, we need to filter
+    out any errors associated with injected arguments (state, store, runtime) since
+    these are not provided by the model and should not be reported as invocation errors.
+
+    Args:
+        validation_error: The Pydantic ValidationError raised during tool invocation.
+        tool_to_state_args: Mapping of state argument names to state field names.
+        tool_to_store_arg: Name of the store argument, if any.
+        tool_to_runtime_arg: Name of the runtime argument, if any.
+
+    Returns:
+        List of ErrorDetails with injected argument errors filtered out and
+        injected values removed from input_value fields.
+    """
+    injected_args = set(tool_to_state_args.keys())
+    if tool_to_store_arg:
+        injected_args.add(tool_to_store_arg)
+    if tool_to_runtime_arg:
+        injected_args.add(tool_to_runtime_arg)
+
+    filtered_errors: list[ErrorDetails] = []
+    for error in validation_error.errors():
+        # Check if error location contains any injected argument
+        # error['loc'] is a tuple like ('field_name',) or ('field_name', 'nested_field')
+        if error["loc"] and error["loc"][0] not in injected_args:
+            # Create a copy of the error dict to avoid mutating the original
+            error_copy: dict[str, Any] = {**error}
+
+            # Remove injected arguments from input_value if it's a dict
+            if isinstance(error_copy.get("input"), dict):
+                input_dict = error_copy["input"]
+                input_copy = {k: v for k, v in input_dict.items() if k not in injected_args}
+                error_copy["input"] = input_copy
+
+            # Cast is safe because ErrorDetails is a TypedDict compatible with this structure
+            filtered_errors.append(error_copy)  # type: ignore[arg-type]
+
+    return filtered_errors
 
 
 class _ToolNode(RunnableCallable):
@@ -626,9 +697,7 @@ class _ToolNode(RunnableCallable):
         # Pass original tool calls without injection
         input_types = [input_type] * len(tool_calls)
         with get_executor_for_config(config) as executor:
-            outputs = list(
-                executor.map(self._run_one, tool_calls, input_types, tool_runtimes)
-            )
+            outputs = list(executor.map(self._run_one, tool_calls, input_types, tool_runtimes))
 
         return self._combine_tool_outputs(outputs, input_type)
 
@@ -743,8 +812,15 @@ class _ToolNode(RunnableCallable):
             try:
                 response = tool.invoke(call_args, config)
             except ValidationError as exc:
+                # Filter out errors for injected arguments
+                filtered_errors = _filter_validation_errors(
+                    exc,
+                    self._tool_to_state_args.get(call["name"], {}),
+                    self._tool_to_store_arg.get(call["name"]),
+                    self._tool_to_runtime_arg.get(call["name"]),
+                )
                 # Use original call["args"] without injected values for error reporting
-                raise ToolInvocationError(call["name"], exc, call["args"]) from exc
+                raise ToolInvocationError(call["name"], exc, call["args"], filtered_errors) from exc
 
         # GraphInterrupt is a special exception that will always be raised.
         # It can be triggered in the following scenarios,
@@ -891,8 +967,15 @@ class _ToolNode(RunnableCallable):
             try:
                 response = await tool.ainvoke(call_args, config)
             except ValidationError as exc:
+                # Filter out errors for injected arguments
+                filtered_errors = _filter_validation_errors(
+                    exc,
+                    self._tool_to_state_args.get(call["name"], {}),
+                    self._tool_to_store_arg.get(call["name"]),
+                    self._tool_to_runtime_arg.get(call["name"]),
+                )
                 # Use original call["args"] without injected values for error reporting
-                raise ToolInvocationError(call["name"], exc, call["args"]) from exc
+                raise ToolInvocationError(call["name"], exc, call["args"], filtered_errors) from exc
 
         # GraphInterrupt is a special exception that will always be raised.
         # It can be triggered in the following scenarios,

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
@@ -10,6 +10,8 @@ from typing import (
     TypeVar,
 )
 from unittest.mock import Mock
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentState
 
 import pytest
 from langchain_core.messages import (
@@ -300,6 +302,70 @@ def test_tool_node_error_handling_default_exception() -> None:
             },
             config=_create_config_with_runtime(),
         )
+
+
+def test_tool_invocation_error_excludes_injected_state() -> None:
+    """Test that tool invocation errors do not include injected state information.
+
+    When a tool has InjectedState parameters and the LLM makes an incorrect
+    invocation (e.g., missing required arguments), the error message should only
+    contain the original arguments from the tool call, not the injected state values.
+
+    This test uses create_agent to ensure the behavior works in a full agent context.
+    """
+    # Define a custom state schema with secret data
+    class TestState(AgentState):
+        secret_data: str
+
+    @dec_tool
+    def tool_with_injected_state(
+        some_val: int,
+        state: Annotated[TestState, InjectedState],
+    ) -> str:
+        """Tool that uses injected state."""
+        return f"some_val: {some_val}"
+
+    # Create a fake model that makes an incorrect tool call (missing 'some_val')
+    # Then returns no tool calls on the second iteration to end the loop
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [
+                {
+                    "name": "tool_with_injected_state",
+                    "args": {"wrong_arg": "value"},  # Missing required 'some_val'
+                    "id": "call_1",
+                }
+            ],
+            [],  # No tool calls on second iteration to end the loop
+        ]
+    )
+
+    # Create an agent with the tool and custom state schema
+    agent = create_agent(
+        model=model,
+        tools=[tool_with_injected_state],
+        state_schema=TestState,
+    )
+
+    # Invoke the agent with secret data in the state
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage("Test message")],
+            "secret_data": "sensitive_secret_123",
+        }
+    )
+
+    # Find the tool error message
+    tool_messages = [m for m in result["messages"] if m.type == "tool"]
+    assert len(tool_messages) == 1
+    tool_message = tool_messages[0]
+    assert tool_message is None
+    assert tool_message.status == "error"
+
+    # The error message should contain the original args in the kwargs section
+    assert "{'wrong_arg': 'value'}" in tool_message.content
+    assert "secret_data" not in tool_message.content
+    assert "sensitive_secret_123" not in tool_message.content
 
 
 async def test_tool_node_error_handling() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
@@ -304,7 +304,9 @@ def test_tool_node_error_handling_default_exception() -> None:
         )
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14"
+)
 def test_tool_invocation_error_excludes_injected_state() -> None:
     """Test that tool invocation errors only include LLM-controllable arguments.
 
@@ -372,7 +374,9 @@ def test_tool_invocation_error_excludes_injected_state() -> None:
     assert "sensitive_secret_123" not in tool_message.content
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14"
+)
 async def test_tool_invocation_error_excludes_injected_state_async() -> None:
     """Test that async tool invocation errors only include LLM-controllable arguments.
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
@@ -304,6 +304,7 @@ def test_tool_node_error_handling_default_exception() -> None:
         )
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14")
 def test_tool_invocation_error_excludes_injected_state() -> None:
     """Test that tool invocation errors only include LLM-controllable arguments.
 
@@ -371,6 +372,7 @@ def test_tool_invocation_error_excludes_injected_state() -> None:
     assert "sensitive_secret_123" not in tool_message.content
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14")
 async def test_tool_invocation_error_excludes_injected_state_async() -> None:
     """Test that async tool invocation errors only include LLM-controllable arguments.
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
@@ -517,10 +517,8 @@ async def test_tool_node_error_handling() -> None:
             result_error["messages"][1].content
             == f"Error: {ToolException('Test error')!r}\n Please fix your mistakes."
         )
-        assert (
-            "ValidationError" in result_error["messages"][2].content
-            or "validation error" in result_error["messages"][2].content
-        )
+        # Check that the validation error contains the field name
+        assert "some_other_val" in result_error["messages"][2].content
 
         assert result_error["messages"][0].tool_call_id == "some id"
         assert result_error["messages"][1].tool_call_id == "some other id"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
@@ -313,6 +313,7 @@ def test_tool_invocation_error_excludes_injected_state() -> None:
 
     This test uses create_agent to ensure the behavior works in a full agent context.
     """
+
     # Define a custom state schema with secret data
     class TestState(AgentState):
         secret_data: str
@@ -359,7 +360,6 @@ def test_tool_invocation_error_excludes_injected_state() -> None:
     tool_messages = [m for m in result["messages"] if m.type == "tool"]
     assert len(tool_messages) == 1
     tool_message = tool_messages[0]
-    assert tool_message is None
     assert tool_message.status == "error"
 
     # The error message should contain the original args in the kwargs section

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node.py
@@ -368,6 +368,97 @@ def test_tool_invocation_error_excludes_injected_state() -> None:
     assert "sensitive_secret_123" not in tool_message.content
 
 
+async def test_tool_invocation_error_excludes_injected_state_async() -> None:
+    """Test that async tool invocation errors exclude injected state information.
+
+    This test verifies that the async execution path (_execute_tool_async and _arun_one)
+    properly filters validation errors to exclude injected arguments, just like the
+    sync path does.
+    """
+
+    # Define a custom state schema
+    class TestState(AgentState):
+        internal_data: str
+
+    @dec_tool
+    async def async_tool_with_injected_state(
+        query: str,
+        max_results: int,
+        state: Annotated[TestState, InjectedState],
+    ) -> str:
+        """Async tool that uses injected state."""
+        return f"query: {query}, max_results: {max_results}"
+
+    # Create a fake model that makes an incorrect tool call
+    # - query has wrong type (int instead of str)
+    # - max_results is missing
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [
+                {
+                    "name": "async_tool_with_injected_state",
+                    "args": {"query": 999},  # Wrong type, missing max_results
+                    "id": "call_async_1",
+                }
+            ],
+            [],  # End the loop
+        ]
+    )
+
+    # Create an agent with the async tool
+    agent = create_agent(
+        model=model,
+        tools=[async_tool_with_injected_state],
+        state_schema=TestState,
+    )
+
+    # Invoke with state data
+    result = await agent.ainvoke(
+        {
+            "messages": [HumanMessage("Test async")],
+            "internal_data": "secret_internal_value_xyz",
+        }
+    )
+
+    # Find the tool error message
+    tool_messages = [m for m in result["messages"] if m.type == "tool"]
+    assert len(tool_messages) == 1
+    tool_message = tool_messages[0]
+    assert tool_message.status == "error"
+
+    # Verify error mentions model-controlled parameters
+    content = tool_message.content
+    assert "query" in content.lower(), "Error should mention 'query'"
+    assert "max_results" in content.lower(), "Error should mention 'max_results'"
+
+    # Verify injected state does not appear in the validation errors
+    # The tool name may contain "state", but the error list should not mention it
+    assert "internal_data" not in content, (
+        "Error should NOT mention 'internal_data' field from state"
+    )
+    assert "secret_internal_value" not in content, "Error should NOT contain state values"
+
+    # Verify only the model-controlled parameters are in the error list
+    # Should see "query" and "max_results" errors, but not "state"
+    lines = content.split("\n")
+    error_lines = [line.strip() for line in lines if line.strip()]
+    # Find lines that look like field names (single words at start of line)
+    field_errors = [
+        line
+        for line in error_lines
+        if line
+        and not line.startswith("input")
+        and not line.startswith("field")
+        and not line.startswith("error")
+        and not line.startswith("please")
+        and len(line.split()) <= 2
+    ]
+    # Check that state is not in the field error list
+    assert not any("state" == field.lower() for field in field_errors), (
+        "The field 'state' should not appear in validation errors"
+    )
+
+
 async def test_tool_node_error_handling() -> None:
     def handle_all(e: ValueError | ToolException | ToolInvocationError):
         return TOOL_CALL_ERROR_TEMPLATE.format(error=repr(e))

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node_validation_error_filtering.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node_validation_error_filtering.py
@@ -1,0 +1,629 @@
+"""Unit tests for ValidationError filtering in ToolNode.
+
+This module tests that validation errors for injected arguments (InjectedState,
+InjectedStore, ToolRuntime) are properly filtered out when tools are invoked with
+invalid arguments, ensuring only model-controllable argument errors are reported.
+"""
+
+from typing import Annotated
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.runnables.config import RunnableConfig
+from langchain_core.tools import tool as dec_tool
+from langgraph.store.base import BaseStore
+from langgraph.store.memory import InMemoryStore
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentState
+from langchain.tools import InjectedState, InjectedStore
+from langchain.tools.tool_node import ToolInvocationError, ToolRuntime, _ToolNode
+
+from .model import FakeToolCallingModel
+
+pytestmark = pytest.mark.anyio
+
+
+def _create_mock_runtime(store: BaseStore | None = None) -> Mock:
+    """Create a mock Runtime object for testing ToolNode outside of graph context."""
+    mock_runtime = Mock()
+    mock_runtime.store = store
+    mock_runtime.context = None
+    mock_runtime.stream_writer = lambda *args, **kwargs: None
+    return mock_runtime
+
+
+def _create_config_with_runtime(store: BaseStore | None = None) -> RunnableConfig:
+    """Create a RunnableConfig with mock Runtime for testing ToolNode."""
+    return {"configurable": {"__pregel_runtime": _create_mock_runtime(store)}}
+
+
+async def test_filter_injected_state_validation_errors() -> None:
+    """Test that validation errors for InjectedState arguments are filtered out."""
+
+    @dec_tool
+    def my_tool(
+        value: int,
+        state: Annotated[dict, InjectedState],
+    ) -> str:
+        """Tool that uses injected state.
+
+        Args:
+            value: An integer value.
+            state: The graph state (injected).
+        """
+        return f"value={value}, messages={len(state.get('messages', []))}"
+
+    tool_node = _ToolNode([my_tool])
+
+    # Call with invalid 'value' argument (should be int, not str)
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "hi?",
+                    tool_calls=[
+                        {
+                            "name": "my_tool",
+                            "args": {"value": "not_an_int"},  # Invalid type
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    # Should get a ToolMessage with error
+    assert len(result["messages"]) == 1
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+    assert tool_message.tool_call_id == "call_1"
+
+    # Error should mention 'value' but NOT 'state' (which is injected)
+    assert "value" in tool_message.content
+    assert "state" not in tool_message.content.lower()
+
+
+async def test_filter_injected_store_validation_errors() -> None:
+    """Test that validation errors for InjectedStore arguments are filtered out."""
+
+    @dec_tool
+    def my_tool(
+        key: str,
+        store: Annotated[BaseStore, InjectedStore()],
+    ) -> str:
+        """Tool that uses injected store.
+
+        Args:
+            key: A key to look up.
+            store: The persistent store (injected).
+        """
+        return f"key={key}"
+
+    tool_node = _ToolNode([my_tool])
+
+    # Call with invalid 'key' argument (missing required argument)
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "hi?",
+                    tool_calls=[
+                        {
+                            "name": "my_tool",
+                            "args": {},  # Missing 'key'
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(store=InMemoryStore()),
+    )
+
+    # Should get a ToolMessage with error
+    assert len(result["messages"]) == 1
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+
+    # Error should mention 'key' is required
+    assert "key" in tool_message.content.lower()
+    # The error should be about 'key' field specifically (not about store field)
+    # Note: 'store' might appear in input_value representation, but the validation
+    # error itself should only be for 'key'
+    assert (
+        "field required" in tool_message.content.lower()
+        or "missing" in tool_message.content.lower()
+    )
+
+
+async def test_filter_tool_runtime_validation_errors() -> None:
+    """Test that validation errors for ToolRuntime arguments are filtered out."""
+
+    @dec_tool
+    def my_tool(
+        query: str,
+        runtime: ToolRuntime,
+    ) -> str:
+        """Tool that uses ToolRuntime.
+
+        Args:
+            query: A query string.
+            runtime: The tool runtime context (injected).
+        """
+        return f"query={query}"
+
+    tool_node = _ToolNode([my_tool])
+
+    # Call with invalid 'query' argument (wrong type)
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "hi?",
+                    tool_calls=[
+                        {
+                            "name": "my_tool",
+                            "args": {"query": 123},  # Should be str, not int
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    # Should get a ToolMessage with error
+    assert len(result["messages"]) == 1
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+
+    # Error should mention 'query' but NOT 'runtime' (which is injected)
+    assert "query" in tool_message.content.lower()
+    assert "runtime" not in tool_message.content.lower()
+
+
+async def test_filter_multiple_injected_args() -> None:
+    """Test filtering when multiple injected arguments have validation errors."""
+
+    @dec_tool
+    def my_tool(
+        value: int,
+        state: Annotated[dict, InjectedState],
+        store: Annotated[BaseStore, InjectedStore()],
+        runtime: ToolRuntime,
+    ) -> str:
+        """Tool with multiple injected arguments.
+
+        Args:
+            value: An integer value.
+            state: The graph state (injected).
+            store: The persistent store (injected).
+            runtime: The tool runtime context (injected).
+        """
+        return f"value={value}"
+
+    tool_node = _ToolNode([my_tool])
+
+    # Call with invalid 'value' - injected args should be filtered from error
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "hi?",
+                    tool_calls=[
+                        {
+                            "name": "my_tool",
+                            "args": {"value": "not_an_int"},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(store=InMemoryStore()),
+    )
+
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+
+    # Only 'value' error should be reported
+    assert "value" in tool_message.content
+    # None of the injected args should appear in error
+    assert "state" not in tool_message.content.lower()
+    assert "store" not in tool_message.content.lower()
+    assert "runtime" not in tool_message.content.lower()
+
+
+async def test_no_filtering_when_all_errors_are_model_args() -> None:
+    """Test that filtering doesn't hide errors for non-injected arguments."""
+
+    @dec_tool
+    def my_tool(
+        value1: int,
+        value2: str,
+        state: Annotated[dict, InjectedState],
+    ) -> str:
+        """Tool with both regular and injected arguments.
+
+        Args:
+            value1: First value.
+            value2: Second value.
+            state: The graph state (injected).
+        """
+        return f"value1={value1}, value2={value2}"
+
+    tool_node = _ToolNode([my_tool])
+
+    # Call with invalid arguments for BOTH non-injected parameters
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "hi?",
+                    tool_calls=[
+                        {
+                            "name": "my_tool",
+                            "args": {
+                                "value1": "not_an_int",  # Invalid
+                                "value2": 456,  # Invalid (should be str)
+                            },
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+
+    # Both errors should be present
+    assert "value1" in tool_message.content
+    assert "value2" in tool_message.content
+    # Injected state should not appear
+    assert "state" not in tool_message.content.lower()
+
+
+async def test_validation_error_with_no_injected_args() -> None:
+    """Test that normal tools without injection still show all errors."""
+
+    @dec_tool
+    def my_tool(value1: int, value2: str) -> str:
+        """Regular tool without injected arguments.
+
+        Args:
+            value1: First value.
+            value2: Second value.
+        """
+        return f"{value1} {value2}"
+
+    tool_node = _ToolNode([my_tool])
+
+    result = await tool_node.ainvoke(
+        {
+            "messages": [
+                AIMessage(
+                    "hi?",
+                    tool_calls=[
+                        {
+                            "name": "my_tool",
+                            "args": {"value1": "invalid", "value2": 123},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+
+    # Both errors should be present since there are no injected args to filter
+    assert "value1" in tool_message.content
+    assert "value2" in tool_message.content
+
+
+async def test_tool_invocation_error_without_handle_errors() -> None:
+    """Test that ToolInvocationError is raised with filtered errors when not handling."""
+
+    @dec_tool
+    def my_tool(
+        value: int,
+        state: Annotated[dict, InjectedState],
+    ) -> str:
+        """Tool with injected state.
+
+        Args:
+            value: An integer value.
+            state: The graph state (injected).
+        """
+        return f"value={value}"
+
+    tool_node = _ToolNode([my_tool], handle_tool_errors=False)
+
+    # Should raise ToolInvocationError with filtered errors
+    with pytest.raises(ToolInvocationError) as exc_info:
+        await tool_node.ainvoke(
+            {
+                "messages": [
+                    AIMessage(
+                        "hi?",
+                        tool_calls=[
+                            {
+                                "name": "my_tool",
+                                "args": {"value": "not_an_int"},
+                                "id": "call_1",
+                                "type": "tool_call",
+                            }
+                        ],
+                    )
+                ]
+            },
+            config=_create_config_with_runtime(),
+        )
+
+    error = exc_info.value
+    assert error.tool_name == "my_tool"
+    assert error.filtered_errors is not None
+    assert len(error.filtered_errors) > 0
+
+    # Filtered errors should only contain 'value' error, not 'state'
+    error_locs = [err["loc"] for err in error.filtered_errors]
+    assert any("value" in str(loc) for loc in error_locs)
+    assert not any("state" in str(loc) for loc in error_locs)
+
+
+async def test_sync_tool_validation_error_filtering() -> None:
+    """Test that error filtering works for sync tools as well."""
+
+    @dec_tool
+    def my_tool(
+        value: int,
+        state: Annotated[dict, InjectedState],
+    ) -> str:
+        """Sync tool with injected state.
+
+        Args:
+            value: An integer value.
+            state: The graph state (injected).
+        """
+        return f"value={value}"
+
+    tool_node = _ToolNode([my_tool])
+
+    # Test sync invocation
+    result = tool_node.invoke(
+        {
+            "messages": [
+                AIMessage(
+                    "hi?",
+                    tool_calls=[
+                        {
+                            "name": "my_tool",
+                            "args": {"value": "not_an_int"},
+                            "id": "call_1",
+                            "type": "tool_call",
+                        }
+                    ],
+                )
+            ]
+        },
+        config=_create_config_with_runtime(),
+    )
+
+    tool_message = result["messages"][0]
+    assert tool_message.status == "error"
+    assert "value" in tool_message.content
+    assert "state" not in tool_message.content.lower()
+
+
+async def test_create_agent_error_content_with_multiple_params() -> None:
+    """Test that error messages contain non-injected params but not injected ones.
+
+    This test uses create_agent to verify that when a tool with both regular
+    and injected parameters receives invalid arguments, the error message:
+    1. Contains details about the non-injected parameter errors
+    2. Does NOT contain any injected parameter names or values
+    3. Properly formats the validation errors for clarity
+    """
+
+    # Custom state with sensitive information
+    class TestState(AgentState):
+        user_id: str
+        api_key: str
+        session_data: dict
+
+    @dec_tool
+    def complex_tool(
+        query: str,
+        limit: int,
+        state: Annotated[TestState, InjectedState],
+        store: Annotated[BaseStore, InjectedStore()],
+        runtime: ToolRuntime,
+    ) -> str:
+        """A complex tool with multiple injected and non-injected parameters.
+
+        Args:
+            query: The search query string.
+            limit: Maximum number of results to return.
+            state: The graph state (injected).
+            store: The persistent store (injected).
+            runtime: The tool runtime context (injected).
+        """
+        # Access injected params to verify they work in normal execution
+        user = state.get("user_id", "unknown")
+        return f"Results for '{query}' (limit={limit}, user={user})"
+
+    # Create a model that makes an incorrect tool call with multiple errors:
+    # - query is wrong type (int instead of str)
+    # - limit is missing
+    # Then returns no tool calls to end the loop
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [
+                {
+                    "name": "complex_tool",
+                    "args": {
+                        "query": 12345,  # Wrong type - should be str
+                        # "limit" is missing - required field
+                    },
+                    "id": "call_complex_1",
+                }
+            ],
+            [],  # No tool calls on second iteration to end the loop
+        ]
+    )
+
+    # Create an agent with the complex tool and custom state
+    # Need to provide a store since the tool uses InjectedStore
+    agent = create_agent(
+        model=model,
+        tools=[complex_tool],
+        state_schema=TestState,
+        store=InMemoryStore(),
+    )
+
+    # Invoke with sensitive data in state
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage("Search for something")],
+            "user_id": "user_12345",
+            "api_key": "sk-secret-key-abc123xyz",
+            "session_data": {"token": "secret_session_token"},
+        }
+    )
+
+    # Find the tool error message
+    tool_messages = [m for m in result["messages"] if m.type == "tool"]
+    assert len(tool_messages) == 1
+    tool_message = tool_messages[0]
+    assert tool_message.status == "error"
+    assert tool_message.tool_call_id == "call_complex_1"
+
+    content = tool_message.content
+
+    # Verify error mentions the non-injected parameter issues
+    # Should mention 'query' error
+    assert "query" in content.lower(), "Error should mention 'query' parameter"
+
+    # Should mention 'limit' error (missing required field)
+    assert "limit" in content.lower(), "Error should mention 'limit' parameter"
+
+    # Should indicate validation errors occurred
+    assert "validation error" in content.lower() or "error" in content.lower(), (
+        "Error should indicate validation occurred"
+    )
+
+    # CRITICAL: Verify NO injected parameter names appear in error
+    assert "state" not in content.lower(), "Error should NOT mention 'state' (injected parameter)"
+    assert "store" not in content.lower(), "Error should NOT mention 'store' (injected parameter)"
+    assert "runtime" not in content.lower(), (
+        "Error should NOT mention 'runtime' (injected parameter)"
+    )
+
+    # CRITICAL: Verify NO sensitive values from state appear in error
+    assert "user_12345" not in content, "Error should NOT contain user_id value from state"
+    assert "sk-secret-key" not in content, "Error should NOT contain api_key value from state"
+    assert "secret_session_token" not in content, "Error should NOT contain session data from state"
+
+    # Verify the original tool call args are mentioned (not the injected ones)
+    # The error template includes: "with kwargs {tool_kwargs}"
+    # This should show the original args from the model's tool call
+    assert "12345" in content, "Error should show the invalid query value (12345)"
+
+    # Additional verification: check error structure
+    # Should be formatted in a readable way
+    assert "complex_tool" in content, "Error should mention the tool name"
+
+
+async def test_create_agent_error_only_model_controllable_params() -> None:
+    """Test that errors only show model-controllable parameter issues.
+
+    This is a focused test ensuring that when ONLY non-injected parameters
+    have validation errors, those errors are clearly shown without any
+    confusion from injected parameters.
+    """
+
+    class StateWithSecrets(AgentState):
+        password: str
+
+    @dec_tool
+    def secure_tool(
+        username: str,
+        email: str,
+        state: Annotated[StateWithSecrets, InjectedState],
+    ) -> str:
+        """Tool that validates user credentials.
+
+        Args:
+            username: The username (3-20 chars).
+            email: The email address.
+            state: State with password (injected).
+        """
+        return f"Validated {username} with email {email}"
+
+    # Model provides invalid username (too short) and invalid email
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [
+                {
+                    "name": "secure_tool",
+                    "args": {
+                        "username": "ab",  # Too short (needs 3-20)
+                        "email": "not-an-email",  # Invalid format
+                    },
+                    "id": "call_secure_1",
+                }
+            ],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[secure_tool],
+        state_schema=StateWithSecrets,
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage("Create account")],
+            "password": "super_secret_password_12345",
+        }
+    )
+
+    tool_messages = [m for m in result["messages"] if m.type == "tool"]
+    assert len(tool_messages) == 1
+    content = tool_messages[0].content
+
+    # The error should clearly show issues with username and/or email
+    # Note: validation might not catch all our expected errors since we're not
+    # using custom validators, but it should at least show the params
+    assert "username" in content.lower() or "email" in content.lower(), (
+        "Error should mention at least one of the invalid parameters"
+    )
+
+    # Critical: password should NEVER appear
+    assert "password" not in content.lower(), (
+        "Error should NOT mention 'password' (injected parameter)"
+    )
+    assert "super_secret_password" not in content, (
+        "Error should NOT contain password value from state"
+    )

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node_validation_error_filtering.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node_validation_error_filtering.py
@@ -8,6 +8,7 @@ feedback about the parameters it can actually control, improving error correctio
 and reducing confusion from irrelevant system implementation details.
 """
 
+import sys
 from typing import Annotated
 from unittest.mock import Mock
 
@@ -476,6 +477,7 @@ async def test_sync_tool_validation_error_filtering() -> None:
     assert "state" not in tool_message.content.lower()
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14")
 async def test_create_agent_error_content_with_multiple_params() -> None:
     """Test that error messages only include LLM-controlled parameter errors.
 
@@ -594,6 +596,7 @@ async def test_create_agent_error_content_with_multiple_params() -> None:
     assert "complex_tool" in content, "Error should mention the tool name"
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14")
 async def test_create_agent_error_only_model_controllable_params() -> None:
     """Test that errors only include LLM-controllable parameter issues.
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node_validation_error_filtering.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node_validation_error_filtering.py
@@ -576,15 +576,15 @@ async def test_create_agent_error_content_with_multiple_params() -> None:
     # These are not controlled by the LLM and should be excluded
     assert "state" not in content.lower(), "Error should NOT mention 'state' (system-injected)"
     assert "store" not in content.lower(), "Error should NOT mention 'store' (system-injected)"
-    assert "runtime" not in content.lower(), (
-        "Error should NOT mention 'runtime' (system-injected)"
-    )
+    assert "runtime" not in content.lower(), "Error should NOT mention 'runtime' (system-injected)"
 
     # Verify NO values from system-injected parameters appear in error
     # The LLM doesn't control these, so they shouldn't distract from the actual issues
     assert "user_12345" not in content, "Error should NOT contain user_id value (from state)"
     assert "sk-secret-key" not in content, "Error should NOT contain api_key value (from state)"
-    assert "secret_session_token" not in content, "Error should NOT contain session_data value (from state)"
+    assert "secret_session_token" not in content, (
+        "Error should NOT contain session_data value (from state)"
+    )
 
     # Verify the LLM's original tool call args are present
     # The error should show what the LLM actually provided to help it correct the mistake

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_node_validation_error_filtering.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_node_validation_error_filtering.py
@@ -477,7 +477,9 @@ async def test_sync_tool_validation_error_filtering() -> None:
     assert "state" not in tool_message.content.lower()
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14"
+)
 async def test_create_agent_error_content_with_multiple_params() -> None:
     """Test that error messages only include LLM-controlled parameter errors.
 
@@ -596,7 +598,9 @@ async def test_create_agent_error_content_with_multiple_params() -> None:
     assert "complex_tool" in content, "Error should mention the tool name"
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14"
+)
 async def test_create_agent_error_only_model_controllable_params() -> None:
     """Test that errors only include LLM-controllable parameter issues.
 


### PR DESCRIPTION
The LLM shouldn't be seeing parameters it cannot control in the ToolMessage error it gets when it invokes a tool with incorrect args.

This fixes the behavior within langchain to address immediate issue.

We may want to change the behavior in langchain_core as well to prevent validation of injected arguments. But this would be done in a separate change