### PR TITLE
fix(mistralai): resolve duplicate tool calls when converting to mistral chat message

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -364,16 +364,14 @@ def _convert_message_to_mistral_chat_message(
         return {"role": "user", "content": message.content}
     if isinstance(message, AIMessage):
         message_dict: dict[str, Any] = {"role": "assistant"}
-        tool_calls = []
+        tool_calls: list = []
         if message.tool_calls or message.invalid_tool_calls:
-            for tool_call in message.tool_calls:
+            if message.tool_calls:
                 tool_calls.extend(
-                    [
-                        _format_tool_call_for_mistral(tool_call)
-                        for tool_call in message.tool_calls
-                    ]
+                    _format_tool_call_for_mistral(tool_call)
+                    for tool_call in message.tool_calls
                 )
-            for invalid_tool_call in message.invalid_tool_calls:
+            if message.invalid_tool_calls:
                 tool_calls.extend(
                     _format_invalid_tool_call_for_mistral(invalid_tool_call)
                     for invalid_tool_call in message.invalid_tool_calls

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -317,3 +317,36 @@ def test_retry_with_failure_then_success() -> None:
         result = chat.invoke("Hello")
         assert result.content == "Hello!"
         assert call_count == 2, f"Expected 2 calls, but got {call_count}"
+
+
+def test_no_duplicate_tool_calls_when_multiple_tools() -> None:
+    """
+    Tests wether the conversion of an AIMessage with more than one tool call
+    to a Mistral assistant message correctly returns each tool call exactly 
+    once in the final payload.
+
+    The current implementation uses a faulty for loop which produces N*N entries in the
+    final tool_calls array of the payload (and thus duplicates tool call ids).
+    """
+    msg = AIMessage(
+        content="",  # content should be blank when tool_calls are present
+        tool_calls=[
+            ToolCall(name="tool_a", args={"x": 1}, id="id_a", type="tool_call"),
+            ToolCall(name="tool_b", args={"y": 2}, id="id_b", type="tool_call"),
+        ],
+        response_metadata={"model_provider": "mistralai"},
+    )
+
+    mistral_msg = _convert_message_to_mistral_chat_message(msg)
+
+    assert mistral_msg["role"] == "assistant"
+    assert "tool_calls" in mistral_msg, "Expected tool_calls to be present."
+
+    tool_calls = mistral_msg["tool_calls"]
+    # With the bug, this would be 4 (2x2); we expect exactly 2 entries.
+    assert len(tool_calls) == 2, f"Expected 2 tool calls, got {len(tool_calls)}"
+
+    # Ensure there are no duplicate ids
+    ids = [tc.get("id") for tc in tool_calls if isinstance(tc, dict)]
+    assert len(ids) == 2
+    assert len(set(ids)) == 2, f"Duplicate tool call ids found: {ids}"

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -322,7 +322,7 @@ def test_retry_with_failure_then_success() -> None:
 def test_no_duplicate_tool_calls_when_multiple_tools() -> None:
     """
     Tests wether the conversion of an AIMessage with more than one tool call
-    to a Mistral assistant message correctly returns each tool call exactly 
+    to a Mistral assistant message correctly returns each tool call exactly
     once in the final payload.
 
     The current implementation uses a faulty for loop which produces N*N entries in the


### PR DESCRIPTION
### Description

A bug inside the mistralai.chat_models._convert_message_to_mistral_chat_message function duplicates tools_calls when converting an AIMessage to a Mistral assistant message. The bug is caused by a for loop structure that iterates over the full list of tool_calls for every tool_call in the list. 

This means that the final Mistral assistant message will contain N*N tool_calls for an N number of tool_calls in the original AIMessage array. If the Mistral model calls one tool then the code will not raise, but any time it calls at least two tools, agent.invoke() will raise with the following error : 
```bash
Error response 400 while fetching https://api.mistral.ai/v1/chat/completions: {"object":"error","message":"Duplicate tool call id in assistant message","type":"invalid_request_message_order","param":null,"code":"3230"}
```

The fix is a simple modification of the looping logic to make sure each tool_call only gets appended once to prevent duplication. Here is the faulty part of the function **before** the fix : 
```python
tool_calls = []
if message.tool_calls or message.invalid_tool_calls:
    for tool_call in message.tool_calls:
        tool_calls.extend(
            [
                _format_tool_call_for_mistral(tool_call)
                for tool_call in message.tool_calls
            ]
        )
    for invalid_tool_call in message.invalid_tool_calls:
        tool_calls.extend(
            _format_invalid_tool_call_for_mistral(invalid_tool_call)
            for invalid_tool_call in message.invalid_tool_calls
        )
```

And here is the same part **after** the fix : 
```python
tool_calls = []
if message.tool_calls or message.invalid_tool_calls:
    if message.tool_calls:
        # Add each tool call exactly once.
        tool_calls.extend(
            _format_tool_call_for_mistral(tc) for tc in message.tool_calls
        )
    if message.invalid_tool_calls:
        # Add each invalid tool call exactly once.
        tool_calls.extend(
            _format_invalid_tool_call_for_mistral(itc)
            for itc in message.invalid_tool_calls
        )
```

I could not find any issue mentioning this specific bug on the github so no issue linked. Lit and test pass correctly. No additional dependencies.
