### PR TITLE
fix: Add video support to convert_to_openai_data_block function

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -132,16 +132,13 @@ def convert_to_openai_data_block(
                     "type": "video",
                     "video": {
                         "data": f"data:{block['mime_type']};base64,{base64_data}",
-                    }
+                    },
                 }
             else:
                 # For Responses API
                 formatted_block = {
                     "type": "input_video",
-                    "input_video": {
-                        "data": base64_data,
-                        "format": video_format
-                    }
+                    "input_video": {"data": base64_data, "format": video_format},
                 }
         elif "url" in block:
             if api == "chat/completions":
@@ -153,10 +150,7 @@ def convert_to_openai_data_block(
         elif "file_id" in block or block.get("source_type") == "id":
             # Handle video file IDs
             file_id = block["id"] if "source_type" in block else block["file_id"]
-            formatted_block = {
-                "type": "video",
-                "video": {"file_id": file_id}
-            }
+            formatted_block = {"type": "video", "video": {"file_id": file_id}}
             if api == "responses":
                 formatted_block = {"type": "input_video", "file_id": file_id}
         else:
@@ -167,6 +161,7 @@ def convert_to_openai_data_block(
         raise ValueError(error_msg)
 
     return formatted_block
+
 
 # v1 / Chat Completions
 def _convert_to_v1_from_chat_completions(
@@ -215,9 +210,11 @@ def _convert_to_v1_from_chat_completions_input(
 
     converted_blocks = []
     unpacked_blocks: list[dict[str, Any]] = [
-        cast("dict[str, Any]", block)
-        if block.get("type") != "non_standard"
-        else block["value"]  # type: ignore[typeddict-item]  # this is only non-standard blocks
+        (
+            cast("dict[str, Any]", block)
+            if block.get("type") != "non_standard"
+            else block["value"]
+        )  # type: ignore[typeddict-item]  # this is only non-standard blocks
         for block in content
     ]
     for block in unpacked_blocks:

--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -210,13 +210,13 @@ def _convert_to_v1_from_chat_completions_input(
 
     converted_blocks = []
     unpacked_blocks: list[dict[str, Any]] = [
-    (
-        cast("dict[str, Any]", block)
-        if block.get("type") != "non_standard"
-        else cast("dict[str, Any]", block.get("value", block))
-    )
-    for block in content
-]
+        (
+            cast("dict[str, Any]", block)
+            if block.get("type") != "non_standard"
+            else cast("dict[str, Any]", block.get("value", block))
+        )
+        for block in content
+    ]
     for block in unpacked_blocks:
         if block.get("type") in {
             "image_url",

--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -210,13 +210,13 @@ def _convert_to_v1_from_chat_completions_input(
 
     converted_blocks = []
     unpacked_blocks: list[dict[str, Any]] = [
-        (
-            cast("dict[str, Any]", block)
-            if block.get("type") != "non_standard"
-            else block["value"]
-        )  # type: ignore[typeddict-item]  # this is only non-standard blocks
-        for block in content
-    ]
+    (
+        cast("dict[str, Any]", block)
+        if block.get("type") != "non_standard"
+        else cast("dict[str, Any]", block.get("value", block))
+    )
+    for block in content
+]
     for block in unpacked_blocks:
         if block.get("type") in {
             "image_url",


### PR DESCRIPTION
## Description
This PR adds missing video support to the `convert_to_openai_data_block` function, addressing issue #33652.

## Changes
- Added `elif block["type"] == "video":` handling in convert_to_openai_data_block
- Support for base64 encoded videos (both Chat Completions and Responses API)
- Support for video URLs (Responses API only, with proper error for Chat API)
- Support for video file IDs
- Comprehensive error handling for missing required keys

## Testing
Tested all video input scenarios:
- ✅ Base64 encoded videos for both APIs
- ✅ Video URLs (Responses API only)
- ✅ Video file IDs
- ✅ Proper error handling for unsupported combinations
- ✅ Existing image/audio functionality remains intact

Fixes #33652