### PR TITLE
chore(infra): remove openai from langchain-core release test matrix

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -395,7 +395,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        partner: [openai, anthropic]
+        partner: [anthropic]
       fail-fast: false # Continue testing other partners if one fails
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
langchain-openai has a test asserting that a schema raises BadRequestError when processed under `strict` mode.

https://github.com/langchain-ai/langchain/pull/32930 adds support for those schemas. So tests for langchain-openai using the new langchain-core will break until we have a new langchain-openai version out. Disabling tests for openai during langchain-core releases until then.