### PR TITLE
fix(core): implement ChatPromptTemplate.save() method

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -1273,14 +1273,6 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
         """Name of prompt type. Used for serialization."""
         return "chat"
 
-    def save(self, file_path: Path | str) -> None:
-        """Save prompt to file.
-
-        Args:
-            file_path: path to file.
-        """
-        raise NotImplementedError
-
     @override
     def pretty_repr(self, html: bool = False) -> str:
         """Human-readable representation.


### PR DESCRIPTION
# Fix ChatPromptTemplate.save() Implementation

## Summary
This PR fixes issue #32637 by enabling the `save()` method for `ChatPromptTemplate`, which was previously raising `NotImplementedError`.

## Problem
Users were unable to save `ChatPromptTemplate` instances to disk, unlike other prompt types such as `PromptTemplate` and `FewShotPromptTemplate`. When calling `.save()`, the method would raise a `NotImplementedError`, preventing serialization to YAML or JSON files.

## Solution
The fix is straightforward: I removed the `save()` method override that was raising `NotImplementedError`. This allows `ChatPromptTemplate` to inherit the fully functional `save()` implementation from its parent class `BasePromptTemplate`.

The parent class implementation already handles serialization correctly using:
- `self.dict()` for converting the prompt to a dictionary
- `self._prompt_type` property (which `ChatPromptTemplate` already implements, returning `"chat"`)

## Changes
- **Removed**: 8 lines from `libs/core/langchain_core/prompts/chat.py` (lines 1276-1283)
- **No new code added** - simply leveraging existing functionality

## Testing
- Verified that `ChatPromptTemplate` instances can now be saved to both YAML and JSON formats
- Confirmed all existing prompt tests pass (118 passed, 18 skipped)
- No breaking changes or regressions introduced

## Impact
After this change, users can:
- Save `ChatPromptTemplate` to YAML files: `chat_prompt.save("prompt.yaml")`
- Save `ChatPromptTemplate` to JSON files: `chat_prompt.save("prompt.json")`
- Serialize prompts consistently across different prompt types

Fixes #32637
