### PR TITLE
docs(langchain): clarify create_tool_calling_agent system_prompt formatting and add troubleshooting

### DIFF
--- a/libs/langchain/langchain_classic/agents/tool_calling_agent/base.py
+++ b/libs/langchain/langchain_classic/agents/tool_calling_agent/base.py
@@ -55,12 +55,11 @@ def create_tool_calling_agent(
                 ("placeholder", "{agent_scratchpad}"),
             ]
         )
-
         model = ChatAnthropic(model="claude-3-opus-20240229")
 
         @tool
         def magic_function(input: int) -> int:
-            """Applies a magic function to an input."""
+            \"\"\"Applies a magic function to an input.\"\"\"
             return input + 2
 
         tools = [magic_function]
@@ -87,11 +86,6 @@ def create_tool_calling_agent(
         The agent prompt must have an `agent_scratchpad` key that is a
             `MessagesPlaceholder`. Intermediate agent actions and tool output
             messages will be passed in here.
-
-        Note: The system message in the prompt can accept either a simple string
-            (e.g., "You are a helpful assistant") or a list format for more complex
-            instructions (e.g., ["SystemMessage1", "SystemMessage2"]). Both formats
-            are supported and will be properly processed by the agent.
 
     Troubleshooting:
         - If you encounter `invalid_tool_calls` errors, ensure that your tool

--- a/libs/langchain/langchain_classic/agents/tool_calling_agent/base.py
+++ b/libs/langchain/langchain_classic/agents/tool_calling_agent/base.py
@@ -55,11 +55,12 @@ def create_tool_calling_agent(
                 ("placeholder", "{agent_scratchpad}"),
             ]
         )
+
         model = ChatAnthropic(model="claude-3-opus-20240229")
 
         @tool
         def magic_function(input: int) -> int:
-            \"\"\"Applies a magic function to an input.\"\"\"
+            """Applies a magic function to an input."""
             return input + 2
 
         tools = [magic_function]
@@ -83,11 +84,20 @@ def create_tool_calling_agent(
         ```
 
     Prompt:
-
         The agent prompt must have an `agent_scratchpad` key that is a
             `MessagesPlaceholder`. Intermediate agent actions and tool output
             messages will be passed in here.
 
+        Note: The system message in the prompt can accept either a simple string
+            (e.g., "You are a helpful assistant") or a list format for more complex
+            instructions (e.g., ["SystemMessage1", "SystemMessage2"]). Both formats
+            are supported and will be properly processed by the agent.
+
+    Troubleshooting:
+        - If you encounter `invalid_tool_calls` errors, ensure that your tool
+          functions return properly formatted responses. Tool outputs should be
+          serializable to JSON. For custom objects, implement proper __str__ or
+          to_dict methods.
     """
     missing_vars = {"agent_scratchpad"}.difference(
         prompt.input_variables + list(prompt.partial_variables),


### PR DESCRIPTION
**Description:** 
Improved documentation for `create_tool_calling_agent` function by adding:
- A note clarifying that the system message in the prompt can accept either a simple string format (e.g., "You are a helpful assistant") or a list/array format for more complex instructions (e.g., ["SystemMessage1", "SystemMessage2"]). Both formats are supported and will be properly processed by the agent.
- A new Troubleshooting section with a tip for handling `invalid_tool_calls` errors, advising users to ensure tool outputs are JSON-serializable and suggesting implementation of __str__ or to_dict methods for custom objects.

These additions help users better understand prompt flexibility and provide guidance for resolving common errors.

**Issue:** N/A - Documentation improvement only

**Dependencies:** None