### PR TITLE
feat: agent runtime w/ agent name

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1020,10 +1020,13 @@ def create_agent(  # noqa: PLR0915
 
     def model_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
-        # Wrap runtime with agent name
+        # Create flat AgentRuntime with all runtime properties
         agent_runtime = AgentRuntime(
             agent_name=name or "LangGraph",
-            runtime=runtime,
+            context=runtime.context,
+            store=runtime.store,
+            stream_writer=runtime.stream_writer,
+            previous=runtime.previous,
         )
 
         request = ModelRequest(
@@ -1079,10 +1082,13 @@ def create_agent(  # noqa: PLR0915
 
     async def amodel_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Async model request handler with sequential middleware processing."""
-        # Wrap runtime with agent name
+        # Create flat AgentRuntime with all runtime properties
         agent_runtime = AgentRuntime(
             agent_name=name or "LangGraph",
-            runtime=runtime,
+            context=runtime.context,
+            store=runtime.store,
+            stream_writer=runtime.stream_writer,
+            previous=runtime.previous,
         )
 
         request = ModelRequest(
@@ -1128,21 +1134,26 @@ def create_agent(  # noqa: PLR0915
             async def async_wrapper(state, runtime: Runtime[ContextT]):
                 agent_runtime = AgentRuntime(
                     agent_name=name or "LangGraph",
-                    runtime=runtime,
+                    context=runtime.context,
+                    store=runtime.store,
+                    stream_writer=runtime.stream_writer,
+                    previous=runtime.previous,
                 )
                 return await hook_fn(state, agent_runtime)
 
             return async_wrapper
-        else:
 
-            def sync_wrapper(state, runtime: Runtime[ContextT]):
-                agent_runtime = AgentRuntime(
-                    agent_name=name or "LangGraph",
-                    runtime=runtime,
-                )
-                return hook_fn(state, agent_runtime)
+        def sync_wrapper(state, runtime: Runtime[ContextT]):
+            agent_runtime = AgentRuntime(
+                agent_name=name or "LangGraph",
+                context=runtime.context,
+                store=runtime.store,
+                stream_writer=runtime.stream_writer,
+                previous=runtime.previous,
+            )
+            return hook_fn(state, agent_runtime)
 
-            return sync_wrapper
+        return sync_wrapper
 
     # Add middleware nodes
     for m in middleware:

--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -32,6 +32,7 @@ from .tool_retry import ToolRetryMiddleware
 from .tool_selection import LLMToolSelectorMiddleware
 from .types import (
     AgentMiddleware,
+    AgentRuntime,
     AgentState,
     ModelRequest,
     ModelResponse,
@@ -47,6 +48,7 @@ from .types import (
 
 __all__ = [
     "AgentMiddleware",
+    "AgentRuntime",
     "AgentState",
     "ClearToolUsesEdit",
     "CodexSandboxExecutionPolicy",

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
@@ -1,0 +1,296 @@
+"""Tests for AgentRuntime functionality in middleware."""
+
+from dataclasses import dataclass
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.runtime import Runtime
+from langgraph.store.memory import InMemoryStore
+
+from langchain.agents import create_agent
+from langchain.agents.middleware import (
+    AgentRuntime,
+    before_agent,
+    before_model,
+    wrap_model_call,
+)
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+
+
+@dataclass
+class Context:
+    """Test context for agent runtime."""
+
+    user_id: str
+    session_id: str
+
+
+@pytest.fixture
+def fake_chat_model():
+    """Fixture providing a fake chat model for testing."""
+    return GenericFakeChatModel(messages=iter([AIMessage(content="test response")]))
+
+
+def test_agent_runtime_structure():
+    """Test that AgentRuntime has correct structure."""
+    @dataclass
+    class LocalContext:
+        user_id: str
+
+    runtime = Runtime(
+        context=LocalContext(user_id="test_user"),
+        store=None,
+    )
+
+    agent_runtime = AgentRuntime(
+        agent_name="TestAgent",
+        runtime=runtime,
+    )
+
+    assert agent_runtime.agent_name == "TestAgent"
+    assert agent_runtime.runtime == runtime
+    assert agent_runtime.runtime.context.user_id == "test_user"
+
+
+def test_agent_runtime_in_before_agent_hook(fake_chat_model):
+    """Test that AgentRuntime is correctly passed to before_agent hooks."""
+    captured_agent_name = None
+    captured_context = None
+
+    @before_agent
+    def capture_runtime(state, runtime: AgentRuntime):
+        nonlocal captured_agent_name, captured_context
+        captured_agent_name = runtime.agent_name
+        captured_context = runtime.runtime.context
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[capture_runtime],
+        name="MyTestAgent",
+        context_schema=Context,
+    )
+
+    agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        context=Context(user_id="user123", session_id="session456"),
+    )
+
+    assert captured_agent_name == "MyTestAgent"
+    assert captured_context.user_id == "user123"
+    assert captured_context.session_id == "session456"
+
+
+def test_agent_runtime_in_before_model_hook(fake_chat_model):
+    """Test that AgentRuntime is correctly passed to before_model hooks."""
+    captured_agent_name = None
+    captured_context = None
+
+    @before_model
+    def capture_runtime(state, runtime: AgentRuntime):
+        nonlocal captured_agent_name, captured_context
+        captured_agent_name = runtime.agent_name
+        captured_context = runtime.runtime.context
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[capture_runtime],
+        name="AnotherAgent",
+        context_schema=Context,
+    )
+
+    agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        context=Context(user_id="user456", session_id="session789"),
+    )
+
+    assert captured_agent_name == "AnotherAgent"
+    assert captured_context.user_id == "user456"
+    assert captured_context.session_id == "session789"
+
+
+def test_agent_runtime_in_wrap_model_call(fake_chat_model):
+    """Test that AgentRuntime is accessible via ModelRequest in wrap_model_call."""
+    captured_agent_name = None
+    captured_context = None
+
+    @wrap_model_call
+    def capture_from_request(request: ModelRequest, handler):
+        nonlocal captured_agent_name, captured_context
+        captured_agent_name = request.runtime.agent_name
+        captured_context = request.runtime.runtime.context
+        return handler(request)
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[capture_from_request],
+        name="WrapAgent",
+        context_schema=Context,
+    )
+
+    agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        context=Context(user_id="user789", session_id="session123"),
+    )
+
+    assert captured_agent_name == "WrapAgent"
+    assert captured_context.user_id == "user789"
+    assert captured_context.session_id == "session123"
+
+
+def test_agent_runtime_default_name(fake_chat_model):
+    """Test that AgentRuntime uses default name when not specified."""
+    captured_agent_name = None
+
+    @before_agent
+    def capture_name(state, runtime: AgentRuntime):
+        nonlocal captured_agent_name
+        captured_agent_name = runtime.agent_name
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[capture_name],
+        # name not specified - should default to "LangGraph"
+    )
+
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    assert captured_agent_name == "LangGraph"
+
+
+def test_agent_runtime_with_store(fake_chat_model):
+    """Test that AgentRuntime provides access to store through underlying runtime."""
+    store = InMemoryStore()
+    store.put(("test",), "key1", {"value": "test_data"})
+
+    captured_store_value = None
+
+    @before_agent
+    def access_store(state, runtime: AgentRuntime):
+        nonlocal captured_store_value
+        if runtime.runtime.store:
+            item = runtime.runtime.store.get(("test",), "key1")
+            if item:
+                captured_store_value = item.value
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[access_store],
+        name="StoreAgent",
+        store=store,
+    )
+
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    assert captured_store_value == {"value": "test_data"}
+
+
+async def test_agent_runtime_async_hooks(fake_chat_model):
+    """Test that AgentRuntime works with async middleware hooks."""
+    captured_agent_name = None
+
+    @before_agent
+    async def async_capture(state, runtime: AgentRuntime):
+        nonlocal captured_agent_name
+        captured_agent_name = runtime.agent_name
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[async_capture],
+        name="AsyncAgent",
+    )
+
+    await agent.ainvoke({"messages": [HumanMessage("Hello")]})
+
+    assert captured_agent_name == "AsyncAgent"
+
+
+def test_agent_runtime_multiple_middleware(fake_chat_model):
+    """Test that all middleware receive correct AgentRuntime."""
+    captured_names = []
+
+    @before_agent(name="first")
+    def first_middleware(state, runtime: AgentRuntime):
+        captured_names.append(("first_before_agent", runtime.agent_name))
+        return None
+
+    @before_model(name="second")
+    def second_middleware(state, runtime: AgentRuntime):
+        captured_names.append(("second_before_model", runtime.agent_name))
+        return None
+
+    @wrap_model_call(name="third")
+    def third_middleware(request: ModelRequest, handler):
+        captured_names.append(("third_wrap_model", request.runtime.agent_name))
+        return handler(request)
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[first_middleware, second_middleware, third_middleware],
+        name="MultiMiddlewareAgent",
+    )
+
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    assert len(captured_names) == 3
+    assert all(name == "MultiMiddlewareAgent" for _, name in captured_names)
+    assert captured_names[0][0] == "first_before_agent"
+    assert captured_names[1][0] == "second_before_model"
+    assert captured_names[2][0] == "third_wrap_model"
+
+
+def test_model_request_runtime_field_type():
+    """Test that ModelRequest.runtime field has correct type."""
+    from langchain.agents.middleware.types import ModelRequest
+
+    # Check that the runtime field is AgentRuntime, not Runtime
+    annotations = ModelRequest.__annotations__
+    runtime_annotation = str(annotations["runtime"])
+
+    # Should contain AgentRuntime
+    assert "AgentRuntime" in runtime_annotation
+
+
+def test_agent_runtime_access_pattern(fake_chat_model):
+    """Test the recommended pattern for accessing agent name and context."""
+
+    @wrap_model_call
+    def middleware_using_runtime(request: ModelRequest, handler):
+        # Access agent name directly
+        agent_name = request.runtime.agent_name
+
+        # Access underlying runtime for context, store, etc.
+        user_id = request.runtime.runtime.context.user_id if request.runtime.runtime.context else None
+        store = request.runtime.runtime.store
+
+        assert agent_name == "PatternTestAgent"
+        assert user_id == "pattern_user"
+        assert store is not None
+
+        return handler(request)
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[middleware_using_runtime],
+        name="PatternTestAgent",
+        context_schema=Context,
+        store=InMemoryStore(),
+    )
+
+    agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        context=Context(user_id="pattern_user", session_id="pattern_session"),
+    )

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
@@ -1,22 +1,16 @@
-"""Tests for wrap_model_call and awrap_model_call functionality."""
-
-from dataclasses import dataclass
+"""Tests for AgentRuntime access via wrap_model_call middleware."""
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.tools import tool
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import wrap_model_call
-from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest
+from langchain.tools import ToolRuntime
 
-
-@dataclass
-class Context:
-    """Test context for agent runtime."""
-
-    user_id: str
-    session_id: str
+from .model import FakeToolCallingModel
 
 
 @pytest.fixture
@@ -25,312 +19,90 @@ def fake_chat_model():
     return GenericFakeChatModel(messages=iter([AIMessage(content="test response")]))
 
 
-def test_wrap_model_call_basic(fake_chat_model):
-    """Test basic wrap_model_call functionality."""
-    call_count = 0
+def test_agent_name_accessible_in_middleware(fake_chat_model):
+    """Test that agent name can be accessed via middleware."""
+    captured_agent_name = None
 
     @wrap_model_call
-    def count_calls(request: ModelRequest, handler):
-        nonlocal call_count
-        call_count += 1
+    def capture_agent_name(request: ModelRequest, handler):
+        nonlocal captured_agent_name
+        captured_agent_name = request.runtime.agent_name
         return handler(request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[count_calls],
+        middleware=[capture_agent_name],
         name="TestAgent",
     )
 
     agent.invoke({"messages": [HumanMessage("Hello")]})
-    assert call_count == 1
+    assert captured_agent_name == "TestAgent"
 
 
-def test_wrap_model_call_access_runtime(fake_chat_model):
-    """Test accessing AgentRuntime via ModelRequest in wrap_model_call."""
-    captured_agent_name = None
-    captured_context = None
+def test_nested_agent_name_accessible_in_tool():
+    """Test that nested agent's name is accessible when agent is used in a tool."""
+    # Track which agent names were captured
+    captured_agent_names = []
 
     @wrap_model_call
-    def capture_from_request(request: ModelRequest, handler):
-        nonlocal captured_agent_name, captured_context
-        captured_agent_name = request.runtime.agent_name
-        captured_context = request.runtime.context
+    def capture_agent_name(request: ModelRequest, handler):
+        captured_agent_names.append(request.runtime.agent_name)
         return handler(request)
 
-    agent = create_agent(
-        fake_chat_model,
+    # Create a nested agent that will be called from within a tool
+    nested_agent = create_agent(
+        FakeToolCallingModel(),
         tools=[],
-        middleware=[capture_from_request],
-        name="RuntimeAgent",
-        context_schema=Context,
+        middleware=[capture_agent_name],
+        name="NestedAgent",
     )
 
-    agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="user123", session_id="session456"),
+    # Create a tool that invokes the nested agent
+    @tool
+    def call_nested_agent(query: str, runtime: ToolRuntime) -> str:
+        """Tool that calls a nested agent."""
+        result = nested_agent.invoke({"messages": [HumanMessage(query)]})
+        return result["messages"][-1].content
+
+    # Create outer agent that uses the tool
+    outer_agent = create_agent(
+        FakeToolCallingModel(
+            tool_calls=[
+                [{"name": "call_nested_agent", "args": {"query": "test"}, "id": "1"}],
+                [],
+            ]
+        ),
+        tools=[call_nested_agent],
+        middleware=[capture_agent_name],
+        name="OuterAgent",
     )
 
-    assert captured_agent_name == "RuntimeAgent"
-    assert captured_context.user_id == "user123"
-    assert captured_context.session_id == "session456"
+    # Invoke the outer agent, which should call the tool, which calls the nested agent
+    outer_agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    # Both agents should have captured their names
+    assert "OuterAgent" in captured_agent_names
+    assert "NestedAgent" in captured_agent_names
 
 
-def test_wrap_model_call_modify_request(fake_chat_model):
-    """Test modifying the model request in wrap_model_call."""
-    modified_messages = []
-
-    @wrap_model_call
-    def modify_request(request: ModelRequest, handler):
-        # Add a system prompt
-        modified_request = request.override(system_prompt="You are a helpful assistant")
-        modified_messages.append(modified_request.system_prompt)
-        return handler(modified_request)
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[modify_request],
-        name="ModifyAgent",
-    )
-
-    agent.invoke({"messages": [HumanMessage("Hello")]})
-    assert modified_messages[0] == "You are a helpful assistant"
-
-
-def test_wrap_model_call_modify_response(fake_chat_model):
-    """Test modifying the model response in wrap_model_call."""
-
-    @wrap_model_call
-    def modify_response(request: ModelRequest, handler):
-        response = handler(request)
-        # Modify the response content
-        original_msg = response.result[0]
-        modified_msg = AIMessage(
-            content=f"[MODIFIED] {original_msg.content}",
-            id=original_msg.id,
-        )
-        return ModelResponse(
-            result=[modified_msg],
-            structured_response=response.structured_response,
-        )
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[modify_response],
-        name="ModifyResponseAgent",
-    )
-
-    result = agent.invoke({"messages": [HumanMessage("Hello")]})
-    assert result["messages"][-1].content == "[MODIFIED] test response"
-
-
-def test_wrap_model_call_retry_logic(fake_chat_model):
-    """Test retry logic in wrap_model_call."""
-    attempt_count = 0
-    model_call_count = 0
-
-    @wrap_model_call
-    def retry_on_error(request: ModelRequest, handler):
-        nonlocal attempt_count, model_call_count
-        max_retries = 3
-        last_error = None
-
-        for attempt in range(max_retries):
-            attempt_count += 1
-            try:
-                # Simulate failure on first two attempts
-                model_call_count += 1
-                if model_call_count < 3:
-                    raise ValueError("Simulated failure")
-                return handler(request)
-            except ValueError as e:
-                last_error = e
-                if attempt == max_retries - 1:
-                    raise
-
-        raise last_error  # Should never reach here
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[retry_on_error],
-        name="RetryAgent",
-    )
-
-    result = agent.invoke({"messages": [HumanMessage("Hello")]})
-    assert attempt_count == 3
-    # The model response should be from fake_chat_model
-    assert result["messages"][-1].content == "test response"
-
-
-def test_wrap_model_call_short_circuit(fake_chat_model):
-    """Test short-circuiting model call in wrap_model_call."""
-    handler_called = False
-
-    @wrap_model_call
-    def short_circuit(request: ModelRequest, handler):
-        nonlocal handler_called
-        # Check if we should short-circuit
-        if len(request.messages) > 0 and "bypass" in request.messages[-1].content:
-            # Return cached response without calling handler
-            return AIMessage(content="Cached response")
-
-        handler_called = True
-        return handler(request)
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[short_circuit],
-        name="ShortCircuitAgent",
-    )
-
-    result = agent.invoke({"messages": [HumanMessage("bypass")]})
-    assert not handler_called
-    assert result["messages"][-1].content == "Cached response"
-
-
-def test_wrap_model_call_multiple_middleware(fake_chat_model):
-    """Test composing multiple wrap_model_call middleware."""
-    execution_order = []
-
-    @wrap_model_call(name="first")
-    def first_middleware(request: ModelRequest, handler):
-        execution_order.append("first_before")
-        response = handler(request)
-        execution_order.append("first_after")
-        return response
-
-    @wrap_model_call(name="second")
-    def second_middleware(request: ModelRequest, handler):
-        execution_order.append("second_before")
-        response = handler(request)
-        execution_order.append("second_after")
-        return response
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[first_middleware, second_middleware],
-        name="MultiWrapAgent",
-    )
-
-    agent.invoke({"messages": [HumanMessage("Hello")]})
-
-    # Middleware should compose as: first -> second -> model -> second -> first
-    assert execution_order == [
-        "first_before",
-        "second_before",
-        "second_after",
-        "first_after",
-    ]
-
-
-async def test_awrap_model_call_basic(fake_chat_model):
-    """Test basic awrap_model_call functionality."""
-    call_count = 0
-
-    @wrap_model_call
-    async def count_calls_async(request: ModelRequest, handler):
-        nonlocal call_count
-        call_count += 1
-        return await handler(request)
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[count_calls_async],
-        name="AsyncTestAgent",
-    )
-
-    await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-    assert call_count == 1
-
-
-async def test_awrap_model_call_access_runtime(fake_chat_model):
-    """Test accessing AgentRuntime in async wrap_model_call."""
+async def test_agent_name_accessible_in_async_middleware():
+    """Test that agent name can be accessed in async middleware."""
     captured_agent_name = None
 
     @wrap_model_call
-    async def capture_async(request: ModelRequest, handler):
+    async def capture_agent_name_async(request: ModelRequest, handler):
         nonlocal captured_agent_name
         captured_agent_name = request.runtime.agent_name
         return await handler(request)
 
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="async response")]))
     agent = create_agent(
-        fake_chat_model,
+        fake_model,
         tools=[],
-        middleware=[capture_async],
-        name="AsyncRuntimeAgent",
+        middleware=[capture_agent_name_async],
+        name="AsyncAgent",
     )
 
     await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-    assert captured_agent_name == "AsyncRuntimeAgent"
-
-
-async def test_awrap_model_call_retry_logic(fake_chat_model):
-    """Test async retry logic in awrap_model_call."""
-    attempt_count = 0
-    model_call_count = 0
-
-    @wrap_model_call
-    async def async_retry_on_error(request: ModelRequest, handler):
-        nonlocal attempt_count, model_call_count
-        max_retries = 3
-        last_error = None
-
-        for attempt in range(max_retries):
-            attempt_count += 1
-            try:
-                # Simulate failure on first two attempts
-                model_call_count += 1
-                if model_call_count < 3:
-                    raise ValueError("Simulated async failure")
-                return await handler(request)
-            except ValueError as e:
-                last_error = e
-                if attempt == max_retries - 1:
-                    raise
-
-        raise last_error  # Should never reach here
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[async_retry_on_error],
-        name="AsyncRetryAgent",
-    )
-
-    result = await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-    assert attempt_count == 3
-    # The model response should be from fake_chat_model
-    assert result["messages"][-1].content == "test response"
-
-
-async def test_awrap_model_call_modify_response(fake_chat_model):
-    """Test modifying response in async wrap_model_call."""
-
-    @wrap_model_call
-    async def async_modify_response(request: ModelRequest, handler):
-        response = await handler(request)
-        original_msg = response.result[0]
-        modified_msg = AIMessage(
-            content=f"[ASYNC MODIFIED] {original_msg.content}",
-            id=original_msg.id,
-        )
-        return ModelResponse(
-            result=[modified_msg],
-            structured_response=response.structured_response,
-        )
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[async_modify_response],
-        name="AsyncModifyAgent",
-    )
-
-    result = await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-    assert result["messages"][-1].content == "[ASYNC MODIFIED] test response"
+    assert captured_agent_name == "AsyncAgent"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
@@ -1,20 +1,13 @@
-"""Tests for AgentRuntime functionality in middleware."""
+"""Tests for wrap_model_call and awrap_model_call functionality."""
 
 from dataclasses import dataclass
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage
-from langgraph.runtime import Runtime
-from langgraph.store.memory import InMemoryStore
 
 from langchain.agents import create_agent
-from langchain.agents.middleware import (
-    AgentRuntime,
-    before_agent,
-    before_model,
-    wrap_model_call,
-)
+from langchain.agents.middleware import wrap_model_call
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 
 
@@ -32,90 +25,29 @@ def fake_chat_model():
     return GenericFakeChatModel(messages=iter([AIMessage(content="test response")]))
 
 
-def test_agent_runtime_structure():
-    """Test that AgentRuntime has correct structure."""
+def test_wrap_model_call_basic(fake_chat_model):
+    """Test basic wrap_model_call functionality."""
+    call_count = 0
 
-    @dataclass
-    class LocalContext:
-        user_id: str
-
-    context = LocalContext(user_id="test_user")
-    agent_runtime = AgentRuntime(
-        agent_name="TestAgent",
-        context=context,
-        store=None,
-        stream_writer=None,
-        previous=None,
-    )
-
-    assert agent_runtime.agent_name == "TestAgent"
-    assert agent_runtime.context == context
-    assert agent_runtime.context.user_id == "test_user"
-    assert agent_runtime.store is None
-
-
-def test_agent_runtime_in_before_agent_hook(fake_chat_model):
-    """Test that AgentRuntime is correctly passed to before_agent hooks."""
-    captured_agent_name = None
-    captured_context = None
-
-    @before_agent
-    def capture_runtime(state, runtime: AgentRuntime):
-        nonlocal captured_agent_name, captured_context
-        captured_agent_name = runtime.agent_name
-        captured_context = runtime.context
-        return None
+    @wrap_model_call
+    def count_calls(request: ModelRequest, handler):
+        nonlocal call_count
+        call_count += 1
+        return handler(request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[capture_runtime],
-        name="MyTestAgent",
-        context_schema=Context,
+        middleware=[count_calls],
+        name="TestAgent",
     )
 
-    agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="user123", session_id="session456"),
-    )
-
-    assert captured_agent_name == "MyTestAgent"
-    assert captured_context.user_id == "user123"
-    assert captured_context.session_id == "session456"
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert call_count == 1
 
 
-def test_agent_runtime_in_before_model_hook(fake_chat_model):
-    """Test that AgentRuntime is correctly passed to before_model hooks."""
-    captured_agent_name = None
-    captured_context = None
-
-    @before_model
-    def capture_runtime(state, runtime: AgentRuntime):
-        nonlocal captured_agent_name, captured_context
-        captured_agent_name = runtime.agent_name
-        captured_context = runtime.context
-        return None
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[capture_runtime],
-        name="AnotherAgent",
-        context_schema=Context,
-    )
-
-    agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="user456", session_id="session789"),
-    )
-
-    assert captured_agent_name == "AnotherAgent"
-    assert captured_context.user_id == "user456"
-    assert captured_context.session_id == "session789"
-
-
-def test_agent_runtime_in_wrap_model_call(fake_chat_model):
-    """Test that AgentRuntime is accessible via ModelRequest in wrap_model_call."""
+def test_wrap_model_call_access_runtime(fake_chat_model):
+    """Test accessing AgentRuntime via ModelRequest in wrap_model_call."""
     captured_agent_name = None
     captured_context = None
 
@@ -130,168 +62,275 @@ def test_agent_runtime_in_wrap_model_call(fake_chat_model):
         fake_chat_model,
         tools=[],
         middleware=[capture_from_request],
-        name="WrapAgent",
+        name="RuntimeAgent",
         context_schema=Context,
     )
 
     agent.invoke(
         {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="user789", session_id="session123"),
+        context=Context(user_id="user123", session_id="session456"),
     )
 
-    assert captured_agent_name == "WrapAgent"
-    assert captured_context.user_id == "user789"
-    assert captured_context.session_id == "session123"
+    assert captured_agent_name == "RuntimeAgent"
+    assert captured_context.user_id == "user123"
+    assert captured_context.session_id == "session456"
 
 
-def test_agent_runtime_default_name(fake_chat_model):
-    """Test that AgentRuntime uses default name when not specified."""
-    captured_agent_name = None
+def test_wrap_model_call_modify_request(fake_chat_model):
+    """Test modifying the model request in wrap_model_call."""
+    modified_messages = []
 
-    @before_agent
-    def capture_name(state, runtime: AgentRuntime):
-        nonlocal captured_agent_name
-        captured_agent_name = runtime.agent_name
-        return None
+    @wrap_model_call
+    def modify_request(request: ModelRequest, handler):
+        # Add a system prompt
+        modified_request = request.override(system_prompt="You are a helpful assistant")
+        modified_messages.append(modified_request.system_prompt)
+        return handler(modified_request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[capture_name],
-        # name not specified - should default to "LangGraph"
+        middleware=[modify_request],
+        name="ModifyAgent",
+    )
+
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert modified_messages[0] == "You are a helpful assistant"
+
+
+def test_wrap_model_call_modify_response(fake_chat_model):
+    """Test modifying the model response in wrap_model_call."""
+
+    @wrap_model_call
+    def modify_response(request: ModelRequest, handler):
+        response = handler(request)
+        # Modify the response content
+        original_msg = response.result[0]
+        modified_msg = AIMessage(
+            content=f"[MODIFIED] {original_msg.content}",
+            id=original_msg.id,
+        )
+        return ModelResponse(
+            result=[modified_msg],
+            structured_response=response.structured_response,
+        )
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[modify_response],
+        name="ModifyResponseAgent",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert result["messages"][-1].content == "[MODIFIED] test response"
+
+
+def test_wrap_model_call_retry_logic(fake_chat_model):
+    """Test retry logic in wrap_model_call."""
+    attempt_count = 0
+    model_call_count = 0
+
+    @wrap_model_call
+    def retry_on_error(request: ModelRequest, handler):
+        nonlocal attempt_count, model_call_count
+        max_retries = 3
+        last_error = None
+
+        for attempt in range(max_retries):
+            attempt_count += 1
+            try:
+                # Simulate failure on first two attempts
+                model_call_count += 1
+                if model_call_count < 3:
+                    raise ValueError("Simulated failure")
+                return handler(request)
+            except ValueError as e:
+                last_error = e
+                if attempt == max_retries - 1:
+                    raise
+
+        raise last_error  # Should never reach here
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[retry_on_error],
+        name="RetryAgent",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert attempt_count == 3
+    # The model response should be from fake_chat_model
+    assert result["messages"][-1].content == "test response"
+
+
+def test_wrap_model_call_short_circuit(fake_chat_model):
+    """Test short-circuiting model call in wrap_model_call."""
+    handler_called = False
+
+    @wrap_model_call
+    def short_circuit(request: ModelRequest, handler):
+        nonlocal handler_called
+        # Check if we should short-circuit
+        if len(request.messages) > 0 and "bypass" in request.messages[-1].content:
+            # Return cached response without calling handler
+            return AIMessage(content="Cached response")
+
+        handler_called = True
+        return handler(request)
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[short_circuit],
+        name="ShortCircuitAgent",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("bypass")]})
+    assert not handler_called
+    assert result["messages"][-1].content == "Cached response"
+
+
+def test_wrap_model_call_multiple_middleware(fake_chat_model):
+    """Test composing multiple wrap_model_call middleware."""
+    execution_order = []
+
+    @wrap_model_call(name="first")
+    def first_middleware(request: ModelRequest, handler):
+        execution_order.append("first_before")
+        response = handler(request)
+        execution_order.append("first_after")
+        return response
+
+    @wrap_model_call(name="second")
+    def second_middleware(request: ModelRequest, handler):
+        execution_order.append("second_before")
+        response = handler(request)
+        execution_order.append("second_after")
+        return response
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[first_middleware, second_middleware],
+        name="MultiWrapAgent",
     )
 
     agent.invoke({"messages": [HumanMessage("Hello")]})
 
-    assert captured_agent_name == "LangGraph"
+    # Middleware should compose as: first -> second -> model -> second -> first
+    assert execution_order == [
+        "first_before",
+        "second_before",
+        "second_after",
+        "first_after",
+    ]
 
 
-def test_agent_runtime_with_store(fake_chat_model):
-    """Test that AgentRuntime provides access to store directly."""
-    store = InMemoryStore()
-    store.put(("test",), "key1", {"value": "test_data"})
+async def test_awrap_model_call_basic(fake_chat_model):
+    """Test basic awrap_model_call functionality."""
+    call_count = 0
 
-    captured_store_value = None
-
-    @before_agent
-    def access_store(state, runtime: AgentRuntime):
-        nonlocal captured_store_value
-        if runtime.store:
-            item = runtime.store.get(("test",), "key1")
-            if item:
-                captured_store_value = item.value
-        return None
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[access_store],
-        name="StoreAgent",
-        store=store,
-    )
-
-    agent.invoke({"messages": [HumanMessage("Hello")]})
-
-    assert captured_store_value == {"value": "test_data"}
-
-
-async def test_agent_runtime_async_hooks(fake_chat_model):
-    """Test that AgentRuntime works with async middleware hooks."""
-    captured_agent_name = None
-
-    @before_agent
-    async def async_capture(state, runtime: AgentRuntime):
-        nonlocal captured_agent_name
-        captured_agent_name = runtime.agent_name
-        return None
+    @wrap_model_call
+    async def count_calls_async(request: ModelRequest, handler):
+        nonlocal call_count
+        call_count += 1
+        return await handler(request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[async_capture],
-        name="AsyncAgent",
+        middleware=[count_calls_async],
+        name="AsyncTestAgent",
     )
 
     await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-
-    assert captured_agent_name == "AsyncAgent"
-
-
-def test_agent_runtime_multiple_middleware(fake_chat_model):
-    """Test that all middleware receive correct AgentRuntime."""
-    captured_names = []
-
-    @before_agent(name="first")
-    def first_middleware(state, runtime: AgentRuntime):
-        captured_names.append(("first_before_agent", runtime.agent_name))
-        return None
-
-    @before_model(name="second")
-    def second_middleware(state, runtime: AgentRuntime):
-        captured_names.append(("second_before_model", runtime.agent_name))
-        return None
-
-    @wrap_model_call(name="third")
-    def third_middleware(request: ModelRequest, handler):
-        captured_names.append(("third_wrap_model", request.runtime.agent_name))
-        return handler(request)
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[first_middleware, second_middleware, third_middleware],
-        name="MultiMiddlewareAgent",
-    )
-
-    agent.invoke({"messages": [HumanMessage("Hello")]})
-
-    assert len(captured_names) == 3
-    assert all(name == "MultiMiddlewareAgent" for _, name in captured_names)
-    assert captured_names[0][0] == "first_before_agent"
-    assert captured_names[1][0] == "second_before_model"
-    assert captured_names[2][0] == "third_wrap_model"
+    assert call_count == 1
 
 
-def test_model_request_runtime_field_type():
-    """Test that ModelRequest.runtime field has correct type."""
-    from langchain.agents.middleware.types import ModelRequest
-
-    # Check that the runtime field is AgentRuntime, not Runtime
-    annotations = ModelRequest.__annotations__
-    runtime_annotation = str(annotations["runtime"])
-
-    # Should contain AgentRuntime
-    assert "AgentRuntime" in runtime_annotation
-
-
-def test_agent_runtime_access_pattern(fake_chat_model):
-    """Test the recommended pattern for accessing agent name and context."""
+async def test_awrap_model_call_access_runtime(fake_chat_model):
+    """Test accessing AgentRuntime in async wrap_model_call."""
+    captured_agent_name = None
 
     @wrap_model_call
-    def middleware_using_runtime(request: ModelRequest, handler):
-        # Access agent name directly
-        agent_name = request.runtime.agent_name
-
-        # Access runtime properties directly (flat structure)
-        user_id = request.runtime.context.user_id if request.runtime.context else None
-        store = request.runtime.store
-
-        assert agent_name == "PatternTestAgent"
-        assert user_id == "pattern_user"
-        assert store is not None
-
-        return handler(request)
+    async def capture_async(request: ModelRequest, handler):
+        nonlocal captured_agent_name
+        captured_agent_name = request.runtime.agent_name
+        return await handler(request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[middleware_using_runtime],
-        name="PatternTestAgent",
-        context_schema=Context,
-        store=InMemoryStore(),
+        middleware=[capture_async],
+        name="AsyncRuntimeAgent",
     )
 
-    agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="pattern_user", session_id="pattern_session"),
+    await agent.ainvoke({"messages": [HumanMessage("Hello")]})
+    assert captured_agent_name == "AsyncRuntimeAgent"
+
+
+async def test_awrap_model_call_retry_logic(fake_chat_model):
+    """Test async retry logic in awrap_model_call."""
+    attempt_count = 0
+    model_call_count = 0
+
+    @wrap_model_call
+    async def async_retry_on_error(request: ModelRequest, handler):
+        nonlocal attempt_count, model_call_count
+        max_retries = 3
+        last_error = None
+
+        for attempt in range(max_retries):
+            attempt_count += 1
+            try:
+                # Simulate failure on first two attempts
+                model_call_count += 1
+                if model_call_count < 3:
+                    raise ValueError("Simulated async failure")
+                return await handler(request)
+            except ValueError as e:
+                last_error = e
+                if attempt == max_retries - 1:
+                    raise
+
+        raise last_error  # Should never reach here
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[async_retry_on_error],
+        name="AsyncRetryAgent",
     )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("Hello")]})
+    assert attempt_count == 3
+    # The model response should be from fake_chat_model
+    assert result["messages"][-1].content == "test response"
+
+
+async def test_awrap_model_call_modify_response(fake_chat_model):
+    """Test modifying response in async wrap_model_call."""
+
+    @wrap_model_call
+    async def async_modify_response(request: ModelRequest, handler):
+        response = await handler(request)
+        original_msg = response.result[0]
+        modified_msg = AIMessage(
+            content=f"[ASYNC MODIFIED] {original_msg.content}",
+            id=original_msg.id,
+        )
+        return ModelResponse(
+            result=[modified_msg],
+            structured_response=response.structured_response,
+        )
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[async_modify_response],
+        name="AsyncModifyAgent",
+    )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("Hello")]})
+    assert result["messages"][-1].content == "[ASYNC MODIFIED] test response"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -1351,7 +1351,7 @@ def test_public_private_state_for_custom_middleware() -> None:
     class CustomMiddleware(AgentMiddleware[CustomState]):
         state_schema: type[CustomState] = CustomState
 
-        def before_model(self, state: CustomState) -> dict[str, Any]:
+        def before_model(self, state: CustomState, runtime) -> dict[str, Any]:
             assert "omit_input" not in state
             assert "omit_output" in state
             assert "private_state" not in state
@@ -1456,11 +1456,11 @@ def test_injected_state_in_middleware_agent() -> None:
 
 def test_jump_to_is_ephemeral() -> None:
     class MyMiddleware(AgentMiddleware):
-        def before_model(self, state: AgentState) -> dict[str, Any]:
+        def before_model(self, state: AgentState, runtime) -> dict[str, Any]:
             assert "jump_to" not in state
             return {"jump_to": "model"}
 
-        def after_model(self, state: AgentState) -> dict[str, Any]:
+        def after_model(self, state: AgentState, runtime) -> dict[str, Any]:
             assert "jump_to" not in state
             return {"jump_to": "model"}
 


### PR DESCRIPTION
Adding `agent_name` to `AgentRuntime` so that you can access more execution metadata on `ModelRequest`.

Likely to expand `AgentRuntime` in the future, but keeping semi-private for now.

```py
"""Script demonstrating wrap_model_call middleware showing agent name for main and subagent calls."""

from langchain.agents import create_agent
from langchain.agents.middleware import wrap_model_call
from langchain_core.messages import HumanMessage
from langchain_core.tools import tool
from langgraph.config import get_config

# This will print the agent name for every model call (main or subagent)
@wrap_model_call
def print_agent_name(request, handler):
    """Middleware that prints the runtime agent_name and passes through the request."""
    print(f"[middleware] agent_name: {request.runtime.agent_name}")
    return handler(request)

# Define a subagent that will be called as a tool
subagent = create_agent(
    model="openai:gpt-4o-mini",
    middleware=[print_agent_name],
    name="subagent_graph"
)

# Define a tool that invokes the subagent
@tool
def trigger_subagent(query: str) -> str:
    """Call the subagent with the query."""
    response = subagent.invoke({"messages": [HumanMessage(content=query)]})
    # Return only the assistant's most recent message content
    return response["messages"][-1].content

# Main agent, which has access to the above tool
agent = create_agent(
    model="openai:gpt-4o-mini",
    tools=[trigger_subagent],
    middleware=[print_agent_name],
    name="sydney_graph"
)

# Compose a user message that requires the agent to call the subagent tool
result = agent.invoke({"messages": [HumanMessage(content="Use the trigger_subagent tool to answer: What's 2+2?")]})

print(result["messages"][-1].content)

# Example output:
# [middleware] agent_name: sydney_graph
# [middleware] agent_name: subagent_graph
# [middleware] agent_name: sydney_graph
# 2 + 2 equals 4.
```