### PR TITLE
fix(langchain): format system message as blocks for ProviderStrategy

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1002,7 +1002,15 @@ def create_agent(  # noqa: PLR0915
         model_, effective_response_format = _get_bound_model(request)
         messages = request.messages
         if request.system_prompt:
-            messages = [SystemMessage(request.system_prompt), *messages]
+            # Format system message content based on response format requirements.
+            # OpenAI's structured output (ProviderStrategy) requires content as blocks.
+            if isinstance(effective_response_format, ProviderStrategy):
+                messages = [
+                    SystemMessage([{"type": "text", "text": request.system_prompt}]),
+                    *messages,
+                ]
+            else:
+                messages = [SystemMessage(request.system_prompt), *messages]
 
         output = model_.invoke(messages)
 
@@ -1055,7 +1063,15 @@ def create_agent(  # noqa: PLR0915
         model_, effective_response_format = _get_bound_model(request)
         messages = request.messages
         if request.system_prompt:
-            messages = [SystemMessage(request.system_prompt), *messages]
+            # Format system message content based on response format requirements.
+            # OpenAI's structured output (ProviderStrategy) requires content as blocks.
+            if isinstance(effective_response_format, ProviderStrategy):
+                messages = [
+                    SystemMessage([{"type": "text", "text": request.system_prompt}]),
+                    *messages,
+                ]
+            else:
+                messages = [SystemMessage(request.system_prompt), *messages]
 
         output = await model_.ainvoke(messages)
 


### PR DESCRIPTION
## Description

Fixes issue #33688 where using create_agent with both system_prompt and response_format=ProviderStrategy caused an OpenAI API error.

The problem was that OpenAI's structured output API requires message content to be formatted as content blocks (arrays of objects) rather than plain strings. When a system prompt was provided, the code was creating a SystemMessage with plain string content, which caused the error:

```
Error code: 400 - Invalid type for messages[0].content[0]: expected an object, but got a string instead.
```

## Changes

- Modified _execute_model_sync and _execute_model_async in factory.py to check if effective_response_format is a ProviderStrategy
- When using ProviderStrategy, format SystemMessage content as blocks: [{type: text, text: system_prompt}]
- Otherwise, keep content as plain string for backward compatibility
- Added comprehensive unit tests to verify the fix and backward compatibility

## Testing

- Added test_system_prompt_with_provider_strategy to verify system message is formatted as blocks when using ProviderStrategy
- Added test_system_prompt_with_tool_strategy to verify backward compatibility (system message remains as string with ToolStrategy)
- All changes pass ruff linting and formatting

Fixes #33688