### PR TITLE
fix(core): improve JSON get_format_instructions using Opik Agent Optimizer

### DIFF
--- a/libs/core/langchain_core/output_parsers/format_instructions.py
+++ b/libs/core/langchain_core/output_parsers/format_instructions.py
@@ -1,11 +1,16 @@
 """Format instructions."""
 
-JSON_FORMAT_INSTRUCTIONS = """The output should be formatted as a JSON instance that conforms to the JSON schema below.
+JSON_FORMAT_INSTRUCTIONS = """STRICT OUTPUT FORMAT:
+- Return only the JSON value that conforms to the schema. Do not include any additional text, explanations, headings, or separators.
+- Do not wrap the JSON in Markdown or code fences (no ``` or ```json).
+- Do not prepend or append any text (e.g., do not write "Here is the JSON:").
+- The response must be a single top-level JSON value exactly as required by the schema (object/array/etc.), with no trailing commas or comments.
 
-As an example, for the schema {{"properties": {{"foo": {{"title": "Foo", "description": "a list of strings", "type": "array", "items": {{"type": "string"}}}}}}, "required": ["foo"]}}
-the object {{"foo": ["bar", "baz"]}} is a well-formatted instance of the schema. The object {{"properties": {{"foo": ["bar", "baz"]}}}} is not well-formatted.
+The output should be formatted as a JSON instance that conforms to the JSON schema below.
 
-Here is the output schema:
+As an example, for the schema {{"properties": {{"foo": {{"title": "Foo", "description": "a list of strings", "type": "array", "items": {{"type": "string"}}}}}}, "required": ["foo"]}} the object {{"foo": ["bar", "baz"]}} is a well-formatted instance of the schema. The object {{"properties": {{"foo": ["bar", "baz"]}}}} is not well-formatted.
+
+Here is the output schema (shown in a code block for readability only — do not include any backticks or Markdown in your output):
 ```
 {schema}
 ```"""  # noqa: E501


### PR DESCRIPTION
**Description:** It's common knowledge that the JSON based `get_format_instructions()` has a high failure rate on some models. We tested the prompt systematically using **JSONSchemaBench** with [Opik Agent Optimizer](https://www.comet.com/docs/opik/agent_optimization/overview) (open-source optimizer toolchain) against a few optimizers to improve the underlying prompt using evaluation-based approach.
- The full analysis, test enviroment, and results [can be found here](https://github.com/comet-ml/agent-optimizations-demos/blob/main/projects/json_schema/README.md).
- We achived a score of 0.97 (+708%) vs. the baseline of 0.12 (orignal prompt) on `gpt-4.1`.
- This ensures robust schema adherance and can be re-applied to other formats like `yaml` `xml` etc.

Results from Opik Optimizer: <img width="1313" height="390" alt="Opik Agent Optimizer results using JSONSchemaBench" src="https://github.com/user-attachments/assets/365b7ace-3475-4301-8a42-e26c40ad2850" />

**Issue:** No issues linked
**Dependencies:** No dependencies

---
- [x] **Lint and test**: Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified. 