### PR TITLE
fix(langchain_v1): remove `thread_model_call_count` and `run_model_call_count` from tool node test

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_wrap_model_call_middleware.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_wrap_model_call_middleware.py
@@ -380,7 +380,6 @@ class TestStateAndRuntime:
                 # Access state from request
                 state_values.append(
                     {
-                        "thread_model_call_count": request.state.get("thread_model_call_count", 0),
                         "messages_count": len(request.state.get("messages", [])),
                     }
                 )


### PR DESCRIPTION
While working on ToolRuntime in TS I discovered that Python still uses `thread_model_call_count` and `run_model_call_count` in ToolNode tests which afaik we removed.