### PR TITLE
fix(core): add `tool_call_id` to `on_tool_error` event data

### DIFF
--- a/libs/core/langchain_core/runnables/schema.py
+++ b/libs/core/langchain_core/runnables/schema.py
@@ -45,6 +45,15 @@ class EventData(TypedDict, total=False):
     chunks support addition in general, and adding them up should result
     in the output of the `Runnable` that generated the event.
     """
+    tool_call_id: NotRequired[str | None]
+    """The tool call ID associated with the tool execution.
+
+    This field is only available for tool-related events (e.g., `on_tool_error`)
+    and can be used to link errors to specific tool calls in stateless agent
+    implementations.
+
+    !!! version-added "Added in version 1.0.0"
+    """
 
 
 class BaseStreamEvent(TypedDict):

--- a/libs/core/langchain_core/runnables/schema.py
+++ b/libs/core/langchain_core/runnables/schema.py
@@ -48,11 +48,8 @@ class EventData(TypedDict, total=False):
     tool_call_id: NotRequired[str | None]
     """The tool call ID associated with the tool execution.
 
-    This field is only available for tool-related events (e.g., `on_tool_error`)
-    and can be used to link errors to specific tool calls in stateless agent
-    implementations.
-
-    !!! version-added "Added in version 1.0.0"
+    This field is available for the `on_tool_error` event and can be used to
+    link errors to specific tool calls in stateless agent implementations.
     """
 
 

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -989,7 +989,7 @@ class ChildTool(BaseTool):
             error_to_raise = e
 
         if error_to_raise:
-            run_manager.on_tool_error(error_to_raise)
+            run_manager.on_tool_error(error_to_raise, tool_call_id=tool_call_id)
             raise error_to_raise
         output = _format_output(content, artifact, tool_call_id, self.name, status)
         run_manager.on_tool_end(output, color=color, name=self.name, **kwargs)
@@ -1119,7 +1119,7 @@ class ChildTool(BaseTool):
             error_to_raise = e
 
         if error_to_raise:
-            await run_manager.on_tool_error(error_to_raise)
+            await run_manager.on_tool_error(error_to_raise, tool_call_id=tool_call_id)
             raise error_to_raise
 
         output = _format_output(content, artifact, tool_call_id, self.name, status)

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -698,10 +698,10 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
         **kwargs: Any,
     ) -> None:
         """Run when tool errors."""
-        # Extract tool_call_id from kwargs first, fallback to run_info if available
+        # Extract tool_call_id from kwargs if passed directly, or from run_info
+        # (which was stored during on_tool_start) as a fallback
         tool_call_id = kwargs.get("tool_call_id")
         run_info, inputs = self._get_tool_run_info_with_inputs(run_id)
-        # If not in kwargs, check run_info (fallback for backward compatibility)
         if tool_call_id is None:
             tool_call_id = run_info.get("tool_call_id")
 


### PR DESCRIPTION
# Add `tool_call_id` to `on_tool_error` event data

## Summary

This PR addresses issue #33597 by adding `tool_call_id` to the `on_tool_error` callback event data. This enables users to link tool errors to specific tool calls in stateless agent implementations, which is essential for building OpenAI-compatible APIs and tracking tool execution flows.

## Problem

When streaming events using `astream_events` with `version="v2"`, the `on_tool_error` event only included the error and input data, but lacked the `tool_call_id`. This made it difficult to:

- Link errors to specific tool calls in stateless agent scenarios
- Implement OpenAI-compatible APIs that require tool call tracking
- Track tool execution flows when using `run_id` is not sufficient

## Solution

The fix adds `tool_call_id` propagation through the callback chain:

1. **Pass `tool_call_id` to callbacks**: Updated `BaseTool.run()` and `BaseTool.arun()` to pass `tool_call_id` to both `on_tool_start` and `on_tool_error` callbacks
2. **Store in event stream handler**: Modified `_AstreamEventsCallbackHandler` to store `tool_call_id` in run info during `on_tool_start`
3. **Include in error events**: Updated `on_tool_error` handler to extract and include `tool_call_id` in the event data

## Changes

- **`libs/core/langchain_core/tools/base.py`**:
  - Pass `tool_call_id` to `on_tool_start` in both sync and async methods
  - Pass `tool_call_id` to `on_tool_error` when errors occur

- **`libs/core/langchain_core/tracers/event_stream.py`**:
  - Store `tool_call_id` in run info during `on_tool_start`
  - Extract `tool_call_id` from kwargs or run info in `on_tool_error`
  - Include `tool_call_id` in the `on_tool_error` event data

## Testing

The fix was verified by:

1. Direct tool invocation: Confirmed `tool_call_id` appears in `on_tool_error` event data when calling tools directly
2. Agent integration: Tested with `create_agent` to ensure `tool_call_id` is present in error events during agent execution

```python
# Example verification
async for event in agent.astream_events(
    {"messages": "Please demonstrate a tool error"},
    version="v2",
):
    if event["event"] == "on_tool_error":
        assert "tool_call_id" in event["data"]  # ✓ Now passes
        print(event["data"]["tool_call_id"])
```

## Backward Compatibility

- ✅ Fully backward compatible: `tool_call_id` is optional (can be `None`)
- ✅ No breaking changes: All changes are additive
- ✅ Existing code continues to work without modification

## Related Issues

Fixes #33597