### PR TITLE
fix(model-profiles): remove langchain-core as a dependency

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -81,6 +81,7 @@ jobs:
             langchain
             langchain_v1
             langchain-classic
+            model-profiles
             standard-tests
             text-splitters
             docs

--- a/libs/model-profiles/pyproject.toml
+++ b/libs/model-profiles/pyproject.toml
@@ -7,7 +7,6 @@ authors = []
 license = { text = "MIT" }
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.0.0,<2.0.0",
     "tomli>=2.0.0,<3.0.0; python_version < '3.11'",
 ]
 

--- a/libs/model-profiles/tests/unit_tests/test_chat_model.py
+++ b/libs/model-profiles/tests/unit_tests/test_chat_model.py
@@ -1,6 +1,7 @@
 """End to end test for fetching model profiles from a chat model."""
 
 import pytest
+
 from langchain.chat_models import init_chat_model
 
 

--- a/libs/model-profiles/tests/unit_tests/test_chat_model.py
+++ b/libs/model-profiles/tests/unit_tests/test_chat_model.py
@@ -1,7 +1,6 @@
 """End to end test for fetching model profiles from a chat model."""
 
 import pytest
-
 from langchain.chat_models import init_chat_model
 
 

--- a/libs/model-profiles/uv.lock
+++ b/libs/model-profiles/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -587,7 +587,6 @@ name = "langchain-model-profiles"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
-    { name = "langchain-core" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 
@@ -621,10 +620,7 @@ typing = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "langchain-core", editable = "../core" },
-    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0,<3.0.0" },
-]
+requires-dist = [{ name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0,<3.0.0" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "httpx", specifier = ">=0.23.0,<1" }]


### PR DESCRIPTION
This package does not need langchain-core.