### PR TITLE
fix(langchain): Update langchain-core dependency version

### DIFF
--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -7,7 +7,7 @@ authors = []
 license = { text = "MIT" }
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.0.0,<2.0.0",
+    "langchain-core>=1.0.2,<2.0.0",
     "langgraph>=1.0.2,<1.1.0",
     "pydantic>=2.7.4,<3.0.0",
 ]


### PR DESCRIPTION
  **Description:** langchain 1.0.3 requires langchain-core>=1.0.2, PR updated the dependency.
  **Issue:** Fixes #33770 