### PR TITLE
fix(core): preserve raw similarity in _max_inner_product_relevance_score_fn

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -391,12 +391,14 @@ class VectorStore(ABC):
         return 1.0 - distance
 
     @staticmethod
-    def _max_inner_product_relevance_score_fn(distance: float) -> float:
-        """Normalize the distance to a score on a scale [0, 1]."""
-        if distance > 0:
-            return 1.0 - distance
-
-        return -1.0 * distance
+    def _max_inner_product_relevance_score_fn(similarity: float) -> float:
+        """
+        Convert raw MAX_INNER_PRODUCT scores into a normalized relevance score.
+        
+        For similarity-based metrics, higher scores are already better, so we
+        simply return the similarity (optionally clamp to 0-1 if needed).
+        """
+        return max(0.0, min(1.0, similarity))
 
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
         """The 'correct' relevance function.

--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -392,11 +392,10 @@ class VectorStore(ABC):
 
     @staticmethod
     def _max_inner_product_relevance_score_fn(similarity: float) -> float:
-        """
-        Convert raw MAX_INNER_PRODUCT scores into a normalized relevance score.
-        
-        For similarity-based metrics, higher scores are already better, so we
-        simply return the similarity (optionally clamp to 0-1 if needed).
+        """Convert raw MAX_INNER_PRODUCT scores into a normalized relevance score.
+
+        For similarity-based metrics, higher scores are already better,
+        so we simply return the similarity (optionally clamp to 0-1 if needed).
         """
         return max(0.0, min(1.0, similarity))
 


### PR DESCRIPTION
**Description:**

This PR fixes an inconsistency in `similarity_search_with_relevance_scores` for MAX_INNER_PRODUCT metrics. 
Currently, the `_max_inner_product_relevance_score_fn` inverts raw MAX_INNER_PRODUCT similarity scores using `1.0 - distance`. This is correct for distance-based metrics (like Euclidean or cosine distances), but for similarity-based metrics (like MAX_INNER_PRODUCT), higher values are already better. Applying `1.0 - similarity` flips the score, which causes inconsistent behavior when filtering with `score_threshold` in `similarity_search_with_relevance_scores`.

**Changes in this PR:**

1. Returns the raw similarity for MAX_INNER_PRODUCT metrics (clamped to 0–1 if necessary).
2. Ensures similarity >= score_threshold works naturally for similarity metrics.
3. Maintains the existing logic for distance-based metrics.

**Behavior before fix:**
- MAX_INNER_PRODUCT raw scores were inverted → higher similarity could become lower relevance → documents could be wrongly filtered.

**Behavior after fix:**
- MAX_INNER_PRODUCT raw scores are returned as-is → score_threshold filtering behaves consistently.

**Issue:**
Fixes langchain-ai/langchain-community#427

**Dependencies:**
No additional dependencies.
