### PR TITLE
fix(standard-tests): update multimodal tests

### DIFF
--- a/libs/partners/anthropic/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/integration_tests/test_chat_models.py
@@ -1078,14 +1078,14 @@ def test_image_tool_calling() -> None:
             "text": "what's your favorite color in this image",
         },
     ]
-    image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+    image_url = "https://raw.githubusercontent.com/langchain-ai/docs/4d11d08b6b0e210bd456943f7a22febbd168b543/src/images/agentic-rag-output.png"
     image_data = b64encode(httpx.get(image_url).content).decode("utf-8")
     human_content.append(
         {
             "type": "image",
             "source": {
                 "type": "base64",
-                "media_type": "image/jpeg",
+                "media_type": "image/png",
                 "data": image_data,
             },
         },
@@ -1098,7 +1098,7 @@ def test_image_tool_calling() -> None:
                 {"type": "text", "text": "Hmm let me think about that"},
                 {
                     "type": "tool_use",
-                    "input": {"fav_color": "green"},
+                    "input": {"fav_color": "purple"},
                     "id": "foo",
                     "name": "color_picker",
                 },
@@ -1112,7 +1112,7 @@ def test_image_tool_calling() -> None:
                     "content": [
                         {
                             "type": "text",
-                            "text": "green is a great pick! that's my sister's favorite color",  # noqa: E501
+                            "text": "purple is a great pick! that's my sister's favorite color",  # noqa: E501
                         },
                     ],
                     "is_error": False,
@@ -1122,7 +1122,7 @@ def test_image_tool_calling() -> None:
         ),
     ]
     llm = ChatAnthropic(model=MODEL_NAME)  # type: ignore[call-arg]
-    llm.bind_tools([color_picker]).invoke(messages)
+    _ = llm.bind_tools([color_picker]).invoke(messages)
 
 
 @pytest.mark.default_cassette("test_web_search.yaml.gz")

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -709,7 +709,7 @@ async def test_openai_response_headers_async(use_responses_api: bool) -> None:
 
 def test_image_token_counting_jpeg() -> None:
     model = ChatOpenAI(model="gpt-4o", temperature=0)
-    image_url = "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg"
+    image_url = "https://raw.githubusercontent.com/langchain-ai/docs/9f99bb977307a1bd5efeb8dc6b67eb13904c4af1/src/oss/images/checkpoints.jpg"
     message = HumanMessage(
         content=[
             {"type": "text", "text": "describe the weather in this image"},
@@ -741,7 +741,7 @@ def test_image_token_counting_jpeg() -> None:
 
 def test_image_token_counting_png() -> None:
     model = ChatOpenAI(model="gpt-4o", temperature=0)
-    image_url = "https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"
+    image_url = "https://raw.githubusercontent.com/langchain-ai/docs/4d11d08b6b0e210bd456943f7a22febbd168b543/src/images/agentic-rag-output.png"
     message = HumanMessage(
         content=[
             {"type": "text", "text": "how many dice are in this image"},

--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -2707,7 +2707,7 @@ class ChatModelIntegrationTests(ChatModelTests):
         for tool_message in [oai_format_message, standard_format_message]:
             messages = [
                 HumanMessage(
-                    "get a random image using the tool and give it a concise "
+                    "get a random diagram using the tool and give it a concise "
                     "description"
                 ),
                 AIMessage(

--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -422,6 +422,16 @@ class ChatModelIntegrationTests(ChatModelTests):
             return True
         ```
 
+        Note: this test downloads audio data from wikimedia.org. You may need to set
+        the `LANGCHAIN_TESTS_USER_AGENT` environment variable to identify these
+        requests, e.g.,
+
+        ```bash
+        export LANGCHAIN_TESTS_USER_AGENT="CoolBot/0.0 (https://example.org/coolbot/; coolbot@example.org) generic-library/0.0"
+        ```
+
+        Refer to the [Wikimedia Foundation User-Agent Policy](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy).
+
     ??? info "`supports_video_inputs`"
 
         Boolean property indicating whether the chat model supports image inputs.
@@ -2445,6 +2455,16 @@ class ChatModelIntegrationTests(ChatModelTests):
             },
         }
         ```
+
+        Note: this test downloads audio data from wikimedia.org. You may need to set
+        the `LANGCHAIN_TESTS_USER_AGENT` environment variable to identify these
+        requests, e.g.,
+
+        ```bash
+        export LANGCHAIN_TESTS_USER_AGENT="CoolBot/0.0 (https://example.org/coolbot/; coolbot@example.org) generic-library/0.0"
+        ```
+
+        Refer to the [Wikimedia Foundation User-Agent Policy](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy).
 
         ??? note "Configuration"
 

--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -2484,7 +2484,7 @@ class ChatModelIntegrationTests(ChatModelTests):
             with audio content blocks, specifically base64-encoded files. Otherwise,
             set the `supports_audio_inputs` property to False.
 
-        """
+        """  # noqa: E501
         if not self.supports_audio_inputs:
             pytest.skip("Model does not support audio inputs.")
 

--- a/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
@@ -515,6 +515,16 @@ class ChatModelUnitTests(ChatModelTests):
             return True
         ```
 
+        Note: this test downloads audio data from wikimedia.org. You may need to set
+        the `LANGCHAIN_TESTS_USER_AGENT` environment variable to identify these
+        requests, e.g.,
+
+        ```bash
+        export LANGCHAIN_TESTS_USER_AGENT="CoolBot/0.0 (https://example.org/coolbot/; coolbot@example.org) generic-library/0.0"
+        ```
+
+        Refer to the [Wikimedia Foundation User-Agent Policy](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy).
+
     ??? info "`supports_video_inputs`"
 
         Boolean property indicating whether the chat model supports image inputs.


### PR DESCRIPTION
As of yesterday Wikimedia appears to block `httpx.get` requests that don't include user agent headers. `langchain-tests` pulls image and audio data from Wikimedia on the fly for testing multimodal features.

For image tests, here we instead use images created by LangChain and hosted on the LangChain docs github repo.

For the audio test, we use a CC0 1.0 Universal audio file, still from Wikimedia. If the `LANGCHAIN_TESTS_USER_AGENT` env var is set, `langchain-tests` will use that when pulling the audio.

Packages that enable `supports_audio_inputs` may need to specify a user agent in `LANGCHAIN_TESTS_USER_AGENT` following Wikimedia's [policy](https://foundation.wikimedia.org/wiki/Policy:Wikimedia_Foundation_User-Agent_Policy).