### PR TITLE
docs: add Code of Conduct link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,4 @@ To improve your LLM application development, pair LangChain with:
 - [API Reference](https://reference.langchain.com/python): Detailed reference on navigating base packages and integrations for LangChain.
 - [Integrations](https://docs.langchain.com/oss/python/integrations/providers/overview): List of LangChain integrations, including chat & embedding models, tools & toolkits, and more
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview): Learn how to contribute to LangChain and find good first issues.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/blob/master/.github/CODE_OF_CONDUCT.md): Our community guidelines and standards for participation.


### PR DESCRIPTION
**Description:** Add link to Code of Conduct in the Additional resources section to make community guidelines more accessible for all contributors.

**Rationale:** 
- **Community Health:** Making the Code of Conduct easily discoverable helps set clear expectations for community behavior and fosters a more inclusive, respectful environment
- **New Contributor Experience:** Many new contributors look to the README as the primary source of project information. Having the Code of Conduct readily available helps onboard them properly
- **Best Practices:** Prominent Code of Conduct links are considered a best practice in open source projects and improve project accessibility
- **Low Impact:** This is a simple, non-breaking change that significantly improves documentation completeness

**Issue:** N/A

**Dependencies:** None