### PR TITLE
fix(langchain): ensure HITL middleware edit decisions persist in agent state

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -237,7 +237,7 @@ class HumanInTheLoopMiddleware(AgentMiddleware):
         decision: Decision,
         tool_call: ToolCall,
         config: InterruptOnConfig,
-    ) -> tuple[ToolCall | None, ToolMessage | None]:
+    ) -> tuple[ToolCall | None, ToolMessage | HumanMessage | None]:
         """Process a single decision and return the revised tool call and optional tool message."""
         allowed_decisions = config["allowed_decisions"]
 
@@ -308,7 +308,7 @@ class HumanInTheLoopMiddleware(AgentMiddleware):
 
         # Process all tool calls that require interrupts
         revised_tool_calls: list[ToolCall] = auto_approved_tool_calls.copy()
-        artificial_tool_messages: list[ToolMessage] = []
+        artificial_tool_messages: list[ToolMessage | HumanMessage] = []
 
         # Create action requests and review configs for all tools that need approval
         action_requests: list[ActionRequest] = []

--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -218,12 +218,14 @@ class HumanInTheLoopMiddleware(AgentMiddleware):
                 if tool_call_id in self._pending_edit_contexts:
                     # Found a ToolMessage for an edited tool call
                     edit_info = self._pending_edit_contexts[tool_call_id]
+                    args_json = json.dumps(edit_info["args"], indent=2)
                     context_msg = HumanMessage(
                         content=(
-                            f"[System Reminder] The tool '{edit_info['name']}' was executed with "
-                            f"edited parameters: {json.dumps(edit_info['args'], indent=2)}. "
-                            f"When responding to the user, reference the edited parameters, "
-                            f"not the original request."
+                            f"[IMPORTANT - DO NOT IGNORE] The tool '{edit_info['name']}' "
+                            f"has ALREADY BEEN EXECUTED SUCCESSFULLY with edited parameters: "
+                            f"{args_json}. The task is COMPLETE. DO NOT execute this tool again. "
+                            f"Your response must reference the edited parameters shown above, "
+                            f"NOT the user's original request."
                         ),
                     )
                     context_messages.append(context_msg)

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -1171,7 +1171,7 @@ def test_human_in_the_loop_middleware_edit_actually_executes_with_edited_args(
     # Check for context messages (HumanMessage)
     # We expect TWO context messages for edit decisions:
     # 1. Pre-execution: "[System Note] The user edited the proposed tool call..."
-    # 2. Post-execution: "[System Reminder] The tool was executed with edited parameters..."
+    # 2. Post-execution: "[IMPORTANT - DO NOT IGNORE] The tool ... has ALREADY BEEN EXECUTED SUCCESSFULLY..."
     context_messages = [m for m in human_messages if "edited" in m.content.lower()]
     assert len(context_messages) == 2, (
         f"Should have exactly two edit context messages (pre and post execution), "
@@ -1180,6 +1180,9 @@ def test_human_in_the_loop_middleware_edit_actually_executes_with_edited_args(
     # Both should mention the edited email address
     for msg in context_messages:
         assert "alice@test.com" in msg.content
+    # Post-execution message should have strong language
+    post_exec_messages = [m for m in context_messages if "ALREADY BEEN EXECUTED" in m.content]
+    assert len(post_exec_messages) == 1, "Should have one strong post-execution reminder"
 
     # Check for execution result (ToolMessage)
     exec_messages = [m for m in tool_messages if "Email sent" in m.content]

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -1168,10 +1168,18 @@ def test_human_in_the_loop_middleware_edit_actually_executes_with_edited_args(
     human_messages = [m for m in result["messages"] if isinstance(m, HumanMessage)]
     tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
 
-    # Check for context message (HumanMessage)
+    # Check for context messages (HumanMessage)
+    # We expect TWO context messages for edit decisions:
+    # 1. Pre-execution: "[System Note] The user edited the proposed tool call..."
+    # 2. Post-execution: "[System Reminder] The tool was executed with edited parameters..."
     context_messages = [m for m in human_messages if "edited" in m.content.lower()]
-    assert len(context_messages) == 1, "Should have exactly one edit context message"
-    assert "alice@test.com" in context_messages[0].content
+    assert len(context_messages) == 2, (
+        f"Should have exactly two edit context messages (pre and post execution), "
+        f"but got {len(context_messages)}"
+    )
+    # Both should mention the edited email address
+    for msg in context_messages:
+        assert "alice@test.com" in msg.content
 
     # Check for execution result (ToolMessage)
     exec_messages = [m for m in tool_messages if "Email sent" in m.content]

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1922,7 +1922,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
## Description

Fixes critical bugs in the Human-in-the-Loop middleware where edited tool calls weren't properly handled, leading to the agent re-executing tools or referencing original parameters instead of edited ones.

## The Problem

When a user edited a tool call via HITL middleware:
1. ✅ The edited tool would execute correctly with the new parameters
2. ✅ The `AIMessage.tool_calls` would be updated in state
3. ❌ **But the agent might still re-execute the original tool call or reference original parameters**

**Example:**
```
User: "Send email to alice@example.com"
[Human edits to alice@test.com]
Tool: Email sent to alice@test.com ✓
Agent: "Email sent to alice@example.com" ✗  ← References original, not edited!
Or worse: Tries to send another email to alice@example.com ✗✗
```

## Root Causes & Progressive Fixes

This PR contains **five progressive fixes** addressing different layers of the problem:

### Fix 1: Data Persistence (Commit `69d4f40`)
**Problem:** Direct mutations to `AIMessage.tool_calls` weren't persisting in LangGraph's state.

**Solution:** Create a new `AIMessage` instance instead of mutating:
```python
# Before: Direct mutation (doesn't persist)
last_ai_msg.tool_calls = revised_tool_calls  ❌

# After: Create new message (persists correctly)
updated_ai_msg = AIMessage(
    tool_calls=revised_tool_calls,
    id=last_ai_msg.id,  # Same ID ensures replacement
    ...
)  ✅
```

### Fix 2: Pre-execution Context (Commit `ce9892f`)
**Problem:** Even with persisted edits, the AI didn't know the tool call had been edited.

**Solution:** Add a `[System Note]` message before tool execution:
```python
HumanMessage(
    "[System Note] The user edited the proposed tool call..."
)
```

### Fix 3: Post-execution Reminder (Commit `4d4039f`)
**Problem:** The pre-execution context was too far from the AI's final response generation.

**Solution:** Add a `before_model()` hook that injects a reminder immediately before the AI generates its final response:
```python
def before_model(self, state, runtime):
    """Inject context messages after tool execution for edited tool calls."""
    return {"messages": [HumanMessage(
        f"[System Reminder] The tool was executed with edited parameters..."
    )]}
```

### Fix 4: Strengthen Message Language (Commit `cba1fa2`)
**Problem:** Some LLMs (e.g., llama-3.3-70b, gpt-3.5-turbo) would still attempt to re-execute tools despite the context messages. They tried to be "helpful" by fulfilling the user's original request even though the task was already complete.

**Solution:** Use more explicit, directive language in the post-execution reminder:

**Before:**
```python
"[System Reminder] The tool was executed with edited parameters..."
```

**After:**
```python
"[IMPORTANT - DO NOT IGNORE] The tool has ALREADY BEEN EXECUTED SUCCESSFULLY
with edited parameters: {...}. The task is COMPLETE. DO NOT execute this
tool again. Your response must reference the edited parameters shown above,
NOT the user's original request."
```

### Fix 5: OpenAI Message Ordering Compliance (Commit `68549cf`) ← **Critical Fix**
**Problem:** The implementation violated OpenAI's strict message ordering rule: `AIMessage` with `tool_calls` MUST be immediately followed by `ToolMessage`. User [@lesong36](https://github.com/langchain-ai/langchain/issues/33787#issuecomment-3500811645) reported:
```
BadRequestError: An assistant message with 'tool_calls' must be followed
by tool messages responding to each 'tool_call_id'
```

Our previous Fix 2 created this invalid sequence:
```
1. AIMessage (with tool_calls)
2. HumanMessage ("[System Note] edited...")  ❌ Breaks OpenAI rule!
3. ToolMessage (execution result)
```

**Solution:** Embed pre-execution edit context directly in `AIMessage.content` instead of creating a separate `HumanMessage`:
```python
# Before (WRONG - separate HumanMessage)
edit_context_message = HumanMessage(
    content="[System Note] The user edited..."
)
return edited_tool_call, edit_context_message  # ❌

# After (CORRECT - embedded in AIMessage.content)
updated_ai_msg = AIMessage(
    content=f"{original_content}\n\n[System Note] The user edited...",
    tool_calls=revised_tool_calls,
    ...
)  # ✅
```

**Design rationale:** This fix maintains OpenAI API compatibility while preserving functionality across all LLM providers. Added `_build_updated_content()` helper method for clean separation of concerns.

## Message Flow After All Fixes

```
1. HumanMessage: "Send email to alice@example.com"
2. AIMessage:                                              ← Fix 1 & 5
   - content: "I'll help\n\n[System Note] edited to alice@test.com"
   - tool_calls: [tool_call(to="alice@test.com")]
3. ToolMessage: "Email sent to alice@test.com"            ← Immediately follows AIMessage ✅
4. HumanMessage: "[IMPORTANT] ALREADY EXECUTED..."        ← Fix 3 & 4
5. AIMessage: "Email sent to alice@test.com" ✓
```

## Changes

**Core middleware changes:**
- **Added `_build_updated_content()`**: Helper method to embed edit information in AIMessage.content
- **Added `_pending_edit_contexts`**: Dictionary to track edited tool calls across middleware hooks
- **Added `before_model()` hook**: Injects post-execution reminder messages
- **Updated `after_model()`**: Embeds edit context in AIMessage.content (OpenAI compliance)
- **Updated `_process_decision()`**: Returns `None` instead of `HumanMessage` for edits
- **Strengthened message language**: More explicit and directive to prevent LLM misbehavior

**Test updates:**
- Updated test expectations to expect embedded edit context in AIMessage.content
- Verify only one HumanMessage (post-execution)
- Verify "ALREADY BEEN EXECUTED" language in post-execution message
- All 16 HITL middleware tests pass

## Testing

✅ All 16 HITL middleware tests pass
✅ Key test `test_human_in_the_loop_middleware_edit_actually_executes_with_edited_args` validates:
  - Tool executes with edited parameters
  - Pre-execution context embedded in AIMessage.content (OpenAI compliance)
  - Post-execution reminder as separate HumanMessage
  - Both messages reference edited parameters
  - Strong post-execution reminder uses "ALREADY BEEN EXECUTED" language
  - AI's final response correctly references edited parameters
  - No re-execution attempts
✅ Linting passes (ruff, mypy)
✅ Type checking passes
✅ **Verified with real LLM** (GROQ llama-3.3-70b-versatile)
✅ **OpenAI API compatible** (message ordering complies with requirements)

## Best Practices

For optimal results with HITL middleware, users should provide appropriate system prompts:

```python
agent = create_agent(
    model="groq/llama-3.3-70b-versatile",
    tools=[...],
    middleware=[HumanInTheLoopMiddleware(...)],
    system_prompt="""You are a helpful assistant.

    IMPORTANT: When you see a ToolMessage, the tool has already been executed.
    Do not execute it again. Report the result."""
)
```

See the PR discussion for a complete best practices guide.

## Architecture

This solution maintains clean architecture by:
- ✅ Keeping fixes localized to the middleware layer
- ✅ Avoiding tight coupling between factory and specific middleware
- ✅ Preserving user control over system prompts
- ✅ Following single responsibility principle
- ✅ **Complying with OpenAI API message ordering requirements**

## Issue

Fixes #33787
Fixes #33784

## Dependencies

No new dependencies added.

---

**Summary:** Five progressive fixes that together solve the HITL edit persistence problem at multiple layers - from state management to LLM behavior guidance to OpenAI API compliance.