### PR TITLE
fix(langchain_v1): disable summarization when max_tokens_before_summary is None

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -104,11 +104,12 @@ class SummarizationMiddleware(AgentMiddleware):
         messages = state["messages"]
         self._ensure_message_ids(messages)
 
+        # If max_tokens_before_summary is None, summarization is disabled
+        if self.max_tokens_before_summary is None:
+            return None
+
         total_tokens = self.token_counter(messages)
-        if (
-            self.max_tokens_before_summary is not None
-            and total_tokens < self.max_tokens_before_summary
-        ):
+        if total_tokens < self.max_tokens_before_summary:
             return None
 
         cutoff_index = self._find_safe_cutoff(messages)

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -1056,10 +1056,16 @@ def test_summarization_middleware_no_summarization_cases() -> None:
     model = FakeToolCallingModel()
     middleware = SummarizationMiddleware(model=model, max_tokens_before_summary=1000)
 
-    # Test when summarization is disabled
+    # Test when summarization is disabled with few messages
     middleware_disabled = SummarizationMiddleware(model=model, max_tokens_before_summary=None)
     state = {"messages": [HumanMessage(content="Hello"), AIMessage(content="Hi")]}
     result = middleware_disabled.before_model(state, None)
+    assert result is None
+
+    # Test when summarization is disabled with many messages (exceeding messages_to_keep)
+    many_messages = [HumanMessage(content=f"Message {i}") for i in range(25)]
+    state_many = {"messages": many_messages}
+    result = middleware_disabled.before_model(state_many, None)
     assert result is None
 
     # Test when token count is below threshold


### PR DESCRIPTION
**Description:** 

Fix `SummarizationMiddleware` to properly disable all summarization when `max_tokens_before_summary=None`, as documented in the docstring. 

Previously, when `max_tokens_before_summary=None`, the middleware would still trigger summarization if the number of messages exceeded `messages_to_keep` (default: 20). This violated the documented behavior that states: "If `None`, summarization is disabled."

The fix adds an early return when `max_tokens_before_summary` is None, ensuring summarization is completely disabled regardless of message count or token count.

**Changes:**
- Added explicit check in `before_model()` to return early when `max_tokens_before_summary` is None
- Added test case with 25 messages (exceeding `messages_to_keep=20`) to verify summarization remains disabled

**Issue:** N/A 
**Dependencies:** None

---

**Testing:**
- ✅ Added new test case: `test_summarization_middleware_no_summarization_cases` with 25 messages
- ✅ Existing tests continue to pass
- ✅ Verified fix 