### PR TITLE
fix(langchain): add explicit langgraph-prebuilt dependency

### DIFF
--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.0.0,<2.0.0",
     "langgraph>=1.0.2,<1.1.0",
+    "langgraph-prebuilt>=1.0.2,<1.1.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1783,6 +1783,7 @@ source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph" },
+    { name = "langgraph-prebuilt" },
     { name = "pydantic" },
 ]
 
@@ -1891,6 +1892,7 @@ requires-dist = [
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
     { name = "langgraph", specifier = ">=1.0.2,<1.1.0" },
+    { name = "langgraph-prebuilt", specifier = ">=1.0.2,<1.1.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["model-profiles", "community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "deepseek", "xai", "perplexity"]


### PR DESCRIPTION
## Problem
Users installing langchain 1.0.3 encountered a ModuleNotFoundError when importing from langgraph.prebuilt.tool_node, even though langgraph>=1.0.2 was correctly specified as a dependency.

While langgraph 1.0.2 declares langgraph-prebuilt>=1.0.2 as a dependency, in certain installation scenarios (particularly with pip), transitive dependencies may not be properly resolved.

## Solution
Add langgraph-prebuilt>=1.0.2,<1.1.0 as an explicit direct dependency in langchain's pyproject.toml. This ensures the package is always installed regardless of dependency resolution order or package manager behavior.

## Testing
- Verified imports work: from langgraph.prebuilt.tool_node import ToolNode
- Verified create_agent() works correctly with the dependency
- All local imports and basic functionality tests pass