### PR TITLE
fix(langchain):resolve version conflicts

### DIFF
--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.0.0,<2.0.0",
     "langgraph>=1.0.2,<1.1.0",
+    "langgraph-prebuilt>=1.0.2,<1.1.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 


### PR DESCRIPTION
 - **Description:** Resolve the dependency issue between create_agent (in LangChain 1.0.3) and langgraph-prebuilt 1.0.2. LangChain 1.0.3 depends on LangGraph with a version requirement of >=1.0.2 and <1.1.0, while LangGraph 1.0.2 itself has a dependency on langgraph-prebuilt. If a different version of langgraph-prebuilt is installed manually, or if there is inconsistency in dependency resolution, it may lead to version conflicts. create_agent is imported from langgraph.prebuilt.tool_node, so ensure that langgraph-prebuilt is version-compatible with LangGraph. It is recommended that users let LangGraph’s dependency system automatically resolve langgraph-prebuilt, instead of installing a conflicting version manually.
  - **Issue:** Fixes #33804