### PR TITLE
chore: correct `langchain-community` references

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,10 +55,10 @@ All out of scope targets defined by huntr as well as:
 * **langchain-experimental**: This repository is for experimental code and is not
   eligible for bug bounties (see [package warning](https://pypi.org/project/langchain-experimental/)), bug reports to it will be marked as interesting or waste of
   time and published with no bounty attached.
-* **tools**: Tools in either langchain or langchain-community are not eligible for bug
+* **tools**: Tools in either `langchain` or `langchain-community` are not eligible for bug
   bounties. This includes the following directories
-  * libs/langchain/langchain/tools
-  * libs/community/langchain_community/tools
+  * `libs/langchain/langchain/tools`
+  * `libs/community/langchain_community/tools`
   * Please review the [Best Practices](#best-practices)
     for more details, but generally tools interact with the real world. Developers are
     expected to understand the security implications of their code and are responsible

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -774,7 +774,7 @@ class Runnable(ABC, Generic[Input, Output]):
         """Assigns new fields to the `dict` output of this `Runnable`.
 
         ```python
-        from langchain_community.llms.fake import FakeStreamingListLLM
+        from langchain_core.language_models.fake import FakeStreamingListLLM
         from langchain_core.output_parsers import StrOutputParser
         from langchain_core.prompts import SystemMessagePromptTemplate
         from langchain_core.runnables import Runnable
@@ -5766,7 +5766,7 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):  # type: ignore[no-re
         ```python
         # Create a Runnable binding that invokes the chat model with the
         # additional kwarg `stop=['-']` when running it.
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
 
         model = ChatOpenAI()
         model.invoke('Say "Parrot-MAGIC"', stop=["-"])  # Should return `Parrot`

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -122,7 +122,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):  # type: ignore[no-redef]
         ```python
         from typing import Optional
 
-        from langchain_community.chat_models import ChatAnthropic
+        from langchain_anthropic import ChatAnthropic
         from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
         from langchain_core.runnables.history import RunnableWithMessageHistory
 

--- a/libs/langchain/langchain_classic/_api/module_import.py
+++ b/libs/langchain/langchain_classic/_api/module_import.py
@@ -26,7 +26,7 @@ def create_importer(
     imports to new imports.
 
     The function will raise deprecation warning on loops using
-    deprecated_lookups or fallback_module.
+    `deprecated_lookups` or `fallback_module`.
 
     Module lookups will import without deprecation warnings (used to speed
     up imports from large namespaces like llms or chat models).
@@ -37,18 +37,20 @@ def create_importer(
     loss of type information, IDE support for going to definition etc).
 
     Args:
-        package: current package. Use __package__
-        module_lookup: maps name of object to the module where it is defined.
+        package: Current package. Use `__package__`
+        module_lookup: Maps name of object to the module where it is defined.
             e.g.,
+            ```json
             {
                 "MyDocumentLoader": (
                     "langchain_community.document_loaders.my_document_loader"
                 )
             }
-        deprecated_lookups: same as module look up, but will raise
+            ```
+        deprecated_lookups: Same as module look up, but will raise
             deprecation warnings.
-        fallback_module: module to import from if the object is not found in
-            module_lookup or if module_lookup is not provided.
+        fallback_module: Module to import from if the object is not found in
+            `module_lookup` or if `module_lookup` is not provided.
 
     Returns:
         A function that imports objects from the specified modules.
@@ -56,7 +58,7 @@ def create_importer(
     all_module_lookup = {**(deprecated_lookups or {}), **(module_lookup or {})}
 
     def import_by_name(name: str) -> Any:
-        """Import stores from langchain_community."""
+        """Import stores from `langchain_community`."""
         # If not in interactive env, raise warning.
         if all_module_lookup and name in all_module_lookup:
             new_module = all_module_lookup[name]

--- a/libs/langchain/langchain_classic/agents/json_chat/base.py
+++ b/libs/langchain/langchain_classic/agents/json_chat/base.py
@@ -50,7 +50,7 @@ def create_json_chat_agent(
     Example:
         ```python
         from langchain_classic import hub
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
         from langchain_classic.agents import AgentExecutor, create_json_chat_agent
 
         prompt = hub.pull("hwchase17/react-chat-json")

--- a/libs/langchain/langchain_classic/agents/openai_functions_agent/base.py
+++ b/libs/langchain/langchain_classic/agents/openai_functions_agent/base.py
@@ -310,7 +310,7 @@ def create_openai_functions_agent(
         Creating an agent with no memory
 
         ```python
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
         from langchain_classic.agents import (
             AgentExecutor,
             create_openai_functions_agent,

--- a/libs/langchain/langchain_classic/agents/openai_tools/base.py
+++ b/libs/langchain/langchain_classic/agents/openai_tools/base.py
@@ -40,7 +40,7 @@ def create_openai_tools_agent(
     Example:
         ```python
         from langchain_classic import hub
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
         from langchain_classic.agents import (
             AgentExecutor,
             create_openai_tools_agent,

--- a/libs/langchain/langchain_classic/agents/react/agent.py
+++ b/libs/langchain/langchain_classic/agents/react/agent.py
@@ -59,7 +59,7 @@ def create_react_agent(
     Examples:
         ```python
         from langchain_classic import hub
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
         from langchain_classic.agents import AgentExecutor, create_react_agent
 
         prompt = hub.pull("hwchase17/react")

--- a/libs/langchain/langchain_classic/agents/self_ask_with_search/base.py
+++ b/libs/langchain/langchain_classic/agents/self_ask_with_search/base.py
@@ -116,7 +116,7 @@ def create_self_ask_with_search_agent(
     Examples:
         ```python
         from langchain_classic import hub
-        from langchain_community.chat_models import ChatAnthropic
+        from langchain_anthropic import ChatAnthropic
         from langchain_classic.agents import (
             AgentExecutor,
             create_self_ask_with_search_agent,

--- a/libs/langchain/langchain_classic/agents/structured_chat/base.py
+++ b/libs/langchain/langchain_classic/agents/structured_chat/base.py
@@ -195,7 +195,7 @@ def create_structured_chat_agent(
     Examples:
         ```python
         from langchain_classic import hub
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
         from langchain_classic.agents import (
             AgentExecutor,
             create_structured_chat_agent,

--- a/libs/langchain/langchain_classic/agents/xml/base.py
+++ b/libs/langchain/langchain_classic/agents/xml/base.py
@@ -146,7 +146,7 @@ def create_xml_agent(
     Example:
         ```python
         from langchain_classic import hub
-        from langchain_community.chat_models import ChatAnthropic
+        from langchain_anthropic import ChatAnthropic
         from langchain_classic.agents import AgentExecutor, create_xml_agent
 
         prompt = hub.pull("hwchase17/xml-agent-convo")

--- a/libs/langchain/langchain_classic/chains/combine_documents/map_reduce.py
+++ b/libs/langchain/langchain_classic/chains/combine_documents/map_reduce.py
@@ -44,7 +44,7 @@ class MapReduceDocumentsChain(BaseCombineDocumentsChain):
             MapReduceDocumentsChain,
         )
         from langchain_core.prompts import PromptTemplate
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
 
         # This controls how each document will be formatted. Specifically,
         # it will be passed to `format_document` - see that function for more

--- a/libs/langchain/langchain_classic/chains/combine_documents/map_rerank.py
+++ b/libs/langchain/langchain_classic/chains/combine_documents/map_rerank.py
@@ -38,7 +38,7 @@ class MapRerankDocumentsChain(BaseCombineDocumentsChain):
         ```python
         from langchain_classic.chains import MapRerankDocumentsChain, LLMChain
         from langchain_core.prompts import PromptTemplate
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
         from langchain_classic.output_parsers.regex import RegexParser
 
         document_variable_name = "context"

--- a/libs/langchain/langchain_classic/chains/combine_documents/reduce.py
+++ b/libs/langchain/langchain_classic/chains/combine_documents/reduce.py
@@ -163,7 +163,7 @@ class ReduceDocumentsChain(BaseCombineDocumentsChain):
             ReduceDocumentsChain,
         )
         from langchain_core.prompts import PromptTemplate
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
 
         # This controls how each document will be formatted. Specifically,
         # it will be passed to `format_document` - see that function for more

--- a/libs/langchain/langchain_classic/chains/combine_documents/refine.py
+++ b/libs/langchain/langchain_classic/chains/combine_documents/refine.py
@@ -46,7 +46,7 @@ class RefineDocumentsChain(BaseCombineDocumentsChain):
         ```python
         from langchain_classic.chains import RefineDocumentsChain, LLMChain
         from langchain_core.prompts import PromptTemplate
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
 
         # This controls how each document will be formatted. Specifically,
         # it will be passed to `format_document` - see that function for more

--- a/libs/langchain/langchain_classic/chains/combine_documents/stuff.py
+++ b/libs/langchain/langchain_classic/chains/combine_documents/stuff.py
@@ -56,9 +56,9 @@ def create_stuff_documents_chain(
 
     Example:
         ```python
-        # pip install -U langchain langchain-community
+        # pip install -U langchain langchain-openai
 
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
         from langchain_core.documents import Document
         from langchain_core.prompts import ChatPromptTemplate
         from langchain_classic.chains.combine_documents import (
@@ -123,7 +123,7 @@ class StuffDocumentsChain(BaseCombineDocumentsChain):
         ```python
         from langchain_classic.chains import StuffDocumentsChain, LLMChain
         from langchain_core.prompts import PromptTemplate
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
 
         # This controls how each document will be formatted. Specifically,
         # it will be passed to `format_document` - see that function for more

--- a/libs/langchain/langchain_classic/chains/constitutional_ai/base.py
+++ b/libs/langchain/langchain_classic/chains/constitutional_ai/base.py
@@ -165,7 +165,7 @@ class ConstitutionalChain(Chain):
 
     Example:
         ```python
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
         from langchain_classic.chains import LLMChain, ConstitutionalChain
         from langchain_classic.chains.constitutional_ai.models \
             import ConstitutionalPrinciple

--- a/libs/langchain/langchain_classic/chains/conversation/base.py
+++ b/libs/langchain/langchain_classic/chains/conversation/base.py
@@ -97,7 +97,7 @@ class ConversationChain(LLMChain):
     Example:
         ```python
         from langchain_classic.chains import ConversationChain
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
 
         conversation = ConversationChain(llm=OpenAI())
         ```

--- a/libs/langchain/langchain_classic/chains/conversational_retrieval/base.py
+++ b/libs/langchain/langchain_classic/chains/conversational_retrieval/base.py
@@ -357,7 +357,7 @@ class ConversationalRetrievalChain(BaseConversationalRetrievalChain):
             ConversationalRetrievalChain,
         )
         from langchain_core.prompts import PromptTemplate
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
 
         combine_docs_chain = StuffDocumentsChain(...)
         vectorstore = ...

--- a/libs/langchain/langchain_classic/chains/elasticsearch_database/base.py
+++ b/libs/langchain/langchain_classic/chains/elasticsearch_database/base.py
@@ -31,7 +31,7 @@ class ElasticsearchDatabaseChain(Chain):
     Example:
         ```python
         from langchain_classic.chains import ElasticsearchDatabaseChain
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
         from elasticsearch import Elasticsearch
 
         database = Elasticsearch("http://localhost:9200")

--- a/libs/langchain/langchain_classic/chains/history_aware_retriever.py
+++ b/libs/langchain/langchain_classic/chains/history_aware_retriever.py
@@ -33,7 +33,7 @@ def create_history_aware_retriever(
         ```python
         # pip install -U langchain langchain-community
 
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
         from langchain_classic.chains import create_history_aware_retriever
         from langchain_classic import hub
 

--- a/libs/langchain/langchain_classic/chains/llm.py
+++ b/libs/langchain/langchain_classic/chains/llm.py
@@ -64,7 +64,7 @@ class LLMChain(Chain):
     Example:
         ```python
         from langchain_classic.chains import LLMChain
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
         from langchain_core.prompts import PromptTemplate
 
         prompt_template = "Tell me a {adjective} joke"

--- a/libs/langchain/langchain_classic/chains/llm_checker/base.py
+++ b/libs/langchain/langchain_classic/chains/llm_checker/base.py
@@ -77,7 +77,7 @@ class LLMCheckerChain(Chain):
 
     Example:
         ```python
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
         from langchain_classic.chains import LLMCheckerChain
 
         model = OpenAI(temperature=0.7)

--- a/libs/langchain/langchain_classic/chains/llm_math/base.py
+++ b/libs/langchain/langchain_classic/chains/llm_math/base.py
@@ -145,7 +145,7 @@ class LLMMathChain(Chain):
     Example:
         ```python
         from langchain_classic.chains import LLMMathChain
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
 
         llm_math = LLMMathChain.from_llm(OpenAI())
         ```

--- a/libs/langchain/langchain_classic/chains/llm_summarization_checker/base.py
+++ b/libs/langchain/langchain_classic/chains/llm_summarization_checker/base.py
@@ -80,7 +80,7 @@ class LLMSummarizationCheckerChain(Chain):
 
     Example:
         ```python
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
         from langchain_classic.chains import LLMSummarizationCheckerChain
 
         model = OpenAI(temperature=0.0)

--- a/libs/langchain/langchain_classic/chains/openai_functions/base.py
+++ b/libs/langchain/langchain_classic/chains/openai_functions/base.py
@@ -85,7 +85,7 @@ def create_openai_fn_chain(
         from typing import Optional
 
         from langchain_classic.chains.openai_functions import create_openai_fn_chain
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
         from langchain_core.prompts import ChatPromptTemplate
 
         from pydantic import BaseModel, Field
@@ -179,7 +179,7 @@ def create_structured_output_chain(
         from typing import Optional
 
         from langchain_classic.chains.openai_functions import create_structured_output_chain
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
         from langchain_core.prompts import ChatPromptTemplate
 
         from pydantic import BaseModel, Field

--- a/libs/langchain/langchain_classic/chains/retrieval.py
+++ b/libs/langchain/langchain_classic/chains/retrieval.py
@@ -36,9 +36,9 @@ def create_retrieval_chain(
 
     Example:
         ```python
-        # pip install -U langchain langchain-community
+        # pip install -U langchain langchain-openai
 
-        from langchain_community.chat_models import ChatOpenAI
+        from langchain_openai import ChatOpenAI
         from langchain_classic.chains.combine_documents import (
             create_stuff_documents_chain,
         )

--- a/libs/langchain/langchain_classic/chains/retrieval_qa/base.py
+++ b/libs/langchain/langchain_classic/chains/retrieval_qa/base.py
@@ -259,7 +259,7 @@ class RetrievalQA(BaseRetrievalQA):
 
     Example:
         ```python
-        from langchain_community.llms import OpenAI
+        from langchain_openai import OpenAI
         from langchain_classic.chains import RetrievalQA
         from langchain_community.vectorstores import FAISS
         from langchain_core.vectorstores import VectorStoreRetriever

--- a/libs/langchain/langchain_classic/embeddings/cache.py
+++ b/libs/langchain/langchain_classic/embeddings/cache.py
@@ -122,7 +122,7 @@ class CacheBackedEmbeddings(Embeddings):
         ```python
         from langchain_classic.embeddings import CacheBackedEmbeddings
         from langchain_classic.storage import LocalFileStore
-        from langchain_community.embeddings import OpenAIEmbeddings
+        from langchain_openai import OpenAIEmbeddings
 
         store = LocalFileStore("./my_cache")
 

--- a/libs/langchain/langchain_classic/evaluation/agents/trajectory_eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/agents/trajectory_eval_chain.py
@@ -104,7 +104,7 @@ class TrajectoryEvalChain(AgentTrajectoryEvaluator, LLMEvalChain):
     Example:
     ```python
     from langchain_classic.agents import AgentType, initialize_agent
-    from langchain_community.chat_models import ChatOpenAI
+    from langchain_openai import ChatOpenAI
     from langchain_classic.evaluation import TrajectoryEvalChain
     from langchain_classic.tools import tool
 

--- a/libs/langchain/langchain_classic/evaluation/comparison/__init__.py
+++ b/libs/langchain/langchain_classic/evaluation/comparison/__init__.py
@@ -6,7 +6,7 @@ preferences, measuring similarity / semantic equivalence between outputs,
 or any other comparison task.
 
 Example:
-    >>> from langchain_community.chat_models import ChatOpenAI
+    >>> from langchain_openai import ChatOpenAI
     >>> from langchain_classic.evaluation.comparison import PairwiseStringEvalChain
     >>> llm = ChatOpenAI(temperature=0)
     >>> chain = PairwiseStringEvalChain.from_llm(llm=llm)

--- a/libs/langchain/langchain_classic/evaluation/comparison/eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/comparison/eval_chain.py
@@ -163,7 +163,7 @@ class PairwiseStringEvalChain(PairwiseStringEvaluator, LLMEvalChain, LLMChain):
         output_parser (BaseOutputParser): The output parser for the chain.
 
     Example:
-        >>> from langchain_community.chat_models import ChatOpenAI
+        >>> from langchain_openai import ChatOpenAI
         >>> from langchain_classic.evaluation.comparison import PairwiseStringEvalChain
         >>> model = ChatOpenAI(
         ...     temperature=0, model_name="gpt-4", model_kwargs={"random_seed": 42}

--- a/libs/langchain/langchain_classic/evaluation/criteria/__init__.py
+++ b/libs/langchain/langchain_classic/evaluation/criteria/__init__.py
@@ -12,7 +12,7 @@ chain against specified criteria.
 Examples:
 --------
 Using a predefined criterion:
->>> from langchain_community.llms import OpenAI
+>>> from langchain_openai import OpenAI
 >>> from langchain_classic.evaluation.criteria import CriteriaEvalChain
 
 >>> model = OpenAI()
@@ -26,7 +26,7 @@ Using a predefined criterion:
 
 Using a custom criterion:
 
->>> from langchain_community.llms import OpenAI
+>>> from langchain_openai import OpenAI
 >>> from langchain_classic.evaluation.criteria import LabeledCriteriaEvalChain
 
 >>> model = OpenAI()

--- a/libs/langchain/langchain_classic/evaluation/scoring/__init__.py
+++ b/libs/langchain/langchain_classic/evaluation/scoring/__init__.py
@@ -5,7 +5,7 @@ be they LLMs, Chains, or otherwise. This can be based on a variety of
 criteria and or a reference answer.
 
 Example:
-    >>> from langchain_community.chat_models import ChatOpenAI
+    >>> from langchain_openai import ChatOpenAI
     >>> from langchain_classic.evaluation.scoring import ScoreStringEvalChain
     >>> model = ChatOpenAI(temperature=0, model_name="gpt-4")
     >>> chain = ScoreStringEvalChain.from_llm(llm=model)

--- a/libs/langchain/langchain_classic/evaluation/scoring/eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/scoring/eval_chain.py
@@ -154,7 +154,7 @@ class ScoreStringEvalChain(StringEvaluator, LLMEvalChain, LLMChain):
         output_parser (BaseOutputParser): The output parser for the chain.
 
     Example:
-        >>> from langchain_community.chat_models import ChatOpenAI
+        >>> from langchain_openai import ChatOpenAI
         >>> from langchain_classic.evaluation.scoring import ScoreStringEvalChain
         >>> model = ChatOpenAI(temperature=0, model_name="gpt-4")
         >>> chain = ScoreStringEvalChain.from_llm(llm=model)


### PR DESCRIPTION
fix docstrings that referenced community versions of now-native packages