### PR TITLE
chore(infra): drop `langchain_v1` pr lint

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -79,8 +79,7 @@ jobs:
             core
             cli
             langchain
-            langchain_v1
-            langchain-classic
+            langchain_classic
             model-profiles
             standard-tests
             text-splitters


### PR DESCRIPTION
Just use `langchain`