### PR TITLE
fix: don't trace conditional edges and no todos in input state

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1268,11 +1268,14 @@ def create_agent(  # noqa: PLR0915
 
         graph.add_conditional_edges(
             "tools",
-            _make_tools_to_model_edge(
-                tool_node=tool_node,
-                model_destination=loop_entry_node,
-                structured_output_tools=structured_output_tools,
-                end_destination=exit_node,
+            RunnableCallable(
+                _make_tools_to_model_edge(
+                    tool_node=tool_node,
+                    model_destination=loop_entry_node,
+                    structured_output_tools=structured_output_tools,
+                    end_destination=exit_node,
+                ),
+                trace=False,
             ),
             tools_to_model_destinations,
         )
@@ -1289,19 +1292,25 @@ def create_agent(  # noqa: PLR0915
 
         graph.add_conditional_edges(
             loop_exit_node,
-            _make_model_to_tools_edge(
-                model_destination=loop_entry_node,
-                structured_output_tools=structured_output_tools,
-                end_destination=exit_node,
+            RunnableCallable(
+                _make_model_to_tools_edge(
+                    model_destination=loop_entry_node,
+                    structured_output_tools=structured_output_tools,
+                    end_destination=exit_node,
+                ),
+                trace=False,
             ),
             model_to_tools_destinations,
         )
     elif len(structured_output_tools) > 0:
         graph.add_conditional_edges(
             loop_exit_node,
-            _make_model_to_model_edge(
-                model_destination=loop_entry_node,
-                end_destination=exit_node,
+            RunnableCallable(
+                _make_model_to_model_edge(
+                    model_destination=loop_entry_node,
+                    end_destination=exit_node,
+                ),
+                trace=False,
             ),
             [loop_entry_node, exit_node],
         )
@@ -1602,7 +1611,7 @@ def _add_middleware_edge(
         if "model" in can_jump_to and name != model_destination:
             destinations.append(model_destination)
 
-        graph.add_conditional_edges(name, jump_edge, destinations)
+        graph.add_conditional_edges(name, RunnableCallable(jump_edge, trace=False), destinations)
 
     else:
         graph.add_edge(name, default_destination)

--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -19,6 +19,7 @@ from langchain.agents.middleware.types import (
     ModelCallResult,
     ModelRequest,
     ModelResponse,
+    OmitFromInput,
 )
 from langchain.tools import InjectedToolCallId
 
@@ -36,7 +37,7 @@ class Todo(TypedDict):
 class PlanningState(AgentState):
     """State schema for the todo middleware."""
 
-    todos: NotRequired[list[Todo]]
+    todos: Annotated[NotRequired[list[Todo]], OmitFromInput]
     """List of todo items for tracking task progress."""
 
 


### PR DESCRIPTION
while experimenting w/ todo middleware

| Before | After |
|--------|-------|
| ![Screenshot 2025-11-05 at 1 56 21 PM](https://github.com/user-attachments/assets/63195ae4-8122-4662-8246-0fbc16cb1e22) | ![Screenshot 2025-11-05 at 1 56 03 PM](https://github.com/user-attachments/assets/255e2fa8-e52d-4d1a-949a-33df52ee6668) |
| Tracing conditional edges (verbose) | Not tracing conditional edges (cleaner) |
| ![Screenshot 2025-11-05 at 1 57 56 PM](https://github.com/user-attachments/assets/449ccfe9-4c21-4c87-8e0e-6e89d7a97611) | ![Screenshot 2025-11-05 at 1 56 58 PM](https://github.com/user-attachments/assets/c5c28d0e-2153-4572-af29-b2528761fec6) |
| Todos in input state (cluttered) | No todos in input state (cleaner) |