### PR TITLE
fix(core): handle missing dependency version information

### DIFF
--- a/libs/core/langchain_core/sys_info.py
+++ b/libs/core/langchain_core/sys_info.py
@@ -125,9 +125,11 @@ def print_sys_info(*, additional_pkgs: Sequence[str] = ()) -> None:
         for dep in sub_dependencies:
             try:
                 dep_version = metadata.version(dep)
-                print(f"> {dep}: {dep_version}")
             except Exception:
-                print(f"> {dep}: Installed. No version info available.")
+                dep_version = None
+
+            if dep_version is not None:
+                print(f"> {dep}: {dep_version}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow up to #33347

This continues to make searching issues difficult