### PR TITLE
fix(anthropic): handle runtime model fallback in caching middleware

### DIFF
--- a/libs/partners/anthropic/tests/integration_tests/test_caching_middleware.py
+++ b/libs/partners/anthropic/tests/integration_tests/test_caching_middleware.py
@@ -10,7 +10,6 @@ from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 
 
-@pytest.mark.integration
 class TestMiddlewareWithFallback:
     """Test middleware behavior with actual model fallback scenarios."""
 

--- a/libs/partners/anthropic/tests/integration_tests/test_caching_middleware.py
+++ b/libs/partners/anthropic/tests/integration_tests/test_caching_middleware.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+import pytest
+from langchain.agents import create_agent
+from langchain.agents.middleware import ModelFallbackMiddleware
+from langchain_core.messages import HumanMessage
+from langgraph.checkpoint.memory import MemorySaver
+
+from langchain_anthropic import ChatAnthropic
+from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
+
+
+@pytest.mark.integration
+class TestMiddlewareWithFallback:
+    """Test middleware behavior with actual model fallback scenarios."""
+
+    def test_fallback_to_openai_without_error(self) -> None:
+        """Test that fallback to OpenAI works without cache_control errors."""
+        # This test requires API keys but can be mocked for CI
+        # Skip if API keys not available
+        pytest.importorskip("langchain_openai")
+
+        from langchain_openai import ChatOpenAI  # type: ignore[import-not-found]
+
+        # Create agent with fallback middleware
+        # Use invalid Anthropic model to force immediate fallback
+        agent: Any = create_agent(
+            model=ChatAnthropic(model="invalid-model-name", api_key="invalid"),
+            checkpointer=MemorySaver(),
+            middleware=[
+                ModelFallbackMiddleware(
+                    ChatOpenAI(model="gpt-4o-mini")  # Will fallback to this
+                ),
+                AnthropicPromptCachingMiddleware(ttl="5m"),
+            ],
+        )
+
+        # This should not raise TypeError about cache_control
+        # It will fail due to invalid API keys, but that's expected
+        # The key is that it doesn't fail with cache_control error
+        config: Any = {"configurable": {"thread_id": "test"}}
+
+        with pytest.raises(Exception) as exc_info:
+            agent.invoke({"messages": [HumanMessage(content="Hello")]}, config)
+        # Should not be a cache_control TypeError
+        assert "cache_control" not in str(exc_info.value).lower()
+
+    @pytest.mark.asyncio
+    async def test_async_fallback_to_openai(self) -> None:
+        """Test async version with fallback to OpenAI."""
+        pytest.importorskip("langchain_openai")
+
+        from langchain_openai import ChatOpenAI  # type: ignore[import-not-found]
+
+        agent: Any = create_agent(
+            model=ChatAnthropic(model="invalid-model", api_key="invalid"),
+            checkpointer=MemorySaver(),
+            middleware=[
+                ModelFallbackMiddleware(ChatOpenAI(model="gpt-4o-mini")),
+                AnthropicPromptCachingMiddleware(ttl="5m"),
+            ],
+        )
+
+        config: Any = {"configurable": {"thread_id": "test"}}
+
+        with pytest.raises(Exception) as exc_info:
+            await agent.ainvoke({"messages": [HumanMessage(content="Hello")]}, config)
+        # Should not be a cache_control TypeError
+        assert "cache_control" not in str(exc_info.value).lower()


### PR DESCRIPTION
## Description

Fixes a bug in `AnthropicPromptCachingMiddleware` where `cache_control` parameters remain in the request after `ModelFallbackMiddleware` switches to non-Anthropic models at runtime, causing `TypeError` in other providers.

When using `AnthropicPromptCachingMiddleware` with `ModelFallbackMiddleware`:
1. Primary Anthropic model fails
2. `ModelFallbackMiddleware` switches `request.model` to OpenAI (or other provider)
3. Anthropic-specific `cache_control` parameters remain in `request.model_settings`
4. OpenAI API rejects the request: `TypeError: Completions.create() got an unexpected keyword argument 'cache_control'`

**Solution**: Add cleanup logic to remove `cache_control` parameters when the middleware detects a non-Anthropic model. This enables graceful fallback to any provider without Anthropic-specific settings causing errors. *The error is raised in the Prompt Caching Middleware. The solution should also be made in the same Middleware.

### Changes
- Add `_remove_cache_control()` method to safely remove cache settings
- Update `wrap_model_call()` to clean up for non-Anthropic models
- Update `awrap_model_call()` with same logic (async version)
- Add comprehensive unit tests for cleanup behavior
- Add integration tests for fallback scenarios (both sync and async)

### Example Usage

```python
from langchain.agents import create_agent
from langchain.agents.middleware import ModelFallbackMiddleware
from langchain_anthropic import ChatAnthropic
from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
from langchain_openai import ChatOpenAI

# Now works correctly with cross-provider fallback
agent = create_agent(
    model="claude-haiku-4-5-20251001",
    middleware=[
        ModelFallbackMiddleware(
            "claude-3-5-haiku-20241022",
            "gpt-4o-mini",  # ✅ No longer causes TypeError!
        ),
        AnthropicPromptCachingMiddleware(ttl="5m"),
    ],
)
```

## Issue

Fixes #33709

## Dependencies

None - no new dependencies added.

## Testing

All tests pass:
- ✅ `make format` - passed
- ✅ `make lint` - passed
- ✅ `make test` - unit tests pass
- ✅ Integration tests added (were not present before)


