### PR TITLE
fix: Solve the issue where create_agent passes the unsupported tool_choice='any' parameter to Bedrock

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1013,7 +1013,7 @@ def create_agent(  # noqa: PLR0915
                     raise ValueError(msg)
 
             # Force tool use if we have structured output tools
-            tool_choice = "any" if structured_output_tools else request.tool_choice
+            tool_choice = "required" if structured_output_tools else request.tool_choice
             return (
                 request.model.bind_tools(
                     final_tools, tool_choice=tool_choice, **request.model_settings


### PR DESCRIPTION
Description: When calling create_agent with ChatLiteLLM, the Bedrock model does not support the tool_choice='any' parameter.
-When creating an agent using the create_agent function, a litellm.exceptions.UnsupportedParamsError will be triggered if the following conditions are all met:
Using ChatLiteLLM as the model
Using a Bedrock model (e.g., bedrock/au.anthropic.claude-sonnet-4-5-20250929-v1:0)
Providing the response_format parameter (a Pydantic model class)
The error will indicate that Bedrock does not support the tool_choice='any' parameter.

Issue: Fixes #33855
Dependencies: None