### PR TITLE
fix: bump up default recursion limit

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1422,7 +1422,7 @@ def create_agent(  # noqa: PLR0915
         debug=debug,
         name=name,
         cache=cache,
-    ).with_config({"recursion_limit": 100})
+    ).with_config({"recursion_limit": 10_000})
 
 
 def _resolve_jump(

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1422,7 +1422,7 @@ def create_agent(  # noqa: PLR0915
         debug=debug,
         name=name,
         cache=cache,
-    )
+    ).with_config({"recursion_limit": 100})
 
 
 def _resolve_jump(


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchain/issues/33740

We don't want to depend on recursion limit here, model call limit middleware is more appropriate