### PR TITLE
fix(anthropic): clean up `cache_control` in middleware to prevent fallback errors

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/prompt_caching.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/prompt_caching.py
@@ -120,7 +120,12 @@ class AnthropicPromptCachingMiddleware(AgentMiddleware):
             return handler(request)
 
         self._apply_cache_control(request)
-        return handler(request)
+        try:
+            return handler(request)
+        finally:
+            # Clean up cache_control to prevent it from being passed to fallback models
+            # that don't support this Anthropic-specific parameter
+            request.model_settings.pop("cache_control", None)
 
     async def awrap_model_call(
         self,
@@ -140,4 +145,9 @@ class AnthropicPromptCachingMiddleware(AgentMiddleware):
             return await handler(request)
 
         self._apply_cache_control(request)
-        return await handler(request)
+        try:
+            return await handler(request)
+        finally:
+            # Clean up cache_control to prevent it from being passed to fallback models
+            # that don't support this Anthropic-specific parameter
+            request.model_settings.pop("cache_control", None)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_prompt_caching.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_prompt_caching.py
@@ -82,14 +82,18 @@ def test_anthropic_prompt_caching_middleware_initialization() -> None:
         model_settings={},
     )
 
+    # Track the state during handler execution
+    settings_during_call = {}
+
     def mock_handler(req: ModelRequest) -> ModelResponse:
+        settings_during_call.update(req.model_settings)
         return ModelResponse(result=[AIMessage(content="mock response")])
 
     middleware.wrap_model_call(fake_request, mock_handler)
-    # Check that model_settings were passed through via the request
-    assert fake_request.model_settings == {
-        "cache_control": {"type": "ephemeral", "ttl": "5m"}
-    }
+    # Check that model_settings were passed through during handler execution
+    assert settings_during_call == {"cache_control": {"type": "ephemeral", "ttl": "5m"}}
+    # Verify cleanup after handler completes
+    assert fake_request.model_settings == {}
 
 
 def test_anthropic_prompt_caching_middleware_unsupported_model() -> None:
@@ -162,15 +166,19 @@ async def test_anthropic_prompt_caching_middleware_async() -> None:
         model_settings={},
     )
 
+    # Track the state during handler execution
+    settings_during_call = {}
+
     async def mock_handler(req: ModelRequest) -> ModelResponse:
+        settings_during_call.update(req.model_settings)
         return ModelResponse(result=[AIMessage(content="mock response")])
 
     result = await middleware.awrap_model_call(fake_request, mock_handler)
     assert isinstance(result, ModelResponse)
-    # Check that model_settings were passed through via the request
-    assert fake_request.model_settings == {
-        "cache_control": {"type": "ephemeral", "ttl": "1h"}
-    }
+    # Check that model_settings were passed through during handler execution
+    assert settings_during_call == {"cache_control": {"type": "ephemeral", "ttl": "1h"}}
+    # Verify cleanup after handler completes
+    assert fake_request.model_settings == {}
 
 
 async def test_anthropic_prompt_caching_middleware_async_unsupported_model() -> None:
@@ -268,15 +276,19 @@ async def test_anthropic_prompt_caching_middleware_async_with_system_prompt() ->
         model_settings={},
     )
 
+    # Track the state during handler execution
+    settings_during_call = {}
+
     async def mock_handler(req: ModelRequest) -> ModelResponse:
+        settings_during_call.update(req.model_settings)
         return ModelResponse(result=[AIMessage(content="mock response")])
 
     result = await middleware.awrap_model_call(fake_request, mock_handler)
     assert isinstance(result, ModelResponse)
     # Cache control should be added when system prompt pushes count to minimum
-    assert fake_request.model_settings == {
-        "cache_control": {"type": "ephemeral", "ttl": "1h"}
-    }
+    assert settings_during_call == {"cache_control": {"type": "ephemeral", "ttl": "1h"}}
+    # Verify cleanup after handler completes
+    assert fake_request.model_settings == {}
 
 
 async def test_anthropic_prompt_caching_middleware_async_default_values() -> None:
@@ -300,12 +312,209 @@ async def test_anthropic_prompt_caching_middleware_async_default_values() -> Non
         model_settings={},
     )
 
+    # Track the state during handler execution
+    settings_during_call = {}
+
     async def mock_handler(req: ModelRequest) -> ModelResponse:
+        settings_during_call.update(req.model_settings)
         return ModelResponse(result=[AIMessage(content="mock response")])
 
     result = await middleware.awrap_model_call(fake_request, mock_handler)
     assert isinstance(result, ModelResponse)
-    # Check that model_settings were added with default values
-    assert fake_request.model_settings == {
-        "cache_control": {"type": "ephemeral", "ttl": "5m"}
-    }
+    # Check that model_settings were added with default values during handler execution
+    assert settings_during_call == {"cache_control": {"type": "ephemeral", "ttl": "5m"}}
+    # Verify cleanup after handler completes
+    assert fake_request.model_settings == {}
+
+
+def test_cache_control_cleanup_on_success() -> None:
+    """Test that cache_control is cleaned up after successful handler execution.
+
+    This test verifies the fix for issue #33709 where cache_control was persisting
+    in model_settings and breaking fallback middleware with non-Anthropic models.
+    """
+    middleware = AnthropicPromptCachingMiddleware()
+    mock_chat_anthropic = MagicMock(spec=ChatAnthropic)
+
+    fake_request = ModelRequest(
+        model=mock_chat_anthropic,
+        messages=[HumanMessage("Hello")],
+        system_prompt=None,
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+        state={"messages": [HumanMessage("Hello")]},
+        runtime=cast(Runtime, object()),
+        model_settings={},
+    )
+
+    # Track the state of model_settings during handler execution
+    settings_during_call = {}
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        # Capture model_settings during handler execution
+        settings_during_call.update(req.model_settings)
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    result = middleware.wrap_model_call(fake_request, mock_handler)
+
+    # Verify cache_control was present during handler execution
+    assert "cache_control" in settings_during_call
+    assert settings_during_call["cache_control"] == {"type": "ephemeral", "ttl": "5m"}
+
+    # Verify cache_control is cleaned up after handler returns
+    assert "cache_control" not in fake_request.model_settings
+    assert fake_request.model_settings == {}
+    assert isinstance(result, ModelResponse)
+
+
+def test_cache_control_cleanup_on_error() -> None:
+    """Test that cache_control is cleaned up even when handler raises exception.
+
+    This ensures cleanup happens in all cases, preventing cache_control from
+    persisting when fallback middleware tries alternative models.
+    """
+    middleware = AnthropicPromptCachingMiddleware()
+    mock_chat_anthropic = MagicMock(spec=ChatAnthropic)
+
+    fake_request = ModelRequest(
+        model=mock_chat_anthropic,
+        messages=[HumanMessage("Hello")],
+        system_prompt=None,
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+        state={"messages": [HumanMessage("Hello")]},
+        runtime=cast(Runtime, object()),
+        model_settings={},
+    )
+
+    # Track the state of model_settings during handler execution
+    settings_during_call = {}
+
+    def failing_handler(req: ModelRequest) -> ModelResponse:
+        # Capture model_settings before raising error
+        settings_during_call.update(req.model_settings)
+        msg = "Simulated API error"
+        raise RuntimeError(msg)
+
+    # Handler should raise the exception
+    with pytest.raises(RuntimeError, match="Simulated API error"):
+        middleware.wrap_model_call(fake_request, failing_handler)
+
+    # Verify cache_control was present during handler execution
+    assert "cache_control" in settings_during_call
+
+    # Verify cache_control is cleaned up even after exception
+    assert "cache_control" not in fake_request.model_settings
+    assert fake_request.model_settings == {}
+
+
+async def test_cache_control_cleanup_on_success_async() -> None:
+    """Test async cleanup of cache_control after successful handler execution."""
+    middleware = AnthropicPromptCachingMiddleware()
+    mock_chat_anthropic = MagicMock(spec=ChatAnthropic)
+
+    fake_request = ModelRequest(
+        model=mock_chat_anthropic,
+        messages=[HumanMessage("Hello")],
+        system_prompt=None,
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+        state={"messages": [HumanMessage("Hello")]},
+        runtime=cast(Runtime, object()),
+        model_settings={},
+    )
+
+    # Track the state of model_settings during handler execution
+    settings_during_call = {}
+
+    async def mock_handler(req: ModelRequest) -> ModelResponse:
+        # Capture model_settings during handler execution
+        settings_during_call.update(req.model_settings)
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    result = await middleware.awrap_model_call(fake_request, mock_handler)
+
+    # Verify cache_control was present during handler execution
+    assert "cache_control" in settings_during_call
+    assert settings_during_call["cache_control"] == {"type": "ephemeral", "ttl": "5m"}
+
+    # Verify cache_control is cleaned up after handler returns
+    assert "cache_control" not in fake_request.model_settings
+    assert fake_request.model_settings == {}
+    assert isinstance(result, ModelResponse)
+
+
+async def test_cache_control_cleanup_on_error_async() -> None:
+    """Test async cleanup of cache_control even when handler raises exception."""
+    middleware = AnthropicPromptCachingMiddleware()
+    mock_chat_anthropic = MagicMock(spec=ChatAnthropic)
+
+    fake_request = ModelRequest(
+        model=mock_chat_anthropic,
+        messages=[HumanMessage("Hello")],
+        system_prompt=None,
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+        state={"messages": [HumanMessage("Hello")]},
+        runtime=cast(Runtime, object()),
+        model_settings={},
+    )
+
+    # Track the state of model_settings during handler execution
+    settings_during_call = {}
+
+    async def failing_handler(req: ModelRequest) -> ModelResponse:
+        # Capture model_settings before raising error
+        settings_during_call.update(req.model_settings)
+        msg = "Simulated async API error"
+        raise RuntimeError(msg)
+
+    # Handler should raise the exception
+    with pytest.raises(RuntimeError, match="Simulated async API error"):
+        await middleware.awrap_model_call(fake_request, failing_handler)
+
+    # Verify cache_control was present during handler execution
+    assert "cache_control" in settings_during_call
+
+    # Verify cache_control is cleaned up even after exception
+    assert "cache_control" not in fake_request.model_settings
+    assert fake_request.model_settings == {}
+
+
+def test_no_cleanup_when_caching_not_applied() -> None:
+    """Test that cleanup doesn't interfere when caching is not applied.
+
+    When using an unsupported model or below min_messages_to_cache,
+    cache_control should never be added or cleaned up.
+    """
+    middleware = AnthropicPromptCachingMiddleware(
+        unsupported_model_behavior="ignore",
+        min_messages_to_cache=10,
+    )
+
+    fake_request = ModelRequest(
+        model=FakeToolCallingModel(),  # Unsupported model
+        messages=[HumanMessage("Hello")],
+        system_prompt=None,
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+        state={"messages": [HumanMessage("Hello")]},
+        runtime=cast(Runtime, object()),
+        model_settings={},
+    )
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        # Verify cache_control was never added
+        assert "cache_control" not in req.model_settings
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    result = middleware.wrap_model_call(fake_request, mock_handler)
+
+    # Verify model_settings remain empty throughout
+    assert fake_request.model_settings == {}
+    assert isinstance(result, ModelResponse)


### PR DESCRIPTION
## Description

Fixes #33709 where `AnthropicPromptCachingMiddleware`'s `cache_control` parameter persisted in `model_settings` when `ModelFallbackMiddleware` switched to non-Anthropic models (OpenAI, Google), causing `TypeError`.

### Problem
When using both `AnthropicPromptCachingMiddleware` and `ModelFallbackMiddleware`:
1. `AnthropicPromptCachingMiddleware` adds `cache_control` to the shared `model_settings` dict
2. If the Anthropic model fails, `ModelFallbackMiddleware` reuses the same `ModelRequest` object
3. The fallback model (OpenAI/Google) receives `cache_control` parameter
4. Non-Anthropic providers reject this parameter with `TypeError`

### Solution
Use `try/finally` blocks to ensure `cache_control` is always removed from `model_settings` after handler execution, regardless of success or failure. This prevents the Anthropic-specific parameter from being passed to fallback models.

## Changes
- ✅ Added cleanup logic in both `wrap_model_call()` and `awrap_model_call()`
- ✅ Updated existing tests to verify cleanup behavior
- ✅ Added comprehensive tests for success and error cases in both sync and async paths
- ✅ Tests verify `cache_control` is present during handler execution but cleaned up afterwards

## Testing
All new and updated tests verify:
- `cache_control` is added during handler execution (functionality preserved)
- `cache_control` is cleaned up after handler returns (bug fix)
- Cleanup happens even when handler raises an exception (robustness)
- No interference when caching is not applied (edge cases)

## Checklist
- [x] Code follows LangChain style guidelines
- [x] Added comprehensive unit tests
- [x] Updated existing tests to reflect cleanup behavior
- [x] No breaking changes to public API
- [x] Commit message follows Conventional Commits format

🤖 Generated with [Claude Code](https://claude.com/claude-code)