### PR TITLE
feat(core): Capture raw provider response

### DIFF
--- a/libs/core/langchain_core/messages/__init__.py
+++ b/libs/core/langchain_core/messages/__init__.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
         InputTokenDetails,
         OutputTokenDetails,
         UsageMetadata,
+        add_ai_message_chunks,
     )
     from langchain_core.messages.base import (
         BaseMessage,
@@ -112,6 +113,7 @@ __all__ = (
     "UsageMetadata",
     "VideoContentBlock",
     "_message_from_dict",
+    "add_ai_message_chunks",
     "convert_to_messages",
     "convert_to_openai_data_block",
     "convert_to_openai_image_block",
@@ -184,6 +186,7 @@ _dynamic_imports = {
     "message_chunk_to_message": "utils",
     "messages_from_dict": "utils",
     "trim_messages": "utils",
+    "add_ai_message_chunks": "ai",
 }
 
 

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -6,7 +6,7 @@ import operator
 from collections.abc import Sequence
 from typing import Any, Literal, cast, overload
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from typing_extensions import NotRequired, Self, TypedDict, override
 
 from langchain_core.messages import content as types
@@ -173,7 +173,10 @@ class AIMessage(BaseMessage):
     type: Literal["ai"] = "ai"
     """The type of the message (used for deserialization)."""
 
-    raw_response: dict[str, Any] | list[dict[str, Any]] | None = None
+    raw_response: dict[str, Any] | list[dict[str, Any]] | None = Field(
+        default=None,
+        exclude=True,  # Exclude from serialization by default
+    )
     """Optional raw model response data, as returned directly by the LLM provider."""
 
     @overload
@@ -413,7 +416,10 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
     `tool_call_chunks` in message content will be parsed into `tool_calls`.
     """
 
-    raw_response: dict[str, Any] | None = None
+    raw_response: dict[str, Any] | None = Field(
+        default=None,
+        exclude=True,  # Exclude from serialization by default
+    )
     """The raw chunk response from the model, as returned directly by the provider."""
 
     @property

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -202,9 +202,13 @@ def message_chunk_to_message(chunk: BaseMessage) -> BaseMessage:
     ignore_keys = ["type"]
     if isinstance(chunk, AIMessageChunk):
         ignore_keys.extend(["tool_call_chunks", "chunk_position"])
-    return chunk.__class__.__mro__[1](
-        **{k: v for k, v in chunk.__dict__.items() if k not in ignore_keys}
-    )
+
+    data = {k: v for k, v in chunk.__dict__.items() if k not in ignore_keys}
+    # Preserve raw_response if it exists and is not None
+    if hasattr(chunk, "raw_response") and chunk.raw_response is not None:
+        data["raw_response"] = chunk.raw_response
+
+    return chunk.__class__.__mro__[1](**data)
 
 
 MessageLikeRepresentation = (

--- a/libs/core/tests/unit_tests/messages/test_imports.py
+++ b/libs/core/tests/unit_tests/messages/test_imports.py
@@ -40,6 +40,7 @@ EXPECTED_ALL = [
     "VideoContentBlock",
     "ReasoningContentBlock",
     "RemoveMessage",
+    "add_ai_message_chunks",
     "convert_to_messages",
     "ensure_id",
     "get_buffer_string",

--- a/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
+++ b/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
@@ -71,6 +71,24 @@
             'default': None,
             'title': 'Name',
           }),
+          'raw_response': dict({
+            'anyOf': list([
+              dict({
+                'type': 'object',
+              }),
+              dict({
+                'items': dict({
+                  'type': 'object',
+                }),
+                'type': 'array',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Raw Response',
+          }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
@@ -181,6 +199,18 @@
             ]),
             'default': None,
             'title': 'Name',
+          }),
+          'raw_response': dict({
+            'anyOf': list([
+              dict({
+                'type': 'object',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Raw Response',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',
@@ -1485,6 +1515,24 @@
             'default': None,
             'title': 'Name',
           }),
+          'raw_response': dict({
+            'anyOf': list([
+              dict({
+                'type': 'object',
+              }),
+              dict({
+                'items': dict({
+                  'type': 'object',
+                }),
+                'type': 'array',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Raw Response',
+          }),
           'response_metadata': dict({
             'title': 'Response Metadata',
             'type': 'object',
@@ -1595,6 +1643,18 @@
             ]),
             'default': None,
             'title': 'Name',
+          }),
+          'raw_response': dict({
+            'anyOf': list([
+              dict({
+                'type': 'object',
+              }),
+              dict({
+                'type': 'null',
+              }),
+            ]),
+            'default': None,
+            'title': 'Raw Response',
           }),
           'response_metadata': dict({
             'title': 'Response Metadata',

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -495,6 +495,24 @@
                   'default': None,
                   'title': 'Name',
                 }),
+                'raw_response': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'object',
+                    }),
+                    dict({
+                      'items': dict({
+                        'type': 'object',
+                      }),
+                      'type': 'array',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
+                  'title': 'Raw Response',
+                }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',
                   'type': 'object',
@@ -605,6 +623,18 @@
                   ]),
                   'default': None,
                   'title': 'Name',
+                }),
+                'raw_response': dict({
+                  'anyOf': list([
+                    dict({
+                      'type': 'object',
+                    }),
+                    dict({
+                      'type': 'null',
+                    }),
+                  ]),
+                  'default': None,
+                  'title': 'Raw Response',
                 }),
                 'response_metadata': dict({
                   'title': 'Response Metadata',

--- a/libs/core/tests/unit_tests/test_ai_message_raw_response.py
+++ b/libs/core/tests/unit_tests/test_ai_message_raw_response.py
@@ -26,8 +26,7 @@ def test_add_ai_message_chunks_merges_raw_response(base_chunk: AIMessageChunk) -
     """Test merging of AIMessageChunk objects combines raw_response correctly."""
     chunk1: AIMessageChunk = base_chunk
     chunk2: AIMessageChunk = AIMessageChunk(
-        content=" world",
-        raw_response={"delta": " world"}
+        content=" world", raw_response={"delta": " world"}
     )
     merged: AIMessageChunk = add_ai_message_chunks(chunk1, chunk2)
     assert merged.content == "hello world"
@@ -45,9 +44,10 @@ def test_add_ai_message_chunks_handles_missing_raw_response() -> None:
 
 
 def test_message_chunk_to_message_transfers_raw_response(
-        base_chunk: AIMessageChunk) -> None:
+    base_chunk: AIMessageChunk,
+) -> None:
     """Test that message_chunk_to_message preserves raw_response."""
-    msg: AIMessage = message_chunk_to_message(base_chunk)
+    msg = message_chunk_to_message(base_chunk)
     assert isinstance(msg, AIMessage)
     # raw_response should be preserved
     assert msg.raw_response == {"delta": "hello"}
@@ -56,7 +56,7 @@ def test_message_chunk_to_message_transfers_raw_response(
 def test_message_chunk_to_message_ignores_non_chunk_input() -> None:
     """Test that message_chunk_to_message passes through non-chunk inputs."""
     raw: AIMessage = AIMessage(content="hi", raw_response={"data": 1})
-    result: AIMessage = message_chunk_to_message(raw)
+    result = message_chunk_to_message(raw)
     # Should simply pass through
     assert result is raw
 

--- a/libs/core/tests/unit_tests/test_ai_message_raw_response.py
+++ b/libs/core/tests/unit_tests/test_ai_message_raw_response.py
@@ -1,0 +1,76 @@
+from typing import Any
+
+import pytest
+
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    add_ai_message_chunks,
+    message_chunk_to_message,
+)
+
+
+@pytest.fixture
+def base_chunk() -> AIMessageChunk:
+    """Create a base AIMessageChunk for reuse."""
+    return AIMessageChunk(content="hello", raw_response={"delta": "hello"})
+
+
+def test_ai_message_stores_raw_response() -> None:
+    """Test that AIMessage correctly stores raw_response."""
+    msg: AIMessage = AIMessage(content="hi", raw_response={"raw": "ok"})
+    assert msg.raw_response == {"raw": "ok"}
+
+
+def test_add_ai_message_chunks_merges_raw_response(base_chunk: AIMessageChunk) -> None:
+    """Test merging of AIMessageChunk objects combines raw_response correctly."""
+    chunk1: AIMessageChunk = base_chunk
+    chunk2: AIMessageChunk = AIMessageChunk(
+        content=" world",
+        raw_response={"delta": " world"}
+    )
+    merged: AIMessageChunk = add_ai_message_chunks(chunk1, chunk2)
+    assert merged.content == "hello world"
+    assert isinstance(merged.raw_response, list)
+    assert merged.raw_response == [{"delta": "hello"}, {"delta": " world"}]
+
+
+def test_add_ai_message_chunks_handles_missing_raw_response() -> None:
+    """Test merging when some chunks have missing raw_response."""
+    c1: AIMessageChunk = AIMessageChunk(content="foo", raw_response={"delta": "foo"})
+    c2: AIMessageChunk = AIMessageChunk(content="bar", raw_response=None)
+    merged: AIMessageChunk = add_ai_message_chunks(c1, c2)
+    # Single raw_response should be kept as dict, not list
+    assert merged.raw_response == {"delta": "foo"}
+
+
+def test_message_chunk_to_message_transfers_raw_response(
+        base_chunk: AIMessageChunk) -> None:
+    """Test that message_chunk_to_message preserves raw_response."""
+    msg: AIMessage = message_chunk_to_message(base_chunk)
+    assert isinstance(msg, AIMessage)
+    # raw_response should be preserved
+    assert msg.raw_response == {"delta": "hello"}
+
+
+def test_message_chunk_to_message_ignores_non_chunk_input() -> None:
+    """Test that message_chunk_to_message passes through non-chunk inputs."""
+    raw: AIMessage = AIMessage(content="hi", raw_response={"data": 1})
+    result: AIMessage = message_chunk_to_message(raw)
+    # Should simply pass through
+    assert result is raw
+
+
+def test_empty_raw_response_not_present_in_serialized_message() -> None:
+    """Test that raw_response is omitted when serializing message with None."""
+    msg: AIMessage = AIMessage(content="test", raw_response=None)
+    attrs: dict[str, Any] = msg.lc_attributes
+    assert "raw_response" not in attrs
+
+
+def test_invalid_input_handling_for_merging_different_types() -> None:
+    """Test add_ai_message_chunks handles single or empty merge cases gracefully."""
+    chunk: AIMessageChunk = AIMessageChunk(content="hello")
+    # Should be unaffected even when others list is empty
+    merged: AIMessageChunk = add_ai_message_chunks(chunk)
+    assert merged.content == "hello"

--- a/libs/langchain/tests/unit_tests/chat_models/test_base.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_base.py
@@ -165,7 +165,7 @@ def test_configurable() -> None:
             "store": None,
             "extra_body": None,
             "include_response_headers": False,
-            "include_raw_response": False, 
+            "include_raw_response": False,
             "stream_usage": True,
             "use_previous_response_id": False,
             "use_responses_api": None,

--- a/libs/langchain/tests/unit_tests/chat_models/test_base.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_base.py
@@ -165,6 +165,7 @@ def test_configurable() -> None:
             "store": None,
             "extra_body": None,
             "include_response_headers": False,
+            "include_raw_response": False, 
             "stream_usage": True,
             "use_previous_response_id": False,
             "use_responses_api": None,

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -166,6 +166,7 @@ def test_configurable() -> None:
             "store": None,
             "extra_body": None,
             "include_response_headers": False,
+            'include_raw_response': False,
             "stream_usage": True,
             "use_previous_response_id": False,
             "use_responses_api": None,

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -57,7 +57,7 @@ def test_init_missing_dep() -> None:
 
 
 def test_init_unknown_provider() -> None:
-    with pytest.raises(ValueError, match="Unsupported model_provider='bar'."):
+    with pytest.raises(ValueError, match=r"Unsupported model_provider='bar'."):
         init_chat_model("foo", model_provider="bar")
 
 
@@ -166,7 +166,7 @@ def test_configurable() -> None:
             "store": None,
             "extra_body": None,
             "include_response_headers": False,
-            'include_raw_response': False,
+            "include_raw_response": False,
             "stream_usage": True,
             "use_previous_response_id": False,
             "use_responses_api": None,

--- a/libs/langchain_v1/tests/unit_tests/embeddings/test_base.py
+++ b/libs/langchain_v1/tests/unit_tests/embeddings/test_base.py
@@ -88,7 +88,7 @@ def test_infer_model_and_provider_errors() -> None:
         _infer_model_and_provider("model", provider="")
 
     # Test invalid provider
-    with pytest.raises(ValueError, match="Provider 'invalid' is not supported.") as exc:
+    with pytest.raises(ValueError, match=r"Provider 'invalid' is not supported.") as exc:
         _infer_model_and_provider("model", provider="invalid")
     # Test provider list is in error
     for provider in _SUPPORTED_PROVIDERS:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1270,9 +1270,9 @@ class BaseChatOpenAI(BaseChatModel):
                     if generation_chunk is None:
                         continue
                     if (
-                        generation_chunk.message.chunk_position == "last"
+                        isinstance(generation_chunk.message, AIMessageChunk)
+                        and generation_chunk.message.chunk_position == "last"
                         and self.include_raw_response
-                        and isinstance(generation_chunk.message, AIMessageChunk)
                     ):
                         generation_chunk.message.raw_response = chunk
 
@@ -1525,9 +1525,9 @@ class BaseChatOpenAI(BaseChatModel):
                         continue
 
                     if (
-                        generation_chunk.message.chunk_position == "last"
+                        isinstance(generation_chunk.message, AIMessageChunk)
+                        and generation_chunk.message.chunk_position == "last"
                         and self.include_raw_response
-                        and isinstance(generation_chunk.message, AIMessageChunk)
                     ):
                         generation_chunk.message.raw_response = chunk
 

--- a/libs/partners/openai/tests/unit_tests/test_chatopenai_raw_response.py
+++ b/libs/partners/openai/tests/unit_tests/test_chatopenai_raw_response.py
@@ -1,0 +1,60 @@
+from langchain_core.messages import (
+    AIMessageChunk,
+    add_ai_message_chunks,
+)
+
+from langchain_openai.chat_models.base import ChatOpenAI
+
+
+def test_chat_openai_has_include_raw_response_field() -> None:
+    """Test that ChatOpenAI has include_raw_response field."""
+
+    model_true = ChatOpenAI(
+        model="gpt-4", include_raw_response=True, api_key="fake-key"
+    )
+    assert model_true.include_raw_response is True
+
+    model_false = ChatOpenAI(
+        model="gpt-4", include_raw_response=False, api_key="fake-key"
+    )
+    assert model_false.include_raw_response is False
+
+    model_default = ChatOpenAI(model="gpt-4", api_key="fake-key")
+    assert model_default.include_raw_response is False
+
+
+def test_merge_streamed_chunks_preserves_raw_response() -> None:
+    """Test that raw_response is preserved when merging chunks."""
+
+    c1: AIMessageChunk = AIMessageChunk(
+        content="Hel", raw_response={"choices": [{"delta": "Hel"}]}
+    )
+    c2: AIMessageChunk = AIMessageChunk(
+        content="lo", raw_response={"choices": [{"delta": "lo"}]}
+    )
+
+    merged = add_ai_message_chunks(c1, c2)
+    assert merged.content == "Hello"
+    assert merged.raw_response == [
+        {"choices": [{"delta": "Hel"}]},
+        {"choices": [{"delta": "lo"}]},
+    ]
+
+
+def test_edge_case_empty_raw_response() -> None:
+    """Test handling of chunks without raw_response."""
+
+    c1: AIMessageChunk = AIMessageChunk(content="test", raw_response=None)
+    merged = add_ai_message_chunks(c1)
+    assert merged.raw_response is None
+
+
+def test_single_chunk_raw_response_preserved() -> None:
+    """Test that single chunk raw_response is preserved as dict."""
+
+    c1: AIMessageChunk = AIMessageChunk(content="test", raw_response={"data": "value"})
+    c2: AIMessageChunk = AIMessageChunk(content=" chunk", raw_response=None)
+
+    merged = add_ai_message_chunks(c1, c2)
+    # Single raw_response should be kept as dict, not list
+    assert merged.raw_response == {"data": "value"}

--- a/libs/partners/openai/tests/unit_tests/test_chatopenai_raw_response.py
+++ b/libs/partners/openai/tests/unit_tests/test_chatopenai_raw_response.py
@@ -2,6 +2,7 @@ from langchain_core.messages import (
     AIMessageChunk,
     add_ai_message_chunks,
 )
+from pydantic import SecretStr
 
 from langchain_openai.chat_models.base import ChatOpenAI
 
@@ -10,16 +11,16 @@ def test_chat_openai_has_include_raw_response_field() -> None:
     """Test that ChatOpenAI has include_raw_response field."""
 
     model_true = ChatOpenAI(
-        model="gpt-4", include_raw_response=True, api_key="fake-key"
+        model="gpt-4", include_raw_response=True, api_key=SecretStr("fake-key")
     )
     assert model_true.include_raw_response is True
 
     model_false = ChatOpenAI(
-        model="gpt-4", include_raw_response=False, api_key="fake-key"
+        model="gpt-4", include_raw_response=False, api_key=SecretStr("fake-key")
     )
     assert model_false.include_raw_response is False
 
-    model_default = ChatOpenAI(model="gpt-4", api_key="fake-key")
+    model_default = ChatOpenAI(model="gpt-4", api_key=SecretStr("fake-key"))
     assert model_default.include_raw_response is False
 
 


### PR DESCRIPTION
### Summary

Resolves #33884

### Design Decisions

### 1. Configuration Location
- **Choice**: Place `include_raw_response` in model wrapper classes, NOT core message classes
- **Rationale**:
  - This is a usage-time option, not a core messaging concern
  - Different providers can independently support it
  - Keeps core message design clean

### 2. Data Structure Flexibility
- **raw_response Type**: `dict[str, Any] | list[dict[str, Any]] | None`
- **Rationale**:
  - Single response → dict (simpler API)
  - Multiple responses → list[dict] (clear aggregation)
  - None → unset/disabled

### 3. Stream Processing Strategy
- **Trigger**: Call `add_ai_message_chunks()` only when `chunk_position="last"` received
- **Rationale**: Ensures complete stream before aggregation

### 4. Backward Compatibility
- All new parameters have defaults
- Existing code runs unchanged
- raw_response completely optional


### Key Changes

### 1. Core Message System (`libs/core/langchain_core/messages/ai.py`)

#### AIMessage Class
- **New Field**: `raw_response: dict[str, Any] | list[dict[str, Any]] | None = None`
- **Constructor Support**: Updated `__init__()` to accept and store `raw_response` parameter
- **Serialization**: Modified `dict()` method to include non-None `raw_response` values
- **Documentation**: Added parameter documentation

#### AIMessageChunk Class
- **New Field**: `raw_response: dict[str, Any] | None = None`
- **Purpose**: Store individual chunk's raw response during streaming

#### New Function: `add_ai_message_chunks()`
Aggregates multiple `AIMessageChunk` objects into a single final `AIMessage`

**Key Features**:
- Intelligent `raw_response` merging:
  - Single response → use directly (dict)
  - Multiple responses → preserve as list
  - None values → filtered out
- Triggered when `chunk_position="last"` marker received
- Handles all other chunk fields (content, tools, metadata)

**Example Usage**:
```python
from langchain_core.messages.ai import add_ai_message_chunks

# Aggregate chunks during streaming
final_message = add_ai_message_chunks(chunk1, chunk2, chunk3)
# If chunks have raw_response, they're merged intelligently
print(final_message.raw_response)  # dict or list[dict] depending on count
```

### 2. Message Utilities (`libs/core/langchain_core/messages/utils.py`)

#### message_chunk_to_message() Function
- **Added Logic**: Transfer `raw_response` from chunk to final message
- **Condition**: Only transfer if value is not None
- **Code**:
  ```python
  if hasattr(chunk, "raw_response") and chunk.raw_response is not None:
      data["raw_response"] = chunk.raw_response
  ```

### 3. Public API Exports (`libs/core/langchain_core/messages/__init__.py`)

#### __all__ List
- Added: `"add_ai_message_chunks"`

#### _dynamic_imports Dictionary
- Added mapping: `"add_ai_message_chunks": "ai"`

### 4. OpenAI Integration (`libs/partners/openai/langchain_openai/chat_models/base.py`)

#### BaseChatOpenAI Class

**New Configuration Field** (line ~686):
```python
include_raw_response: bool = False
```
- Controls whether to capture raw OpenAI API responses
- Default: False (maintains backward compatibility)
- Type: Pydantic model field with documentation

**Implementation Locations**:

1. **_convert_chunk_to_generation_chunk()** (~line 1071)
   - Captures streaming chunk's raw response
   - Code: `if self.include_raw_response: message_chunk.raw_response = chunk`

2. **_stream()** (~line 1274)
   - Handles sync streaming
   - Transfers final chunk to generation message
   - Code: `if self.include_raw_response and chunk_position == "last": ...`

3. **_create_chat_result()** (~line 1440)
   - Handles non-streaming calls
   - Attaches response_dict to message
   - Code: `if self.include_raw_response and isinstance(message, AIMessage): ...`

4. **_astream()** (~line 1529)
   - Handles async streaming
   - Same logic as sync stream

### Scope

Currently, only the OpenAI model class has been adapted.  
If this PR is accepted, similar adaptations will be implemented for other partner integrations (Anthropic, Google, Bedrock, etc.) in follow-up PRs.

### Testing

- All new and existing tests pass locally.
- Added isolated unit tests under `tests/unit_tests/core/` and `tests/unit_tests/partners/openai/`.
- No external API calls are made; all model interactions are fully mocked.
