### PR TITLE
fix(langchain, openai): backward compat for response_format

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1009,9 +1009,8 @@ def create_agent(  # noqa: PLR0915
 
         # Bind model based on effective response format
         if isinstance(effective_response_format, ProviderStrategy):
-            kwargs: dict[str, Any] = {
-                "response_format": effective_response_format.schema_spec.json_schema
-            }
+            # (Backward compatibility) Use OpenAI format structured output
+            kwargs = effective_response_format.to_model_kwargs()
             return (
                 request.model.bind_tools(
                     final_tools, strict=True, **kwargs, **request.model_settings

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1844,6 +1844,14 @@ class BaseChatOpenAI(BaseChatModel):
             kwargs["tool_choice"] = tool_choice
 
         if response_format:
+            if (
+                isinstance(response_format, dict)
+                and response_format.get("type") == "json_schema"
+                and "schema" in response_format.get("json_schema", {})
+            ):
+                # compat with langchain.agents.create_agent response_format, which is
+                # an approximation of OpenAI format
+                response_format = cast(dict, response_format["json_schema"]["schema"])
             kwargs["response_format"] = _convert_to_openai_response_format(
                 response_format
             )


### PR DESCRIPTION
Following https://github.com/langchain-ai/langchain/pull/33939

We revert the functional change in `langchain` and add handling in `langchain-openai` to do this in a backward compatible way.

Covered by existing tests.