### PR TITLE
fix(groq): bump min ver for `core` dep

### DIFF
--- a/libs/partners/groq/pyproject.toml
+++ b/libs/partners/groq/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "1.0.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.0.0,<2.0.0",
+    "langchain-core>=1.0.2,<2.0.0",
     "groq>=0.30.0,<1.0.0"
 ]
 


### PR DESCRIPTION
Due to issue with unit tests and docs URL for exceptions