### PR TITLE
refactor(standard-tests): improve VCR config

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/conftest.py
+++ b/libs/langchain_v1/tests/unit_tests/conftest.py
@@ -5,10 +5,7 @@ from importlib import util
 from typing import Any
 
 import pytest
-from langchain_tests.conftest import CustomPersister, CustomSerializer
-from langchain_tests.conftest import (
-    _base_vcr_config as _base_vcr_config,  # noqa: PLC0414
-)
+from langchain_tests.conftest import CustomPersister, CustomSerializer, base_vcr_config
 from vcr import VCR
 
 _EXTRA_HEADERS = [
@@ -34,9 +31,9 @@ def remove_response_headers(response: dict) -> dict:
 
 
 @pytest.fixture(scope="session")
-def vcr_config(_base_vcr_config: dict) -> dict:  # noqa: F811
+def vcr_config() -> dict:
     """Extend the default configuration coming from langchain_tests."""
-    config = _base_vcr_config.copy()
+    config = base_vcr_config()
     config.setdefault("filter_headers", []).extend(_EXTRA_HEADERS)
     config["before_record_request"] = remove_request_headers
     config["before_record_response"] = remove_response_headers

--- a/libs/partners/anthropic/tests/conftest.py
+++ b/libs/partners/anthropic/tests/conftest.py
@@ -1,10 +1,7 @@
 from typing import Any
 
 import pytest
-from langchain_tests.conftest import CustomPersister, CustomSerializer
-from langchain_tests.conftest import (
-    _base_vcr_config as _base_vcr_config,  # noqa: PLC0414
-)
+from langchain_tests.conftest import CustomPersister, CustomSerializer, base_vcr_config
 from vcr import VCR  # type: ignore[import-untyped]
 
 
@@ -21,9 +18,9 @@ def remove_response_headers(response: dict) -> dict:
 
 
 @pytest.fixture(scope="session")
-def vcr_config(_base_vcr_config: dict) -> dict:  # noqa: F811
+def vcr_config() -> dict:
     """Extend the default configuration coming from langchain_tests."""
-    config = _base_vcr_config.copy()
+    config = base_vcr_config()
     config["before_record_request"] = remove_request_headers
     config["before_record_response"] = remove_response_headers
     config["serializer"] = "yaml.gz"

--- a/libs/partners/groq/tests/conftest.py
+++ b/libs/partners/groq/tests/conftest.py
@@ -1,10 +1,7 @@
 from typing import Any
 
 import pytest
-from langchain_tests.conftest import CustomPersister, CustomSerializer
-from langchain_tests.conftest import (
-    _base_vcr_config as _base_vcr_config,  # noqa: PLC0414
-)
+from langchain_tests.conftest import CustomPersister, CustomSerializer, base_vcr_config
 from vcr import VCR  # type: ignore[import-untyped]
 
 
@@ -21,9 +18,9 @@ def remove_response_headers(response: dict) -> dict:
 
 
 @pytest.fixture(scope="session")
-def vcr_config(_base_vcr_config: dict) -> dict:  # noqa: F811
+def vcr_config() -> dict:
     """Extend the default configuration coming from langchain_tests."""
-    config = _base_vcr_config.copy()
+    config = base_vcr_config()
     config["before_record_request"] = remove_request_headers
     config["before_record_response"] = remove_response_headers
     config["serializer"] = "yaml.gz"

--- a/libs/partners/openai/tests/conftest.py
+++ b/libs/partners/openai/tests/conftest.py
@@ -1,10 +1,7 @@
 from typing import Any
 
 import pytest
-from langchain_tests.conftest import CustomPersister, CustomSerializer
-from langchain_tests.conftest import (
-    _base_vcr_config as _base_vcr_config,  # noqa: PLC0414
-)
+from langchain_tests.conftest import CustomPersister, CustomSerializer, base_vcr_config
 from vcr import VCR  # type: ignore[import-untyped]
 
 _EXTRA_HEADERS = [
@@ -30,9 +27,9 @@ def remove_response_headers(response: dict) -> dict:
 
 
 @pytest.fixture(scope="session")
-def vcr_config(_base_vcr_config: dict) -> dict:  # noqa: F811
+def vcr_config() -> dict:
     """Extend the default configuration coming from langchain_tests."""
-    config = _base_vcr_config.copy()
+    config = base_vcr_config()
     config.setdefault("filter_headers", []).extend(_EXTRA_HEADERS)
     config["before_record_request"] = remove_request_headers
     config["before_record_response"] = remove_response_headers

--- a/libs/standard-tests/langchain_tests/conftest.py
+++ b/libs/standard-tests/langchain_tests/conftest.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 import yaml
+from langchain_core._api.deprecation import deprecated
 from vcr import VCR
 from vcr.persisters.filesystem import CassetteNotFoundError
 from vcr.request import Request
@@ -98,8 +99,7 @@ _BASE_FILTER_HEADERS = [
 ]
 
 
-@pytest.fixture(scope="session")
-def _base_vcr_config() -> dict:
+def base_vcr_config() -> dict:
     """Return VCR configuration that every cassette will receive.
 
     (Anything permitted by `vcr.VCR(**kwargs)` can be put here.)
@@ -116,6 +116,12 @@ def _base_vcr_config() -> dict:
 
 
 @pytest.fixture(scope="session")
-def vcr_config(_base_vcr_config: dict) -> dict:
+@deprecated("1.0.3", alternative="base_vcr_config", removal="2.0")
+def _base_vcr_config() -> dict:
+    return base_vcr_config()
+
+
+@pytest.fixture(scope="session")
+def vcr_config() -> dict:
     """VCR config fixture."""
-    return _base_vcr_config
+    return base_vcr_config()

--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -628,9 +628,7 @@ class ChatModelIntegrationTests(ChatModelTests):
 
             ```python title="tests/conftest.py"
             import pytest
-            from langchain_tests.conftest import (
-                _base_vcr_config as _base_vcr_config,
-            )
+            from langchain_tests.conftest import base_vcr_config
 
             _EXTRA_HEADERS = [
                 # Specify additional headers to redact
@@ -645,9 +643,9 @@ class ChatModelIntegrationTests(ChatModelTests):
 
 
             @pytest.fixture(scope="session")
-            def vcr_config(_base_vcr_config: dict) -> dict:  # noqa: F811
+            def vcr_config() -> dict:
                 """Extend the default configuration from langchain_tests."""
-                config = _base_vcr_config.copy()
+                config = base_vcr_config()
                 config.setdefault("filter_headers", []).extend(_EXTRA_HEADERS)
                 config["before_record_response"] = remove_response_headers
 
@@ -667,9 +665,7 @@ class ChatModelIntegrationTests(ChatModelTests):
                     CustomPersister,
                     CustomSerializer,
                 )
-                from langchain_tests.conftest import (
-                    _base_vcr_config as _base_vcr_config,
-                )
+                from langchain_tests.conftest import base_vcr_config
                 from vcr import VCR
 
                 _EXTRA_HEADERS = [
@@ -685,9 +681,9 @@ class ChatModelIntegrationTests(ChatModelTests):
 
 
                 @pytest.fixture(scope="session")
-                def vcr_config(_base_vcr_config: dict) -> dict:  # noqa: F811
+                def vcr_config() -> dict:
                     """Extend the default configuration from langchain_tests."""
-                    config = _base_vcr_config.copy()
+                    config = base_vcr_config()
                     config.setdefault("filter_headers", []).extend(_EXTRA_HEADERS)
                     config["before_record_response"] = remove_response_headers
                     # New: enable serializer and set file extension

--- a/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
@@ -759,9 +759,7 @@ class ChatModelUnitTests(ChatModelTests):
 
             ```python title="tests/conftest.py"
             import pytest
-            from langchain_tests.conftest import (
-                _base_vcr_config as _base_vcr_config,
-            )
+            from langchain_tests.conftest import base_vcr_config
 
             _EXTRA_HEADERS = [
                 # Specify additional headers to redact
@@ -776,9 +774,9 @@ class ChatModelUnitTests(ChatModelTests):
 
 
             @pytest.fixture(scope="session")
-            def vcr_config(_base_vcr_config: dict) -> dict:  # noqa: F811
+            def vcr_config() -> dict:
                 """Extend the default configuration from langchain_tests."""
-                config = _base_vcr_config.copy()
+                config = base_vcr_config()
                 config.setdefault("filter_headers", []).extend(_EXTRA_HEADERS)
                 config["before_record_response"] = remove_response_headers
 
@@ -798,9 +796,7 @@ class ChatModelUnitTests(ChatModelTests):
                     CustomPersister,
                     CustomSerializer,
                 )
-                from langchain_tests.conftest import (
-                    _base_vcr_config as _base_vcr_config,
-                )
+                from langchain_tests.conftest import base_vcr_config
                 from vcr import VCR
 
                 _EXTRA_HEADERS = [
@@ -816,9 +812,9 @@ class ChatModelUnitTests(ChatModelTests):
 
 
                 @pytest.fixture(scope="session")
-                def vcr_config(_base_vcr_config: dict) -> dict:  # noqa: F811
+                def vcr_config() -> dict:
                     """Extend the default configuration from langchain_tests."""
-                    config = _base_vcr_config.copy()
+                    config = base_vcr_config()
                     config.setdefault("filter_headers", []).extend(_EXTRA_HEADERS)
                     config["before_record_response"] = remove_response_headers
                     # New: enable serializer and set file extension


### PR DESCRIPTION
Use of the fixture `_base_vcr_config` is deprecated with alternative function `base_vcr_config()`
This way:
* we don't need to import `_base_vcr_config` seen as unused (which leads to ruff violations PLC0414 and F811)
* we don't need to make a copy since a new dict is created at each function invocation

