### PR TITLE
fix: shell tools of all sorts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,3 @@ node_modules
 
 prof
 virtualenv/
-
-anthropic_demos_final/
-anthropic_demos/

--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -21,7 +21,6 @@ from langchain.agents.middleware.types import (
 )
 from langchain.tools import ToolRuntime, tool
 from langchain_core.messages import ToolMessage
-from langchain_core.tools import BaseTool
 from langgraph.types import Command
 from typing_extensions import NotRequired, TypedDict
 

--- a/libs/partners/anthropic/langchain_anthropic/middleware/bash.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/bash.py
@@ -3,19 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any, Literal
+from typing import Any
 
-from langchain.agents.middleware.shell_tool import ShellToolMiddleware, ShellToolState
+from langchain.agents.middleware.shell_tool import SHELL_TOOL_NAME, ShellToolMiddleware
 from langchain.agents.middleware.types import (
     ModelRequest,
     ModelResponse,
 )
-from langchain.tools import ToolRuntime, tool
-from langchain_core.messages import ToolMessage
 
-# Tool type constants
-BASH_TOOL_TYPE = "bash_20250124"
-BASH_TOOL_NAME = "bash"
+# Tool type constants for Anthropic
+TOOL_TYPE = "bash_20250124"
+TOOL_NAME = SHELL_TOOL_NAME
 
 
 class ClaudeBashToolMiddleware(ShellToolMiddleware):
@@ -25,7 +23,6 @@ class ClaudeBashToolMiddleware(ShellToolMiddleware):
         self,
         workspace_root: str | None = None,
         *,
-        tool_name: str = BASH_TOOL_NAME,
         startup_commands: tuple[str, ...] | list[str] | str | None = None,
         shutdown_commands: tuple[str, ...] | list[str] | str | None = None,
         execution_policy: Any | None = None,
@@ -38,7 +35,6 @@ class ClaudeBashToolMiddleware(ShellToolMiddleware):
         Args:
             workspace_root: Base directory for the shell session.
                 If omitted, a temporary directory is created.
-            tool_name: Name for the bash tool (default: "bash").
             startup_commands: Optional commands executed after the session starts.
             shutdown_commands: Optional commands executed before session shutdown.
             execution_policy: Execution policy controlling timeouts and limits.
@@ -56,45 +52,17 @@ class ClaudeBashToolMiddleware(ShellToolMiddleware):
             shell_command=("/bin/bash",),
             env=env,
         )
-        self.tool_name = tool_name
-
-        # Create tool that will be executed by the tool node
-        @tool(tool_name)
-        def bash_tool(
-            *,
-            runtime: ToolRuntime[None, ShellToolState],
-            command: str,
-            restart: bool = False,
-        ) -> ToolMessage | str:
-            """Execute bash commands.
-
-            Args:
-                runtime: Tool runtime providing access to state and tool_call_id.
-                command: The bash command to execute.
-                restart: Whether to restart the shell session.
-
-            Returns:
-                The command output as ToolMessage or string.
-            """
-            resources = self._ensure_resources(runtime.state)
-            return self._run_shell_tool(
-                resources,
-                {"command": command, "restart": restart},
-                tool_call_id=runtime.tool_call_id,
-            )
-
-        self.tools = [bash_tool]
+        # Parent class creates a "shell" tool that we'll use
 
     def wrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], ModelResponse],
     ) -> ModelResponse:
-        """Replace our tool with Claude's bash descriptor."""
-        # Filter out our registered bash tool and replace with Claude's descriptor
-        tools = [
-            t for t in request.tools if getattr(t, "name", None) != self.tool_name
-        ] + [{"type": BASH_TOOL_TYPE, "name": self.tool_name}]
+        """Replace parent's shell tool with Claude's bash descriptor."""
+        tools = [t for t in request.tools if getattr(t, "name", None) != "shell"] + [
+            {"type": TOOL_TYPE, "name": TOOL_NAME}
+        ]
         return handler(request.override(tools=tools))
 
     async def awrap_model_call(
@@ -102,31 +70,11 @@ class ClaudeBashToolMiddleware(ShellToolMiddleware):
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelResponse:
-        """Async: replace our tool with Claude's bash descriptor."""
-        # Filter out our registered bash tool and replace with Claude's descriptor
-        tools = [
-            t for t in request.tools if getattr(t, "name", None) != self.tool_name
-        ] + [{"type": BASH_TOOL_TYPE, "name": self.tool_name}]
+        """Async: replace parent's shell tool with Claude's bash descriptor."""
+        tools = [t for t in request.tools if getattr(t, "name", None) != "shell"] + [
+            {"type": TOOL_TYPE, "name": TOOL_NAME}
+        ]
         return await handler(request.override(tools=tools))
-
-    def _format_tool_message(
-        self,
-        content: str,
-        tool_call_id: str | None,
-        *,
-        status: Literal["success", "error"],
-        artifact: dict[str, Any] | None = None,
-    ) -> ToolMessage | str:
-        """Format tool responses using Claude's bash descriptor."""
-        if tool_call_id is None:
-            return content
-        return ToolMessage(
-            content=content,
-            tool_call_id=tool_call_id,
-            name=self.tool_name,
-            status=status,
-            artifact=artifact or {},
-        )
 
 
 __all__ = ["ClaudeBashToolMiddleware"]

--- a/libs/partners/anthropic/langchain_anthropic/middleware/bash.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/bash.py
@@ -13,21 +13,53 @@ from langchain.agents.middleware.types import (
 from langchain.tools import ToolRuntime, tool
 from langchain_core.messages import ToolMessage
 
-_CLAUDE_BASH_DESCRIPTOR = {"type": "bash_20250124", "name": "bash"}
+# Tool type constants
+BASH_TOOL_TYPE = "bash_20250124"
+BASH_TOOL_NAME = "bash"
 
 
 class ClaudeBashToolMiddleware(ShellToolMiddleware):
     """Middleware that exposes Anthropic's native bash tool to models."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Initialize middleware without registering a client-side tool."""
-        kwargs["shell_command"] = ("/bin/bash",)
-        super().__init__(*args, **kwargs)
-        # Remove the base tool so Claude's native descriptor is the sole entry.
-        self._tool = None  # type: ignore[assignment]
+    def __init__(
+        self,
+        workspace_root: str | None = None,
+        *,
+        tool_name: str = BASH_TOOL_NAME,
+        startup_commands: tuple[str, ...] | list[str] | str | None = None,
+        shutdown_commands: tuple[str, ...] | list[str] | str | None = None,
+        execution_policy: Any | None = None,
+        redaction_rules: tuple[Any, ...] | list[Any] | None = None,
+        tool_description: str | None = None,
+        env: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize middleware for Claude's native bash tool.
+
+        Args:
+            workspace_root: Base directory for the shell session.
+                If omitted, a temporary directory is created.
+            tool_name: Name for the bash tool (default: "bash").
+            startup_commands: Optional commands executed after the session starts.
+            shutdown_commands: Optional commands executed before session shutdown.
+            execution_policy: Execution policy controlling timeouts and limits.
+            redaction_rules: Optional redaction rules to sanitize output.
+            tool_description: Optional override for tool description.
+            env: Optional environment variables for the shell session.
+        """
+        super().__init__(
+            workspace_root=workspace_root,
+            startup_commands=startup_commands,
+            shutdown_commands=shutdown_commands,
+            execution_policy=execution_policy,
+            redaction_rules=redaction_rules,
+            tool_description=tool_description,
+            shell_command=("/bin/bash",),
+            env=env,
+        )
+        self.tool_name = tool_name
 
         # Create tool that will be executed by the tool node
-        @tool("bash")
+        @tool(tool_name)
         def bash_tool(
             *,
             runtime: ToolRuntime[None, ShellToolState],
@@ -60,9 +92,9 @@ class ClaudeBashToolMiddleware(ShellToolMiddleware):
     ) -> ModelResponse:
         """Replace our tool with Claude's bash descriptor."""
         # Filter out our registered bash tool and replace with Claude's descriptor
-        tools = [t for t in request.tools if getattr(t, "name", None) != "bash"] + [
-            _CLAUDE_BASH_DESCRIPTOR
-        ]
+        tools = [
+            t for t in request.tools if getattr(t, "name", None) != self.tool_name
+        ] + [{"type": BASH_TOOL_TYPE, "name": self.tool_name}]
         return handler(request.override(tools=tools))
 
     async def awrap_model_call(
@@ -72,9 +104,9 @@ class ClaudeBashToolMiddleware(ShellToolMiddleware):
     ) -> ModelResponse:
         """Async: replace our tool with Claude's bash descriptor."""
         # Filter out our registered bash tool and replace with Claude's descriptor
-        tools = [t for t in request.tools if getattr(t, "name", None) != "bash"] + [
-            _CLAUDE_BASH_DESCRIPTOR
-        ]
+        tools = [
+            t for t in request.tools if getattr(t, "name", None) != self.tool_name
+        ] + [{"type": BASH_TOOL_TYPE, "name": self.tool_name}]
         return await handler(request.override(tools=tools))
 
     def _format_tool_message(
@@ -91,7 +123,7 @@ class ClaudeBashToolMiddleware(ShellToolMiddleware):
         return ToolMessage(
             content=content,
             tool_call_id=tool_call_id,
-            name=_CLAUDE_BASH_DESCRIPTOR["name"],
+            name=self.tool_name,
             status=status,
             artifact=artifact or {},
         )

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_bash.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_bash.py
@@ -38,7 +38,7 @@ def test_replaces_tool_with_claude_descriptor() -> None:
         tool_choice=None,
         tools=[bash_tool],
         response_format=None,
-        state={},
+        state={"messages": []},
         runtime=MagicMock(),
     )
 

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_bash.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_bash.py
@@ -12,31 +12,31 @@ from langchain_anthropic.middleware.bash import ClaudeBashToolMiddleware
 
 
 def test_creates_bash_tool(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that ClaudeBashToolMiddleware creates a 'bash' tool."""
+    """Test that ClaudeBashToolMiddleware inherits parent's 'shell' tool."""
     middleware = ClaudeBashToolMiddleware()
 
-    # Should have exactly one tool registered
+    # Should have exactly one tool registered (from parent)
     assert len(middleware.tools) == 1
 
-    # The tool should be named "bash"
-    bash_tool = middleware.tools[0]
-    assert bash_tool.name == "bash"
+    # Tool is named "shell" (from parent), replaced with "bash" in wrap_model_call
+    shell_tool = middleware.tools[0]
+    assert shell_tool.name == "shell"
 
 
 def test_replaces_tool_with_claude_descriptor() -> None:
-    """Test that wrap_model_call replaces bash tool with Claude's native descriptor."""
+    """Test wrap_model_call replaces shell tool with Claude's bash descriptor."""
     from langchain.agents.middleware.types import ModelRequest
 
     middleware = ClaudeBashToolMiddleware()
 
-    # Create a mock request with the bash tool
-    bash_tool = middleware.tools[0]
+    # Create a mock request with the shell tool (inherited from parent)
+    shell_tool = middleware.tools[0]
     request = ModelRequest(
         model=MagicMock(),
         system_prompt=None,
         messages=[],
         tool_choice=None,
-        tools=[bash_tool],
+        tools=[shell_tool],
         response_format=None,
         state={"messages": []},
         runtime=MagicMock(),
@@ -52,10 +52,10 @@ def test_replaces_tool_with_claude_descriptor() -> None:
 
     middleware.wrap_model_call(request, handler)
 
-    # The bash tool should be replaced with Claude's native descriptor
+    # The shell tool should be replaced with Claude's native bash descriptor
     assert captured_request is not None
     assert len(captured_request.tools) == 1
     assert captured_request.tools[0] == {
         "type": "bash_20250124",
-        "name": "bash",
+        "name": "shell",
     }

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_bash.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_bash.py
@@ -12,31 +12,31 @@ from langchain_anthropic.middleware.bash import ClaudeBashToolMiddleware
 
 
 def test_creates_bash_tool(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that ClaudeBashToolMiddleware inherits parent's 'shell' tool."""
+    """Test that ClaudeBashToolMiddleware creates a tool named 'bash'."""
     middleware = ClaudeBashToolMiddleware()
 
     # Should have exactly one tool registered (from parent)
     assert len(middleware.tools) == 1
 
-    # Tool is named "shell" (from parent), replaced with "bash" in wrap_model_call
-    shell_tool = middleware.tools[0]
-    assert shell_tool.name == "shell"
+    # Tool is named "bash" (via tool_name parameter)
+    bash_tool = middleware.tools[0]
+    assert bash_tool.name == "bash"
 
 
 def test_replaces_tool_with_claude_descriptor() -> None:
-    """Test wrap_model_call replaces shell tool with Claude's bash descriptor."""
+    """Test wrap_model_call replaces bash tool with Claude's bash descriptor."""
     from langchain.agents.middleware.types import ModelRequest
 
     middleware = ClaudeBashToolMiddleware()
 
-    # Create a mock request with the shell tool (inherited from parent)
-    shell_tool = middleware.tools[0]
+    # Create a mock request with the bash tool (inherited from parent)
+    bash_tool = middleware.tools[0]
     request = ModelRequest(
         model=MagicMock(),
         system_prompt=None,
         messages=[],
         tool_choice=None,
-        tools=[shell_tool],
+        tools=[bash_tool],
         response_format=None,
         state={"messages": []},
         runtime=MagicMock(),
@@ -52,10 +52,10 @@ def test_replaces_tool_with_claude_descriptor() -> None:
 
     middleware.wrap_model_call(request, handler)
 
-    # The shell tool should be replaced with Claude's native bash descriptor
+    # The bash tool should be replaced with Claude's native bash descriptor
     assert captured_request is not None
     assert len(captured_request.tools) == 1
     assert captured_request.tools[0] == {
         "type": "bash_20250124",
-        "name": "shell",
+        "name": "bash",
     }


### PR DESCRIPTION
* properly register shell tool w/ tool node
* inherit this improvement in claude shell tool middleware as well
* allow for configuration of tool name (which allows for claude impl to use `bash` as required by the anthropic api)