### PR TITLE
feat: allow `AND` for summarization `trigger` conditions

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -58,13 +58,19 @@ _DEFAULT_FALLBACK_MESSAGE_COUNT = 15
 _SEARCH_RANGE_FOR_TOOL_PAIRS = 5
 
 ContextFraction = tuple[Literal["fraction"], float]
+"""Tuple specifying context size as a fraction of the model's context window."""
 ContextTokens = tuple[Literal["tokens"], int]
+"""Tuple specifying context size as a number of tokens."""
 ContextMessages = tuple[Literal["messages"], int]
+"""Tuple specifying context size as a number of messages."""
 
 ContextSize = ContextFraction | ContextTokens | ContextMessages
-# Recursive type to support nested AND/OR conditions
-# Top-level list = OR logic, nested list = AND logic
-ContextCondition = ContextSize | list["ContextSize | list[ContextSize]"]
+"""Context size tuple to specify how much history to preserve."""
+
+ContextCondition = ContextSize | list[ContextSize | list[ContextSize]]
+"""Recursive type to support nested AND/OR conditions
+
+Top-level list = OR logic, nested list = AND logic."""
 
 
 class SummarizationMiddleware(AgentMiddleware):

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -262,31 +262,37 @@ class SummarizationMiddleware(AgentMiddleware):
     ) -> bool:
         """Check if a single condition is satisfied."""
         kind, value = condition
+
         if kind == "messages":
             return len(messages) >= value
+
         if kind == "tokens":
             return total_tokens >= value
-        if kind == "fraction":
-            max_input_tokens = self._get_profile_limits()
-            if max_input_tokens is None:
-                return False
-            threshold = int(max_input_tokens * value)
-            if threshold <= 0:
-                threshold = 1
-            return total_tokens >= threshold
-        return False
+
+        if kind != "fraction":
+            return False
+
+        max_input_tokens = self._get_profile_limits()
+        if max_input_tokens is None:
+            return False
+
+        threshold = max(1, int(max_input_tokens * value))
+        return total_tokens >= threshold
 
     def _determine_cutoff_index(self, messages: list[AnyMessage]) -> int:
         """Choose cutoff index respecting retention configuration."""
         kind, value = self.keep
-        if kind in {"tokens", "fraction"}:
-            token_based_cutoff = self._find_token_based_cutoff(messages)
-            if token_based_cutoff is not None:
-                return token_based_cutoff
-            # None cutoff -> model profile data not available (caught in __init__ but
-            # here for safety), fallback to message count
-            return self._find_safe_cutoff(messages, _DEFAULT_MESSAGES_TO_KEEP)
-        return self._find_safe_cutoff(messages, cast("int", value))
+
+        if kind not in {"tokens", "fraction"}:
+            return self._find_safe_cutoff(messages, cast("int", value))
+
+        token_based_cutoff = self._find_token_based_cutoff(messages)
+        if token_based_cutoff is not None:
+            return token_based_cutoff
+
+        # None cutoff -> model profile data not available (caught in __init__ but
+        # here for safety), fallback to message count
+        return self._find_safe_cutoff(messages, _DEFAULT_MESSAGES_TO_KEEP)
 
     def _find_token_based_cutoff(self, messages: list[AnyMessage]) -> int | None:
         """Find cutoff index based on target token retention."""
@@ -294,6 +300,7 @@ class SummarizationMiddleware(AgentMiddleware):
             return 0
 
         kind, value = self.keep
+
         if kind == "fraction":
             max_input_tokens = self._get_profile_limits()
             if max_input_tokens is None:
@@ -304,8 +311,7 @@ class SummarizationMiddleware(AgentMiddleware):
         else:
             return None
 
-        if target_token_count <= 0:
-            target_token_count = 1
+        target_token_count = max(1, target_token_count)
 
         if self.token_counter(messages) <= target_token_count:
             return 0
@@ -471,9 +477,11 @@ class SummarizationMiddleware(AgentMiddleware):
 
     def _has_tool_calls(self, message: AnyMessage) -> bool:
         """Check if message is an AI message with tool calls."""
-        return (
-            isinstance(message, AIMessage) and hasattr(message, "tool_calls") and message.tool_calls  # type: ignore[return-value]
-        )
+        if not isinstance(message, AIMessage):
+            return False
+        if not hasattr(message, "tool_calls"):
+            return False
+        return bool(message.tool_calls)
 
     def _extract_tool_call_ids(self, ai_message: AIMessage) -> set[str]:
         """Extract tool call IDs from an AI message."""
@@ -494,11 +502,15 @@ class SummarizationMiddleware(AgentMiddleware):
         """Check if cutoff separates an AI message from its corresponding tool messages."""
         for j in range(ai_message_index + 1, len(messages)):
             message = messages[j]
-            if isinstance(message, ToolMessage) and message.tool_call_id in tool_call_ids:
-                ai_before_cutoff = ai_message_index < cutoff_index
-                tool_before_cutoff = j < cutoff_index
-                if ai_before_cutoff != tool_before_cutoff:
-                    return True
+            if not isinstance(message, ToolMessage):
+                continue
+            if message.tool_call_id not in tool_call_ids:
+                continue
+
+            ai_before_cutoff = ai_message_index < cutoff_index
+            tool_before_cutoff = j < cutoff_index
+            if ai_before_cutoff != tool_before_cutoff:
+                return True
         return False
 
     def _create_summary(self, messages_to_summarize: list[AnyMessage]) -> str:


### PR DESCRIPTION
The trigger parameter now supports AND/OR logic via nested lists.
Top-level items are OR'd together, nested lists are AND'd together.

Before (OR logic only):
```py
SummarizationMiddleware(
    ...,
    trigger=[("tokens", 3000), ("messages", 100)]
)
# Triggers when tokens >= 3000 OR messages >= 100
```

After (AND/OR logic):
```py
SummarizationMiddleware(
    ...,
    trigger=[("messages", 10), [("tokens", 500), ("fraction", 0.8)]]
)
# Triggers when messages >= 10 OR (tokens >= 500 AND fraction >= 0.8)
```