### PR TITLE
fix(core): `get_buffer_string` to support modern `tool_calls`

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -135,7 +135,9 @@ def get_buffer_string(
             msg = f"Got unsupported message type: {m}"
             raise ValueError(msg)  # noqa: TRY004
         message = f"{role}: {m.text}"
-        if isinstance(m, AIMessage) and "function_call" in m.additional_kwargs:
+        if isinstance(m, AIMessage) and m.tool_calls:
+            message += f"{m.tool_calls}"
+        elif isinstance(m, AIMessage) and "function_call" in m.additional_kwargs:
             message += f"{m.additional_kwargs['function_call']}"
         string_messages.append(message)
 


### PR DESCRIPTION
Fixes #33970 

## Problem
The `get_buffer_string()` function was still using the deprecated `function_call` field from `additional_kwargs`. Modern AI providers (OpenAI, Anthropic, Gemini, etc.) now use the `tool_calls` attribute instead, which meant tool call information couldn't be output for messages from these providers.

## Solution
Updated `get_buffer_string()` in `libs/core/langchain_core/messages/utils.py` to:
- Prioritize `tool_calls` over the deprecated `function_call`
- Maintain backward compatibility with legacy `function_call` format
- Ensure tool call information is correctly included in buffer strings

## Changes
- Modified `get_buffer_string()` to check for `tool_calls` first, then fall back to `function_call`
- Added two new tests:
  - `test_get_buffer_string_with_tool_calls()` - tests modern tool_calls format
  - `test_get_buffer_string_tool_calls_priority()` - verifies tool_calls takes priority
- Kept existing `test_get_buffer_string_with_function_call()` to ensure backward compatibility

## Testing
Verified the fix works correctly with:
- ✅ Modern tool_calls format
- ✅ Legacy function_call format (backward compatibility)
- ✅ Priority behavior (tool_calls takes precedence when both are present)

All changes are in the `langchain-core` package as specified in the issue.