### PR TITLE
fix(ollama): strip reasoning tags when reasoning=False (#33993) 

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -1121,7 +1121,7 @@ class ChatOllama(BaseChatModel):
                     generation_info = None
 
                 # Strip reasoning tags when reasoning=False
-                # Some models (e.g., qwen3:4b) may output reasoning tags even when think=False
+                # Some models (e.g., qwen3:4b) output tags even when reasoning=False.
                 if reasoning is False:
                     content = _strip_reasoning_tags(content)
 
@@ -1203,7 +1203,7 @@ class ChatOllama(BaseChatModel):
                     generation_info = None
 
                 # Strip reasoning tags when reasoning=False
-                # Some models (e.g., qwen3:4b) may output reasoning tags even when think=False
+                # Some models (e.g., qwen3:4b) output tags even when reasoning=False.
                 if reasoning is False:
                     content = _strip_reasoning_tags(content)
 


### PR DESCRIPTION
### Description

This PR fixes a bug where the `qwen3:4b` model incorrectly includes reasoning tags (e.g., `</think>`) in its response even when `reasoning=False` was specified. This change ensures that when `reasoning` is explicitly set to `False`, any reasoning-related tags and content are stripped from the final output.

### The Bug

The `qwen3:4b` model does not fully suppress its reasoning output when requested. It omits the opening `<think>` tag but still includes a block of reasoning text followed by a `</think>` tag before the final answer, leaking its internal monologue.

**Example buggy output:**
```
...internal reasoning monologue...
</think>

5 + 5 = **10**
```

### The Fix

A helper function, `_strip_reasoning_tags`, is now called from the stream processing methods **only when `reasoning is False`**. This function robustly cleans the output by:
1.  Removing any complete `<think>...</think>` blocks.
2.  Handling the `qwen3:4b` case by finding the first `</think>` tag and returning only the content that follows it.

The regex patterns are compiled at the module level for performance. The change is targeted and does not alter the behavior for `reasoning=True` or `None`.

### How It Was Tested

The fix was validated by confirming that the following assertions pass for `qwen3:4b`, which previously failed:

```python
# 1. Verify that no reasoning tags are present in the final content
assert "</think>" not in response.content
assert "<think>" not in response.content

# 2. Verify that the actual answer is preserved
assert "10" in response.content

# 3. Verify that the `additional_kwargs` remain clean
assert "reasoning_content" not in response.additional_kwargs
```
Also confirmed that the behavior of other models like `deepseek-r1:1.5b` and `qwen3:1.7b` remains correct and unaffected.

### Is this Safe?

This fix is safe because it is:
*   **Targeted and Safe:** The logic is strictly guarded by an `if reasoning is False` check, minimizing the risk of side effects.
*   **Performance-Oriented:** It uses compiled regex patterns, a standard optimization for production code.
*   **Clean and Maintainable:** The logic is encapsulated in a small, well-documented, internal helper function.

### Issue

Fixes #33993

### Dependencies

None.