### PR TITLE
chore: Support tool runtime injection when custom args schema is prov…

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -569,6 +569,14 @@ class ChildTool(BaseTool):
             self.name, full_schema, fields, fn_description=self.description
         )
 
+    @functools.cached_property
+    def _injected_args_keys(self) -> frozenset[str]:
+        return frozenset(
+            k
+            for k, v in get_all_basemodel_annotations(self.args_schema).items()
+            if _is_injected_arg_type(v)
+        )
+
     # --- Runnable ---
 
     @override
@@ -646,6 +654,7 @@ class ChildTool(BaseTool):
                     raise TypeError(msg)
             return tool_input
         if input_args is not None:
+            injected_args = {}
             if isinstance(input_args, dict):
                 return tool_input
             if issubclass(input_args, BaseModel):
@@ -661,6 +670,7 @@ class ChildTool(BaseTool):
                             )
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
+                        injected_args[k] = tool_call_id
                 result = input_args.model_validate(tool_input)
                 result_dict = result.model_dump()
             elif issubclass(input_args, BaseModelV1):
@@ -676,6 +686,7 @@ class ChildTool(BaseTool):
                             )
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
+                        injected_args[k] = tool_call_id
                 result = input_args.parse_obj(tool_input)
                 result_dict = result.dict()
             else:
@@ -683,9 +694,19 @@ class ChildTool(BaseTool):
                     f"args_schema must be a Pydantic BaseModel, got {self.args_schema}"
                 )
                 raise NotImplementedError(msg)
-            return {
-                k: getattr(result, k) for k, v in result_dict.items() if k in tool_input
+            validated_input = {
+                k: getattr(result, k) for k in result_dict if k in tool_input
             }
+            for k in self._injected_args_keys:
+                if k not in result_dict and k in tool_input:
+                    injected_val = tool_input[k]
+                    validated_input[k] = injected_val
+                    if isinstance(
+                        injected_val,
+                        (InjectedToolArg, InjectedToolCallId, _DirectlyInjectedToolArg),
+                    ):
+                        validated_input[k] = injected_val
+            return validated_input
         return tool_input
 
     @abstractmethod

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -701,11 +701,6 @@ class ChildTool(BaseTool):
                 if k not in result_dict and k in tool_input:
                     injected_val = tool_input[k]
                     validated_input[k] = injected_val
-                    if isinstance(
-                        injected_val,
-                        (InjectedToolArg, InjectedToolCallId, _DirectlyInjectedToolArg),
-                    ):
-                        validated_input[k] = injected_val
             return validated_input
         return tool_input
 

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -26,7 +26,6 @@ from langchain_core.tools.base import (
     FILTERED_ARGS,
     ArgsSchema,
     BaseTool,
-    InjectedToolCallId,
     _get_runnable_config_param,
     _is_injected_arg_type,
     create_schema_from_function,
@@ -254,21 +253,6 @@ class StructuredTool(BaseTool):
             k
             for k, v in signature(fn).parameters.items()
             if _is_injected_arg_type(v.annotation)
-        )
-
-    def _get_injected_tool_call_id_keys(self) -> frozenset[str]:
-        """Get parameter names that are annotated with InjectedToolCallId.
-
-        Returns:
-            Set of parameter names with `InjectedToolCallId` annotation.
-        """
-        fn = self.func or self.coroutine
-        if fn is None:
-            return _EMPTY_SET
-        return frozenset(
-            k
-            for k, v in signature(fn).parameters.items()
-            if _is_injected_arg_type(v.annotation, injected_type=InjectedToolCallId)
         )
 
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2428,26 +2428,6 @@ def test_tool_injected_arg_with_custom_schema() -> None:
     assert captured["context"].value == "test_context"
 
 
-def test_tool_does_not_inject_extra_runtime_args() -> None:
-    """Ensure runtime args are preserved even if not in the args schema."""
-
-    class InputSchema(BaseModel):
-        query: str
-
-    @dataclass
-    class MyRuntime(_DirectlyInjectedToolArg):
-        some_obj: object
-
-    @tool(args_schema=InputSchema)
-    def runtime_tool(query: str) -> str:
-        """Echo the query and capture runtime value."""
-        return query
-
-    runtime_obj = object()
-    runtime = MyRuntime(some_obj=runtime_obj)
-    assert runtime_tool.invoke({"query": "hello", "runtime": runtime}) == "hello"
-
-
 def test_tool_injected_tool_call_id() -> None:
     @tool
     def foo(x: int, tool_call_id: Annotated[str, InjectedToolCallId]) -> ToolMessage:


### PR DESCRIPTION
Support injection of injected args (like `InjectedToolCallId`, `ToolRuntime`) when an `args_schema` is specified that doesn't contain said args.

This allows for pydantic validation of other args while retaining the ability to inject langchain specific arguments.

fixes https://github.com/langchain-ai/langchain/issues/33646
fixes https://github.com/langchain-ai/langchain/issues/31688

Taking a deep dive here reminded me that we definitely need to revisit our internal tooling logic, but I don't think we should do that in this PR.