### PR TITLE
feat(huggingface): expose reasoning_content in AIMessageChunk

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -258,6 +258,10 @@ def _convert_chunk_to_message_chunk(
     if role == "user" or default_class == HumanMessageChunk:
         return HumanMessageChunk(content=content)
     if role == "assistant" or default_class == AIMessageChunk:
+
+        reasoning = cast(str, _dict.get("reasoning") or "")
+        additional_kwargs["reasoning_content"] = reasoning
+
         if usage := chunk.get("usage"):
             input_tokens = usage.get("prompt_tokens", 0)
             output_tokens = usage.get("completion_tokens", 0)

--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -232,8 +232,17 @@ def _is_huggingface_hub(llm: Any) -> bool:
 def _convert_chunk_to_message_chunk(
     chunk: Mapping[str, Any], default_class: type[BaseMessageChunk]
 ) -> BaseMessageChunk:
+
+    if hasattr(chunk, 'choices'):
+        choice_obj = chunk.choices[0]
+        delta_obj = choice_obj.delta
+        reasoning_content_value = getattr(delta_obj, "reasoning_content", None)
+    else:
+        reasoning_content_value = None
+
     choice = chunk["choices"][0]
     _dict = choice["delta"]
+
     role = cast(str, _dict.get("role"))
     content = cast(str, _dict.get("content") or "")
     additional_kwargs: dict = {}
@@ -259,7 +268,7 @@ def _convert_chunk_to_message_chunk(
         return HumanMessageChunk(content=content)
     if role == "assistant" or default_class == AIMessageChunk:
 
-        reasoning = cast(str, _dict.get("reasoning") or "")
+        reasoning = _dict.get("reasoning") or reasoning_content_value
         additional_kwargs["reasoning_content"] = reasoning
 
         if usage := chunk.get("usage"):


### PR DESCRIPTION
### **Description**

This PR enhances the HuggingFace integration by including `reasoning_content` extracted from the model response in `AIMessageChunk.additional_kwargs`.

Previously, `AIMessageChunk` did not expose the `"reasoning"` or `"reasoning_content"` field returned by reasoning models, making it inaccessible to downstream LangChain components.
This change ensures that any `"reasoning"`  or `"reasoning_content"` value in the provider response is propagated and available to users.

The updated logic inside the HuggingFace formatter now includes:

```python

def _convert_chunk_to_message_chunk(
    chunk: Mapping[str, Any], default_class: type[BaseMessageChunk]
) -> BaseMessageChunk:

    if hasattr(chunk, 'choices'):
        choice_obj = chunk.choices[0]
        delta_obj = choice_obj.delta
        reasoning_content_value = getattr(delta_obj, "reasoning_content", None)
    else:
        reasoning_content_value = None

    choice = chunk["choices"][0]
    _dict = choice["delta"]

    ....
    if role == "assistant" or default_class == AIMessageChunk:

        reasoning = _dict.get("reasoning") or reasoning_content_value
        additional_kwargs["reasoning_content"] = reasoning

        if usage := chunk.get("usage"):
            input_tokens = usage.get("prompt_tokens", 0)
            output_tokens = usage.get("completion_tokens", 0)
            usage_metadata = {
                "input_tokens": input_tokens,
                "output_tokens": output_tokens,
                "total_tokens": usage.get("total_tokens", input_tokens + output_tokens),
            }
        else:
            usage_metadata = None
        return AIMessageChunk(
            content=content,
            additional_kwargs=additional_kwargs,
            tool_call_chunks=tool_call_chunks,
            usage_metadata=usage_metadata,  # type: ignore[arg-type]
        )
    ...
```

This makes reasoning traces accessible to agents, logging utilities, tracing tools, and any consumer of `AIMessageChunk`.

### **Issue**

No existing issue, this adds missing support for reasoning fields in the HuggingFace integration.

### **Dependencies**

No new dependencies required.
