### PR TITLE
chore(openai): skip Azure text completions tests

### DIFF
--- a/libs/partners/openai/tests/integration_tests/llms/test_azure.py
+++ b/libs/partners/openai/tests/integration_tests/llms/test_azure.py
@@ -19,6 +19,15 @@ DEPLOYMENT_NAME = os.environ.get(
     os.environ.get("AZURE_OPENAI_LLM_DEPLOYMENT_NAME", ""),
 )
 
+pytestmark = pytest.mark.skipif(
+    True,
+    reason=(
+        "This entire module is skipped as all Azure OpenAI models supporting text "
+        "completions are retired. See: "
+        "https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models"
+    ),
+)
+
 
 def _get_llm(**kwargs: Any) -> AzureOpenAI:
     return AzureOpenAI(  # type: ignore[call-arg, call-arg, call-arg]


### PR DESCRIPTION
`gpt-35-turbo-instruct` is retired and I believe there are no more supported text completions models in Azure OpenAI.

https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/legacy-models