### PR TITLE
chore(infra): disable integration tests temporarily when releasing v0.3

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -376,6 +376,7 @@ jobs:
   test-prior-published-packages-against-new-core:
     # Installs the new core with old partners: Installs the new unreleased core
     # alongside the previously published partner packages and runs integration tests
+    if: github.ref != 'refs/heads/v0.3'
     needs:
       - build
       - release-notes


### PR DESCRIPTION
Temporarily disable running tests against latest published packages with core 0.3 as the latest published packages only work with core>1.0