### PR TITLE
chore(infra): properly disable testing for 0.3 against latest packages 

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -465,7 +465,6 @@ jobs:
       - release-notes
       - test-pypi-publish
       - pre-release-checks
-      - test-prior-published-packages-against-new-core
     runs-on: ubuntu-latest
     permissions:
       # This permission is used for trusted publishing:


### PR DESCRIPTION
properly disable testing for 0.3 against latest packages (since latest packages only work with langchain_core > 1.0)