### PR TITLE
fix(core): Decouple provider prefix from model name in init_chat_mode…

### DIFF
--- a/libs/langchain/langchain_classic/chat_models/base.py
+++ b/libs/langchain/langchain_classic/chat_models/base.py
@@ -547,13 +547,17 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
 
 
 def _parse_model(model: str, model_provider: str | None) -> tuple[str, str]:
-    if (
-        not model_provider
-        and ":" in model
-        and model.split(":")[0] in _SUPPORTED_PROVIDERS
-    ):
-        model_provider = model.split(":")[0]
-        model = ":".join(model.split(":")[1:])
+    if not model_provider and ":" in model:
+        prefix, suffix = model.split(":", 1)
+        if prefix in _SUPPORTED_PROVIDERS:
+            model_provider = prefix
+            model = suffix
+        else:
+            inferred = _attempt_infer_model_provider(prefix)
+            if inferred:
+                model_provider = inferred
+                model = suffix
+
     model_provider = model_provider or _attempt_infer_model_provider(model)
     if not model_provider:
         msg = (


### PR DESCRIPTION
:…l logic

Addresses Issue #34007.
Fixes a bug where aliases like 'mistral:' were inferred correctly as a provider but the prefix was not stripped from the model name, causing API 400 errors. Added logic to strip prefix when inference succeeds.

**Description**
This PR resolves a logic error in `init_chat_model` where inferred provider aliases (specifically `mistral:`) were correctly identified but not stripped from the model string.

**The Problem**
When passing a string like `mistral:ministral-8b-latest`, the factory logic correctly inferred the provider as `mistralai` but failed to enter the string-splitting block because the alias `mistral` was not in the hardcoded `_SUPPORTED_PROVIDERS` list. This caused the raw string `mistral:ministral-8b-latest` to be passed to the `ChatMistralAI` constructor, resulting in a 400 API error.

**The Fix**
I updated `_parse_model` in `libs/langchain/langchain/chat_models/base.py`. The logic now attempts to infer the provider from the prefix *before* determining whether to split the string. This ensures that valid aliases trigger the stripping logic, passing only the clean `model_name` to the integration class.

**Issue**
Fixes #34007

**Dependencies**
None.

**Verification**
Validated locally with a reproduction script:
- Input: `mistral:ministral-8b-latest`
- Result: Successfully instantiates `ChatMistralAI` with `model="ministral-8b-latest"`.
- Validated that standard inputs (e.g., `gpt-4o`) remain unaffected.