### PR TITLE
feat(openai): Include support for reasoning blocks when using openai compatible llm gateways

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -334,6 +334,11 @@ def _convert_message_to_dict(
             )
         if audio:
             message_dict["audio"] = audio
+        # add reasoning and thinking blocks from additional_kwargs from LiteLLM proxy for thiking models
+        if reasoning_content := message.additional_kwargs.get("reasoning_content"):
+            message_dict["reasoning_content"] = reasoning_content
+        if thinking_blocks := message.additional_kwargs.get("thinking_blocks"):
+            message_dict["thinking_blocks"] = thinking_blocks
     elif isinstance(message, SystemMessage):
         message_dict["role"] = message.additional_kwargs.get(
             "__openai_role__", "system"

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -163,11 +163,9 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # Also OpenAI returns None for tool invocations
         content = _dict.get("content", "") or ""
         additional_kwargs: dict = {}
-        # add reasoning and thinking blocks from litellm to additional_kwargs
+        # add reasoning blocks if available
         if reasoning_content := _dict.get("reasoning_content"):
             additional_kwargs["reasoning_content"] = reasoning_content
-        if thinking_blocks := _dict.get("thinking_blocks"):
-            additional_kwargs["thinking_blocks"] = thinking_blocks
         # add function call to additional_kwargs
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
@@ -334,11 +332,9 @@ def _convert_message_to_dict(
             )
         if audio:
             message_dict["audio"] = audio
-        # add reasoning and thinking blocks for LiteLLM thiking models
+        # add reasoning blocks if available
         if reasoning_content := message.additional_kwargs.get("reasoning_content"):
             message_dict["reasoning_content"] = reasoning_content
-        if thinking_blocks := message.additional_kwargs.get("thinking_blocks"):
-            message_dict["thinking_blocks"] = thinking_blocks
     elif isinstance(message, SystemMessage):
         message_dict["role"] = message.additional_kwargs.get(
             "__openai_role__", "system"
@@ -390,8 +386,6 @@ def _convert_delta_to_message_chunk(
     if role == "assistant" or default_class == AIMessageChunk:
         if reasoning_content := _dict.get("reasoning_content"):
             additional_kwargs["reasoning_content"] = reasoning_content
-        if thinking_blocks := _dict.get("thinking_blocks"):
-            additional_kwargs["thinking_blocks"] = thinking_blocks
         return AIMessageChunk(
             content=content,
             additional_kwargs=additional_kwargs,
@@ -1032,11 +1026,9 @@ class BaseChatOpenAI(BaseChatModel):
     ) -> ChatGenerationChunk | None:
         if chunk.get("type") == "content.delta":  # From beta.chat.completions.stream
             return None
-        # add reasoning and thinking blocks for LiteLLM thiking models
+        # add reasoning blocks if available
         if reasoning_content := chunk.get("reasoning_content"):
             chunk["additional_kwargs"]["reasoning_content"] = reasoning_content
-        if thinking_blocks := chunk.get("thinking_blocks"):
-            chunk["additional_kwargs"]["thinking_blocks"] = thinking_blocks
         token_usage = chunk.get("usage")
         choices = (
             chunk.get("choices", [])

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -388,6 +388,10 @@ def _convert_delta_to_message_chunk(
     if role == "user" or default_class == HumanMessageChunk:
         return HumanMessageChunk(content=content, id=id_)
     if role == "assistant" or default_class == AIMessageChunk:
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = reasoning_content
+        if thinking_blocks := _dict.get("thinking_blocks"):
+            additional_kwargs["thinking_blocks"] = thinking_blocks
         return AIMessageChunk(
             content=content,
             additional_kwargs=additional_kwargs,
@@ -1028,6 +1032,11 @@ class BaseChatOpenAI(BaseChatModel):
     ) -> ChatGenerationChunk | None:
         if chunk.get("type") == "content.delta":  # From beta.chat.completions.stream
             return None
+        # add reasoning and thinking blocks for LiteLLM thiking models
+        if reasoning_content := chunk.get("reasoning_content"):
+            chunk["additional_kwargs"]["reasoning_content"] = reasoning_content
+        if thinking_blocks := chunk.get("thinking_blocks"):
+            chunk["additional_kwargs"]["thinking_blocks"] = thinking_blocks
         token_usage = chunk.get("usage")
         choices = (
             chunk.get("choices", [])

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -163,6 +163,12 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # Also OpenAI returns None for tool invocations
         content = _dict.get("content", "") or ""
         additional_kwargs: dict = {}
+        # add reasoning and thinking blocks from litellm to additional_kwargs
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = reasoning_content
+        if thinking_blocks := _dict.get("thinking_blocks"):
+            additional_kwargs["thinking_blocks"] = thinking_blocks
+        # add function call to additional_kwargs
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
         tool_calls = []

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -166,7 +166,6 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # add reasoning blocks if available
         if reasoning_content := _dict.get("reasoning_content"):
             additional_kwargs["reasoning_content"] = reasoning_content
-        # add function call to additional_kwargs
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
         tool_calls = []
@@ -332,9 +331,6 @@ def _convert_message_to_dict(
             )
         if audio:
             message_dict["audio"] = audio
-        # add reasoning blocks if available
-        if reasoning_content := message.additional_kwargs.get("reasoning_content"):
-            message_dict["reasoning_content"] = reasoning_content
     elif isinstance(message, SystemMessage):
         message_dict["role"] = message.additional_kwargs.get(
             "__openai_role__", "system"

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -334,7 +334,7 @@ def _convert_message_to_dict(
             )
         if audio:
             message_dict["audio"] = audio
-        # add reasoning and thinking blocks from additional_kwargs from LiteLLM proxy for thiking models
+        # add reasoning and thinking blocks for LiteLLM thiking models
         if reasoning_content := message.additional_kwargs.get("reasoning_content"):
             message_dict["reasoning_content"] = reasoning_content
         if thinking_blocks := message.additional_kwargs.get("thinking_blocks"):

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -44,6 +44,7 @@ test = [
     "langchain",
     "langchain-core",
     "langchain-tests",
+    "httpx>=0.28.1",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
 dev = ["langchain-core"]

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1323,7 +1323,8 @@ async def test_schema_parsing_failures_responses_api_async() -> None:
 
 
 # Integration test to verify that reasoning blocks are returned from the model when using thinking models with LiteLLM proxy
-@pytest.mark.scheduled
+@pytest.mark.scheduled()
+@pytest.mark.skipif(os.environ.get("REASONING_BASE_URL") is None or os.environ.get("REASONING_API_KEY") is None, reason="REASONING_BASE_URL or REASONING_API_KEY is not set")
 def test_chat_reasoning_blocks() -> None:
     """Test ChatOpenAI wrapper."""
     chat = ChatOpenAI(

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1343,7 +1343,6 @@ def test_with_reasoning_proxy() -> None:
     # Using a prompt that will trigger reasoning
     message = HumanMessage(content="Reason and think about the meaning of life")
     response = chat.invoke([message])
-    response: AIMessage = response
     assert isinstance(response, AIMessage)
     assert isinstance(response.content, str)
     # Assert that reasoning_content and thinking_blocks are in additional_kwargs

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1322,6 +1322,7 @@ async def test_schema_parsing_failures_responses_api_async() -> None:
         raise AssertionError
 
 
+# Integration test to verify that reasoning blocks are returned from the model when using thinking models with LiteLLM proxy
 @pytest.mark.scheduled
 def test_chat_reasoning_blocks() -> None:
     """Test ChatOpenAI wrapper."""
@@ -1333,7 +1334,7 @@ def test_chat_reasoning_blocks() -> None:
         max_retries=3,
         http_client=httpx.Client(verify=False),
     )
-    print(chat.model_dump_json())
+    # Using a prompt that will trigger reasoning
     message = HumanMessage(content="please reason and think critically about how to explain the reason about our life in this world")
     response = chat.invoke([message])
     print(response)

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1325,17 +1325,17 @@ async def test_schema_parsing_failures_responses_api_async() -> None:
 # Test thinking models with LiteLLM proxy
 @pytest.mark.scheduled
 @pytest.mark.skipif(
-    os.environ.get("LITELLM_BASE_URL") is None
-    or os.environ.get("LITELLM_API_KEY") is None,
-    reason="LITELLM_BASE_URL or LITELLM_API_KEY is not set",
+    os.environ.get("REASONING_BASE_URL") is None
+    or os.environ.get("REASONING_API_KEY") is None,
+    reason="REASONING_BASE_URL or REASONING_API_KEY is not set",
 )
-def test_thinking_models_with_lite_llm() -> None:
-    """Test thinking models with LiteLLM proxy."""
+def test_with_reasoning_proxy() -> None:
+    """Test reasoning models with proxy."""
     chat = ChatOpenAI(
         model="claude-sonnet-4-5-20250929",
         reasoning_effort="medium",
-        base_url=os.environ["LITELLM_BASE_URL"],
-        api_key=SecretStr(os.environ["LITELLM_API_KEY"]),
+        base_url=os.environ["REASONING_BASE_URL"],
+        api_key=SecretStr(os.environ["REASONING_API_KEY"]),
         max_retries=3,
         # Disable SSL verification for self-signed certificates
         http_client=httpx.Client(verify=False),  # noqa: S501
@@ -1343,8 +1343,8 @@ def test_thinking_models_with_lite_llm() -> None:
     # Using a prompt that will trigger reasoning
     message = HumanMessage(content="Reason and think about the meaning of life")
     response = chat.invoke([message])
+    response: AIMessage = response
     assert isinstance(response, AIMessage)
     assert isinstance(response.content, str)
     # Assert that reasoning_content and thinking_blocks are in additional_kwargs
     assert "reasoning_content" in response.additional_kwargs
-    assert "thinking_blocks" in response.additional_kwargs

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1320,3 +1320,29 @@ async def test_schema_parsing_failures_responses_api_async() -> None:
         assert e.response is not None  # type: ignore[attr-defined]
     else:
         raise AssertionError
+
+
+@pytest.mark.scheduled
+def test_chat_reasoning_blocks() -> None:
+    """Test ChatOpenAI wrapper."""
+    chat = ChatOpenAI(
+        model="claude-sonnet-4-5-20250929",
+        reasoning_effort="medium",
+        base_url=os.environ["OPENAI_BASE_URL"],
+        api_key=os.environ["OPENAI_API_KEY"],
+        max_retries=3,
+        http_client=httpx.Client(verify=False),
+    )
+    print(chat.model_dump_json())
+    message = HumanMessage(content="please reason and think critically about how to explain the reason about our life in this world")
+    response = chat.invoke([message])
+    print(response)
+    assert isinstance(response, AIMessage)
+    assert isinstance(response.content, str)
+    # Assert that reasoning_content and thinking_blocks are in additional_kwargs
+    assert "reasoning_content" in response.additional_kwargs
+    assert "thinking_blocks" in response.additional_kwargs
+    # Optionally assert they have values
+    assert response.additional_kwargs["reasoning_content"] is not None
+    assert response.additional_kwargs["thinking_blocks"] is not None
+

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1328,8 +1328,8 @@ def test_chat_reasoning_blocks() -> None:
     chat = ChatOpenAI(
         model="claude-sonnet-4-5-20250929",
         reasoning_effort="medium",
-        base_url=os.environ["OPENAI_BASE_URL"],
-        api_key=os.environ["OPENAI_API_KEY"],
+        base_url=os.environ["REASONING_BASE_URL"],
+        api_key=os.environ["REASONING_API_KEY"],
         max_retries=3,
         http_client=httpx.Client(verify=False),
     )

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -280,6 +280,21 @@ def test__convert_dict_to_message_tool_call() -> None:
     )
     assert reverted_message_dict == message
 
+def test__convert_dict_to_message_reasoning_blocks() -> None:
+    message = {"role": "assistant", "content": "foo", "reasoning_content": "bar", "thinking_blocks": {
+                "type": "thinking",
+                "thinking": "thinking...",
+                "signature": "sig..."
+            }}
+    result = _convert_dict_to_message(message)
+    expected_output = AIMessage(content="foo", additional_kwargs={"reasoning_content": "bar", "thinking_blocks": {
+                "type": "thinking",
+                "thinking": "thinking...",
+                "signature": "sig..."
+            }})
+    assert result == expected_output
+    assert _convert_message_to_dict(expected_output) == message
+
 
 class MockAsyncContextManager:
     def __init__(self, chunk_list: list) -> None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -285,23 +285,13 @@ def test__convert_dict_to_message_reasoning_blocks() -> None:
     message = {
         "role": "assistant",
         "content": "foo",
-        "reasoning_content": "bar",
-        "thinking_blocks": {
-            "type": "thinking",
-            "thinking": "thinking...",
-            "signature": "sig...",
-        },
+        "reasoning_content": "bar"
     }
     result = _convert_dict_to_message(message)
     expected_output = AIMessage(
         content="foo",
         additional_kwargs={
-            "reasoning_content": "bar",
-            "thinking_blocks": {
-                "type": "thinking",
-                "thinking": "thinking...",
-                "signature": "sig...",
-            },
+            "reasoning_content": "bar"
         },
     )
     assert result == expected_output

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -280,18 +280,30 @@ def test__convert_dict_to_message_tool_call() -> None:
     )
     assert reverted_message_dict == message
 
+
 def test__convert_dict_to_message_reasoning_blocks() -> None:
-    message = {"role": "assistant", "content": "foo", "reasoning_content": "bar", "thinking_blocks": {
-                "type": "thinking",
-                "thinking": "thinking...",
-                "signature": "sig..."
-            }}
+    message = {
+        "role": "assistant",
+        "content": "foo",
+        "reasoning_content": "bar",
+        "thinking_blocks": {
+            "type": "thinking",
+            "thinking": "thinking...",
+            "signature": "sig...",
+        },
+    }
     result = _convert_dict_to_message(message)
-    expected_output = AIMessage(content="foo", additional_kwargs={"reasoning_content": "bar", "thinking_blocks": {
+    expected_output = AIMessage(
+        content="foo",
+        additional_kwargs={
+            "reasoning_content": "bar",
+            "thinking_blocks": {
                 "type": "thinking",
                 "thinking": "thinking...",
-                "signature": "sig..."
-            }})
+                "signature": "sig...",
+            },
+        },
+    )
     assert result == expected_output
     assert _convert_message_to_dict(expected_output) == message
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -282,17 +282,11 @@ def test__convert_dict_to_message_tool_call() -> None:
 
 
 def test__convert_dict_to_message_reasoning_blocks() -> None:
-    message = {
-        "role": "assistant",
-        "content": "foo",
-        "reasoning_content": "bar"
-    }
+    message = {"role": "assistant", "content": "foo", "reasoning_content": "bar"}
     result = _convert_dict_to_message(message)
     expected_output = AIMessage(
         content="foo",
-        additional_kwargs={
-            "reasoning_content": "bar"
-        },
+        additional_kwargs={"reasoning_content": "bar"},
     )
     assert result == expected_output
     assert _convert_message_to_dict(expected_output) == message

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -289,7 +289,6 @@ def test__convert_dict_to_message_reasoning_blocks() -> None:
         additional_kwargs={"reasoning_content": "bar"},
     )
     assert result == expected_output
-    assert _convert_message_to_dict(expected_output) == message
 
 
 class MockAsyncContextManager:

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -610,7 +610,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.0.5"
+version = "1.0.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -687,6 +687,7 @@ lint = [
 ]
 test = [
     { name = "freezegun" },
+    { name = "httpx" },
     { name = "langchain" },
     { name = "langchain-core" },
     { name = "langchain-tests" },
@@ -727,6 +728,7 @@ dev = [{ name = "langchain-core", editable = "../../core" }]
 lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "langchain", editable = "../../langchain_v1" },
     { name = "langchain-core", editable = "../../core" },
     { name = "langchain-tests", editable = "../../standard-tests" },

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -610,7 +610,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.0.7"
+version = "1.0.5"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
**Description:**

Include reasoning and thinking blocks inside additional_args for AIMessage when using reasoning models with custom llm gateway proxies.

This makes the openai chatmodel compatible with OpenAI compatible LLM Gateways such as the LiteLLM proxy with reasoning and thinking models like anthropic and deepseek:
https://docs.litellm.ai/docs/reasoning_content


**Issue:**
Fixes [#30530](https://github.com/langchain-ai/langchain/issues/30530)

**Dependencies:**
- needs httpx in test dependencies of the openai partner library in order to ignore the self signed certs when using custom proxies for the integration test

**Lint and test**
- make format — passed
- make lint — passed
- make test — passed
- make integration_tests — passed 


