### PR TITLE
feat(core): add as_message_state and to_message_state utilities with tests

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -18,6 +18,7 @@ from typing import (
     Protocol,
     TypeGuard,
     TypeVar,
+    Dict
 )
 
 from typing_extensions import override
@@ -36,7 +37,9 @@ if TYPE_CHECKING:
     )
     from contextvars import Context
 
+    from langchain_core.runnables import RunnableLambda
     from langchain_core.runnables.schema import StreamEvent
+    from langchain_core.messages import BaseMessage, HumanMessage
 
 Input = TypeVar("Input", contravariant=True)  # noqa: PLC0105
 # Output type should implement __concat__, as eg str, list, dict do
@@ -147,6 +150,48 @@ def coro_with_context(
     if create_task:
         return asyncio.create_task(coro)  # type: ignore[arg-type]
     return coro
+
+
+def to_message_state(obj: Any) -> Dict[str, list[BaseMessage]]:
+    """Convert any supported input into a message-state dict: {'messages': [BaseMessage, ...]}.
+
+    Args:
+        obj: The input to convert.
+
+    Returns:
+        A dictionary with a 'messages' key containing a list of BaseMessages.
+    """
+    # None
+    if obj is None:
+        return {"messages": []}
+    # String → assume HumanMessage
+    if isinstance(obj, str):
+        return {"messages": [HumanMessage(content=obj)]}
+    # Already a BaseMessage (could be HumanMessage, AIMessage, SystemMessage, etc.)
+    if isinstance(obj, BaseMessage):
+        return {"messages": [obj]}
+    # List of items → flatten convert each
+    if isinstance(obj, list):
+        msgs: list[BaseMessage] = []
+        for item in obj:
+            state = to_message_state(item)
+            msgs.extend(state["messages"])
+        return {"messages": msgs}
+    # Already a dict in message state shape
+    if isinstance(obj, dict) and "messages" in obj:
+        # Optionally: validate that each element is a BaseMessage
+        return obj
+    # Unsupported type
+    raise TypeError(f"Unsupported type for to_message_state: {type(obj)}")
+
+
+def as_message_state() -> RunnableLambda:
+    """Runnable that normalizes output to message-state structure.
+
+    Returns:
+        A Runnable Lambda that normalizes output to message-state structure.
+    """
+    return RunnableLambda(lambda x: to_message_state(x))
 
 
 class IsLocalDict(ast.NodeVisitor):

--- a/libs/core/tests/unit_tests/runnables/test_utils.py
+++ b/libs/core/tests/unit_tests/runnables/test_utils.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 
 import pytest
 
-from langchain_core.runnables.base import RunnableLambda
 from langchain_core.runnables.utils import (
     get_function_nonlocals,
     get_lambda_source,
@@ -10,9 +9,12 @@ from langchain_core.runnables.utils import (
     as_message_state,
     to_message_state
 )
+from langchain_core.runnables.base import RunnableLambda
 from langchain_core.messages import (
     BaseMessage,
-    HumanMessage
+    HumanMessage,
+    AIMessage,
+    SystemMessage
 )
 
 

--- a/libs/core/tests/unit_tests/runnables/test_utils.py
+++ b/libs/core/tests/unit_tests/runnables/test_utils.py
@@ -7,6 +7,12 @@ from langchain_core.runnables.utils import (
     get_function_nonlocals,
     get_lambda_source,
     indent_lines_after_first,
+    as_message_state,
+    to_message_state
+)
+from langchain_core.messages import (
+    BaseMessage,
+    HumanMessage
 )
 
 
@@ -72,3 +78,88 @@ def test_nonlocals() -> None:
     assert RunnableLambda(my_func3).deps == [agent]
     assert RunnableLambda(my_func4).deps == [global_agent]
     assert RunnableLambda(func).deps == [nl]
+
+
+def test_to_message_state_none() -> None:
+    result = to_message_state(None)
+    assert result == {"messages": []}
+
+
+def test_to_message_state_string() -> None:
+    result = to_message_state("hello")
+    assert isinstance(result["messages"][0], HumanMessage)
+    assert result == {"messages": [HumanMessage(content="hello")]}
+
+
+def test_to_message_state_human_message() -> None:
+    msg = HumanMessage(content="hey")
+    result = to_message_state(msg)
+    assert result == {"messages": [msg]}
+
+
+def test_to_message_state_ai_message() -> None:
+    msg = AIMessage(content="ok")
+    result = to_message_state(msg)
+    assert result == {"messages": [msg]}
+
+
+def test_to_message_state_system_message() -> None:
+    msg = SystemMessage(content="sys state")
+    result = to_message_state(msg)
+    assert result == {"messages": [msg]}
+
+
+def test_to_message_state_list_of_mixed_items() -> None:
+    items = [HumanMessage(content="h"), "a", AIMessage(content="x")]
+    result = to_message_state(items)
+    messages = result["messages"]
+    assert isinstance(messages[0], HumanMessage)
+    assert isinstance(messages[1], HumanMessage)
+    assert isinstance(messages[2], AIMessage)
+    assert messages[0].content == "h"
+    assert messages[1].content == "a"
+    assert messages[2].content == "x"
+
+
+def test_to_message_state_existing_message_state_dict() -> None:
+    msg = HumanMessage(content="ok")
+    result = to_message_state({"messages": [msg]})
+    assert result == {"messages": [msg]}
+
+
+def test_to_message_state_invalid_type() -> None:
+    with pytest.raises(TypeError):
+        to_message_state(123)  # type: ignore[arg-type]
+
+
+def test_as_message_state_wraps_string() -> None:
+    chain = as_message_state()
+    result = chain.invoke("hello")
+    assert result == {"messages": [HumanMessage(content="hello")]}
+
+
+def test_as_message_state_wraps_ai_message() -> None:
+    chain = as_message_state()
+    result = chain.invoke(AIMessage(content="ok"))
+    assert result == {"messages": [AIMessage(content="ok")]}
+
+
+def test_as_message_state_with_preceding_lc_chain() -> None:
+    llm_output = AIMessage(content="done")
+
+    def fake_llm(_: str) -> BaseMessage:
+        return llm_output
+
+    chain = RunnableLambda(fake_llm) | as_message_state()
+    result = chain.invoke("hello")
+    assert result == {"messages": [llm_output]}
+
+
+def test_as_message_state_with_list_input() -> None:
+    chain = as_message_state()
+    items = ["a", "b", AIMessage(content="x")]
+    result = chain.invoke(items)
+    msgs = result["messages"]
+    assert msgs[0].content == "a"
+    assert msgs[1].content == "b"
+    assert msgs[2].content == "x"


### PR DESCRIPTION
## Description
This PR introduces two new utility helpers, `as_message_state` and `to_message_state`,
to normalize LangChain `BaseMessage` objects into a consistent message-state format.
These helpers simplify handling of different return types from LLM calls (e.g.,
strings, lists, AIMessage, SystemMessage, dict forms, etc.) and ensure that
message state is returned in a structured list format.

Additionally, this PR includes accompanying unit tests validating conversions
across all supported message types.

### Key additions
- `as_message_state` and `to_message_state` utility functions
- Normalization support for:
  - `AIMessage`, `HumanMessage`, `SystemMessage`
  - Raw `str`
  - `BaseMessage`
  - `list` of mixed message objects
  - `dict` containing a `messages` key
- Unit tests covering typical and edge cases

## Issue
Fixes #34061  (message normalization utilities discussion)

## Dependencies
None