### PR TITLE
fix(deepseek): deepseek-reasoner model cannot return `reasoning_content` with tools

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -4,7 +4,6 @@ import copy
 import json
 import logging
 from json import JSONDecodeError
-from mailbox import Message
 from typing import Annotated, Any
 
 from pydantic import SkipValidation, ValidationError


### PR DESCRIPTION
Fixes: #34082

### **Description**

This change restores DeepSeek-specific reasoning that is lost when LangChain routes messages through the OpenAI-style tool-calling pipeline. When tools are bound, the OpenAI tools parser rewrites the model response schema and drops non-OpenAI fields such as `reasoning_content` and `_deepseek_reasoning`. This patch re-attaches these fields inside `ChatDeepSeek._create_chat_result()`

### **Dependencies**

None.

#### Expected output after fix

```
(AIMessageChunk(content='', additional_kwargs={}, response_metadata={'finish_reason': 'stop', 'model_name': 'deepseek-chat', 'system_fingerprint': 'fp_ffc7281d48_prod0820_fp8_kvcache', 'model_provider': 'deepseek'}, id='lc_run--1cfb846c-0626-4b96-a078-b1baa8e8b5c9', usage_metadata={'input_tokens': 153, 'output_tokens': 38, 'total_tokens': 191, 'input_token_details': {'cache_read': 128}, 'output_token_details': {}}, chunk_position='last'), {'langgraph_step': 1, 'langgraph_node': 'model', 'langgraph_triggers': ('branch:to:model',), 'langgraph_path': ('__pregel_pull', 'model'), 'langgraph_checkpoint_ns': 'model:2c51adc2-5aba-d990-71f7-325ab7aa624c', 'checkpoint_ns': 'model:2c51adc2-5aba-d990-71f7-325ab7aa624c', 'ls_provider': 'deepseek', 'ls_model_name': 'deepseek-reasoner', 'ls_model_type': 'chat', 'ls_temperature': None})
```
