### PR TITLE
fix(core): `NotRequired` in TypedDict causes TypeError when converting to OpenAI function schema

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -238,8 +238,8 @@ def _convert_any_typed_dicts_to_pydantic(
         fields: dict = {}
         for arg, arg_type in annotations_.items():
             origin = get_origin(arg_type)
-            is_not_required = origin is NotRequired
-            if origin in {NotRequired, Required}:
+            is_not_required = origin is NotRequired  # type: ignore[comparison-overlap]
+            if origin in {NotRequired, Required}:  # type: ignore[comparison-overlap]
                 inner_arg_type = get_args(arg_type)[0]
             else:
                 inner_arg_type = arg_type
@@ -280,10 +280,10 @@ def _convert_any_typed_dicts_to_pydantic(
         visited[typed_dict] = model
         return model
 
-    if (origin := get_origin(type_)) and origin in {NotRequired, Required}:
+    if (origin := get_origin(type_)) and origin in {NotRequired, Required}:  # type: ignore[assignment]
         return type_
 
-    if (origin := get_origin(type_)) and (type_args := get_args(type_)):
+    if (origin := get_origin(type_)) and (type_args := get_args(type_)):  # type: ignore[assignment]
         subscriptable_origin = _py_38_safe_origin(origin)
         type_args = tuple(
             _convert_any_typed_dicts_to_pydantic(arg, depth=depth + 1, visited=visited)

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -244,7 +244,7 @@ def _convert_any_typed_dicts_to_pydantic(
             else:
                 inner_arg_type = arg_type
 
-            if get_origin(inner_arg_type) is Annotated:  # type: ignore[comparison-overlap]
+            if get_origin(inner_arg_type) is Annotated:
                 annotated_args = get_args(inner_arg_type)
                 new_arg_type = _convert_any_typed_dicts_to_pydantic(
                     annotated_args[0], depth=depth + 1, visited=visited

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -19,7 +19,6 @@ from typing import (
     get_origin,
 )
 
-from httpcore import Origin
 from pydantic import BaseModel
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import Field as Field_v1

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -4,7 +4,6 @@ from typing import Annotated as ExtensionsAnnotated
 from typing import (
     Any,
     Literal,
-    NotRequired,
     TypeAlias,
 )
 from typing import TypedDict as TypingTypedDict
@@ -12,6 +11,7 @@ from typing import TypedDict as TypingTypedDict
 import pytest
 from pydantic import BaseModel as BaseModelV2Maybe  # pydantic: ignore
 from pydantic import Field as FieldV2Maybe  # pydantic: ignore
+from typing_extensions import NotRequired
 from typing_extensions import TypedDict as ExtensionsTypedDict
 
 try:

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -4,6 +4,7 @@ from typing import Annotated as ExtensionsAnnotated
 from typing import (
     Any,
     Literal,
+    NotRequired,
     TypeAlias,
 )
 from typing import TypedDict as TypingTypedDict
@@ -1168,3 +1169,19 @@ def test_convert_to_openai_function_strict_required() -> None:
     func = convert_to_openai_function(MyModel, strict=True)
     actual = func["parameters"]["required"]
     assert actual == expected
+
+
+def test_convert_to_openai_function_typed_dict_with_not_required() -> None:
+    class MyTypedDict(TypingTypedDict):
+        """A TypedDict with NotRequired field."""
+
+        required_field: str
+        optional_field: NotRequired[str]
+
+    result = convert_to_openai_function(MyTypedDict)
+
+    assert result["name"] == "MyTypedDict"
+    assert "required_field" in result["parameters"]["properties"]
+    assert "optional_field" in result["parameters"]["properties"]
+    assert "required_field" in result["parameters"]["required"]
+    assert "optional_field" not in result["parameters"]["required"]


### PR DESCRIPTION
## Description

Fixed a bug where `NotRequired` fields in `TypedDict` caused a `TypeError` when converting to OpenAI function schema. The fix properly handles `NotRequired` and `Required` type annotations by:

Detecting and unwrapping `NotRequired`/`Required` annotations, Correctly excluding `NotRequired` fields from the `required` list in the OpenAI schema

## Issue

Fixes: #34085

## Dependencies

None

The implementation also includes a test case that validates the proper handling of `TypedDict` with `NotRequired` fields when converting to OpenAI function schema format.