### PR TITLE
feat(core): add to_message_state and as_message_state helpers for LCEL message normalization

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -14,12 +14,13 @@ import inspect
 import json
 import logging
 import math
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Iterable, Sequence
 from functools import partial
 from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    Callable,
     Literal,
     cast,
     overload,
@@ -1794,7 +1795,7 @@ def to_message_state(obj: Any) -> dict[str, list[BaseMessage]]:
     raise TypeError(msg)
 
 
-def as_message_state() -> callable:
+def as_message_state() -> Callable[[Any], dict[str, list[BaseMessage]]]:
     """Return an LCEL-friendly wrapper that normalizes outputs into message state.
 
     Returns:

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -14,13 +14,12 @@ import inspect
 import json
 import logging
 import math
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from functools import partial
 from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
-    Callable,
     Literal,
     cast,
     overload,

--- a/libs/core/tests/unit_tests/messages/test_message_state.py
+++ b/libs/core/tests/unit_tests/messages/test_message_state.py
@@ -1,0 +1,57 @@
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages.utils import as_message_state, to_message_state
+
+
+def test_string_to_message_state() -> None:
+    result = to_message_state("hello")
+    assert isinstance(result, dict)
+    assert "messages" in result
+    assert len(result["messages"]) == 1
+    msg = result["messages"][0]
+    assert isinstance(msg, HumanMessage)
+    assert msg.content == "hello"
+
+
+def test_base_message_preserved() -> None:
+    msg = AIMessage(content="hi")
+    result = to_message_state(msg)
+    assert result["messages"][0] is msg
+
+
+def test_list_of_strings() -> None:
+    result = to_message_state(["a", "b"])
+    msgs = result["messages"]
+    assert len(msgs) == 2
+    assert isinstance(msgs[0], HumanMessage)
+    assert msgs[0].content == "a"
+    assert isinstance(msgs[1], HumanMessage)
+    assert msgs[1].content == "b"
+
+
+def test_list_mixed_message_and_string() -> None:
+    m = AIMessage(content="x")
+    result = to_message_state(["hello", m])
+    msgs = result["messages"]
+    assert isinstance(msgs[0], HumanMessage)
+    assert msgs[0].content == "hello"
+    assert msgs[1] is m
+
+
+def test_message_state_passthrough() -> None:
+    existing = {"messages": [HumanMessage(content="y")]}
+    result = to_message_state(existing)
+    # should return the original dict, not copy
+    assert result is existing
+
+
+def test_none_returns_empty_list() -> None:
+    result = to_message_state(None)
+    assert result == {"messages": []}
+
+
+def test_as_message_state_wrapper() -> None:
+    fn = as_message_state()
+    out = fn("yo")
+    msg = out["messages"][0]
+    assert isinstance(msg, HumanMessage)
+    assert msg.content == "yo"


### PR DESCRIPTION
### Description

This PR introduces two new utilities to the `langchain_core.messages` module:

- `to_message_state`
- `as_message_state`

These helpers provide a consistent and centralized way to normalize various message-like inputs into the canonical LCEL message state:

    {"messages": [BaseMessage, ...]}

They allow LCEL pipelines to seamlessly handle strings, `BaseMessage` instances, mixed lists, and pre-existing `{"messages": [...]}` dicts without needing to duplicate normalization logic across runnables.

This change follows the discussion in **Issue #34061** and places the implementation in the appropriate module (`messages.utils`), preserving clear domain boundaries and avoiding unnecessary coupling with `runnables`.

**Fixes #34061**

---

### Issue

The absence of a standardized message-normalization helper required LCEL chains to implement small variations of the same logic.  
This PR resolves that by providing a unified, well-tested implementation.

---

### Dependencies

No new dependencies were added.  
No modifications to `pyproject.toml` or `uv.lock`.  
Changes are limited to:

    langchain_core/messages/utils.py
    tests/unit_tests/messages/test_message_state.py

---

### Tests

This PR includes a dedicated test file:

    tests/unit_tests/messages/test_message_state.py

Test coverage includes:

- string → `HumanMessage`
- `BaseMessage` passthrough
- mixed lists (string + `BaseMessage`)
- message-state passthrough
- `None` normalization
- LCEL integration via `as_message_state`

All tests pass locally:

    7 passed in 0.04s

Linting and formatting also pass (`ruff check .` is clean).

---

### Notes

An earlier community PR attempted to introduce message normalization inside `runnables`, but message transformation belongs to the `messages` domain.  
This PR follows the expected architecture of LangChain Core, keeps responsibilities separated, and avoids circular dependencies.

Happy to adjust naming or behavior based on reviewer feedback.
