### PR TITLE
fix(core): handle missing `StructuredPrompt` schema

### DIFF
--- a/libs/core/langchain_core/prompts/structured.py
+++ b/libs/core/langchain_core/prompts/structured.py
@@ -49,7 +49,13 @@ class StructuredPrompt(ChatPromptTemplate):
             structured_output_kwargs: additional kwargs for structured output.
             template_format: template format for the prompt.
         """
-        schema_ = schema_ or kwargs.pop("schema")
+        schema_ = schema_ or kwargs.pop("schema", None)
+        if not schema_:
+            err_msg = (
+                "Must pass in a non-empty structured output schema. Received: "
+                f"{schema_}"
+            )
+            raise ValueError(err_msg)
         structured_output_kwargs = structured_output_kwargs or {}
         for k in set(kwargs).difference(get_pydantic_field_names(self.__class__)):
             structured_output_kwargs[k] = kwargs.pop(k)

--- a/libs/core/tests/unit_tests/prompts/test_structured.py
+++ b/libs/core/tests/unit_tests/prompts/test_structured.py
@@ -125,7 +125,9 @@ def test_structured_prompt_kwargs() -> None:
 
 def test_structured_prompt_template_format() -> None:
     prompt = StructuredPrompt(
-        [("human", "hi {{person.name}}")], schema={}, template_format="mustache"
+        [("human", "hi {{person.name}}")],
+        schema={"type": "object", "properties": {}, "title": "foo"},
+        template_format="mustache",
     )
     assert prompt.messages[0].prompt.template_format == "mustache"  # type: ignore[union-attr, union-attr]
     assert prompt.input_variables == ["person"]
@@ -136,4 +138,8 @@ def test_structured_prompt_template_format() -> None:
 
 def test_structured_prompt_template_empty_vars() -> None:
     with pytest.raises(ChevronError, match="empty tag"):
-        StructuredPrompt([("human", "hi {{}}")], schema={}, template_format="mustache")
+        StructuredPrompt(
+            [("human", "hi {{}}")],
+            schema={"type": "object", "properties": {}, "title": "foo"},
+            template_format="mustache",
+        )


### PR DESCRIPTION
- **Description:** if you dont pass in schema= or schema_= to StrucutredPrompt(...) today you get a confusing KeyError. Raise a more readable ValueError instead.
- **Issue:** na
- **Dependencies:** na