### PR TITLE
feat: Add extra_content field to ToolCall for provider-specific metadata

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -227,6 +227,13 @@ class ToolCall(TypedDict):
 
     """
     type: NotRequired[Literal["tool_call"]]
+    extra_content: NotRequired[dict[str, Any]]
+    """Optional provider-specific metadata.
+
+    For example, Google's Gemini API returns thought_signature in:
+    extra_content.google.thought_signature
+
+    """
 
 
 def tool_call(
@@ -234,6 +241,7 @@ def tool_call(
     name: str,
     args: dict[str, Any],
     id: str | None,
+    extra_content: dict[str, Any] | None = None,
 ) -> ToolCall:
     """Create a tool call.
 
@@ -241,11 +249,15 @@ def tool_call(
         name: The name of the tool to be called.
         args: The arguments to the tool call.
         id: An identifier associated with the tool call.
+        extra_content: Optional provider-specific metadata.
 
     Returns:
         The created tool call.
     """
-    return ToolCall(name=name, args=args, id=id, type="tool_call")
+    result = ToolCall(name=name, args=args, id=id, type="tool_call")
+    if extra_content is not None:
+        result["extra_content"] = extra_content
+    return result
 
 
 class ToolCallChunk(TypedDict):
@@ -347,6 +359,7 @@ def default_tool_parser(
                 name=function_name or "",
                 args=function_args or {},
                 id=raw_tool_call.get("id"),
+                extra_content=raw_tool_call.get("extra_content"),
             )
             tool_calls.append(parsed)
         except json.JSONDecodeError:

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -72,6 +72,9 @@ def parse_tool_call(
     }
     if return_id:
         parsed["id"] = raw_tool_call.get("id")
+        # Preserve extra_content if present (e.g., for Google's thought_signature)
+        if "extra_content" in raw_tool_call:
+            parsed["extra_content"] = raw_tool_call["extra_content"]
         parsed = create_tool_call(**parsed)  # type: ignore[assignment,arg-type]
     return parsed
 

--- a/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
+++ b/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
@@ -988,6 +988,10 @@
             'title': 'Args',
             'type': 'object',
           }),
+          'extra_content': dict({
+            'title': 'Extra Content',
+            'type': 'object',
+          }),
           'id': dict({
             'anyOf': list([
               dict({
@@ -2402,6 +2406,10 @@
         'properties': dict({
           'args': dict({
             'title': 'Args',
+            'type': 'object',
+          }),
+          'extra_content': dict({
+            'title': 'Extra Content',
             'type': 'object',
           }),
           'id': dict({

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -1412,6 +1412,10 @@
                   'title': 'Args',
                   'type': 'object',
                 }),
+                'extra_content': dict({
+                  'title': 'Extra Content',
+                  'type': 'object',
+                }),
                 'id': dict({
                   'anyOf': list([
                     dict({

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
@@ -2932,6 +2932,10 @@
             'title': 'Args',
             'type': 'object',
           }),
+          'extra_content': dict({
+            'title': 'Extra Content',
+            'type': 'object',
+          }),
           'id': dict({
             'anyOf': list([
               dict({
@@ -4408,6 +4412,10 @@
         'properties': dict({
           'args': dict({
             'title': 'Args',
+            'type': 'object',
+          }),
+          'extra_content': dict({
+            'title': 'Extra Content',
             'type': 'object',
           }),
           'id': dict({
@@ -5900,6 +5908,10 @@
             'title': 'Args',
             'type': 'object',
           }),
+          'extra_content': dict({
+            'title': 'Extra Content',
+            'type': 'object',
+          }),
           'id': dict({
             'anyOf': list([
               dict({
@@ -7244,6 +7256,10 @@
         'properties': dict({
           'args': dict({
             'title': 'Args',
+            'type': 'object',
+          }),
+          'extra_content': dict({
+            'title': 'Extra Content',
             'type': 'object',
           }),
           'id': dict({
@@ -8766,6 +8782,10 @@
             'title': 'Args',
             'type': 'object',
           }),
+          'extra_content': dict({
+            'title': 'Extra Content',
+            'type': 'object',
+          }),
           'id': dict({
             'anyOf': list([
               dict({
@@ -10155,6 +10175,10 @@
         'properties': dict({
           'args': dict({
             'title': 'Args',
+            'type': 'object',
+          }),
+          'extra_content': dict({
+            'title': 'Extra Content',
             'type': 'object',
           }),
           'id': dict({
@@ -11596,6 +11620,10 @@
             'title': 'Args',
             'type': 'object',
           }),
+          'extra_content': dict({
+            'title': 'Extra Content',
+            'type': 'object',
+          }),
           'id': dict({
             'anyOf': list([
               dict({
@@ -13034,6 +13062,10 @@
         'properties': dict({
           'args': dict({
             'title': 'Args',
+            'type': 'object',
+          }),
+          'extra_content': dict({
+            'title': 'Extra Content',
             'type': 'object',
           }),
           'id': dict({

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3406,7 +3406,7 @@ def _is_pydantic_class(obj: Any) -> bool:
 
 
 def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
-    return {
+    result = {
         "type": "function",
         "id": tool_call["id"],
         "function": {
@@ -3414,6 +3414,10 @@ def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
             "arguments": json.dumps(tool_call["args"], ensure_ascii=False),
         },
     }
+    # Include extra_content if present (for thought_signature, etc.)
+    if "extra_content" in tool_call:
+        result["extra_content"] = tool_call["extra_content"]
+    return result
 
 
 def _lc_invalid_tool_call_to_openai_tool_call(


### PR DESCRIPTION
- Add optional extra_content field to ToolCall TypedDict
- Preserve extra_content in parse_tool_call()
- Include extra_content in OpenAI format conversion

Enables support for Google Gemini's thought_signature and other provider-specific metadata while maintaining backward compatibility.

---

Cloudflare's AI Gateway offers an OpenAI-style calling method for Google AI Studio and Google Vertex AI. OpenRouter also adopts this style. However, Google's Gemini 3 series models currently require the `thought_signature` field to be passed. Therefore, this modification is essential for the above scenarios.

[https://ai.google.dev/gemini-api/docs/thought-signatures#openai](https://ai.google.dev/gemini-api/docs/thought-signatures#openai)