### PR TITLE
docs: Add complete runnable examples to tool decorator docstrings

### DIFF
--- a/libs/langchain_v1/langchain/tools/__init__.py
+++ b/libs/langchain_v1/langchain/tools/__init__.py
@@ -1,46 +1,55 @@
-'''LangChain Tools module.
+'''
+LangChain Tools module.
 
 This module provides the ``tool`` decorator and ``ToolRuntime`` for creating
 custom tools that can be used with LangChain agents.
 
-Example - Basic Tool:
-    Create simple tools using the ``@tool`` decorator:
+Examples
+--------
+Basic Tool
+~~~~~~~~~~
+Create simple tools using the ``@tool`` decorator::
 
     from langchain.tools import tool
     from langchain.agents import create_agent
 
     @tool
     def search(query: str) -> str:
-        """Search for information on the web."""
+        """Search for information on the web.
 
         Args:
             query: The search query string.
-        
+
+        Returns:
+            str: Search result text.
+        """
         return f"Results for: {query}"
 
     @tool
     def get_weather(location: str) -> str:
-        """Get weather information for a location."""
+        """Get weather information for a location.
 
         Args:
             location: City name or coordinates.
-        
+
+        Returns:
+            str: Weather result text.
+        """
         return f"Weather in {location}: Sunny, 72F"
 
-    # Create agent with tools
     agent = create_agent(
         model="gpt-4o-mini",
         tools=[search, get_weather],
         system_prompt="You are a helpful assistant."
     )
 
-    # Run the agent
     result = agent.invoke({
         "messages": [{"role": "user", "content": "What is the weather in SF?"}]
     })
 
-Example - Tool with Runtime Context:
-    Access runtime context (user info, state) within tools:
+Tool with Runtime Context
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Access runtime context (user info, state) within tools::
 
     from dataclasses import dataclass
     from langchain.tools import tool, ToolRuntime
@@ -57,7 +66,14 @@ Example - Tool with Runtime Context:
 
     @tool
     def get_user_info(runtime: ToolRuntime[UserContext]) -> str:
-        """Get information about the current user."""
+        """Get information about the current user.
+
+        Args:
+            runtime: Tool runtime containing the user context.
+
+        Returns:
+            str: User information text.
+        """
         user_id = runtime.context.user_id
         if user_id in USER_DATABASE:
             user = USER_DATABASE[user_id]
@@ -74,23 +90,33 @@ Example - Tool with Runtime Context:
         {"messages": [{"role": "user", "content": "Who am I?"}]},
         context=UserContext(user_id="user_123")
     )
-    # Output: User: Alice, Role: admin
+    # Output: "User: Alice, Role: admin"
 
-Example - Custom Tool Name and Description:
-    Override the default tool name and provide explicit description:
+Custom Tool Name and Description
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Override the default tool name and description::
 
     from langchain.tools import tool
 
     @tool(
         "web_search",
-        description="Search the web for current information. "
-                    "Use this for any factual queries."
+        description=(
+            "Search the web for current information. "
+            "Use this for any factual queries."
+        ),
     )
     def search(query: str) -> str:
-        """Internal search implementation."""
+        """Internal search implementation.
+
+        Args:
+            query: Query string.
+
+        Returns:
+            str: Search result text.
+        """
         return f"Results for: {query}"
 
-    print(search.name)  # Output: web_search
+    print(search.name)  # Output: "web_search"
 '''
 
 from langchain_core.tools import (

--- a/libs/langchain_v1/langchain/tools/__init__.py
+++ b/libs/langchain_v1/langchain/tools/__init__.py
@@ -4,138 +4,109 @@ LangChain Tools module.
 This module provides the ``tool`` decorator and ``ToolRuntime`` for creating
 custom tools that can be used with LangChain agents.
 
-Examples
---------
-Basic Tool
-~~~~~~~~~~
-Create simple tools using the ``@tool`` decorator::
+Examples:
+    Basic Tool::
 
-    from langchain.tools import tool
-    from langchain.agents import create_agent
+        from langchain.tools import tool
+        from langchain.agents import create_agent
 
-    @tool
-    def search(query: str) -> str:
-        """Search for information on the web.
+        @tool
+        def search(query: str) -> str:
+            """Search for information on the web.
 
-        Args:
-            query: The search query string.
+            Args:
+                query: The search query string.
 
-        Returns:
-            str: Search result text.
-        """
-        return f"Results for: {query}"
+            Returns:
+                str: Search result text.
+            """
+            return f"Results for: {query}"
 
-    @tool
-    def get_weather(location: str) -> str:
-        """Get weather information for a location.
+        @tool
+        def get_weather(location: str) -> str:
+            """Get weather information for a location.
 
-        Args:
-            location: City name or coordinates.
+            Args:
+                location: City name or coordinates.
 
-        Returns:
-            str: Weather result text.
-        """
-        return f"Weather in {location}: Sunny, 72F"
+            Returns:
+                str: Weather result text.
+            """
+            return f"Weather in {location}: Sunny, 72F"
 
-    agent = create_agent(
-        model="gpt-4o-mini",
-        tools=[search, get_weather],
-        system_prompt="You are a helpful assistant."
-    )
+        agent = create_agent(
+            model="gpt-4o-mini",
+            tools=[search, get_weather],
+            system_prompt="You are a helpful assistant."
+        )
 
-    result = agent.invoke({
-        "messages": [{"role": "user", "content": "What is the weather in SF?"}]
-    })
+        result = agent.invoke({
+            "messages": [{"role": "user", "content": "What is the weather in SF?"}]
+        })
 
-Tool with Runtime Context
-~~~~~~~~~~~~~~~~~~~~~~~~~
-Access runtime context (user info, state) within tools::
+    Tool with Runtime Context::
 
-    from dataclasses import dataclass
-    from langchain.tools import tool, ToolRuntime
-    from langchain.agents import create_agent
+        from dataclasses import dataclass
+        from langchain.tools import tool, ToolRuntime
+        from langchain.agents import create_agent
 
-    @dataclass
-    class UserContext:
-        user_id: str
+        @dataclass
+        class UserContext:
+            user_id: str
 
-    USER_DATABASE = {
-        "user_123": {"name": "Alice", "role": "admin"},
-        "user_456": {"name": "Bob", "role": "user"},
-    }
+        USER_DATABASE = {
+            "user_123": {"name": "Alice", "role": "admin"},
+            "user_456": {"name": "Bob", "role": "user"},
+        }
 
-    @tool
-    def get_user_info(runtime: ToolRuntime[UserContext]) -> str:
-        """Get information about the current user.
+        @tool
+        def get_user_info(runtime: ToolRuntime[UserContext]) -> str:
+            """Get information about the current user.
 
-        Args:
-            runtime: Tool runtime containing the user context.
+            Args:
+                runtime: Tool runtime containing the user context.
 
-        Returns:
-            str: User information text.
-        """
-        user_id = runtime.context.user_id
-        if user_id in USER_DATABASE:
-            user = USER_DATABASE[user_id]
-            return f"User: {user['name']}, Role: {user['role']}"
-        return "User not found"
+            Returns:
+                str: User information text.
+            """
+            user_id = runtime.context.user_id
+            if user_id in USER_DATABASE:
+                user = USER_DATABASE[user_id]
+                return f"User: {user['name']}, Role: {user['role']}"
+            return "User not found"
 
-    agent = create_agent(
-        model="gpt-4o-mini",
-        tools=[get_user_info],
-        context_schema=UserContext,
-    )
+        agent = create_agent(
+            model="gpt-4o-mini",
+            tools=[get_user_info],
+            context_schema=UserContext,
+        )
 
-    result = agent.invoke(
-        {"messages": [{"role": "user", "content": "Who am I?"}]},
-        context=UserContext(user_id="user_123")
-    )
-    # Output: "User: Alice, Role: admin"
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": "Who am I?"}]},
+            context=UserContext(user_id="user_123")
+        )
 
-Custom Tool Name and Description
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Override the default tool name and description::
+    Custom Tool Name and Description::
 
-    from langchain.tools import tool
+        from langchain.tools import tool
 
-    @tool(
-        "web_search",
-        description=(
-            "Search the web for current information. "
-            "Use this for any factual queries."
-        ),
-    )
-    def search(query: str) -> str:
-        """Internal search implementation.
+        @tool(
+            "web_search",
+            description=(
+                "Search the web for current information. "
+                "Use this for any factual queries."
+            ),
+        )
+        def search(query: str) -> str:
+            """Internal search implementation.
 
-        Args:
-            query: Query string.
+            Args:
+                query: Query string.
 
-        Returns:
-            str: Search result text.
-        """
-        return f"Results for: {query}"
+            Returns:
+                str: Search result text.
+            """
+            return f"Results for: {query}"
 
-    print(search.name)  # Output: "web_search"
+        print(search.name)  # Output: "web_search"
 '''
-
-from langchain_core.tools import (
-    BaseTool,
-    InjectedToolArg,
-    InjectedToolCallId,
-    ToolException,
-    tool,
-)
-
-from langchain.tools.tool_node import InjectedState, InjectedStore, ToolRuntime
-
-__all__ = [
-    "BaseTool",
-    "InjectedState",
-    "InjectedStore",
-    "InjectedToolArg",
-    "InjectedToolCallId",
-    "ToolException",
-    "ToolRuntime",
-    "tool",
-]

--- a/libs/langchain_v1/langchain/tools/__init__.py
+++ b/libs/langchain_v1/langchain/tools/__init__.py
@@ -1,4 +1,4 @@
-"""LangChain Tools module.
+'''LangChain Tools module.
 
 This module provides the ``tool`` decorator and ``ToolRuntime`` for creating
 custom tools that can be used with LangChain agents.
@@ -91,7 +91,7 @@ Example - Custom Tool Name and Description:
         return f"Results for: {query}"
 
     print(search.name)  # Output: web_search
-"""
+'''
 
 from langchain_core.tools import (
     BaseTool,

--- a/libs/langchain_v1/langchain/tools/__init__.py
+++ b/libs/langchain_v1/langchain/tools/__init__.py
@@ -1,5 +1,3 @@
-"""Tools."""
-
 """LangChain Tools module.
 
 This module provides the ``tool`` decorator and ``ToolRuntime`` for creating

--- a/libs/langchain_v1/langchain/tools/__init__.py
+++ b/libs/langchain_v1/langchain/tools/__init__.py
@@ -6,97 +6,91 @@ custom tools that can be used with LangChain agents.
 Example - Basic Tool:
     Create simple tools using the ``@tool`` decorator:
 
-    .. code-block:: python
+    from langchain.tools import tool
+    from langchain.agents import create_agent
 
-        from langchain.tools import tool
-        from langchain.agents import create_agent
+    @tool
+    def search(query: str) -> str:
+        """Search for information on the web."""
 
-        @tool
-        def search(query: str) -> str:
-            \"\"\"Search for information on the web.
+        Args:
+            query: The search query string.
+        
+        return f"Results for: {query}"
 
-            Args:
-                query: The search query string.
-            \"\"\"
-            return f"Results for: {query}"
+    @tool
+    def get_weather(location: str) -> str:
+        """Get weather information for a location."""
 
-        @tool
-        def get_weather(location: str) -> str:
-            \"\"\"Get weather information for a location.
+        Args:
+            location: City name or coordinates.
+        
+        return f"Weather in {location}: Sunny, 72F"
 
-            Args:
-                location: City name or coordinates.
-            \"\"\"
-            return f"Weather in {location}: Sunny, 72F"
+    # Create agent with tools
+    agent = create_agent(
+        model="gpt-4o-mini",
+        tools=[search, get_weather],
+        system_prompt="You are a helpful assistant."
+    )
 
-        # Create agent with tools
-        agent = create_agent(
-            model="gpt-4o-mini",
-            tools=[search, get_weather],
-            system_prompt="You are a helpful assistant."
-        )
-
-        # Run the agent
-        result = agent.invoke({
-            "messages": [{"role": "user", "content": "What is the weather in SF?"}]
-        })
+    # Run the agent
+    result = agent.invoke({
+        "messages": [{"role": "user", "content": "What is the weather in SF?"}]
+    })
 
 Example - Tool with Runtime Context:
     Access runtime context (user info, state) within tools:
 
-    .. code-block:: python
+    from dataclasses import dataclass
+    from langchain.tools import tool, ToolRuntime
+    from langchain.agents import create_agent
 
-        from dataclasses import dataclass
-        from langchain.tools import tool, ToolRuntime
-        from langchain.agents import create_agent
+    @dataclass
+    class UserContext:
+        user_id: str
 
-        @dataclass
-        class UserContext:
-            user_id: str
+    USER_DATABASE = {
+        "user_123": {"name": "Alice", "role": "admin"},
+        "user_456": {"name": "Bob", "role": "user"},
+    }
 
-        USER_DATABASE = {
-            "user_123": {"name": "Alice", "role": "admin"},
-            "user_456": {"name": "Bob", "role": "user"},
-        }
+    @tool
+    def get_user_info(runtime: ToolRuntime[UserContext]) -> str:
+        """Get information about the current user."""
+        user_id = runtime.context.user_id
+        if user_id in USER_DATABASE:
+            user = USER_DATABASE[user_id]
+            return f"User: {user['name']}, Role: {user['role']}"
+        return "User not found"
 
-        @tool
-        def get_user_info(runtime: ToolRuntime[UserContext]) -> str:
-            \"\"\"Get information about the current user.\"\"\"
-            user_id = runtime.context.user_id
-            if user_id in USER_DATABASE:
-                user = USER_DATABASE[user_id]
-                return f"User: {user['name']}, Role: {user['role']}"
-            return "User not found"
+    agent = create_agent(
+        model="gpt-4o-mini",
+        tools=[get_user_info],
+        context_schema=UserContext,
+    )
 
-        agent = create_agent(
-            model="gpt-4o-mini",
-            tools=[get_user_info],
-            context_schema=UserContext,
-        )
-
-        result = agent.invoke(
-            {"messages": [{"role": "user", "content": "Who am I?"}]},
-            context=UserContext(user_id="user_123")
-        )
-        # Output: User: Alice, Role: admin
+    result = agent.invoke(
+        {"messages": [{"role": "user", "content": "Who am I?"}]},
+        context=UserContext(user_id="user_123")
+    )
+    # Output: User: Alice, Role: admin
 
 Example - Custom Tool Name and Description:
     Override the default tool name and provide explicit description:
 
-    .. code-block:: python
+    from langchain.tools import tool
 
-        from langchain.tools import tool
+    @tool(
+        "web_search",
+        description="Search the web for current information. "
+                    "Use this for any factual queries."
+    )
+    def search(query: str) -> str:
+        """Internal search implementation."""
+        return f"Results for: {query}"
 
-        @tool(
-            "web_search",
-            description="Search the web for current information. "
-                        "Use this for any factual queries."
-        )
-        def search(query: str) -> str:
-            \"\"\"Internal search implementation.\"\"\"
-            return f"Results for: {query}"
-
-        print(search.name)  # Output: web_search
+    print(search.name)  # Output: web_search
 """
 
 from langchain_core.tools import (

--- a/libs/langchain_v1/langchain/tools/__init__.py
+++ b/libs/langchain_v1/langchain/tools/__init__.py
@@ -110,3 +110,25 @@ Examples:
 
         print(search.name)  # Output: "web_search"
 '''
+"""Tools."""
+
+from langchain_core.tools import (
+    BaseTool,
+    InjectedToolArg,
+    InjectedToolCallId,
+    ToolException,
+    tool,
+)
+
+from langchain.tools.tool_node import InjectedState, InjectedStore, ToolRuntime
+
+__all__ = [
+    "BaseTool",
+    "InjectedState",
+    "InjectedStore",
+    "InjectedToolArg",
+    "InjectedToolCallId",
+    "ToolException",
+    "ToolRuntime",
+    "tool",
+]

--- a/libs/langchain_v1/langchain/tools/__init__.py
+++ b/libs/langchain_v1/langchain/tools/__init__.py
@@ -1,5 +1,106 @@
 """Tools."""
 
+"""LangChain Tools module.
+
+This module provides the ``tool`` decorator and ``ToolRuntime`` for creating
+custom tools that can be used with LangChain agents.
+
+Example - Basic Tool:
+    Create simple tools using the ``@tool`` decorator:
+
+    .. code-block:: python
+
+        from langchain.tools import tool
+        from langchain.agents import create_agent
+
+        @tool
+        def search(query: str) -> str:
+            \"\"\"Search for information on the web.
+
+            Args:
+                query: The search query string.
+            \"\"\"
+            return f"Results for: {query}"
+
+        @tool
+        def get_weather(location: str) -> str:
+            \"\"\"Get weather information for a location.
+
+            Args:
+                location: City name or coordinates.
+            \"\"\"
+            return f"Weather in {location}: Sunny, 72F"
+
+        # Create agent with tools
+        agent = create_agent(
+            model="gpt-4o-mini",
+            tools=[search, get_weather],
+            system_prompt="You are a helpful assistant."
+        )
+
+        # Run the agent
+        result = agent.invoke({
+            "messages": [{"role": "user", "content": "What is the weather in SF?"}]
+        })
+
+Example - Tool with Runtime Context:
+    Access runtime context (user info, state) within tools:
+
+    .. code-block:: python
+
+        from dataclasses import dataclass
+        from langchain.tools import tool, ToolRuntime
+        from langchain.agents import create_agent
+
+        @dataclass
+        class UserContext:
+            user_id: str
+
+        USER_DATABASE = {
+            "user_123": {"name": "Alice", "role": "admin"},
+            "user_456": {"name": "Bob", "role": "user"},
+        }
+
+        @tool
+        def get_user_info(runtime: ToolRuntime[UserContext]) -> str:
+            \"\"\"Get information about the current user.\"\"\"
+            user_id = runtime.context.user_id
+            if user_id in USER_DATABASE:
+                user = USER_DATABASE[user_id]
+                return f"User: {user['name']}, Role: {user['role']}"
+            return "User not found"
+
+        agent = create_agent(
+            model="gpt-4o-mini",
+            tools=[get_user_info],
+            context_schema=UserContext,
+        )
+
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": "Who am I?"}]},
+            context=UserContext(user_id="user_123")
+        )
+        # Output: User: Alice, Role: admin
+
+Example - Custom Tool Name and Description:
+    Override the default tool name and provide explicit description:
+
+    .. code-block:: python
+
+        from langchain.tools import tool
+
+        @tool(
+            "web_search",
+            description="Search the web for current information. "
+                        "Use this for any factual queries."
+        )
+        def search(query: str) -> str:
+            \"\"\"Internal search implementation.\"\"\"
+            return f"Results for: {query}"
+
+        print(search.name)  # Output: web_search
+"""
+
 from langchain_core.tools import (
     BaseTool,
     InjectedToolArg,


### PR DESCRIPTION
## Description

This PR improves the developer experience by adding complete, runnable code examples to the `tools` module docstring in `langchain_v1`.

### Changes Made

1. **Basic `@tool` usage example** - Complete example with all necessary imports showing how to create tools and use them with `create_agent`

2. **`ToolRuntime` context access example** - Real-world example demonstrating how to access user context within tools using `ToolRuntime[UserContext]`

3. **Custom tool name and description example** - Shows how to override default tool name and provide explicit descriptions

### Why This Change

- Current docstrings lack complete runnable examples
- Users often need to search external documentation for basic usage patterns  
- Context7 documentation shows great examples that should be available in source code
- Improves IDE hover documentation experience

### Testing

All examples are self-contained and can be copied and run as-is (with appropriate API keys configured).

## Issue

N/A - Documentation enhancement

## Dependencies

None

## Checklist

- [x] PR title follows conventional commits format
- [x] Documentation only change - no code logic changes
- [x] Examples are complete and runnable