### PR TITLE
fix(openai): pass `strict` for `response_format` in `bind_tools()`

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1801,6 +1801,7 @@ class BaseChatOpenAI(BaseChatModel):
 
         Args:
             tools: A list of tool definitions to bind to this chat model.
+
                 Supports any tool definition handled by
                 `langchain_core.utils.function_calling.convert_to_openai_tool`.
             tool_choice: Which tool to require the model to call. Options are:
@@ -1812,22 +1813,31 @@ class BaseChatOpenAI(BaseChatModel):
                 - `dict` of the form `{"type": "function", "function": {"name": <<tool_name>>}}`: calls `<<tool_name>>` tool.
                 - `False` or `None`: no effect, default OpenAI behavior.
             strict: If `True`, model output is guaranteed to exactly match the JSON Schema
-                provided in the tool definition. The input schema will also be validated according to the
+                provided in the tool definition.
+
+                The input schema will also be validated according to the
                 [supported schemas](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas?api-mode=responses#supported-schemas).
+
                 If `False`, input schema will not be validated and model output will not
-                be validated. If `None`, `strict` argument will not be passed to the model.
+                be validated.
+
+                If `None`, `strict` argument will not be passed to the model.
             parallel_tool_calls: Set to `False` to disable parallel tool use.
+
                 Defaults to `None` (no specification, which allows parallel tool use).
-            response_format: Optional schema to format model response. If provided
-                and the model does not call a tool, the model will generate a
-                [structured response](https://platform.openai.com/docs/guides/structured-outputs).
+            response_format: Optional schema to format model response.
+
+                If provided and the model **does not** call a tool, the model will
+                generate a [structured response](https://platform.openai.com/docs/guides/structured-outputs).
             kwargs: Any additional parameters are passed directly to `bind`.
         """  # noqa: E501
         if parallel_tool_calls is not None:
             kwargs["parallel_tool_calls"] = parallel_tool_calls
+
         formatted_tools = [
             convert_to_openai_tool(tool, strict=strict) for tool in tools
         ]
+
         tool_names = []
         for tool in formatted_tools:
             if "function" in tool:
@@ -1836,6 +1846,7 @@ class BaseChatOpenAI(BaseChatModel):
                 tool_names.append(tool["name"])
             else:
                 pass
+
         if tool_choice:
             if isinstance(tool_choice, str):
                 # tool_choice is a tool/function name
@@ -1865,17 +1876,20 @@ class BaseChatOpenAI(BaseChatModel):
             kwargs["tool_choice"] = tool_choice
 
         if response_format:
+            # response_format present when using agents.create_agent's ProviderStrategy
+            # ---
+            # ProviderStrategy converts to OpenAI-style format, uses
+            # response_format
             if (
                 isinstance(response_format, dict)
                 and response_format.get("type") == "json_schema"
                 and "schema" in response_format.get("json_schema", {})
             ):
-                # compat with langchain.agents.create_agent response_format, which is
-                # an approximation of OpenAI format
                 response_format = cast(dict, response_format["json_schema"]["schema"])
             kwargs["response_format"] = _convert_to_openai_response_format(
-                response_format
+                response_format, strict=strict
             )
+
         return super().bind(tools=formatted_tools, **kwargs)
 
     def with_structured_output(

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -544,7 +544,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.0.5"
+version = "1.1.0"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
when passing `response_format`, we didn't use strict validation, leading to occasional omission of required fields

https://platform.openai.com/docs/guides/structured-outputs