### PR TITLE
fix(openai): Fixing error that comes up using the Responses API with built-in tools and custom tools

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3750,7 +3750,7 @@ def _construct_responses_api_payload(
                     if payload.get("stream") and "partial_images" not in tool:
                         # OpenAI requires this parameter be set; we ignore it during
                         # streaming.
-                        tool["partial_images"] = 1
+                        tool = {**tool, "partial_images": 1}
                     else:
                         pass
 


### PR DESCRIPTION
## Description

I want to use the OpenAI Responses API in streaming mode with the built in tools and other custom tools like from a local MCP server. When I tried this I kept getting this error:

 `NotImplementedError: Partial image generation is not yet supported via the LangChain ChatOpenAI client. Please drop the 'partial_images' key from the image_generation tool.`

It looks like openai requires the `partial_images` parameter to be set. Because partial image generation is currently not supported in LangChain this is set manually in the code and then we get an error the next time an LLM call happens because we now have partial_images set. The issue is that it is manually set in the `_construct_responses_api_payload` function. This breaks things when running an agent that often does more than one tool call in a conversation thread.  

### The current implementation

In `_construct_responses_api_payload` the code does:
```python
tool["partial_images"] = 1
```

This mutates the original tool dictionary. On the second call, the check `if "partial_images" in tool` is triggered, raising:
```
NotImplementedError: Partial image generation is not yet supported via the LangChain ChatOpenAI client. Please drop the 'partial_images' key from the image_generation tool.
```

### Duplicate error 

```python
from langchain_openai import ChatOpenAI
from langchain_core.tools import tool
from langchain.agents import create_agent

@tool
def my_custom_tool(query: str) -> str:
    """A custom tool."""
    return f"Result: {query}"

# Define tools first
tools = [
    {"type": "image_generation"},  # Responses API built-in tool
    my_custom_tool,                 # Custom tool
]

# Create model with Responses API
model = ChatOpenAI(
    model="gpt-5-mini",
    use_responses_api=True,
    streaming=True,
)

# Create agent with tools
agent = create_agent(model=model, tools=tools)

# First call works fine
for chunk in agent.stream({"messages": [{"role": "user", "content": "Hello"}]}):
    print(chunk)

# Second call fails
for chunk in agent.stream({"messages": [{"role": "user", "content": "Hello again"}]}):
    print(chunk)
```

### Fix

Create a new dict to send to OpenAI instead of mutating in place:
```python
tool = {**tool, "partial_images": 1}
```

## Issue

This issue occurs when:
1. Using `use_responses_api=True`
2. Using `streaming=True`
3. Combining `image_generation` tool with custom/MCP tools
4. Making multiple model calls (e.g., in an agent loop)

## Testing

Added the test `test_responses_stream_with_image_generation_multiple_calls` that:
- Creates a model with `image_generation` + custom function tools
- Calls `stream()` twice
- Verifies both calls succeed (previously the second call would fail)

The test was verified to fail without the fix and pass with the fix.