### PR TITLE
fix(core): avoid concatenating streaming ids in merge

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -44,6 +44,12 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 )
                 raise TypeError(msg)
             elif isinstance(merged[right_k], str):
+                if right_k == "id":
+                    # Prefer the most recent non-null ID instead of concatenating
+                    if merged[right_k] == right_v or right_v is None:
+                        continue
+                    merged[right_k] = right_v
+                    continue
                 # TODO: Add below special handling for 'type' key in 0.3 and remove
                 # merge_lists 'type' logic.
                 #

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1013,6 +1013,11 @@ def test_tool_message_str() -> None:
             [[{"index": 0, "text": "bar"}]],
             [{"text": "foo"}, {"index": 0, "text": "bar"}],
         ),
+        (
+            [{"index": 0, "text": "foo", "id": "msg_1"}],
+            [[{"index": 0, "type": "text", "id": "msg_2"}]],
+            [{"index": 0, "text": "foo", "id": "msg_2"}],
+        ),
     ],
 )
 def test_merge_content(first: list | str, others: list, expected: list | str) -> None:


### PR DESCRIPTION
### Problem

OpenAI Responses streaming sometimes emits differing `item_id` values for the same content block. Chunk aggregation merged those blocks and concatenated the differing ids (`msg_...msg_...`), producing invalid, over‑64‑char IDs that break subsequent calls.

### Solution

Treat `id` as "latest wins" during merge instead of concatenating strings.

### Details

- In `libs/partners/openai/langchain_openai/chat_models/base.py`, `_convert_responses_chunk_to_generation_chunk` emits text blocks with `{"type": "text", "id": chunk.item_id, "index": current_index}` for `response.output_text.done`.
- Aggregation flows through `AIMessageChunk.__add__` → `add_ai_message_chunks` (`libs/core/langchain_core/messages/ai.py`), which uses `merge_content` to combine content lists.
- `merge_content` → `merge_lists` (`libs/core/langchain_core/utils/_merge.py`) merges dicts with the same index via `merge_dicts`; previously that concatenated differing `id` strings. Now `merge_dicts` overwrites `id` with the latest non-null value, preventing `msg_...msg_...` IDs. Added a regression in `tests/unit_tests/test_messages.py` to ensure this behavior.