### PR TITLE
fix(mistralai): enforce max_concurrent_requests

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -611,6 +611,10 @@ class ChatMistralAI(BaseChatModel):
             or "https://api.mistral.ai/v1"
         )
         self.endpoint = base_url_str
+        limits = httpx.Limits(
+            max_connections=self.max_concurrent_requests,
+            max_keepalive_connections=self.max_concurrent_requests,
+        )
         if not self.client:
             self.client = httpx.Client(
                 base_url=base_url_str,
@@ -621,6 +625,7 @@ class ChatMistralAI(BaseChatModel):
                 },
                 timeout=self.timeout,
                 verify=global_ssl_context,
+                limits=limits,
             )
         # TODO: handle retries and max_concurrency
         if not self.async_client:
@@ -633,6 +638,7 @@ class ChatMistralAI(BaseChatModel):
                 },
                 timeout=self.timeout,
                 verify=global_ssl_context,
+                limits=limits,
             )
 
         if self.temperature is not None and not 0 <= self.temperature <= 1:

--- a/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
@@ -1,6 +1,10 @@
+import asyncio
 import os
 from typing import cast
+from unittest.mock import MagicMock, patch
 
+import pytest
+from httpx import Response
 from pydantic import SecretStr
 
 from langchain_mistralai import MistralAIEmbeddings
@@ -15,3 +19,74 @@ def test_mistral_init() -> None:
     ]:
         assert model.model == "mistral-embed"
         assert cast("SecretStr", model.mistral_api_key).get_secret_value() == "test"
+
+
+def test_embeddings_uses_max_concurrent_requests_for_limits() -> None:
+    """Ensure HTTPX client limits respect max_concurrent_requests configuration."""
+
+    with patch("langchain_mistralai.embeddings.httpx.Client") as mock_client, patch(
+        "langchain_mistralai.embeddings.httpx.AsyncClient",
+    ) as mock_async_client:
+        mock_client.return_value = MagicMock()
+        mock_async_client.return_value = MagicMock()
+
+        max_concurrent = 5
+        _ = MistralAIEmbeddings(  # noqa: F841
+            model="mistral-embed",
+            mistral_api_key="test",  # type: ignore[call-arg]
+            max_concurrent_requests=max_concurrent,
+        )
+
+        _, client_kwargs = mock_client.call_args
+        _, async_kwargs = mock_async_client.call_args
+
+        client_limits = client_kwargs["limits"]
+        async_limits = async_kwargs["limits"]
+
+        assert client_limits.max_connections == max_concurrent
+        assert client_limits.max_keepalive_connections == max_concurrent
+        assert async_limits.max_connections == max_concurrent
+        assert async_limits.max_keepalive_connections == max_concurrent
+
+
+@pytest.mark.asyncio
+async def test_aembed_documents_respects_max_concurrent_requests() -> None:
+    """Verify that concurrent async embedding requests are bounded by a semaphore."""
+
+    embed = MistralAIEmbeddings(
+        model="mistral-embed",
+        mistral_api_key="test",  # type: ignore[call-arg]
+        max_concurrent_requests=1,
+    )
+
+    class _SimpleTokenizer:
+        @staticmethod
+        def encode_batch(texts: list[str]) -> list[list[str]]:
+            return [list(text) for text in texts]
+
+    embed.tokenizer = _SimpleTokenizer()  # type: ignore[assignment]
+
+    active = 0
+    max_active = 0
+
+    async def fake_post(*args, **kwargs) -> Response:  # type: ignore[override]
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0)
+        response = MagicMock(spec=Response)
+        response.json.return_value = {
+            "data": [
+                {"embedding": [0.0]} for _ in kwargs["json"]["input"]  # type: ignore[index]
+            ]
+        }
+        active -= 1
+        return response
+
+    embed.async_client.post = fake_post  # type: ignore[assignment]
+
+    texts = ["a", "b", "c"]
+    result = await embed.aembed_documents(texts)
+
+    assert len(result) == len(texts)
+    assert max_active <= 1

--- a/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
@@ -31,7 +31,7 @@ def test_embeddings_uses_max_concurrent_requests_for_limits() -> None:
         mock_async_client.return_value = MagicMock()
 
         max_concurrent = 5
-        _ = MistralAIEmbeddings(  # noqa: F841
+        MistralAIEmbeddings(
             model="mistral-embed",
             mistral_api_key="test",  # type: ignore[call-arg]
             max_concurrent_requests=max_concurrent,
@@ -69,7 +69,7 @@ async def test_aembed_documents_respects_max_concurrent_requests() -> None:
     active = 0
     max_active = 0
 
-    async def fake_post(*args, **kwargs) -> Response:  # type: ignore[override]
+    async def fake_post(*args: object, **kwargs: object) -> Response:  # type: ignore[override]
         nonlocal active, max_active
         active += 1
         max_active = max(max_active, active)

--- a/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
@@ -24,9 +24,12 @@ def test_mistral_init() -> None:
 def test_embeddings_uses_max_concurrent_requests_for_limits() -> None:
     """Ensure HTTPX client limits respect max_concurrent_requests configuration."""
 
-    with patch("langchain_mistralai.embeddings.httpx.Client") as mock_client, patch(
-        "langchain_mistralai.embeddings.httpx.AsyncClient",
-    ) as mock_async_client:
+    with (
+        patch("langchain_mistralai.embeddings.httpx.Client") as mock_client,
+        patch(
+            "langchain_mistralai.embeddings.httpx.AsyncClient",
+        ) as mock_async_client,
+    ):
         mock_client.return_value = MagicMock()
         mock_async_client.return_value = MagicMock()
 
@@ -77,7 +80,8 @@ async def test_aembed_documents_respects_max_concurrent_requests() -> None:
         response = MagicMock(spec=Response)
         response.json.return_value = {
             "data": [
-                {"embedding": [0.0]} for _ in kwargs["json"]["input"]  # type: ignore[index]
+                {"embedding": [0.0]}
+                for _ in kwargs["json"]["input"]  # type: ignore[index]
             ]
         }
         active -= 1


### PR DESCRIPTION
This pull request enforces max_concurrent_requests for the Mistral integration by wiring it into HTTPX client limits for both chat models and embeddings, and by bounding concurrent aembed_documents calls with a semaphore. It also adds unit tests to verify that HTTPX limits and async concurrency behave as configured.

Scope: libs/partners/mistralai

Breaking changes: None. All changes are internal and backward-compatible.

Tests: uv run --group test pytest libs/partners/mistralai/tests/unit_tests -q

AI disclaimer: Parts of this change were implemented with the assistance of an AI coding assistant; I reviewed and validated all modifications.
