### PR TITLE
fix: add strict flag to ProviderStrategy structured output

### DIFF
--- a/libs/langchain_v1/langchain/agents/structured_output.py
+++ b/libs/langchain_v1/langchain/agents/structured_output.py
@@ -255,10 +255,17 @@ class ProviderStrategy(Generic[SchemaT]):
     def __init__(
         self,
         schema: type[SchemaT],
+        *,
+        strict: bool = False,
     ) -> None:
-        """Initialize ProviderStrategy with schema."""
+        """Initialize ProviderStrategy with schema.
+
+        Args:
+            schema: Schema to enforce via the provider's native structured output.
+            strict: Whether to request strict provider-side schema enforcement.
+        """
         self.schema = schema
-        self.schema_spec = _SchemaSpec(schema)
+        self.schema_spec = _SchemaSpec(schema, strict=strict)
 
     def to_model_kwargs(self) -> dict[str, Any]:
         """Convert to kwargs to bind to a model to force structured output."""
@@ -271,6 +278,8 @@ class ProviderStrategy(Generic[SchemaT]):
                 "schema": self.schema_spec.json_schema,
             },
         }
+        if self.schema_spec.strict:
+            response_format["json_schema"]["strict"] = True
         return {"response_format": response_format}
 
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -737,6 +737,18 @@ class TestResponseFormatAsProviderStrategy:
         assert response["structured_response"] == EXPECTED_WEATHER_DICT
         assert len(response["messages"]) == 4
 
+    def test_provider_strategy_strict_flag(self) -> None:
+        """ProviderStrategy should pass through strict flag for provider schemas."""
+        # Default should not set strict
+        strategy_default = ProviderStrategy(WeatherBaseModel)
+        kwargs_default = strategy_default.to_model_kwargs()
+        assert "strict" not in kwargs_default["response_format"]["json_schema"]
+
+        # Explicit strict True should include the flag
+        strategy_strict = ProviderStrategy(WeatherBaseModel, strict=True)
+        kwargs_strict = strategy_strict.to_model_kwargs()
+        assert kwargs_strict["response_format"]["json_schema"]["strict"] is True
+
 
 class TestDynamicModelWithResponseFormat:
     """Test response_format with middleware that modifies the model."""


### PR DESCRIPTION
## Summary
- ensure ProviderStrategy propagates the strict flag into provider response_format so strict JSON schema validation can be requested
- document the new strict argument while keeping defaults unchanged
- add a unit test covering default vs strict response_format payloads



## Testing
- python3 -m uv run --group test pytest tests/unit_tests/agents/test_response_format.py -k provider_strategy_strict_flag
- python3 -m uv run --all-groups mypy langchain/agents/structured_output.py
- make format
- make lint
- make test
