### PR TITLE
fix: custom state schema fields not accessible in middleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1148,7 +1148,7 @@ def create_agent(  # noqa: PLR0915
     def model_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
         # Merge state defaults with runtime state to ensure custom fields are accessible
-        complete_state = cast(AgentState, {**state_defaults, **state})
+        complete_state = cast("AgentState", {**state_defaults, **state})
 
         request = ModelRequest(
             model=model,
@@ -1204,7 +1204,7 @@ def create_agent(  # noqa: PLR0915
     async def amodel_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Async model request handler with sequential middleware processing."""
         # Merge state defaults with runtime state to ensure custom fields are accessible
-        complete_state = cast(AgentState, {**state_defaults, **state})
+        complete_state = cast("AgentState", {**state_defaults, **state})
 
         request = ModelRequest(
             model=model,

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1148,7 +1148,7 @@ def create_agent(  # noqa: PLR0915
     def model_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
         # Merge state defaults with runtime state to ensure custom fields are accessible
-        complete_state = {**state_defaults, **state}
+        complete_state = cast(AgentState, {**state_defaults, **state})
 
         request = ModelRequest(
             model=model,
@@ -1204,7 +1204,7 @@ def create_agent(  # noqa: PLR0915
     async def amodel_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Async model request handler with sequential middleware processing."""
         # Merge state defaults with runtime state to ensure custom fields are accessible
-        complete_state = {**state_defaults, **state}
+        complete_state = cast(AgentState, {**state_defaults, **state})
 
         request = ModelRequest(
             model=model,

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -78,29 +78,32 @@ FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT = [
 
 def _get_state_defaults(state_schema: type[AgentState]) -> dict[str, Any]:
     """Extract default values from state schema class attributes.
-    
+
     TypedDict with class-level defaults don't automatically populate runtime dicts.
     This function extracts those defaults to ensure middleware can access custom
     state fields even when not explicitly provided in the input.
-    
+
     Args:
         state_schema: The state schema class (TypedDict subclass)
-        
+
     Returns:
         Dictionary of field names to their default values
     """
     defaults = {}
-    
+
     # Get all attributes from the class, including inherited ones
     for base in reversed(state_schema.__mro__):
         if base is dict or base is object:
             continue
         # Get class-level attributes (defaults)
-        for key, value in base.__dict__.items():
-            if not key.startswith('_') and not callable(value):
-                # This is a class attribute with a default value
-                defaults[key] = value
-    
+        defaults.update(
+            {
+                key: value
+                for key, value in base.__dict__.items()
+                if not key.startswith("_") and not callable(value)
+            }
+        )
+
     return defaults
 
 
@@ -1146,7 +1149,7 @@ def create_agent(  # noqa: PLR0915
         """Sync model request handler with sequential middleware processing."""
         # Merge state defaults with runtime state to ensure custom fields are accessible
         complete_state = {**state_defaults, **state}
-        
+
         request = ModelRequest(
             model=model,
             tools=default_tools,
@@ -1202,7 +1205,7 @@ def create_agent(  # noqa: PLR0915
         """Async model request handler with sequential middleware processing."""
         # Merge state defaults with runtime state to ensure custom fields are accessible
         complete_state = {**state_defaults, **state}
-        
+
         request = ModelRequest(
             model=model,
             tools=default_tools,

--- a/libs/langchain_v1/tests/unit_tests/agents/test_custom_state_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_custom_state_schema.py
@@ -12,7 +12,7 @@ from langchain.agents.middleware.types import (
     add_messages,
 )
 
-from ..model import FakeToolCallingModel
+from .model import FakeToolCallingModel
 
 
 class CustomState(AgentState):

--- a/libs/langchain_v1/tests/unit_tests/agents/test_custom_state_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_custom_state_schema.py
@@ -30,12 +30,13 @@ def test_custom_state_schema_with_defaults_in_middleware():
     class StateAccessMiddleware(AgentMiddleware):
         """Middleware that accesses custom state fields."""
         
-        def before_model(self, request: ModelRequest):
+        def wrap_model_call(self, request, handler):
             # Should be able to access custom fields even if not in input
             accessed_values.append({
                 "custom_field": request.state.get("custom_field"),
                 "another_field": request.state.get("another_field"),
             })
+            return handler(request)
     
     agent = create_agent(
         model=FakeToolCallingModel(tool_calls=[[]]),
@@ -66,11 +67,12 @@ def test_custom_state_schema_with_provided_values():
     class StateAccessMiddleware(AgentMiddleware):
         """Middleware that accesses custom state fields."""
         
-        def before_model(self, request: ModelRequest):
+        def wrap_model_call(self, request, handler):
             accessed_values.append({
                 "custom_field": request.state.get("custom_field"),
                 "another_field": request.state.get("another_field"),
             })
+            return handler(request)
     
     agent = create_agent(
         model=FakeToolCallingModel(tool_calls=[[]]),
@@ -99,12 +101,13 @@ def test_custom_state_schema_direct_access_no_keyerror():
     class DirectAccessMiddleware(AgentMiddleware):
         """Middleware that directly accesses custom state fields."""
         
-        def before_model(self, request: ModelRequest):
+        def wrap_model_call(self, request, handler):
             # This should NOT raise KeyError with the fix
             custom_field = request.state["custom_field"]
             another_field = request.state["another_field"]
             assert custom_field is False
             assert another_field == "default_value"
+            return handler(request)
     
     agent = create_agent(
         model=FakeToolCallingModel(tool_calls=[[]]),

--- a/libs/langchain_v1/tests/unit_tests/agents/test_custom_state_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_custom_state_schema.py
@@ -1,0 +1,119 @@
+"""Tests for custom state schema with default values in middleware."""
+
+from langchain_core.messages import AIMessage, HumanMessage
+from typing_extensions import Required, NotRequired
+from typing import Annotated
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ModelRequest,
+    add_messages,
+)
+
+from ..model import FakeToolCallingModel
+
+
+class CustomState(AgentState):
+    """Custom state schema with additional fields."""
+    
+    messages: Required[Annotated[list, add_messages]]
+    custom_field: bool = False
+    another_field: str = "default_value"
+
+
+def test_custom_state_schema_with_defaults_in_middleware():
+    """Test that custom state fields with defaults are accessible in middleware."""
+    accessed_values = []
+    
+    class StateAccessMiddleware(AgentMiddleware):
+        """Middleware that accesses custom state fields."""
+        
+        def before_model(self, request: ModelRequest):
+            # Should be able to access custom fields even if not in input
+            accessed_values.append({
+                "custom_field": request.state.get("custom_field"),
+                "another_field": request.state.get("another_field"),
+            })
+    
+    agent = create_agent(
+        model=FakeToolCallingModel(tool_calls=[[]]),
+        tools=[],
+        system_prompt="Test assistant",
+        state_schema=CustomState,
+        middleware=[StateAccessMiddleware()],
+    )
+    
+    # Invoke with only messages, not providing custom fields
+    result = agent.invoke({"messages": [HumanMessage(content="test")]})
+    
+    # Middleware should have accessed the default values
+    assert len(accessed_values) == 1
+    assert accessed_values[0]["custom_field"] is False
+    assert accessed_values[0]["another_field"] == "default_value"
+    
+    # Result should contain the message
+    assert len(result["messages"]) == 2
+    assert isinstance(result["messages"][0], HumanMessage)
+    assert isinstance(result["messages"][1], AIMessage)
+
+
+def test_custom_state_schema_with_provided_values():
+    """Test that explicitly provided custom state values override defaults."""
+    accessed_values = []
+    
+    class StateAccessMiddleware(AgentMiddleware):
+        """Middleware that accesses custom state fields."""
+        
+        def before_model(self, request: ModelRequest):
+            accessed_values.append({
+                "custom_field": request.state.get("custom_field"),
+                "another_field": request.state.get("another_field"),
+            })
+    
+    agent = create_agent(
+        model=FakeToolCallingModel(tool_calls=[[]]),
+        tools=[],
+        system_prompt="Test assistant",
+        state_schema=CustomState,
+        middleware=[StateAccessMiddleware()],
+    )
+    
+    # Invoke with custom field values provided
+    result = agent.invoke({
+        "messages": [HumanMessage(content="test")],
+        "custom_field": True,
+        "another_field": "custom_value",
+    })
+    
+    # Middleware should have accessed the provided values
+    assert len(accessed_values) == 1
+    assert accessed_values[0]["custom_field"] is True
+    assert accessed_values[0]["another_field"] == "custom_value"
+
+
+def test_custom_state_schema_direct_access_no_keyerror():
+    """Test that direct dictionary access to custom fields doesn't raise KeyError."""
+    
+    class DirectAccessMiddleware(AgentMiddleware):
+        """Middleware that directly accesses custom state fields."""
+        
+        def before_model(self, request: ModelRequest):
+            # This should NOT raise KeyError with the fix
+            custom_field = request.state["custom_field"]
+            another_field = request.state["another_field"]
+            assert custom_field is False
+            assert another_field == "default_value"
+    
+    agent = create_agent(
+        model=FakeToolCallingModel(tool_calls=[[]]),
+        tools=[],
+        system_prompt="Test assistant",
+        state_schema=CustomState,
+        middleware=[DirectAccessMiddleware()],
+    )
+    
+    # This should not raise KeyError
+    result = agent.invoke({"messages": [HumanMessage(content="test")]})
+    assert result is not None


### PR DESCRIPTION
## Problem

Fixes #34156

When users provide a custom `state_schema` to `create_agent()` with additional fields that have default values (e.g., `requirements_gathered: bool = False`), those fields raise a `KeyError` when accessed in middleware. This happens because TypedDict class attributes with default values are only type hints - they don't automatically populate runtime dictionaries.

### Before
```python
class GraphState(AgentState):
    requirements_gathered: bool = False

@dynamic_prompt
def change_system_prompt(request: ModelRequest):
    if request.state["requirements_gathered"]:  # KeyError!
        return SEARCH_HOTELS_INSTRUCTION
    else:
        return REQUIREMENT_GATHERING_INSTRUCTION

agent = create_agent(
    model=llm,
    state_schema=GraphState,
    middleware=[change_system_prompt]
)
```

### Error
```
KeyError: 'requirements_gathered'
```

## Solution

Extract default values from the state schema class and merge them with the runtime state before passing to middleware. This ensures custom fields are always accessible, even when not explicitly provided in the input.

### Changes

1. **Added `_get_state_defaults()` helper function** - Extracts default values from state schema class by inspecting class attributes across the inheritance chain
2. **Modified `model_node()` and `amodel_node()`** - Merge state defaults with runtime state before creating `ModelRequest`
3. **Maintains backward compatibility** - Explicitly provided values in input override defaults

### After
```python
# Same code now works without KeyError
agent.invoke({"messages": [HumanMessage("test")]})
# Middleware can access request.state["requirements_gathered"] = False
```

## Testing

Added comprehensive test coverage in `test_custom_state_schema.py`:

- ✅ Test that custom fields with defaults are accessible in middleware
- ✅ Test that explicitly provided values override defaults
- ✅ Test that direct dictionary access doesn't raise KeyError

## Backward Compatibility

- No breaking changes
- Existing code continues to work unchanged
- Only affects behavior when custom `state_schema` is provided with default values
- Runtime values always take precedence over defaults