### PR TITLE
chore: disable blockbuster for `langchain-classic`

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -133,12 +133,12 @@ def _get_configs_for_single_dir(job: str, dir_: str) -> List[Dict[str, str]]:
     if job == "codspeed":
         py_versions = ["3.13"]
     elif dir_ == "libs/core":
-        py_versions = ["3.10", "3.11", "3.12", "3.13"]
+        py_versions = ["3.10", "3.11", "3.12", "3.13", "3.14"]
     # custom logic for specific directories
     elif dir_ in {"libs/partners/chroma"}:
         py_versions = ["3.10", "3.13"]
     else:
-        py_versions = ["3.10", "3.13"]
+        py_versions = ["3.10", "3.14"]
 
     return [{"working-directory": dir_, "python-version": py_v} for py_v in py_versions]
 

--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -133,12 +133,12 @@ def _get_configs_for_single_dir(job: str, dir_: str) -> List[Dict[str, str]]:
     if job == "codspeed":
         py_versions = ["3.13"]
     elif dir_ == "libs/core":
-        py_versions = ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        py_versions = ["3.10", "3.11", "3.12", "3.13"]
     # custom logic for specific directories
     elif dir_ in {"libs/partners/chroma"}:
         py_versions = ["3.10", "3.13"]
     else:
-        py_versions = ["3.10", "3.14"]
+        py_versions = ["3.10", "3.13"]
 
     return [{"working-directory": dir_, "python-version": py_v} for py_v in py_versions]
 

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -70,7 +70,6 @@ test = [
     "pandas>=2.0.0,<3.0.0",
     "syrupy>=4.0.2,<5.0.0",
     "requests-mock>=1.11.0,<2.0.0",
-    "blockbuster>=1.5.18,<1.6.0",
     "toml>=0.10.2,<1.0.0",
     "packaging>=24.2.0,<26.0.0",
     "langchain-tests",

--- a/libs/langchain/tests/unit_tests/conftest.py
+++ b/libs/langchain/tests/unit_tests/conftest.py
@@ -31,6 +31,15 @@ def blockbuster() -> Iterator[None]:
                 "_default_retry_config",
             )
 
+        # Allow blocking writes during bytecode caching (.pyc files)
+        # This happens when SQLAlchemy imports dialects during async engine init
+        for write_func in ["io.BufferedWriter.write", "io.FileIO.write"]:
+            if write_func in bb.functions:
+                bb.functions[write_func].can_block_in(
+                    "importlib/_bootstrap_external.py",
+                    "_write_atomic",
+                )
+
         for bb_function in bb.functions.values():
             bb_function.can_block_in(
                 "freezegun/api.py",

--- a/libs/langchain/tests/unit_tests/test_dependencies.py
+++ b/libs/langchain/tests/unit_tests/test_dependencies.py
@@ -73,7 +73,6 @@ def test_test_group_dependencies(uv_conf: Mapping[str, Any]) -> None:
             "pytest-socket",
             "pytest-watcher",
             "pytest-xdist",
-            "blockbuster",
             "responses",
             "syrupy",
             "toml",

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -375,18 +375,6 @@ wheels = [
 [package.optional-dependencies]
 css = [
     { name = "tinycss2" },
-]
-
-[[package]]
-name = "blockbuster"
-version = "1.5.25"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "forbiddenfruit", marker = "implementation_name == 'cpython'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/bc/57c49465decaeeedd58ce2d970b4cdfd93a74ba9993abff2dc498a31c283/blockbuster-1.5.25.tar.gz", hash = "sha256:b72f1d2aefdeecd2a820ddf1e1c8593bf00b96e9fdc4cd2199ebafd06f7cb8f0", size = 36058, upload-time = "2025-07-14T16:00:20.766Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/01/dccc277c014f171f61a6047bb22c684e16c7f2db6bb5c8cce1feaf41ec55/blockbuster-1.5.25-py3-none-any.whl", hash = "sha256:cb06229762273e0f5f3accdaed3d2c5a3b61b055e38843de202311ede21bb0f5", size = 13196, upload-time = "2025-07-14T16:00:19.396Z" },
 ]
 
 [[package]]
@@ -1041,12 +1029,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/5b/39/a39c176fca0cdd8f4
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/de/576c2dab45914e08c1fc4adfa4a334da037b8b4ad4df1fdab4b56904bd07/fireworks_ai-0.16.4-py3-none-any.whl", hash = "sha256:e7592fdec64aa35f0068b8fa8277e2440ef6f0d6355e818b7220e098f7ea0ee9", size = 193771, upload-time = "2025-05-18T07:16:20.611Z" },
 ]
-
-[[package]]
-name = "forbiddenfruit"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e6/79/d4f20e91327c98096d605646bdc6a5ffedae820f38d378d3515c42ec5e60/forbiddenfruit-0.1.4.tar.gz", hash = "sha256:e3f7e66561a29ae129aac139a85d610dbf3dd896128187ed5454b6421f624253", size = 43756, upload-time = "2021-01-16T21:03:35.401Z" }
 
 [[package]]
 name = "fqdn"
@@ -2333,7 +2315,6 @@ lint = [
     { name = "ruff" },
 ]
 test = [
-    { name = "blockbuster" },
     { name = "cffi" },
     { name = "freezegun" },
     { name = "langchain-core" },
@@ -2424,7 +2405,6 @@ lint = [
     { name = "ruff", specifier = ">=0.13.1,<0.14.0" },
 ]
 test = [
-    { name = "blockbuster", specifier = ">=1.5.18,<1.6.0" },
     { name = "cffi", marker = "python_full_version < '3.10'", specifier = "<1.17.1" },
     { name = "cffi", marker = "python_full_version >= '3.10'" },
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -2478,7 +2458,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.0.3"
+version = "1.1.0"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2512,7 +2492,6 @@ test = [
     { name = "blockbuster", specifier = ">=1.5.18,<1.6.0" },
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
     { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
-    { name = "langchain-model-profiles", directory = "../model-profiles" },
     { name = "langchain-tests", directory = "../standard-tests" },
     { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
@@ -2529,7 +2508,6 @@ test = [
 ]
 test-integration = []
 typing = [
-    { name = "langchain-model-profiles", directory = "../model-profiles" },
     { name = "langchain-text-splitters", directory = "../text-splitters" },
     { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
@@ -2659,7 +2637,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },
@@ -2722,7 +2700,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Blockbuster failing w/ blocking sqlalchemy calls and not worth the maintenance burden right now in `langchain-classic`