### PR TITLE
fix(core): handle None/empty tool call arguments in tool parsers

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -342,7 +342,11 @@ def default_tool_parser(
             continue
         function_name = raw_tool_call["function"]["name"]
         try:
-            function_args = json.loads(raw_tool_call["function"]["arguments"])
+            args = raw_tool_call["function"]["arguments"]
+            if args in (None, "", {}):
+                function_args = {}
+            else:
+                function_args = json.loads(args)
             parsed = tool_call(
                 name=function_name or "",
                 args=function_args or {},

--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -343,10 +343,7 @@ def default_tool_parser(
         function_name = raw_tool_call["function"]["name"]
         try:
             args = raw_tool_call["function"]["arguments"]
-            if args in (None, "", {}):
-                function_args = {}
-            else:
-                function_args = json.loads(args)
+            function_args = {} if args in (None, "", {}) else json.loads(args)
             parsed = tool_call(
                 name=function_name or "",
                 args=function_args or {},

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -47,25 +47,29 @@ def parse_tool_call(
     """
     if "function" not in raw_tool_call:
         return None
-    if partial:
-        try:
-            function_args = parse_partial_json(
-                raw_tool_call["function"]["arguments"], strict=strict
-            )
-        except (JSONDecodeError, TypeError):  # None args raise TypeError
-            return None
+    args = raw_tool_call["function"].get("arguments")
+    if args in (None, "", {}):
+            function_args={}
     else:
-        try:
-            function_args = json.loads(
-                raw_tool_call["function"]["arguments"], strict=strict
-            )
-        except JSONDecodeError as e:
-            msg = (
-                f"Function {raw_tool_call['function']['name']} arguments:\n\n"
-                f"{raw_tool_call['function']['arguments']}\n\nare not valid JSON. "
-                f"Received JSONDecodeError {e}"
-            )
-            raise OutputParserException(msg) from e
+        if partial:
+                try:
+                    function_args = parse_partial_json(
+                        raw_tool_call["function"]["arguments"], strict=strict
+                    )
+                except (JSONDecodeError, TypeError):  # None args raise TypeError
+                    return None
+        else:
+            try:
+                function_args = json.loads(
+                    raw_tool_call["function"]["arguments"], strict=strict
+                )
+            except JSONDecodeError as e:
+                msg = (
+                    f"Function {raw_tool_call['function']['name']} arguments:\n\n"
+                    f"{raw_tool_call['function']['arguments']}\n\nare not valid JSON. "
+                    f"Received JSONDecodeError {e}"
+                )
+                raise OutputParserException(msg) from e
     parsed = {
         "name": raw_tool_call["function"]["name"] or "",
         "args": function_args or {},

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -50,15 +50,15 @@ def parse_tool_call(
     args = raw_tool_call["function"].get("arguments")
     if args in (None, "", {}):
             function_args={}
-    else:
-        if partial:
+
+    elif partial:
                 try:
                     function_args = parse_partial_json(
                         raw_tool_call["function"]["arguments"], strict=strict
                     )
                 except (JSONDecodeError, TypeError):  # None args raise TypeError
                     return None
-        else:
+    else:
             try:
                 function_args = json.loads(
                     raw_tool_call["function"]["arguments"], strict=strict


### PR DESCRIPTION
Fixes #34123 
Fixes a bug in the core tool-call parser where None or empty tool arguments caused a TypeError/JSONDecodeError. Empty or missing arguments are now safely treated as {} for consistent behavior.



