### PR TITLE
fix(core): handle `None`/empty tool call arguments in tool parsers

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -342,7 +342,8 @@ def default_tool_parser(
             continue
         function_name = raw_tool_call["function"]["name"]
         try:
-            function_args = json.loads(raw_tool_call["function"]["arguments"])
+            args = raw_tool_call["function"].get("arguments")
+            function_args = {} if args in (None, "", {}) else json.loads(args)
             parsed = tool_call(
                 name=function_name or "",
                 args=function_args or {},

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -48,7 +48,7 @@ def parse_tool_call(
     if "function" not in raw_tool_call:
         return None
     args = raw_tool_call["function"].get("arguments")
-    if args in (None, "",{}):
+    if args in (None, "", {}):
         function_args = {}
     elif partial:
         try:

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -47,7 +47,10 @@ def parse_tool_call(
     """
     if "function" not in raw_tool_call:
         return None
-    if partial:
+    args = raw_tool_call["function"].get("arguments")
+    if args in (None, "",{}):
+        function_args = {}
+    elif partial:
         try:
             function_args = parse_partial_json(
                 raw_tool_call["function"]["arguments"], strict=strict


### PR DESCRIPTION
Fixes #34123 
Fixes a bug in the core tool-call parser where None or empty tool arguments caused a TypeError/JSONDecodeError. Empty or missing arguments are now safely treated as {} for consistent behavior.
