### PR TITLE
fix(core): `RunnablePick` method return types

### DIFF
--- a/libs/core/langchain_core/runnables/passthrough.py
+++ b/libs/core/langchain_core/runnables/passthrough.py
@@ -753,25 +753,19 @@ class RunnablePick(RunnableSerializable[dict[str, Any], Any]):
             return AddableDict(picked)
         return None
 
-    def _invoke(
-        self,
-        value: dict[str, Any],
-    ) -> dict[str, Any]:
-        return self._pick(value)
-
     @override
     def invoke(
         self,
         input: dict[str, Any],
         config: RunnableConfig | None = None,
         **kwargs: Any,
-    ) -> dict[str, Any]:
-        return self._call_with_config(self._invoke, input, config, **kwargs)
+    ) -> Any:
+        return self._call_with_config(self._pick, input, config, **kwargs)
 
     async def _ainvoke(
         self,
         value: dict[str, Any],
-    ) -> dict[str, Any]:
+    ) -> Any:
         return self._pick(value)
 
     @override
@@ -780,13 +774,13 @@ class RunnablePick(RunnableSerializable[dict[str, Any], Any]):
         input: dict[str, Any],
         config: RunnableConfig | None = None,
         **kwargs: Any,
-    ) -> dict[str, Any]:
+    ) -> Any:
         return await self._acall_with_config(self._ainvoke, input, config, **kwargs)
 
     def _transform(
         self,
         chunks: Iterator[dict[str, Any]],
-    ) -> Iterator[dict[str, Any]]:
+    ) -> Iterator[Any]:
         for chunk in chunks:
             picked = self._pick(chunk)
             if picked is not None:
@@ -798,7 +792,7 @@ class RunnablePick(RunnableSerializable[dict[str, Any], Any]):
         input: Iterator[dict[str, Any]],
         config: RunnableConfig | None = None,
         **kwargs: Any,
-    ) -> Iterator[dict[str, Any]]:
+    ) -> Iterator[Any]:
         yield from self._transform_stream_with_config(
             input, self._transform, config, **kwargs
         )
@@ -806,7 +800,7 @@ class RunnablePick(RunnableSerializable[dict[str, Any], Any]):
     async def _atransform(
         self,
         chunks: AsyncIterator[dict[str, Any]],
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[Any]:
         async for chunk in chunks:
             picked = self._pick(chunk)
             if picked is not None:
@@ -818,7 +812,7 @@ class RunnablePick(RunnableSerializable[dict[str, Any], Any]):
         input: AsyncIterator[dict[str, Any]],
         config: RunnableConfig | None = None,
         **kwargs: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[Any]:
         async for chunk in self._atransform_stream_with_config(
             input, self._atransform, config, **kwargs
         ):
@@ -830,7 +824,7 @@ class RunnablePick(RunnableSerializable[dict[str, Any], Any]):
         input: dict[str, Any],
         config: RunnableConfig | None = None,
         **kwargs: Any,
-    ) -> Iterator[dict[str, Any]]:
+    ) -> Iterator[Any]:
         return self.transform(iter([input]), config, **kwargs)
 
     @override
@@ -839,7 +833,7 @@ class RunnablePick(RunnableSerializable[dict[str, Any], Any]):
         input: dict[str, Any],
         config: RunnableConfig | None = None,
         **kwargs: Any,
-    ) -> AsyncIterator[dict[str, Any]]:
+    ) -> AsyncIterator[Any]:
         async def input_aiter() -> AsyncIterator[dict[str, Any]]:
             yield input
 


### PR DESCRIPTION
Following https://github.com/langchain-ai/langchain/pull/31321, the `Output` type of `RunnablePick` is `Any`.