### PR TITLE
fix(mistralai): respect `max_retries` during streaming failures

### DIFF
--- a/libs/partners/mistralai/tests/unit_tests/test_streaming_retry.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_streaming_retry.py
@@ -1,0 +1,63 @@
+import asyncio
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from langchain_mistralai.chat_models import ChatMistralAI
+
+
+def test_streaming_retry_on_stream_failure() -> None:
+    """
+    Test that retries are attempted when a failure occurs *during* streaming.
+    We use httpx.MockTransport to simulate a network error mid-stream.
+    """
+
+    async def _run_test() -> None:
+        request_count = 0
+
+        async def request_handler(request: httpx.Request) -> httpx.Response:
+            nonlocal request_count
+            request_count += 1
+
+            # Simulate a stream that yields one valid chunk then crashes
+            async def faulty_stream() -> AsyncIterator[bytes]:
+                # Valid SSE chunk (Mistral format)
+                data = (
+                    b'data: {"choices": [{"index": 0, "delta": '
+                    b'{"role": "assistant", "content": "Hi"}}]}\n\n'
+                )
+                yield data
+                # Simulate network cut
+                msg = "Network Error"
+                raise httpx.StreamError(msg)
+
+            return httpx.Response(
+                200,
+                content=faulty_stream(),
+                headers={"content-type": "text/event-stream"},
+            )
+
+        # Inject our mock client directly with a base_url to support
+        # relative paths used by ChatMistralAI.
+        mock_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(request_handler),
+            base_url="https://api.mistral.ai/v1",
+        )
+
+        chat = ChatMistralAI(  
+            model="test",# type: ignore[call-arg]
+            max_retries=3,
+            async_client=mock_client,
+            api_key="secret",  # Required to avoid validation error
+        )
+
+        # Verify that the exception bubbles up (after retries failed)
+        with pytest.raises(httpx.StreamError):
+            async for _ in chat.astream("Hello"):
+                pass
+
+        # request_count should be > 1 because retries happened
+        assert request_count > 1
+
+    asyncio.run(_run_test())


### PR DESCRIPTION
## Summary

This PR fixes an issue in the `langchain-mistralai` chat integration where `max_retries` were not respected when a failure occurred *during* streaming (e.g., `httpx.StreamError` after the first chunk).
Yesterday, Mistral was experiencing failure systems (30% of requests were not returning any chunks). I lowered retry to 5 secondes, because 100% of calls not returning any chunks in 5 secondes were bug? And I discovered the retry mechanism was not correctly implemented. This behavior was inconsistent with ChatOpenAI LLM, for exemple.

Changes:
- Update `ChatMistralAI._astream` so that the async streaming loop is wrapped in a retry policy based on `tenacity.AsyncRetrying`.
- Ensure that `httpx.RequestError` and `httpx.StreamError` raised while consuming the SSE stream trigger new attempts, instead of failing after a single try.
- Add a regression test `test_streaming_retry_on_stream_failure` using `httpx.MockTransport` to simulate a mid-stream network failure and assert that multiple HTTP requests are made when retries are enabled.

## Rationale

The current Mistral integration uses raw `httpx` + `httpx-sse` instead of the official Mistral client, so it must implement its own retry logic. Previously, the retry decorator only wrapped the initial connection. Once the SSE iterator was returned, any `StreamError` occurring during consumption bypassed the retry logic, resulting in only one failed attempt regardless of the configured `max_retries`.

This PR preserves the existing public API and behavior while making the streaming path consistent with the `max_retries` setting.

## Testing

Local tests run:

uv run pytest libs/partners/mistralai/tests/unit_tests/test_streaming_retry.py

# Future work

The current integration is built directly on top of `httpx` and `httpx-sse`. In the long term, it would likely be more robust and easier to maintain to layer `ChatMistralAI` on top of the official Mistral Python SDK instead of reimplementing low-level HTTP, streaming, and retry behavior by hand. That refactor would be a larger, separate change, but this PR moves the current `httpx`-based implementation to a more correct and resilient state in the meantime.

# AI: Description of PR was made by AI.