### PR TITLE
feat(langchain): add support for Upstage (Solar) in `init_chat_model`

### DIFF
--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -102,6 +102,7 @@ def init_chat_model(
             - `deepseek...`                       -> `deepseek`
             - `grok...`                           -> `xai`
             - `sonar...`                          -> `perplexity`
+            - `solar...`                          -> `upstage`
         model_provider: The model provider if not specified as part of the model arg
             (see above).
 
@@ -129,6 +130,7 @@ def init_chat_model(
             - `nvidia`                  -> [`langchain-nvidia-ai-endpoints`](https://docs.langchain.com/oss/python/integrations/providers/nvidia)
             - `xai`                     -> [`langchain-xai`](https://docs.langchain.com/oss/python/integrations/providers/xai)
             - `perplexity`              -> [`langchain-perplexity`](https://docs.langchain.com/oss/python/integrations/providers/perplexity)
+            - `upstage`                 -> [`langchain-upstage`](https://docs.langchain.com/oss/python/integrations/providers/upstage)
 
         configurable_fields: Which model parameters are configurable at runtime:
 
@@ -449,6 +451,11 @@ def _init_chat_model_helper(
         from langchain_perplexity import ChatPerplexity
 
         return ChatPerplexity(model=model, **kwargs)
+    if model_provider == "upstage":
+        _check_pkg("langchain_upstage")
+        from langchain_upstage import ChatUpstage
+
+        return ChatUpstage(model=model, **kwargs)
     supported = ", ".join(_SUPPORTED_PROVIDERS)
     msg = f"Unsupported {model_provider=}.\n\nSupported model providers are: {supported}"
     raise ValueError(msg)
@@ -475,6 +482,7 @@ _SUPPORTED_PROVIDERS = {
     "ibm",
     "xai",
     "perplexity",
+    "upstage",
 }
 
 
@@ -499,6 +507,8 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
         return "xai"
     if model_name.startswith("sonar"):
         return "perplexity"
+    if model_name.startswith("solar"):
+        return "upstage"
     return None
 
 


### PR DESCRIPTION
## Summary
This PR adds support for the **Upstage** provider to the `init_chat_model` factory function. It enables users to initialize Upstage models directly and includes automatic inference for models prefixed with `solar-`.

## Details
- Added `upstage` to `_SUPPORTED_PROVIDERS`.
- Updated `_init_chat_model_helper` to import and initialize `ChatUpstage` from `langchain-upstage`.
- Added logic to `_attempt_infer_model_provider` to infer `upstage` provider when the model name starts with `solar`.
- Updated docstrings to include Upstage in the supported list and inference examples.

## Checklist
- [x] Ran `make format`, `make lint`, and `make test`.
- [x] No changes to `uv.lock` or `pyproject.toml`.