### PR TITLE
test(openai): mark `test_structured_output_and_tools` flaky

### DIFF
--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -1157,6 +1157,7 @@ class ResponseFormatDict(TypedDict):
     explanation: str
 
 
+@pytest.mark.flaky(retries=3, delay=1)
 @pytest.mark.parametrize(
     "schema", [ResponseFormat, ResponseFormat.model_json_schema(), ResponseFormatDict]
 )


### PR DESCRIPTION
Often raises `KeyError: 'explanation'`