### PR TITLE
docs: Add prominent warning about state_schema requirement for custom fields

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -538,7 +538,7 @@ def _chain_async_tool_call_wrappers(
     return result
 
 
-def create_agent(  # noqa: PLR0915
+def create_agent(  # noqa: PLR0915, D417
     model: str | BaseChatModel,
     tools: Sequence[BaseTool | Callable | dict[str, Any]] | None = None,
     *,
@@ -627,14 +627,15 @@ def create_agent(  # noqa: PLR0915
                 preserved in the runtime state, and any additional fields passed during
                 invocation will be silently ignored.
 
-                Example:
-
+    Example:
                 ```python
                 from langchain.agents import AgentState, create_agent
+
 
                 class MyState(AgentState):
                     authenticated: bool
                     user_id: str
+
 
                 agent = create_agent(
                     model=model,
@@ -689,9 +690,11 @@ def create_agent(  # noqa: PLR0915
         ```python
         from langchain.agents import create_agent
 
+
         def check_weather(location: str) -> str:
             '''Return the weather forecast for the specified location.'''
             return f"It's always sunny in {location}"
+
 
         graph = create_agent(
             model="anthropic:claude-sonnet-4-5-20250929",

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -630,14 +630,11 @@ def create_agent(  # noqa: PLR0915
                 Example:
 
                 ```python
-                from typing import Annotated
                 from langchain.agents import AgentState, create_agent
-                from langgraph.graph import add_messages
 
                 class MyState(AgentState):
-                    messages: Annotated[list, add_messages]
                     authenticated: bool
-                    password: str
+                    user_id: str
 
                 agent = create_agent(
                     model=model,
@@ -692,11 +689,9 @@ def create_agent(  # noqa: PLR0915
         ```python
         from langchain.agents import create_agent
 
-
         def check_weather(location: str) -> str:
             '''Return the weather forecast for the specified location.'''
             return f"It's always sunny in {location}"
-
 
         graph = create_agent(
             model="anthropic:claude-sonnet-4-5-20250929",

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -619,6 +619,33 @@ def create_agent(  # noqa: PLR0915
             schema for merging with middleware state schemas. This allows users to
             add custom state fields without needing to create custom middleware.
 
+            !!! warning "Custom State Fields Require state_schema"
+
+                If you need to track custom fields in your agent state (beyond `messages`),
+                you **must** provide a `state_schema` that extends `AgentState` and includes
+                those fields. Without `state_schema`, only the `messages` field will be
+                preserved in the runtime state, and any additional fields passed during
+                invocation will be silently ignored.
+
+                Example:
+
+                ```python
+                from typing import Annotated
+                from langchain.agents import AgentState, create_agent
+                from langgraph.graph import add_messages
+
+                class MyState(AgentState):
+                    messages: Annotated[list, add_messages]
+                    authenticated: bool
+                    password: str
+
+                agent = create_agent(
+                    model=model,
+                    tools=tools,
+                    state_schema=MyState,  # Required for custom fields!
+                )
+                ```
+
             Generally, it's recommended to use `state_schema` extensions via middleware
             to keep relevant extensions scoped to corresponding hooks / tools.
         context_schema: An optional schema for runtime context.

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2166,7 +2166,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Addresses #34108 

This PR improves documentation to prevent a common user mistake where custom state fields are silently ignored because state_schema was not provided to create_agent().

Users expect custom fields to be preserved in runtime.state when they pass them during invocation. However, without providing a state_schema that extends AgentState with those fields, only the messages field is preserved, leading to silent data loss.

Added a prominent warning callout in the state_schema parameter documentation with a clear code example showing the correct usage.