### PR TITLE
feat: add agent name to `AIMessage`

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1100,6 +1100,8 @@ def create_agent(  # noqa: PLR0915
             messages = [request.system_message, *messages]
 
         output = model_.invoke(messages)
+        if name:
+            output.name = name
 
         # Handle model output to get messages and structured_response
         handled_output = _handle_model_output(output, effective_response_format)
@@ -1153,6 +1155,8 @@ def create_agent(  # noqa: PLR0915
             messages = [request.system_message, *messages]
 
         output = await model_.ainvoke(messages)
+        if name:
+            output.name = name
 
         # Handle model output to get messages and structured_response
         handled_output = _handle_model_output(output, effective_response_format)

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_name.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_name.py
@@ -1,0 +1,99 @@
+"""Test agent name parameter in create_agent.
+
+This module tests that the name parameter correctly sets .name on AIMessage outputs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.tools import tool
+
+from langchain.agents import create_agent
+
+from .model import FakeToolCallingModel
+
+
+@tool
+def simple_tool(x: int) -> str:
+    """Simple tool for basic tests."""
+    return f"Result: {x}"
+
+
+def test_agent_name_set_on_ai_message() -> None:
+    """Test that agent name is set on AIMessage when name is provided."""
+    agent = create_agent(
+        model=FakeToolCallingModel(tool_calls=[[]]),
+        name="test_agent",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) == 1
+    assert ai_messages[0].name == "test_agent"
+
+
+def test_agent_name_not_set_when_none() -> None:
+    """Test that AIMessage.name is not set when name is not provided."""
+    agent = create_agent(
+        model=FakeToolCallingModel(tool_calls=[[]]),
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) == 1
+    assert ai_messages[0].name is None
+
+
+def test_agent_name_on_multiple_iterations() -> None:
+    """Test that agent name is set on all AIMessages in multi-turn conversation."""
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[[{"args": {"x": 1}, "id": "call_1", "name": "simple_tool"}], []]
+        ),
+        tools=[simple_tool],
+        name="multi_turn_agent",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Call a tool")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) == 2
+    for msg in ai_messages:
+        assert msg.name == "multi_turn_agent"
+
+
+@pytest.mark.asyncio
+async def test_agent_name_async() -> None:
+    """Test that agent name is set on AIMessage in async execution."""
+    agent = create_agent(
+        model=FakeToolCallingModel(tool_calls=[[]]),
+        name="async_agent",
+    )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("Hello async")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) == 1
+    assert ai_messages[0].name == "async_agent"
+
+
+@pytest.mark.asyncio
+async def test_agent_name_async_multiple_iterations() -> None:
+    """Test that agent name is set on all AIMessages in async multi-turn."""
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[[{"args": {"x": 5}, "id": "call_1", "name": "simple_tool"}], []]
+        ),
+        tools=[simple_tool],
+        name="async_multi_agent",
+    )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("Call tool async")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) == 2
+    for msg in ai_messages:
+        assert msg.name == "async_multi_agent"

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2166,7 +2166,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.1.1"
+version = "1.1.2"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2347,7 +2347,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Reasonable, based on logic in prebuilt that wasn't ported over, see [here](https://github.com/langchain-ai/langgraph/blob/94698c8a349e2f795593ee3a94e03e0a60228240/libs/prebuilt/langgraph/prebuilt/chat_agent_executor.py#L670-L671)

Helpful for applications w/ subagents
