### PR TITLE
fix: remove partial usage for retriever func + afunc

### DIFF
--- a/libs/core/langchain_core/tools/retriever.py
+++ b/libs/core/langchain_core/tools/retriever.py
@@ -14,7 +14,7 @@ from langchain_core.prompts import (
     aformat_document,
     format_document,
 )
-from langchain_core.tools.simple import Tool
+from langchain_core.tools.structured import StructuredTool
 
 if TYPE_CHECKING:
     from langchain_core.retrievers import BaseRetriever
@@ -79,7 +79,7 @@ def create_retriever_tool(
             return (content, docs)
         return content
 
-    return Tool(
+    return StructuredTool(
         name=name,
         description=description,
         func=func,

--- a/libs/core/langchain_core/tools/retriever.py
+++ b/libs/core/langchain_core/tools/retriever.py
@@ -34,7 +34,7 @@ def create_retriever_tool(
     document_prompt: BasePromptTemplate | None = None,
     document_separator: str = "\n\n",
     response_format: Literal["content", "content_and_artifact"] = "content",
-) -> Tool:
+) -> StructuredTool:
     r"""Create a tool to do retrieval of documents.
 
     Args:

--- a/libs/core/langchain_core/tools/retriever.py
+++ b/libs/core/langchain_core/tools/retriever.py
@@ -57,9 +57,6 @@ def create_retriever_tool(
     """
     document_prompt_ = document_prompt or PromptTemplate.from_template("{page_content}")
 
-    # Use wrapper functions instead of functools.partial to ensure compatibility
-    # with typing.get_type_hints(), which fails on partial objects in Python 3.12+.
-    # This allows tools like LangGraph's ToolNode to inspect the function signature.
     def func(
         query: str, callbacks: Callbacks = None
     ) -> str | tuple[str, list[Document]]:

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2245,6 +2245,33 @@ def test_create_retriever_tool() -> None:
     )
 
 
+def test_create_retriever_tool_get_type_hints() -> None:
+    """Verify get_type_hints works on retriever tool's func.
+
+    This test ensures compatibility with Python 3.12+ where get_type_hints()
+    raises TypeError on functools.partial objects. Tools like LangGraph's
+    ToolNode call get_type_hints(tool.func) to generate schemas.
+    """
+    from typing import get_type_hints
+
+    class MyRetriever(BaseRetriever):
+        @override
+        def _get_relevant_documents(
+            self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        ) -> list[Document]:
+            return [Document(page_content="test")]
+
+    retriever = MyRetriever()
+    retriever_tool = tools.create_retriever_tool(
+        retriever, "test_tool", "Test tool for type hints"
+    )
+
+    # This should not raise TypeError (as it did with functools.partial)
+    hints = get_type_hints(retriever_tool.func)
+    assert "query" in hints
+    assert hints["query"] is str
+
+
 def test_tool_args_schema_pydantic_v2_with_metadata() -> None:
     class Foo(BaseModel):
         x: list[int] = Field(

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -17,6 +17,7 @@ from typing import (
     Literal,
     TypeVar,
     cast,
+    get_type_hints,
 )
 
 import pytest
@@ -2252,7 +2253,6 @@ def test_create_retriever_tool_get_type_hints() -> None:
     raises TypeError on functools.partial objects. Tools like LangGraph's
     ToolNode call get_type_hints(tool.func) to generate schemas.
     """
-    from typing import get_type_hints
 
     class MyRetriever(BaseRetriever):
         @override


### PR DESCRIPTION
Added test that fails on `master`.

`ToolNode` uses `get_type_hints` which doesn't work properly w/ partial funcs on Python 3.12+

The diff here is nice anyways when we inline the logic.