### PR TITLE
fix(mistralai): handle null content in tool call responses

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -148,7 +148,8 @@ def _convert_mistral_chat_message_to_message(
     if role != "assistant":
         msg = f"Expected role to be 'assistant', got {role}"
         raise ValueError(msg)
-    content = cast("str", _message["content"])
+    # Mistral returns None for tool invocations
+    content = _message.get("content", "") or ""
 
     additional_kwargs: dict = {}
     tool_calls = []

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -238,6 +238,58 @@ def test__convert_dict_to_message_tool_call() -> None:
     assert _convert_message_to_mistral_chat_message(expected_output) == message
 
 
+def test__convert_dict_to_message_tool_call_with_null_content() -> None:
+    raw_tool_call = {
+        "id": "ssAbar4Dr",
+        "function": {
+            "arguments": '{"name": "Sally", "hair_color": "green"}',
+            "name": "GenerateUsername",
+        },
+    }
+    message = {"role": "assistant", "content": None, "tool_calls": [raw_tool_call]}
+    result = _convert_mistral_chat_message_to_message(message)
+    expected_output = AIMessage(
+        content="",
+        additional_kwargs={"tool_calls": [raw_tool_call]},
+        tool_calls=[
+            ToolCall(
+                name="GenerateUsername",
+                args={"name": "Sally", "hair_color": "green"},
+                id="ssAbar4Dr",
+                type="tool_call",
+            )
+        ],
+        response_metadata={"model_provider": "mistralai"},
+    )
+    assert result == expected_output
+
+
+def test__convert_dict_to_message_with_missing_content() -> None:
+    raw_tool_call = {
+        "id": "ssAbar4Dr",
+        "function": {
+            "arguments": '{"query": "test search"}',
+            "name": "search",
+        },
+    }
+    message = {"role": "assistant", "tool_calls": [raw_tool_call]}
+    result = _convert_mistral_chat_message_to_message(message)
+    expected_output = AIMessage(
+        content="",
+        additional_kwargs={"tool_calls": [raw_tool_call]},
+        tool_calls=[
+            ToolCall(
+                name="search",
+                args={"query": "test search"},
+                id="ssAbar4Dr",
+                type="tool_call",
+            )
+        ],
+        response_metadata={"model_provider": "mistralai"},
+    )
+    assert result == expected_output
+
+
 def test_custom_token_counting() -> None:
     def token_encoder(text: str) -> list[int]:
         return [1, 2, 3]


### PR DESCRIPTION
## Summary
- Handle null content in tool call responses from Mistral API
- Follow the same pattern as OpenAI and Groq implementations

Fixes #31121

## Description
When Mistral API returns a tool call response, the `content` field is often `null` instead of an empty string. The previous implementation used `cast("str", _message["content"])` which preserved the `None` value, causing Pydantic validation to fail when creating `AIMessage`.

The fix uses `_message.get("content", "") or ""` which:
- Returns empty string if `content` key is missing
- Converts `None` to empty string
- Preserves actual content values

This follows the same pattern used by:
- OpenAI: `libs/partners/openai/langchain_openai/chat_models/base.py:177`
- Groq: `libs/partners/groq/langchain_groq/chat_models.py`

## Test Plan
- [x] Added unit test for null content with tool calls
- [x] Added unit test for missing content key
- [x] All 31 existing tests pass
- [x] Lint checks pass (ruff, mypy)