### PR TITLE
fix(anthropic): ignore null values of caller on tool_use blocks

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -439,7 +439,7 @@ def _format_messages(
                         if (
                             isinstance(message, AIMessage)
                             and (block["id"] in [tc["id"] for tc in message.tool_calls])
-                            and "caller" not in block  # take caller from content
+                            and not block.get("caller")
                         ):
                             overlapping = [
                                 tc
@@ -467,8 +467,8 @@ def _format_messages(
                                 input=args,
                                 id=block["id"],
                             )
-                            if "caller" in block:
-                                tool_use_block["caller"] = block["caller"]
+                            if caller := block.get("caller"):
+                                tool_use_block["caller"] = caller
                             content.append(tool_use_block)
                     elif block["type"] in ("server_tool_use", "mcp_tool_use"):
                         formatted_block = {
@@ -2349,19 +2349,17 @@ class ChatAnthropic(BaseChatModel):
 
         # Remove citations if they are None - introduced in anthropic sdk 0.45
         for block in content:
-            if (
-                isinstance(block, dict)
-                and "citations" in block
-                and block["citations"] is None
-            ):
-                block.pop("citations")
-            if (
-                isinstance(block, dict)
-                and block.get("type") == "thinking"
-                and "text" in block
-                and block["text"] is None
-            ):
-                block.pop("text")
+            if isinstance(block, dict):
+                if "citations" in block and block["citations"] is None:
+                    block.pop("citations")
+                if "caller" in block and block["caller"] is None:
+                    block.pop("caller")
+                if (
+                    block.get("type") == "thinking"
+                    and "text" in block
+                    and block["text"] is None
+                ):
+                    block.pop("text")
 
         llm_output = {
             k: v for k, v in data_dict.items() if k not in ("content", "role", "type")
@@ -3278,6 +3276,8 @@ def _make_message_chunk_from_anthropic_event(
             warnings.warn("Received unexpected tool content block.", stacklevel=2)
 
         content_block = event.content_block.model_dump()
+        if "caller" in content_block and content_block["caller"] is None:
+            content_block.pop("caller")
         content_block["index"] = event.index
         if event.content_block.type == "tool_use":
             if (


### PR DESCRIPTION
If we route through `beta.messages.create`, we can get null values of `caller` on tool use blocks. When these values are passed back in, Anthropic will raise BadRequestError.

To reproduce, add an unrelated beta, e.g., `"betas": ["structured-outputs-2025-11-13"]` to chat model params and run `TestAnthropicStandard::test_agent_loop`:
> anthropic.BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'messages.1.content.1.tool_use.caller: Extra inputs are not permitted'}

Here we drop null values of `caller` from AIMessage content and ignore them on input.