### PR TITLE
chore(langchain): add qwen support in init_chat_model

### DIFF
--- a/libs/langchain/langchain_classic/chat_models/base.py
+++ b/libs/langchain/langchain_classic/chat_models/base.py
@@ -135,13 +135,14 @@ def init_chat_model(
             - `mistralai`               -> [`langchain-mistralai`](https://docs.langchain.com/oss/python/integrations/providers/mistralai)
             - `huggingface`             -> [`langchain-huggingface`](https://docs.langchain.com/oss/python/integrations/providers/huggingface)
             - `groq`                    -> [`langchain-groq`](https://docs.langchain.com/oss/python/integrations/providers/groq)
-            - `ollama`                  -> [`langchain-ollama`](https://docs.langchain.com/oss/python/integrations/providers/ollama)
+            - `ollama`                  -> [`langchain_attempt_infer_model_provider-ollama`](https://docs.langchain.com/oss/python/integrations/providers/ollama)
             - `google_anthropic_vertex` -> [`langchain-google-vertexai`](https://docs.langchain.com/oss/python/integrations/providers/google)
             - `deepseek`                -> [`langchain-deepseek`](https://docs.langchain.com/oss/python/integrations/providers/deepseek)
             - `ibm`                     -> [`langchain-ibm`](https://docs.langchain.com/oss/python/integrations/providers/ibm)
             - `nvidia`                  -> [`langchain-nvidia-ai-endpoints`](https://docs.langchain.com/oss/python/integrations/providers/nvidia)
             - `xai`                     -> [`langchain-xai`](https://docs.langchain.com/oss/python/integrations/providers/xai)
             - `perplexity`              -> [`langchain-perplexity`](https://docs.langchain.com/oss/python/integrations/providers/perplexity)
+            - `qwen`                    -> [`langchain-qwq`](https://docs.langchain.com/oss/python/integrations/chat/qwen)
         configurable_fields: Which model parameters are configurable at runtime:
 
             - `None`: No configurable fields (i.e., a fixed model).
@@ -495,6 +496,11 @@ def _init_chat_model_helper(
         from langchain_perplexity import ChatPerplexity
 
         return ChatPerplexity(model=model, **kwargs)
+    if model_provider == "qwen":
+        _check_pkg("langchain_qwq")
+        from langchain_qwq import ChatQwen
+
+        return ChatQwen(model=model, **kwargs)
     supported = ", ".join(_SUPPORTED_PROVIDERS)
     msg = (
         f"Unsupported {model_provider=}.\n\nSupported model providers are: {supported}"
@@ -523,6 +529,7 @@ _SUPPORTED_PROVIDERS = {
     "ibm",
     "xai",
     "perplexity",
+    "qwen",
 }
 
 
@@ -547,6 +554,8 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
         return "xai"
     if model_name.startswith("sonar"):
         return "perplexity"
+    if model_name.startswith("qwen"):
+        return "qwen"
     return None
 
 

--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -451,6 +451,11 @@ def _init_chat_model_helper(
         from langchain_perplexity import ChatPerplexity
 
         return ChatPerplexity(model=model, **kwargs)
+    if model_provider == "qwen":
+        _check_pkg("langchain_qwq")
+        from langchain_qwq import ChatQwen
+
+        return ChatQwen(model=model, **kwargs)
     if model_provider == "upstage":
         _check_pkg("langchain_upstage")
         from langchain_upstage import ChatUpstage
@@ -483,6 +488,7 @@ _SUPPORTED_PROVIDERS = {
     "xai",
     "perplexity",
     "upstage",
+    "qwen",
 }
 
 
@@ -509,6 +515,8 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
         return "perplexity"
     if model_name.startswith("solar"):
         return "upstage"
+    if model_name.startswith("qwen"):
+        return "qwen"
     return None
 
 

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
@@ -1,0 +1,23 @@
+# libs/test.py
+
+import os
+import pytest
+
+pytest.importorskip("langchain_qwq")
+
+from langchain_classic.chat_models import init_chat_model
+from langchain_qwq import ChatQwen
+
+
+def test_init_chat_model_qwen(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Set a dummy key so ChatQwen's Pydantic validation passes.
+    # We are NOT actually calling the API in this test.
+    monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
+
+    llm = init_chat_model(
+        model="qwen:Qwen/Qwen2.5-72B-Instruct",
+        temperature=0,
+    )
+
+    assert isinstance(llm, ChatQwen)
+    # Important: do NOT call llm.invoke() here, to avoid network calls.

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
@@ -7,6 +7,7 @@ pytest.importorskip("langchain_qwq")
 
 from langchain_classic.chat_models import init_chat_model
 from langchain_qwq import ChatQwen
+from langchain_tests.conftest import CustomPersister, CustomSerializer
 
 
 def test_init_chat_model_qwen(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
@@ -1,16 +1,14 @@
-# libs/test.py
-
-import os
 import pytest
 
 pytest.importorskip("langchain_qwq")
 
-from langchain_classic.chat_models import init_chat_model
+from langchain.chat_models import init_chat_model
 from langchain_qwq import ChatQwen
-from langchain_tests.conftest import CustomPersister, CustomSerializer
 
 
 def test_init_chat_model_qwen(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure init_chat_model wires qwen -> ChatQwen without real network calls."""
+
     # Set a dummy key so ChatQwen's Pydantic validation passes.
     # We are NOT actually calling the API in this test.
     monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
@@ -1,16 +1,14 @@
 import pytest
 
-pytest.importorskip("langchain_qwq")
-
 from langchain.chat_models import init_chat_model
-from langchain_qwq import ChatQwen
+
+langchain_qwq = pytest.importorskip("langchain_qwq")
 
 
-def test_init_chat_model_qwen(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Ensure init_chat_model wires qwen -> ChatQwen without real network calls."""
+def test_init_chat_model_qwen(monkeypatch) -> None:
+    """init_chat_model returns ChatQwen when the qwen provider is used."""
+    from langchain_qwq import ChatQwen
 
-    # Set a dummy key so ChatQwen's Pydantic validation passes.
-    # We are NOT actually calling the API in this test.
     monkeypatch.setenv("DASHSCOPE_API_KEY", "test-key")
 
     llm = init_chat_model(
@@ -19,4 +17,3 @@ def test_init_chat_model_qwen(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     assert isinstance(llm, ChatQwen)
-    # Important: do NOT call llm.invoke() here, to avoid network calls.

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py
@@ -5,7 +5,7 @@ from langchain.chat_models import init_chat_model
 langchain_qwq = pytest.importorskip("langchain_qwq")
 
 
-def test_init_chat_model_qwen(monkeypatch) -> None:
+def test_init_chat_model_qwen(monkeypatch: pytest.MonkeyPatch) -> None:
     """init_chat_model returns ChatQwen when the qwen provider is used."""
     from langchain_qwq import ChatQwen
 

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2166,7 +2166,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Add support for initializing `ChatQwen` via `init_chat_model` using the third-party `langchain-qwq` integration. This wires the `qwen` provider into `init_chat_model` so that users can call `init_chat_model("qwen:Qwen/Qwen2.5-72B-Instruct", ...)` and receive a `ChatQwen` instance when `langchain_qwq` is installed.

Fixes #34183.

Changes:
- Add a `qwen` branch to `_init_chat_model_helper` that checks for `langchain_qwq` and returns `ChatQwen(model=model, **kwargs)`.
- Register `"qwen"` in `_SUPPORTED_PROVIDERS` so `model="qwen:..."` is correctly parsed.
- Add a unit test that verifies `init_chat_model` returns `ChatQwen` when `langchain_qwq` is available, using a dummy `DASHSCOPE_API_KEY` and not making any real network calls.

Testing:
- `pytest libs/langchain_v1/tests/unit_tests/chat_models/test_qwen_init_chat_model.py -k "init_chat_model"`
- `make format`
- `make lint`
- `make test`
