### PR TITLE
chore(infra,openai): make integration tests output verbose

### DIFF
--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -24,7 +24,7 @@ test tests:
 	TIKTOKEN_CACHE_DIR=tiktoken_cache uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -n auto -vvv --timeout 30 $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)


### PR DESCRIPTION
to match anthropic

without this, have to wait until all tests fail to begin debugging / see output

also add timeout since it was missing