### PR TITLE
fix(langchain): shell output multithreading race condition

### DIFF
--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2102,7 +2102,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.1.3"
+version = "1.2.0"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2283,7 +2283,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
If the `stdout` "done marker" arrives before the `stderr` output is enqueued, the method returns early without capturing the `stderr` line.

The two reader threads run independently with no synchronization guaranteeing `stderr` arrives before the done marker. 

In environments with Python 3.10, timing differences can cause the `stdout` marker to win the race, resulting in `<no output>` instead of `[stderr]` error.

Observed as a flaky test on `test_stderr_output_labeling` in CI:

```shell
FAILED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_stderr_output_labeling - AssertionError: assert '[stderr] error' in '<no output>'
```