### PR TITLE
test(openai): switch model from nano to mini when using flex

### DIFF
--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -239,7 +239,7 @@ async def test_openai_abatch_tags(use_responses_api: bool) -> None:
 def test_openai_invoke() -> None:
     """Test invoke tokens from ChatOpenAI."""
     llm = ChatOpenAI(
-        model="gpt-5-nano",
+        model="gpt-5-mini",
         service_tier="flex",  # Also test service_tier
         max_retries=3,  # Add retries for 503 capacity errors
     )
@@ -272,7 +272,7 @@ def test_openai_invoke() -> None:
 def test_stream() -> None:
     """Test streaming tokens from OpenAI."""
     llm = ChatOpenAI(
-        model="gpt-5-nano",
+        model="gpt-5-mini",
         service_tier="flex",  # Also test service_tier
         max_retries=3,  # Add retries for 503 capacity errors
     )
@@ -399,7 +399,7 @@ async def test_astream() -> None:
 @pytest.mark.parametrize("streaming", [False, True])
 def test_flex_usage_responses(streaming: bool) -> None:
     llm = ChatOpenAI(
-        model="gpt-5-nano",
+        model="gpt-5-mini",
         service_tier="flex",
         max_retries=3,
         use_responses_api=True,


### PR DESCRIPTION
Issues with combining flex and nano

```shell
FAILED tests/integration_tests/chat_models/test_base.py::test_openai_invoke - openai.InternalServerError: Error code: 500 - {'error': {'message': 'The server had an error while processing your request. Sorry about that!', 'type': 'server_error', 'param': None, 'code': None}}
FAILED tests/integration_tests/chat_models/test_base.py::test_stream - openai.InternalServerError: Error code: 500 - {'error': {'message': 'The server had an error processing your request. Sorry about that! You can retry your request, or contact us through our help center at help.openai.com if you keep seeing this error. (Please include the request ID req_e726769d95994fd4bccbe55680a35f59 in your email.)', 'type': 'server_error', 'param': None, 'code': None}}
FAILED tests/integration_tests/chat_models/test_base.py::test_flex_usage_responses[False] - openai.InternalServerError: Error code: 500 - {'error': {'message': 'An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID req_935316418319494d8682e4adcd67ab47 in your message.', 'type': 'server_error', 'param': None, 'code': 'server_error'}}
FAILED tests/integration_tests/chat_models/test_base.py::test_flex_usage_responses[True] - openai.APIError: An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID req_f3c164d0d1f045a5a0f5965ab5c253bf in your message.
```