### PR TITLE
fix(openai): handle streaming reasoning tokens.

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -77,6 +77,7 @@ from langchain_core.messages.block_translators.openai import (
     _convert_from_v03_ai_message,
     convert_to_openai_data_block,
 )
+from langchain_core.messages.content import ReasoningContentBlock
 from langchain_core.messages.tool import tool_call_chunk
 from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.openai_tools import (
@@ -372,6 +373,17 @@ def _convert_delta_to_message_chunk(
         if "name" in function_call and function_call["name"] is None:
             function_call["name"] = ""
         additional_kwargs["function_call"] = function_call
+
+    reasoning_content_block : ReasoningContentBlock | None = None
+    if _dict.get("reasoning_content"):
+        reasoning_content_block = ReasoningContentBlock(reasoning=cast(
+            str, _dict.get("reasoning_content") or ""
+        ))
+    elif _dict.get("reasoning"):
+        reasoning_content_block = ReasoningContentBlock(reasoning=cast(
+            str, _dict.get("reasoning") or ""
+        ))
+
     tool_call_chunks = []
     if raw_tool_calls := _dict.get("tool_calls"):
         try:
@@ -392,6 +404,7 @@ def _convert_delta_to_message_chunk(
     if role == "assistant" or default_class == AIMessageChunk:
         return AIMessageChunk(
             content=content,
+            content_blocks=[ reasoning_content_block ] if reasoning_content_block else None,
             additional_kwargs=additional_kwargs,
             id=id_,
             tool_call_chunks=tool_call_chunks,  # type: ignore[arg-type]

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -377,10 +377,12 @@ def _convert_delta_to_message_chunk(
     reasoning_content_block: ReasoningContentBlock | None = None
     if _dict.get("reasoning_content"):
         reasoning_content_block = ReasoningContentBlock(
+            type="reasoning",
             reasoning=cast(str, _dict.get("reasoning_content") or "")
         )
     elif _dict.get("reasoning"):
         reasoning_content_block = ReasoningContentBlock(
+            type="reasoning",
             reasoning=cast(str, _dict.get("reasoning") or "")
         )
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -374,15 +374,15 @@ def _convert_delta_to_message_chunk(
             function_call["name"] = ""
         additional_kwargs["function_call"] = function_call
 
-    reasoning_content_block : ReasoningContentBlock | None = None
+    reasoning_content_block: ReasoningContentBlock | None = None
     if _dict.get("reasoning_content"):
-        reasoning_content_block = ReasoningContentBlock(reasoning=cast(
-            str, _dict.get("reasoning_content") or ""
-        ))
+        reasoning_content_block = ReasoningContentBlock(
+            reasoning=cast(str, _dict.get("reasoning_content") or "")
+        )
     elif _dict.get("reasoning"):
-        reasoning_content_block = ReasoningContentBlock(reasoning=cast(
-            str, _dict.get("reasoning") or ""
-        ))
+        reasoning_content_block = ReasoningContentBlock(
+            reasoning=cast(str, _dict.get("reasoning") or "")
+        )
 
     tool_call_chunks = []
     if raw_tool_calls := _dict.get("tool_calls"):
@@ -405,9 +405,7 @@ def _convert_delta_to_message_chunk(
         return AIMessageChunk(
             content=content,
             content_blocks=(
-                [ reasoning_content_block ]
-                if reasoning_content_block
-                else None
+                [reasoning_content_block] if reasoning_content_block else None
             ),
             additional_kwargs=additional_kwargs,
             id=id_,

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -404,7 +404,11 @@ def _convert_delta_to_message_chunk(
     if role == "assistant" or default_class == AIMessageChunk:
         return AIMessageChunk(
             content=content,
-            content_blocks=[ reasoning_content_block ] if reasoning_content_block else None,
+            content_blocks=(
+                [ reasoning_content_block ]
+                if reasoning_content_block
+                else None
+            ),
             additional_kwargs=additional_kwargs,
             id=id_,
             tool_call_chunks=tool_call_chunks,  # type: ignore[arg-type]

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -377,13 +377,11 @@ def _convert_delta_to_message_chunk(
     reasoning_content_block: ReasoningContentBlock | None = None
     if _dict.get("reasoning_content"):
         reasoning_content_block = ReasoningContentBlock(
-            type="reasoning",
-            reasoning=cast(str, _dict.get("reasoning_content") or "")
+            type="reasoning", reasoning=cast(str, _dict.get("reasoning_content") or "")
         )
     elif _dict.get("reasoning"):
         reasoning_content_block = ReasoningContentBlock(
-            type="reasoning",
-            reasoning=cast(str, _dict.get("reasoning") or "")
+            type="reasoning", reasoning=cast(str, _dict.get("reasoning") or "")
         )
 
     tool_call_chunks = []


### PR DESCRIPTION
This adds the ability to handle reasoning tokens returned from Deepseek like and openai reasoning models. It complements this PR: https://github.com/langchain-ai/langchain/pull/34236

I ran this against llama.cpp running a DeepSeek variant and I'm parsing the results using a CallbackHandler like this:

```python
   # Called once per token (LangChain-level)
    async def on_llm_new_token(self, token : str| list | None, **kwargs):
        if token:
            if isinstance(token, str):
                if self.mode != 2:
                    print(flush=True)
                    print("RESPONDING", flush=True)
                    self.mode = 2
                self.tokens.append(token)
                print(token, end="", flush=True)
            elif isinstance(token, list):
                reasoning : str | None = next((d['reasoning'] for d in token if 'reasoning' in d), None)
                if reasoning:
                    if self.mode != 1:
                        print(flush=True)
                        print("REASONING", flush=True)
                        self.mode=1
                    print(reasoning, end="", flush=True)
```

If someone points me to an appropriate unit test to extend that works in a similar area, I'll update it to check this explicitly.
