### PR TITLE
fix(langchain): Explicitly disable callbacks in `LLMToolSelectorMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
@@ -140,6 +140,10 @@ class LLMToolSelectorMiddleware(AgentMiddleware):
             always_include: Tool names to always include regardless of selection.
 
                 These do not count against the `max_tools` limit.
+            disable_streaming: Whether to disable streaming for the tool selection.
+
+                Defaults to True. If True, the internal tool selection call will
+                not emit events to the parent callback manager.
         """
         super().__init__()
         self.system_prompt = system_prompt

--- a/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
@@ -121,6 +121,7 @@ class LLMToolSelectorMiddleware(AgentMiddleware):
         system_prompt: str = DEFAULT_SYSTEM_PROMPT,
         max_tools: int | None = None,
         always_include: list[str] | None = None,
+        disable_streaming: bool = True,
     ) -> None:
         """Initialize the tool selector.
 
@@ -144,6 +145,7 @@ class LLMToolSelectorMiddleware(AgentMiddleware):
         self.system_prompt = system_prompt
         self.max_tools = max_tools
         self.always_include = always_include or []
+        self.disable_streaming = disable_streaming
 
         if isinstance(model, (BaseChatModel, type(None))):
             self.model: BaseChatModel | None = model
@@ -272,12 +274,22 @@ class LLMToolSelectorMiddleware(AgentMiddleware):
         schema = type_adapter.json_schema()
         structured_model = selection_request.model.with_structured_output(schema)
 
-        response = structured_model.invoke(
-            [
-                {"role": "system", "content": selection_request.system_message},
-                selection_request.last_user_message,
-            ]
-        )
+        if self.disable_streaming:
+            # Explicitly disable callbacks to prevent parent stream leakage
+            response = structured_model.invoke(
+                [
+                    {"role": "system", "content": selection_request.system_message},
+                    selection_request.last_user_message,
+                ],
+                config={"callbacks": []},
+            )
+        else:
+            response = structured_model.invoke(
+                [
+                    {"role": "system", "content": selection_request.system_message},
+                    selection_request.last_user_message,
+                ]
+            )
 
         # Response should be a dict since we're passing a schema (not a Pydantic model class)
         if not isinstance(response, dict):
@@ -303,12 +315,22 @@ class LLMToolSelectorMiddleware(AgentMiddleware):
         schema = type_adapter.json_schema()
         structured_model = selection_request.model.with_structured_output(schema)
 
-        response = await structured_model.ainvoke(
-            [
-                {"role": "system", "content": selection_request.system_message},
-                selection_request.last_user_message,
-            ]
-        )
+        if self.disable_streaming:
+            # Explicitly disable callbacks to prevent parent stream leakage
+            response = await structured_model.ainvoke(
+                [
+                    {"role": "system", "content": selection_request.system_message},
+                    selection_request.last_user_message,
+                ],
+                config={"callbacks": []},
+            )
+        else:
+            response = await structured_model.ainvoke(
+                [
+                    {"role": "system", "content": selection_request.system_message},
+                    selection_request.last_user_message,
+                ]
+            )
 
         # Response should be a dict since we're passing a schema (not a Pydantic model class)
         if not isinstance(response, dict):


### PR DESCRIPTION
Fixes #34139

When using `LLMToolSelectorMiddleware` with stream_mode="messages", the internal tool selection tokens (the JSON output) are leaked into the final user stream. This happens because the internal LLM call inherits the parent's callback manager, which streams every token generated, even those intended only for middleware logic.

This PR introduces a fix to prevent the leakage:

1. Added `disable_streaming` parameter to the middleware init (defaults to `True`) to give users control.
2. Explicitly cleared Callbacks, instead of relying on model.bind(streaming= `False`) which is not respected by all model providers (e.g ChatOllama still leaks callback events) this implementation passes config={"callbacks": []} to the internal invoke and ainvoke calls.

I verified this locally using a reproduction script with ChatOllama (llama3.2).
Before: Output contained mixed internal JSON tokens `({"tools": ...})`.
After: Output is clean and contains only the final response tokens.