### PR TITLE
fix(core): preserve `Field(description=...)` in `@tool` decorator

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -31,6 +31,7 @@ from pydantic import (
     ValidationError,
     validate_arguments,
 )
+from pydantic.fields import FieldInfo
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import ValidationError as ValidationErrorV1
 from pydantic.v1 import validate_arguments as validate_arguments_v1
@@ -100,6 +101,8 @@ def _is_annotated_type(typ: type[Any]) -> bool:
 def _get_annotation_description(arg_type: type) -> str | None:
     """Extract description from an Annotated type.
 
+    Checks for string annotations and FieldInfo objects with descriptions.
+
     Args:
         arg_type: The type to extract description from.
 
@@ -111,6 +114,8 @@ def _get_annotation_description(arg_type: type) -> str | None:
         for annotation in annotated_args[1:]:
             if isinstance(annotation, str):
                 return annotation
+            if isinstance(annotation, FieldInfo) and annotation.description:
+                return annotation.description
     return None
 
 

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -101,7 +101,7 @@ def _is_annotated_type(typ: type[Any]) -> bool:
 def _get_annotation_description(arg_type: type) -> str | None:
     """Extract description from an Annotated type.
 
-    Checks for string annotations and FieldInfo objects with descriptions.
+    Checks for string annotations and `FieldInfo` objects with descriptions.
 
     Args:
         arg_type: The type to extract description from.

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -1408,6 +1408,39 @@ def test_tool_annotated_descriptions() -> None:
     }
 
 
+def test_tool_field_description_preserved() -> None:
+    """Test that Field(description=...) is preserved in @tool decorator."""
+
+    @tool
+    def my_tool(
+        topic: Annotated[str, Field(description="The research topic")],
+        depth: Annotated[int, Field(description="Search depth level")] = 3,
+    ) -> str:
+        """A tool for research."""
+        return f"{topic} at depth {depth}"
+
+    args_schema = _schema(my_tool.args_schema)
+    assert args_schema == {
+        "title": "my_tool",
+        "type": "object",
+        "description": "A tool for research.",
+        "properties": {
+            "topic": {
+                "title": "Topic",
+                "type": "string",
+                "description": "The research topic",
+            },
+            "depth": {
+                "title": "Depth",
+                "type": "integer",
+                "description": "Search depth level",
+                "default": 3,
+            },
+        },
+        "required": ["topic"],
+    }
+
+
 def test_tool_call_input_tool_message_output() -> None:
     tool_call = {
         "name": "structured_api",

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -1409,7 +1409,7 @@ def test_tool_annotated_descriptions() -> None:
 
 
 def test_tool_field_description_preserved() -> None:
-    """Test that Field(description=...) is preserved in @tool decorator."""
+    """Test that `Field(description=...)` is preserved in `@tool` decorator."""
 
     @tool
     def my_tool(


### PR DESCRIPTION
## Summary

Fixes #34247

When using `Annotated[type, Field(description="...")]` syntax with the `@tool` decorator, field descriptions were being lost during schema generation. The `_get_annotation_description()` function only checked for string annotations but not for Pydantic `FieldInfo` objects.

## Changes

- Extended `_get_annotation_description()` to also extract descriptions from `FieldInfo` objects within `Annotated` types
- Added import for `pydantic.fields.FieldInfo`
- Added unit test to verify `Field(description=...)` is preserved

## Why this approach

The fix is minimal and targeted - it extends the existing description extraction logic rather than restructuring the schema generation. This maintains backward compatibility while supporting both annotation styles:

```python
# Both now work correctly:
topic: Annotated[str, "The research topic"]           # existing
topic: Annotated[str, Field(description="...")]       # now fixed
```

## Known limitation

This fix only handles `pydantic.fields.FieldInfo` (Pydantic v2). The v1 compatibility layer (`pydantic.v1.fields.FieldInfo`) is a different class and will not have descriptions extracted. This is intentional:

- Pydantic v1 is deprecated; users should migrate to v2
- The v1 compat layer exists for legacy model migration, not new tool definitions
- Duck-typing on `description` attribute could match unintended objects

If v1 `Field` support is needed, it can be addressed in a follow-up PR with explicit handling.

## Testing

- Added `test_tool_field_description_preserved()` covering required and optional params
- Verified existing `test_tool_annotated_descriptions` still passes
- Lint and type checks pass

---

> [!NOTE]
> This PR was developed with AI agent assistance (Factory/Droid).