### PR TITLE
fix(core): use tool_calls instead of deprecated function_call in get_buffer_string

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -109,6 +109,11 @@ def get_buffer_string(
     Raises:
         ValueError: If an unsupported message type is encountered.
 
+    Note:
+        If a message is an `AIMessage` and contains both tool calls under `tool_calls`
+        and a function call under `additional_kwargs["function_call"]`, only the tool
+        calls will be appended to the string representation.
+
     Example:
         ```python
         from langchain_core import AIMessage, HumanMessage
@@ -143,6 +148,7 @@ def get_buffer_string(
             if m.tool_calls:
                 message += f"{m.tool_calls}"
             elif "function_call" in m.additional_kwargs:
+                # Legacy behavior assumes only one function call per message
                 message += f"{m.additional_kwargs['function_call']}"
         string_messages.append(message)
 

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -139,8 +139,11 @@ def get_buffer_string(
             msg = f"Got unsupported message type: {m}"
             raise ValueError(msg)  # noqa: TRY004
         message = f"{role}: {m.text}"
-        if isinstance(m, AIMessage) and "function_call" in m.additional_kwargs:
-            message += f"{m.additional_kwargs['function_call']}"
+        if isinstance(m, AIMessage):
+            if m.tool_calls:
+                message += f"{m.tool_calls}"
+            elif "function_call" in m.additional_kwargs:
+                message += f"{m.additional_kwargs['function_call']}"
         string_messages.append(message)
 
     return "\n".join(string_messages)

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1537,7 +1537,7 @@ def test_get_buffer_string_with_empty_content() -> None:
 
 
 def test_get_buffer_string_with_tool_calls() -> None:
-    """Test get_buffer_string with modern tool_calls field."""
+    """Test `get_buffer_string` with `tool_calls` field."""
     messages = [
         HumanMessage(content="What's the weather?"),
         AIMessage(
@@ -1560,7 +1560,7 @@ def test_get_buffer_string_with_tool_calls() -> None:
 
 
 def test_get_buffer_string_with_tool_calls_empty_content() -> None:
-    """Test get_buffer_string with tool_calls and empty content."""
+    """Test `get_buffer_string` with `tool_calls` and empty `content`."""
     messages = [
         AIMessage(
             content="",
@@ -1580,7 +1580,7 @@ def test_get_buffer_string_with_tool_calls_empty_content() -> None:
 
 
 def test_get_buffer_string_tool_calls_preferred_over_function_call() -> None:
-    """Test that tool_calls takes precedence over legacy function_call."""
+    """Test that `tool_calls` takes precedence over legacy `function_call`."""
     messages = [
         AIMessage(
             content="Calling tools",


### PR DESCRIPTION
## Summary

Fixes #33970

`get_buffer_string` was only checking for the deprecated `function_call` field in `additional_kwargs`, which modern LLM providers no longer return. This fix updates the function to check for the modern `tool_calls` field first, falling back to `function_call` for legacy compatibility.

## Changes

- Check `AIMessage.tool_calls` first (modern standard)
- Fall back to `additional_kwargs["function_call"]` (legacy support)
- Added 3 unit tests covering tool_calls, empty content, and precedence behavior

## Testing

```python
# Before fix: tool_calls info was lost
msg = AIMessage(content="Hi", tool_calls=[{"name": "search", ...}])
get_buffer_string([msg])  # "AI: Hi" (no tool info)

# After fix: tool_calls are included
get_buffer_string([msg])  # "AI: Hi[{\"name\": \"search\", ...}]"
```

- All existing `get_buffer_string` tests pass
- Legacy `function_call` behavior preserved

---

> [!NOTE]
> This PR was developed with AI agent assistance (Factory/Droid).