### PR TITLE
fix: Secure API key representation in __repr__ method to prevent cred…

### DIFF
--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -409,6 +409,32 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             ).embeddings
         return self
 
+    def __repr__(self) -> str:
+        """Return a string representation with API key redacted."""
+        repr_str = super().__repr__()
+
+        if self.openai_api_key is not None:
+            if hasattr(self.openai_api_key, "get_secret_value"):
+                secret_value = self.openai_api_key.get_secret_value()
+                if secret_value:
+                    if len(secret_value) > 7:
+                        redacted = f"{secret_value[:3]}...{secret_value[-4:]}"
+                    else:
+                        redacted = "***"
+
+                    if "SecretStr('**********')" in repr_str:
+                        repr_str = repr_str.replace(
+                            "SecretStr('**********')", f"SecretStr('{redacted}')"
+                        )
+                    else:
+                        repr_str = repr_str.replace(secret_value, redacted)
+            elif callable(self.openai_api_key):
+                repr_str = repr_str.replace(
+                    f"openai_api_key={self.openai_api_key!r}", "openai_api_key='***'"
+                )
+
+        return repr_str
+
     @property
     def _invocation_params(self) -> dict[str, Any]:
         params: dict = {"model": self.model, **self.model_kwargs}

--- a/libs/partners/openai/langchain_openai/llms/base.py
+++ b/libs/partners/openai/langchain_openai/llms/base.py
@@ -341,6 +341,32 @@ class BaseOpenAI(BaseLLM):
 
         return self
 
+    def __repr__(self) -> str:
+        """Return a string representation with API key redacted."""
+        repr_str = super().__repr__()
+
+        if self.openai_api_key is not None:
+            if hasattr(self.openai_api_key, "get_secret_value"):
+                secret_value = self.openai_api_key.get_secret_value()
+                if secret_value:
+                    if len(secret_value) > 7:
+                        redacted = f"{secret_value[:3]}...{secret_value[-4:]}"
+                    else:
+                        redacted = "***"
+
+                    if "SecretStr('**********')" in repr_str:
+                        repr_str = repr_str.replace(
+                            "SecretStr('**********')", f"SecretStr('{redacted}')"
+                        )
+                    else:
+                        repr_str = repr_str.replace(secret_value, redacted)
+            elif callable(self.openai_api_key):
+                repr_str = repr_str.replace(
+                    f"openai_api_key={self.openai_api_key!r}", "openai_api_key='***'"
+                )
+
+        return repr_str
+
     @property
     def _default_params(self) -> dict[str, Any]:
         """Get the default parameters for calling OpenAI API."""


### PR DESCRIPTION
…ential leakage

- Added custom __repr__ methods to ChatOpenAI, BaseOpenAI, and OpenAIEmbeddings classes
- API keys are now redacted showing only first 3 and last 4 characters (e.g., 'sk-...wxyz')
- Short keys (< 8 chars) are completely masked with '***'
- Callable API key providers are also properly masked
- Added comprehensive unit tests to verify the fix

Fixes langchain-ai/langchain-community#478

(Replace this entire block of text)

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

Thank you for contributing to LangChain! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

  - Examples:
    - fix(anthropic): resolve flag parsing error
    - feat(core): add multi-tenant support
    - test(openai): update API usage tests
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langchain/blob/master/.github/workflows/pr_lint.yml#L15-L33

2. PR description:

  - Write 1-2 sentences summarizing the change.
  - If this PR addresses a specific issue, please include "Fixes #ISSUE_NUMBER" in the description to automatically close the issue when the PR is merged.
  - If there are any breaking changes, please clearly describe them.
  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" inthe description.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

Additional guidelines:

  - We ask that if you use generative AI for your contribution, you include a disclaimer.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files unless or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.
