### PR TITLE
fix: handle missing `tools` key in `LLMToolSelectorMiddleware` response

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
@@ -235,8 +235,8 @@ class LLMToolSelectorMiddleware(AgentMiddleware):
             tools_list = valid_tool_names
         elif not isinstance(response["tools"], list):
             logger.warning(
-                f"Model response 'tools' key is not a list (got {type(response['tools'])}). "
-                "Using all available tools for selection."
+                "Model response 'tools' key is not a list (got %s). Using all available tools for selection.",
+                type(response["tools"]),
             )
             tools_list = valid_tool_names
         else:

--- a/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
@@ -226,7 +226,23 @@ class LLMToolSelectorMiddleware(AgentMiddleware):
         selected_tool_names: list[str] = []
         invalid_tool_selections = []
 
-        for tool_name in response["tools"]:
+        # Handle missing or invalid 'tools' key in response
+        if "tools" not in response:
+            logger.warning(
+                "Model response missing 'tools' key. Using all available tools for selection."
+            )
+            # Use all available tools when response is malformed
+            tools_list = valid_tool_names
+        elif not isinstance(response["tools"], list):
+            logger.warning(
+                f"Model response 'tools' key is not a list (got {type(response['tools'])}). "
+                "Using all available tools for selection."
+            )
+            tools_list = valid_tool_names
+        else:
+            tools_list = response["tools"]
+
+        for tool_name in tools_list:
             if tool_name not in valid_tool_names:
                 invalid_tool_selections.append(tool_name)
                 continue

--- a/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
@@ -235,7 +235,8 @@ class LLMToolSelectorMiddleware(AgentMiddleware):
             tools_list = valid_tool_names
         elif not isinstance(response["tools"], list):
             logger.warning(
-                "Model response 'tools' key is not a list (got %s). Using all available tools for selection.",
+                "Model response 'tools' key is not a list (got %s). "
+                "Using all available tools for selection.",
                 type(response["tools"]),
             )
             tools_list = valid_tool_names

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_selection.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_selection.py
@@ -234,7 +234,7 @@ class TestMaxToolsLimiting:
             )
         )
 
-        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+        model = FakeModel(messages=[AIMessage(content="Done")])
 
         # But max_tools=2, so only first 2 should be used
         tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
@@ -288,7 +288,7 @@ class TestMaxToolsLimiting:
             )
         )
 
-        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+        model = FakeModel(messages=[AIMessage(content="Done")])
 
         # No max_tools specified
         tool_selector = LLMToolSelectorMiddleware(model=tool_selection_model)
@@ -344,7 +344,7 @@ class TestAlwaysInclude:
             )
         )
 
-        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+        model = FakeModel(messages=[AIMessage(content="Done")])
 
         # But send_email is always included
         tool_selector = LLMToolSelectorMiddleware(
@@ -394,7 +394,7 @@ class TestAlwaysInclude:
             )
         )
 
-        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+        model = FakeModel(messages=[AIMessage(content="Done")])
 
         # max_tools=2, but we also have 2 always_include tools
         tool_selector = LLMToolSelectorMiddleware(
@@ -448,7 +448,7 @@ class TestAlwaysInclude:
             )
         )
 
-        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+        model = FakeModel(messages=[AIMessage(content="Done")])
 
         tool_selector = LLMToolSelectorMiddleware(
             max_tools=1,
@@ -512,7 +512,7 @@ class TestDuplicateAndInvalidTools:
             )
         )
 
-        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+        model = FakeModel(messages=[AIMessage(content="Done")])
 
         tool_selector = LLMToolSelectorMiddleware(max_tools=5, model=tool_selection_model)
 
@@ -566,7 +566,7 @@ class TestDuplicateAndInvalidTools:
             )
         )
 
-        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+        model = FakeModel(messages=[AIMessage(content="Done")])
 
         tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
 
@@ -616,7 +616,7 @@ class TestEdgeCases:
             messages=cycle([AIMessage(content="")])
         )
 
-        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+        model = FakeModel(messages=[AIMessage(content="Done")])
 
         tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
 
@@ -659,7 +659,7 @@ class TestEdgeCases:
             messages=cycle([AIMessage(content="")])
         )
 
-        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+        model = FakeModel(messages=[AIMessage(content="Done")])
 
         tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_selection.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_selection.py
@@ -8,7 +8,7 @@ import pytest
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import BaseMessage, HumanMessage
-from langchain_core.runnables import Runnable
+from langchain_core.runnables import Runnable, RunnableLambda
 from langchain_core.tools import BaseTool, tool
 from pydantic import BaseModel
 
@@ -594,3 +594,89 @@ class TestEdgeCases:
         """Test that empty tools list raises an error in schema creation."""
         with pytest.raises(AssertionError, match="tools must be non-empty"):
             _create_tool_selection_response([])
+
+    def test_missing_tools_key_uses_all_tools(self) -> None:
+        """Test that missing 'tools' key in response uses all available tools."""
+        model_requests = []
+
+        @wrap_model_call
+        def trace_model_requests(request, handler):
+            model_requests.append(request)
+            return handler(request)
+
+        # Create a model that returns response without 'tools' key
+        class FakeModelMissingTools(FakeModel):
+            def with_structured_output(
+                self, schema: dict | type[BaseModel], **kwargs: Any
+            ) -> Runnable:
+                # Return a dict without 'tools' key to simulate malformed response
+                return RunnableLambda(lambda _: {})
+
+        tool_selection_model = FakeModelMissingTools(
+            messages=cycle([AIMessage(content="")])
+        )
+
+        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+
+        tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
+
+        agent = create_agent(
+            model=model,
+            tools=[get_weather, search_web, calculate],
+            middleware=[tool_selector, trace_model_requests],
+        )
+
+        # Should not raise KeyError, should use all available tools
+        agent.invoke({"messages": [HumanMessage("test")]})
+
+        # Should have used all available tools (up to max_tools limit)
+        assert len(model_requests) > 0
+        for request in model_requests:
+            # Should have tools, even though response was malformed
+            assert len(request.tools) > 0
+            tool_names = [tool.name for tool in request.tools]
+            # Should use available tools (respecting max_tools=2)
+            assert len(tool_names) <= 2
+
+    def test_invalid_tools_type_uses_all_tools(self) -> None:
+        """Test that invalid 'tools' type in response uses all available tools."""
+        model_requests = []
+
+        @wrap_model_call
+        def trace_model_requests(request, handler):
+            model_requests.append(request)
+            return handler(request)
+
+        # Create a model that returns response with 'tools' as a string instead of list
+        class FakeModelInvalidTools(FakeModel):
+            def with_structured_output(
+                self, schema: dict | type[BaseModel], **kwargs: Any
+            ) -> Runnable:
+                # Return a dict with 'tools' as a string to simulate invalid response
+                return RunnableLambda(lambda _: {"tools": "invalid"})
+
+        tool_selection_model = FakeModelInvalidTools(
+            messages=cycle([AIMessage(content="")])
+        )
+
+        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+
+        tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
+
+        agent = create_agent(
+            model=model,
+            tools=[get_weather, search_web, calculate],
+            middleware=[tool_selector, trace_model_requests],
+        )
+
+        # Should not raise TypeError, should use all available tools
+        agent.invoke({"messages": [HumanMessage("test")]})
+
+        # Should have used all available tools (up to max_tools limit)
+        assert len(model_requests) > 0
+        for request in model_requests:
+            # Should have tools, even though response was malformed
+            assert len(request.tools) > 0
+            tool_names = [tool.name for tool in request.tools]
+            # Should use available tools (respecting max_tools=2)
+            assert len(tool_names) <= 2


### PR DESCRIPTION
Description:
This PR fixes a `KeyError: 'tools'` that occurs in `LLMToolSelectorMiddleware` when the LLM returns a response missing the expected `'tools'` key. The middleware now gracefully handles malformed or incomplete responses by falling back to using all available tools (respecting the `max_tools` limit) instead of raising an exception.
 Problem：

When using `LLMToolSelectorMiddleware` with an agent, the middleware calls an LLM to select relevant tools before the main model invocation. However, if the LLM response doesn't strictly follow the structured output schema (e.g., missing the `'tools'` key or having an invalid type), the code would raise a `KeyError` at line 229 in `tool_selection.py`, interrupting all downstream processing.

This issue occurs intermittently, especially with complex prompts or edge cases where the LLM doesn't strictly adhere to the expected schema format.

Solution:
The fix adds defensive checks in `_process_selection_response()` to handle three scenarios:

1. **Missing 'tools' key**: When the response dictionary doesn't contain a `'tools'` key, the middleware logs a warning and falls back to using all available tools (up to `max_tools` limit).

2. **Invalid 'tools' type**: When the `'tools'` key exists but is not a list, the middleware logs a warning and falls back to using all available tools.

3. **Normal case**: When the response is valid, the existing logic continues to work as before.

This approach ensures backward compatibility while making the middleware more resilient to LLM response variations. The fallback behavior (using all available tools) is reasonable because:
- It maintains functionality even when tool selection fails
- The `max_tools` limit is still respected
- `always_include` tools are still added as expected
- Users get a warning in logs to help debug LLM response issues

Changes

- Modified `_process_selection_response()` in `libs/langchain_v1/langchain/agents/middleware/tool_selection.py` to check for missing or invalid `'tools'` key before accessing it
- Added warning logs when malformed responses are detected
- Added two new test cases to verify the fix handles missing and invalid `'tools'` keys correctly
Issue: Fixes : #34358 
Dependencies: None