### PR TITLE
fix(langchain): handle malformed LLM response in `LLMToolSelectorMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
@@ -223,10 +223,20 @@ class LLMToolSelectorMiddleware(AgentMiddleware):
         request: ModelRequest,
     ) -> ModelRequest:
         """Process the selection response and return filtered `ModelRequest`."""
+        # Validate response structure
+        tools_value = response.get("tools")
+        if tools_value is None or not isinstance(tools_value, list):
+            msg = (
+                "LLM returned invalid response for tool selection. "
+                f"Expected dict with 'tools' list, got: {response!r}. "
+                "Consider using a model with better structured output support."
+            )
+            raise ValueError(msg)
+
         selected_tool_names: list[str] = []
         invalid_tool_selections = []
 
-        for tool_name in response["tools"]:
+        for tool_name in tools_value:
             if tool_name not in valid_tool_names:
                 invalid_tool_selections.append(tool_name)
                 continue


### PR DESCRIPTION
## Summary

- Add validation in `_process_selection_response` to check that the LLM response contains a valid `tools` list before processing
- Raise a clear `ValueError` with actionable guidance instead of cryptic `KeyError: 'tools'`
- Add unit tests for malformed response handling (missing key and null value cases)

## Root Cause

When using `with_structured_output()`, some models may not strictly follow the schema and could return responses without the expected `tools` key. The previous code directly accessed `response["tools"]` without validation, causing intermittent `KeyError` failures.

## Test Plan

- [x] Added `test_malformed_response_missing_tools_key` - verifies `ValueError` is raised when `tools` key is missing
- [x] Added `test_malformed_response_null_tools` - verifies `ValueError` is raised when `tools` is `None`
- [x] All 12 existing tests pass
- [x] Lint checks pass

Fixes #34358