### PR TITLE
fix(openai): Correct hyperlinks in documentation of function with_structured_output

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3058,16 +3058,16 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
 
                 - `'json_schema'`:
                     Uses OpenAI's [Structured Output API](https://platform.openai.com/docs/guides/structured-outputs).
-                    See the docs for a list of supported models.
+                    See the docs for [supported models](https://platform.openai.com/docs/guides/structured-outputs#supported-models).
                 - `'function_calling'`:
                     Uses OpenAI's [tool-calling API](https://platform.openai.com/docs/guides/function-calling)
                     (formerly called function calling).
                 - `'json_mode'`:
-                    Uses OpenAI's [JSON mode](https://platform.openai.com/docs/guides/structured-outputs/json-mode).
+                    Uses OpenAI's [JSON mode](https://platform.openai.com/docs/guides/structured-outputs#json-mode).
                     Note that if using JSON mode then you must include instructions for
                     formatting the output into the desired schema into the model call.
 
-                Learn more about the [differences between methods](https://platform.openai.com/docs/guides/structured-outputs/function-calling-vs-response-format).
+                Learn more about the [differences between methods](https://platform.openai.com/docs/guides/structured-outputs#function-calling-vs-response-format).
 
             include_raw:
                 If `False` then only the parsed structured output is returned.
@@ -3087,7 +3087,7 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
                 - `True`:
                     Model output is guaranteed to exactly match the schema.
                     The input schema will also be validated according to the
-                    [supported schemas](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas?api-mode=responses#supported-schemas).
+                    [supported schemas](https://platform.openai.com/docs/guides/structured-outputs#supported-schemas).
                 - `False`:
                     Input schema will not be validated and model output will not be
                     validated.
@@ -3179,7 +3179,7 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
             specify any Field metadata (like min/max constraints) and fields cannot
             have default values.
 
-            See [all constraints](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas).
+            See [all constraints](https://platform.openai.com/docs/guides/structured-outputs#supported-schemas).
 
             ```python
             from langchain_openai import ChatOpenAI


### PR DESCRIPTION
Just a small fix of some broken hyperlinks in the documentation of the function `langchain_openai/chat_models/base.py#with_structured_output` and a rephrase of the reference to supported models.
