### PR TITLE
fix(core): Add config isolation utilities to prevent middleware streaming leaks

### DIFF
--- a/libs/core/langchain_core/runnables/__init__.py
+++ b/libs/core/langchain_core/runnables/__init__.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
         get_config_list,
         patch_config,
         run_in_executor,
+        isolate_config,
+        aisolate_config,
     )
     from langchain_core.runnables.fallbacks import RunnableWithFallbacks
     from langchain_core.runnables.history import RunnableWithMessageHistory
@@ -89,6 +91,8 @@ __all__ = (
     "get_config_list",
     "patch_config",
     "run_in_executor",
+    "isolate_config",
+    "aisolate_config",
 )
 
 _dynamic_imports = {

--- a/libs/core/langchain_core/runnables/__init__.py
+++ b/libs/core/langchain_core/runnables/__init__.py
@@ -36,12 +36,12 @@ if TYPE_CHECKING:
     from langchain_core.runnables.branch import RunnableBranch
     from langchain_core.runnables.config import (
         RunnableConfig,
+        aisolate_config,
         ensure_config,
         get_config_list,
+        isolate_config,
         patch_config,
         run_in_executor,
-        isolate_config,
-        aisolate_config,
     )
     from langchain_core.runnables.fallbacks import RunnableWithFallbacks
     from langchain_core.runnables.history import RunnableWithMessageHistory
@@ -86,13 +86,13 @@ __all__ = (
     "RunnableWithMessageHistory",
     "aadd",
     "add",
+    "aisolate_config",
     "chain",
     "ensure_config",
     "get_config_list",
+    "isolate_config",
     "patch_config",
     "run_in_executor",
-    "isolate_config",
-    "aisolate_config",
 )
 
 _dynamic_imports = {

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 import asyncio
 import uuid
 import warnings
-from collections.abc import Awaitable, Callable, Generator, Iterable, Iterator, Sequence
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Generator,
+    Iterable,
+    Iterator,
+    Sequence,
+)
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import Context, ContextVar, Token, copy_context
@@ -12,8 +20,6 @@ from functools import partial
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncIterator,
-    Iterator,
     ParamSpec,
     TypeVar,
     cast,

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -1,5 +1,4 @@
 """Configuration utilities for Runnables."""
-
 from __future__ import annotations
 
 import asyncio
@@ -7,13 +6,14 @@ import uuid
 import warnings
 from collections.abc import Awaitable, Callable, Generator, Iterable, Iterator, Sequence
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
-from contextlib import contextmanager, asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import Context, ContextVar, Token, copy_context
 from functools import partial
-from typing import Iterator, AsyncIterator
 from typing import (
     TYPE_CHECKING,
     Any,
+    AsyncIterator,
+    Iterator,
     ParamSpec,
     TypeVar,
     cast,

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -7,9 +7,10 @@ import uuid
 import warnings
 from collections.abc import Awaitable, Callable, Generator, Iterable, Iterator, Sequence
 from concurrent.futures import Executor, Future, ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import contextmanager, asynccontextmanager
 from contextvars import Context, ContextVar, Token, copy_context
 from functools import partial
+from typing import Iterator, AsyncIterator
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -611,3 +612,75 @@ async def run_in_executor(
         )
 
     return await asyncio.get_running_loop().run_in_executor(executor_or_config, wrapper)
+
+@contextmanager
+def isolate_config() -> Iterator[None]:
+    """Context manager to isolate runnable config from parent context.
+
+    When making model calls inside callbacks, middleware hooks, or other nested
+    contexts, the calls may unexpectedly inherit parent streaming callbacks via
+    the `var_child_runnable_config` context variable. This causes tokens to
+    "leak" into the parent's stream output.
+
+    This context manager temporarily clears the inherited config context,
+    ensuring that model calls within do not inherit parent callbacks.
+
+    Example:
+        .. code-block:: python
+
+            from langchain_core.runnables import isolate_config
+
+            class MyMiddleware(AgentMiddleware):
+                def before_model(self, state, runtime):
+                    with isolate_config():
+                        # This call won't stream to the parent
+                        response = self.model.invoke("Internal query")
+                    return None
+
+    Note:
+        After exiting the context, the original config context is restored.
+
+    .. versionadded:: 0.3.x
+    """
+    token = var_child_runnable_config.set(None)
+    try:
+        yield
+    finally:
+        var_child_runnable_config.reset(token)
+
+
+@asynccontextmanager
+async def aisolate_config() -> AsyncIterator[None]:
+    """Async context manager to isolate runnable config from parent context.
+
+    This is the async version of :func:`isolate_config`. Use this when making
+    async model calls inside middleware or callbacks that should not inherit
+    parent streaming callbacks.
+
+    When using `astream()` on an agent, any model calls made in middleware
+    hooks (like `abefore_model()`) will inherit the streaming callbacks,
+    causing their tokens to appear in the parent stream. This context manager
+    prevents that behavior.
+
+    Example:
+        .. code-block:: python
+
+            from langchain_core.runnables import aisolate_config
+
+            class MyMiddleware(AgentMiddleware):
+                async def abefore_model(self, state, runtime):
+                    async with aisolate_config():
+                        # This call won't stream to the parent
+                        response = await self.model.ainvoke("Internal query")
+                    return None
+
+    Note:
+        After exiting the context, the original config context is restored.
+
+    .. versionadded:: 0.3.x
+    """
+    token = var_child_runnable_config.set(None)
+    try:
+        yield
+    finally:
+        var_child_runnable_config.reset(token)

--- a/libs/core/tests/unit_tests/runnables/test_config_isolation.py
+++ b/libs/core/tests/unit_tests/runnables/test_config_isolation.py
@@ -1,0 +1,146 @@
+"""Tests for config isolation utilities."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from langchain_core.runnables.config import (
+    var_child_runnable_config,
+    isolate_config,
+    aisolate_config,
+    RunnableConfig,
+)
+
+
+class TestIsolateConfig:
+    """Tests for isolate_config context manager."""
+
+    def test_isolate_config_clears_context(self) -> None:
+        """Test that isolate_config clears the parent config context."""
+        # Setup: set a parent config with callbacks
+        mock_callback = MagicMock()
+        parent_config: RunnableConfig = {
+            "callbacks": [mock_callback],
+            "tags": ["parent-tag"],
+            "metadata": {"source": "parent"},
+        }
+        var_child_runnable_config.set(parent_config)
+
+        # Verify parent config is set
+        assert var_child_runnable_config.get() == parent_config
+
+        # Act: enter isolated context
+        with isolate_config():
+            # Inside isolated context, config should be None
+            inner_config = var_child_runnable_config.get()
+            assert inner_config is None
+
+        # After exiting, parent config should be restored
+        restored_config = var_child_runnable_config.get()
+        assert restored_config == parent_config
+
+    def test_isolate_config_restores_on_exception(self) -> None:
+        """Test that isolate_config restores context even on exception."""
+        parent_config: RunnableConfig = {"tags": ["test"]}
+        var_child_runnable_config.set(parent_config)
+
+        with pytest.raises(ValueError, match="test error"):
+            with isolate_config():
+                assert var_child_runnable_config.get() is None
+                raise ValueError("test error")
+
+        # Config should still be restored
+        assert var_child_runnable_config.get() == parent_config
+
+    def test_isolate_config_with_no_parent(self) -> None:
+        """Test isolate_config when there's no parent config."""
+        # Ensure no parent config
+        var_child_runnable_config.set(None)
+
+        with isolate_config():
+            assert var_child_runnable_config.get() is None
+
+        # Should remain None
+        assert var_child_runnable_config.get() is None
+
+    def test_nested_isolate_config(self) -> None:
+        """Test nested isolate_config contexts."""
+        outer_config: RunnableConfig = {"tags": ["outer"]}
+        var_child_runnable_config.set(outer_config)
+
+        with isolate_config():
+            assert var_child_runnable_config.get() is None
+
+            # Set a new config inside isolated context
+            inner_config: RunnableConfig = {"tags": ["inner"]}
+            var_child_runnable_config.set(inner_config)
+
+            with isolate_config():
+                # Nested isolation should also clear
+                assert var_child_runnable_config.get() is None
+
+            # Inner config should be restored after nested isolation
+            # Note: this tests the token-based reset behavior
+
+        # Outer config should be restored
+        assert var_child_runnable_config.get() == outer_config
+
+
+class TestAisolateConfig:
+    """Tests for aisolate_config async context manager."""
+
+    @pytest.mark.asyncio
+    async def test_aisolate_config_clears_context(self) -> None:
+        """Test that aisolate_config clears the parent config context."""
+        mock_callback = MagicMock()
+        parent_config: RunnableConfig = {
+            "callbacks": [mock_callback],
+            "tags": ["parent-tag"],
+        }
+        var_child_runnable_config.set(parent_config)
+
+        async with aisolate_config():
+            inner_config = var_child_runnable_config.get()
+            assert inner_config is None
+
+        restored_config = var_child_runnable_config.get()
+        assert restored_config == parent_config
+
+    @pytest.mark.asyncio
+    async def test_aisolate_config_restores_on_exception(self) -> None:
+        """Test that aisolate_config restores context even on exception."""
+        parent_config: RunnableConfig = {"tags": ["test"]}
+        var_child_runnable_config.set(parent_config)
+
+        with pytest.raises(ValueError, match="async test error"):
+            async with aisolate_config():
+                assert var_child_runnable_config.get() is None
+                raise ValueError("async test error")
+
+        assert var_child_runnable_config.get() == parent_config
+
+    @pytest.mark.asyncio
+    async def test_aisolate_config_with_no_parent(self) -> None:
+        """Test aisolate_config when there's no parent config."""
+        var_child_runnable_config.set(None)
+
+        async with aisolate_config():
+            assert var_child_runnable_config.get() is None
+
+        assert var_child_runnable_config.get() is None
+
+    @pytest.mark.asyncio
+    async def test_aisolate_config_with_await(self) -> None:
+        """Test aisolate_config with actual async operations."""
+        import asyncio
+
+        parent_config: RunnableConfig = {"callbacks": [MagicMock()]}
+        var_child_runnable_config.set(parent_config)
+
+        async with aisolate_config():
+            # Simulate async model call
+            await asyncio.sleep(0.01)
+            assert var_child_runnable_config.get() is None
+            await asyncio.sleep(0.01)
+            assert var_child_runnable_config.get() is None
+
+        assert var_child_runnable_config.get() == parent_config


### PR DESCRIPTION
## Description

This PR adds `isolate_config()` and `aisolate_config()` context managers to prevent model calls in middleware from unexpectedly inheriting parent streaming callbacks.

### Problem

When making language model calls (e.g., `model.ainvoke()`) inside agent middleware hooks like `abefore_model()`, the model tokens unexpectedly stream to the parent agent's output. 

This happens because LangChain's `ensure_config()` function automatically inherits context variables from `var_child_runnable_config` (defined in `langchain_core/runnables/config.py`), which includes streaming callback handlers. When an agent is invoked with `astream()`, any model calls in middleware inherit these streaming callbacks, causing their output to leak into the agent stream.

**Reproduction:**

```python
class TestMiddleware(AgentMiddleware):
    def __init__(self):
        self.model = ChatOpenAI()
    
    async def abefore_model(self, state, runtime):
        # This leaks into the parent stream ❌
        response = await self.model.ainvoke("What's the capital of France?")
        return None

agent = create_agent(model=ChatOpenAI(), middleware=[TestMiddleware()])
async for event in agent.astream({"messages": [...]}, stream_mode=["messages"]):
    # Unexpectedly receives tokens from TestMiddleware's model call
    print(event)