### PR TITLE
fix(openai): rely on langchain-core for setting chunk_position

### DIFF
--- a/libs/partners/deepseek/uv.lock
+++ b/libs/partners/deepseek/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.1.1"
+version = "1.2.2"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -477,7 +477,7 @@ typing = [{ name = "mypy", specifier = ">=1.10.0,<2.0.0" }]
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.0"
+version = "1.1.4"
 source = { editable = "../openai" }
 dependencies = [
     { name = "langchain-core" },
@@ -527,7 +527,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.0.2"
+version = "1.1.1"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1107,8 +1107,6 @@ class BaseChatOpenAI(BaseChatModel):
                 generation_info["system_fingerprint"] = system_fingerprint
             if service_tier := chunk.get("service_tier"):
                 generation_info["service_tier"] = service_tier
-            if isinstance(message_chunk, AIMessageChunk):
-                message_chunk.chunk_position = "last"
 
         logprobs = choice.get("logprobs")
         if logprobs:

--- a/libs/partners/xai/uv.lock
+++ b/libs/partners/xai/uv.lock
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.1.1"
+version = "1.2.2"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -681,7 +681,7 @@ typing = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.0"
+version = "1.1.4"
 source = { editable = "../openai" }
 dependencies = [
     { name = "langchain-core" },
@@ -731,7 +731,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.0.2"
+version = "1.1.1"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Better to rely on core for this (core emits a final chunk with `chunk_position="last"` if it's missing)
- When `stream_usage` is enabled, we are currently setting `chunk_position="last"` on the wrong chunk
- Behavior around this may vary with child classes of BaseChatOpenAI