### PR TITLE
fix(core): defer persisting traces for iterator inputs

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -2267,6 +2267,8 @@ class Runnable(ABC, Generic[Input, Output]):
         ],
         config: RunnableConfig | None,
         run_type: str | None = None,
+        *,
+        defers_inputs: bool = False,
         **kwargs: Any | None,
     ) -> Iterator[Output]:
         """Transform a stream with config.
@@ -2293,7 +2295,7 @@ class Runnable(ABC, Generic[Input, Output]):
             run_type=run_type,
             name=config.get("run_name") or self.get_name(),
             run_id=config.pop("run_id", None),
-            defers_inputs=True,
+            defers_inputs=defers_inputs,
         )
         try:
             child_config = patch_config(config, callbacks=run_manager.get_child())
@@ -2365,6 +2367,8 @@ class Runnable(ABC, Generic[Input, Output]):
         ],
         config: RunnableConfig | None,
         run_type: str | None = None,
+        *,
+        defers_inputs: bool = False,
         **kwargs: Any | None,
     ) -> AsyncIterator[Output]:
         """Transform a stream with config.
@@ -2391,7 +2395,7 @@ class Runnable(ABC, Generic[Input, Output]):
             run_type=run_type,
             name=config.get("run_name") or self.get_name(),
             run_id=config.pop("run_id", None),
-            defers_inputs=True,
+            defers_inputs=defers_inputs,
         )
         try:
             child_config = patch_config(config, callbacks=run_manager.get_child())
@@ -4325,6 +4329,7 @@ class RunnableGenerator(Runnable[Input, Output]):
             input,
             self._transform,  # type: ignore[arg-type]
             config,
+            defers_inputs=True,
             **kwargs,
         )
 
@@ -4358,7 +4363,7 @@ class RunnableGenerator(Runnable[Input, Output]):
             raise NotImplementedError(msg)
 
         return self._atransform_stream_with_config(
-            input, self._atransform, config, **kwargs
+            input, self._atransform, config, defers_inputs=True, **kwargs
         )
 
     @override

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -2293,6 +2293,7 @@ class Runnable(ABC, Generic[Input, Output]):
             run_type=run_type,
             name=config.get("run_name") or self.get_name(),
             run_id=config.pop("run_id", None),
+            defers_inputs=True,
         )
         try:
             child_config = patch_config(config, callbacks=run_manager.get_child())
@@ -2390,6 +2391,7 @@ class Runnable(ABC, Generic[Input, Output]):
             run_type=run_type,
             name=config.get("run_name") or self.get_name(),
             run_id=config.pop("run_id", None),
+            defers_inputs=True,
         )
         try:
             child_config = patch_config(config, callbacks=run_manager.get_child())

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -2267,8 +2267,6 @@ class Runnable(ABC, Generic[Input, Output]):
         ],
         config: RunnableConfig | None,
         run_type: str | None = None,
-        *,
-        defers_inputs: bool = False,
         **kwargs: Any | None,
     ) -> Iterator[Output]:
         """Transform a stream with config.
@@ -2279,6 +2277,9 @@ class Runnable(ABC, Generic[Input, Output]):
         Use this to implement `stream` or `transform` in `Runnable` subclasses.
 
         """
+        # Extract defers_inputs from kwargs if present
+        defers_inputs = kwargs.pop("defers_inputs", False)
+
         # tee the input so we can iterate over it twice
         input_for_tracing, input_for_transform = tee(inputs, 2)
         # Start the input iterator to ensure the input Runnable starts before this one
@@ -2367,8 +2368,6 @@ class Runnable(ABC, Generic[Input, Output]):
         ],
         config: RunnableConfig | None,
         run_type: str | None = None,
-        *,
-        defers_inputs: bool = False,
         **kwargs: Any | None,
     ) -> AsyncIterator[Output]:
         """Transform a stream with config.
@@ -2379,6 +2378,9 @@ class Runnable(ABC, Generic[Input, Output]):
         Use this to implement `astream` or `atransform` in `Runnable` subclasses.
 
         """
+        # Extract defers_inputs from kwargs if present
+        defers_inputs = kwargs.pop("defers_inputs", False)
+
         # tee the input so we can iterate over it twice
         input_for_tracing, input_for_transform = atee(inputs, 2)
         # Start the input iterator to ensure the input Runnable starts before this one

--- a/libs/core/langchain_core/tracers/langchain.py
+++ b/libs/core/langchain_core/tracers/langchain.py
@@ -276,15 +276,28 @@ class LangChainTracer(BaseTracer):
         """Process the Chain Run upon start."""
         if run.parent_run_id is None:
             run.reference_example_id = self.example_id
-        self._persist_run_single(run)
+        # Skip persisting if inputs are deferred (e.g., iterator/generator inputs).
+        # The run will be posted when _on_chain_end is called with realized inputs.
+        if not run.extra.get("defers_inputs"):
+            self._persist_run_single(run)
 
     def _on_chain_end(self, run: Run) -> None:
         """Process the Chain Run."""
-        self._update_run_single(run)
+        # If inputs were deferred, persist (POST) the run now that inputs are realized.
+        # Otherwise, update (PATCH) the existing run.
+        if run.extra.get("defers_inputs"):
+            self._persist_run_single(run)
+        else:
+            self._update_run_single(run)
 
     def _on_chain_error(self, run: Run) -> None:
         """Process the Chain Run upon error."""
-        self._update_run_single(run)
+        # If inputs were deferred, persist (POST) the run now that inputs are realized.
+        # Otherwise, update (PATCH) the existing run.
+        if run.extra.get("defers_inputs"):
+            self._persist_run_single(run)
+        else:
+            self._update_run_single(run)
 
     def _on_tool_start(self, run: Run) -> None:
         """Process the Tool Run upon start."""

--- a/libs/core/tests/unit_tests/tracers/test_langchain.py
+++ b/libs/core/tests/unit_tests/tracers/test_langchain.py
@@ -166,7 +166,7 @@ def test_on_chain_start_skips_persist_when_defers_inputs() -> None:
 
     persist_called = False
 
-    def mock_persist(r: Run) -> None:
+    def mock_persist() -> None:
         nonlocal persist_called
         persist_called = True
 
@@ -195,7 +195,7 @@ def test_on_chain_start_persists_when_not_defers_inputs() -> None:
 
     persist_called = False
 
-    def mock_persist(r: Run) -> None:
+    def mock_persist() -> None:
         nonlocal persist_called
         persist_called = True
 
@@ -227,11 +227,11 @@ def test_on_chain_end_persists_when_defers_inputs() -> None:
     persist_called = False
     update_called = False
 
-    def mock_persist(r: Run) -> None:
+    def mock_persist() -> None:
         nonlocal persist_called
         persist_called = True
 
-    def mock_update(r: Run) -> None:
+    def mock_update() -> None:
         nonlocal update_called
         update_called = True
 
@@ -265,11 +265,11 @@ def test_on_chain_end_updates_when_not_defers_inputs() -> None:
     persist_called = False
     update_called = False
 
-    def mock_persist(r: Run) -> None:
+    def mock_persist() -> None:
         nonlocal persist_called
         persist_called = True
 
-    def mock_update(r: Run) -> None:
+    def mock_update() -> None:
         nonlocal update_called
         update_called = True
 
@@ -305,11 +305,11 @@ def test_on_chain_error_persists_when_defers_inputs() -> None:
     persist_called = False
     update_called = False
 
-    def mock_persist(r: Run) -> None:
+    def mock_persist() -> None:
         nonlocal persist_called
         persist_called = True
 
-    def mock_update(r: Run) -> None:
+    def mock_update() -> None:
         nonlocal update_called
         update_called = True
 
@@ -343,11 +343,11 @@ def test_on_chain_error_updates_when_not_defers_inputs() -> None:
     persist_called = False
     update_called = False
 
-    def mock_persist(r: Run) -> None:
+    def mock_persist() -> None:
         nonlocal persist_called
         persist_called = True
 
-    def mock_update(r: Run) -> None:
+    def mock_update() -> None:
         nonlocal update_called
         update_called = True
 

--- a/libs/core/tests/unit_tests/tracers/test_langchain.py
+++ b/libs/core/tests/unit_tests/tracers/test_langchain.py
@@ -145,3 +145,218 @@ def test_correct_get_tracer_project(
         )
         tracer.wait_for_futures()
         assert projects == [expected_project_name]
+
+
+def test_on_chain_start_skips_persist_when_defers_inputs() -> None:
+    """Test that _on_chain_start skips persist when defers_inputs is set."""
+    client = unittest.mock.MagicMock(spec=Client)
+    client.tracing_queue = None
+    tracer = LangChainTracer(client=client)
+
+    run_id = UUID("9d878ab3-e5ca-4218-aef6-44cbdc90160a")
+    # Pass defers_inputs=True to signal deferred inputs
+    tracer.on_chain_start(
+        {"name": "test_chain"},
+        {"input": ""},
+        run_id=run_id,
+        defers_inputs=True,
+    )
+
+    run = tracer.run_map[str(run_id)]
+
+    persist_called = False
+
+    def mock_persist(r: Run) -> None:
+        nonlocal persist_called
+        persist_called = True
+
+    with unittest.mock.patch.object(tracer, "_persist_run_single", mock_persist):
+        tracer._on_chain_start(run)
+
+    # Should NOT call persist when defers_inputs is set
+    assert not persist_called
+
+
+def test_on_chain_start_persists_when_not_defers_inputs() -> None:
+    """Test that _on_chain_start persists when defers_inputs is not set."""
+    client = unittest.mock.MagicMock(spec=Client)
+    client.tracing_queue = None
+    tracer = LangChainTracer(client=client)
+
+    run_id = UUID("9d878ab3-e5ca-4218-aef6-44cbdc90160a")
+    # Normal chain start without defers_inputs
+    tracer.on_chain_start(
+        {"name": "test_chain"},
+        {"input": "hello"},
+        run_id=run_id,
+    )
+
+    run = tracer.run_map[str(run_id)]
+
+    persist_called = False
+
+    def mock_persist(r: Run) -> None:
+        nonlocal persist_called
+        persist_called = True
+
+    with unittest.mock.patch.object(tracer, "_persist_run_single", mock_persist):
+        tracer._on_chain_start(run)
+
+    # Should call persist when defers_inputs is not set
+    assert persist_called
+
+
+def test_on_chain_end_persists_when_defers_inputs() -> None:
+    """Test that _on_chain_end calls persist (POST) when defers_inputs is set."""
+    client = unittest.mock.MagicMock(spec=Client)
+    client.tracing_queue = None
+    tracer = LangChainTracer(client=client)
+
+    run_id = UUID("9d878ab3-e5ca-4218-aef6-44cbdc90160a")
+    tracer.on_chain_start(
+        {"name": "test_chain"},
+        {"input": ""},
+        run_id=run_id,
+        defers_inputs=True,
+    )
+
+    run = tracer.run_map[str(run_id)]
+    run.outputs = {"output": "result"}
+    run.inputs = {"input": "realized input"}
+
+    persist_called = False
+    update_called = False
+
+    def mock_persist(r: Run) -> None:
+        nonlocal persist_called
+        persist_called = True
+
+    def mock_update(r: Run) -> None:
+        nonlocal update_called
+        update_called = True
+
+    with (
+        unittest.mock.patch.object(tracer, "_persist_run_single", mock_persist),
+        unittest.mock.patch.object(tracer, "_update_run_single", mock_update),
+    ):
+        tracer._on_chain_end(run)
+
+    # Should call persist (POST), not update (PATCH) for deferred inputs
+    assert persist_called
+    assert not update_called
+
+
+def test_on_chain_end_updates_when_not_defers_inputs() -> None:
+    """Test that _on_chain_end calls update (PATCH) when defers_inputs is not set."""
+    client = unittest.mock.MagicMock(spec=Client)
+    client.tracing_queue = None
+    tracer = LangChainTracer(client=client)
+
+    run_id = UUID("9d878ab3-e5ca-4218-aef6-44cbdc90160a")
+    tracer.on_chain_start(
+        {"name": "test_chain"},
+        {"input": "hello"},
+        run_id=run_id,
+    )
+
+    run = tracer.run_map[str(run_id)]
+    run.outputs = {"output": "result"}
+
+    persist_called = False
+    update_called = False
+
+    def mock_persist(r: Run) -> None:
+        nonlocal persist_called
+        persist_called = True
+
+    def mock_update(r: Run) -> None:
+        nonlocal update_called
+        update_called = True
+
+    with (
+        unittest.mock.patch.object(tracer, "_persist_run_single", mock_persist),
+        unittest.mock.patch.object(tracer, "_update_run_single", mock_update),
+    ):
+        tracer._on_chain_end(run)
+
+    # Should call update (PATCH), not persist (POST) for normal inputs
+    assert not persist_called
+    assert update_called
+
+
+def test_on_chain_error_persists_when_defers_inputs() -> None:
+    """Test that _on_chain_error calls persist (POST) when defers_inputs is set."""
+    client = unittest.mock.MagicMock(spec=Client)
+    client.tracing_queue = None
+    tracer = LangChainTracer(client=client)
+
+    run_id = UUID("9d878ab3-e5ca-4218-aef6-44cbdc90160a")
+    tracer.on_chain_start(
+        {"name": "test_chain"},
+        {"input": ""},
+        run_id=run_id,
+        defers_inputs=True,
+    )
+
+    run = tracer.run_map[str(run_id)]
+    run.error = "Test error"
+    run.inputs = {"input": "realized input"}
+
+    persist_called = False
+    update_called = False
+
+    def mock_persist(r: Run) -> None:
+        nonlocal persist_called
+        persist_called = True
+
+    def mock_update(r: Run) -> None:
+        nonlocal update_called
+        update_called = True
+
+    with (
+        unittest.mock.patch.object(tracer, "_persist_run_single", mock_persist),
+        unittest.mock.patch.object(tracer, "_update_run_single", mock_update),
+    ):
+        tracer._on_chain_error(run)
+
+    # Should call persist (POST), not update (PATCH) for deferred inputs
+    assert persist_called
+    assert not update_called
+
+
+def test_on_chain_error_updates_when_not_defers_inputs() -> None:
+    """Test that _on_chain_error calls update (PATCH) when defers_inputs is not set."""
+    client = unittest.mock.MagicMock(spec=Client)
+    client.tracing_queue = None
+    tracer = LangChainTracer(client=client)
+
+    run_id = UUID("9d878ab3-e5ca-4218-aef6-44cbdc90160a")
+    tracer.on_chain_start(
+        {"name": "test_chain"},
+        {"input": "hello"},
+        run_id=run_id,
+    )
+
+    run = tracer.run_map[str(run_id)]
+    run.error = "Test error"
+
+    persist_called = False
+    update_called = False
+
+    def mock_persist(r: Run) -> None:
+        nonlocal persist_called
+        persist_called = True
+
+    def mock_update(r: Run) -> None:
+        nonlocal update_called
+        update_called = True
+
+    with (
+        unittest.mock.patch.object(tracer, "_persist_run_single", mock_persist),
+        unittest.mock.patch.object(tracer, "_update_run_single", mock_update),
+    ):
+        tracer._on_chain_error(run)
+
+    # Should call update (PATCH), not persist (POST) for normal inputs
+    assert not persist_called
+    assert update_called

--- a/libs/core/tests/unit_tests/tracers/test_langchain.py
+++ b/libs/core/tests/unit_tests/tracers/test_langchain.py
@@ -195,7 +195,7 @@ def test_on_chain_start_persists_when_not_defers_inputs() -> None:
 
     persist_called = False
 
-    def mock_persist() -> None:
+    def mock_persist(_: Any) -> None:
         nonlocal persist_called
         persist_called = True
 
@@ -227,11 +227,11 @@ def test_on_chain_end_persists_when_defers_inputs() -> None:
     persist_called = False
     update_called = False
 
-    def mock_persist() -> None:
+    def mock_persist(_: Any) -> None:
         nonlocal persist_called
         persist_called = True
 
-    def mock_update() -> None:
+    def mock_update(_: Any) -> None:
         nonlocal update_called
         update_called = True
 
@@ -265,11 +265,11 @@ def test_on_chain_end_updates_when_not_defers_inputs() -> None:
     persist_called = False
     update_called = False
 
-    def mock_persist() -> None:
+    def mock_persist(_: Any) -> None:
         nonlocal persist_called
         persist_called = True
 
-    def mock_update() -> None:
+    def mock_update(_: Any) -> None:
         nonlocal update_called
         update_called = True
 
@@ -305,11 +305,11 @@ def test_on_chain_error_persists_when_defers_inputs() -> None:
     persist_called = False
     update_called = False
 
-    def mock_persist() -> None:
+    def mock_persist(_: Any) -> None:
         nonlocal persist_called
         persist_called = True
 
-    def mock_update() -> None:
+    def mock_update(_: Any) -> None:
         nonlocal update_called
         update_called = True
 
@@ -343,11 +343,11 @@ def test_on_chain_error_updates_when_not_defers_inputs() -> None:
     persist_called = False
     update_called = False
 
-    def mock_persist() -> None:
+    def mock_persist(_: Any) -> None:
         nonlocal persist_called
         persist_called = True
 
-    def mock_update() -> None:
+    def mock_update(_: Any) -> None:
         nonlocal update_called
         update_called = True
 

--- a/libs/core/tests/unit_tests/tracers/test_langchain.py
+++ b/libs/core/tests/unit_tests/tracers/test_langchain.py
@@ -148,7 +148,7 @@ def test_correct_get_tracer_project(
 
 
 def test_on_chain_start_skips_persist_when_defers_inputs() -> None:
-    """Test that _on_chain_start skips persist when defers_inputs is set."""
+    """Test that `_on_chain_start` skips persist when `defers_inputs` is set."""
     client = unittest.mock.MagicMock(spec=Client)
     client.tracing_queue = None
     tracer = LangChainTracer(client=client)
@@ -178,7 +178,7 @@ def test_on_chain_start_skips_persist_when_defers_inputs() -> None:
 
 
 def test_on_chain_start_persists_when_not_defers_inputs() -> None:
-    """Test that _on_chain_start persists when defers_inputs is not set."""
+    """Test that `_on_chain_start` persists when `defers_inputs` is not set."""
     client = unittest.mock.MagicMock(spec=Client)
     client.tracing_queue = None
     tracer = LangChainTracer(client=client)
@@ -207,7 +207,7 @@ def test_on_chain_start_persists_when_not_defers_inputs() -> None:
 
 
 def test_on_chain_end_persists_when_defers_inputs() -> None:
-    """Test that _on_chain_end calls persist (POST) when defers_inputs is set."""
+    """Test that `_on_chain_end` calls persist (POST) when `defers_inputs` is set."""
     client = unittest.mock.MagicMock(spec=Client)
     client.tracing_queue = None
     tracer = LangChainTracer(client=client)
@@ -247,7 +247,7 @@ def test_on_chain_end_persists_when_defers_inputs() -> None:
 
 
 def test_on_chain_end_updates_when_not_defers_inputs() -> None:
-    """Test that _on_chain_end calls update (PATCH) when defers_inputs is not set."""
+    """Tests `_on_chain_end` calls update (PATCH) when `defers_inputs` is not set."""
     client = unittest.mock.MagicMock(spec=Client)
     client.tracing_queue = None
     tracer = LangChainTracer(client=client)
@@ -285,7 +285,7 @@ def test_on_chain_end_updates_when_not_defers_inputs() -> None:
 
 
 def test_on_chain_error_persists_when_defers_inputs() -> None:
-    """Test that _on_chain_error calls persist (POST) when defers_inputs is set."""
+    """Test that `_on_chain_error` calls persist (POST) when `defers_inputs` is set."""
     client = unittest.mock.MagicMock(spec=Client)
     client.tracing_queue = None
     tracer = LangChainTracer(client=client)
@@ -325,7 +325,7 @@ def test_on_chain_error_persists_when_defers_inputs() -> None:
 
 
 def test_on_chain_error_updates_when_not_defers_inputs() -> None:
-    """Test that _on_chain_error calls update (PATCH) when defers_inputs is not set."""
+    """Tests `_on_chain_error` calls update (PATCH) when `defers_inputs` is not set."""
     client = unittest.mock.MagicMock(spec=Client)
     client.tracing_queue = None
     tracer = LangChainTracer(client=client)


### PR DESCRIPTION
ref https://github.com/langchain-ai/langchainjs/pull/9665

Fixes trace persistence for iterator/generator inputs (like `RunnableGenerator`) where the full input isn't available at chain start. Instead of POSTing a run with incomplete inputs on start and PATCHing later, this defers the POST until chain end when inputs are fully realized.