### PR TITLE
fix(langchain): typing fixes for custom middleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -86,13 +86,19 @@ def _normalize_to_model_response(result: ModelResponse | AIMessage) -> ModelResp
 def _chain_model_call_handlers(
     handlers: Sequence[
         Callable[
-            [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], ModelResponse]],
+            [
+                ModelRequest[Any, ContextT],
+                Callable[[ModelRequest[Any, ContextT]], ModelResponse],
+            ],
             ModelResponse | AIMessage,
         ]
     ],
 ) -> (
     Callable[
-        [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], ModelResponse]],
+        [
+            ModelRequest[Any, ContextT],
+            Callable[[ModelRequest[Any, ContextT]], ModelResponse],
+        ],
         ModelResponse,
     ]
     | None
@@ -140,8 +146,8 @@ def _chain_model_call_handlers(
         single_handler = handlers[0]
 
         def normalized_single(
-            request: ModelRequest[ContextT],
-            handler: Callable[[ModelRequest[ContextT]], ModelResponse],
+            request: ModelRequest[Any, ContextT],
+            handler: Callable[[ModelRequest[Any, ContextT]], ModelResponse],
         ) -> ModelResponse:
             result = single_handler(request, handler)
             return _normalize_to_model_response(result)
@@ -150,25 +156,34 @@ def _chain_model_call_handlers(
 
     def compose_two(
         outer: Callable[
-            [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], ModelResponse]],
+            [
+                ModelRequest[Any, ContextT],
+                Callable[[ModelRequest[Any, ContextT]], ModelResponse],
+            ],
             ModelResponse | AIMessage,
         ],
         inner: Callable[
-            [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], ModelResponse]],
+            [
+                ModelRequest[Any, ContextT],
+                Callable[[ModelRequest[Any, ContextT]], ModelResponse],
+            ],
             ModelResponse | AIMessage,
         ],
     ) -> Callable[
-        [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], ModelResponse]],
+        [
+            ModelRequest[Any, ContextT],
+            Callable[[ModelRequest[Any, ContextT]], ModelResponse],
+        ],
         ModelResponse,
     ]:
         """Compose two handlers where outer wraps inner."""
 
         def composed(
-            request: ModelRequest[ContextT],
-            handler: Callable[[ModelRequest[ContextT]], ModelResponse],
+            request: ModelRequest[Any, ContextT],
+            handler: Callable[[ModelRequest[Any, ContextT]], ModelResponse],
         ) -> ModelResponse:
             # Create a wrapper that calls inner with the base handler and normalizes
-            def inner_handler(req: ModelRequest[ContextT]) -> ModelResponse:
+            def inner_handler(req: ModelRequest[Any, ContextT]) -> ModelResponse:
                 inner_result = inner(req, handler)
                 return _normalize_to_model_response(inner_result)
 
@@ -185,8 +200,8 @@ def _chain_model_call_handlers(
 
     # Wrap to ensure final return type is exactly ModelResponse
     def final_normalized(
-        request: ModelRequest[ContextT],
-        handler: Callable[[ModelRequest[ContextT]], ModelResponse],
+        request: ModelRequest[Any, ContextT],
+        handler: Callable[[ModelRequest[Any, ContextT]], ModelResponse],
     ) -> ModelResponse:
         # result here is typed as returning ModelResponse | AIMessage but compose_two normalizes
         final_result = result(request, handler)
@@ -198,13 +213,19 @@ def _chain_model_call_handlers(
 def _chain_async_model_call_handlers(
     handlers: Sequence[
         Callable[
-            [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse]]],
+            [
+                ModelRequest[Any, ContextT],
+                Callable[[ModelRequest[Any, ContextT]], Awaitable[ModelResponse]],
+            ],
             Awaitable[ModelResponse | AIMessage],
         ]
     ],
 ) -> (
     Callable[
-        [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse]]],
+        [
+            ModelRequest[Any, ContextT],
+            Callable[[ModelRequest[Any, ContextT]], Awaitable[ModelResponse]],
+        ],
         Awaitable[ModelResponse],
     ]
     | None
@@ -225,8 +246,8 @@ def _chain_async_model_call_handlers(
         single_handler = handlers[0]
 
         async def normalized_single(
-            request: ModelRequest[ContextT],
-            handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse]],
+            request: ModelRequest[Any, ContextT],
+            handler: Callable[[ModelRequest[Any, ContextT]], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             result = await single_handler(request, handler)
             return _normalize_to_model_response(result)
@@ -235,25 +256,34 @@ def _chain_async_model_call_handlers(
 
     def compose_two(
         outer: Callable[
-            [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse]]],
+            [
+                ModelRequest[Any, ContextT],
+                Callable[[ModelRequest[Any, ContextT]], Awaitable[ModelResponse]],
+            ],
             Awaitable[ModelResponse | AIMessage],
         ],
         inner: Callable[
-            [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse]]],
+            [
+                ModelRequest[Any, ContextT],
+                Callable[[ModelRequest[Any, ContextT]], Awaitable[ModelResponse]],
+            ],
             Awaitable[ModelResponse | AIMessage],
         ],
     ) -> Callable[
-        [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse]]],
+        [
+            ModelRequest[Any, ContextT],
+            Callable[[ModelRequest[Any, ContextT]], Awaitable[ModelResponse]],
+        ],
         Awaitable[ModelResponse],
     ]:
         """Compose two async handlers where outer wraps inner."""
 
         async def composed(
-            request: ModelRequest[ContextT],
-            handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse]],
+            request: ModelRequest[Any, ContextT],
+            handler: Callable[[ModelRequest[Any, ContextT]], Awaitable[ModelResponse]],
         ) -> ModelResponse:
             # Create a wrapper that calls inner with the base handler and normalizes
-            async def inner_handler(req: ModelRequest[ContextT]) -> ModelResponse:
+            async def inner_handler(req: ModelRequest[Any, ContextT]) -> ModelResponse:
                 inner_result = await inner(req, handler)
                 return _normalize_to_model_response(inner_result)
 
@@ -270,8 +300,8 @@ def _chain_async_model_call_handlers(
 
     # Wrap to ensure final return type is exactly ModelResponse
     async def final_normalized(
-        request: ModelRequest[ContextT],
-        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse]],
+        request: ModelRequest[Any, ContextT],
+        handler: Callable[[ModelRequest[Any, ContextT]], Awaitable[ModelResponse]],
     ) -> ModelResponse:
         # result here is typed as returning ModelResponse | AIMessage but compose_two normalizes
         final_result = await result(request, handler)
@@ -973,7 +1003,9 @@ def create_agent(
 
         return {"messages": [output]}
 
-    def _get_bound_model(request: ModelRequest[ContextT]) -> tuple[Runnable, ResponseFormat | None]:
+    def _get_bound_model(
+        request: ModelRequest[Any, ContextT],
+    ) -> tuple[Runnable, ResponseFormat | None]:
         """Get the model with appropriate tool bindings.
 
         Performs auto-detection of strategy if needed based on model capabilities.
@@ -1087,7 +1119,7 @@ def create_agent(
             )
         return request.model.bind(**request.model_settings), None
 
-    def _execute_model_sync(request: ModelRequest[ContextT]) -> ModelResponse:
+    def _execute_model_sync(request: ModelRequest[Any, ContextT]) -> ModelResponse:
         """Execute model and return response.
 
         This is the core model execution logic wrapped by `wrap_model_call` handlers.
@@ -1140,7 +1172,7 @@ def create_agent(
 
         return state_updates
 
-    async def _execute_model_async(request: ModelRequest[ContextT]) -> ModelResponse:
+    async def _execute_model_async(request: ModelRequest[Any, ContextT]) -> ModelResponse:
         """Execute model asynchronously and return response.
 
         This is the core async model execution logic wrapped by `wrap_model_call`

--- a/libs/langchain_v1/tests/integration_tests/agents/middleware/test_shell_tool_integration.py
+++ b/libs/langchain_v1/tests/integration_tests/agents/middleware/test_shell_tool_integration.py
@@ -19,7 +19,7 @@ def _get_model(provider: str) -> Any:
     if provider == "anthropic":
         from langchain_anthropic import ChatAnthropic
 
-        return ChatAnthropic(model="claude-sonnet-4-5-20250929")
+        return ChatAnthropic(model="claude-sonnet-4-5-20250929")  # type: ignore[call-arg]
     if provider == "openai":
         from langchain_openai import ChatOpenAI
 

--- a/libs/langchain_v1/tests/integration_tests/agents/middleware/test_shell_tool_integration.py
+++ b/libs/langchain_v1/tests/integration_tests/agents/middleware/test_shell_tool_integration.py
@@ -19,7 +19,7 @@ def _get_model(provider: str) -> Any:
     if provider == "anthropic":
         from langchain_anthropic import ChatAnthropic
 
-        return ChatAnthropic(model="claude-sonnet-4-5-20250929")  # type: ignore[call-arg]
+        return ChatAnthropic(model="claude-sonnet-4-5-20250929")
     if provider == "openai":
         from langchain_openai import ChatOpenAI
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_middleware_typing.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_middleware_typing.py
@@ -1,0 +1,390 @@
+"""Tests demonstrating proper typing support for middleware.
+
+This test file verifies that:
+1. ModelRequest is properly generic over ContextT
+2. Async middleware decorators work without type errors
+3. Sync middleware decorators work without type errors
+4. Custom context types flow through properly
+5. Handler callbacks have correct async/sync signatures
+
+These tests should pass mypy type checking without any type: ignore comments.
+"""
+
+from collections.abc import Awaitable, Callable
+from typing import TypedDict
+from unittest.mock import MagicMock
+
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ModelCallResult,
+    ModelRequest,
+    ModelResponse,
+    after_agent,
+    after_model,
+    before_agent,
+    before_model,
+    dynamic_prompt,
+    wrap_model_call,
+    wrap_tool_call,
+)
+
+
+# Custom context type for testing
+class ServiceContext(TypedDict):
+    """Custom context for service-level information."""
+
+    user_id: str
+    session_id: str
+    environment: str
+
+
+class CustomState(AgentState):
+    """Custom state extending AgentState."""
+
+    custom_field: str
+
+
+# =============================================================================
+# Test 1: ModelRequest generic typing with custom context
+# =============================================================================
+
+
+def test_model_request_generic_context_typing() -> None:
+    """Test that ModelRequest[ContextT] properly types the runtime field."""
+    # Create a mock model
+    mock_model = MagicMock()
+
+    # Create ModelRequest with explicit context type annotation
+    request: ModelRequest[ServiceContext] = ModelRequest(
+        model=mock_model,
+        messages=[HumanMessage(content="Hello")],
+    )
+
+    # The request should be created without type errors
+    assert request.model == mock_model
+    assert len(request.messages) == 1
+
+
+# =============================================================================
+# Test 2: Sync dynamic_prompt decorator with proper typing
+# =============================================================================
+
+
+def test_sync_dynamic_prompt_typing() -> None:
+    """Test that sync @dynamic_prompt decorator works without type errors."""
+
+    @dynamic_prompt
+    def my_prompt(request: ModelRequest[ServiceContext]) -> str:
+        # This should work without type: ignore - accessing generic ModelRequest
+        return f"System prompt for messages: {len(request.messages)}"
+
+    # The decorator should return an AgentMiddleware
+    assert isinstance(my_prompt, AgentMiddleware)
+
+
+def test_sync_dynamic_prompt_returning_system_message() -> None:
+    """Test that sync @dynamic_prompt can return SystemMessage."""
+
+    @dynamic_prompt
+    def my_prompt(request: ModelRequest[None]) -> SystemMessage:
+        return SystemMessage(content="You are a helpful assistant")
+
+    assert isinstance(my_prompt, AgentMiddleware)
+
+
+# =============================================================================
+# Test 3: Async dynamic_prompt decorator with proper typing
+# =============================================================================
+
+
+def test_async_dynamic_prompt_typing() -> None:
+    """Test that async @dynamic_prompt decorator works without type errors."""
+
+    @dynamic_prompt
+    async def my_async_prompt(request: ModelRequest[ServiceContext]) -> str:
+        # Async function should work without type errors
+        return "Async system prompt"
+
+    assert isinstance(my_async_prompt, AgentMiddleware)
+
+
+def test_async_dynamic_prompt_returning_system_message() -> None:
+    """Test that async @dynamic_prompt can return SystemMessage."""
+
+    @dynamic_prompt
+    async def my_async_prompt(request: ModelRequest[None]) -> SystemMessage:
+        return SystemMessage(content="Async system message")
+
+    assert isinstance(my_async_prompt, AgentMiddleware)
+
+
+# =============================================================================
+# Test 4: Sync wrap_model_call decorator with proper handler typing
+# =============================================================================
+
+
+def test_sync_wrap_model_call_typing() -> None:
+    """Test that sync @wrap_model_call decorator properly types the handler."""
+
+    @wrap_model_call
+    def retry_middleware(
+        request: ModelRequest[ServiceContext],
+        handler: Callable[[ModelRequest[ServiceContext]], ModelResponse],
+    ) -> ModelCallResult:
+        # Handler should be typed as sync - no Awaitable
+        return handler(request)
+
+    assert isinstance(retry_middleware, AgentMiddleware)
+
+
+def test_sync_wrap_model_call_returning_ai_message() -> None:
+    """Test that sync @wrap_model_call can return AIMessage directly."""
+
+    @wrap_model_call
+    def simple_middleware(
+        request: ModelRequest[None],
+        handler: Callable[[ModelRequest[None]], ModelResponse],
+    ) -> ModelCallResult:
+        # Can return AIMessage directly (converted automatically)
+        return AIMessage(content="Simple response")
+
+    assert isinstance(simple_middleware, AgentMiddleware)
+
+
+# =============================================================================
+# Test 5: Async wrap_model_call decorator with proper handler typing
+# =============================================================================
+
+
+def test_async_wrap_model_call_typing() -> None:
+    """Test that async @wrap_model_call decorator properly types the async handler."""
+
+    @wrap_model_call
+    async def async_retry_middleware(
+        request: ModelRequest[ServiceContext],
+        handler: Callable[[ModelRequest[ServiceContext]], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        # Handler should be typed as async - returns Awaitable
+        return await handler(request)
+
+    assert isinstance(async_retry_middleware, AgentMiddleware)
+
+
+def test_async_wrap_model_call_with_error_handling() -> None:
+    """Test async @wrap_model_call with try/except pattern."""
+
+    @wrap_model_call
+    async def error_handling_middleware(
+        request: ModelRequest[None],
+        handler: Callable[[ModelRequest[None]], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        try:
+            return await handler(request)
+        except Exception:
+            return AIMessage(content="Error occurred")
+
+    assert isinstance(error_handling_middleware, AgentMiddleware)
+
+
+# =============================================================================
+# Test 6: Sync wrap_tool_call decorator with proper handler typing
+# =============================================================================
+
+
+def test_sync_wrap_tool_call_typing() -> None:
+    """Test that sync @wrap_tool_call decorator properly types the handler."""
+
+    @wrap_tool_call
+    def tool_error_handler(
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        try:
+            return handler(request)
+        except Exception as e:
+            return ToolMessage(
+                content=str(e),
+                tool_call_id=request.tool_call["id"],
+            )
+
+    assert isinstance(tool_error_handler, AgentMiddleware)
+
+
+# =============================================================================
+# Test 7: Async wrap_tool_call decorator with proper handler typing
+# =============================================================================
+
+
+def test_async_wrap_tool_call_typing() -> None:
+    """Test that async @wrap_tool_call decorator properly types the async handler."""
+
+    @wrap_tool_call
+    async def async_tool_error_handler(
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        try:
+            return await handler(request)
+        except Exception as e:
+            return ToolMessage(
+                content=str(e),
+                tool_call_id=request.tool_call["id"],
+            )
+
+    assert isinstance(async_tool_error_handler, AgentMiddleware)
+
+
+# =============================================================================
+# Test 8: before_model/after_model decorators with custom state
+# =============================================================================
+
+
+def test_before_model_with_custom_state_typing() -> None:
+    """Test @before_model decorator with custom state schema."""
+
+    @before_model(state_schema=CustomState)
+    def log_before_model(
+        state: CustomState,
+        runtime: object,  # Runtime type comes from langgraph
+    ) -> dict[str, object] | None:
+        # Should have access to custom_field without type errors
+        _ = state.get("custom_field")  # Access custom field
+        return None
+
+    assert isinstance(log_before_model, AgentMiddleware)
+    assert log_before_model.state_schema == CustomState
+
+
+def test_after_model_with_custom_state_typing() -> None:
+    """Test @after_model decorator with custom state schema."""
+
+    @after_model(state_schema=CustomState)
+    def log_after_model(
+        state: CustomState,
+        runtime: object,
+    ) -> dict[str, object] | None:
+        return {"custom_field": "updated"}
+
+    assert isinstance(log_after_model, AgentMiddleware)
+
+
+# =============================================================================
+# Test 9: before_agent/after_agent decorators
+# =============================================================================
+
+
+def test_before_agent_async_typing() -> None:
+    """Test async @before_agent decorator."""
+
+    @before_agent
+    async def setup_agent(
+        state: AgentState,
+        runtime: object,
+    ) -> dict[str, object] | None:
+        return None
+
+    assert isinstance(setup_agent, AgentMiddleware)
+
+
+def test_after_agent_async_typing() -> None:
+    """Test async @after_agent decorator."""
+
+    @after_agent
+    async def cleanup_agent(
+        state: AgentState,
+        runtime: object,
+    ) -> dict[str, object] | None:
+        return None
+
+    assert isinstance(cleanup_agent, AgentMiddleware)
+
+
+# =============================================================================
+# Test 10: Class-based middleware with proper generic typing
+# =============================================================================
+
+
+class TypedMiddleware(AgentMiddleware[CustomState, ServiceContext]):
+    """Class-based middleware with explicit type parameters."""
+
+    state_schema = CustomState
+
+    def before_model(
+        self,
+        state: CustomState,
+        runtime: object,
+    ) -> dict[str, object] | None:
+        # State is properly typed as CustomState
+        return None
+
+
+def test_class_based_middleware_typing() -> None:
+    """Test class-based middleware with explicit generics."""
+    middleware = TypedMiddleware()
+    assert middleware.state_schema == CustomState
+
+
+# =============================================================================
+# Test 11: ModelRequest.override() preserves generic type
+# =============================================================================
+
+
+def test_model_request_override_preserves_generic() -> None:
+    """Test that ModelRequest.override() returns properly typed ModelRequest."""
+    mock_model = MagicMock()
+
+    request: ModelRequest[ServiceContext] = ModelRequest(
+        model=mock_model,
+        messages=[HumanMessage(content="Hello")],
+    )
+
+    # override() should return ModelRequest[ServiceContext], not ModelRequest[Any]
+    new_request = request.override(system_message=SystemMessage(content="New system prompt"))
+
+    # This should be type-safe
+    assert new_request.system_message is not None
+    assert new_request.system_message.content == "New system prompt"
+
+
+# =============================================================================
+# Test 12: Multiple middleware in a list (simulating create_agent usage)
+# =============================================================================
+
+
+def test_middleware_list_typing() -> None:
+    """Test that middleware can be collected in a properly typed list."""
+
+    @dynamic_prompt
+    async def system_prompt(request: ModelRequest[ServiceContext]) -> SystemMessage:
+        return SystemMessage(content="System")
+
+    @wrap_model_call
+    async def censor_response(
+        request: ModelRequest[ServiceContext],
+        handler: Callable[[ModelRequest[ServiceContext]], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        return await handler(request)
+
+    @wrap_tool_call
+    async def handle_errors(
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        try:
+            return await handler(request)
+        except Exception as e:
+            return ToolMessage(content=str(e), tool_call_id=request.tool_call["id"])
+
+    # All middleware should be assignable to a list of AgentMiddleware
+    # Note: The decorators return AgentMiddleware with inferred generic parameters
+    middleware_list: list[AgentMiddleware[AgentState, ServiceContext]] = [
+        system_prompt,
+        censor_response,
+    ]
+
+    assert len(middleware_list) == 2

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_middleware_typing.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_middleware_typing.py
@@ -1,7 +1,7 @@
 """Tests demonstrating proper typing support for middleware.
 
 This test file verifies that:
-1. ModelRequest is properly generic over ContextT
+1. ModelRequest is properly generic over StateT and ContextT
 2. Async middleware decorators work without type errors
 3. Sync middleware decorators work without type errors
 4. Custom context types flow through properly
@@ -55,12 +55,12 @@ class CustomState(AgentState):
 
 
 def test_model_request_generic_context_typing() -> None:
-    """Test that ModelRequest[ContextT] properly types the runtime field."""
+    """Test that ModelRequest[StateT, ContextT] properly types the state and runtime fields."""
     # Create a mock model
     mock_model = MagicMock()
 
-    # Create ModelRequest with explicit context type annotation
-    request: ModelRequest[ServiceContext] = ModelRequest(
+    # Create ModelRequest with explicit state and context type annotation
+    request: ModelRequest[AgentState, ServiceContext] = ModelRequest(
         model=mock_model,
         messages=[HumanMessage(content="Hello")],
     )
@@ -79,7 +79,7 @@ def test_sync_dynamic_prompt_typing() -> None:
     """Test that sync @dynamic_prompt decorator works without type errors."""
 
     @dynamic_prompt
-    def my_prompt(request: ModelRequest[ServiceContext]) -> str:
+    def my_prompt(request: ModelRequest[AgentState, ServiceContext]) -> str:
         # This should work without type: ignore - accessing generic ModelRequest
         return f"System prompt for messages: {len(request.messages)}"
 
@@ -91,7 +91,7 @@ def test_sync_dynamic_prompt_returning_system_message() -> None:
     """Test that sync @dynamic_prompt can return SystemMessage."""
 
     @dynamic_prompt
-    def my_prompt(request: ModelRequest[None]) -> SystemMessage:
+    def my_prompt(request: ModelRequest[AgentState, None]) -> SystemMessage:
         return SystemMessage(content="You are a helpful assistant")
 
     assert isinstance(my_prompt, AgentMiddleware)
@@ -106,7 +106,7 @@ def test_async_dynamic_prompt_typing() -> None:
     """Test that async @dynamic_prompt decorator works without type errors."""
 
     @dynamic_prompt
-    async def my_async_prompt(request: ModelRequest[ServiceContext]) -> str:
+    async def my_async_prompt(request: ModelRequest[AgentState, ServiceContext]) -> str:
         # Async function should work without type errors
         return "Async system prompt"
 
@@ -117,7 +117,7 @@ def test_async_dynamic_prompt_returning_system_message() -> None:
     """Test that async @dynamic_prompt can return SystemMessage."""
 
     @dynamic_prompt
-    async def my_async_prompt(request: ModelRequest[None]) -> SystemMessage:
+    async def my_async_prompt(request: ModelRequest[AgentState, None]) -> SystemMessage:
         return SystemMessage(content="Async system message")
 
     assert isinstance(my_async_prompt, AgentMiddleware)
@@ -133,8 +133,8 @@ def test_sync_wrap_model_call_typing() -> None:
 
     @wrap_model_call
     def retry_middleware(
-        request: ModelRequest[ServiceContext],
-        handler: Callable[[ModelRequest[ServiceContext]], ModelResponse],
+        request: ModelRequest[AgentState, ServiceContext],
+        handler: Callable[[ModelRequest[AgentState, ServiceContext]], ModelResponse],
     ) -> ModelCallResult:
         # Handler should be typed as sync - no Awaitable
         return handler(request)
@@ -147,8 +147,8 @@ def test_sync_wrap_model_call_returning_ai_message() -> None:
 
     @wrap_model_call
     def simple_middleware(
-        request: ModelRequest[None],
-        handler: Callable[[ModelRequest[None]], ModelResponse],
+        request: ModelRequest[AgentState, None],
+        handler: Callable[[ModelRequest[AgentState, None]], ModelResponse],
     ) -> ModelCallResult:
         # Can return AIMessage directly (converted automatically)
         return AIMessage(content="Simple response")
@@ -166,8 +166,8 @@ def test_async_wrap_model_call_typing() -> None:
 
     @wrap_model_call
     async def async_retry_middleware(
-        request: ModelRequest[ServiceContext],
-        handler: Callable[[ModelRequest[ServiceContext]], Awaitable[ModelResponse]],
+        request: ModelRequest[AgentState, ServiceContext],
+        handler: Callable[[ModelRequest[AgentState, ServiceContext]], Awaitable[ModelResponse]],
     ) -> ModelCallResult:
         # Handler should be typed as async - returns Awaitable
         return await handler(request)
@@ -180,8 +180,8 @@ def test_async_wrap_model_call_with_error_handling() -> None:
 
     @wrap_model_call
     async def error_handling_middleware(
-        request: ModelRequest[None],
-        handler: Callable[[ModelRequest[None]], Awaitable[ModelResponse]],
+        request: ModelRequest[AgentState, None],
+        handler: Callable[[ModelRequest[AgentState, None]], Awaitable[ModelResponse]],
     ) -> ModelCallResult:
         try:
             return await handler(request)
@@ -338,12 +338,12 @@ def test_model_request_override_preserves_generic() -> None:
     """Test that ModelRequest.override() returns properly typed ModelRequest."""
     mock_model = MagicMock()
 
-    request: ModelRequest[ServiceContext] = ModelRequest(
+    request: ModelRequest[AgentState, ServiceContext] = ModelRequest(
         model=mock_model,
         messages=[HumanMessage(content="Hello")],
     )
 
-    # override() should return ModelRequest[ServiceContext], not ModelRequest[Any]
+    # override() should return ModelRequest[AgentState, ServiceContext], not ModelRequest[Any, Any]
     new_request = request.override(system_message=SystemMessage(content="New system prompt"))
 
     # This should be type-safe
@@ -360,13 +360,13 @@ def test_middleware_list_typing() -> None:
     """Test that middleware can be collected in a properly typed list."""
 
     @dynamic_prompt
-    async def system_prompt(request: ModelRequest[ServiceContext]) -> SystemMessage:
+    async def system_prompt(request: ModelRequest[AgentState, ServiceContext]) -> SystemMessage:
         return SystemMessage(content="System")
 
     @wrap_model_call
     async def censor_response(
-        request: ModelRequest[ServiceContext],
-        handler: Callable[[ModelRequest[ServiceContext]], Awaitable[ModelResponse]],
+        request: ModelRequest[AgentState, ServiceContext],
+        handler: Callable[[ModelRequest[AgentState, ServiceContext]], Awaitable[ModelResponse]],
     ) -> ModelCallResult:
         return await handler(request)
 


### PR DESCRIPTION
* Make `ModelRequest` generic on `ContextT` so that types can flow through appropriately
* Proper typing for coroutines used w/ our middleware shortcut decorators
* Public input + output state

TODO: confirm this is not breaking for existing custom middlewares