### PR TITLE
fix(openai): handle missing function field in streaming `tool_calls`

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -377,10 +377,10 @@ def _convert_delta_to_message_chunk(
         try:
             tool_call_chunks = [
                 tool_call_chunk(
-                    name=rtc["function"].get("name"),
-                    args=rtc["function"].get("arguments"),
+                    name=rtc.get("function", {}).get("name"),
+                    args=rtc.get("function", {}).get("arguments"),
                     id=rtc.get("id"),
-                    index=rtc["index"],
+                    index=rtc.get("index"),
                 )
                 for rtc in raw_tool_calls
             ]

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -377,10 +377,10 @@ def _convert_delta_to_message_chunk(
         try:
             tool_call_chunks = [
                 tool_call_chunk(
-                    name=rtc["function"].get("name"),
-                    args=rtc["function"].get("arguments"),
+                    name=(rtc.get("function") or {}).get("name"),
+                    args=(rtc.get("function") or {}).get("arguments"),
                     id=rtc.get("id"),
-                    index=rtc["index"],
+                    index=rtc.get("index"),
                 )
                 for rtc in raw_tool_calls
             ]

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3167,6 +3167,7 @@ def test_model_prefers_responses_api() -> None:
     assert _model_prefers_responses_api("gpt-5.2-pro")
     assert not _model_prefers_responses_api("gpt-5.1")
 
+
 def test_convert_delta_to_message_chunk_with_missing_function() -> None:
     """Test handling of tool_calls with missing function field."""
     delta_dict = {
@@ -3178,7 +3179,7 @@ def test_convert_delta_to_message_chunk_with_missing_function() -> None:
                 "type": "function",
                 # Note: no function field
             }
-        ]
+        ],
     }
     result = _convert_delta_to_message_chunk(delta_dict, AIMessageChunk)
 
@@ -3186,6 +3187,7 @@ def test_convert_delta_to_message_chunk_with_missing_function() -> None:
     assert len(result.tool_call_chunks) == 1
     assert result.tool_call_chunks[0]["name"] is None
     assert result.tool_call_chunks[0]["args"] is None
+
 
 def test_convert_delta_to_message_chunk_with_none_function() -> None:
     """Test handling of tool_calls with function=None."""
@@ -3198,8 +3200,10 @@ def test_convert_delta_to_message_chunk_with_none_function() -> None:
                 "type": "function",
                 "function": None,
             }
-        ]
+        ],
     }
     result = _convert_delta_to_message_chunk(delta_dict, AIMessageChunk)
     assert isinstance(result, AIMessageChunk)
     assert len(result.tool_call_chunks) == 1
+    assert result.tool_call_chunks[0]["name"] is None
+    assert result.tool_call_chunks[0]["args"] is None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -66,6 +66,7 @@ from langchain_openai.chat_models._compat import (
 from langchain_openai.chat_models.base import (
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
+    _convert_delta_to_message_chunk,
     _convert_dict_to_message,
     _convert_message_to_dict,
     _convert_to_openai_response_format,
@@ -3165,3 +3166,40 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
 def test_model_prefers_responses_api() -> None:
     assert _model_prefers_responses_api("gpt-5.2-pro")
     assert not _model_prefers_responses_api("gpt-5.1")
+
+def test_convert_delta_to_message_chunk_with_missing_function() -> None:
+    """Test handling of tool_calls with missing function field."""
+    delta_dict = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "index": 0,
+                "id": "call_abc123",
+                "type": "function",
+                # Note: no function field
+            }
+        ]
+    }
+    result = _convert_delta_to_message_chunk(delta_dict, AIMessageChunk)
+
+    assert isinstance(result, AIMessageChunk)
+    assert len(result.tool_call_chunks) == 1
+    assert result.tool_call_chunks[0]["name"] is None
+    assert result.tool_call_chunks[0]["args"] is None
+
+def test_convert_delta_to_message_chunk_with_none_function() -> None:
+    """Test handling of tool_calls with function=None."""
+    delta_dict = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "index": 0,
+                "id": "call_abc123",
+                "type": "function",
+                "function": None,
+            }
+        ]
+    }
+    result = _convert_delta_to_message_chunk(delta_dict, AIMessageChunk)
+    assert isinstance(result, AIMessageChunk)
+    assert len(result.tool_call_chunks) == 1

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -66,6 +66,7 @@ from langchain_openai.chat_models._compat import (
 from langchain_openai.chat_models.base import (
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
+    _convert_delta_to_message_chunk,
     _convert_dict_to_message,
     _convert_message_to_dict,
     _convert_to_openai_response_format,
@@ -3165,3 +3166,40 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
 def test_model_prefers_responses_api() -> None:
     assert _model_prefers_responses_api("gpt-5.2-pro")
     assert not _model_prefers_responses_api("gpt-5.1")
+
+def test_convert_delta_to_message_chunk_with_missing_function():
+    """Test handling of tool_calls with missing function field."""
+    delta_dict = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "index": 0,
+                "id": "call_abc123",
+                "type": "function",
+                # Note: no function field
+            }
+        ]
+    }
+    result = _convert_delta_to_message_chunk(delta_dict, AIMessageChunk)
+
+    assert isinstance(result, AIMessageChunk)
+    assert len(result.tool_call_chunks) == 1
+    assert result.tool_call_chunks[0]["name"] is None
+    assert result.tool_call_chunks[0]["args"] is None
+
+def test_convert_delta_to_message_chunk_with_none_function():
+    """Test handling of tool_calls with function=None."""
+    delta_dict = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "index": 0,
+                "id": "call_abc123",
+                "type": "function",
+                "function": None,
+            }
+        ]
+    }
+    result = _convert_delta_to_message_chunk(delta_dict, AIMessageChunk)
+    assert isinstance(result, AIMessageChunk)
+    assert len(result.tool_call_chunks) == 1


### PR DESCRIPTION
Fixes a `KeyError` that occurs when processing streaming tool_calls from OpenAI-compatible clients that return non-standard formats (where the `function` field may be missing or `None`). Uses safe dictionary access (`rtc.get("function") or {}`) to gracefully handle these edge cases while maintaining backward compatibility with standard OpenAI responses.

### Problem
When using OpenAI-compatible clients (such as some local model servers or third-party API providers), streaming responses may return tool_calls that don't strictly follow the OpenAI format. Specifically, the `function` field within tool_calls can be missing or `None` in intermediate streaming chunks. The current implementation directly accesses `rtc["function"]`, which causes a `KeyError` exception when processing these non-standard but valid responses.

This issue is particularly relevant when:
- Using OpenAI-compatible local model servers (e.g., vLLM, Ollama with OpenAI compatibility mode)
- Integrating with third-party API providers that claim OpenAI compatibility but have slight format variations
- Processing streaming responses where intermediate chunks may have incomplete structures

### Solution
- Use `(rtc.get("function") or {})` to safely access the `function` field
- Change `rtc["index"]` to `rtc.get("index")` for consistency
- Added test cases to cover missing field and `None` value scenarios

### Testing
All checks have been run and passed:
- `make format` - Code formatting completed
- `make lint` - Code linting and type checking passed (68 source files, no issues)
- `make test` - 296 unit tests passed, including 2 new test cases

### Areas for Review
1. **Backward compatibility**: Ensure the fix doesn't affect normal behavior
2. **Error handling**: Check if the related `try-except KeyError` block is still necessary

---
**Modified files**:
- `libs/partners/openai/langchain_openai/chat_models/base.py` (6 lines modified)
- `libs/partners/openai/tests/unit_tests/chat_models/test_base.py` (42 lines added)