### PR TITLE
feat(openai): add embeddings rate limiter support

### DIFF
--- a/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
@@ -2,10 +2,10 @@ import os
 from typing import Any
 from unittest.mock import Mock, patch
 
-from pydantic import SecretStr
 import pytest
-
 from langchain_core.rate_limiters import BaseRateLimiter
+from pydantic import SecretStr
+
 from langchain_openai import OpenAIEmbeddings
 
 os.environ["OPENAI_API_KEY"] = "foo"

--- a/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
@@ -2,8 +2,8 @@ import os
 from typing import Any
 from unittest.mock import Mock, patch
 
-import pytest
 from pydantic import SecretStr
+import pytest
 
 from langchain_core.rate_limiters import BaseRateLimiter
 from langchain_openai import OpenAIEmbeddings


### PR DESCRIPTION
- add rate_limiter to OpenAIEmbeddings
- apply limiter in sync/async paths
- add unit coverage

Tests: pytest libs/partners/openai/tests/unit_tests/embeddings/test_base.py