### PR TITLE
fix(deepseek): preserve `reasoning_content` for `AIMessages` with `tool_calls`

### DIFF
--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -414,9 +414,7 @@ class TestChatDeepSeekCustomUnit:
                         "id": "call_2",
                     }
                 ],
-                additional_kwargs={
-                    "reasoning_content": "I should use the tool here."
-                },
+                additional_kwargs={"reasoning_content": "I should use the tool here."},
             ),
         ]
 


### PR DESCRIPTION
Fixes #34436

Fixed the issue where DeepSeek API was returning 400 error: Missing reasoning_content field in the assistant message when using agents with tool calls.

**Root Cause**:
When _get_request_payload calls the base class method, it converts messages and loses the
reasoning_content from additional_kwargs. According to DeepSeek API docs,
reasoning_content is Required when tool_calls are present during tool invocation.

**Solution**:
- Preserved reasoning_content from AIMessages with tool_calls before base class conversion
- Restored it to the payload after conversion for assistant messages with tool_calls
- Only added reasoning_content when tool_calls are present (as per API requirements)