### PR TITLE
fix(core): URL-encode bgColor in mermaid API calls

### DIFF
--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -8,6 +8,7 @@ import random
 import re
 import string
 import time
+import urllib.parse
 from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -434,9 +435,11 @@ def _render_mermaid_using_api(
         if not hex_color_pattern.match(background_color):
             background_color = f"!{background_color}"
 
+    # URL-encode the background color to handle special characters like '!'
+    encoded_bg_color = urllib.parse.quote(str(background_color), safe="")
     image_url = (
         f"{base_url}/img/{mermaid_syntax_encoded}"
-        f"?type={file_type}&bgColor={background_color}"
+        f"?type={file_type}&bgColor={encoded_bg_color}"
     )
 
     error_msg_suffix = (


### PR DESCRIPTION
URL-encode the bgColor parameter to fix 400 errors from mermaid.ink API.

The `!` character in `!white` was not encoded, causing API failures.

Fixes #34444

---
*This PR was created with AI assistance.*