### PR TITLE
fix(langchain): allow Gemini 3 models to use native structured output…

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -386,8 +386,14 @@ def _supports_provider_strategy(model: str | BaseChatModel, tools: list | None =
             model_profile is not None
             and model_profile.get("structured_output")
             # We make an exception for Gemini models, which currently do not support
-            # simultaneous tool use with structured output
-            and not (tools and isinstance(model_name, str) and "gemini" in model_name.lower())
+            # simultaneous tool use with structured output. Gemini 3 models however
+            # do support this.
+            and not (
+                tools
+                and isinstance(model_name, str)
+                and "gemini" in model_name.lower()
+                and "gemini-3" not in model_name.lower()
+            )
         ):
             return True
 


### PR DESCRIPTION
Problem: Models in 
create_agent
 are checked for provider-native structured output support via 
_supports_provider_strategy
. Previously, this function was hard-coded to return False for all Gemini models if tools were present, as earlier Gemini versions (e.g., 1.5) did not support simultaneous tool use and native structured output.

Solution: This PR updates the logic to allow Gemini 3 series models (e.g., gemini-3-flash) to use 
ProviderStrategy.py
 even when tools are present, as these models now natively support this combination. The restriction remains in place for older Gemini 1.x models.
 
 Changes:

Modified 
libs/langchain_v1/langchain/agents/factory.py
 to refine the Gemini model check.