### PR TITLE
perf(core): precompile hex color regex pattern at module level

### DIFF
--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -40,7 +40,6 @@ except ImportError:
 
 MARKDOWN_SPECIAL_CHARS = "*_`"
 
-# Precompile regex pattern for hex color validation
 _HEX_COLOR_PATTERN = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
 
 

--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -40,6 +40,9 @@ except ImportError:
 
 MARKDOWN_SPECIAL_CHARS = "*_`"
 
+# Precompile regex pattern for hex color validation
+_HEX_COLOR_PATTERN = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
+
 
 def draw_mermaid(
     nodes: dict[str, Node],
@@ -429,10 +432,8 @@ def _render_mermaid_using_api(
     )
 
     # Check if the background color is a hexadecimal color code using regex
-    if background_color is not None:
-        hex_color_pattern = re.compile(r"^#(?:[0-9a-fA-F]{3}){1,2}$")
-        if not hex_color_pattern.match(background_color):
-            background_color = f"!{background_color}"
+    if background_color is not None and not _HEX_COLOR_PATTERN.match(background_color):
+        background_color = f"!{background_color}"
 
     image_url = (
         f"{base_url}/img/{mermaid_syntax_encoded}"


### PR DESCRIPTION
Moves hex color validation regex from inside `_render_mermaid_using_api()` to module-level constant `_HEX_COLOR_PATTERN`. This avoids recompiling the regex on every function call, improving performance when rendering multiple Mermaid graphs.


**Testing:**
- `make lint` passes
- `make test` passes