### PR TITLE
perf(core): move origin type map to module level in `function_calling.py`

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -48,6 +48,22 @@ PYTHON_TO_JSON_TYPES = {
     "bool": "boolean",
 }
 
+# Precomputed origin type mapping for _py_38_safe_origin
+# Avoids dict creation on every function call
+_ORIGIN_MAP: dict[type, Any] = {
+    dict: dict,
+    list: list,
+    tuple: tuple,
+    set: set,
+    collections.abc.Iterable: typing.Iterable,
+    collections.abc.Mapping: typing.Mapping,
+    collections.abc.Sequence: typing.Sequence,
+    collections.abc.MutableMapping: typing.MutableMapping,
+}
+# Add UnionType mapping for Python 3.10+
+if hasattr(types, "UnionType"):
+    _ORIGIN_MAP[types.UnionType] = Union
+
 
 class FunctionDescription(TypedDict):
     """Representation of a callable function to send to an LLM."""
@@ -732,22 +748,7 @@ def _parse_google_docstring(
 
 
 def _py_38_safe_origin(origin: type) -> type:
-    origin_union_type_map: dict[type, Any] = (
-        {types.UnionType: Union} if hasattr(types, "UnionType") else {}
-    )
-
-    origin_map: dict[type, Any] = {
-        dict: dict,
-        list: list,
-        tuple: tuple,
-        set: set,
-        collections.abc.Iterable: typing.Iterable,
-        collections.abc.Mapping: typing.Mapping,
-        collections.abc.Sequence: typing.Sequence,
-        collections.abc.MutableMapping: typing.MutableMapping,
-        **origin_union_type_map,
-    }
-    return cast("type", origin_map.get(origin, origin))
+    return cast("type", _ORIGIN_MAP.get(origin, origin))
 
 
 def _recursive_set_additional_properties_false(

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -48,8 +48,6 @@ PYTHON_TO_JSON_TYPES = {
     "bool": "boolean",
 }
 
-# Precomputed origin type mapping for _py_38_safe_origin
-# Avoids dict creation on every function call
 _ORIGIN_MAP: dict[type, Any] = {
     dict: dict,
     list: list,


### PR DESCRIPTION
Moves `_ORIGIN_MAP` dict from inside `_py_38_safe_origin()` to module level constant. This avoids dict allocation on every function call, reducing garbage collection pressure during frequent tool conversions.

The function is called during typed dict to pydantic model conversion which happens during tool binding and invocation - a hot path in LangChain.

**Testing:** `make lint` passes