### PR TITLE
fix(core): Fix validation of empty list tool message content

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1271,7 +1271,7 @@ def _is_message_content_type(obj: Any) -> bool:
     Returns:
         `True` if the object is valid message content, `False` otherwise.
     """
-    if isinstance(obj, list) and not obj:  # Check if it's an empty list
+    if isinstance(obj, list) and not obj:
         return False  # Empty lists should be considered invalid
     return isinstance(obj, str) or (
         isinstance(obj, list) and all(_is_message_content_block(e) for e in obj)

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1271,6 +1271,8 @@ def _is_message_content_type(obj: Any) -> bool:
     Returns:
         `True` if the object is valid message content, `False` otherwise.
     """
+    if isinstance(obj, list) and not obj:  # Check if it's an empty list
+        return False  # Empty lists should be considered invalid
     return isinstance(obj, str) or (
         isinstance(obj, list) and all(_is_message_content_block(e) for e in obj)
     )

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1272,7 +1272,7 @@ def _is_message_content_type(obj: Any) -> bool:
         `True` if the object is valid message content, `False` otherwise.
     """
     if isinstance(obj, list) and not obj:
-        return False  # Empty lists should be considered invalid
+        return False
     return isinstance(obj, str) or (
         isinstance(obj, list) and all(_is_message_content_block(e) for e in obj)
     )

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2122,6 +2122,7 @@ def test__is_message_content_block(obj: Any, *, expected: bool) -> None:
         ("foo", True),
         (valid_tool_result_blocks, True),
         (invalid_tool_result_blocks, False),
+        ([], False),
     ],
 )
 def test__is_message_content_type(obj: Any, *, expected: bool) -> None:


### PR DESCRIPTION
Fixes #33758

### Summary

This PR fixes an edge case in tool message content validation where an empty list (`[]`) was previously considered valid message content.

While non-empty lists of valid content blocks are supported, an empty list results in an invalid request payload for several providers (e.g. DeepSeek), which expect tool message content to be a string. This could lead to request deserialization errors at runtime.

### What was changed

- Updated `_is_message_content_type` to treat empty lists as invalid message content
- Added a unit test to cover this edge case and prevent regressions

### Why this is needed

Previously, `_is_message_content_type([])` returned `True`, allowing empty list content to pass validation. This led to malformed JSON request bodies and downstream provider errors such as:invalid type: sequence, expected a string

Rejecting empty lists at validation time makes message handling more robust and avoids generating invalid requests.

### Tests

- Added a unit test case to ensure empty list content is correctly rejected
- All existing tests continue to pass



