### PR TITLE
feat(core): add approximate image token counting support

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1890,7 +1890,18 @@ def count_tokens_approximately(
         if isinstance(message.content, str):
             message_chars += len(message.content)
 
-        # TODO: add support for approximate counting for image blocks
+        elif isinstance(message.content, list):
+            for block in message.content:
+                if isinstance(block, str):
+                    message_chars += len(block)
+                elif isinstance(block, dict):
+                    if block.get("type") == "text":
+                        message_chars += len(block.get("text", ""))
+                    elif block.get("type") == "image_url":
+                        # Approximate 85 tokens per image
+                        message_chars += 85 * chars_per_token
+                    else:
+                        message_chars += len(repr(block))
         else:
             content = repr(message.content)
             message_chars += len(content)

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1899,7 +1899,7 @@ def count_tokens_approximately(
                         message_chars += len(block.get("text", ""))
                     elif block.get("type") == "image_url":
                         # Approximate 85 tokens per image
-                        message_chars += 85 * chars_per_token
+                        message_chars += int(85 * chars_per_token)
                     else:
                         message_chars += len(repr(block))
         else:

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1778,3 +1778,20 @@ def test_convert_to_openai_messages_reasoning_content() -> None:
         ],
     }
     assert mixed_result == expected_mixed
+
+
+def test_count_tokens_approximately_with_image() -> None:
+    """Test that images are counted as approximately 85 tokens."""
+    # Text = 20 chars = 5 tokens
+    # Image = 85 tokens
+    # Overhead = 3 tokens
+    # Total expected ~ 93
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": "Describe this image:"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+        ]
+    )
+    count = count_tokens_approximately([message])
+    # allow for some small Floating point variance / change in default constants
+    assert 90 <= count <= 100

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1789,7 +1789,10 @@ def test_count_tokens_approximately_with_image() -> None:
     message = HumanMessage(
         content=[
             {"type": "text", "text": "Describe this image:"},
-            {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.png"},
+            },
         ]
     )
     count = count_tokens_approximately([message])


### PR DESCRIPTION
## Title
feat(core): add approximate image token counting support

## Description
This PR addresses a TODO in [langchain_core/messages/utils.py](cci:7://file:///c:/Users/aman0/OneDrive/Desktop/opensource/langchain/libs/core/langchain_core/messages/utils.py:0:0-0:0) to support approximate token counting for image blocks in messages.

### Issue Addressed
Previously, [count_tokens_approximately](cci:1://file:///c:/Users/aman0/OneDrive/Desktop/opensource/langchain/libs/core/langchain_core/messages/utils.py:1837:0-1925:33) would fall back to `repr(content)` for any non-string content (including lists of blocks). For `image_url` blocks, this resulted in drastically undercounting tokens (only counting the URL characters), typically around ~30-40 tokens instead of the actual cost (~85) of an image.

### Changes
- Updated [count_tokens_approximately](cci:1://file:///c:/Users/aman0/OneDrive/Desktop/opensource/langchain/libs/core/langchain_core/messages/utils.py:1837:0-1925:33) in [libs/core/langchain_core/messages/utils.py](cci:7://file:///c:/Users/aman0/OneDrive/Desktop/opensource/langchain/libs/core/langchain_core/messages/utils.py:0:0-0:0) to iterate through content blocks.
- Added handling for `type: image_url` blocks, assigning a constant cost of **85 tokens** (standard low-detail approximation).
- Maintained fallback behavior for unknown dictionary blocks to ensure no regression for generic JSON content.
- Added [test_count_tokens_approximately_with_image](cci:1://file:///c:/Users/aman0/OneDrive/Desktop/opensource/langchain/libs/core/tests/unit_tests/messages/test_utils.py:1782:0-1796:29) to [tests/unit_tests/messages/test_utils.py](cci:7://file:///c:/Users/aman0/OneDrive/Desktop/opensource/langchain/libs/core/tests/unit_tests/messages/test_utils.py:0:0-0:0) to verify the fix.

### Verification
- Verified with reproduction script: Token count for a standard image message increased from ~36 to 94.
- Ran existing unit tests: `uv run --group test pytest tests/unit_tests/messages/test_utils.py`
- All 91 tests passed (including regression tests for generic list content).