### PR TITLE
fix(xai): stream usage metadata by default

### DIFF
--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -526,6 +526,11 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
                 **client_params,
                 **async_specific,
             )
+
+        # Enable streaming usage metadata by default
+        if self.stream_usage is not False:
+            self.stream_usage = True
+
         return self
 
     @model_validator(mode="after")

--- a/libs/partners/xai/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/partners/xai/tests/integration_tests/test_chat_models_standard.py
@@ -35,7 +35,6 @@ class TestXAIStandard(ChatModelIntegrationTests):
         return {
             "model": MODEL_NAME,
             "rate_limiter": rate_limiter,
-            "stream_usage": True,
         }
 
     @pytest.mark.xfail(

--- a/libs/partners/xai/tests/unit_tests/__snapshots__/test_chat_models_standard.ambr
+++ b/libs/partners/xai/tests/unit_tests/__snapshots__/test_chat_models_standard.ambr
@@ -13,6 +13,7 @@
       'request_timeout': 60.0,
       'stop': list([
       ]),
+      'stream_usage': True,
       'temperature': 0.0,
       'xai_api_base': 'https://api.x.ai/v1/',
       'xai_api_key': dict({

--- a/libs/partners/xai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/xai/tests/unit_tests/test_chat_models.py
@@ -134,3 +134,11 @@ def test_convert_dict_to_message_tool() -> None:
     expected_output = ToolMessage(content="foo", tool_call_id="bar")
     assert result == expected_output
     assert _convert_message_to_dict(expected_output) == message
+
+
+def test_stream_usage_metadata() -> None:
+    model = ChatXAI(model=MODEL_NAME)
+    assert model.stream_usage is True
+
+    model = ChatXAI(model=MODEL_NAME, stream_usage=False)
+    assert model.stream_usage is False

--- a/libs/partners/xai/uv.lock
+++ b/libs/partners/xai/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -621,7 +621,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.4"
+version = "1.2.5"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
`langchain-xai` currently uses xAI's chat completions endpoint via a dependency on `langchain-openai`.

BaseChatOpenAI doesn't enable streaming usage metadata for non-OpenAI endpoints, because many chat completions endpoints don't support this parameter. xAI does though, so IMO we should enable by default.