### PR TITLE
refactor(core): remove redundant ainvoke in `StructuredTool`

### DIFF
--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -47,8 +47,6 @@ class StructuredTool(BaseTool):
 
     # --- Runnable ---
 
-
-
     # --- Tool ---
 
     def _run(
@@ -222,9 +220,8 @@ class StructuredTool(BaseTool):
             name=name,
             func=func,
             coroutine=coroutine,
-            args_schema=args_schema,  # type: ignore[arg-type]
+            args_schema=args_schema,
             description=description_,
-
             return_direct=return_direct,
             response_format=response_format,
             **kwargs,

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -7,21 +7,19 @@ import textwrap
 from collections.abc import Awaitable, Callable
 from inspect import signature
 from typing import (
-    TYPE_CHECKING,
     Annotated,
     Any,
     Literal,
 )
 
 from pydantic import Field, SkipValidation
-from typing_extensions import override
 
 # Cannot move to TYPE_CHECKING as _run/_arun parameter annotations are needed at runtime
 from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,  # noqa: TC001
     CallbackManagerForToolRun,  # noqa: TC001
 )
-from langchain_core.runnables import RunnableConfig, run_in_executor
+from langchain_core.runnables import RunnableConfig  # noqa: TC001
 from langchain_core.tools.base import (
     _EMPTY_SET,
     FILTERED_ARGS,
@@ -32,9 +30,6 @@ from langchain_core.tools.base import (
     create_schema_from_function,
 )
 from langchain_core.utils.pydantic import is_basemodel_subclass
-
-if TYPE_CHECKING:
-    from langchain_core.messages import ToolCall
 
 
 class StructuredTool(BaseTool):
@@ -52,19 +47,7 @@ class StructuredTool(BaseTool):
 
     # --- Runnable ---
 
-    # TODO: Is this needed?
-    @override
-    async def ainvoke(
-        self,
-        input: str | dict | ToolCall,
-        config: RunnableConfig | None = None,
-        **kwargs: Any,
-    ) -> Any:
-        if not self.coroutine:
-            # If the tool does not implement async, fall back to default implementation
-            return await run_in_executor(config, self.invoke, input, config, **kwargs)
 
-        return await super().ainvoke(input, config, **kwargs)
 
     # --- Tool ---
 
@@ -204,6 +187,7 @@ class StructuredTool(BaseTool):
                 filter_args=_filter_schema_args(source_function),
             )
         description_ = description
+
         if description is None and not parse_docstring:
             description_ = source_function.__doc__ or None
         if description_ is None and args_schema:
@@ -238,8 +222,9 @@ class StructuredTool(BaseTool):
             name=name,
             func=func,
             coroutine=coroutine,
-            args_schema=args_schema,
+            args_schema=args_schema,  # type: ignore[arg-type]
             description=description_,
+
             return_direct=return_direct,
             response_format=response_format,
             **kwargs,


### PR DESCRIPTION
## refactor(core): remove redundant `ainvoke` in `StructuredTool`

### Description
This PR removes the redundant `ainvoke` override in `StructuredTool` (`libs/core/langchain_core/tools/structured.py`).  
A TODO in the code questioned the necessity of this override. After analysis and verification, it was confirmed that `BaseTool.ainvoke` already provides identical behavior for both sync and async tools, making the override unnecessary.

**Behavioral parity reasoning:**

- **If `self.coroutine` exists:**  
  - `StructuredTool.ainvoke` previously called `super().ainvoke()`, which internally calls `self._arun`.  
  - `StructuredTool` overrides `_arun` to use `self.coroutine`, so behavior is preserved under `BaseTool.ainvoke`.

- **If `self.coroutine` is missing:**  
  - `StructuredTool.ainvoke` previously called `run_in_executor(config, ...)`.  
  - `BaseTool.ainvoke` calls `self._arun`, which delegates to `run_in_executor(None, ...)`.  
  - `run_in_executor` treats both `None` and a `config` dict identically (default executor), so the result is the same.

### Verification
- Implemented a local concurrency test to confirm thread/executor behavior remains unchanged.
- Existing tests validated:  
  - `pytest libs/core/tests/unit_tests/tools/test_structured.py`  
  
### Checklists
- [x] PR title follows `TYPE(SCOPE): DESCRIPTION`
- [x] Changes are limited to `langchain-core` package
- [x] `make format`, `make lint`, and `make test` all pass
