### PR TITLE
chore(core): Update LangChainTracer to use Pydantic v2 methods

### DIFF
--- a/libs/core/langchain_core/document_loaders/langsmith.py
+++ b/libs/core/langchain_core/document_loaders/langsmith.py
@@ -118,7 +118,10 @@ class LangSmithLoader(BaseLoader):
             for key in self.content_key:
                 content = content[key]
             content_str = self.format_content(content)
-            metadata = example.dict()
+            if hasattr(example, "model_dump"):
+                metadata = example.model_dump()
+            else:
+                metadata = example.dict()  # type: ignore[deprecated]
             # Stringify datetime and UUID types.
             for k in ("dataset_id", "created_at", "modified_at", "source_run_id", "id"):
                 metadata[k] = str(metadata[k]) if metadata[k] else metadata[k]

--- a/libs/core/langchain_core/document_loaders/langsmith.py
+++ b/libs/core/langchain_core/document_loaders/langsmith.py
@@ -11,6 +11,7 @@ from typing_extensions import override
 
 from langchain_core.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
+from langchain_core.tracers._compat import pydantic_to_dict
 
 
 class LangSmithLoader(BaseLoader):
@@ -118,10 +119,7 @@ class LangSmithLoader(BaseLoader):
             for key in self.content_key:
                 content = content[key]
             content_str = self.format_content(content)
-            if hasattr(example, "model_dump"):
-                metadata = example.model_dump()
-            else:
-                metadata = example.dict()  # type: ignore[deprecated]
+            metadata = pydantic_to_dict(example)
             # Stringify datetime and UUID types.
             for k in ("dataset_id", "created_at", "modified_at", "source_run_id", "id"):
                 metadata[k] = str(metadata[k]) if metadata[k] else metadata[k]

--- a/libs/core/langchain_core/tracers/_compat.py
+++ b/libs/core/langchain_core/tracers/_compat.py
@@ -1,0 +1,54 @@
+"""Compatibility helpers for Pydantic v1/v2 with langsmith Run objects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tracers.schemas import Run
+
+# Detect Pydantic version once at import time based on Run model
+_RUN_IS_PYDANTIC_V2 = hasattr(Run, "model_dump")
+
+
+def run_to_dict(run: Run, **kwargs: Any) -> dict[str, Any]:
+    """Convert run to dict, compatible with both Pydantic v1 and v2.
+
+    Args:
+        run: The run to convert.
+        **kwargs: Additional arguments passed to model_dump/dict.
+
+    Returns:
+        Dictionary representation of the run.
+    """
+    if _RUN_IS_PYDANTIC_V2:
+        return run.model_dump(**kwargs)
+    return run.dict(**kwargs)  # type: ignore[deprecated]
+
+
+def run_copy(run: Run, **kwargs: Any) -> Run:
+    """Copy run, compatible with both Pydantic v1 and v2.
+
+    Args:
+        run: The run to copy.
+        **kwargs: Additional arguments passed to model_copy/copy.
+
+    Returns:
+        A copy of the run.
+    """
+    if _RUN_IS_PYDANTIC_V2:
+        return run.model_copy(**kwargs)
+    return run.copy(**kwargs)  # type: ignore[deprecated]
+
+
+def run_construct(**kwargs: Any) -> Run:
+    """Construct run without validation, compatible with both Pydantic v1 and v2.
+
+    Args:
+        **kwargs: Fields to set on the run.
+
+    Returns:
+        A new Run instance constructed without validation.
+    """
+    if _RUN_IS_PYDANTIC_V2:
+        return Run.model_construct(**kwargs)
+    return Run.construct(**kwargs)  # type: ignore[deprecated]

--- a/libs/core/langchain_core/tracers/_compat.py
+++ b/libs/core/langchain_core/tracers/_compat.py
@@ -1,4 +1,11 @@
-"""Compatibility helpers for Pydantic v1/v2 with langsmith Run objects."""
+"""Compatibility helpers for Pydantic v1/v2 with langsmith Run objects.
+
+Note: The generic helpers (`pydantic_to_dict`, `pydantic_copy`) detect Pydantic
+version based on the langsmith `Run` model. They're intended for langsmith objects
+(`Run`, `Example`) which migrate together.
+
+For general Pydantic v1/v2 handling, see `langchain_core.utils.pydantic`.
+"""
 
 from __future__ import annotations
 

--- a/libs/core/langchain_core/tracers/_compat.py
+++ b/libs/core/langchain_core/tracers/_compat.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, TypeVar
 
 from langchain_core.tracers.schemas import Run
 
 # Detect Pydantic version once at import time based on Run model
 _RUN_IS_PYDANTIC_V2 = hasattr(Run, "model_dump")
+
+T = TypeVar("T")
 
 
 def run_to_dict(run: Run, **kwargs: Any) -> dict[str, Any]:
@@ -52,3 +54,33 @@ def run_construct(**kwargs: Any) -> Run:
     if _RUN_IS_PYDANTIC_V2:
         return Run.model_construct(**kwargs)
     return Run.construct(**kwargs)  # type: ignore[deprecated]
+
+
+def pydantic_to_dict(obj: Any, **kwargs: Any) -> dict[str, Any]:
+    """Convert any Pydantic model to dict, compatible with both v1 and v2.
+
+    Args:
+        obj: The Pydantic model to convert.
+        **kwargs: Additional arguments passed to model_dump/dict.
+
+    Returns:
+        Dictionary representation of the model.
+    """
+    if _RUN_IS_PYDANTIC_V2:
+        return obj.model_dump(**kwargs)  # type: ignore[no-any-return]
+    return obj.dict(**kwargs)  # type: ignore[no-any-return]
+
+
+def pydantic_copy(obj: T, **kwargs: Any) -> T:
+    """Copy any Pydantic model, compatible with both v1 and v2.
+
+    Args:
+        obj: The Pydantic model to copy.
+        **kwargs: Additional arguments passed to model_copy/copy.
+
+    Returns:
+        A copy of the model.
+    """
+    if _RUN_IS_PYDANTIC_V2:
+        return obj.model_copy(**kwargs)  # type: ignore[attr-defined,no-any-return]
+    return obj.copy(**kwargs)  # type: ignore[attr-defined,no-any-return]

--- a/libs/core/langchain_core/tracers/core.py
+++ b/libs/core/langchain_core/tracers/core.py
@@ -184,7 +184,7 @@ class _TracerCore(ABC):
             # Changing this to "chat_model" may break triggering on_llm_start
             run_type="chat_model",
             tags=tags,
-            name=name,  # type: ignore[arg-type]
+            name=name,
         )
 
     def _create_llm_run(
@@ -213,7 +213,7 @@ class _TracerCore(ABC):
             start_time=start_time,
             run_type="llm",
             tags=tags or [],
-            name=name,  # type: ignore[arg-type]
+            name=name,
         )
 
     def _llm_run_with_token_event(
@@ -346,7 +346,7 @@ class _TracerCore(ABC):
             start_time=start_time,
             child_runs=[],
             run_type=run_type or "chain",
-            name=name,  # type: ignore[arg-type]
+            name=name,
             tags=tags or [],
         )
 
@@ -443,7 +443,7 @@ class _TracerCore(ABC):
             child_runs=[],
             run_type="tool",
             tags=tags or [],
-            name=name,  # type: ignore[arg-type]
+            name=name,
         )
 
     def _complete_tool_run(

--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -13,6 +13,7 @@ import langsmith
 from langsmith.evaluation.evaluator import EvaluationResult, EvaluationResults
 
 from langchain_core.tracers import langchain as langchain_tracer
+from langchain_core.tracers._compat import run_copy
 from langchain_core.tracers.base import BaseTracer
 from langchain_core.tracers.context import tracing_v2_enabled
 from langchain_core.tracers.langchain import _get_executor
@@ -206,7 +207,7 @@ class EvaluatorCallbackHandler(BaseTracer):
         if self.skip_unfinished and not run.outputs:
             logger.debug("Skipping unfinished run %s", run.id)
             return
-        run_ = run.model_copy() if hasattr(run, "model_copy") else run.copy()  # type: ignore[deprecated]
+        run_ = run_copy(run)
         run_.reference_example_id = self.example_id
         for evaluator in self.evaluators:
             if self.executor is None:

--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -188,7 +188,7 @@ class EvaluatorCallbackHandler(BaseTracer):
                 run_id_,
                 res.key,
                 score=res.score,
-                value=res.value,
+                value=res.value,  # type: ignore[arg-type]
                 comment=res.comment,
                 correction=res.correction,
                 source_info=source_info_,
@@ -206,7 +206,10 @@ class EvaluatorCallbackHandler(BaseTracer):
         if self.skip_unfinished and not run.outputs:
             logger.debug("Skipping unfinished run %s", run.id)
             return
-        run_ = run.copy()
+        if hasattr(run, "model_copy"):
+            run_ = run.model_copy()
+        else:
+            run_ = run.copy()  # type: ignore[deprecated]
         run_.reference_example_id = self.example_id
         for evaluator in self.evaluators:
             if self.executor is None:

--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -206,10 +206,7 @@ class EvaluatorCallbackHandler(BaseTracer):
         if self.skip_unfinished and not run.outputs:
             logger.debug("Skipping unfinished run %s", run.id)
             return
-        if hasattr(run, "model_copy"):
-            run_ = run.model_copy()
-        else:
-            run_ = run.copy()  # type: ignore[deprecated]
+        run_ = run.model_copy() if hasattr(run, "model_copy") else run.copy()  # type: ignore[deprecated]
         run_.reference_example_id = self.example_id
         for evaluator in self.evaluators:
             if self.executor is None:

--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -189,7 +189,7 @@ class EvaluatorCallbackHandler(BaseTracer):
                 run_id_,
                 res.key,
                 score=res.score,
-                value=res.value,  # type: ignore[arg-type]
+                value=res.value,
                 comment=res.comment,
                 correction=res.correction,
                 source_info=source_info_,

--- a/libs/core/langchain_core/tracers/langchain.py
+++ b/libs/core/langchain_core/tracers/langchain.py
@@ -22,6 +22,7 @@ from typing_extensions import override
 from langchain_core.env import get_runtime_environment
 from langchain_core.load import dumpd
 from langchain_core.messages.ai import UsageMetadata, add_usage
+from langchain_core.tracers._compat import run_construct, run_to_dict
 from langchain_core.tracers.base import BaseTracer
 from langchain_core.tracers.schemas import Run
 
@@ -192,23 +193,12 @@ class LangChainTracer(BaseTracer):
     def _persist_run(self, run: Run) -> None:
         # We want to free up more memory by avoiding keeping a reference to the
         # whole nested run tree.
-        if hasattr(run, "model_dump"):
-            run_data = run.model_dump(exclude={"child_runs", "inputs", "outputs"})
-        else:
-            run_data = run.dict(exclude={"child_runs", "inputs", "outputs"})  # type: ignore[deprecated]
-
-        if hasattr(Run, "model_construct"):
-            self.latest_run = Run.model_construct(
-                **run_data,
-                inputs=run.inputs,
-                outputs=run.outputs,
-            )
-        else:
-            self.latest_run = Run.construct(  # type: ignore[deprecated]
-                **run_data,
-                inputs=run.inputs,
-                outputs=run.outputs,
-            )
+        run_data = run_to_dict(run, exclude={"child_runs", "inputs", "outputs"})
+        self.latest_run = run_construct(
+            **run_data,
+            inputs=run.inputs,
+            outputs=run.outputs,
+        )
 
     def get_run_url(self) -> str:
         """Get the LangSmith root run URL.

--- a/libs/core/langchain_core/tracers/langchain.py
+++ b/libs/core/langchain_core/tracers/langchain.py
@@ -192,7 +192,6 @@ class LangChainTracer(BaseTracer):
     def _persist_run(self, run: Run) -> None:
         # We want to free up more memory by avoiding keeping a reference to the
         # whole nested run tree.
-        # Use Pydantic v2 methods if available, fall back to v1 for compatibility
         if hasattr(run, "model_dump"):
             run_data = run.model_dump(exclude={"child_runs", "inputs", "outputs"})
         else:

--- a/libs/core/langchain_core/tracers/run_collector.py
+++ b/libs/core/langchain_core/tracers/run_collector.py
@@ -35,9 +35,6 @@ class RunCollectorCallbackHandler(BaseTracer):
         Args:
             run: The run to be persisted.
         """
-        if hasattr(run, "model_copy"):
-            run_ = run.model_copy()
-        else:
-            run_ = run.copy()  # type: ignore[deprecated]
+        run_ = run.model_copy() if hasattr(run, "model_copy") else run.copy()  # type: ignore[deprecated]
         run_.reference_example_id = self.example_id
         self.traced_runs.append(run_)

--- a/libs/core/langchain_core/tracers/run_collector.py
+++ b/libs/core/langchain_core/tracers/run_collector.py
@@ -35,6 +35,9 @@ class RunCollectorCallbackHandler(BaseTracer):
         Args:
             run: The run to be persisted.
         """
-        run_ = run.copy()
+        if hasattr(run, "model_copy"):
+            run_ = run.model_copy()
+        else:
+            run_ = run.copy()  # type: ignore[deprecated]
         run_.reference_example_id = self.example_id
         self.traced_runs.append(run_)

--- a/libs/core/langchain_core/tracers/run_collector.py
+++ b/libs/core/langchain_core/tracers/run_collector.py
@@ -3,6 +3,7 @@
 from typing import Any
 from uuid import UUID
 
+from langchain_core.tracers._compat import run_copy
 from langchain_core.tracers.base import BaseTracer
 from langchain_core.tracers.schemas import Run
 
@@ -35,6 +36,6 @@ class RunCollectorCallbackHandler(BaseTracer):
         Args:
             run: The run to be persisted.
         """
-        run_ = run.model_copy() if hasattr(run, "model_copy") else run.copy()  # type: ignore[deprecated]
+        run_ = run_copy(run)
         run_.reference_example_id = self.example_id
         self.traced_runs.append(run_)

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "1.2.5"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langsmith>=0.3.45,<1.0.0",
+    "langsmith>=0.6.0,<1.0.0",
     "tenacity!=8.4.0,>=8.1.0,<10.0.0",
     "jsonpatch>=1.33.0,<2.0.0",
     "PyYAML>=5.3.0,<7.0.0",

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "1.2.5"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langsmith>=0.6.0rc0,<1.0.0",
+    "langsmith>=0.3.45,<1.0.0",
     "tenacity!=8.4.0,>=8.1.0,<10.0.0",
     "jsonpatch>=1.33.0,<2.0.0",
     "PyYAML>=5.3.0,<7.0.0",

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "1.2.5"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langsmith>=0.6.0,<1.0.0",
+    "langsmith>=0.3.45,<1.0.0",
     "tenacity!=8.4.0,>=8.1.0,<10.0.0",
     "jsonpatch>=1.33.0,<2.0.0",
     "PyYAML>=5.3.0,<7.0.0",

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -12,7 +12,7 @@ authors = []
 version = "1.2.5"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langsmith>=0.3.45,<1.0.0",
+    "langsmith>=0.6.0rc0,<1.0.0",
     "tenacity!=8.4.0,>=8.1.0,<10.0.0",
     "jsonpatch>=1.33.0,<2.0.0",
     "PyYAML>=5.3.0,<7.0.0",

--- a/libs/core/tests/unit_tests/document_loaders/test_langsmith.py
+++ b/libs/core/tests/unit_tests/document_loaders/test_langsmith.py
@@ -6,6 +6,7 @@ from langsmith.schemas import Example
 
 from langchain_core.document_loaders import LangSmithLoader
 from langchain_core.documents import Document
+from langchain_core.tracers._compat import pydantic_to_dict
 
 
 def test_init() -> None:
@@ -47,9 +48,7 @@ def test_lazy_load() -> None:
     )
     expected = []
     for example in EXAMPLES:
-        example_dict = (
-            example.model_dump() if hasattr(example, "model_dump") else example.dict()  # type: ignore[deprecated]
-        )
+        example_dict = pydantic_to_dict(example)
         metadata = {
             k: v if not v or isinstance(v, dict) else str(v)
             for k, v in example_dict.items()

--- a/libs/core/tests/unit_tests/document_loaders/test_langsmith.py
+++ b/libs/core/tests/unit_tests/document_loaders/test_langsmith.py
@@ -49,7 +49,7 @@ def test_lazy_load() -> None:
     for example in EXAMPLES:
         metadata = {
             k: v if not v or isinstance(v, dict) else str(v)
-            for k, v in example.dict().items()
+            for k, v in (example.model_dump() if hasattr(example, "model_dump") else example.dict()).items()  # type: ignore[deprecated]
         }
         expected.append(
             Document(example.inputs["first"]["second"].upper(), metadata=metadata)

--- a/libs/core/tests/unit_tests/document_loaders/test_langsmith.py
+++ b/libs/core/tests/unit_tests/document_loaders/test_langsmith.py
@@ -47,9 +47,14 @@ def test_lazy_load() -> None:
     )
     expected = []
     for example in EXAMPLES:
+        example_dict = (
+            example.model_dump()
+            if hasattr(example, "model_dump")
+            else example.dict()  # type: ignore[deprecated]
+        )
         metadata = {
             k: v if not v or isinstance(v, dict) else str(v)
-            for k, v in (example.model_dump() if hasattr(example, "model_dump") else example.dict()).items()  # type: ignore[deprecated]
+            for k, v in example_dict.items()
         }
         expected.append(
             Document(example.inputs["first"]["second"].upper(), metadata=metadata)

--- a/libs/core/tests/unit_tests/document_loaders/test_langsmith.py
+++ b/libs/core/tests/unit_tests/document_loaders/test_langsmith.py
@@ -48,9 +48,7 @@ def test_lazy_load() -> None:
     expected = []
     for example in EXAMPLES:
         example_dict = (
-            example.model_dump()
-            if hasattr(example, "model_dump")
-            else example.dict()  # type: ignore[deprecated]
+            example.model_dump() if hasattr(example, "model_dump") else example.dict()  # type: ignore[deprecated]
         )
         metadata = {
             k: v if not v or isinstance(v, dict) else str(v)

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -147,19 +147,20 @@ class FakeTracer(BaseTracer):
             new_dotted_order = ".".join(processed_levels)
         else:
             new_dotted_order = None
-        return run.copy(
-            update={
-                "id": self._replace_uuid(run.id),
-                "parent_run_id": (
-                    self.uuids_map[run.parent_run_id] if run.parent_run_id else None
-                ),
-                "child_runs": [self._copy_run(child) for child in run.child_runs],
-                "trace_id": self._replace_uuid(run.trace_id) if run.trace_id else None,
-                "dotted_order": new_dotted_order,
-                "inputs": self._replace_message_id(run.inputs),
-                "outputs": self._replace_message_id(run.outputs),
-            }
-        )
+        update_dict = {
+            "id": self._replace_uuid(run.id),
+            "parent_run_id": (
+                self.uuids_map[run.parent_run_id] if run.parent_run_id else None
+            ),
+            "child_runs": [self._copy_run(child) for child in run.child_runs],
+            "trace_id": self._replace_uuid(run.trace_id) if run.trace_id else None,
+            "dotted_order": new_dotted_order,
+            "inputs": self._replace_message_id(run.inputs),
+            "outputs": self._replace_message_id(run.outputs),
+        }
+        if hasattr(run, "model_copy"):
+            return run.model_copy(update=update_dict)
+        return run.copy(update=update_dict)  # type: ignore[deprecated]
 
     def _persist_run(self, run: Run) -> None:
         """Persist a run."""

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -88,6 +88,7 @@ from langchain_core.tracers import (
     RunLog,
     RunLogPatch,
 )
+from langchain_core.tracers._compat import pydantic_copy
 from langchain_core.tracers.context import collect_runs
 from langchain_core.utils.pydantic import PYDANTIC_VERSION
 from tests.unit_tests.pydantic_utils import _normalize_schema, _schema
@@ -158,9 +159,7 @@ class FakeTracer(BaseTracer):
             "inputs": self._replace_message_id(run.inputs),
             "outputs": self._replace_message_id(run.outputs),
         }
-        if hasattr(run, "model_copy"):
-            return run.model_copy(update=update_dict)
-        return run.copy(update=update_dict)  # type: ignore[deprecated]
+        return pydantic_copy(run, update=update_dict)
 
     def _persist_run(self, run: Run) -> None:
         """Persist a run."""

--- a/libs/core/tests/unit_tests/runnables/test_tracing_interops.py
+++ b/libs/core/tests/unit_tests/runnables/test_tracing_interops.py
@@ -77,7 +77,7 @@ def test_tracing_context() -> None:
 
 def test_config_traceable_handoff() -> None:
     if hasattr(get_env_var, "cache_clear"):
-        get_env_var.cache_clear()
+        get_env_var.cache_clear()  # type: ignore[attr-defined]
     tracer = _create_tracer_with_mocked_client(
         project_name="another-flippin-project", tags=["such-a-tag"]
     )
@@ -240,7 +240,7 @@ def test_tracing_enable_disable(
         return a + 1
 
     if hasattr(get_env_var, "cache_clear"):
-        get_env_var.cache_clear()
+        get_env_var.cache_clear()  # type: ignore[attr-defined]
     env_on = env == "true"
     with (
         patch.dict("os.environ", {"LANGSMITH_TRACING": env}),

--- a/libs/core/tests/unit_tests/runnables/test_tracing_interops.py
+++ b/libs/core/tests/unit_tests/runnables/test_tracing_interops.py
@@ -76,7 +76,8 @@ def test_tracing_context() -> None:
 
 
 def test_config_traceable_handoff() -> None:
-    get_env_var.cache_clear()
+    if hasattr(get_env_var, "cache_clear"):
+        get_env_var.cache_clear()
     tracer = _create_tracer_with_mocked_client(
         project_name="another-flippin-project", tags=["such-a-tag"]
     )
@@ -238,7 +239,8 @@ def test_tracing_enable_disable(
     def my_func(a: int) -> int:
         return a + 1
 
-    get_env_var.cache_clear()
+    if hasattr(get_env_var, "cache_clear"):
+        get_env_var.cache_clear()
     env_on = env == "true"
     with (
         patch.dict("os.environ", {"LANGSMITH_TRACING": env}),

--- a/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
@@ -90,7 +90,7 @@ async def test_tracer_chat_model_run() -> None:
         serialized=SERIALIZED_CHAT, messages=[[HumanMessage(content="")]]
     )
     compare_run = Run(
-        id=str(run_managers[0].run_id),  # type: ignore[arg-type]
+        id=str(run_managers[0].run_id),
         name="chat_model",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -158,7 +158,7 @@ async def test_tracer_chain_run() -> None:
     """Test tracer on a Chain run."""
     uuid = uuid4()
     compare_run = Run(
-        id=str(uuid),  # type: ignore[arg-type]
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -186,7 +186,7 @@ async def test_tracer_tool_run() -> None:
     """Test tracer on a Tool run."""
     uuid = uuid4()
     compare_run = Run(
-        id=str(uuid),  # type: ignore[arg-type]
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -247,7 +247,7 @@ async def test_tracer_nested_run() -> None:
         await tracer.on_chain_end(outputs={}, run_id=chain_uuid)
 
     compare_run = Run(
-        id=str(chain_uuid),  # type: ignore[arg-type]
+        id=str(chain_uuid),
         error=None,
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -263,7 +263,7 @@ async def test_tracer_nested_run() -> None:
         trace_id=chain_uuid,
         dotted_order=f"20230101T000000000000Z{chain_uuid}",
         child_runs=[
-            Run(  # type: ignore[call-arg]
+            Run(
                 id=tool_uuid,
                 parent_run_id=chain_uuid,
                 start_time=datetime.now(timezone.utc),
@@ -281,9 +281,9 @@ async def test_tracer_nested_run() -> None:
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{tool_uuid}",
                 child_runs=[
-                    Run(  # type: ignore[call-arg]
-                        id=str(llm_uuid1),  # type: ignore[arg-type]
-                        parent_run_id=str(tool_uuid),  # type: ignore[arg-type]
+                    Run(
+                        id=str(llm_uuid1),
+                        parent_run_id=str(tool_uuid),
                         error=None,
                         start_time=datetime.now(timezone.utc),
                         end_time=datetime.now(timezone.utc),
@@ -301,9 +301,9 @@ async def test_tracer_nested_run() -> None:
                     )
                 ],
             ),
-            Run(  # type: ignore[call-arg]
-                id=str(llm_uuid2),  # type: ignore[arg-type]
-                parent_run_id=str(chain_uuid),  # type: ignore[arg-type]
+            Run(
+                id=str(llm_uuid2),
+                parent_run_id=str(chain_uuid),
                 error=None,
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -332,7 +332,7 @@ async def test_tracer_llm_run_on_error() -> None:
     uuid = uuid4()
 
     compare_run = Run(
-        id=str(uuid),  # type: ignore[arg-type]
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -363,7 +363,7 @@ async def test_tracer_llm_run_on_error_callback() -> None:
     uuid = uuid4()
 
     compare_run = Run(
-        id=str(uuid),  # type: ignore[arg-type]
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -399,7 +399,7 @@ async def test_tracer_chain_run_on_error() -> None:
     uuid = uuid4()
 
     compare_run = Run(
-        id=str(uuid),  # type: ignore[arg-type]
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -429,7 +429,7 @@ async def test_tracer_tool_run_on_error() -> None:
     uuid = uuid4()
 
     compare_run = Run(
-        id=str(uuid),  # type: ignore[arg-type]
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -501,7 +501,7 @@ async def test_tracer_nested_runs_on_error() -> None:
         await tracer.on_chain_error(exception, run_id=chain_uuid)
 
     compare_run = Run(
-        id=str(chain_uuid),  # type: ignore[arg-type]
+        id=str(chain_uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -517,9 +517,9 @@ async def test_tracer_nested_runs_on_error() -> None:
         trace_id=chain_uuid,
         dotted_order=f"20230101T000000000000Z{chain_uuid}",
         child_runs=[
-            Run(  # type: ignore[call-arg]
+            Run(
                 id=str(llm_uuid1),  # type: ignore[arg-type]
-                parent_run_id=str(chain_uuid),  # type: ignore[arg-type]
+                parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
                 events=[
@@ -535,9 +535,9 @@ async def test_tracer_nested_runs_on_error() -> None:
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid1}",
             ),
-            Run(  # type: ignore[call-arg]
-                id=str(llm_uuid2),  # type: ignore[arg-type]
-                parent_run_id=str(chain_uuid),  # type: ignore[arg-type]
+            Run(
+                id=str(llm_uuid2),
+                parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
                 events=[
@@ -553,9 +553,9 @@ async def test_tracer_nested_runs_on_error() -> None:
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid2}",
             ),
-            Run(  # type: ignore[call-arg]
+            Run(
                 id=str(tool_uuid),  # type: ignore[arg-type]
-                parent_run_id=str(chain_uuid),  # type: ignore[arg-type]
+                parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
                 events=[
@@ -570,9 +570,9 @@ async def test_tracer_nested_runs_on_error() -> None:
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{tool_uuid}",
                 child_runs=[
-                    Run(  # type: ignore[call-arg]
+                    Run(
                         id=str(llm_uuid3),  # type: ignore[arg-type]
-                        parent_run_id=str(tool_uuid),  # type: ignore[arg-type]
+                        parent_run_id=str(tool_uuid),
                         start_time=datetime.now(timezone.utc),
                         end_time=datetime.now(timezone.utc),
                         events=[

--- a/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
@@ -66,6 +66,7 @@ async def test_tracer_llm_run() -> None:
     uuid = uuid4()
     compare_run = Run(
         id=uuid,
+        name="llm",
         parent_run_id=None,
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -167,6 +168,7 @@ async def test_tracer_chain_run() -> None:
     uuid = uuid4()
     compare_run = Run(
         id=str(uuid),
+        name="chain",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -195,6 +197,7 @@ async def test_tracer_tool_run() -> None:
     uuid = uuid4()
     compare_run = Run(
         id=str(uuid),
+        name="tool",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -256,6 +259,7 @@ async def test_tracer_nested_run() -> None:
 
     compare_run = Run(
         id=str(chain_uuid),
+        name="chain",
         error=None,
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -273,6 +277,7 @@ async def test_tracer_nested_run() -> None:
         child_runs=[
             Run(
                 id=tool_uuid,
+                name="tool",
                 parent_run_id=chain_uuid,
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -291,6 +296,7 @@ async def test_tracer_nested_run() -> None:
                 child_runs=[
                     Run(
                         id=str(llm_uuid1),
+                        name="llm",
                         parent_run_id=str(tool_uuid),
                         error=None,
                         start_time=datetime.now(timezone.utc),
@@ -311,6 +317,7 @@ async def test_tracer_nested_run() -> None:
             ),
             Run(
                 id=str(llm_uuid2),
+                name="llm",
                 parent_run_id=str(chain_uuid),
                 error=None,
                 start_time=datetime.now(timezone.utc),
@@ -341,6 +348,7 @@ async def test_tracer_llm_run_on_error() -> None:
 
     compare_run = Run(
         id=str(uuid),
+        name="llm",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -372,6 +380,7 @@ async def test_tracer_llm_run_on_error_callback() -> None:
 
     compare_run = Run(
         id=str(uuid),
+        name="llm",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -408,6 +417,7 @@ async def test_tracer_chain_run_on_error() -> None:
 
     compare_run = Run(
         id=str(uuid),
+        name="chain",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -438,6 +448,7 @@ async def test_tracer_tool_run_on_error() -> None:
 
     compare_run = Run(
         id=str(uuid),
+        name="tool",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -510,6 +521,7 @@ async def test_tracer_nested_runs_on_error() -> None:
 
     compare_run = Run(
         id=str(chain_uuid),
+        name="chain",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -527,6 +539,7 @@ async def test_tracer_nested_runs_on_error() -> None:
         child_runs=[
             Run(
                 id=str(llm_uuid1),
+                name="llm",
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -545,6 +558,7 @@ async def test_tracer_nested_runs_on_error() -> None:
             ),
             Run(
                 id=str(llm_uuid2),
+                name="llm",
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -563,6 +577,7 @@ async def test_tracer_nested_runs_on_error() -> None:
             ),
             Run(
                 id=str(tool_uuid),
+                name="tool",
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -580,6 +595,7 @@ async def test_tracer_nested_runs_on_error() -> None:
                 child_runs=[
                     Run(
                         id=str(llm_uuid3),
+                        name="llm",
                         parent_run_id=str(tool_uuid),
                         start_time=datetime.now(timezone.utc),
                         end_time=datetime.now(timezone.utc),

--- a/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
@@ -39,9 +39,15 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
             run.child_runs, expected_run.child_runs, strict=False
         ):
             _compare_run_with_error(received, expected)
-    received = run.model_dump(exclude={"child_runs"}) if hasattr(run, "model_dump") else run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
+    if hasattr(run, "model_dump"):
+        received = run.model_dump(exclude={"child_runs"})
+    else:
+        received = run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
     received_err = received.pop("error")
-    expected = expected_run.model_dump(exclude={"child_runs"}) if hasattr(expected_run, "model_dump") else expected_run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
+    if hasattr(expected_run, "model_dump"):
+        expected = expected_run.model_dump(exclude={"child_runs"})
+    else:
+        expected = expected_run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
     expected_err = expected.pop("error")
 
     assert received == expected
@@ -518,7 +524,7 @@ async def test_tracer_nested_runs_on_error() -> None:
         dotted_order=f"20230101T000000000000Z{chain_uuid}",
         child_runs=[
             Run(
-                id=str(llm_uuid1),  # type: ignore[arg-type]
+                id=str(llm_uuid1),
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -554,7 +560,7 @@ async def test_tracer_nested_runs_on_error() -> None:
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid2}",
             ),
             Run(
-                id=str(tool_uuid),  # type: ignore[arg-type]
+                id=str(tool_uuid),
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -571,7 +577,7 @@ async def test_tracer_nested_runs_on_error() -> None:
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{tool_uuid}",
                 child_runs=[
                     Run(
-                        id=str(llm_uuid3),  # type: ignore[arg-type]
+                        id=str(llm_uuid3),
                         parent_run_id=str(tool_uuid),
                         start_time=datetime.now(timezone.utc),
                         end_time=datetime.now(timezone.utc),

--- a/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
@@ -13,6 +13,7 @@ from langchain_core.callbacks import AsyncCallbackManager
 from langchain_core.exceptions import TracerException
 from langchain_core.messages import HumanMessage
 from langchain_core.outputs import LLMResult
+from langchain_core.tracers._compat import pydantic_to_dict
 from langchain_core.tracers.base import AsyncBaseTracer
 from langchain_core.tracers.schemas import Run
 
@@ -39,17 +40,9 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
             run.child_runs, expected_run.child_runs, strict=False
         ):
             _compare_run_with_error(received, expected)
-    received = (
-        run.model_dump(exclude={"child_runs"})
-        if hasattr(run, "model_dump")
-        else run.dict(exclude={"child_runs"})
-    )
+    received = pydantic_to_dict(run, exclude={"child_runs"})
     received_err = received.pop("error")
-    expected = (
-        expected_run.model_dump(exclude={"child_runs"})
-        if hasattr(expected_run, "model_dump")
-        else expected_run.dict(exclude={"child_runs"})
-    )
+    expected = pydantic_to_dict(expected_run, exclude={"child_runs"})
     expected_err = expected.pop("error")
 
     assert received == expected

--- a/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
@@ -39,15 +39,17 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
             run.child_runs, expected_run.child_runs, strict=False
         ):
             _compare_run_with_error(received, expected)
-    if hasattr(run, "model_dump"):
-        received = run.model_dump(exclude={"child_runs"})
-    else:
-        received = run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
+    received = (
+        run.model_dump(exclude={"child_runs"})
+        if hasattr(run, "model_dump")
+        else run.dict(exclude={"child_runs"})
+    )
     received_err = received.pop("error")
-    if hasattr(expected_run, "model_dump"):
-        expected = expected_run.model_dump(exclude={"child_runs"})
-    else:
-        expected = expected_run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
+    expected = (
+        expected_run.model_dump(exclude={"child_runs"})
+        if hasattr(expected_run, "model_dump")
+        else expected_run.dict(exclude={"child_runs"})
+    )
     expected_err = expected.pop("error")
 
     assert received == expected

--- a/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_async_base_tracer.py
@@ -39,9 +39,9 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
             run.child_runs, expected_run.child_runs, strict=False
         ):
             _compare_run_with_error(received, expected)
-    received = run.dict(exclude={"child_runs"})
+    received = run.model_dump(exclude={"child_runs"}) if hasattr(run, "model_dump") else run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
     received_err = received.pop("error")
-    expected = expected_run.dict(exclude={"child_runs"})
+    expected = expected_run.model_dump(exclude={"child_runs"}) if hasattr(expected_run, "model_dump") else expected_run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
     expected_err = expected.pop("error")
 
     assert received == expected
@@ -56,7 +56,7 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
 async def test_tracer_llm_run() -> None:
     """Test tracer on an LLM run."""
     uuid = uuid4()
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=uuid,
         parent_run_id=None,
         start_time=datetime.now(timezone.utc),
@@ -68,7 +68,7 @@ async def test_tracer_llm_run() -> None:
         extra={},
         serialized=SERIALIZED,
         inputs={"prompts": []},
-        outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+        outputs=LLMResult(generations=[[]]).model_dump(),
         error=None,
         run_type="llm",
         trace_id=uuid,
@@ -101,7 +101,7 @@ async def test_tracer_chat_model_run() -> None:
         extra={},
         serialized=SERIALIZED_CHAT,
         inputs={"prompts": ["Human: "]},
-        outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+        outputs=LLMResult(generations=[[]]).model_dump(),
         error=None,
         run_type="llm",
         trace_id=run_managers[0].run_id,
@@ -137,7 +137,7 @@ async def test_tracer_multiple_llm_runs() -> None:
         extra={},
         serialized=SERIALIZED,
         inputs={"prompts": []},
-        outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+        outputs=LLMResult(generations=[[]]).model_dump(),
         error=None,
         run_type="llm",
         trace_id=uuid,
@@ -157,7 +157,7 @@ async def test_tracer_multiple_llm_runs() -> None:
 async def test_tracer_chain_run() -> None:
     """Test tracer on a Chain run."""
     uuid = uuid4()
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=str(uuid),  # type: ignore[arg-type]
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -185,7 +185,7 @@ async def test_tracer_chain_run() -> None:
 async def test_tracer_tool_run() -> None:
     """Test tracer on a Tool run."""
     uuid = uuid4()
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=str(uuid),  # type: ignore[arg-type]
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -246,7 +246,7 @@ async def test_tracer_nested_run() -> None:
         await tracer.on_llm_end(response=LLMResult(generations=[[]]), run_id=llm_uuid2)
         await tracer.on_chain_end(outputs={}, run_id=chain_uuid)
 
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=str(chain_uuid),  # type: ignore[arg-type]
         error=None,
         start_time=datetime.now(timezone.utc),
@@ -294,7 +294,7 @@ async def test_tracer_nested_run() -> None:
                         extra={},
                         serialized=SERIALIZED,
                         inputs={"prompts": []},
-                        outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+                        outputs=LLMResult(generations=[[]]).model_dump(),
                         run_type="llm",
                         trace_id=chain_uuid,
                         dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{tool_uuid}.20230101T000000000000Z{llm_uuid1}",
@@ -314,7 +314,7 @@ async def test_tracer_nested_run() -> None:
                 extra={},
                 serialized=SERIALIZED,
                 inputs={"prompts": []},
-                outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+                outputs=LLMResult(generations=[[]]).model_dump(),
                 run_type="llm",
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid2}",
@@ -331,7 +331,7 @@ async def test_tracer_llm_run_on_error() -> None:
     exception = Exception("test")
     uuid = uuid4()
 
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=str(uuid),  # type: ignore[arg-type]
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -362,7 +362,7 @@ async def test_tracer_llm_run_on_error_callback() -> None:
     exception = Exception("test")
     uuid = uuid4()
 
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=str(uuid),  # type: ignore[arg-type]
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -398,7 +398,7 @@ async def test_tracer_chain_run_on_error() -> None:
     exception = Exception("test")
     uuid = uuid4()
 
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=str(uuid),  # type: ignore[arg-type]
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -428,7 +428,7 @@ async def test_tracer_tool_run_on_error() -> None:
     exception = Exception("test")
     uuid = uuid4()
 
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=str(uuid),  # type: ignore[arg-type]
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -500,7 +500,7 @@ async def test_tracer_nested_runs_on_error() -> None:
         await tracer.on_tool_error(exception, run_id=tool_uuid)
         await tracer.on_chain_error(exception, run_id=chain_uuid)
 
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=str(chain_uuid),  # type: ignore[arg-type]
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -530,7 +530,7 @@ async def test_tracer_nested_runs_on_error() -> None:
                 serialized=SERIALIZED,
                 error=None,
                 inputs={"prompts": []},
-                outputs=LLMResult(generations=[[]], llm_output=None),  # type: ignore[arg-type]
+                outputs=LLMResult(generations=[[]], llm_output=None).model_dump(),
                 run_type="llm",
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid1}",
@@ -548,7 +548,7 @@ async def test_tracer_nested_runs_on_error() -> None:
                 serialized=SERIALIZED,
                 error=None,
                 inputs={"prompts": []},
-                outputs=LLMResult(generations=[[]], llm_output=None),  # type: ignore[arg-type]
+                outputs=LLMResult(generations=[[]], llm_output=None).model_dump(),
                 run_type="llm",
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid2}",

--- a/libs/core/tests/unit_tests/tracers/test_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_base_tracer.py
@@ -519,7 +519,7 @@ def test_tracer_nested_runs_on_error() -> None:
         dotted_order=f"20230101T000000000000Z{chain_uuid}",
         child_runs=[
             Run(
-                id=str(llm_uuid1),  # type: ignore[arg-type]
+                id=str(llm_uuid1),
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -555,7 +555,7 @@ def test_tracer_nested_runs_on_error() -> None:
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid2}",
             ),
             Run(
-                id=str(tool_uuid),  # type: ignore[arg-type]
+                id=str(tool_uuid),
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -572,7 +572,7 @@ def test_tracer_nested_runs_on_error() -> None:
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{tool_uuid}",
                 child_runs=[
                     Run(
-                        id=str(llm_uuid3),  # type: ignore[arg-type]
+                        id=str(llm_uuid3),
                         parent_run_id=str(tool_uuid),
                         start_time=datetime.now(timezone.utc),
                         end_time=datetime.now(timezone.utc),

--- a/libs/core/tests/unit_tests/tracers/test_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_base_tracer.py
@@ -44,9 +44,9 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
             run.child_runs, expected_run.child_runs, strict=False
         ):
             _compare_run_with_error(received, expected)
-    received = run.dict(exclude={"child_runs"})
+    received = run.model_dump(exclude={"child_runs"}) if hasattr(run, "model_dump") else run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
     received_err = received.pop("error")
-    expected = expected_run.dict(exclude={"child_runs"})
+    expected = expected_run.model_dump(exclude={"child_runs"}) if hasattr(expected_run, "model_dump") else expected_run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
     expected_err = expected.pop("error")
 
     assert received == expected
@@ -61,7 +61,7 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
 def test_tracer_llm_run() -> None:
     """Test tracer on an LLM run."""
     uuid = uuid4()
-    compare_run = Run(  # type: ignore[call-arg]
+    compare_run = Run(
         id=uuid,
         parent_run_id=None,
         start_time=datetime.now(timezone.utc),
@@ -73,7 +73,7 @@ def test_tracer_llm_run() -> None:
         extra={},
         serialized=SERIALIZED,
         inputs={"prompts": []},
-        outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+        outputs=LLMResult(generations=[[]]).model_dump(),
         error=None,
         run_type="llm",
         trace_id=uuid,
@@ -95,7 +95,7 @@ def test_tracer_chat_model_run() -> None:
         serialized=SERIALIZED_CHAT, messages=[[HumanMessage(content="")]]
     )
     compare_run = Run(
-        id=str(run_managers[0].run_id),  # type: ignore[arg-type]
+        id=str(run_managers[0].run_id),
         name="chat_model",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -106,7 +106,7 @@ def test_tracer_chat_model_run() -> None:
         extra={},
         serialized=SERIALIZED_CHAT,
         inputs={"prompts": ["Human: "]},
-        outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+        outputs=LLMResult(generations=[[]]).model_dump(),
         error=None,
         run_type="llm",
         trace_id=run_managers[0].run_id,
@@ -142,7 +142,7 @@ def test_tracer_multiple_llm_runs() -> None:
         extra={},
         serialized=SERIALIZED,
         inputs={"prompts": []},
-        outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+        outputs=LLMResult(generations=[[]]).model_dump(),
         error=None,
         run_type="llm",
         trace_id=uuid,
@@ -162,8 +162,8 @@ def test_tracer_multiple_llm_runs() -> None:
 def test_tracer_chain_run() -> None:
     """Test tracer on a Chain run."""
     uuid = uuid4()
-    compare_run = Run(  # type: ignore[call-arg]
-        id=str(uuid),  # type: ignore[arg-type]
+    compare_run = Run(
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -190,8 +190,8 @@ def test_tracer_chain_run() -> None:
 def test_tracer_tool_run() -> None:
     """Test tracer on a Tool run."""
     uuid = uuid4()
-    compare_run = Run(  # type: ignore[call-arg]
-        id=str(uuid),  # type: ignore[arg-type]
+    compare_run = Run(
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -249,8 +249,8 @@ def test_tracer_nested_run() -> None:
         tracer.on_llm_end(response=LLMResult(generations=[[]]), run_id=llm_uuid2)
         tracer.on_chain_end(outputs={}, run_id=chain_uuid)
 
-    compare_run = Run(  # type: ignore[call-arg]
-        id=str(chain_uuid),  # type: ignore[arg-type]
+    compare_run = Run(
+        id=str(chain_uuid),
         error=None,
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -266,7 +266,7 @@ def test_tracer_nested_run() -> None:
         trace_id=chain_uuid,
         dotted_order=f"20230101T000000000000Z{chain_uuid}",
         child_runs=[
-            Run(  # type: ignore[call-arg]
+            Run(
                 id=tool_uuid,
                 parent_run_id=chain_uuid,
                 start_time=datetime.now(timezone.utc),
@@ -284,9 +284,9 @@ def test_tracer_nested_run() -> None:
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{tool_uuid}",
                 child_runs=[
-                    Run(  # type: ignore[call-arg]
-                        id=str(llm_uuid1),  # type: ignore[arg-type]
-                        parent_run_id=str(tool_uuid),  # type: ignore[arg-type]
+                    Run(
+                        id=str(llm_uuid1),
+                        parent_run_id=str(tool_uuid),
                         error=None,
                         start_time=datetime.now(timezone.utc),
                         end_time=datetime.now(timezone.utc),
@@ -297,16 +297,16 @@ def test_tracer_nested_run() -> None:
                         extra={},
                         serialized=SERIALIZED,
                         inputs={"prompts": []},
-                        outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+                        outputs=LLMResult(generations=[[]]).model_dump(),
                         run_type="llm",
                         trace_id=chain_uuid,
                         dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{tool_uuid}.20230101T000000000000Z{llm_uuid1}",
                     )
                 ],
             ),
-            Run(  # type: ignore[call-arg]
-                id=str(llm_uuid2),  # type: ignore[arg-type]
-                parent_run_id=str(chain_uuid),  # type: ignore[arg-type]
+            Run(
+                id=str(llm_uuid2),
+                parent_run_id=str(chain_uuid),
                 error=None,
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -317,7 +317,7 @@ def test_tracer_nested_run() -> None:
                 extra={},
                 serialized=SERIALIZED,
                 inputs={"prompts": []},
-                outputs=LLMResult(generations=[[]]),  # type: ignore[arg-type]
+                outputs=LLMResult(generations=[[]]).model_dump(),
                 run_type="llm",
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid2}",
@@ -334,8 +334,8 @@ def test_tracer_llm_run_on_error() -> None:
     exception = Exception("test")
     uuid = uuid4()
 
-    compare_run = Run(  # type: ignore[call-arg]
-        id=str(uuid),  # type: ignore[arg-type]
+    compare_run = Run(
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -365,8 +365,8 @@ def test_tracer_llm_run_on_error_callback() -> None:
     exception = Exception("test")
     uuid = uuid4()
 
-    compare_run = Run(  # type: ignore[call-arg]
-        id=str(uuid),  # type: ignore[arg-type]
+    compare_run = Run(
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -401,8 +401,8 @@ def test_tracer_chain_run_on_error() -> None:
     exception = Exception("test")
     uuid = uuid4()
 
-    compare_run = Run(  # type: ignore[call-arg]
-        id=str(uuid),  # type: ignore[arg-type]
+    compare_run = Run(
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -431,8 +431,8 @@ def test_tracer_tool_run_on_error() -> None:
     exception = Exception("test")
     uuid = uuid4()
 
-    compare_run = Run(  # type: ignore[call-arg]
-        id=str(uuid),  # type: ignore[arg-type]
+    compare_run = Run(
+        id=str(uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -501,8 +501,8 @@ def test_tracer_nested_runs_on_error() -> None:
         tracer.on_tool_error(exception, run_id=tool_uuid)
         tracer.on_chain_error(exception, run_id=chain_uuid)
 
-    compare_run = Run(  # type: ignore[call-arg]
-        id=str(chain_uuid),  # type: ignore[arg-type]
+    compare_run = Run(
+        id=str(chain_uuid),
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -518,9 +518,9 @@ def test_tracer_nested_runs_on_error() -> None:
         trace_id=chain_uuid,
         dotted_order=f"20230101T000000000000Z{chain_uuid}",
         child_runs=[
-            Run(  # type: ignore[call-arg]
+            Run(
                 id=str(llm_uuid1),  # type: ignore[arg-type]
-                parent_run_id=str(chain_uuid),  # type: ignore[arg-type]
+                parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
                 events=[
@@ -531,14 +531,14 @@ def test_tracer_nested_runs_on_error() -> None:
                 serialized=SERIALIZED,
                 error=None,
                 inputs={"prompts": []},
-                outputs=LLMResult(generations=[[]], llm_output=None),  # type: ignore[arg-type]
+                outputs=LLMResult(generations=[[]], llm_output=None).model_dump(),
                 run_type="llm",
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid1}",
             ),
-            Run(  # type: ignore[call-arg]
-                id=str(llm_uuid2),  # type: ignore[arg-type]
-                parent_run_id=str(chain_uuid),  # type: ignore[arg-type]
+            Run(
+                id=str(llm_uuid2),
+                parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
                 events=[
@@ -549,14 +549,14 @@ def test_tracer_nested_runs_on_error() -> None:
                 serialized=SERIALIZED,
                 error=None,
                 inputs={"prompts": []},
-                outputs=LLMResult(generations=[[]], llm_output=None),  # type: ignore[arg-type]
+                outputs=LLMResult(generations=[[]], llm_output=None).model_dump(),
                 run_type="llm",
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{llm_uuid2}",
             ),
-            Run(  # type: ignore[call-arg]
+            Run(
                 id=str(tool_uuid),  # type: ignore[arg-type]
-                parent_run_id=str(chain_uuid),  # type: ignore[arg-type]
+                parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
                 events=[
@@ -571,9 +571,9 @@ def test_tracer_nested_runs_on_error() -> None:
                 trace_id=chain_uuid,
                 dotted_order=f"20230101T000000000000Z{chain_uuid}.20230101T000000000000Z{tool_uuid}",
                 child_runs=[
-                    Run(  # type: ignore[call-arg]
+                    Run(
                         id=str(llm_uuid3),  # type: ignore[arg-type]
-                        parent_run_id=str(tool_uuid),  # type: ignore[arg-type]
+                        parent_run_id=str(tool_uuid),
                         start_time=datetime.now(timezone.utc),
                         end_time=datetime.now(timezone.utc),
                         events=[

--- a/libs/core/tests/unit_tests/tracers/test_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_base_tracer.py
@@ -44,9 +44,15 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
             run.child_runs, expected_run.child_runs, strict=False
         ):
             _compare_run_with_error(received, expected)
-    received = run.model_dump(exclude={"child_runs"}) if hasattr(run, "model_dump") else run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
+    if hasattr(run, "model_dump"):
+        received = run.model_dump(exclude={"child_runs"})
+    else:
+        received = run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
     received_err = received.pop("error")
-    expected = expected_run.model_dump(exclude={"child_runs"}) if hasattr(expected_run, "model_dump") else expected_run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
+    if hasattr(expected_run, "model_dump"):
+        expected = expected_run.model_dump(exclude={"child_runs"})
+    else:
+        expected = expected_run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
     expected_err = expected.pop("error")
 
     assert received == expected

--- a/libs/core/tests/unit_tests/tracers/test_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_base_tracer.py
@@ -17,6 +17,7 @@ from langchain_core.exceptions import TracerException
 from langchain_core.messages import HumanMessage
 from langchain_core.outputs import LLMResult
 from langchain_core.runnables import chain as as_runnable
+from langchain_core.tracers._compat import pydantic_to_dict
 from langchain_core.tracers.base import BaseTracer
 from langchain_core.tracers.schemas import Run
 
@@ -44,17 +45,9 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
             run.child_runs, expected_run.child_runs, strict=False
         ):
             _compare_run_with_error(received, expected)
-    received = (
-        run.model_dump(exclude={"child_runs"})
-        if hasattr(run, "model_dump")
-        else run.dict(exclude={"child_runs"})
-    )
+    received = pydantic_to_dict(run, exclude={"child_runs"})
     received_err = received.pop("error")
-    expected = (
-        expected_run.model_dump(exclude={"child_runs"})
-        if hasattr(expected_run, "model_dump")
-        else expected_run.dict(exclude={"child_runs"})
-    )
+    expected = pydantic_to_dict(expected_run, exclude={"child_runs"})
     expected_err = expected.pop("error")
 
     assert received == expected

--- a/libs/core/tests/unit_tests/tracers/test_base_tracer.py
+++ b/libs/core/tests/unit_tests/tracers/test_base_tracer.py
@@ -44,15 +44,17 @@ def _compare_run_with_error(run: Any, expected_run: Any) -> None:
             run.child_runs, expected_run.child_runs, strict=False
         ):
             _compare_run_with_error(received, expected)
-    if hasattr(run, "model_dump"):
-        received = run.model_dump(exclude={"child_runs"})
-    else:
-        received = run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
+    received = (
+        run.model_dump(exclude={"child_runs"})
+        if hasattr(run, "model_dump")
+        else run.dict(exclude={"child_runs"})
+    )
     received_err = received.pop("error")
-    if hasattr(expected_run, "model_dump"):
-        expected = expected_run.model_dump(exclude={"child_runs"})
-    else:
-        expected = expected_run.dict(exclude={"child_runs"})  # type: ignore[deprecated]
+    expected = (
+        expected_run.model_dump(exclude={"child_runs"})
+        if hasattr(expected_run, "model_dump")
+        else expected_run.dict(exclude={"child_runs"})
+    )
     expected_err = expected.pop("error")
 
     assert received == expected
@@ -69,6 +71,7 @@ def test_tracer_llm_run() -> None:
     uuid = uuid4()
     compare_run = Run(
         id=uuid,
+        name="llm",
         parent_run_id=None,
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -170,6 +173,7 @@ def test_tracer_chain_run() -> None:
     uuid = uuid4()
     compare_run = Run(
         id=str(uuid),
+        name="chain",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -198,6 +202,7 @@ def test_tracer_tool_run() -> None:
     uuid = uuid4()
     compare_run = Run(
         id=str(uuid),
+        name="tool",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -257,6 +262,7 @@ def test_tracer_nested_run() -> None:
 
     compare_run = Run(
         id=str(chain_uuid),
+        name="chain",
         error=None,
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
@@ -274,6 +280,7 @@ def test_tracer_nested_run() -> None:
         child_runs=[
             Run(
                 id=tool_uuid,
+                name="tool",
                 parent_run_id=chain_uuid,
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -292,6 +299,7 @@ def test_tracer_nested_run() -> None:
                 child_runs=[
                     Run(
                         id=str(llm_uuid1),
+                        name="llm",
                         parent_run_id=str(tool_uuid),
                         error=None,
                         start_time=datetime.now(timezone.utc),
@@ -312,6 +320,7 @@ def test_tracer_nested_run() -> None:
             ),
             Run(
                 id=str(llm_uuid2),
+                name="llm",
                 parent_run_id=str(chain_uuid),
                 error=None,
                 start_time=datetime.now(timezone.utc),
@@ -342,6 +351,7 @@ def test_tracer_llm_run_on_error() -> None:
 
     compare_run = Run(
         id=str(uuid),
+        name="llm",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -373,6 +383,7 @@ def test_tracer_llm_run_on_error_callback() -> None:
 
     compare_run = Run(
         id=str(uuid),
+        name="llm",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -409,6 +420,7 @@ def test_tracer_chain_run_on_error() -> None:
 
     compare_run = Run(
         id=str(uuid),
+        name="chain",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -439,6 +451,7 @@ def test_tracer_tool_run_on_error() -> None:
 
     compare_run = Run(
         id=str(uuid),
+        name="tool",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -509,6 +522,7 @@ def test_tracer_nested_runs_on_error() -> None:
 
     compare_run = Run(
         id=str(chain_uuid),
+        name="chain",
         start_time=datetime.now(timezone.utc),
         end_time=datetime.now(timezone.utc),
         events=[
@@ -526,6 +540,7 @@ def test_tracer_nested_runs_on_error() -> None:
         child_runs=[
             Run(
                 id=str(llm_uuid1),
+                name="llm",
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -544,6 +559,7 @@ def test_tracer_nested_runs_on_error() -> None:
             ),
             Run(
                 id=str(llm_uuid2),
+                name="llm",
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -562,6 +578,7 @@ def test_tracer_nested_runs_on_error() -> None:
             ),
             Run(
                 id=str(tool_uuid),
+                name="tool",
                 parent_run_id=str(chain_uuid),
                 start_time=datetime.now(timezone.utc),
                 end_time=datetime.now(timezone.utc),
@@ -579,6 +596,7 @@ def test_tracer_nested_runs_on_error() -> None:
                 child_runs=[
                     Run(
                         id=str(llm_uuid3),
+                        name="llm",
                         parent_run_id=str(tool_uuid),
                         start_time=datetime.now(timezone.utc),
                         end_time=datetime.now(timezone.utc),

--- a/libs/core/tests/unit_tests/tracers/test_langchain.py
+++ b/libs/core/tests/unit_tests/tracers/test_langchain.py
@@ -125,9 +125,9 @@ def test_correct_get_tracer_project(
     envvars: dict[str, str], expected_project_name: str
 ) -> None:
     if hasattr(get_env_var, "cache_clear"):
-        get_env_var.cache_clear()
+        get_env_var.cache_clear()  # type: ignore[attr-defined]
     if hasattr(get_tracer_project, "cache_clear"):
-        get_tracer_project.cache_clear()
+        get_tracer_project.cache_clear()  # type: ignore[attr-defined]
     with pytest.MonkeyPatch.context() as mp:
         for k, v in envvars.items():
             mp.setenv(k, v)

--- a/libs/core/tests/unit_tests/tracers/test_langchain.py
+++ b/libs/core/tests/unit_tests/tracers/test_langchain.py
@@ -124,8 +124,10 @@ def test_log_lock() -> None:
 def test_correct_get_tracer_project(
     envvars: dict[str, str], expected_project_name: str
 ) -> None:
-    get_env_var.cache_clear()
-    get_tracer_project.cache_clear()
+    if hasattr(get_env_var, "cache_clear"):
+        get_env_var.cache_clear()
+    if hasattr(get_tracer_project, "cache_clear"):
+        get_tracer_project.cache_clear()
     with pytest.MonkeyPatch.context() as mp:
         for k, v in envvars.items():
             mp.setenv(k, v)

--- a/libs/core/tests/unit_tests/tracers/test_langchain.py
+++ b/libs/core/tests/unit_tests/tracers/test_langchain.py
@@ -127,7 +127,7 @@ def test_correct_get_tracer_project(
     if hasattr(get_env_var, "cache_clear"):
         get_env_var.cache_clear()  # type: ignore[attr-defined]
     if hasattr(get_tracer_project, "cache_clear"):
-        get_tracer_project.cache_clear()  # type: ignore[attr-defined]
+        get_tracer_project.cache_clear()
     with pytest.MonkeyPatch.context() as mp:
         for k, v in envvars.items():
             mp.setenv(k, v)

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1034,7 +1034,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langsmith", specifier = ">=0.6.0,<1.0.0" },
+    { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0,<26.0.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
     { name = "pyyaml", specifier = ">=5.3.0,<7.0.0" },

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1034,7 +1034,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
+    { name = "langsmith", specifier = ">=0.6.0rc0,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0,<26.0.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
     { name = "pyyaml", specifier = ">=5.3.0,<7.0.0" },
@@ -1112,12 +1112,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
+lint = [{ name = "ruff", specifier = ">=0.14.10,<0.15.0" }]
 test = [{ name = "langchain-core", editable = "." }]
 test-integration = []
 typing = [
     { name = "langchain-core", editable = "." },
-    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
 ]
 
@@ -1139,7 +1139,7 @@ dev = [
 ]
 lint = [
     { name = "langchain-core", editable = "." },
-    { name = "ruff", specifier = ">=0.13.1,<0.14.0" },
+    { name = "ruff", specifier = ">=0.14.10,<0.15.0" },
 ]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -1156,7 +1156,7 @@ test-integration = [
     { name = "nltk", specifier = ">=3.9.1,<4.0.0" },
     { name = "scipy", marker = "python_full_version == '3.12.*'", specifier = ">=1.7.0,<2.0.0" },
     { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.14.1,<2.0.0" },
-    { name = "sentence-transformers", marker = "python_full_version < '3.14'", specifier = ">=3.0.1,<4.0.0" },
+    { name = "sentence-transformers", specifier = ">=3.0.1,<4.0.0" },
     { name = "spacy", marker = "python_full_version < '3.14'", specifier = ">=3.8.7,<4.0.0" },
     { name = "thinc", specifier = ">=8.3.6,<9.0.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
@@ -1165,14 +1165,14 @@ test-integration = [
 typing = [
     { name = "beautifulsoup4", specifier = ">=4.13.5,<5.0.0" },
     { name = "lxml-stubs", specifier = ">=0.5.1,<1.0.0" },
-    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
     { name = "types-requests", specifier = ">=2.31.0.20240218,<3.0.0.0" },
 ]
 
 [[package]]
 name = "langsmith"
-version = "0.4.56"
+version = "0.6.0rc0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1184,9 +1184,9 @@ dependencies = [
     { name = "uuid-utils" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/e0/6d8a07b25a3ac308156707edaeffebbc30b2737bba8a75e65c40908beb94/langsmith-0.4.56.tar.gz", hash = "sha256:c3dc53509972689dbbc24f9ac92a095dcce00f76bb0db03ae385815945572540", size = 991755, upload-time = "2025-12-06T00:15:52.893Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/58/08d0038d43ad479e838167f7caec1741c65a845a8c572ab7465d595e1aad/langsmith-0.6.0rc0.tar.gz", hash = "sha256:df07150c83a509d264adeaf80f11bd87fd58adc1bf816890e35260df99dbd2a0", size = 883154, upload-time = "2025-12-30T13:55:07.23Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/6f/d5f9c4f1e03c91045d3675dc99df0682bc657952ad158c92c1f423de04f4/langsmith-0.4.56-py3-none-any.whl", hash = "sha256:f2c61d3f10210e78f16f77e3115f407d40f562ab00ac8c76927c7dd55b5c17b2", size = 411849, upload-time = "2025-12-06T00:15:50.828Z" },
+    { url = "https://files.pythonhosted.org/packages/24/32/f3c24b1628012598abd15fa3331b1aa7cdee4e111b9631c334eab99de60f/langsmith-0.6.0rc0-py3-none-any.whl", hash = "sha256:6052a99b7d67cc651f23a66e5a20697a36b13de22020048133de30cc1b23e4ac", size = 283322, upload-time = "2025-12-30T13:55:05.633Z" },
 ]
 
 [[package]]

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1034,7 +1034,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langsmith", specifier = ">=0.6.0rc0,<1.0.0" },
+    { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0,<26.0.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
     { name = "pyyaml", specifier = ">=5.3.0,<7.0.0" },
@@ -1112,12 +1112,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.14.10,<0.15.0" }]
+lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
 test = [{ name = "langchain-core", editable = "." }]
 test-integration = []
 typing = [
     { name = "langchain-core", editable = "." },
-    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
+    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
 ]
 
@@ -1139,7 +1139,7 @@ dev = [
 ]
 lint = [
     { name = "langchain-core", editable = "." },
-    { name = "ruff", specifier = ">=0.14.10,<0.15.0" },
+    { name = "ruff", specifier = ">=0.13.1,<0.14.0" },
 ]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -1156,7 +1156,7 @@ test-integration = [
     { name = "nltk", specifier = ">=3.9.1,<4.0.0" },
     { name = "scipy", marker = "python_full_version == '3.12.*'", specifier = ">=1.7.0,<2.0.0" },
     { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.14.1,<2.0.0" },
-    { name = "sentence-transformers", specifier = ">=3.0.1,<4.0.0" },
+    { name = "sentence-transformers", marker = "python_full_version < '3.14'", specifier = ">=3.0.1,<4.0.0" },
     { name = "spacy", marker = "python_full_version < '3.14'", specifier = ">=3.8.7,<4.0.0" },
     { name = "thinc", specifier = ">=8.3.6,<9.0.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
@@ -1165,14 +1165,14 @@ test-integration = [
 typing = [
     { name = "beautifulsoup4", specifier = ">=4.13.5,<5.0.0" },
     { name = "lxml-stubs", specifier = ">=0.5.1,<1.0.0" },
-    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
+    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
     { name = "types-requests", specifier = ">=2.31.0.20240218,<3.0.0.0" },
 ]
 
 [[package]]
 name = "langsmith"
-version = "0.6.0rc0"
+version = "0.4.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1184,9 +1184,9 @@ dependencies = [
     { name = "uuid-utils" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/58/08d0038d43ad479e838167f7caec1741c65a845a8c572ab7465d595e1aad/langsmith-0.6.0rc0.tar.gz", hash = "sha256:df07150c83a509d264adeaf80f11bd87fd58adc1bf816890e35260df99dbd2a0", size = 883154, upload-time = "2025-12-30T13:55:07.23Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/e0/6d8a07b25a3ac308156707edaeffebbc30b2737bba8a75e65c40908beb94/langsmith-0.4.56.tar.gz", hash = "sha256:c3dc53509972689dbbc24f9ac92a095dcce00f76bb0db03ae385815945572540", size = 991755, upload-time = "2025-12-06T00:15:52.893Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/32/f3c24b1628012598abd15fa3331b1aa7cdee4e111b9631c334eab99de60f/langsmith-0.6.0rc0-py3-none-any.whl", hash = "sha256:6052a99b7d67cc651f23a66e5a20697a36b13de22020048133de30cc1b23e4ac", size = 283322, upload-time = "2025-12-30T13:55:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6f/d5f9c4f1e03c91045d3675dc99df0682bc657952ad158c92c1f423de04f4/langsmith-0.4.56-py3-none-any.whl", hash = "sha256:f2c61d3f10210e78f16f77e3115f407d40f562ab00ac8c76927c7dd55b5c17b2", size = 411849, upload-time = "2025-12-06T00:15:50.828Z" },
 ]
 
 [[package]]

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1034,7 +1034,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
+    { name = "langsmith", specifier = ">=0.6.0,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0,<26.0.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
     { name = "pyyaml", specifier = ">=5.3.0,<7.0.0" },
@@ -1112,12 +1112,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
+lint = [{ name = "ruff", specifier = ">=0.14.10,<0.15.0" }]
 test = [{ name = "langchain-core", editable = "." }]
 test-integration = []
 typing = [
     { name = "langchain-core", editable = "." },
-    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
 ]
 
@@ -1139,7 +1139,7 @@ dev = [
 ]
 lint = [
     { name = "langchain-core", editable = "." },
-    { name = "ruff", specifier = ">=0.13.1,<0.14.0" },
+    { name = "ruff", specifier = ">=0.14.10,<0.15.0" },
 ]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -1156,7 +1156,7 @@ test-integration = [
     { name = "nltk", specifier = ">=3.9.1,<4.0.0" },
     { name = "scipy", marker = "python_full_version == '3.12.*'", specifier = ">=1.7.0,<2.0.0" },
     { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.14.1,<2.0.0" },
-    { name = "sentence-transformers", marker = "python_full_version < '3.14'", specifier = ">=3.0.1,<4.0.0" },
+    { name = "sentence-transformers", specifier = ">=3.0.1,<4.0.0" },
     { name = "spacy", marker = "python_full_version < '3.14'", specifier = ">=3.8.7,<4.0.0" },
     { name = "thinc", specifier = ">=8.3.6,<9.0.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
@@ -1165,14 +1165,14 @@ test-integration = [
 typing = [
     { name = "beautifulsoup4", specifier = ">=4.13.5,<5.0.0" },
     { name = "lxml-stubs", specifier = ">=0.5.1,<1.0.0" },
-    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
     { name = "types-requests", specifier = ">=2.31.0.20240218,<3.0.0.0" },
 ]
 
 [[package]]
 name = "langsmith"
-version = "0.4.56"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1184,9 +1184,9 @@ dependencies = [
     { name = "uuid-utils" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/e0/6d8a07b25a3ac308156707edaeffebbc30b2737bba8a75e65c40908beb94/langsmith-0.4.56.tar.gz", hash = "sha256:c3dc53509972689dbbc24f9ac92a095dcce00f76bb0db03ae385815945572540", size = 991755, upload-time = "2025-12-06T00:15:52.893Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/48/fb62df712cfd77804999f3bc08e3cba33ecb81064dd2973dd67cd68eaf93/langsmith-0.6.0.tar.gz", hash = "sha256:b60f1785aed4dac5e01f24db01aa18fa1af258bad4531e045e739438daa3f8c2", size = 883012, upload-time = "2026-01-02T18:42:13.721Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/6f/d5f9c4f1e03c91045d3675dc99df0682bc657952ad158c92c1f423de04f4/langsmith-0.4.56-py3-none-any.whl", hash = "sha256:f2c61d3f10210e78f16f77e3115f407d40f562ab00ac8c76927c7dd55b5c17b2", size = 411849, upload-time = "2025-12-06T00:15:50.828Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c6/322df2c18ab462712c968415fb31779ed3e1fd1976357fd78f31f51b2632/langsmith-0.6.0-py3-none-any.whl", hash = "sha256:f7570175aed705b1f4c4dae724c07980a737b8b565252444d11394dda9931e8c", size = 283280, upload-time = "2026-01-02T18:42:11.966Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description
In LangSmith 0.6.0, we update the Run and RunTree object to use pydantic v2. This PR adds support for this change by using the correct method for langsmith >= 0.6.0 pydantic >= v2. It has backwards compatibility for older sdk versions as well with deprecated methods