### PR TITLE
chore(deps): Update outdated GitHub Actions versions

### DIFF
--- a/.github/actions/uv_setup/action.yml
+++ b/.github/actions/uv_setup/action.yml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Install uv and set the python version
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         version: ${{ env.UV_VERSION }}
         python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
This PR updates an outdated GitHub Action version.

- Updated `astral-sh/setup-uv` from `v6` to `v7` in `.github/actions/uv_setup/action.yml`

Looks like this was missed as part of https://github.com/langchain-ai/langchain/pull/33457 so hopefully safe to bring it into alignment.