### PR TITLE
feat(core): support custom message separator in get_buffer_string()

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -99,7 +99,10 @@ AnyMessage = Annotated[
 
 
 def get_buffer_string(
-    messages: Sequence[BaseMessage], human_prefix: str = "Human", ai_prefix: str = "AI"
+    messages: Sequence[BaseMessage],
+    human_prefix: str = "Human",
+    ai_prefix: str = "AI",
+    message_separator: str = "\n",
 ) -> str:
     r"""Convert a sequence of messages to strings and concatenate them into one string.
 
@@ -107,6 +110,7 @@ def get_buffer_string(
         messages: Messages to be converted to strings.
         human_prefix: The prefix to prepend to contents of `HumanMessage`s.
         ai_prefix: The prefix to prepend to contents of `AIMessage`.
+        message_separator: The separator to use between messages.
 
     Returns:
         A single string concatenation of all input messages.
@@ -157,7 +161,7 @@ def get_buffer_string(
                 message += f"{m.additional_kwargs['function_call']}"
         string_messages.append(message)
 
-    return "\n".join(string_messages)
+    return message_separator.join(string_messages)
 
 
 def _message_from_dict(message: dict) -> BaseMessage:

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -370,6 +370,14 @@ class TestGetBufferString:
 
         assert get_buffer_string(msgs) == expected_output
 
+    def test_custom_message_separator(self) -> None:
+        msgs = [
+            self._HUMAN_MSG,
+            self._AI_MSG,
+        ]
+        expected_output = "Human: human\n\nAI: ai"
+        assert get_buffer_string(msgs, message_separator="\n\n") == expected_output
+
 
 def test_multiple_msg() -> None:
     human_msg = HumanMessage(content="human", additional_kwargs={"key": "value"})


### PR DESCRIPTION
# Title
feat(core): support custom message separator in get_buffer_string()

# Description
Small enhancement to support user-configurable message separator in `get_buffer_string()`.

## Issue Addressed
Currently, `get_buffer_string()` uses a single newline to separate messages. If messages contain complex content with newlines, then the message boundaries become obfuscated in the output:

```python
from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, get_buffer_string

messages = [
    HumanMessage(content="I have a question.\n\nCan you help me?"),
    AIMessage(content="Sure!\n\nI can help you."),
    HumanMessage(content="What is the capital of France?"),
]

print(get_buffer_string(messages))
# Human: I have a question.
#
# Can you help me?
# AI: Sure!
#
# I can help you.
# Human: What is the capital of France?
```

## Changes
- Implemented a `message_separator` argument for the `get_buffer_string()` function.
  - The name was chosen to be consistent with other `*_separator` arguments in the code base.
- Updated unit tests to test the new argument.

## Example
```python
print(get_buffer_string(messages, message_separator="\n\n"))
# Human: I have a question.
#
# Can you help me?
#
# AI: Sure!
#
# I can help you.
#
# Human: What is the capital of France?
```