### PR TITLE
feat(langchain): sanitize Summarization Content to remove extra metadata

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -559,7 +559,7 @@ class SummarizationMiddleware(AgentMiddleware):
         Returns:
             Sanitized message copies with only essential content.
         """
-        sanitized = []
+        sanitized: list[AnyMessage] = []
         for msg in messages:
             if isinstance(msg, AIMessage):
                 # Simplify tool_calls to just name and args
@@ -607,12 +607,7 @@ class SummarizationMiddleware(AgentMiddleware):
                     )
                 )
             else:
-                # For other message types, create a basic copy
-                sanitized.append(
-                    msg.__class__(
-                        content=msg.content,
-                        name=msg.name,
-                        id=msg.id,
-                    )
-                )
+                # For other message types, preserve the original message
+                # since we don't know what fields are required
+                sanitized.append(msg)
         return sanitized

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -3,7 +3,14 @@ from unittest.mock import patch
 import pytest
 from langchain_core.language_models import ModelProfile
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, RemoveMessage, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    HumanMessage,
+    RemoveMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
 
@@ -1031,8 +1038,6 @@ def test_sanitize_messages_for_summary_preserves_essential_fields() -> None:
 
 def test_sanitize_messages_for_summary_handles_system_messages() -> None:
     """Test that SystemMessage is handled correctly."""
-    from langchain_core.messages import SystemMessage
-
     middleware = SummarizationMiddleware(model=MockChatModel(), trigger=("messages", 5))
 
     messages: list[AnyMessage] = [
@@ -1056,8 +1061,6 @@ def test_sanitize_messages_for_summary_handles_system_messages() -> None:
 
 def test_sanitize_messages_for_summary_handles_mixed_message_types() -> None:
     """Test sanitization with a realistic mix of message types."""
-    from langchain_core.messages import SystemMessage
-
     middleware = SummarizationMiddleware(model=MockChatModel(), trigger=("messages", 5))
 
     messages: list[AnyMessage] = [

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -1182,7 +1182,9 @@ async def test_sanitize_messages_integration_with_acreate_summary() -> None:
             return ChatResult(generations=[ChatGeneration(message=AIMessage(content="Sync"))])
 
         async def _agenerate(self, messages, **kwargs):
-            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="Async summary"))])
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="Async summary"))]
+            )
 
         @property
         def _llm_type(self):

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2380,12 +2380,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
+lint = [{ name = "ruff", specifier = ">=0.14.10,<0.15.0" }]
 test = [{ name = "langchain-core", editable = "../core" }]
 test-integration = []
 typing = [
     { name = "langchain-core", editable = "../core" },
-    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
 ]
 
@@ -2407,7 +2407,7 @@ dev = [
 ]
 lint = [
     { name = "langchain-core", editable = "../core" },
-    { name = "ruff", specifier = ">=0.13.1,<0.14.0" },
+    { name = "ruff", specifier = ">=0.14.10,<0.15.0" },
 ]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -2433,7 +2433,7 @@ test-integration = [
 typing = [
     { name = "beautifulsoup4", specifier = ">=4.13.5,<5.0.0" },
     { name = "lxml-stubs", specifier = ">=0.5.1,<1.0.0" },
-    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
     { name = "types-requests", specifier = ">=2.31.0.20240218,<3.0.0.0" },
 ]


### PR DESCRIPTION
- Simple Change to sanitize the Messages and remove extra metadata to save on extra tokens. I saw there is a PR #34557 for this, but that completely get's rid of Tool Call information which might be important for Summarization.
- Fixes #34517 