### PR TITLE
docs: Add "What's New" section to README linking to releases page 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ To improve your LLM application development, pair LangChain with:
 - [LangSmith Deployment](https://docs.langchain.com/langsmith/deployments) – Deploy and scale agents effortlessly with a purpose-built deployment platform for long-running, stateful workflows. Discover, reuse, configure, and share agents across teams – and iterate quickly with visual prototyping in [LangSmith Studio](https://docs.langchain.com/langsmith/studio).
 - [Deep Agents](https://github.com/langchain-ai/deepagents) *(new!)* – Build agents that can plan, use subagents, and leverage file systems for complex tasks
 
+## What's New
+
+LangChain is under active development. For the latest updates, release notes, and breaking changes,
+please refer to the official [Releases page](https://github.com/langchain-ai/langchain/releases).
+
 ## Additional resources
 
 - [API Reference](https://reference.langchain.com/python) – Detailed reference on navigating base packages and integrations for LangChain.


### PR DESCRIPTION
### Description
Adds a small "What's New" section to the README that points users to the existing Releases page
for recent updates and breaking changes.

### Motivation
Users often skim the README to understand the current state of the project. This provides a
lightweight entry point to recent changes without duplicating release notes or adding maintenance overhead.

### Scope
- Documentation-only change
- No code or API changes
