### PR TITLE
fix(core): exclude injected args from tool schema

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -566,7 +566,7 @@ class ChildTool(BaseTool):
         elif self.args_schema and issubclass(self.args_schema, BaseModelV1):
             json_schema = self.args_schema.schema()
         else:
-            input_schema = self.get_input_schema()
+            input_schema = self.tool_call_schema
             json_schema = input_schema.model_json_schema()
         return cast("dict", json_schema["properties"])
 

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -567,7 +567,10 @@ class ChildTool(BaseTool):
             json_schema = self.args_schema.schema()
         else:
             input_schema = self.tool_call_schema
-            json_schema = input_schema.model_json_schema()
+            if isinstance(input_schema, dict):
+                json_schema = input_schema
+            else:
+                json_schema = input_schema.model_json_schema()
         return cast("dict", json_schema["properties"])
 
     @property

--- a/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
@@ -46,6 +46,8 @@ def test_tool_runtime_basic_injection() -> None:
         injected_data["stream_writer"] = runtime.stream_writer
         return f"Processed {x}"
 
+    assert runtime_tool.args
+
     agent = create_agent(
         model=FakeToolCallingModel(
             tool_calls=[


### PR DESCRIPTION
Summary
This PR resolves an issue where accessing `BaseTool.args` (and by extension, the tool's JSON schema) would raise `PydanticInvalidForJsonSchema` when the tool used runtime-injected arguments like `ToolRuntime`. This occurred because `BaseTool.args` was previously attempting to generate a schema for the entire input model, including injected fields that cannot be represented in JSON schema.

The fix modifies `BaseTool.args` in [libs/core/langchain_core/tools/base.py](cci:7://file:///Users/mohankumarsagadevan/Documents/projects/github/langchain/libs/core/langchain_core/tools/base.py:0:0-0:0) to use `self.tool_call_schema`. This property correctly filters out injected arguments that are not part of the tool's external interface, preventing the crash.

Fixes #34581

Validation
- Verified with a reproduction script: `ToolRuntime` no longer causes `PydanticInvalidForJsonSchema` crash.
- Ran existing unit tests: [libs/core/tests/unit_tests/test_tools.py](cci:7://file:///Users/mohankumarsagadevan/Documents/projects/github/langchain/libs/core/tests/unit_tests/test_tools.py:0:0-0:0) passed (159 tests).
- Successfully ran `make format` and `make lint` in `libs/core`.