### PR TITLE
refactor(core): eagerly validate `trim_messages` arguments

### DIFF
--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -669,6 +669,7 @@ def test_trim_messages_start_on_with_allow_partial() -> None:
     )
 
     assert len(result) == 1
+    assert isinstance(result, list)
     assert result[0].content == "Second human message"
     assert messages == messages_copy
 
@@ -743,6 +744,7 @@ def test_trim_messages_token_counter_shortcut_with_options() -> None:
     )
 
     # Should include system message and start on human
+    assert isinstance(result, list)
     assert len(result) >= 2
     assert isinstance(result[0], SystemMessage)
     assert any(isinstance(msg, HumanMessage) for msg in result[1:])

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -526,7 +526,6 @@ def test_trim_messages_bound_model_token_counter() -> None:
 
 
 def test_trim_messages_bad_token_counter() -> None:
-    trimmer = trim_messages(max_tokens=10, token_counter={})  # type: ignore[call-overload]
     with pytest.raises(
         ValueError,
         match=re.escape(
@@ -535,7 +534,7 @@ def test_trim_messages_bad_token_counter() -> None:
             "Received object of type <class 'dict'>."
         ),
     ):
-        trimmer.invoke([HumanMessage("foobar")])
+        trim_messages(max_tokens=10, token_counter={})  # type: ignore[call-overload]
 
 
 def dummy_token_counter(messages: list[BaseMessage]) -> int:

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1112,12 +1112,12 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
+lint = [{ name = "ruff", specifier = ">=0.14.10,<0.15.0" }]
 test = [{ name = "langchain-core", editable = "." }]
 test-integration = []
 typing = [
     { name = "langchain-core", editable = "." },
-    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
 ]
 
@@ -1139,7 +1139,7 @@ dev = [
 ]
 lint = [
     { name = "langchain-core", editable = "." },
-    { name = "ruff", specifier = ">=0.13.1,<0.14.0" },
+    { name = "ruff", specifier = ">=0.14.10,<0.15.0" },
 ]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -1156,7 +1156,7 @@ test-integration = [
     { name = "nltk", specifier = ">=3.9.1,<4.0.0" },
     { name = "scipy", marker = "python_full_version == '3.12.*'", specifier = ">=1.7.0,<2.0.0" },
     { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.14.1,<2.0.0" },
-    { name = "sentence-transformers", marker = "python_full_version < '3.14'", specifier = ">=3.0.1,<4.0.0" },
+    { name = "sentence-transformers", specifier = ">=3.0.1,<4.0.0" },
     { name = "spacy", marker = "python_full_version < '3.14'", specifier = ">=3.8.7,<4.0.0" },
     { name = "thinc", specifier = ">=8.3.6,<9.0.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
@@ -1165,7 +1165,7 @@ test-integration = [
 typing = [
     { name = "beautifulsoup4", specifier = ">=4.13.5,<5.0.0" },
     { name = "lxml-stubs", specifier = ">=0.5.1,<1.0.0" },
-    { name = "mypy", specifier = ">=1.18.1,<1.19.0" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
     { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
     { name = "types-requests", specifier = ">=2.31.0.20240218,<3.0.0.0" },
 ]


### PR DESCRIPTION
## PR Title
refactor(core): eagerly validate trim_messages arguments

---

## PR Description

This PR refactors `trim_messages` in **langchain-core** to validate its arguments (specifically `token_counter`, `strategy`, `start_on`, and `include_system`) eagerly at initialization time, rather than lazily when the returned `Runnable` is invoked.

---

## Motivation

Previously, `trim_messages` was decorated with `@_runnable_support`, which deferred argument validation until the returned `Runnable` was actually invoked. This caused errors to surface late in the execution flow, making debugging harder.

This refactor removes the decorator and manually constructs a `RunnableLambda`, enabling **fail-fast behavior** by validating inputs immediately and improving developer experience.

---

## Changes

- Removed the `@_runnable_support` decorator from `trim_messages`.
- Added eager validation for:
  - `token_counter`
  - compatibility between `strategy` and `token_counter`
  - other related arguments (`start_on`, `include_system`).
- Manually handles the `messages=None` case to return a `RunnableLambda` **after** validation, preserving original behavior.
- Updated `test_trim_messages_bad_token_counter` in `test_utils.py` to expect an eager `ValueError`.

---

## Related Issues

- Addresses the TODO in `libs/core/langchain_core/messages/utils.py`.

---

## Checklist

- [x] I have run relevant tests locally and they pass  
  (`libs/core/tests/unit_tests/messages/test_utils.py`)
- [x] Added/updated tests  
  - Updated `test_trim_messages_bad_token_counter` to assert eager validation.

