### PR TITLE
refactor(core): select chunk_id via ranking and remove extra allocation

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -652,7 +652,10 @@ def add_ai_message_chunks(
     else:
         usage_metadata = None
 
-    # higher is better
+    # Ranks are defined by the order of precedence. Higher is better:
+    # 2. Provider-assigned IDs (non-run-* and non-lc_*)
+    # 1. lc_run-* IDs
+    # 0. lc_* and other remaining IDs
     best_rank = -1
     chunk_id = None
     candidates = itertools.chain([left.id], (o.id for o in others))
@@ -661,14 +664,12 @@ def add_ai_message_chunks(
         if not id_:
             continue
 
-        # pick the first provider-assigned id (non-run-* and non-lc_*)
         if not id_.startswith(LC_ID_PREFIX) and not id_.startswith(LC_AUTO_PREFIX):
             chunk_id = id_
+            # Highest rank, return instantly
             break
 
-        # prefer lc_run-* IDs over lc_* IDs
         rank = 1 if id_.startswith(LC_ID_PREFIX) else 0
-        # otherwise take any remaining ID (auto-generated lc_* IDs)
 
         if rank > best_rank:
             best_rank = rank

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -653,7 +653,7 @@ def add_ai_message_chunks(
         usage_metadata = None
 
     # higher is better
-    best_id = -1
+    best_rank = -1
     chunk_id = None
     candidates = itertools.chain([left.id], (o.id for o in others))
 
@@ -670,8 +670,8 @@ def add_ai_message_chunks(
         rank = 1 if id_.startswith(LC_ID_PREFIX) else 0
         # otherwise take any remaining ID (auto-generated lc_* IDs)
 
-        if rank > best_id:
-            best_id = rank
+        if rank > best_rank:
+            best_rank = rank
             chunk_id = id_
 
     chunk_position: Literal["last"] | None = (

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -1,11 +1,11 @@
 """AI message."""
 
+import itertools
 import json
 import logging
 import operator
 from collections.abc import Sequence
 from typing import Any, Literal, cast, overload
-import itertools
 
 from pydantic import Field, model_validator
 from typing_extensions import NotRequired, Self, TypedDict, override

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -652,8 +652,8 @@ def add_ai_message_chunks(
     else:
         usage_metadata = None
 
-    # Ranks are defined by the order of precedence. Higher is better:
-    # 2. Provider-assigned IDs (non-run-* and non-lc_*)
+    # Ranks are defined by the order of preference. Higher is better:
+    # 2. Provider-assigned IDs (non lc_* and non lc_run-*)
     # 1. lc_run-* IDs
     # 0. lc_* and other remaining IDs
     best_rank = -1


### PR DESCRIPTION
A small refactor to improve the way that chunk id is chosen in order to improve speed and reduce code complexity. I ran a simple test and saw that the code is now also marginally faster.

Make commands succeeded.

Disclaimer: I asked AI to review the change I made and it suggested I use itertools.chain in order to reduce an extra allocation.
