### PR TITLE
docs: add LangChain Academy link to Additional resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ To improve your LLM application development, pair LangChain with:
 - [API Reference](https://reference.langchain.com/python) – Detailed reference on navigating base packages and integrations for LangChain.
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) – Learn how to contribute to LangChain projects and find good first issues.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) – Our community guidelines and standards for participation.
-- [LangChain Academy](https://academy.langchain.com/) – comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.

--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ To improve your LLM application development, pair LangChain with:
 - [API Reference](https://reference.langchain.com/python) – Detailed reference on navigating base packages and integrations for LangChain.
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) – Learn how to contribute to LangChain projects and find good first issues.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) – Our community guidelines and standards for participation.
+- [LangChain Academy](https://academy.langchain.com/) – comprehensive, free courses on LangChain libraries and products, made by the LangChain team

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ To improve your LLM application development, pair LangChain with:
 - [API Reference](https://reference.langchain.com/python) – Detailed reference on navigating base packages and integrations for LangChain.
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) – Learn how to contribute to LangChain projects and find good first issues.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) – Our community guidelines and standards for participation.
-- [LangChain Academy](https://academy.langchain.com/) – comprehensive, free courses on LangChain libraries and products, made by the LangChain team
+- [LangChain Academy](https://academy.langchain.com/) – comprehensive, free courses on LangChain libraries and products, made by the LangChain team.


### PR DESCRIPTION
Add a link to LangChain Academy (free official courses) in the "Additional resources" section of the main README.md to improve the visibility of this learning resource for users.

This change only modifies the README.md file (no code changes, no breaking changes, no dependency updates).