### PR TITLE
fix(langchain): correct typo 'langchain experiment' to 'langchain_experimental' in error messages

### DIFF
--- a/libs/langchain/langchain_classic/agents/__init__.py
+++ b/libs/langchain/langchain_classic/agents/__init__.py
@@ -109,7 +109,7 @@ def __getattr__(name: str) -> Any:
         old_path = "langchain_classic." + relative_path
         new_path = "langchain_experimental." + relative_path
         msg = (
-            f"{name} has been moved to langchain experimental. "
+            f"{name} has been moved to langchain_experimental. "
             "See https://github.com/langchain-ai/langchain/discussions/11680"
             "for more information.\n"
             f"Please update your import statement from: `{old_path}` to `{new_path}`."

--- a/libs/langchain/langchain_classic/agents/agent_toolkits/__init__.py
+++ b/libs/langchain/langchain_classic/agents/agent_toolkits/__init__.py
@@ -122,7 +122,7 @@ def __getattr__(name: str) -> Any:
         old_path = "langchain_classic." + relative_path
         new_path = "langchain_experimental." + relative_path
         msg = (
-            f"{name} has been moved to langchain experimental. "
+            f"{name} has been moved to langchain_experimental. "
             "See https://github.com/langchain-ai/langchain/discussions/11680"
             "for more information.\n"
             f"Please update your import statement from: `{old_path}` to `{new_path}`."

--- a/libs/langchain/langchain_classic/agents/agent_toolkits/csv/__init__.py
+++ b/libs/langchain/langchain_classic/agents/agent_toolkits/csv/__init__.py
@@ -5,12 +5,12 @@ def __getattr__(name: str) -> Any:
     """Get attr name."""
     if name == "create_csv_agent":
         msg = (
-            "This agent has been moved to langchain experiment. "
+            "This agent has been moved to langchain_experimental. "
             "This agent relies on python REPL tool under the hood, so to use it "
             "safely please sandbox the python REPL. "
             "Read https://github.com/langchain-ai/langchain/blob/master/SECURITY.md "
             "and https://github.com/langchain-ai/langchain/discussions/11680"
-            "To keep using this code as is, install langchain experimental and "
+            "To keep using this code as is, install langchain_experimental and "
             "update your import statement from:\n "
             f"`langchain_classic.agents.agent_toolkits.csv.{name}` to "
             f"`langchain_experimental.agents.agent_toolkits.{name}`."

--- a/libs/langchain/langchain_classic/agents/agent_toolkits/pandas/__init__.py
+++ b/libs/langchain/langchain_classic/agents/agent_toolkits/pandas/__init__.py
@@ -5,12 +5,12 @@ def __getattr__(name: str) -> Any:
     """Get attr name."""
     if name == "create_pandas_dataframe_agent":
         msg = (
-            "This agent has been moved to langchain experiment. "
+            "This agent has been moved to langchain_experimental. "
             "This agent relies on python REPL tool under the hood, so to use it "
             "safely please sandbox the python REPL. "
             "Read https://github.com/langchain-ai/langchain/blob/master/SECURITY.md "
             "and https://github.com/langchain-ai/langchain/discussions/11680"
-            "To keep using this code as is, install langchain experimental and "
+            "To keep using this code as is, install langchain_experimental and "
             "update your import statement from:\n"
             f"`langchain_classic.agents.agent_toolkits.pandas.{name}` to "
             f"`langchain_experimental.agents.agent_toolkits.{name}`."

--- a/libs/langchain/langchain_classic/agents/agent_toolkits/python/__init__.py
+++ b/libs/langchain/langchain_classic/agents/agent_toolkits/python/__init__.py
@@ -5,12 +5,12 @@ def __getattr__(name: str) -> Any:
     """Get attr name."""
     if name == "create_python_agent":
         msg = (
-            "This agent has been moved to langchain experiment. "
+            "This agent has been moved to langchain_experimental. "
             "This agent relies on python REPL tool under the hood, so to use it "
             "safely please sandbox the python REPL. "
             "Read https://github.com/langchain-ai/langchain/blob/master/SECURITY.md "
             "and https://github.com/langchain-ai/langchain/discussions/11680"
-            "To keep using this code as is, install langchain experimental and "
+            "To keep using this code as is, install langchain_experimental and "
             "update your import statement from:\n"
             f"`langchain_classic.agents.agent_toolkits.python.{name}` to "
             f"`langchain_experimental.agents.agent_toolkits.{name}`."

--- a/libs/langchain/langchain_classic/agents/agent_toolkits/spark/__init__.py
+++ b/libs/langchain/langchain_classic/agents/agent_toolkits/spark/__init__.py
@@ -5,12 +5,12 @@ def __getattr__(name: str) -> Any:
     """Get attr name."""
     if name == "create_spark_dataframe_agent":
         msg = (
-            "This agent has been moved to langchain experiment. "
+            "This agent has been moved to langchain_experimental. "
             "This agent relies on python REPL tool under the hood, so to use it "
             "safely please sandbox the python REPL. "
             "Read https://github.com/langchain-ai/langchain/blob/master/SECURITY.md "
             "and https://github.com/langchain-ai/langchain/discussions/11680"
-            "To keep using this code as is, install langchain experimental and "
+            "To keep using this code as is, install langchain_experimental and "
             "update your import statement from:\n"
             f"`langchain_classic.agents.agent_toolkits.spark.{name}` to "
             f"`langchain_experimental.agents.agent_toolkits.{name}`."

--- a/libs/langchain/langchain_classic/agents/agent_toolkits/xorbits/__init__.py
+++ b/libs/langchain/langchain_classic/agents/agent_toolkits/xorbits/__init__.py
@@ -5,12 +5,12 @@ def __getattr__(name: str) -> Any:
     """Get attr name."""
     if name == "create_xorbits_agent":
         msg = (
-            "This agent has been moved to langchain experiment. "
+            "This agent has been moved to langchain_experimental. "
             "This agent relies on python REPL tool under the hood, so to use it "
             "safely please sandbox the python REPL. "
             "Read https://github.com/langchain-ai/langchain/blob/master/SECURITY.md "
             "and https://github.com/langchain-ai/langchain/discussions/11680"
-            "To keep using this code as is, install langchain experimental and "
+            "To keep using this code as is, install langchain_experimental and "
             "update your import statement from:\n"
             f"`langchain_classic.agents.agent_toolkits.xorbits.{name}` to "
             f"`langchain_experimental.agents.agent_toolkits.{name}`."

--- a/libs/langchain/langchain_classic/tools/__init__.py
+++ b/libs/langchain/langchain_classic/tools/__init__.py
@@ -27,11 +27,11 @@ _DEPRECATED_TOOLS = {"PythonAstREPLTool", "PythonREPLTool"}
 
 def _import_python_tool_python_ast_repl_tool() -> Any:
     msg = (
-        "This tool has been moved to langchain experiment. "
+        "This tool has been moved to langchain_experimental. "
         "This tool has access to a python REPL. "
         "For best practices make sure to sandbox this tool. "
         "Read https://github.com/langchain-ai/langchain/blob/master/SECURITY.md "
-        "To keep using this code as is, install langchain experimental and "
+        "To keep using this code as is, install langchain_experimental and "
         "update relevant imports replacing 'langchain' with 'langchain_experimental'"
     )
     raise ImportError(msg)
@@ -39,11 +39,11 @@ def _import_python_tool_python_ast_repl_tool() -> Any:
 
 def _import_python_tool_python_repl_tool() -> Any:
     msg = (
-        "This tool has been moved to langchain experiment. "
+        "This tool has been moved to langchain_experimental. "
         "This tool has access to a python REPL. "
         "For best practices make sure to sandbox this tool. "
         "Read https://github.com/langchain-ai/langchain/blob/master/SECURITY.md "
-        "To keep using this code as is, install langchain experimental and "
+        "To keep using this code as is, install langchain_experimental and "
         "update relevant imports replacing 'langchain' with 'langchain_experimental'"
     )
     raise ImportError(msg)

--- a/libs/langchain/langchain_classic/tools/python/__init__.py
+++ b/libs/langchain/langchain_classic/tools/python/__init__.py
@@ -3,11 +3,11 @@ from typing import Any
 
 def __getattr__(_: str = "") -> Any:
     msg = (
-        "This tool has been moved to langchain experiment. "
+        "This tool has been moved to langchain_experimental. "
         "This tool has access to a python REPL. "
         "For best practices make sure to sandbox this tool. "
         "Read https://github.com/langchain-ai/langchain/blob/master/SECURITY.md "
-        "To keep using this code as is, install langchain experimental and "
+        "To keep using this code as is, install langchain_experimental and "
         "update relevant imports replacing 'langchain' with 'langchain_experimental'"
     )
     raise AttributeError(msg)


### PR DESCRIPTION
Fixed typo in ImportError messages where "langchain experiment" should be "langchain_experimental" for consistency with the actual package name.

This helps improve clarity for users who encounter these error messages when trying to use deprecated tools that have moved to the langchain_experimental package.

Related issues: #13858, #13859