### PR TITLE
fix: warn when Chain.run returns structured output (dict)

### DIFF
--- a/libs/langchain/langchain_classic/chains/base.py
+++ b/libs/langchain/langchain_classic/chains/base.py
@@ -608,6 +608,10 @@ class Chain(RunnableSerializable[dict[str, Any], dict[str, Any]], ABC):
         Returns:
             The chain output.
 
+            Note:
+                If the chain returns a structured output (e.g. a dict), this method will
+                return that dict.
+
         Example:
             ```python
             # Suppose we have a single-input chain that takes a 'question' string:
@@ -629,14 +633,38 @@ class Chain(RunnableSerializable[dict[str, Any], dict[str, Any]], ABC):
             if len(args) != 1:
                 msg = "`run` supports only one positional argument."
                 raise ValueError(msg)
-            return self(args[0], callbacks=callbacks, tags=tags, metadata=metadata)[
+            return_val = self(args[0], callbacks=callbacks, tags=tags, metadata=metadata)[
                 _output_key
             ]
+            if isinstance(return_val, dict):
+                warnings.warn(
+                    (
+                        "Chain.run returned a structured output (dict). "
+                        "This is expected for chains that produce structured outputs (e.g. structured-output/Tool calling). "
+                        "If you expected a string, either extract the desired key from the returned dict, "
+                        "or use an appropriate helper to serialize it (e.g., `json.dumps(result)`). "
+                        "See: https://docs.langchain.com/oss/python/langchain/structured-output for more details."
+                    ),
+                    UserWarning,
+                )
+            return return_val
 
         if kwargs and not args:
-            return self(kwargs, callbacks=callbacks, tags=tags, metadata=metadata)[
+            return_val = self(kwargs, callbacks=callbacks, tags=tags, metadata=metadata)[
                 _output_key
             ]
+            if isinstance(return_val, dict):
+                warnings.warn(
+                    (
+                        "Chain.run returned a structured output (dict). "
+                        "This is expected for chains that produce structured outputs (e.g. structured-output/Tool calling). "
+                        "If you expected a string, either extract the desired key from the returned dict, "
+                        "or use an appropriate helper to serialize it (e.g., `json.dumps(result)`). "
+                        "See: https://docs.langchain.com/oss/python/langchain/structured-output for more details."
+                    ),
+                    UserWarning,
+                )
+            return return_val
 
         if not kwargs and not args:
             msg = (

--- a/libs/langchain/langchain_classic/chains/base.py
+++ b/libs/langchain/langchain_classic/chains/base.py
@@ -608,9 +608,9 @@ class Chain(RunnableSerializable[dict[str, Any], dict[str, Any]], ABC):
         Returns:
             The chain output.
 
-            Note:
-                If the chain returns a structured output (e.g. a dict), this method will
-                return that dict.
+        Note:
+            If the chain returns a structured output (e.g. a dict), this method will
+            return that dict.
 
         Example:
             ```python
@@ -633,36 +633,40 @@ class Chain(RunnableSerializable[dict[str, Any], dict[str, Any]], ABC):
             if len(args) != 1:
                 msg = "`run` supports only one positional argument."
                 raise ValueError(msg)
-            return_val = self(args[0], callbacks=callbacks, tags=tags, metadata=metadata)[
-                _output_key
-            ]
+            return_val = self(
+                args[0], callbacks=callbacks, tags=tags, metadata=metadata
+            )[_output_key]
             if isinstance(return_val, dict):
                 warnings.warn(
-                    (
-                        "Chain.run returned a structured output (dict). "
-                        "This is expected for chains that produce structured outputs (e.g. structured-output/Tool calling). "
-                        "If you expected a string, either extract the desired key from the returned dict, "
-                        "or use an appropriate helper to serialize it (e.g., `json.dumps(result)`). "
-                        "See: https://docs.langchain.com/oss/python/langchain/structured-output for more details."
-                    ),
+                    "Chain.run returned a structured output (dict). "
+                    "This is expected for chains that produce structured outputs "
+                    "(e.g. structured-output/Tool calling). "
+                    "If you expected a string, either extract the desired key "
+                    "from the returned dict, or use an appropriate helper to "
+                    "serialize it (e.g., `json.dumps(result)`). "
+                    "See: https://docs.langchain.com/oss/python/langchain/"
+                    "structured-output for more details.",
                     UserWarning,
+                    stacklevel=2,
                 )
             return return_val
 
         if kwargs and not args:
-            return_val = self(kwargs, callbacks=callbacks, tags=tags, metadata=metadata)[
-                _output_key
-            ]
+            return_val = self(
+                kwargs, callbacks=callbacks, tags=tags, metadata=metadata
+            )[_output_key]
             if isinstance(return_val, dict):
                 warnings.warn(
-                    (
-                        "Chain.run returned a structured output (dict). "
-                        "This is expected for chains that produce structured outputs (e.g. structured-output/Tool calling). "
-                        "If you expected a string, either extract the desired key from the returned dict, "
-                        "or use an appropriate helper to serialize it (e.g., `json.dumps(result)`). "
-                        "See: https://docs.langchain.com/oss/python/langchain/structured-output for more details."
-                    ),
+                    "Chain.run returned a structured output (dict). "
+                    "This is expected for chains that produce structured outputs "
+                    "(e.g. structured-output/Tool calling). "
+                    "If you expected a string, either extract the desired key "
+                    "from the returned dict, or use an appropriate helper to "
+                    "serialize it (e.g., `json.dumps(result)`). "
+                    "See: https://docs.langchain.com/oss/python/langchain/"
+                    "structured-output for more details.",
                     UserWarning,
+                    stacklevel=2,
                 )
             return return_val
 

--- a/libs/langchain/tests/unit_tests/chains/test_run_structured_output_warning.py
+++ b/libs/langchain/tests/unit_tests/chains/test_run_structured_output_warning.py
@@ -24,6 +24,7 @@ class DummyStructuredChain(Chain):
         # The 'output' key contains the structured result (a dict)
         return {"output": {"field1": "value1", "field2": 2}}
 
+
 def test_run_emits_warning_for_structured_output() -> None:
     c = DummyStructuredChain()
     with warnings.catch_warnings(record=True) as w:

--- a/libs/langchain/tests/unit_tests/chains/test_run_structured_output_warning.py
+++ b/libs/langchain/tests/unit_tests/chains/test_run_structured_output_warning.py
@@ -1,0 +1,34 @@
+import warnings
+import pytest
+from langchain_classic.chains.base import Chain
+from typing import Dict, List, Any
+
+class DummyStructuredChain(Chain):
+    """Minimal Chain that returns a dict to emulate structured output chain."""
+    
+    @property
+    def input_keys(self) -> List[str]:
+        return ["input"]
+        
+    @property
+    def output_keys(self) -> List[str]:
+        return ["output"]
+
+    def _call(self, inputs: Dict[str, Any], run_manager=None) -> Dict[str, Any]:
+        # return a structured dict (simulate structured output chain)
+        # The 'output' key contains the structured result (a dict)
+        return {"output": {"field1": "value1", "field2": 2}}
+
+def test_run_emits_warning_for_structured_output() -> None:
+    c = DummyStructuredChain()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = c.run("ignore this input")
+        
+        # assert we got a dict back 
+        assert isinstance(result, dict)
+        assert result == {"field1": "value1", "field2": 2}
+        
+        # assert warning was emitted
+        assert len(w) > 0
+        assert any("structured output" in str(warn.message).lower() for warn in w)

--- a/libs/langchain/tests/unit_tests/chains/test_run_structured_output_warning.py
+++ b/libs/langchain/tests/unit_tests/chains/test_run_structured_output_warning.py
@@ -1,20 +1,25 @@
 import warnings
-import pytest
+from typing import Any
+
 from langchain_classic.chains.base import Chain
-from typing import Dict, List, Any
+
 
 class DummyStructuredChain(Chain):
     """Minimal Chain that returns a dict to emulate structured output chain."""
-    
+
     @property
-    def input_keys(self) -> List[str]:
+    def input_keys(self) -> list[str]:
         return ["input"]
-        
+
     @property
-    def output_keys(self) -> List[str]:
+    def output_keys(self) -> list[str]:
         return ["output"]
 
-    def _call(self, inputs: Dict[str, Any], run_manager=None) -> Dict[str, Any]:
+    def _call(
+        self,
+        _inputs: dict[str, Any],
+        _run_manager: Any = None,
+    ) -> dict[str, Any]:
         # return a structured dict (simulate structured output chain)
         # The 'output' key contains the structured result (a dict)
         return {"output": {"field1": "value1", "field2": 2}}
@@ -24,11 +29,11 @@ def test_run_emits_warning_for_structured_output() -> None:
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         result = c.run("ignore this input")
-        
-        # assert we got a dict back 
+
+        # assert we got a dict back
         assert isinstance(result, dict)
         assert result == {"field1": "value1", "field2": 2}
-        
+
         # assert warning was emitted
         assert len(w) > 0
         assert any("structured output" in str(warn.message).lower() for warn in w)


### PR DESCRIPTION
Problem
-------
Users are sometimes surprised when `Chain.run(...)` returns a dict (structured output) instead of a string. This often causes confusion and hard-to-debug errors for users who expect a string.

What I changed
-------------
- Emit a clear `UserWarning` when `Chain.run` returns a `dict`, explaining the situation and pointing to the structured output docs.
- Clarified the `run` method docstring to mention that structured outputs (dicts) can be returned.
- Added a unit test `tests/chains/test_run_structured_output_warning.py` that demonstrates the behavior and asserts the warning.

Why
---
Non-breaking, helps users understand and quickly debug issues where they expected a string. Prepares the codebase for later tooling or stricter validation if maintainers want to enforce structured output patterns.

Notes
-----