### PR TITLE
fix(openai): raise proper exception `OpenAIRefusalError` on structured output refusal

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3588,15 +3588,13 @@ def _oai_structured_outputs_parser(
     if ai_msg.additional_kwargs.get("refusal"):
         raise OpenAIRefusalError(ai_msg.additional_kwargs["refusal"])
     if any(
-        isinstance(block, dict)
-        and block.get("type") == "refusal"
+        isinstance(block, dict) and block.get("type") == "refusal"
         for block in ai_msg.content
     ):
         refusal = next(
             block["refusal"]
             for block in ai_msg.content
-            if isinstance(block, dict)
-            and block["type"] == "refusal"
+            if isinstance(block, dict) and block["type"] == "refusal"
         )
         raise OpenAIRefusalError(refusal)
     if ai_msg.tool_calls:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3589,16 +3589,14 @@ def _oai_structured_outputs_parser(
         raise OpenAIRefusalError(ai_msg.additional_kwargs["refusal"])
     if any(
         isinstance(block, dict)
-        and block.get("type") == "non_standard"
-        and "refusal" in block["value"]
+        and block.get("type") == "refusal"
         for block in ai_msg.content
     ):
         refusal = next(
-            block["value"]["refusal"]
+            block["refusal"]
             for block in ai_msg.content
             if isinstance(block, dict)
-            and block["type"] == "non_standard"
-            and "refusal" in block["value"]
+            and block["type"] == "refusal"
         )
         raise OpenAIRefusalError(refusal)
     if ai_msg.tool_calls:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3588,13 +3588,17 @@ def _oai_structured_outputs_parser(
     if ai_msg.additional_kwargs.get("refusal"):
         raise OpenAIRefusalError(ai_msg.additional_kwargs["refusal"])
     if any(
-        isinstance(block, dict) and block.get("type") == "refusal"
-        for block in ai_msg.content
+        isinstance(block, dict)
+        and block.get("type") == "non_standard"
+        and "refusal" in block["value"]  # type: ignore[typeddict-item]
+        for block in ai_msg.content_blocks
     ):
         refusal = next(
-            block["refusal"]
-            for block in ai_msg.content
-            if isinstance(block, dict) and block["type"] == "refusal"
+            block["value"]["refusal"]
+            for block in ai_msg.content_blocks
+            if isinstance(block, dict)
+            and block["type"] == "non_standard"
+            and "refusal" in block["value"]
         )
         raise OpenAIRefusalError(refusal)
     if ai_msg.tool_calls:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -64,6 +64,7 @@ from langchain_openai.chat_models._compat import (
     _convert_to_v03_ai_message,
 )
 from langchain_openai.chat_models.base import (
+    OpenAIRefusalError,
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
     _convert_dict_to_message,
@@ -3191,3 +3192,62 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
 def test_model_prefers_responses_api() -> None:
     assert _model_prefers_responses_api("gpt-5.2-pro")
     assert not _model_prefers_responses_api("gpt-5.1")
+
+
+def test_openai_structured_output_refusal_handling_responses_api() -> None:
+    """
+    Test that _oai_structured_outputs_parser raises OpenAIRefusalError
+    when the AIMessage contains a refusal block from OpenAI's Responses API.
+    """
+    # This is a AIMessage instance copied from a real langchain output
+    # which is an structured output from OpenAI's Responses API
+    # ids are faked
+    # The refusal content block to indicate a refusal response of structured output
+    mocked_ai_msg = AIMessage(
+        content=[
+            {
+                "id": "rs_fake_id",
+                "summary": [],
+                "type": "reasoning",
+                "encrypted_content": "fake_encrypted_content",
+            },
+            # This block represents a refusal message
+            {
+                "type": "refusal",
+                "refusal": "refused content in string",
+                "id": "msg_fake_id",
+            },
+        ],
+        additional_kwargs={},
+        response_metadata={
+            "id": "resp_fake_id",
+            "created_at": 1766276465.0,
+            "metadata": {},
+            "model": "o3",
+            "object": "response",
+            "service_tier": "default",
+            "status": "completed",
+            "model_provider": "openai",
+            "model_name": "o3",
+        },
+        id="resp_fake_id",
+        usage_metadata={
+            "input_tokens": 10260,
+            "output_tokens": 775,
+            "total_tokens": 11035,
+            "input_token_details": {"cache_read": 0},
+            "output_token_details": {"reasoning": 512},
+        },
+    )
+
+    # schema does not matter in this issue
+    class MySchema(BaseModel):
+        foo: int
+
+    try:
+        _oai_structured_outputs_parser(mocked_ai_msg, MySchema)
+    except OpenAIRefusalError:
+        # OpenAIRefusalError was raised. This is the proper behavior.
+        assert True
+    except ValueError as e:
+        pytest.fail(f"This is a wrong behavior. Error details: {e}")

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3199,11 +3199,7 @@ def test_openai_structured_output_refusal_handling_responses_api() -> None:
     Test that _oai_structured_outputs_parser raises OpenAIRefusalError
     when the AIMessage contains a refusal block from OpenAI's Responses API.
     """
-    # This is a AIMessage instance copied from a real langchain output
-    # which is an structured output from OpenAI's Responses API
-    # ids are faked
-    # The refusal content block to indicate a refusal response of structured output
-    mocked_ai_msg = AIMessage(
+    ai_msg = AIMessage(
         content=[
             {
                 "id": "rs_fake_id",
@@ -3211,33 +3207,12 @@ def test_openai_structured_output_refusal_handling_responses_api() -> None:
                 "type": "reasoning",
                 "encrypted_content": "fake_encrypted_content",
             },
-            # This block represents a refusal message
             {
                 "type": "refusal",
                 "refusal": "refused content in string",
                 "id": "msg_fake_id",
             },
         ],
-        additional_kwargs={},
-        response_metadata={
-            "id": "resp_fake_id",
-            "created_at": 1766276465.0,
-            "metadata": {},
-            "model": "o3",
-            "object": "response",
-            "service_tier": "default",
-            "status": "completed",
-            "model_provider": "openai",
-            "model_name": "o3",
-        },
-        id="resp_fake_id",
-        usage_metadata={
-            "input_tokens": 10260,
-            "output_tokens": 775,
-            "total_tokens": 11035,
-            "input_token_details": {"cache_read": 0},
-            "output_token_details": {"reasoning": 512},
-        },
     )
 
     # schema does not matter in this issue
@@ -3245,9 +3220,9 @@ def test_openai_structured_output_refusal_handling_responses_api() -> None:
         foo: int
 
     try:
-        _oai_structured_outputs_parser(mocked_ai_msg, MySchema)
+        _oai_structured_outputs_parser(ai_msg, MySchema)
     except OpenAIRefusalError:
         # OpenAIRefusalError was raised. This is the proper behavior.
-        assert True
+        pass
     except ValueError as e:
         pytest.fail(f"This is a wrong behavior. Error details: {e}")

--- a/libs/partners/openai/tests/unit_tests/llms/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/llms/test_base.py
@@ -1,9 +1,15 @@
 import os
 
 import pytest
+from langchain.messages import AIMessage
 from langchain_core.outputs import GenerationChunk
+from pydantic import BaseModel
 
 from langchain_openai import OpenAI
+from langchain_openai.chat_models.base import (
+    OpenAIRefusalError,
+    _oai_structured_outputs_parser,
+)
 from langchain_openai.llms.base import _stream_response_to_generation_chunk
 
 os.environ["OPENAI_API_KEY"] = "foo"
@@ -118,3 +124,62 @@ def test_generate_streaming_multiple_prompts_error() -> None:
         ValueError, match="Cannot stream results with multiple prompts\\."
     ):
         llm._generate(["foo", "bar"])
+
+
+def test_openai_structured_output_refusal_handling_responses_api() -> None:
+    """
+    Test that _oai_structured_outputs_parser raises OpenAIRefusalError
+    when the AIMessage contains a refusal block from OpenAI's Responses API.
+    """
+    # This is a AIMessage instance copied from a real langchain output
+    # which is an structured output from OpenAI's Responses API
+    # ids are faked
+    # The refusal content block to indicate a refusal response of structured output
+    mocked_ai_msg = AIMessage(
+        content=[
+            {
+                "id": "rs_fake_id",
+                "summary": [],
+                "type": "reasoning",
+                "encrypted_content": "fake_encrypted_content",
+            },
+            # This block represents a refusal message
+            {
+                "type": "refusal",
+                "refusal": "refused content in string",
+                "id": "msg_fake_id",
+            },
+        ],
+        additional_kwargs={},
+        response_metadata={
+            "id": "resp_fake_id",
+            "created_at": 1766276465.0,
+            "metadata": {},
+            "model": "o3",
+            "object": "response",
+            "service_tier": "default",
+            "status": "completed",
+            "model_provider": "openai",
+            "model_name": "o3",
+        },
+        id="resp_fake_id",
+        usage_metadata={
+            "input_tokens": 10260,
+            "output_tokens": 775,
+            "total_tokens": 11035,
+            "input_token_details": {"cache_read": 0},
+            "output_token_details": {"reasoning": 512},
+        },
+    )
+
+    # schema does not matter in this issue
+    class MySchema(BaseModel):
+        foo: int
+
+    try:
+        _oai_structured_outputs_parser(mocked_ai_msg, MySchema)
+    except OpenAIRefusalError:
+        # OpenAIRefusalError was raised. This is the proper behavior.
+        assert True
+    except ValueError as e:
+        pytest.fail(f"This is a wrong behavior. Error details: {e}")


### PR DESCRIPTION
Fixes #34616

Replace the logic to get refusal content block. Instead of looking for "non_standard", use "refusal".
> [!NOTE]
> About correctness of the mock ai message of Responses API, see [here](https://github.com/langchain-ai/langchain/blob/0438f8c27755a25595cdeada19ff7e4007904800/libs/partners/openai/langchain_openai/chat_models/_compat.py#L53)
