### PR TITLE
refactor(langchain): engage summarization based on reported `usage_metadata`

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1841,7 +1841,6 @@ def count_tokens_approximately(
     chars_per_token: float = 4.0,
     extra_tokens_per_message: float = 3.0,
     count_name: bool = True,
-    use_usage_metadata_scaling: bool = False,
 ) -> int:
     """Approximate the total number of tokens in messages.
 
@@ -1861,14 +1860,6 @@ def count_tokens_approximately(
             [See more here](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb).
         count_name: Whether to include message names in the count.
             Enabled by default.
-        use_usage_metadata_scaling: If True and conditions are met, use usage metadata
-            from AIMessages to scale the approximate token count. Conditions:
-            (1) All AIMessages have usage_metadata with total_tokens,
-            (2) All AIMessages have consistent model_provider in response_metadata,
-            (3) total_tokens are monotonically non-decreasing.
-            When these conditions are met, the approximate count is scaled based on
-            the ratio of actual total_tokens to approximate count up to the last
-            AIMessage.
 
     Returns:
         Approximate number of tokens in the messages.
@@ -1883,24 +1874,8 @@ def count_tokens_approximately(
     !!! version-added "Added in `langchain-core` 0.3.46"
 
     """
-    message_list = list(convert_to_messages(messages))
-
-    # Track AIMessages for potential usage metadata scaling
-    ai_messages_with_indices: list[tuple[int, AIMessage]] = []
-    if use_usage_metadata_scaling:
-        ai_messages_with_indices = [
-            (i, msg) for i, msg in enumerate(message_list) if isinstance(msg, AIMessage)
-        ]
-
-    # Determine if we need to track partial count (up to last AIMessage)
-    last_ai_index = -1
-    if ai_messages_with_indices:
-        last_ai_index = ai_messages_with_indices[-1][0]
-
     token_count = 0.0
-    token_count_partial = 0.0
-
-    for i, message in enumerate(message_list):
+    for message in convert_to_messages(messages):
         message_chars = 0
         if isinstance(message.content, str):
             message_chars += len(message.content)
@@ -1931,93 +1906,13 @@ def count_tokens_approximately(
         # NOTE: we're rounding up per message to ensure that
         # individual message token counts add up to the total count
         # for a list of messages
-        message_tokens = (
-            math.ceil(message_chars / chars_per_token) + extra_tokens_per_message
-        )
-        token_count += message_tokens
+        token_count += math.ceil(message_chars / chars_per_token)
 
-        # Track partial count if needed
-        if i <= last_ai_index:
-            token_count_partial += message_tokens
+        # add extra tokens per message
+        token_count += extra_tokens_per_message
 
     # round up once more time in case extra_tokens_per_message is a float
-    approx_count_full = math.ceil(token_count)
-
-    # Apply usage metadata scaling if conditions are met
-    if use_usage_metadata_scaling and ai_messages_with_indices:
-        return _apply_usage_metadata_scaling(
-            ai_messages_with_indices,
-            token_count_partial,
-            approx_count_full,
-        )
-
-    return approx_count_full
-
-
-def _apply_usage_metadata_scaling(
-    ai_messages_with_indices: list[tuple[int, AIMessage]],
-    token_count_partial: float,
-    approx_count_full: int,
-) -> int:
-    """Apply scaling based on usage metadata from AIMessages.
-
-    Args:
-        ai_messages_with_indices: List of (index, AIMessage) tuples.
-        token_count_partial: Approximate token count up to last AIMessage.
-        approx_count_full: Approximate token count for full message sequence.
-
-    Returns:
-        Scaled token count if conditions are met, otherwise approx_count_full.
-    """
-    try:
-        # Condition 1: All AIMessages have usage_metadata with total_tokens
-        if not all(
-            msg.usage_metadata is not None and "total_tokens" in msg.usage_metadata
-            for _, msg in ai_messages_with_indices
-        ):
-            return approx_count_full
-
-        # Condition 2: All AIMessages have model_provider in response_metadata
-        if not all(
-            "model_provider" in msg.response_metadata
-            for _, msg in ai_messages_with_indices
-        ):
-            return approx_count_full
-
-        # Condition 2b: All model_providers are consistent
-        model_providers = {
-            msg.response_metadata["model_provider"]
-            for _, msg in ai_messages_with_indices
-        }
-        if len(model_providers) != 1:
-            return approx_count_full
-
-        # Condition 3: total_tokens are monotonically non-decreasing
-        for i in range(len(ai_messages_with_indices) - 1):
-            current_total = ai_messages_with_indices[i][1].usage_metadata[
-                "total_tokens"
-            ]  # type: ignore[index]
-            next_total = ai_messages_with_indices[i + 1][1].usage_metadata[
-                "total_tokens"
-            ]  # type: ignore[index]
-            if current_total > next_total:
-                return approx_count_full
-
-        # All conditions met - apply scaling
-        approx_count_partial = math.ceil(token_count_partial)
-        last_ai_msg = ai_messages_with_indices[-1][1]
-        actual_total = last_ai_msg.usage_metadata["total_tokens"]  # type: ignore[index]
-
-        # Avoid division by zero
-        if approx_count_partial == 0:
-            return approx_count_full
-
-        scale_factor = actual_total / approx_count_partial
-        return math.ceil(approx_count_full * scale_factor)
-
-    except (KeyError, TypeError, ZeroDivisionError):
-        # If anything goes wrong, fall back to approximate count
-        return approx_count_full
+    return math.ceil(token_count)
 
 
 # Mapping from string shortcuts to token counter functions

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -333,7 +333,8 @@ class SummarizationMiddleware(AgentMiddleware):
             and last_ai_message.usage_metadata is not None
             and (reported_tokens := last_ai_message.usage_metadata.get("total_tokens", -1))
             and reported_tokens >= threshold
-            # add check for same provider as self.model
+            and (message_provider := last_ai_message.response_metadata.get("model_provider"))
+            and message_provider == self.model._get_ls_params().get("ls_provider")  # noqa: SLF001
         ):
             return True
         return False

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -7,6 +7,7 @@ from functools import partial
 from typing import Any, Literal, cast
 
 from langchain_core.messages import (
+    AIMessage,
     AnyMessage,
     MessageLikeRepresentation,
     RemoveMessage,
@@ -319,6 +320,24 @@ class SummarizationMiddleware(AgentMiddleware):
             ]
         }
 
+    def _should_summarize_based_on_reported_tokens(
+        self, messages: list[AnyMessage], threshold: float
+    ) -> bool:
+        """Check if reported token usage from last AIMessage exceeds threshold."""
+        last_ai_message = next(
+            (msg for msg in reversed(messages) if isinstance(msg, AIMessage)),
+            None,
+        )
+        if (  # noqa: SIM103
+            isinstance(last_ai_message, AIMessage)
+            and last_ai_message.usage_metadata is not None
+            and (reported_tokens := last_ai_message.usage_metadata.get("total_tokens", -1))
+            and reported_tokens >= threshold
+            # add check for same provider as self.model
+        ):
+            return True
+        return False
+
     def _should_summarize(self, messages: list[AnyMessage], total_tokens: int) -> bool:
         """Determine whether summarization should run for the current token usage."""
         if not self._trigger_conditions:
@@ -329,6 +348,10 @@ class SummarizationMiddleware(AgentMiddleware):
                 return True
             if kind == "tokens" and total_tokens >= value:
                 return True
+            if kind == "tokens" and self._should_summarize_based_on_reported_tokens(
+                messages, value
+            ):
+                return True
             if kind == "fraction":
                 max_input_tokens = self._get_profile_limits()
                 if max_input_tokens is None:
@@ -337,6 +360,9 @@ class SummarizationMiddleware(AgentMiddleware):
                 if threshold <= 0:
                     threshold = 1
                 if total_tokens >= threshold:
+                    return True
+
+                if self._should_summarize_based_on_reported_tokens(messages, threshold):
                     return True
         return False
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -968,4 +968,4 @@ def test_usage_metadata_trigger() -> None:
             ),
         ]
     )
-    assert not middleware._should_summarize(messages, 0)
+    assert middleware._should_summarize(messages, 0)  # check test engages

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -1024,4 +1024,4 @@ def test_usage_metadata_trigger() -> None:
             ),
         ]
     )
-    assert middleware._should_summarize(messages, 0)  # check test engages
+    assert not middleware._should_summarize(messages, 0)


### PR DESCRIPTION
Characters per token can vary considerably (10-20%) across runs for a single provider. So `count_tokens_approximately`, even if using the correct average characters per token, can measure < 85% of a model's context window when the true value is > 100%.

To prevent errors from context overflow, here we add a check based on the total tokens reported by the provider.

We assume that the `usage_metadata` in the last AIMessage in a message sequence represents the cumulative total tokens up to that point. If the provider for this message does not match the model, we disregard this check.

N.B. after summarization, the total token counts in successive AIMessages may no longer monotonically increase, but the most recent should represent the cumulative total up to that point.