### PR TITLE
fix(langchain): handle parallel usage of the todo tool in planning middleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -259,12 +259,9 @@ class TodoListMiddleware(AgentMiddleware):
                 for tc in write_todos_calls
             ]
 
-            # Remove all write_todos tool calls from the AI message
-            last_ai_msg.tool_calls = [
-                tc for tc in last_ai_msg.tool_calls if tc["name"] != "write_todos"
-            ]
-
-            return {"messages": [last_ai_msg, *error_messages]}
+            # Keep the tool calls in the AI message but return error messages
+            # This follows the same pattern as HumanInTheLoopMiddleware
+            return {"messages": error_messages}
 
         return None
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
@@ -529,25 +529,28 @@ def test_parallel_write_todos_calls_rejected() -> None:
     result = middleware.after_model(state, _fake_runtime())
 
     # Should return error messages
-    assert result is not None
-    assert "messages" in result
-    messages = result["messages"]
-
-    # Should have 2 error tool messages (tool calls remain in AI message)
-    assert len(messages) == 2
-
-    # Both should be error tool messages
-    error_msg_1 = messages[0]
-    assert isinstance(error_msg_1, ToolMessage)
-    assert error_msg_1.tool_call_id == "call_1"
-    assert error_msg_1.status == "error"
-    assert "never be called multiple times in parallel" in error_msg_1.content
-
-    error_msg_2 = messages[1]
-    assert isinstance(error_msg_2, ToolMessage)
-    assert error_msg_2.tool_call_id == "call_2"
-    assert error_msg_2.status == "error"
-    assert "never be called multiple times in parallel" in error_msg_2.content
+    assert result == {
+        "messages": [
+            ToolMessage(
+                content=(
+                    "Error: The `write_todos` tool should never be called multiple times "
+                    "in parallel. Please call it only once per model invocation to update "
+                    "the todo list."
+                ),
+                tool_call_id="call_1",
+                status="error",
+            ),
+            ToolMessage(
+                content=(
+                    "Error: The `write_todos` tool should never be called multiple times "
+                    "in parallel. Please call it only once per model invocation to update "
+                    "the todo list."
+                ),
+                tool_call_id="call_2",
+                status="error",
+            ),
+        ]
+    }
 
 
 def test_parallel_write_todos_with_other_tools() -> None:
@@ -584,20 +587,29 @@ def test_parallel_write_todos_with_other_tools() -> None:
     # Call after_model hook
     result = middleware.after_model(state, _fake_runtime())
 
-    # Should return error messages
-    assert result is not None
-    assert "messages" in result
-    messages = result["messages"]
-
-    # Should have 2 error tool messages (all tool calls remain in AI message)
-    assert len(messages) == 2
-
-    # Both should be error tool messages for write_todos
-    for i, msg in enumerate(messages, 1):
-        assert isinstance(msg, ToolMessage)
-        assert msg.tool_call_id == f"call_{i}"
-        assert msg.status == "error"
-        assert "never be called multiple times in parallel" in msg.content
+    # Should return error messages for write_todos calls only
+    assert result == {
+        "messages": [
+            ToolMessage(
+                content=(
+                    "Error: The `write_todos` tool should never be called multiple times "
+                    "in parallel. Please call it only once per model invocation to update "
+                    "the todo list."
+                ),
+                tool_call_id="call_1",
+                status="error",
+            ),
+            ToolMessage(
+                content=(
+                    "Error: The `write_todos` tool should never be called multiple times "
+                    "in parallel. Please call it only once per model invocation to update "
+                    "the todo list."
+                ),
+                tool_call_id="call_2",
+                status="error",
+            ),
+        ]
+    }
 
 
 def test_single_write_todos_call_allowed() -> None:
@@ -655,25 +667,28 @@ async def test_parallel_write_todos_calls_rejected_async() -> None:
     result = await middleware.aafter_model(state, _fake_runtime())
 
     # Should return error messages
-    assert result is not None
-    assert "messages" in result
-    messages = result["messages"]
-
-    # Should have 2 error tool messages (tool calls remain in AI message)
-    assert len(messages) == 2
-
-    # Both should be error tool messages
-    error_msg_1 = messages[0]
-    assert isinstance(error_msg_1, ToolMessage)
-    assert error_msg_1.tool_call_id == "call_1"
-    assert error_msg_1.status == "error"
-    assert "never be called multiple times in parallel" in error_msg_1.content
-
-    error_msg_2 = messages[1]
-    assert isinstance(error_msg_2, ToolMessage)
-    assert error_msg_2.tool_call_id == "call_2"
-    assert error_msg_2.status == "error"
-    assert "never be called multiple times in parallel" in error_msg_2.content
+    assert result == {
+        "messages": [
+            ToolMessage(
+                content=(
+                    "Error: The `write_todos` tool should never be called multiple times "
+                    "in parallel. Please call it only once per model invocation to update "
+                    "the todo list."
+                ),
+                tool_call_id="call_1",
+                status="error",
+            ),
+            ToolMessage(
+                content=(
+                    "Error: The `write_todos` tool should never be called multiple times "
+                    "in parallel. Please call it only once per model invocation to update "
+                    "the todo list."
+                ),
+                tool_call_id="call_2",
+                status="error",
+            ),
+        ]
+    }
 
 
 async def test_parallel_write_todos_with_other_tools_async() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
@@ -533,22 +533,17 @@ def test_parallel_write_todos_calls_rejected() -> None:
     assert "messages" in result
     messages = result["messages"]
 
-    # Should have modified AI message + 2 error tool messages
-    assert len(messages) == 3
+    # Should have 2 error tool messages (tool calls remain in AI message)
+    assert len(messages) == 2
 
-    # First message should be the modified AI message with no write_todos calls
-    modified_ai = messages[0]
-    assert isinstance(modified_ai, AIMessage)
-    assert len(modified_ai.tool_calls) == 0
-
-    # Next two should be error tool messages
-    error_msg_1 = messages[1]
+    # Both should be error tool messages
+    error_msg_1 = messages[0]
     assert isinstance(error_msg_1, ToolMessage)
     assert error_msg_1.tool_call_id == "call_1"
     assert error_msg_1.status == "error"
     assert "never be called multiple times in parallel" in error_msg_1.content
 
-    error_msg_2 = messages[2]
+    error_msg_2 = messages[1]
     assert isinstance(error_msg_2, ToolMessage)
     assert error_msg_2.tool_call_id == "call_2"
     assert error_msg_2.status == "error"
@@ -594,18 +589,11 @@ def test_parallel_write_todos_with_other_tools() -> None:
     assert "messages" in result
     messages = result["messages"]
 
-    # Should have modified AI message + 2 error tool messages
-    assert len(messages) == 3
+    # Should have 2 error tool messages (all tool calls remain in AI message)
+    assert len(messages) == 2
 
-    # First message should be the modified AI message with only the other tool call
-    modified_ai = messages[0]
-    assert isinstance(modified_ai, AIMessage)
-    assert len(modified_ai.tool_calls) == 1
-    assert modified_ai.tool_calls[0]["name"] == "some_other_tool"
-    assert modified_ai.tool_calls[0]["id"] == "call_other"
-
-    # Next two should be error tool messages for write_todos
-    for i, msg in enumerate(messages[1:], 1):
+    # Both should be error tool messages for write_todos
+    for i, msg in enumerate(messages, 1):
         assert isinstance(msg, ToolMessage)
         assert msg.tool_call_id == f"call_{i}"
         assert msg.status == "error"

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
@@ -725,20 +725,29 @@ async def test_parallel_write_todos_with_other_tools_async() -> None:
     # Call aafter_model hook
     result = await middleware.aafter_model(state, _fake_runtime())
 
-    # Should return error messages
-    assert result is not None
-    assert "messages" in result
-    messages = result["messages"]
-
-    # Should have 2 error tool messages (all tool calls remain in AI message)
-    assert len(messages) == 2
-
-    # Both should be error tool messages for write_todos
-    for i, msg in enumerate(messages, 1):
-        assert isinstance(msg, ToolMessage)
-        assert msg.tool_call_id == f"call_{i}"
-        assert msg.status == "error"
-        assert "never be called multiple times in parallel" in msg.content
+    # Should return error messages for write_todos calls only
+    assert result == {
+        "messages": [
+            ToolMessage(
+                content=(
+                    "Error: The `write_todos` tool should never be called multiple times "
+                    "in parallel. Please call it only once per model invocation to update "
+                    "the todo list."
+                ),
+                tool_call_id="call_1",
+                status="error",
+            ),
+            ToolMessage(
+                content=(
+                    "Error: The `write_todos` tool should never be called multiple times "
+                    "in parallel. Please call it only once per model invocation to update "
+                    "the todo list."
+                ),
+                tool_call_id="call_2",
+                status="error",
+            ),
+        ]
+    }
 
 
 async def test_single_write_todos_call_allowed_async() -> None:


### PR DESCRIPTION
The agent should only make a single call to update the todo list at a time. A parallel call doesn't make sense, but also cannot work as there's no obvious reducer to use.

On parallel calls of the todo tool, we return ToolMessage containing to guide the LLM to not call the tool in parallel.