### PR TITLE
fix(core): added ChatBedrockConverse to serializable mapping whitelist

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -263,6 +263,11 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "bedrock",
         "ChatBedrock",
     ),
+    ("langchain", "chat_models", "ChatBedrockConverse"): (
+        "langchain_aws",
+        "chat_models",
+        "ChatBedrockConverse",
+    ),
     ("langchain", "chat_models", "anthropic", "ChatAnthropic"): (
         "langchain_anthropic",
         "chat_models",


### PR DESCRIPTION
Fixes #34645

As described in #34645, ChatBedrockConverse was not added as an allowed de-serializable class, as such, pulling from langsmith with include_model set to True when using Bedrock models would fail with an uninformative error message. This PR adds the necessary class to the whitelist.
