### PR TITLE
fix(langchain): fix copy-paste error on azure_openai embedding provider map

### DIFF
--- a/libs/langchain_v1/langchain/embeddings/base.py
+++ b/libs/langchain_v1/langchain/embeddings/base.py
@@ -13,7 +13,7 @@ def _call(cls: type[Embeddings], **kwargs: Any) -> Embeddings:
 
 
 _SUPPORTED_PROVIDERS: dict[str, tuple[str, str, Callable[..., Embeddings]]] = {
-    "azure_openai": ("langchain_openai", "OpenAIEmbeddings", _call),
+    "azure_openai": ("langchain_openai", "AzureOpenAIEmbeddings", _call),
     "bedrock": (
         "langchain_aws",
         "BedrockEmbeddings",


### PR DESCRIPTION
Fixes a bug introduced with commit 85f1ba2 (released in `langchain == 1.2.1`).

Whenever the index embedding of the langgraph-server is configured with `azure_openai` provider, the wrong class is going to be initialized (and fails to do so if the now unexpected credentials in environment variable `OPENAI_API_KEY` is not provided).

Example configuration file `langgraph.json` that will reproduce the issue:
(see https://docs.langchain.com/langsmith/cli#adding-semantic-search-to-the-store)

```json
{
  "dependencies": ["."],
  "graphs": {
    "chat": "src/agents/chat/graph.py:graph",
  },
  "store": {
    "index": {
      "embed": "azure_openai:text-embedding-3-small",
      "dims": 1536
    }
  },
  "python_version": "3.13",
  "image_distro": "wolfi"
}
```

