### PR TITLE
test(langchain): cover chat model provider inference

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -79,6 +79,8 @@ def test_supported_providers_is_sorted() -> None:
         ("command-r-plus", "cohere"),
         ("accounts/fireworks/models/mixtral-8x7b-instruct", "fireworks"),
         ("gemini-1.5-pro", "google_vertexai"),
+        ("gemini-2.5-pro", "google_vertexai"),
+        ("gemini-3-pro-preview", "google_vertexai"),
         ("amazon.titan-text-express-v1", "bedrock"),
         ("anthropic.claude-v2", "bedrock"),
         ("mistral-small", "mistralai"),

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -89,9 +89,7 @@ def test_supported_providers_is_sorted() -> None:
         ("solar-pro", "upstage"),
     ],
 )
-def test_attempt_infer_model_provider(
-    model_name: str, expected_provider: str
-) -> None:
+def test_attempt_infer_model_provider(model_name: str, expected_provider: str) -> None:
     assert _attempt_infer_model_provider(model_name) == expected_provider
 
 

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -8,7 +8,7 @@ from langchain_core.runnables import RunnableConfig, RunnableSequence
 from pydantic import SecretStr
 
 from langchain.chat_models import __all__, init_chat_model
-from langchain.chat_models.base import _SUPPORTED_PROVIDERS
+from langchain.chat_models.base import _SUPPORTED_PROVIDERS, _attempt_infer_model_provider
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
@@ -65,6 +65,34 @@ def test_init_unknown_provider() -> None:
 def test_supported_providers_is_sorted() -> None:
     """Test that supported providers are sorted alphabetically."""
     assert list(_SUPPORTED_PROVIDERS) == sorted(_SUPPORTED_PROVIDERS.keys())
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected_provider"),
+    [
+        ("gpt-4o", "openai"),
+        ("o1-mini", "openai"),
+        ("o3-mini", "openai"),
+        ("chatgpt-4o-latest", "openai"),
+        ("text-davinci-003", "openai"),
+        ("claude-3-haiku-20240307", "anthropic"),
+        ("command-r-plus", "cohere"),
+        ("accounts/fireworks/models/mixtral-8x7b-instruct", "fireworks"),
+        ("gemini-1.5-pro", "google_vertexai"),
+        ("amazon.titan-text-express-v1", "bedrock"),
+        ("anthropic.claude-v2", "bedrock"),
+        ("mistral-small", "mistralai"),
+        ("mixtral-8x7b", "mistralai"),
+        ("deepseek-v3", "deepseek"),
+        ("grok-beta", "xai"),
+        ("sonar-small", "perplexity"),
+        ("solar-pro", "upstage"),
+    ],
+)
+def test_attempt_infer_model_provider(
+    model_name: str, expected_provider: str
+) -> None:
+    assert _attempt_infer_model_provider(model_name) == expected_provider
 
 
 @pytest.mark.requires("langchain_openai")


### PR DESCRIPTION
Add unit coverage for chat model provider inference across common model name prefixes. This improves regression protection without touching runtime