### PR TITLE
fix: don't trace injected args only found in signature

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -805,6 +805,9 @@ class ChildTool(BaseTool):
         # Start with filtered args from the constant
         filtered_keys = set[str](FILTERED_ARGS)
 
+        # Add injected args from function signature (e.g., ToolRuntime parameters)
+        filtered_keys.update(self._injected_args_keys)
+
         # If we have an args_schema, use it to identify injected args
         if self.args_schema is not None:
             try:


### PR DESCRIPTION
for the case when they're not included in the `args_schema`

this was predicted by @eyurtsev's comment here: https://github.com/langchain-ai/langchain/pull/33729/files#r2475538173

pairing w/ this PR in mcp adapters: https://github.com/langchain-ai/langchain-mcp-adapters/pull/407