### PR TITLE
fix(core): format content blocks in `pretty_repr`

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any, cast, overload
 
 from pydantic import ConfigDict, Field
@@ -322,10 +323,15 @@ class BaseMessage(Serializable):
 
         """
         title = get_msg_title_repr(self.type.title() + " Message", bold=html)
-        # TODO: handle non-string content.
         if self.name is not None:
             title += f"\nName: {self.name}"
-        return f"{title}\n\n{self.content}"
+        content = self.content
+        if not isinstance(content, str):
+            try:
+                content = json.dumps(content, indent=2, ensure_ascii=False)
+            except (TypeError, ValueError):
+                content = repr(content)
+        return f"{title}\n\n{content}"
 
     def pretty_print(self) -> None:
         """Print a pretty representation of the message."""

--- a/libs/core/tests/unit_tests/messages/test_base.py
+++ b/libs/core/tests/unit_tests/messages/test_base.py
@@ -1,0 +1,17 @@
+from langchain_core.messages import AIMessage
+
+
+def test_pretty_repr_formats_content_blocks() -> None:
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Hello"},
+            {"type": "image", "url": "https://example.com/image.png"},
+        ]
+    )
+
+    rendered = message.pretty_repr()
+
+    assert "Ai Message" in rendered
+    assert '"type": "text"' in rendered
+    assert '"type": "image"' in rendered
+    assert "[\n" in rendered


### PR DESCRIPTION
Improve pretty_repr to render content blocks as readable JSON (falling back to repr) and add a unit test to cover it.