### PR TITLE
fix(core): improve error message for missing title in JSON schema functions

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -428,11 +428,17 @@ def convert_to_openai_function(
             "dict", _convert_python_function_to_openai_function(function)
         )
     else:
+        if isinstance(function, dict) and ("type" in function or "properties" in function):
+            msg = (
+                "Unsupported function\n\nTo use a JSON schema as a function, "
+                "it must have a top-level 'title' key to be used as the function name."
+            )
+            raise ValueError(msg)
         msg = (
             f"Unsupported function\n\n{function}\n\nFunctions must be passed in"
             " as Dict, pydantic.BaseModel, or Callable. If they're a dict they must"
             " either be in OpenAI function format or valid JSON schema with top-level"
-            " 'title' and 'description' keys."
+            " 'title' key."
         )
         raise ValueError(msg)
 

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -428,10 +428,13 @@ def convert_to_openai_function(
             "dict", _convert_python_function_to_openai_function(function)
         )
     else:
-        if isinstance(function, dict) and ("type" in function or "properties" in function):
+        if isinstance(function, dict) and (
+            "type" in function or "properties" in function
+        ):
             msg = (
-                "Unsupported function\n\nTo use a JSON schema as a function, "
-                "it must have a top-level 'title' key to be used as the function name."
+                f"Unsupported function\n\n{function}\n\nTo use a JSON schema as a "
+                "function, it must have a top-level 'title' key to be used as the "
+                "function name."
             )
             raise ValueError(msg)
         msg = (

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1179,3 +1179,32 @@ def test_convert_to_openai_function_strict_defaults() -> None:
 
     func = convert_to_openai_function(MyModel, strict=True)
     assert func["parameters"]["additionalProperties"] is False
+
+
+def test_convert_to_openai_function_json_schema_missing_title_with_type() -> None:
+    """Test error for JSON schema with 'type' but no 'title'."""
+    schema_without_title = {
+        "type": "object",
+        "properties": {"arg1": {"type": "string"}},
+    }
+    with pytest.raises(ValueError, match="must have a top-level 'title' key"):
+        convert_to_openai_function(schema_without_title)
+
+
+def test_convert_to_openai_function_json_schema_missing_title_properties() -> None:
+    """Test error for JSON schema with 'properties' but no 'title'."""
+    schema_without_title = {
+        "properties": {"arg1": {"type": "string"}},
+    }
+    with pytest.raises(ValueError, match="must have a top-level 'title' key"):
+        convert_to_openai_function(schema_without_title)
+
+
+def test_convert_to_openai_function_json_schema_missing_title_includes_schema() -> None:
+    """Test that the error message includes the schema for debugging."""
+    schema_without_title = {
+        "type": "object",
+        "properties": {"my_field": {"type": "integer"}},
+    }
+    with pytest.raises(ValueError, match="my_field"):
+        convert_to_openai_function(schema_without_title)


### PR DESCRIPTION
Changes Created
I have fixed the issue where a generic and misleading error message was displayed when a JSON schema was missing the top-level 
title
 key.

[Fix: Improve error message for missing title in JSON schema functions](https://github.com/Bhavesh007Sharma/langchain/tree/fix-json-schema-title-error)
File Modified: 
libs/core/langchain_core/utils/function_calling.py

I updated the 
convert_to_openai_function
 validation logic to specifically check for 
dict
 inputs that look like schemas (
type
 or 
properties
 keys present) but are missing the 
title
 key.

# Before (Generic Error)
raise ValueError(
    f"Unsupported function\n\n{function}\n\nFunctions must be passed in"
    " as Dict, pydantic.BaseModel, or Callable. If they're a dict they must"
    " either be in OpenAI function format or valid JSON schema with top-level"
    " 'title' and 'description' keys."
)
# After (Specific Error)
if isinstance(function, dict) and ("type" in function or "properties" in function):
    msg = (
        "Unsupported function\n\nTo use a JSON schema as a function, "
        "it must have a top-level 'title' key to be used as the function name."
    )
    raise ValueError(msg)
Verification Results
Automated Tests
I created a reproduction script 
reproduce_issue.py
 to confirm the behavior.

Before Fix: The script would have raised the generic "Unsupported function" error claiming description was also required.
After Fix: The script now confirms that the new, specific error message is raised when 
title
 is missing.
(Note: Verification was performed by inspecting the code logic and running a lightweight reproduction script locally, as full suite verification had environment dependency issues.)