### PR TITLE
feat(langchain): add `state` to `_ModelRequestOverrides`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -81,6 +81,7 @@ class _ModelRequestOverrides(TypedDict, total=False):
     tools: list[BaseTool | dict]
     response_format: ResponseFormat | None
     model_settings: dict[str, Any]
+    state: AgentState
 
 
 @dataclass(init=False)
@@ -213,6 +214,7 @@ class ModelRequest:
                 - `tools`: `list` of available tools
                 - `response_format`: Response format specification
                 - `model_settings`: Additional model settings
+                - `state`: Agent state dictionary
 
         Returns:
             New `ModelRequest` instance with specified overrides applied.


### PR DESCRIPTION
Appears `override()`'s docstring in `langgraph` already shows `state=new_state` as a valid usage pattern

Works since `dataclasses.replace()` accepts any field, but the `TypedDicts` weren't updated to match. Caused mypy to flag legitimate usage as an error.