### PR TITLE
fix(openai): preserve reasoning_content from reasoning models in AIMessage

### DIFF
--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3250,7 +3250,6 @@ def test_openai_structured_output_refusal_handling_responses_api() -> None:
         pytest.fail(f"This is a wrong behavior. Error details: {e}")
 
 
-
 def test_create_chat_result_preserves_reasoning_content() -> None:
     """Test that _create_chat_result preserves reasoning_content from reasoning models.
 
@@ -3306,4 +3305,3 @@ def test_create_chat_result_preserves_reasoning_content() -> None:
         "First, I need to multiply 15 by 23. "
         "Breaking it down: 15 * 20 = 300, 15 * 3 = 45, so 300 + 45 = 345."
     )
-

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3294,7 +3294,7 @@ def test_create_chat_result_preserves_reasoning_content() -> None:
         "model": "grok-3",
     }
 
-    llm = ChatOpenAI(model="grok-3", api_key="fake-key")
+    llm = ChatOpenAI(model="grok-3", api_key=SecretStr("fake-key"))
     result = llm._create_chat_result(mock_response)
 
     assert len(result.generations) == 1


### PR DESCRIPTION
## Problem

Reasoning models (e.g., OpenAI o1, xAI Grok) return a `reasoning_content` field in their Chat Completions API response, containing the model's chain-of-thought reasoning. This field is currently being silently dropped when `ChatOpenAI` converts the raw OpenAI response to a LangChain `AIMessage`.

The drop occurs in two places:

1. **`_convert_dict_to_message()`** - only copies `content`, `function_call`, `tool_calls`, and `audio` to `additional_kwargs`, ignoring `reasoning_content`

2. **`_create_chat_result()`** - has special handling for `parsed` and `refusal` attributes from the raw response, but not for `reasoning_content`

## Solution

Add `reasoning_content` to the list of preserved fields in both locations:

1. In `_convert_dict_to_message()`: copy `reasoning_content` to `additional_kwargs` when present in the message dict

2. In `_create_chat_result()`: extract `reasoning_content` from the raw OpenAI response message (checking both direct attribute and `model_extra` for pydantic v2 compatibility) and inject into `additional_kwargs`

## Usage

After this fix, users can access the reasoning content via:

```python
response = await llm.ainvoke(messages)
reasoning = response.additional_kwargs.get("reasoning_content")
if reasoning:
    print(f"Model reasoning: {reasoning}")
```

## Testing

Added two unit tests:
- `test__convert_dict_to_message_ai_with_reasoning_content` - verifies dict conversion preserves the field
- `test_create_chat_result_preserves_reasoning_content` - verifies raw response handling preserves the field

## Related

This affects users of reasoning models who want to inspect or log the model's chain-of-thought reasoning for debugging, monitoring, or transparency purposes.