### PR TITLE
fix: JSON schema `'title'` requirement not clearly documented

### DIFF
--- a/libs/langchain_v1/langchain/agents/structured_output.py
+++ b/libs/langchain_v1/langchain/agents/structured_output.py
@@ -156,7 +156,9 @@ class _SchemaSpec(Generic[SchemaT]):
         if name:
             self.name = name
         elif isinstance(schema, dict):
-            self.name = str(schema.get("title", f"response_format_{str(uuid.uuid4())[:4]}"))
+            if "title" not in schema:
+                schema["title"] = f"response_format_{str(uuid.uuid4())[:4]}"
+            self.name = schema["title"]
         else:
             self.name = str(getattr(schema, "__name__", f"response_format_{str(uuid.uuid4())[:4]}"))
 


### PR DESCRIPTION
Fix schema title handling in structured_output.py

- Ensure `self.name` uses `schema['title']` when present for JSON schemas.
- Generate a fallback title only if missing.
- Keep description fallback consistent with schema or docstring.
- Improves schema consistency compared to the previous implementation.
