### PR TITLE
docs: Add official Conda support installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ LangChain is a framework for building agents and LLM-powered applications. It he
 
 ```bash
 pip install langchain
+# or
+conda install langchain -c conda-forge
 ```
 
 If you're looking for more advanced customization or agent orchestration, check out [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview), our framework for building controllable agent workflows.


### PR DESCRIPTION
This PR adds the missing Conda installation command to the README, addressing issue #34578.\n\n## Description\nAdded `conda install langchain -c conda-forge` to the installation section.