### PR TITLE
docs(core): document JSON schema `'title'` requirement for function calling

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -393,15 +393,15 @@ def convert_to_openai_function(
                 "type": "object",
                 "description": "Get weather for a location",
                 "properties": {
-                    "location": {"type": "string", "description": "City name"}
+                    "location": {"type": "string", "description": "City name"},
                 },
-                "required": ["location"]
+                "required": ["location"],
             }
 
             # This will raise ValueError - missing 'title'
             bad_schema = {
                 "type": "object",
-                "properties": {"location": {"type": "string"}}
+                "properties": {"location": {"type": "string"}},
             }
 
         Alternatively, use Pydantic models which handle this automatically.

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -381,6 +381,30 @@ def convert_to_openai_function(
 
         `description` and `parameters` keys are now optional. Only `name` is
         required and guaranteed to be part of the output.
+
+    !!! note "JSON Schema dict requirements"
+
+        When passing a JSON schema dict directly, it **must** include a top-level
+        ``title`` key which will be used as the function/tool name. Example::
+
+            # Correct - includes required 'title' key
+            schema = {
+                "title": "GetWeather",  # Required: becomes the function name
+                "type": "object",
+                "description": "Get weather for a location",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"}
+                },
+                "required": ["location"]
+            }
+
+            # This will raise ValueError - missing 'title'
+            bad_schema = {
+                "type": "object",
+                "properties": {"location": {"type": "string"}}
+            }
+
+        Alternatively, use Pydantic models which handle this automatically.
     """
     # an Anthropic format tool
     if isinstance(function, dict) and all(


### PR DESCRIPTION
## Summary

- Documents the requirement that JSON schema dicts must include a top-level `title` key when using `convert_to_openai_function`
- Adds clear code examples showing correct and incorrect usage
- Suggests Pydantic models as an alternative approach

## Problem

Users passing raw JSON schemas to function calling APIs receive a confusing error message without understanding **why** the `title` field is required. The error mentions it but doesn't explain that `title` becomes the function name.

## Solution

Added a `!!! note` block to the docstring with:
- Clear explanation that `title` is **required** and used as the function name
- Working code example with comments
- Example of what causes the ValueError
- Alternative approach using Pydantic

## Test plan

- [x] Docstring renders correctly (follows existing MkDocs Material format)
- [x] No code changes, documentation only

## AI Disclosure

This PR was developed with assistance from Claude (AI).

Fixes #34662

🤖 Generated with [Claude Code](https://claude.ai/code)