### PR TITLE
docs(langchain): clarify streaming behavior in create_agent

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -685,6 +685,22 @@ def create_agent(
         for chunk in graph.stream(inputs, stream_mode="updates"):
             print(chunk)
         ```
+
+    !!! note "Streaming behavior"
+
+        When using ``stream()`` or ``astream()`` with ``stream_mode="messages"``,
+        the agent yields **complete messages** (not individual tokens). This is
+        because the agent internally uses ``model.invoke()`` / ``model.ainvoke()``
+        rather than streaming methods.
+
+        For token-level streaming, use the model directly::
+
+            # Token-level streaming (outside agent)
+            async for token in model.astream(messages):
+                print(token.content, end="")
+
+        The agent's streaming is designed for observing state updates between
+        tool calls, not for real-time token output.
     """
     # init chat model
     if isinstance(model, str):


### PR DESCRIPTION
## Summary

- Documents that agent streaming yields **complete messages**, not individual tokens
- Clarifies the difference between `stream_mode="messages"` and token-level streaming
- Provides workaround for users who need token-level output

## Problem

Users expect `astream()` with `stream_mode="messages"` to yield individual tokens like `model.astream()` does. However, agents internally use `model.invoke()` / `model.ainvoke()`, so streaming only provides state updates between tool calls.

This has caused confusion (see #34648) where users thought their deep-thinking models weren't streaming properly.

## Solution

Added a `!!! note "Streaming behavior"` block to the `create_agent` docstring explaining:
- Agent streaming yields complete messages, not tokens
- Why: agent uses `invoke()` internally, not streaming methods
- Workaround: use `model.astream()` directly for token-level output

## Test plan

- [x] Docstring follows existing MkDocs Material format
- [x] No code changes, documentation only

## AI Disclosure

This PR was developed with assistance from Claude (AI).

Related to #34648

🤖 Generated with [Claude Code](https://claude.ai/code)