### PR TITLE
Fix/OpenAI preserve reasoning content

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1506,7 +1506,9 @@ class BaseChatOpenAI(BaseChatModel):
             if hasattr(message, "refusal"):
                 generations[0].message.additional_kwargs["refusal"] = message.refusal
             if hasattr(message, "reasoning_content"):
-                generations[0].message.additional_kwargs["reasoning_content"] = message.reasoning_content
+                generations[0].message.additional_kwargs["reasoning_content"] = (
+                    message.reasoning_content
+                )
 
         return ChatResult(generations=generations, llm_output=llm_output)
 
@@ -2640,12 +2642,13 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
             response items into the message's `content` field, rather than
             `additional_kwargs`. We recommend this format for new applications.
 
-        ??? info "Reasoning content (chain-of-thought)"
+    ??? info "Reasoning content (chain-of-thought)"
 
         Some reasoning models (OpenAI o1/o3, xAI Grok, DeepSeek-R1, Qwen) expose
         their chain-of-thought reasoning in the `reasoning_content` field. This is
         automatically preserved in `AIMessage.additional_kwargs`.
-```python
+
+        ```python
         from langchain_openai import ChatOpenAI
 
         # Using a reasoning model
@@ -2660,8 +2663,8 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
         reasoning = response.additional_kwargs.get("reasoning_content")
         if reasoning:
             print(f"Reasoning: {reasoning}")
-            # Output: "Reasoning: First, I recognize that 100 = 10 × 10..."
-```
+            # Output: "Reasoning: First, I recognize that 100 = 10 * 10..."
+        ```
 
         The `reasoning_content` field is available for:
         - OpenAI: o1-preview, o1-mini, o3-mini

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2640,6 +2640,38 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
             response items into the message's `content` field, rather than
             `additional_kwargs`. We recommend this format for new applications.
 
+        ??? info "Reasoning content (chain-of-thought)"
+
+        Some reasoning models (OpenAI o1/o3, xAI Grok, DeepSeek-R1, Qwen) expose
+        their chain-of-thought reasoning in the `reasoning_content` field. This is
+        automatically preserved in `AIMessage.additional_kwargs`.
+```python
+        from langchain_openai import ChatOpenAI
+
+        # Using a reasoning model
+        llm = ChatOpenAI(model="o1-preview")  # or grok-3-mini, deepseek-reasoner
+        response = llm.invoke("What is 10^2")
+
+        # Get the answer
+        print(response.content)
+        # Output: "The square of 10 is 100."
+
+        # Get the model's reasoning process
+        reasoning = response.additional_kwargs.get("reasoning_content")
+        if reasoning:
+            print(f"Reasoning: {reasoning}")
+            # Output: "Reasoning: First, I recognize that 100 = 10 × 10..."
+```
+
+        The `reasoning_content` field is available for:
+        - OpenAI: o1-preview, o1-mini, o3-mini
+        - xAI: grok-3-mini, grok-beta
+        - DeepSeek: deepseek-reasoner
+        - Qwen: qwen reasoning variants
+
+        This works in both streaming and non-streaming modes.
+
+
     ??? info "Structured output"
 
         ```python

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -190,6 +190,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
                     )
         if audio := _dict.get("audio"):
             additional_kwargs["audio"] = audio
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = reasoning_content
         return AIMessage(
             content=content,
             additional_kwargs=additional_kwargs,
@@ -1503,6 +1505,8 @@ class BaseChatOpenAI(BaseChatModel):
                 generations[0].message.additional_kwargs["parsed"] = message.parsed
             if hasattr(message, "refusal"):
                 generations[0].message.additional_kwargs["refusal"] = message.refusal
+            if hasattr(message, "reasoning_content"):
+                generations[0].message.additional_kwargs["reasoning_content"] = message.reasoning_content
 
         return ChatResult(generations=generations, llm_output=llm_output)
 

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -577,7 +577,7 @@ requires-dist = [
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "deepseek", "xai", "perplexity"]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.14.10,<0.15.0" }]
+lint = [{ name = "ruff", specifier = ">=0.14.11,<0.15.0" }]
 test = [
     { name = "langchain-openai", editable = "." },
     { name = "langchain-tests", editable = "../../standard-tests" },
@@ -637,7 +637,7 @@ dev = [
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
     { name = "setuptools", specifier = ">=67.6.1,<68.0.0" },
 ]
-lint = [{ name = "ruff", specifier = ">=0.14.10,<0.15.0" }]
+lint = [{ name = "ruff", specifier = ">=0.14.11,<0.15.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.18,<1.6.0" },
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -787,7 +787,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.14.10,<0.15.0" }]
+lint = [{ name = "ruff", specifier = ">=0.14.11,<0.15.0" }]
 test = [{ name = "langchain-core", editable = "../../core" }]
 test-integration = []
 typing = [


### PR DESCRIPTION
fix(langchain-openai): preserve reasoning_content from reasoning models  
  
2. PR description:
Updates ChatOpenAI to correctly preserve the reasoning_content field in AIMessage.additional_kwargs for reasoning models (e.g., o1, Grok, DeepSeek) and adds documentation on how to access chain-of-thought data. Simple fixes in the langchain_openai/chat_models_base.py directory.



fixes #34706