### PR TITLE
fix(core): correctly guard against non-text-block types

### DIFF
--- a/libs/core/langchain_core/outputs/chat_generation.py
+++ b/libs/core/langchain_core/outputs/chat_generation.py
@@ -57,16 +57,18 @@ class ChatGeneration(Generation):
         text = ""
         if isinstance(self.message.content, str):
             text = self.message.content
-        # Assumes text in content blocks in OpenAI format.
-        # Uses first text block.
+        # Extracts first text block from content blocks.
+        # Skips blocks with explicit non-text type (e.g., thinking, reasoning).
         elif isinstance(self.message.content, list):
             for block in self.message.content:
                 if isinstance(block, str):
                     text = block
                     break
                 if isinstance(block, dict) and "text" in block:
-                    text = block["text"]
-                    break
+                    block_type = block.get("type")
+                    if block_type is None or block_type == "text":
+                        text = block["text"]
+                        break
         self.text = text
         return self
 


### PR DESCRIPTION
# Before

```python
if isinstance(block, dict) and "text" in block:
    text = block["text"]
    break
```
Extracts text from any `dict` with a `'text'` key, including thinking/reasoning blocks.

# After

```python
if isinstance(block, dict) and "text" in block:
    block_type = block.get("type")
    if block_type is None or block_type == "text":
        text = block["text"]
        break
```

Skips blocks with explicit non-text types (e.g., `type: 'thinking'`).

# Justification

Models like Gemini 3 return structured content with multiple block types:

```python
[
    {"type": "thinking", "text": "let me reason..."},
    {"type": "text", "text": "The answer is 42"}
]
```

The old logic extracted `'let me reason...'` (the thinking block) because it matched first. The new logic skips it and correctly extracts `'The answer is 42'`.

The `ChatGeneration.text` field is used by `on_llm_new_token(token, chunk=chunk)` callbacks during streaming. Consequently, it would get tokens incorrectly for reasoning blocks.

Related: #34727