### PR TITLE
feat(openai): add rate_limiter support to OpenAIEmbeddings

### DIFF
--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -13,9 +13,10 @@ from langchain_core.embeddings import Embeddings
 from langchain_core.rate_limiters import BaseRateLimiter
 from langchain_core.runnables.config import run_in_executor
 from langchain_core.utils import from_env, get_pydantic_field_names, secret_from_env
-from langchain_openai.chat_models._client_utils import _resolve_sync_and_async_api_keys
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
+
+from langchain_openai.chat_models._client_utils import _resolve_sync_and_async_api_keys
 
 logger = logging.getLogger(__name__)
 
@@ -296,17 +297,19 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         longer than embedding_ctx_length."""
 
     rate_limiter: BaseRateLimiter | None = None
-    """Optional rate limiter. If provided, will be used to throttle requests to the OpenAI API.
+    """Optional rate limiter. If provided, will be used to throttle requests
+    to the OpenAI API.
 
-    Supports objects like `InMemoryRateLimiter` with `wait()` and `wait_async()` methods
-    for synchronous and asynchronous embedding calls, respectively.
+    Supports objects like `InMemoryRateLimiter` with `acquire()` and
+    `aacquire()` methods for synchronous and asynchronous embedding calls,
+    respectively.
     """
 
     model_config = ConfigDict(
         extra="forbid",
         populate_by_name=True,
         protected_namespaces=(),
-        arbitrary_types_allowed=True  # ⚡ 允许 BaseRateLimiter 这种自定义类型
+        arbitrary_types_allowed=True,  # ⚡ 允许 BaseRateLimiter 这种自定义类型
     )
 
     @model_validator(mode="before")

--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -10,12 +10,12 @@ from typing import Any, Literal, cast
 import openai
 import tiktoken
 from langchain_core.embeddings import Embeddings
+from langchain_core.rate_limiters import BaseRateLimiter
 from langchain_core.runnables.config import run_in_executor
 from langchain_core.utils import from_env, get_pydantic_field_names, secret_from_env
+from langchain_openai.chat_models._client_utils import _resolve_sync_and_async_api_keys
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
-
-from langchain_core.rate_limiters import BaseRateLimiter
 
 logger = logging.getLogger(__name__)
 
@@ -303,7 +303,10 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     """
 
     model_config = ConfigDict(
-        extra="forbid", populate_by_name=True, protected_namespaces=()
+        extra="forbid",
+        populate_by_name=True,
+        protected_namespaces=(),
+        arbitrary_types_allowed=True  # ⚡ 允许 BaseRateLimiter 这种自定义类型
     )
 
     @model_validator(mode="before")

--- a/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
@@ -118,9 +118,9 @@ def test_embeddings_respects_token_limit() -> None:
             )
             call_counts.append(total_tokens)
             # Verify this call doesn't exceed limit
-            assert (
-                total_tokens <= 300000
-            ), f"Batch exceeded token limit: {total_tokens} tokens"
+            assert total_tokens <= 300000, (
+                f"Batch exceeded token limit: {total_tokens} tokens"
+            )
 
         # Return mock response
         mock_response = Mock()

--- a/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
@@ -150,14 +150,3 @@ def test_embeddings_respects_token_limit() -> None:
     # Verify each call respected the limit
     for count in call_counts:
         assert count <= 300000, f"Batch exceeded limit: {count}"
-
-
-def test_sync_embed_with_rate_limiter():
-    rate_limiter = InMemoryRateLimiter(
-        requests_per_second=0.1,  # <-- Super slow! We can only make a request once every 10 seconds!!
-        check_every_n_seconds=0.1,  # Wake up every 100 ms to check whether allowed to make a request,
-        max_bucket_size=10,  # Controls the maximum burst size.
-    )
-    embed = OpenAIEmbeddings(rate_limiter=rate_limiter)
-    vector = embed.embed_query("hello world")
-    assert isinstance(vector, list)

--- a/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
@@ -6,8 +6,6 @@ import pytest
 from pydantic import SecretStr
 
 from langchain_openai import OpenAIEmbeddings
-from langchain_core.rate_limiters import InMemoryRateLimiter
-
 
 os.environ["OPENAI_API_KEY"] = "foo"
 
@@ -120,9 +118,9 @@ def test_embeddings_respects_token_limit() -> None:
             )
             call_counts.append(total_tokens)
             # Verify this call doesn't exceed limit
-            assert total_tokens <= 300000, (
-                f"Batch exceeded token limit: {total_tokens} tokens"
-            )
+            assert (
+                total_tokens <= 300000
+            ), f"Batch exceeded token limit: {total_tokens} tokens"
 
         # Return mock response
         mock_response = Mock()


### PR DESCRIPTION
Add client-side rate limiting support to OpenAI embedding models.

This introduces an optional `rate_limiter` parameter to `OpenAIEmbeddings`,
allowing users to throttle embedding requests in synchronous and asynchronous
calls. Existing behavior without a limiter remains unchanged.

Fixes #34417

### Changes
- Added `rate_limiter: BaseRateLimiter | None = None` to `OpenAIEmbeddings`.
- Support for `rate_limiter.acquire()` in synchronous embedding calls.
- Support for `await rate_limiter.aacquire()` in asynchronous embedding calls.

### AI assistance disclosure
Parts of this contribution were assisted by generative AI (ChatGPT) for code
structuring, comments, and documentation drafting. All logic and changes were
reviewed and validated by the author.