### PR TITLE
feat(core): Add OutputFixingParser for LCEL chain retry support

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -181,7 +181,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "Document",
     ),
     ("langchain", "output_parsers", "fix", "OutputFixingParser"): (
-        "langchain",
+        "langchain_core",
         "output_parsers",
         "fix",
         "OutputFixingParser",

--- a/libs/core/langchain_core/output_parsers/__init__.py
+++ b/libs/core/langchain_core/output_parsers/__init__.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         BaseLLMOutputParser,
         BaseOutputParser,
     )
+    from langchain_core.output_parsers.fix import OutputFixingParser
     from langchain_core.output_parsers.json import (
         JsonOutputParser,
         SimpleJsonOutputParser,
@@ -62,6 +63,7 @@ __all__ = [
     "ListOutputParser",
     "MarkdownListOutputParser",
     "NumberedListOutputParser",
+    "OutputFixingParser",
     "PydanticOutputParser",
     "PydanticToolsParser",
     "SimpleJsonOutputParser",
@@ -73,6 +75,7 @@ _dynamic_imports = {
     "BaseLLMOutputParser": "base",
     "BaseGenerationOutputParser": "base",
     "BaseOutputParser": "base",
+    "OutputFixingParser": "fix",
     "JsonOutputParser": "json",
     "SimpleJsonOutputParser": "json",
     "ListOutputParser": "list",

--- a/libs/core/langchain_core/output_parsers/fix.py
+++ b/libs/core/langchain_core/output_parsers/fix.py
@@ -11,7 +11,7 @@ from langchain_core.exceptions import OutputParserException
 from langchain_core.output_parsers.base import BaseOutputParser
 from langchain_core.output_parsers.string import StrOutputParser
 from langchain_core.prompts.prompt import PromptTemplate
-from langchain_core.runnables import Runnable, RunnableSerializable
+from langchain_core.runnables import Runnable, RunnableSerializable  # noqa: TC001
 
 T = TypeVar("T")
 
@@ -58,7 +58,10 @@ class OutputFixingParser(BaseOutputParser[T]):
     Example:
         .. code-block:: python
 
-            from langchain_core.output_parsers import JsonOutputParser, OutputFixingParser
+            from langchain_core.output_parsers import (
+                JsonOutputParser,
+                OutputFixingParser,
+            )
             from langchain_openai import ChatOpenAI
 
             llm = ChatOpenAI()
@@ -66,13 +69,13 @@ class OutputFixingParser(BaseOutputParser[T]):
 
             # Wrap the parser with retry capability
             fixing_parser = OutputFixingParser.from_llm(
-                llm=llm,
-                parser=json_parser,
-                max_retries=3
+                llm=llm, parser=json_parser, max_retries=3
             )
 
             # Now parsing errors will trigger automatic retry
-            result = fixing_parser.parse('{"key": value}')  # Missing quotes around value
+            result = fixing_parser.parse(
+                '{"key": value}'
+            )  # Missing quotes around value
     """
 
     parser: Annotated[BaseOutputParser[T], SkipValidation()]
@@ -122,16 +125,16 @@ class OutputFixingParser(BaseOutputParser[T]):
                 from langchain_openai import ChatOpenAI
                 from pydantic import BaseModel
 
+
                 class Person(BaseModel):
                     name: str
                     age: int
 
+
                 llm = ChatOpenAI()
                 parser = PydanticOutputParser(pydantic_object=Person)
                 fixing_parser = OutputFixingParser.from_llm(
-                    llm=llm,
-                    parser=parser,
-                    max_retries=3
+                    llm=llm, parser=parser, max_retries=3
                 )
         """
         chain = prompt | llm | StrOutputParser()

--- a/libs/core/langchain_core/output_parsers/fix.py
+++ b/libs/core/langchain_core/output_parsers/fix.py
@@ -1,0 +1,237 @@
+"""Output parser that wraps another parser and retries on failure."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, TypeVar
+
+from pydantic import SkipValidation
+from typing_extensions import TypedDict, override
+
+from langchain_core.exceptions import OutputParserException
+from langchain_core.output_parsers.base import BaseOutputParser
+from langchain_core.output_parsers.string import StrOutputParser
+from langchain_core.prompts.prompt import PromptTemplate
+from langchain_core.runnables import Runnable, RunnableSerializable
+
+T = TypeVar("T")
+
+NAIVE_FIX = """Instructions:
+--------------
+{instructions}
+--------------
+Completion:
+--------------
+{completion}
+--------------
+
+Above, the Completion did not satisfy the constraints given in the Instructions.
+Error:
+--------------
+{error}
+--------------
+
+Please try again. Please only respond with an answer that satisfies the constraints laid out in the Instructions:"""  # noqa: E501
+
+
+NAIVE_FIX_PROMPT = PromptTemplate.from_template(NAIVE_FIX)
+"""Default prompt template for fixing parsing errors."""
+
+
+class OutputFixingParserRetryChainInput(TypedDict, total=False):
+    """Input for the retry chain of the OutputFixingParser."""
+
+    instructions: str
+    completion: str
+    error: str
+
+
+class OutputFixingParser(BaseOutputParser[T]):
+    """Wrap a parser and try to fix parsing errors.
+
+    This parser wraps another output parser and, in the event that the first one
+    fails to parse the output, it calls an LLM to fix the errors and try again.
+
+    This is useful for cases where the LLM output is almost correct but has minor
+    formatting issues that cause parsing to fail. Rather than failing entirely,
+    this parser gives the LLM a chance to correct its mistakes.
+
+    Example:
+        .. code-block:: python
+
+            from langchain_core.output_parsers import JsonOutputParser, OutputFixingParser
+            from langchain_openai import ChatOpenAI
+
+            llm = ChatOpenAI()
+            json_parser = JsonOutputParser()
+
+            # Wrap the parser with retry capability
+            fixing_parser = OutputFixingParser.from_llm(
+                llm=llm,
+                parser=json_parser,
+                max_retries=3
+            )
+
+            # Now parsing errors will trigger automatic retry
+            result = fixing_parser.parse('{"key": value}')  # Missing quotes around value
+    """
+
+    parser: Annotated[BaseOutputParser[T], SkipValidation()]
+    """The parser to use to parse the output."""
+
+    retry_chain: Annotated[
+        RunnableSerializable[OutputFixingParserRetryChainInput, str],
+        SkipValidation(),
+    ]
+    """The runnable chain to use to retry the completion."""
+
+    max_retries: int = 1
+    """The maximum number of times to retry the parse."""
+
+    @classmethod
+    @override
+    def is_lc_serializable(cls) -> bool:
+        return True
+
+    @classmethod
+    def from_llm(
+        cls,
+        llm: Runnable[Any, Any],
+        parser: BaseOutputParser[T],
+        prompt: PromptTemplate = NAIVE_FIX_PROMPT,
+        max_retries: int = 1,
+    ) -> OutputFixingParser[T]:
+        """Create an OutputFixingParser from a language model and a parser.
+
+        Args:
+            llm: The language model to use for fixing parsing errors.
+            parser: The parser to wrap with retry capability.
+            prompt: The prompt template to use for fixing errors.
+                Defaults to NAIVE_FIX_PROMPT.
+            max_retries: Maximum number of retries to attempt. Defaults to 1.
+
+        Returns:
+            An OutputFixingParser instance.
+
+        Example:
+            .. code-block:: python
+
+                from langchain_core.output_parsers import (
+                    PydanticOutputParser,
+                    OutputFixingParser,
+                )
+                from langchain_openai import ChatOpenAI
+                from pydantic import BaseModel
+
+                class Person(BaseModel):
+                    name: str
+                    age: int
+
+                llm = ChatOpenAI()
+                parser = PydanticOutputParser(pydantic_object=Person)
+                fixing_parser = OutputFixingParser.from_llm(
+                    llm=llm,
+                    parser=parser,
+                    max_retries=3
+                )
+        """
+        chain = prompt | llm | StrOutputParser()
+        return cls(parser=parser, retry_chain=chain, max_retries=max_retries)
+
+    @override
+    def parse(self, completion: str) -> T:
+        """Parse the completion, retrying with LLM if parsing fails.
+
+        Args:
+            completion: The string output from the model.
+
+        Returns:
+            The parsed output.
+
+        Raises:
+            OutputParserException: If parsing fails after all retries.
+        """
+        retries = 0
+
+        while retries <= self.max_retries:
+            try:
+                return self.parser.parse(completion)
+            except OutputParserException as e:
+                if retries == self.max_retries:
+                    raise
+                retries += 1
+                try:
+                    completion = self.retry_chain.invoke(
+                        {
+                            "instructions": self.parser.get_format_instructions(),
+                            "completion": completion,
+                            "error": repr(e),
+                        },
+                    )
+                except (NotImplementedError, AttributeError):
+                    # Case: self.parser does not have get_format_instructions
+                    completion = self.retry_chain.invoke(
+                        {
+                            "completion": completion,
+                            "error": repr(e),
+                        },
+                    )
+
+        msg = "Failed to parse"
+        raise OutputParserException(msg)
+
+    @override
+    async def aparse(self, completion: str) -> T:
+        """Async version of parse.
+
+        Args:
+            completion: The string output from the model.
+
+        Returns:
+            The parsed output.
+
+        Raises:
+            OutputParserException: If parsing fails after all retries.
+        """
+        retries = 0
+
+        while retries <= self.max_retries:
+            try:
+                return await self.parser.aparse(completion)
+            except OutputParserException as e:
+                if retries == self.max_retries:
+                    raise
+                retries += 1
+                try:
+                    completion = await self.retry_chain.ainvoke(
+                        {
+                            "instructions": self.parser.get_format_instructions(),
+                            "completion": completion,
+                            "error": repr(e),
+                        },
+                    )
+                except (NotImplementedError, AttributeError):
+                    # Case: self.parser does not have get_format_instructions
+                    completion = await self.retry_chain.ainvoke(
+                        {
+                            "completion": completion,
+                            "error": repr(e),
+                        },
+                    )
+
+        msg = "Failed to parse"
+        raise OutputParserException(msg)
+
+    @override
+    def get_format_instructions(self) -> str:
+        """Get format instructions from the wrapped parser."""
+        return self.parser.get_format_instructions()
+
+    @property
+    def _type(self) -> str:
+        return "output_fixing"
+
+    @property
+    @override
+    def OutputType(self) -> type[T]:
+        """Return the output type of the wrapped parser."""
+        return self.parser.OutputType

--- a/libs/core/tests/unit_tests/output_parsers/test_fix.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_fix.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -19,13 +19,14 @@ class MockParser(BaseOutputParser[dict[str, Any]]):
     """Number of times to fail before succeeding."""
     current_failures: int = 0
     """Current number of failures."""
-    expected_output: dict[str, Any] = {"result": "success"}
+    expected_output: ClassVar[dict[str, Any]] = {"result": "success"}
     """Output to return on success."""
 
-    def parse(self, text: str) -> dict[str, Any]:
+    def parse(self, text: str) -> dict[str, Any]:  # noqa: ARG002
         if self.current_failures < self.fail_count:
             self.current_failures += 1
-            raise OutputParserException(f"Parse failed (attempt {self.current_failures})")
+            msg = f"Parse failed (attempt {self.current_failures})"
+            raise OutputParserException(msg)
         return self.expected_output
 
     async def aparse(self, text: str) -> dict[str, Any]:
@@ -42,14 +43,16 @@ class MockParser(BaseOutputParser[dict[str, Any]]):
 class MockParserNoInstructions(BaseOutputParser[str]):
     """A mock parser without get_format_instructions."""
 
-    def parse(self, text: str) -> str:
-        raise OutputParserException("Always fails")
+    def parse(self, text: str) -> str:  # noqa: ARG002
+        msg = "Always fails"
+        raise OutputParserException(msg)
 
     async def aparse(self, text: str) -> str:
         return self.parse(text)
 
     def get_format_instructions(self) -> str:
-        raise NotImplementedError("No format instructions")
+        msg = "No format instructions"
+        raise NotImplementedError(msg)
 
     @property
     def _type(self) -> str:
@@ -61,7 +64,7 @@ def test_output_fixing_parser_success_first_try() -> None:
     mock_parser = MockParser(fail_count=0)
     mock_llm = MagicMock()
 
-    fixing_parser = OutputFixingParser.from_llm(
+    fixing_parser: OutputFixingParser[dict[str, Any]] = OutputFixingParser.from_llm(
         llm=mock_llm,
         parser=mock_parser,
         max_retries=3,
@@ -83,7 +86,7 @@ def test_output_fixing_parser_success_after_retry() -> None:
     mock_chain = MagicMock()
     mock_chain.invoke.return_value = "fixed output"
 
-    fixing_parser = OutputFixingParser(
+    fixing_parser: OutputFixingParser[dict[str, Any]] = OutputFixingParser(
         parser=mock_parser,
         retry_chain=mock_chain,
         max_retries=3,
@@ -101,7 +104,7 @@ def test_output_fixing_parser_fails_after_max_retries() -> None:
     mock_chain = MagicMock()
     mock_chain.invoke.return_value = "still invalid"
 
-    fixing_parser = OutputFixingParser(
+    fixing_parser: OutputFixingParser[dict[str, Any]] = OutputFixingParser(
         parser=mock_parser,
         retry_chain=mock_chain,
         max_retries=2,
@@ -120,7 +123,7 @@ def test_output_fixing_parser_without_format_instructions() -> None:
     mock_chain = MagicMock()
     mock_chain.invoke.return_value = "fixed output"
 
-    fixing_parser = OutputFixingParser(
+    fixing_parser: OutputFixingParser[str] = OutputFixingParser(
         parser=mock_parser,
         retry_chain=mock_chain,
         max_retries=1,
@@ -141,7 +144,7 @@ def test_output_fixing_parser_get_format_instructions() -> None:
     mock_parser = MockParser()
     mock_chain = MagicMock()
 
-    fixing_parser = OutputFixingParser(
+    fixing_parser: OutputFixingParser[dict[str, Any]] = OutputFixingParser(
         parser=mock_parser,
         retry_chain=mock_chain,
         max_retries=1,
@@ -155,7 +158,7 @@ def test_output_fixing_parser_output_type() -> None:
     mock_parser = MockParser()
     mock_chain = MagicMock()
 
-    fixing_parser = OutputFixingParser(
+    fixing_parser: OutputFixingParser[dict[str, Any]] = OutputFixingParser(
         parser=mock_parser,
         retry_chain=mock_chain,
         max_retries=1,
@@ -170,7 +173,7 @@ async def test_output_fixing_parser_aparse_success() -> None:
     mock_parser = MockParser(fail_count=0)
     mock_chain = MagicMock()
 
-    fixing_parser = OutputFixingParser(
+    fixing_parser: OutputFixingParser[dict[str, Any]] = OutputFixingParser(
         parser=mock_parser,
         retry_chain=mock_chain,
         max_retries=1,
@@ -188,7 +191,7 @@ async def test_output_fixing_parser_aparse_with_retry() -> None:
     mock_chain = AsyncMock()
     mock_chain.ainvoke.return_value = "fixed output"
 
-    fixing_parser = OutputFixingParser(
+    fixing_parser: OutputFixingParser[dict[str, Any]] = OutputFixingParser(
         parser=mock_parser,
         retry_chain=mock_chain,
         max_retries=3,
@@ -210,7 +213,7 @@ def test_output_fixing_parser_type() -> None:
     mock_parser = MockParser()
     mock_chain = MagicMock()
 
-    fixing_parser = OutputFixingParser(
+    fixing_parser: OutputFixingParser[dict[str, Any]] = OutputFixingParser(
         parser=mock_parser,
         retry_chain=mock_chain,
         max_retries=1,

--- a/libs/core/tests/unit_tests/output_parsers/test_fix.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_fix.py
@@ -1,0 +1,219 @@
+"""Tests for OutputFixingParser."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from langchain_core.exceptions import OutputParserException
+from langchain_core.output_parsers import OutputFixingParser
+from langchain_core.output_parsers.base import BaseOutputParser
+
+
+class MockParser(BaseOutputParser[dict[str, Any]]):
+    """A mock parser that fails a configurable number of times before succeeding."""
+
+    fail_count: int = 0
+    """Number of times to fail before succeeding."""
+    current_failures: int = 0
+    """Current number of failures."""
+    expected_output: dict[str, Any] = {"result": "success"}
+    """Output to return on success."""
+
+    def parse(self, text: str) -> dict[str, Any]:
+        if self.current_failures < self.fail_count:
+            self.current_failures += 1
+            raise OutputParserException(f"Parse failed (attempt {self.current_failures})")
+        return self.expected_output
+
+    async def aparse(self, text: str) -> dict[str, Any]:
+        return self.parse(text)
+
+    def get_format_instructions(self) -> str:
+        return "Return valid JSON."
+
+    @property
+    def _type(self) -> str:
+        return "mock"
+
+
+class MockParserNoInstructions(BaseOutputParser[str]):
+    """A mock parser without get_format_instructions."""
+
+    def parse(self, text: str) -> str:
+        raise OutputParserException("Always fails")
+
+    async def aparse(self, text: str) -> str:
+        return self.parse(text)
+
+    def get_format_instructions(self) -> str:
+        raise NotImplementedError("No format instructions")
+
+    @property
+    def _type(self) -> str:
+        return "mock_no_instructions"
+
+
+def test_output_fixing_parser_success_first_try() -> None:
+    """Test that parsing succeeds on first try when output is valid."""
+    mock_parser = MockParser(fail_count=0)
+    mock_llm = MagicMock()
+
+    fixing_parser = OutputFixingParser.from_llm(
+        llm=mock_llm,
+        parser=mock_parser,
+        max_retries=3,
+    )
+
+    result = fixing_parser.parse('{"result": "success"}')
+
+    assert result == {"result": "success"}
+    mock_llm.invoke.assert_not_called()
+
+
+def test_output_fixing_parser_success_after_retry() -> None:
+    """Test that parsing succeeds after retrying."""
+    mock_parser = MockParser(fail_count=1)
+    mock_llm = MagicMock()
+    mock_llm.invoke.return_value = MagicMock(content="fixed output")
+
+    # Create a mock chain that returns the fixed output
+    mock_chain = MagicMock()
+    mock_chain.invoke.return_value = "fixed output"
+
+    fixing_parser = OutputFixingParser(
+        parser=mock_parser,
+        retry_chain=mock_chain,
+        max_retries=3,
+    )
+
+    result = fixing_parser.parse("invalid json")
+
+    assert result == {"result": "success"}
+    mock_chain.invoke.assert_called_once()
+
+
+def test_output_fixing_parser_fails_after_max_retries() -> None:
+    """Test that parsing fails after exhausting all retries."""
+    mock_parser = MockParser(fail_count=10)  # Always fails
+    mock_chain = MagicMock()
+    mock_chain.invoke.return_value = "still invalid"
+
+    fixing_parser = OutputFixingParser(
+        parser=mock_parser,
+        retry_chain=mock_chain,
+        max_retries=2,
+    )
+
+    with pytest.raises(OutputParserException):
+        fixing_parser.parse("invalid json")
+
+    # Should have retried max_retries times
+    assert mock_chain.invoke.call_count == 2
+
+
+def test_output_fixing_parser_without_format_instructions() -> None:
+    """Test that parsing works when parser doesn't have format instructions."""
+    mock_parser = MockParserNoInstructions()
+    mock_chain = MagicMock()
+    mock_chain.invoke.return_value = "fixed output"
+
+    fixing_parser = OutputFixingParser(
+        parser=mock_parser,
+        retry_chain=mock_chain,
+        max_retries=1,
+    )
+
+    with pytest.raises(OutputParserException):
+        fixing_parser.parse("invalid")
+
+    # Should have called without instructions
+    call_args = mock_chain.invoke.call_args[0][0]
+    assert "completion" in call_args
+    assert "error" in call_args
+    assert "instructions" not in call_args
+
+
+def test_output_fixing_parser_get_format_instructions() -> None:
+    """Test that format instructions are passed through from wrapped parser."""
+    mock_parser = MockParser()
+    mock_chain = MagicMock()
+
+    fixing_parser = OutputFixingParser(
+        parser=mock_parser,
+        retry_chain=mock_chain,
+        max_retries=1,
+    )
+
+    assert fixing_parser.get_format_instructions() == "Return valid JSON."
+
+
+def test_output_fixing_parser_output_type() -> None:
+    """Test that OutputType is passed through from wrapped parser."""
+    mock_parser = MockParser()
+    mock_chain = MagicMock()
+
+    fixing_parser = OutputFixingParser(
+        parser=mock_parser,
+        retry_chain=mock_chain,
+        max_retries=1,
+    )
+
+    assert fixing_parser.OutputType == mock_parser.OutputType
+
+
+@pytest.mark.asyncio
+async def test_output_fixing_parser_aparse_success() -> None:
+    """Test async parsing succeeds on first try."""
+    mock_parser = MockParser(fail_count=0)
+    mock_chain = MagicMock()
+
+    fixing_parser = OutputFixingParser(
+        parser=mock_parser,
+        retry_chain=mock_chain,
+        max_retries=1,
+    )
+
+    result = await fixing_parser.aparse('{"result": "success"}')
+
+    assert result == {"result": "success"}
+
+
+@pytest.mark.asyncio
+async def test_output_fixing_parser_aparse_with_retry() -> None:
+    """Test async parsing with retry."""
+    mock_parser = MockParser(fail_count=1)
+    mock_chain = AsyncMock()
+    mock_chain.ainvoke.return_value = "fixed output"
+
+    fixing_parser = OutputFixingParser(
+        parser=mock_parser,
+        retry_chain=mock_chain,
+        max_retries=3,
+    )
+
+    result = await fixing_parser.aparse("invalid json")
+
+    assert result == {"result": "success"}
+    mock_chain.ainvoke.assert_called_once()
+
+
+def test_output_fixing_parser_is_serializable() -> None:
+    """Test that OutputFixingParser is marked as serializable."""
+    assert OutputFixingParser.is_lc_serializable() is True
+
+
+def test_output_fixing_parser_type() -> None:
+    """Test that parser type is correct."""
+    mock_parser = MockParser()
+    mock_chain = MagicMock()
+
+    fixing_parser = OutputFixingParser(
+        parser=mock_parser,
+        retry_chain=mock_chain,
+        max_retries=1,
+    )
+
+    assert fixing_parser._type == "output_fixing"

--- a/libs/core/tests/unit_tests/output_parsers/test_imports.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_imports.py
@@ -18,6 +18,7 @@ EXPECTED_ALL = [
     "JsonOutputToolsParser",
     "JsonOutputKeyToolsParser",
     "PydanticToolsParser",
+    "OutputFixingParser",
 ]
 
 


### PR DESCRIPTION
## Summary

This PR adds `OutputFixingParser` to `langchain-core`, providing automatic retry capability for output parsing failures in LCEL chains.

## Problem

LCEL chains (`prompt | llm | parser`) are still fully supported in LangChain v1, but there's currently **no official retry mechanism for output parsing failures** in this pattern.

The existing `ToolStrategy` with `handle_errors=True` only works with `create_agent` - it doesn't integrate with LCEL chains. This creates a gap for users who:

1. Have existing LCEL-based architectures they don't want to fully refactor
2. Prefer the composability of LCEL over the agent abstraction
3. Need a safety net for occasional LLM parsing failures in production

## Solution

Add `OutputFixingParser` to `langchain-core/output_parsers/`. This parser:

- Wraps any `BaseOutputParser` with retry capability
- On parse failure, prompts an LLM to fix the malformed output
- Supports configurable `max_retries`
- Works with both sync (`parse`) and async (`aparse`)
- Integrates seamlessly with LCEL chains

### Example Usage

```python
from langchain_core.output_parsers import JsonOutputParser, OutputFixingParser
from langchain_openai import ChatOpenAI

llm = ChatOpenAI()

# Wrap parser with automatic retry
parser = OutputFixingParser.from_llm(
    llm=llm,
    parser=JsonOutputParser(),
    max_retries=3
)

# Use in LCEL chain - parsing failures automatically retry
chain = prompt | llm | parser
result = chain.invoke({"input": "..."})
```

## Real-World Use Case

I use this pattern in production for insurance underwriting where we extract structured data (8+ JSON objects with complex nested schemas) from documents using Claude Sonnet 4 and Llama Maverick 4. Even high-quality models occasionally produce outputs that fail Pydantic validation or JSON parsing - the fixing parser catches these edge cases without requiring full rewrites.

## Changes

- **New file**: `libs/core/langchain_core/output_parsers/fix.py` - The `OutputFixingParser` implementation
- **Modified**: `libs/core/langchain_core/output_parsers/__init__.py` - Export the new parser
- **New file**: `libs/core/tests/unit_tests/output_parsers/test_fix.py` - Comprehensive unit tests

## Why `langchain-core`?

All dependencies already exist in `langchain-core`:
- `BaseOutputParser`, `StrOutputParser`
- `OutputParserException`
- `PromptTemplate`
- `Runnable`, `RunnableSerializable`

There's no reason this functionality should require the full `langchain` package.

## Migration Note

This provides a clean migration path for users currently relying on `langchain-classic.output_parsers.OutputFixingParser`:

```python
# Before (langchain-classic)
from langchain_classic.output_parsers import OutputFixingParser

# After (langchain-core)
from langchain_core.output_parsers import OutputFixingParser
```

---

**Related**: This was previously discussed in #33120 (docs PR, closed due to repo restructuring). @eyurtsev mentioned OutputFixingParser "isn't yet included in langchain_v1" - this PR aims to fill that gap.