### PR TITLE
fix(langchain): add metadata configuration to summarization model invocation

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -564,7 +564,7 @@ class SummarizationMiddleware(AgentMiddleware):
         # orphaned tool responses
         return idx
 
-    def _create_summary(self, messages_to_summarize: list[AnyMessage], runtime: Runtime) -> str:
+    def _create_summary(self, messages_to_summarize: list[AnyMessage], _runtime: Runtime) -> str:
         """Generate summary for the given messages.
 
         Args:
@@ -606,7 +606,7 @@ class SummarizationMiddleware(AgentMiddleware):
             return f"Error generating summary: {e!s}"
 
     async def _acreate_summary(
-        self, messages_to_summarize: list[AnyMessage], runtime: Runtime
+        self, messages_to_summarize: list[AnyMessage], _runtime: Runtime
     ) -> str:
         """Generate summary for the given messages.
 

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -576,7 +576,10 @@ class SummarizationMiddleware(AgentMiddleware):
         formatted_messages = get_buffer_string(trimmed_messages)
 
         try:
-            response = self.model.invoke(self.summary_prompt.format(messages=formatted_messages))
+            response = self.model.invoke(
+                self.summary_prompt.format(messages=formatted_messages),
+                config={"metadata": {"lc_source": "summarization"}},
+            )
             return response.text.strip()
         except Exception as e:
             return f"Error generating summary: {e!s}"
@@ -596,7 +599,8 @@ class SummarizationMiddleware(AgentMiddleware):
 
         try:
             response = await self.model.ainvoke(
-                self.summary_prompt.format(messages=formatted_messages)
+                self.summary_prompt.format(messages=formatted_messages),
+                config={"metadata": {"lc_source": "summarization"}},
             )
             return response.text.strip()
         except Exception as e:

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -271,7 +271,7 @@ class SummarizationMiddleware(AgentMiddleware):
             raise ValueError(msg)
 
     @override
-    def before_model(self, state: AgentState[Any], runtime: Runtime) -> dict[str, Any] | None:
+    def before_model(self, state: AgentState[Any], _runtime: Runtime) -> dict[str, Any] | None:
         """Process messages before model invocation, potentially triggering summarization.
 
         Args:
@@ -295,7 +295,7 @@ class SummarizationMiddleware(AgentMiddleware):
 
         messages_to_summarize, preserved_messages = self._partition_messages(messages, cutoff_index)
 
-        summary = self._create_summary(messages_to_summarize, runtime)
+        summary = self._create_summary(messages_to_summarize)
         new_messages = self._build_new_messages(summary)
 
         return {
@@ -308,7 +308,7 @@ class SummarizationMiddleware(AgentMiddleware):
 
     @override
     async def abefore_model(
-        self, state: AgentState[Any], runtime: Runtime
+        self, state: AgentState[Any], _runtime: Runtime
     ) -> dict[str, Any] | None:
         """Process messages before model invocation, potentially triggering summarization.
 
@@ -333,7 +333,7 @@ class SummarizationMiddleware(AgentMiddleware):
 
         messages_to_summarize, preserved_messages = self._partition_messages(messages, cutoff_index)
 
-        summary = await self._acreate_summary(messages_to_summarize, runtime)
+        summary = await self._acreate_summary(messages_to_summarize)
         new_messages = self._build_new_messages(summary)
 
         return {
@@ -564,14 +564,11 @@ class SummarizationMiddleware(AgentMiddleware):
         # orphaned tool responses
         return idx
 
-    def _create_summary(self, messages_to_summarize: list[AnyMessage], _runtime: Runtime) -> str:
+    def _create_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
         """Generate summary for the given messages.
 
         Args:
             messages_to_summarize: Messages to summarize.
-            runtime: The runtime environment, used to inherit config (including
-                `langgraph_checkpoint_ns`) so that LangGraph's `StreamMessagesHandler`
-                can properly track and tag the summarization model call.
         """
         if not messages_to_summarize:
             return "No previous conversation history."
@@ -605,16 +602,11 @@ class SummarizationMiddleware(AgentMiddleware):
         except Exception as e:
             return f"Error generating summary: {e!s}"
 
-    async def _acreate_summary(
-        self, messages_to_summarize: list[AnyMessage], _runtime: Runtime
-    ) -> str:
+    async def _acreate_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
         """Generate summary for the given messages.
 
         Args:
             messages_to_summarize: Messages to summarize.
-            runtime: The runtime environment, used to inherit config (including
-                `langgraph_checkpoint_ns`) so that LangGraph's `StreamMessagesHandler`
-                can properly track and tag the summarization model call.
         """
         if not messages_to_summarize:
             return "No previous conversation history."

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -1219,7 +1219,7 @@ def test_usage_metadata_trigger() -> None:
 class ConfigCapturingModel(BaseChatModel):
     """Mock model that captures the config passed to invoke/ainvoke."""
 
-    captured_configs: list[RunnableConfig | None] = []
+    captured_configs: list[RunnableConfig | None] = Field(default_factory=list, exclude=True)
 
     @override
     def invoke(
@@ -1261,7 +1261,7 @@ class ConfigCapturingModel(BaseChatModel):
 
 
 @pytest.mark.parametrize("use_async", [False, True], ids=["sync", "async"])
-async def test_create_summary_passes_lc_source_metadata(use_async: bool) -> None:
+async def test_create_summary_passes_lc_source_metadata(use_async: bool) -> None:  # noqa: FBT001
     """Test that summary creation passes `lc_source` metadata to the model.
 
     When called outside a LangGraph runnable context, `get_config()` raises


### PR DESCRIPTION
We need to set `{"metadata": {"lc_source": "summarization"}}` on the invocation so that consumers (e.g. `deepagents-cli`) can see that a summarization LLM call is being made, and therefore take any necessary actions (such as updating the status line to say `'Currently summarizing...'`

See https://github.com/langchain-ai/deepagents/pull/742 for more

Related to #34693 (but for outbound)