### PR TITLE
feat(infra): test against `deepagents`

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -474,6 +474,7 @@ jobs:
   # Test external packages that depend on langchain-core/langchain against the new release
   # Only runs for core and langchain_v1 releases to catch breaking changes before publish
   test-dependents:
+    name: "📦 Dependent: ${{ matrix.package.name }}"
     needs:
       - build
       - release-notes

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -497,8 +497,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-
-      - uses: actions/checkout@v6
         with:
           repository: ${{ matrix.package.repo }}
           path: ${{ matrix.package.name }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -471,6 +471,66 @@ jobs:
           uv pip install ../../core/dist/*.whl
           make integration_tests
 
+  # Test external packages that depend on langchain-core/langchain against the new release
+  # Only runs for core and langchain_v1 releases to catch breaking changes before publish
+  test-dependents:
+    needs:
+      - build
+      - release-notes
+      - test-pypi-publish
+      - pre-release-checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # Only run for core or langchain_v1 releases
+    if: startsWith(inputs.working-directory, 'libs/core') || startsWith(inputs.working-directory, 'libs/langchain_v1')
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - name: deepagents
+            repo: langchain-ai/deepagents
+            path: libs/deepagents
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/checkout@v6
+        with:
+          repository: ${{ matrix.package.repo }}
+          path: ${{ matrix.package.name }}
+
+      - name: Set up Python + uv
+        uses: "./.github/actions/uv_setup"
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Install ${{ matrix.package.name }} with local packages
+        # External dependents don't have [tool.uv.sources] pointing to this repo,
+        # so we install the package normally then override with the built wheel.
+        run: |
+          cd ${{ matrix.package.name }}/${{ matrix.package.path }}
+
+          # Install the package with test dependencies
+          uv sync --group test
+
+          # Override with the built wheel from this release
+          uv pip install $GITHUB_WORKSPACE/dist/*.whl
+
+      - name: Run ${{ matrix.package.name }} tests
+        run: |
+          cd ${{ matrix.package.name }}/${{ matrix.package.path }}
+          make test
+
   publish:
     # Publishes the package to PyPI
     needs:

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -474,7 +474,7 @@ jobs:
   # Test external packages that depend on langchain-core/langchain against the new release
   # Only runs for core and langchain_v1 releases to catch breaking changes before publish
   test-dependents:
-    name: "📦 Dependent: ${{ matrix.package.name }}"
+    name: "🐍 Python ${{ matrix.python-version }}: ${{ matrix.package.path }}"
     needs:
       - build
       - release-notes
@@ -488,6 +488,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: ["3.10", "3.13"]
         package:
           - name: deepagents
             repo: langchain-ai/deepagents
@@ -505,7 +506,7 @@ jobs:
       - name: Set up Python + uv
         uses: "./.github/actions/uv_setup"
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python-version }}
 
       - uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -492,10 +492,7 @@ jobs:
           - name: deepagents
             repo: langchain-ai/deepagents
             path: libs/deepagents
-    env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    # No API keys needed for now - deepagents `make test` only runs unit tests
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -488,7 +488,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.11", "3.13"]
         package:
           - name: deepagents
             repo: langchain-ai/deepagents

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -208,7 +208,7 @@ jobs:
     # Defend against forks running scheduled jobs, but allow manual runs from forks
     if: github.repository_owner == 'langchain-ai' || github.event_name != 'schedule'
 
-    name: "📦 Dependents: ${{ matrix.package }}"
+    name: "📦 Dependent: ${{ matrix.package.name }}"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -251,15 +251,8 @@ jobs:
             -e $GITHUB_WORKSPACE/langchain/libs/core \
             -e $GITHUB_WORKSPACE/langchain/libs/langchain_v1
 
+      # No API keys needed for now - deepagents `make test` only runs unit tests
       - name: "🚀 Run ${{ matrix.package.name }} Tests"
-        env:
-          # Add any necessary secrets for dependent package tests here
-          # WARNING: All secrets below are available to every matrix job regardless of
-          # which package is being tested. This is intentional for simplicity, but means
-          # any test file could technically access any key. Only use for trusted code.
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           cd ${{ matrix.package.name }}/${{ matrix.package.path }}
           make test

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -202,3 +202,64 @@ jobs:
           # grep will exit non-zero if the target message isn't found,
           # and `set -e` above will cause the step to fail.
           echo "$STATUS" | grep 'nothing to commit, working tree clean'
+
+  # Test dependent packages against local packages to catch breaking changes
+  test-dependents:
+    # Defend against forks running scheduled jobs, but allow manual runs from forks
+    if: github.repository_owner == 'langchain-ai' || github.event_name != 'schedule'
+
+    name: "📦 Dependents: ${{ matrix.package }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+        package:
+          - name: deepagents
+            repo: langchain-ai/deepagents
+            path: libs/deepagents
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: langchain
+
+      - uses: actions/checkout@v6
+        with:
+          repository: ${{ matrix.package.repo }}
+          path: ${{ matrix.package.name }}
+
+      - name: "🐍 Set up Python ${{ matrix.python-version }} + UV"
+        uses: "./langchain/.github/actions/uv_setup"
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: "📦 Install ${{ matrix.package.name }} with Local"
+        # Unlike partner packages (which use [tool.uv.sources] for local resolution),
+        # external dependents live in separate repos and need explicit overrides to
+        # test against the langchain versions from the current branch, as their
+        # pyproject.toml files point to released versions.
+        run: |
+          cd ${{ matrix.package.name }}/${{ matrix.package.path }}
+
+          # Install the package with test dependencies
+          uv sync --group test
+
+          # Override langchain packages with local versions
+          uv pip install \
+            -e $GITHUB_WORKSPACE/langchain/libs/core \
+            -e $GITHUB_WORKSPACE/langchain/libs/langchain_v1
+
+      - name: "🚀 Run ${{ matrix.package.name }} Tests"
+        env:
+          # Add any necessary secrets for dependent package tests here
+          # WARNING: All secrets below are available to every matrix job regardless of
+          # which package is being tested. This is intentional for simplicity, but means
+          # any test file could technically access any key. Only use for trusted code.
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          cd ${{ matrix.package.name }}/${{ matrix.package.path }}
+          make test

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -208,13 +208,14 @@ jobs:
     # Defend against forks running scheduled jobs, but allow manual runs from forks
     if: github.repository_owner == 'langchain-ai' || github.event_name != 'schedule'
 
-    name: "📦 Dependent: ${{ matrix.package.name }}"
+    name: "🐍 Python ${{ matrix.python-version }}: ${{ matrix.package.path }}"
     runs-on: ubuntu-latest
+    needs: [compute-matrix]
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ${{ fromJSON(needs.compute-matrix.outputs.matrix).python-version }}
         package:
           - name: deepagents
             repo: langchain-ai/deepagents


### PR DESCRIPTION
Add testing for `deepagents` both (1) on scheduled interval and (2) release of `langchain-core` or `langchain` to ensure compatibility. Should catch breaking changes early.

Note: we test `deepagents` against the most recent commit on its `master`
