### PR TITLE
fix(openai): handle null choices from model_dump() for vLLM compatibility

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1571,6 +1571,19 @@ class BaseChatOpenAI(BaseChatModel):
             msg = f"Response missing 'choices' key: {response_dict.keys()}"
             raise KeyError(msg) from e
 
+        # For OpenAI-compatible APIs (like vLLM), model_dump() may return null
+        # for choices even when the response object has valid choices. In this
+        # case, try to extract choices directly from the response object and
+        # convert to dict format.
+        if choices is None and isinstance(response, openai.BaseModel):
+            raw_choices = getattr(response, "choices", None)
+            if raw_choices is not None:
+                choices = [
+                    choice.model_dump() if hasattr(choice, "model_dump") else choice
+                    for choice in raw_choices
+                ]
+                response_dict["choices"] = choices
+
         if choices is None:
             # Some OpenAI-compatible APIs (e.g., vLLM) may return null choices
             # when the response format differs or an error occurs without

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3476,6 +3476,55 @@ def test_context_overflow_error_backwards_compatibility() -> None:
     assert isinstance(exc_info.value, ContextOverflowError)
 
 
+def test_create_chat_result_with_null_choices_in_model_dump() -> None:
+    """
+    Test that _create_chat_result handles the case where model_dump() returns
+    null for choices, but the response object has valid choices (common with
+    OpenAI-compatible APIs like vLLM).
+
+    Regression test for: https://github.com/langchain-ai/langchain/issues/32252
+    """
+    from unittest.mock import MagicMock
+
+    import openai
+
+    # Create a mock response that simulates vLLM behavior:
+    # - model_dump() returns {"choices": None, ...}
+    # - but response.choices has valid data
+    mock_choice = MagicMock()
+    mock_choice.model_dump.return_value = {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": None,
+        "message": {
+            "content": "Hello! How can I help you?",
+            "role": "assistant",
+            "tool_calls": None,
+        },
+    }
+
+    # Use spec to make mock pass isinstance(response, openai.BaseModel) check
+    mock_response = MagicMock(spec=openai.BaseModel)
+    mock_response.model_dump.return_value = {
+        "choices": None,  # Simulates the bug where model_dump returns null
+        "created": 1234567890,
+        "id": "chatcmpl-test",
+        "model": "test-model",
+        "object": "chat.completion",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    }
+    # But the response object itself has valid choices
+    mock_response.choices = [mock_choice]
+
+    llm = ChatOpenAI(model="test-model", api_key="test-key")  # type: ignore
+
+    # This should succeed by falling back to direct attribute access
+    result = llm._create_chat_result(mock_response)
+
+    assert len(result.generations) == 1
+    assert result.generations[0].message.content == "Hello! How can I help you?"
+
+
 def test_tool_search_passthrough() -> None:
     """Test that tool_search dict is passed through as a built-in tool."""
     llm = ChatOpenAI(model="gpt-4o")


### PR DESCRIPTION
## Summary

Fixes #32252

When using OpenAI-compatible APIs like vLLM, `model_dump()` can return `null` for `choices` even though the response object has valid choices accessible via direct attribute access. This occurs because the OpenAI SDK's Pydantic model may serialize differently when handling non-OpenAI API responses.

## Changes

- Added fallback logic in `_create_chat_result` that extracts `choices` directly from the response object when `model_dump()` returns `null`
- Added unit test to verify the fix

## Test plan

- [x] Added unit test `test_create_chat_result_with_null_choices_in_model_dump` that simulates the vLLM scenario
- [ ] Manual testing with actual vLLM endpoint (not available in my environment)