### PR TITLE
fix: reuse ToolStrategy in agent factory to prevent name mismatch

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1035,16 +1035,15 @@ def create_agent(
             if _supports_provider_strategy(request.model, tools=request.tools):
                 # Model supports provider strategy - use it
                 effective_response_format = ProviderStrategy(schema=request.response_format.schema)
-            else:
+            elif (
+                request.response_format is initial_response_format
+                and tool_strategy_for_setup is not None
+            ):
                 # Model doesn't support provider strategy - use ToolStrategy
                 # Reuse the strategy from setup if possible to preserve tool names
-                if (
-                    request.response_format is initial_response_format
-                    and tool_strategy_for_setup is not None
-                ):
-                    effective_response_format = tool_strategy_for_setup
-                else:
-                    effective_response_format = ToolStrategy(schema=request.response_format.schema)
+                effective_response_format = tool_strategy_for_setup
+            else:
+                effective_response_format = ToolStrategy(schema=request.response_format.schema)
         else:
             # User explicitly specified a strategy - preserve it
             effective_response_format = request.response_format

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1037,7 +1037,14 @@ def create_agent(
                 effective_response_format = ProviderStrategy(schema=request.response_format.schema)
             else:
                 # Model doesn't support provider strategy - use ToolStrategy
-                effective_response_format = ToolStrategy(schema=request.response_format.schema)
+                # Reuse the strategy from setup if possible to preserve tool names
+                if (
+                    request.response_format is initial_response_format
+                    and tool_strategy_for_setup is not None
+                ):
+                    effective_response_format = tool_strategy_for_setup
+                else:
+                    effective_response_format = ToolStrategy(schema=request.response_format.schema)
         else:
             # User explicitly specified a strategy - preserve it
             effective_response_format = request.response_format

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -220,13 +220,11 @@ class TestResponseFormatAsModel:
             # matching our anonymous schema, but it should NOT raise ValueError
             # during the binding phase.
             try:
-                agent.invoke(
-                    {"messages": [HumanMessage("hi")]}, config={"recursion_limit": 1}
-                )
+                agent.invoke({"messages": [HumanMessage("hi")]}, config={"recursion_limit": 1})
             except ValueError as e:
                 if "which wasn't declared" in str(e):
                     pytest.fail(f"Tool name mismatch occurred: {e}")
-            except Exception:
+            except Exception:  # noqa: S110
                 # Other exceptions mean we passed the binding phase
                 pass
 


### PR DESCRIPTION
fixes #34796 

I updated the logic to reuse the tool_strategy_for_setup instance. This ensures the tool names stay consistent throughout the agent's lifecycle.

Testing:

Added a unit test: test_autostrategy_with_anonymous_json_schema in libs/langchain_v1/tests/unit_tests/agents/test_response_format.py.

The test mocks a "dumb" model to force the ToolStrategy fallback and confirms the tool names now match.

Verified that Pydantic-based schemas still work as expected.

