### PR TITLE
feat(core): add XML format option for `get_buffer_string`

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -303,10 +303,11 @@ def get_buffer_string(
         function_prefix: The prefix to prepend to contents of `FunctionMessage`s.
         tool_prefix: The prefix to prepend to contents of `ToolMessage`s.
         message_separator: The separator to use between messages.
-        format: The output format. ``'prefix'`` uses ``Role: content`` format
-            (default). ``'xml'`` uses XML-style ``<message type="role">`` format
-            with proper character escaping, which is useful when message content
-            may contain role-like prefixes that could cause ambiguity.
+        format: The output format. `'prefix'` uses `Role: content` format (default).
+
+            `'xml'` uses XML-style `<message type='role'>` format with proper character
+            escaping, which is useful when message content may contain role-like
+            prefixes that could cause ambiguity.
 
     Returns:
         A single string concatenation of all input messages.

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -159,16 +159,17 @@ def get_buffer_string(
         and a function call under `additional_kwargs["function_call"]`, only the tool
         calls will be appended to the string representation.
 
-        When using ``format='xml'``:
+        When using `format='xml'`:
 
-        - All messages use uniform ``<message type="role">content</message>`` format.
-        - The ``type`` attribute uses ``human_prefix`` (lowercased) for `HumanMessage`,
-          ``ai_prefix`` (lowercased) for `AIMessage`, and lowercase role names for
-          other message types.
-        - Message content is escaped using ``xml.sax.saxutils.escape()``.
-        - Attribute values are escaped using ``xml.sax.saxutils.quoteattr()``.
-        - AI messages with tool calls use nested structure with ``<content>`` and
-          ``<tool_call>`` elements.
+        - All messages use uniform `<message type="role">content</message>` format.
+        - The `type` attribute uses `human_prefix` (lowercased) for `HumanMessage`,
+            `ai_prefix` (lowercased) for `AIMessage`, lowercase names for
+            `SystemMessage`/`FunctionMessage`/`ToolMessage`, and the original role
+            (unchanged) for `ChatMessage`.
+        - Message content is escaped using `xml.sax.saxutils.escape()`.
+        - Attribute values are escaped using `xml.sax.saxutils.quoteattr()`.
+        - AI messages with tool calls use nested structure with `<content>` and
+            `<tool_call>` elements.
 
     Example:
         Default prefix format:

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -99,6 +99,130 @@ AnyMessage = Annotated[
 """A type representing any defined `Message` or `MessageChunk` type."""
 
 
+def _has_base64_data(block: dict) -> bool:
+    """Check if a content block contains base64 encoded data.
+
+    Args:
+        block: A content block dictionary.
+
+    Returns:
+        Whether the block contains base64 data.
+    """
+    # Check for explicit base64 field (standard content blocks)
+    if block.get("base64"):
+        return True
+
+    # Check for data: URL in url field
+    url = block.get("url", "")
+    if isinstance(url, str) and url.startswith("data:"):
+        return True
+
+    # Check for OpenAI-style image_url with data: URL
+    image_url = block.get("image_url", {})
+    if isinstance(image_url, dict):
+        url = image_url.get("url", "")
+        if isinstance(url, str) and url.startswith("data:"):
+            return True
+
+    return False
+
+
+def _format_content_block_xml(block: dict) -> str | None:
+    """Format a content block as XML.
+
+    Args:
+        block: A LangChain content block.
+
+    Returns:
+        XML string representation of the block, or `None` if the block should be
+            skipped.
+    """
+    block_type = block.get("type", "")
+
+    # Skip blocks with base64 encoded data
+    if _has_base64_data(block):
+        return None
+
+    # Text blocks
+    if block_type == "text":
+        text = block.get("text", "")
+        return escape(text) if text else None
+
+    # Reasoning blocks
+    if block_type == "reasoning":
+        reasoning = block.get("reasoning", "")
+        if reasoning:
+            return f"<reasoning>{escape(reasoning)}</reasoning>"
+        return None
+
+    # Image blocks (URL only, base64 already filtered)
+    if block_type == "image":
+        url = block.get("url")
+        file_id = block.get("file_id")
+        if url:
+            return f"<image url={quoteattr(url)} />"
+        if file_id:
+            return f"<image file_id={quoteattr(file_id)} />"
+        return None
+
+    # OpenAI-style image_url blocks
+    if block_type == "image_url":
+        image_url = block.get("image_url", {})
+        if isinstance(image_url, dict):
+            url = image_url.get("url", "")
+            if url and not url.startswith("data:"):
+                return f"<image url={quoteattr(url)} />"
+        return None
+
+    # Audio blocks (URL only)
+    if block_type == "audio":
+        url = block.get("url")
+        file_id = block.get("file_id")
+        if url:
+            return f"<audio url={quoteattr(url)} />"
+        if file_id:
+            return f"<audio file_id={quoteattr(file_id)} />"
+        return None
+
+    # Video blocks (URL only)
+    if block_type == "video":
+        url = block.get("url")
+        file_id = block.get("file_id")
+        if url:
+            return f"<video url={quoteattr(url)} />"
+        if file_id:
+            return f"<video file_id={quoteattr(file_id)} />"
+        return None
+
+    # Plain text document blocks
+    if block_type == "text-plain":
+        text = block.get("text", "")
+        return escape(text) if text else None
+
+    # Server tool call blocks (from AI messages)
+    if block_type == "server_tool_call":
+        tc_id = quoteattr(str(block.get("id") or ""))
+        tc_name = quoteattr(str(block.get("name") or ""))
+        tc_args = escape(json.dumps(block.get("args", {}), ensure_ascii=False))
+        return (
+            f"<server_tool_call id={tc_id} name={tc_name}>{tc_args}</server_tool_call>"
+        )
+
+    # Server tool result blocks
+    if block_type == "server_tool_result":
+        tool_call_id = quoteattr(str(block.get("tool_call_id") or ""))
+        status = quoteattr(str(block.get("status") or ""))
+        output = block.get("output")
+        output_str = escape(json.dumps(output, ensure_ascii=False)) if output else ""
+        return (
+            f"<server_tool_result tool_call_id={tool_call_id} status={status}>"
+            f"{output_str}</server_tool_result>"
+        )
+
+    # Unknown block type - skip silently
+    return None
+
+
 def _get_message_type_str(m: BaseMessage, human_prefix: str, ai_prefix: str) -> str:
     """Get the type string for XML message element.
 
@@ -170,6 +294,13 @@ def get_buffer_string(
         - Attribute values are escaped using `xml.sax.saxutils.quoteattr()`.
         - AI messages with tool calls use nested structure with `<content>` and
             `<tool_call>` elements.
+        - For multi-modal content (list of content blocks), supported block types
+            are: `text`, `reasoning`, `image` (URL/file_id only), `image_url`
+            (OpenAI-style, URL only), `audio` (URL/file_id only), `video` (URL/file_id
+            only), `text-plain`, `server_tool_call`, and `server_tool_result`.
+        - Content blocks with base64-encoded data are skipped (including blocks
+            with `base64` field or `data:` URLs).
+        - Unknown block types are skipped.
 
     Example:
         Default prefix format:
@@ -250,11 +381,23 @@ def get_buffer_string(
             msg = f"Got unsupported message type: {m}"
             raise ValueError(msg)  # noqa: TRY004
 
-        content = m.text
-
         if format == "xml":
             msg_type = _get_message_type_str(m, human_prefix, ai_prefix)
-            escaped_content = escape(content)
+
+            # Format content blocks
+            if isinstance(m.content, str):
+                content_parts = [escape(m.content)] if m.content else []
+            else:
+                # List of content blocks
+                content_parts = []
+                for block in m.content:
+                    if isinstance(block, str):
+                        if block:
+                            content_parts.append(escape(block))
+                    else:
+                        formatted = _format_content_block_xml(block)
+                        if formatted:
+                            content_parts.append(formatted)
 
             # Check if this is an AIMessage with tool calls
             has_tool_calls = isinstance(m, AIMessage) and m.tool_calls
@@ -269,8 +412,8 @@ def get_buffer_string(
                 # Type narrowing: at this point m is AIMessage (verified above)
                 ai_msg = cast("AIMessage", m)
                 parts = [f"<message type={quoteattr(msg_type)}>"]
-                if escaped_content:
-                    parts.append(f"  <content>{escaped_content}</content>")
+                if content_parts:
+                    parts.append(f"  <content>{' '.join(content_parts)}</content>")
 
                 if has_tool_calls:
                     for tc in ai_msg.tool_calls:
@@ -295,10 +438,12 @@ def get_buffer_string(
                 message = "\n".join(parts)
             else:
                 # Simple structure for messages without tool calls
+                joined_content = " ".join(content_parts)
                 message = (
-                    f"<message type={quoteattr(msg_type)}>{escaped_content}</message>"
+                    f"<message type={quoteattr(msg_type)}>{joined_content}</message>"
                 )
         else:  # format == "prefix"
+            content = m.text
             message = f"{role}: {content}"
             tool_info = ""
             if isinstance(m, AIMessage):

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1786,14 +1786,21 @@ def test_convert_to_openai_messages_reasoning_content() -> None:
 
 
 def test_get_buffer_string_xml_basic() -> None:
-    """Test basic XML format output."""
+    """Test XML format output with all message types."""
     messages = [
-        HumanMessage(content="Hello"),
-        AIMessage(content="Hi there"),
+        SystemMessage(content="System message"),
+        HumanMessage(content="Human message"),
+        AIMessage(content="AI message"),
+        FunctionMessage(content="Function result", name="test_fn"),
+        ToolMessage(content="Tool result", tool_call_id="123"),
     ]
     result = get_buffer_string(messages, format="xml")
     expected = (
-        '<message type="human">Hello</message>\n<message type="ai">Hi there</message>'
+        '<message type="system">System message</message>\n'
+        '<message type="human">Human message</message>\n'
+        '<message type="ai">AI message</message>\n'
+        '<message type="function">Function result</message>\n'
+        '<message type="tool">Tool result</message>'
     )
     assert result == expected
 
@@ -1810,26 +1817,6 @@ def test_get_buffer_string_xml_custom_prefixes() -> None:
     expected = (
         '<message type="user">Hello</message>\n'
         '<message type="assistant">Hi there</message>'
-    )
-    assert result == expected
-
-
-def test_get_buffer_string_xml_all_message_types() -> None:
-    """Test XML format with all message types."""
-    messages = [
-        SystemMessage(content="System message"),
-        HumanMessage(content="Human message"),
-        AIMessage(content="AI message"),
-        FunctionMessage(content="Function result", name="test_fn"),
-        ToolMessage(content="Tool result", tool_call_id="123"),
-    ]
-    result = get_buffer_string(messages, format="xml")
-    expected = (
-        '<message type="system">System message</message>\n'
-        '<message type="human">Human message</message>\n'
-        '<message type="ai">AI message</message>\n'
-        '<message type="function">Function result</message>\n'
-        '<message type="tool">Tool result</message>'
     )
     assert result == expected
 
@@ -1858,17 +1845,6 @@ def test_get_buffer_string_prefix_custom_separator() -> None:
     assert result == expected
 
 
-def test_get_buffer_string_backward_compatibility() -> None:
-    """Test that default behavior is unchanged (backward compatible)."""
-    messages = [
-        HumanMessage(content="Hello"),
-        AIMessage(content="Hi there"),
-    ]
-    result = get_buffer_string(messages)
-    expected = "Human: Hello\nAI: Hi there"
-    assert result == expected
-
-
 def test_get_buffer_string_xml_escaping() -> None:
     """Test XML format properly escapes special characters in content."""
     messages = [
@@ -1880,21 +1856,6 @@ def test_get_buffer_string_xml_escaping() -> None:
     expected = (
         '<message type="human">Is 5 &lt; 10 &amp; 10 &gt; 5?</message>\n'
         '<message type="ai">Yes, and here\'s a "quote"</message>'
-    )
-    assert result == expected
-
-
-def test_get_buffer_string_xml_role_like_content() -> None:
-    """Test XML format handles content containing role-like prefixes."""
-    messages = [
-        HumanMessage(content="Example: Human: some text"),
-        AIMessage(content="I see the example with AI: prefix"),
-    ]
-    result = get_buffer_string(messages, format="xml")
-    # XML format avoids ambiguity - the role-like prefixes are just content
-    expected = (
-        '<message type="human">Example: Human: some text</message>\n'
-        '<message type="ai">I see the example with AI: prefix</message>'
     )
     assert result == expected
 

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1785,6 +1785,14 @@ def test_convert_to_openai_messages_reasoning_content() -> None:
 # Tests for get_buffer_string XML format
 
 
+def test_get_buffer_string_xml_empty_messages_list() -> None:
+    """Test XML format with empty messages list."""
+    messages: list[BaseMessage] = []
+    result = get_buffer_string(messages, format="xml")
+    expected = ""
+    assert result == expected
+
+
 def test_get_buffer_string_xml_basic() -> None:
     """Test XML format output with all message types."""
     messages = [
@@ -1860,8 +1868,22 @@ def test_get_buffer_string_xml_escaping() -> None:
     assert result == expected
 
 
+def test_get_buffer_string_xml_unicode_content() -> None:
+    """Test XML format with Unicode content."""
+    messages = [
+        HumanMessage(content="你好世界"),  # Chinese: Hello World
+        AIMessage(content="こんにちは"),  # Japanese: Hello
+    ]
+    result = get_buffer_string(messages, format="xml")
+    expected = (
+        '<message type="human">你好世界</message>\n'
+        '<message type="ai">こんにちは</message>'
+    )
+    assert result == expected
+
+
 def test_get_buffer_string_xml_chat_message_valid_role() -> None:
-    """Test XML format with ChatMessage having valid XML tag name role."""
+    """Test XML format with `ChatMessage` having valid XML tag name role."""
     messages = [
         ChatMessage(content="Hello", role="Assistant"),
     ]
@@ -1870,9 +1892,7 @@ def test_get_buffer_string_xml_chat_message_valid_role() -> None:
     expected = '<message type="Assistant">Hello</message>'
     assert result == expected
 
-
-def test_get_buffer_string_xml_chat_message_custom_role() -> None:
-    """Test XML format with ChatMessage having custom role (spaces allowed)."""
+    # Spaces in role
     messages = [
         ChatMessage(content="Hello", role="my custom role"),
     ]
@@ -1881,9 +1901,7 @@ def test_get_buffer_string_xml_chat_message_custom_role() -> None:
     expected = '<message type="my custom role">Hello</message>'
     assert result == expected
 
-
-def test_get_buffer_string_xml_chat_message_role_special_chars() -> None:
-    """Test XML format escapes special characters in role attribute."""
+    # Special characters in role
     messages = [
         ChatMessage(content="Hello", role='role"with<special>'),
     ]
@@ -1894,8 +1912,19 @@ def test_get_buffer_string_xml_chat_message_role_special_chars() -> None:
     assert result == expected
 
 
+def test_get_buffer_string_xml_empty_content() -> None:
+    """Test XML format with empty content."""
+    messages = [
+        HumanMessage(content=""),
+        AIMessage(content=""),
+    ]
+    result = get_buffer_string(messages, format="xml")
+    expected = '<message type="human"></message>\n<message type="ai"></message>'
+    assert result == expected
+
+
 def test_get_buffer_string_xml_tool_calls_with_content() -> None:
-    """Test XML format with AIMessage having both content and tool_calls."""
+    """Test XML format with `AIMessage` having both `content` and `tool_calls`."""
     messages = [
         AIMessage(
             content="Let me check that",
@@ -1921,7 +1950,7 @@ def test_get_buffer_string_xml_tool_calls_with_content() -> None:
 
 
 def test_get_buffer_string_xml_tool_calls_empty_content() -> None:
-    """Test XML format with AIMessage having empty content and tool_calls."""
+    """Test XML format with `AIMessage` having empty `content` and `tool_calls`."""
     messages = [
         AIMessage(
             content="",
@@ -1971,7 +2000,7 @@ def test_get_buffer_string_xml_tool_calls_escaping() -> None:
 
 
 def test_get_buffer_string_xml_function_call_legacy() -> None:
-    """Test XML format with legacy function_call in additional_kwargs."""
+    """Test XML format with legacy `function_call` in `additional_kwargs`."""
     messages = [
         AIMessage(
             content="Calling function",
@@ -1992,17 +2021,6 @@ def test_get_buffer_string_xml_function_call_legacy() -> None:
     assert result == expected
 
 
-def test_get_buffer_string_xml_empty_content() -> None:
-    """Test XML format with empty content."""
-    messages = [
-        HumanMessage(content=""),
-        AIMessage(content=""),
-    ]
-    result = get_buffer_string(messages, format="xml")
-    expected = '<message type="human"></message>\n<message type="ai"></message>'
-    assert result == expected
-
-
 def test_get_buffer_string_xml_structured_content() -> None:
     """Test XML format with structured content (list content blocks)."""
     messages = [
@@ -2010,32 +2028,10 @@ def test_get_buffer_string_xml_structured_content() -> None:
         AIMessage(content=[{"type": "text", "text": "Hi there!"}]),
     ]
     result = get_buffer_string(messages, format="xml")
-    # m.text property should extract text from structured content
+    # message.text property should extract text from structured content
     expected = (
         '<message type="human">Hello, world!</message>\n'
         '<message type="ai">Hi there!</message>'
-    )
-    assert result == expected
-
-
-def test_get_buffer_string_xml_empty_messages_list() -> None:
-    """Test XML format with empty messages list."""
-    messages: list[BaseMessage] = []
-    result = get_buffer_string(messages, format="xml")
-    expected = ""
-    assert result == expected
-
-
-def test_get_buffer_string_xml_unicode_content() -> None:
-    """Test XML format with Unicode content."""
-    messages = [
-        HumanMessage(content="你好世界"),  # Chinese: Hello World
-        AIMessage(content="こんにちは"),  # Japanese: Hello
-    ]
-    result = get_buffer_string(messages, format="xml")
-    expected = (
-        '<message type="human">你好世界</message>\n'
-        '<message type="ai">こんにちは</message>'
     )
     assert result == expected
 
@@ -2051,7 +2047,7 @@ def test_get_buffer_string_xml_multiline_content() -> None:
 
 
 def test_get_buffer_string_xml_tool_calls_preferred_over_function_call() -> None:
-    """Test that tool_calls takes precedence over legacy function_call in XML."""
+    """Test that `tool_calls` takes precedence over legacy `function_call` in XML."""
     messages = [
         AIMessage(
             content="Calling tools",
@@ -2077,7 +2073,7 @@ def test_get_buffer_string_xml_tool_calls_preferred_over_function_call() -> None
 
 
 def test_get_buffer_string_xml_multiple_tool_calls() -> None:
-    """Test XML format with AIMessage having multiple tool_calls."""
+    """Test XML format with `AIMessage` having multiple `tool_calls`."""
     messages = [
         AIMessage(
             content="I'll help with that",
@@ -2131,7 +2127,7 @@ def test_get_buffer_string_xml_tool_call_special_chars_in_attrs() -> None:
 
 
 def test_get_buffer_string_xml_tool_call_none_id() -> None:
-    """Test that tool calls with None id are handled correctly."""
+    """Test that tool calls with `None` id are handled correctly."""
     messages: list[BaseMessage] = [
         AIMessage(
             content="",
@@ -2151,7 +2147,7 @@ def test_get_buffer_string_xml_tool_call_none_id() -> None:
 
 
 def test_get_buffer_string_xml_function_call_special_chars_in_name() -> None:
-    """Test that function_call name with quotes is properly escaped."""
+    """Test that `function_call` name with quotes is properly escaped."""
     messages: list[BaseMessage] = [
         AIMessage(
             content="",
@@ -2169,7 +2165,7 @@ def test_get_buffer_string_xml_function_call_special_chars_in_name() -> None:
 
 
 def test_get_buffer_string_invalid_format() -> None:
-    """Test that invalid format values raise ValueError."""
+    """Test that invalid format values raise `ValueError`."""
     messages: list[BaseMessage] = [HumanMessage(content="Hello")]
     with pytest.raises(ValueError, match="Unrecognized format"):
         get_buffer_string(messages, format="xm")  # type: ignore[arg-type]

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2549,3 +2549,115 @@ def test_get_buffer_string_xml_no_truncation_under_limit() -> None:
     result = get_buffer_string(messages, format="xml")
     assert short_text in result
     assert "..." not in result
+
+
+def test_get_buffer_string_custom_system_prefix() -> None:
+    """Test `get_buffer_string` with custom `system_prefix`."""
+    messages: list[BaseMessage] = [
+        SystemMessage(content="You are a helpful assistant."),
+        HumanMessage(content="Hello"),
+    ]
+    result = get_buffer_string(messages, system_prefix="Instructions")
+    assert result == "Instructions: You are a helpful assistant.\nHuman: Hello"
+
+
+def test_get_buffer_string_custom_function_prefix() -> None:
+    """Test `get_buffer_string` with custom `function_prefix`."""
+    messages: list[BaseMessage] = [
+        HumanMessage(content="Call a function"),
+        FunctionMessage(name="test_func", content="Function result"),
+    ]
+    result = get_buffer_string(messages, function_prefix="Func")
+    assert result == "Human: Call a function\nFunc: Function result"
+
+
+def test_get_buffer_string_custom_tool_prefix() -> None:
+    """Test `get_buffer_string` with custom `tool_prefix`."""
+    messages: list[BaseMessage] = [
+        HumanMessage(content="Use a tool"),
+        ToolMessage(tool_call_id="call_123", content="Tool result"),
+    ]
+    result = get_buffer_string(messages, tool_prefix="ToolResult")
+    assert result == "Human: Use a tool\nToolResult: Tool result"
+
+
+def test_get_buffer_string_all_custom_prefixes() -> None:
+    """Test `get_buffer_string` with all custom prefixes."""
+    messages: list[BaseMessage] = [
+        SystemMessage(content="System says hello"),
+        HumanMessage(content="Human says hello"),
+        AIMessage(content="AI says hello"),
+        FunctionMessage(name="func", content="Function says hello"),
+        ToolMessage(tool_call_id="call_1", content="Tool says hello"),
+    ]
+    result = get_buffer_string(
+        messages,
+        human_prefix="User",
+        ai_prefix="Assistant",
+        system_prefix="Sys",
+        function_prefix="Fn",
+        tool_prefix="T",
+    )
+    expected = (
+        "Sys: System says hello\n"
+        "User: Human says hello\n"
+        "Assistant: AI says hello\n"
+        "Fn: Function says hello\n"
+        "T: Tool says hello"
+    )
+    assert result == expected
+
+
+def test_get_buffer_string_xml_custom_system_prefix() -> None:
+    """Test `get_buffer_string` XML format with custom `system_prefix`."""
+    messages: list[BaseMessage] = [
+        SystemMessage(content="You are a helpful assistant."),
+    ]
+    result = get_buffer_string(messages, system_prefix="Instructions", format="xml")
+    assert (
+        result == '<message type="instructions">You are a helpful assistant.</message>'
+    )
+
+
+def test_get_buffer_string_xml_custom_function_prefix() -> None:
+    """Test `get_buffer_string` XML format with custom `function_prefix`."""
+    messages: list[BaseMessage] = [
+        FunctionMessage(name="test_func", content="Function result"),
+    ]
+    result = get_buffer_string(messages, function_prefix="Fn", format="xml")
+    assert result == '<message type="fn">Function result</message>'
+
+
+def test_get_buffer_string_xml_custom_tool_prefix() -> None:
+    """Test `get_buffer_string` XML format with custom `tool_prefix`."""
+    messages: list[BaseMessage] = [
+        ToolMessage(tool_call_id="call_123", content="Tool result"),
+    ]
+    result = get_buffer_string(messages, tool_prefix="ToolOutput", format="xml")
+    assert result == '<message type="tooloutput">Tool result</message>'
+
+
+def test_get_buffer_string_xml_all_custom_prefixes() -> None:
+    """Test `get_buffer_string` XML format with all custom prefixes."""
+    messages: list[BaseMessage] = [
+        SystemMessage(content="System message"),
+        HumanMessage(content="Human message"),
+        AIMessage(content="AI message"),
+        FunctionMessage(name="func", content="Function message"),
+        ToolMessage(tool_call_id="call_1", content="Tool message"),
+    ]
+    result = get_buffer_string(
+        messages,
+        human_prefix="User",
+        ai_prefix="Assistant",
+        system_prefix="Sys",
+        function_prefix="Fn",
+        tool_prefix="T",
+        format="xml",
+    )
+    # The messages are processed in order, not by type
+    assert '<message type="sys">System message</message>' in result
+    assert '<message type="user">Human message</message>' in result
+    assert '<message type="assistant">AI message</message>' in result
+    assert '<message type="fn">Function message</message>' in result
+    assert '<message type="t">Tool message</message>' in result


### PR DESCRIPTION
  ## Summary

  Add XML format option for `get_buffer_string()` to provide unambiguous message serialization. This fixes role prefix ambiguity when message content contains strings like "Human:" or "AI:".

  Fixes #34786

  ## Changes

  - Add `format="xml"` parameter with proper XML escaping using `quoteattr()` for attributes
  - Add explicit validation for format parameter (raises `ValueError` for invalid values)
  - Add comprehensive tests for XML format edge cases

<img width="1952" height="706" alt="image" src="https://github.com/user-attachments/assets/1cd6f887-9365-43cf-a532-72d7addd8bad" />
<img width="2786" height="776" alt="image" src="https://github.com/user-attachments/assets/a07b0db0-519c-46d7-b34b-b404237d812b" />

