### PR TITLE
fix(core): resolve tools losing optional runnable config

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -6,6 +6,7 @@ import functools
 import inspect
 import json
 import logging
+import types
 import typing
 import warnings
 from abc import ABC, abstractmethod
@@ -17,6 +18,7 @@ from typing import (
     Any,
     Literal,
     TypeVar,
+    Union,
     cast,
     get_args,
     get_origin,
@@ -1352,6 +1354,11 @@ def _get_runnable_config_param(func: Callable) -> str | None:
         return None
     for name, type_ in type_hints.items():
         if type_ is RunnableConfig:
+            return name
+
+        origin = get_origin(type_)
+
+        if origin in (Union, types.UnionType) and RunnableConfig in get_args(type_):
             return name
     return None
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -57,6 +57,7 @@ from langchain_core.tools.base import (
     InjectedToolCallId,
     SchemaAnnotationError,
     _DirectlyInjectedToolArg,
+    _get_runnable_config_param,
     _is_message_content_block,
     _is_message_content_type,
     get_all_basemodel_annotations,
@@ -1175,6 +1176,13 @@ async def test_async_tool_pass_config(tool: BaseTool) -> None:
         await tool.ainvoke({"bar": "baz"}, {"configurable": {"foo": "not-bar"}})
         == "baz"
     )
+
+
+def test_get_runnable_config_param_optional() -> None:
+    async def fn(*, config: RunnableConfig | None) -> None:
+        pass
+
+    assert _get_runnable_config_param(fn) == "config"
 
 
 class OptionalConfigTool(BaseTool):

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -1177,6 +1177,35 @@ async def test_async_tool_pass_config(tool: BaseTool) -> None:
     )
 
 
+class OptionalConfigTool(BaseTool):
+    name: str = "optional_config_tool"
+    description: str = "Tool that accepts Optional[RunnableConfig]"
+
+    def _run(
+        self,
+        query: str,
+        *,
+        config: RunnableConfig | None,
+        **kwargs: Any,
+    ) -> str:
+        # Fail loudly if config was not passed
+        assert config is not None
+        return f"config_value={config.get('configurable', {}).get('value')}"
+
+
+def test_optional_runnable_config_is_passed() -> None:
+    tool = OptionalConfigTool()
+
+    runnable_config = RunnableConfig(configurable={"value": "test123"})
+
+    result = tool.invoke(
+        {"query": "hello"},
+        config=runnable_config,
+    )
+
+    assert result == "config_value=test123"
+
+
 def test_tool_description() -> None:
     def foo(bar: str) -> str:
         """The foo."""


### PR DESCRIPTION
## Summary
This PR fixes detection of RunnableConfig parameters when they are declared as optional (e.g. Optional[RunnableConfig] or RunnableConfig | None). This ensures runnable config is correctly passed through to tools and runnables even when the parameter is not strictly required.

## Details
Previously, _get_runnable_config_param only detected parameters whose type was exactly RunnableConfig. As a result, tools defining config as optional would silently lose the config at runtime. This PR extends detection to union types that include RunnableConfig.

## Minimal Example
```
import logging
from typing import Any, Optional, Type

from langchain.agents import create_agent
from langchain_core.messages import HumanMessage
from langchain_core.runnables import RunnableConfig
from langchain_core.tools import BaseTool
from langchain_openai import ChatOpenAI
from pydantic import BaseModel, Field

logging.basicConfig(level=logging.INFO)
logger = logging.getLogger(__name__)


class SearchInput(BaseModel):
    query: str = Field(
        default="", description="The search query string to find relevant information."
    )


class CustomBaseTool(BaseTool):
    def _run(self, *args: Any, config: Optional[RunnableConfig] = None, **kwargs: Any):
        logger.info("executing tool %s", self.name)
        tool_response = self._perform_action(*args, config=config, **kwargs)
        return tool_response

    def _perform_action(self, *args, **kwargs):
        raise NotImplementedError("Subclasses must implement _perform_action")


class SearchToolWithoutConfig(CustomBaseTool):
    name: str = "tool_without_config"
    description: str = "Search Tool"  # without runnable config"
    args_schema: Type[BaseModel] = SearchInput

    def _perform_action(self, query: str, **kwargs):
        answer = f"Echo: {query}"
        return answer


class SearchToolWithConfig(CustomBaseTool):
    name: str = "tool_with_config"
    description: str = "Search Tool"  # with runnable config
    args_schema: Type[BaseModel] = SearchInput

    def _perform_action(self, query: str, config: RunnableConfig, **kwargs):
        assert config is not None
        metadata = config.get("configurable", {}).get("metadata")
        answer = f"Echo: {query} | config metadata: {metadata}"
        return answer


def main():
    model = ChatOpenAI(model="gpt-4.1")
    tools = [SearchToolWithConfig(), SearchToolWithoutConfig()]

    agent = create_agent(
        model=model,
        tools=tools,
        system_prompt="You are a helpful assistant. Use both tools (`tool_without_config` and `tool_with_config`) to answer user queries.",
    )

    input_state = {
        "messages": [HumanMessage(content="Search for information about AI research.")]
    }

    return agent.invoke(input_state)


if __name__ == "__main__":
    main()

```
