### PR TITLE
fix(core): prevent merging of tool calls with different IDs

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -110,7 +110,15 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                     to_merge = [
                         i
                         for i, e_left in enumerate(merged)
-                        if "index" in e_left and e_left["index"] == e["index"]
+                        if "index" in e_left
+                        and e_left["index"] == e["index"]
+                        and (
+                            "id" not in e_left
+                            or "id" not in e
+                            or e_left["id"] is None
+                            or e["id"] is None
+                            or e_left["id"] == e["id"]
+                        )
                     ]
                     if to_merge:
                         # TODO: Remove this once merge_dict is updated with special

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -435,6 +435,49 @@ def test_merge_lists(
     assert right == right_copy
 
 
+def test_merge_lists_collision_with_ids() -> None:
+    """Test `merge_lists` with colliding indices but different IDs."""
+    # This scenario is common with some providers (e.g. Bedrock) where tool calls
+    # are streamed with the same index (e.g. 0) but different IDs.
+    left = [
+        {
+            "index": 0,
+            "id": "call_123",
+            "name": "tool_a",
+            "type": "function",
+            "function": {"arguments": '{"arg": "foo"}'},
+        }
+    ]
+    right = [
+        {
+            "index": 0,
+            "id": "call_456",
+            "name": "tool_b",
+            "type": "function",
+            "function": {"arguments": '{"arg": "bar"}'},
+        }
+    ]
+    # Should NOT merge, but append
+    expected = [
+        {
+            "index": 0,
+            "id": "call_123",
+            "name": "tool_a",
+            "type": "function",
+            "function": {"arguments": '{"arg": "foo"}'},
+        },
+        {
+            "index": 0,
+            "id": "call_456",
+            "name": "tool_b",
+            "type": "function",
+            "function": {"arguments": '{"arg": "bar"}'},
+        },
+    ]
+    actual = merge_lists(left, right)
+    assert actual == expected
+
+
 def test_merge_lists_multiple_others() -> None:
     """Test `merge_lists` with multiple lists."""
     result = merge_lists([1], [2], [3])


### PR DESCRIPTION
# fix(core): prevent merging of tool calls with different IDs

Fixes #34807

The `merge_lists` utility was incorrectly merging dictionaries (specifically tool calls) that shared the same `index` but had different `id`s. This caused concatenation of tool names and arguments into invalid strings (e.g., `read_filesearch_text`) when providers like Bedrock/Anthropic streamed parallel tool calls with colliding indices.

This change adds a check to `merge_lists` to ensure items are only merged if their `id`s match. It treats `None` (missing `id`) as a wildcard to maintain backward compatibility for streams that do not provide IDs.

## Verification
- Added regression test `test_merge_lists_collision_with_ids` in `libs/core/tests/unit_tests/utils/test_utils.py` which fails without the fix.
- Verified that existing merge logic (including partial merging) continues to pass with `test_tool_calls_merge`.
- Ran `make test` in `libs/core` (1582 tests passed).
- Ran `make lint` and `make format`.
- Validated locally using a reproduction script that parallel tool calls are now correctly separated.