### PR TITLE
feat(langchain): add case_insensitive parameter to grep_search tool

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -372,8 +372,8 @@ class TestGrepEdgeCases:
 
         assert "/test.py" in result
 
-    def test_grep_case_insensitive(self, tmp_path: Path) -> None:
-        """Test grep with case-insensitive search."""
+    def test_grep_case_insensitive_regex(self, tmp_path: Path) -> None:
+        """Test grep with case-insensitive search via regex flag."""
         (tmp_path / "test.py").write_text("HELLO world\n", encoding="utf-8")
 
         middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
@@ -383,6 +383,56 @@ class TestGrepEdgeCases:
         result = middleware.grep_search.func(pattern="(?i)hello")
 
         assert "/test.py" in result
+
+    def test_grep_case_insensitive_flag(self, tmp_path: Path) -> None:
+        """Test grep with case_insensitive parameter."""
+        (tmp_path / "test.py").write_text("HELLO world\n", encoding="utf-8")
+        (tmp_path / "other.py").write_text("goodbye\n", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+
+        # Case-insensitive search should find HELLO
+        result = middleware.grep_search.func(pattern="hello", case_insensitive=True)
+        assert "/test.py" in result
+
+        # Case-sensitive search should not find HELLO
+        result = middleware.grep_search.func(pattern="hello", case_insensitive=False)
+        assert "/test.py" not in result
+
+    def test_grep_case_insensitive_ripgrep_command(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Ensure ripgrep receives -i flag when case_insensitive=True."""
+        (tmp_path / "example.py").write_text("print('hello')\n", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=True)
+
+        captured: dict[str, list[str]] = {}
+
+        class DummyResult:
+            stdout = ""
+
+        def fake_run(*args: Any, **kwargs: Any) -> DummyResult:
+            cmd = args[0]
+            captured["cmd"] = cmd
+            return DummyResult()
+
+        monkeypatch.setattr("langchain.agents.middleware.file_search.subprocess.run", fake_run)
+
+        middleware._ripgrep_search("hello", "/", None, case_insensitive=True)
+
+        assert "cmd" in captured
+        cmd = captured["cmd"]
+        assert "-i" in cmd
+
+        # Test without case_insensitive
+        captured.clear()
+        middleware._ripgrep_search("hello", "/", None, case_insensitive=False)
+        cmd = captured["cmd"]
+        assert "-i" not in cmd
 
     def test_grep_with_large_file_skipping(self, tmp_path: Path) -> None:
         """Test that grep skips files larger than max_file_size_mb."""


### PR DESCRIPTION
Adds a `case_insensitive` keyword-only parameter to the `grep_search` tool in `FilesystemFileSearchMiddleware`. When enabled, ripgrep receives the `-i` flag and the Python fallback uses `re.IGNORECASE`, providing a more discoverable API compared to embedding `(?i)` in regex patterns.

Motivation: was looking to implement a grep based agent and using this pre-built middleware seemed like a no-brainer; however, would want the ability to ignore case on the grep commands.

Implemented such that it is non-breaking for existing users but provides an interface for people interested in using this in a case sensitive manner.