### PR TITLE
test(fireworks): fix model name

### DIFF
--- a/libs/partners/fireworks/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/integration_tests/test_chat_models.py
@@ -21,7 +21,7 @@ _MODEL = "accounts/fireworks/models/gpt-oss-120b"
 @pytest.mark.parametrize("strict", [None, True, False])
 def test_tool_choice_bool(strict: bool | None) -> None:  # noqa: FBT001
     """Test that tool choice is respected with different strict values."""
-    llm = ChatFireworks(model="fireworks/kimi-k2-instruct-0905")
+    llm = ChatFireworks(model="accounts/fireworks/models/kimi-k2-instruct-0905")
 
     class MyTool(BaseModel):
         name: str
@@ -59,7 +59,7 @@ def test_tool_choice_bool(strict: bool | None) -> None:  # noqa: FBT001
 
 async def test_astream() -> None:
     """Test streaming tokens from ChatFireworks."""
-    llm = ChatFireworks(model="fireworks/kimi-k2-instruct-0905")
+    llm = ChatFireworks(model="accounts/fireworks/models/kimi-k2-instruct-0905")
 
     full: BaseMessageChunk | None = None
     chunks_with_token_counts = 0
@@ -157,7 +157,7 @@ def _get_joke_class(
 
 @pytest.mark.parametrize("schema_type", ["pydantic", "typeddict", "json_schema"])
 def test_structured_output_json_schema(schema_type: str) -> None:
-    llm = ChatFireworks(model="fireworks/kimi-k2-instruct-0905")
+    llm = ChatFireworks(model="accounts/fireworks/models/kimi-k2-instruct-0905")
     schema, validation_function = _get_joke_class(schema_type)  # type: ignore[arg-type]
     chat = llm.with_structured_output(schema, method="json_schema")
 

--- a/libs/partners/fireworks/tests/integration_tests/test_standard.py
+++ b/libs/partners/fireworks/tests/integration_tests/test_standard.py
@@ -18,7 +18,7 @@ class TestFireworksStandard(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {
-            "model": "fireworks/kimi-k2-instruct-0905",
+            "model": "accounts/fireworks/models/kimi-k2-instruct-0905",
             "temperature": 0,
         }
 


### PR DESCRIPTION
i guess we were using an outdated/no longer supported alias