### PR TITLE
feat: enable dynamic tool registration w/ `create_agent`

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -779,7 +779,7 @@ def create_agent(
     # This allows middleware to dynamically add tools that ToolNode can execute
     current_tools_container: dict[str, list[BaseTool | dict[str, Any]]] = {"tools": []}
 
-    def get_dynamic_tools() -> list[BaseTool]:
+    async def get_dynamic_tools() -> list[BaseTool]:
         """Return tools from the last model request, or static tools if none set."""
         tools_from_request = current_tools_container.get("tools", [])
         if tools_from_request:


### PR DESCRIPTION
Built on the back of https://github.com/langchain-ai/langgraph/pull/6707

Summary                                                                                                                       
                                                                                                                                
- Enable middleware to dynamically add tools at runtime that weren't pre-registered with create_agent()                       
- Replace static tool list in ToolNode with a callable that returns tools from the current model request                      
- Remove validation that blocked middleware from adding new tools dynamically                                                 
                                                                                                                              
Motivation                                                                                                                    
                                                                                                                              
Previously, middleware could only select from tools that were declared upfront in create_agent(tools=[...]). This change      
allows middleware to inject entirely new tools during request processing, enabling use cases like context-aware tool          
availability, lazy tool loading, or tools that depend on conversation state.                                                  
                                                                                                                              
Example:                                                                                                                      
                           
```py                                                                                                   
from langchain.agents import create_agent, AgentMiddleware, ModelRequest                                                      
                                                                                                                              
@tool                                                                                                                         
def fetch_user_data(user_id: str) -> str:                                                                                     
    """Fetch data for a specific user."""                                                                                     
    return f"Data for {user_id}"                                                                                              
                                                                                                                              
class DynamicToolMiddleware(AgentMiddleware):                                                                                 
    def wrap_model_call(self, request, handler):                                                                              
        # Add tools dynamically based on context                                                                              
        return handler(request.override(tools=[*request.tools, fetch_user_data]))                                             
                                                                                                                              
agent = create_agent(                                                                                                         
    model=model,                                                                                                              
    tools=[],  # No static tools required                                                                                     
    middleware=[DynamicToolMiddleware()],                                                                                     
)
```       

Open questions
* Should we support the use of a callable in `create_agent(tools=[])`? I think this could be added later and the middleware support is enough for now...                                                                                                               