### PR TITLE
fix(text-splitters): reverse replacement order in HTMLSemanticPreserv…

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -1046,7 +1046,12 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
         Returns:
             The content with placeholders replaced by preserved elements.
         """
-        for placeholder, preserved_content in preserved_elements.items():
+        # Sort placeholders by length descending to prevent shorter placeholders
+        # from matching inside longer ones (e.g., PRESERVED_1 inside PRESERVED_11).
+        sorted_placeholders = sorted(
+            preserved_elements.items(), key=lambda x: len(x[0]), reverse=True
+        )
+        for placeholder, preserved_content in sorted_placeholders:
             content = content.replace(placeholder, preserved_content.strip())
         return content
 


### PR DESCRIPTION
**Description:**
This PR fixes a bug in `HTMLSemanticPreservingSplitter` where the placeholder replacement order was arbitrary. This caused shorter placeholders (e.g., `PRESERVED_1`) to match as substrings inside longer placeholders (e.g., `PRESERVED_11`) during re-assembly, resulting in data corruption.

**The Fix:**
I updated `_reinsert_preserved_elements` to sort the preserved elements by length (descending) before replacement. This ensures longer placeholders are restored first, preventing substring collisions.

**Issue:**
Fixes #31568