### PR TITLE
fix(core): prevent tool call field concatenation in merge_dicts

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -56,9 +56,17 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "should either occur once or have the same value across "
                 #             "all dicts."
                 #         )
-                if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
-                    and merged[right_k] == right_v
+                if (
+                    (right_k == "index" and merged[right_k].startswith("lc_"))
+                    or (
+                        right_k in {"output_version", "model_provider"}
+                        and merged[right_k] == right_v
+                    )
+                    or (
+                        # Skip concatenation for tool call fields to prevent invalid
+                        # merged values like "read_filesearch_text" from parallel calls
+                        right_k in {"name", "id", "type", "function"}
+                    )
                 ):
                     continue
                 merged[right_k] += right_v

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -117,6 +117,31 @@ def test_check_package_version(
             {"a": [{"idx": 0, "b": "f"}]},
             {"a": [{"idx": 0, "b": "{"}, {"idx": 0, "b": "f"}]},
         ),
+        # Tool call fields should NOT be concatenated (fixes #34807)
+        # 'name' field - different values should keep first (not concatenate)
+        (
+            {"name": "read_file", "id": "abc"},
+            {"name": "search_text", "id": "def"},
+            {"name": "read_file", "id": "abc"},
+        ),
+        # 'type' field should not concatenate
+        (
+            {"type": "tool_call", "value": "a"},
+            {"type": "function", "value": "b"},
+            {"type": "tool_call", "value": "ab"},
+        ),
+        # 'function' field should not concatenate
+        (
+            {"function": "get_data", "value": "x"},
+            {"function": "process_data", "value": "y"},
+            {"function": "get_data", "value": "xy"},
+        ),
+        # 'id' field should not concatenate even when different
+        (
+            {"id": "tooluse_ABC", "name": "foo"},
+            {"id": "tooluse_DEF", "name": "bar"},
+            {"id": "tooluse_ABC", "name": "foo"},
+        ),
     ],
 )
 def test_merge_dicts(


### PR DESCRIPTION
Skip concatenation for tool call fields (`name`, `id`, `type`, `function`) in `merge_dicts()` to prevent invalid merged values like `"read_filesearch_text"` during streaming.

Fixes #34807