### PR TITLE
docs: add missing module-level docstrings to partner integrations

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/__init__.py
+++ b/libs/partners/fireworks/langchain_fireworks/__init__.py
@@ -1,3 +1,5 @@
+"""Fireworks AI integration for LangChain."""
+
 from langchain_fireworks.chat_models import ChatFireworks
 from langchain_fireworks.embeddings import FireworksEmbeddings
 from langchain_fireworks.llms import Fireworks

--- a/libs/partners/huggingface/langchain_huggingface/__init__.py
+++ b/libs/partners/huggingface/langchain_huggingface/__init__.py
@@ -1,3 +1,5 @@
+"""Hugging Face integration for LangChain."""
+
 from langchain_huggingface.chat_models import (
     ChatHuggingFace,  # type: ignore[import-not-found]
 )

--- a/libs/partners/mistralai/langchain_mistralai/__init__.py
+++ b/libs/partners/mistralai/langchain_mistralai/__init__.py
@@ -1,3 +1,5 @@
+"""Mistral AI integration for LangChain."""
+
 from langchain_mistralai.chat_models import ChatMistralAI
 from langchain_mistralai.embeddings import MistralAIEmbeddings
 

--- a/libs/partners/perplexity/langchain_perplexity/__init__.py
+++ b/libs/partners/perplexity/langchain_perplexity/__init__.py
@@ -1,3 +1,5 @@
+"""Perplexity AI integration for LangChain."""
+
 from langchain_perplexity.chat_models import ChatPerplexity
 from langchain_perplexity.output_parsers import (
     ReasoningJsonOutputParser,

--- a/libs/partners/prompty/langchain_prompty/__init__.py
+++ b/libs/partners/prompty/langchain_prompty/__init__.py
@@ -1,3 +1,5 @@
+"""Microsoft Prompty integration for LangChain."""
+
 from langchain_prompty.core import InvokerFactory
 from langchain_prompty.langchain import create_chat_prompt
 from langchain_prompty.parsers import PromptyChatParser

--- a/libs/partners/qdrant/langchain_qdrant/__init__.py
+++ b/libs/partners/qdrant/langchain_qdrant/__init__.py
@@ -1,3 +1,5 @@
+"""Qdrant vector database integration for LangChain."""
+
 from langchain_qdrant.fastembed_sparse import FastEmbedSparse
 from langchain_qdrant.qdrant import QdrantVectorStore, RetrievalMode
 from langchain_qdrant.sparse_embeddings import SparseEmbeddings, SparseVector


### PR DESCRIPTION
  docs: add missing module-level docstrings to partner integrations

  Added module-level docstrings to 6 partner integration __init__.py files
  that were missing documentation:
