### PR TITLE
docs: add usage examples to InMemoryCache and LengthBasedExampleSelector

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -148,7 +148,32 @@ class BaseCache(ABC):
 
 
 class InMemoryCache(BaseCache):
-    """Cache that stores things in memory."""
+    """Cache that stores things in memory.
+
+    Example:
+
+        ```python
+        from langchain_core.caches import InMemoryCache
+        from langchain_core.outputs import Generation
+
+        # Initialize cache
+        cache = InMemoryCache()
+
+        # Update cache
+        cache.update(
+            prompt="What is the capital of France?",
+            llm_string="model='gpt-3.5-turbo', temperature=0.1",
+            return_val=[Generation(text="Paris")]
+        )
+
+        # Lookup cache
+        result = cache.lookup(
+            prompt="What is the capital of France?",
+            llm_string="model='gpt-3.5-turbo', temperature=0.1"
+        )
+        # result is [Generation(text="Paris")]
+        ```
+    """
 
     def __init__(self, *, maxsize: int | None = None) -> None:
         """Initialize with empty cache.

--- a/libs/core/langchain_core/example_selectors/length_based.py
+++ b/libs/core/langchain_core/example_selectors/length_based.py
@@ -15,7 +15,39 @@ def _get_length_based(text: str) -> int:
 
 
 class LengthBasedExampleSelector(BaseExampleSelector, BaseModel):
-    """Select examples based on length."""
+    """Select examples based on length.
+
+    Example:
+
+        ```python
+        from langchain_core.example_selectors import LengthBasedExampleSelector
+        from langchain_core.prompts import PromptTemplate
+
+        # Define examples
+        examples = [
+            {"input": "happy", "output": "sad"},
+            {"input": "tall", "output": "short"},
+            {"input": "fast", "output": "slow"},
+        ]
+
+        # Create prompt template
+        example_prompt = PromptTemplate(
+            input_variables=["input", "output"],
+            template="Input: {input}\\nOutput: {output}"
+        )
+
+        # Create selector with max length constraint
+        selector = LengthBasedExampleSelector(
+            examples=examples,
+            example_prompt=example_prompt,
+            max_length=50  # Maximum prompt length
+        )
+
+        # Select examples for a new input
+        selected = selector.select_examples({"input": "large", "output": "tiny"})
+        # Returns examples that fit within max_length constraint
+        ```
+    """
 
     examples: list[dict]
     """A list of the examples that the prompt template expects."""


### PR DESCRIPTION
Added usage examples to two core classes that were missing documentation:

- InMemoryCache: Shows how to initialize, update, and lookup cache entries
- LengthBasedExampleSelector: Shows how to create and use the selector with max_length constraint