### PR TITLE
feat(groq): support lc image types

### DIFF
--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -1284,31 +1284,6 @@ def _format_message_content(content: Any) -> Any:
             # Handle LangChain standard data content blocks (image, audio, file)
             if isinstance(block, dict) and is_data_content_block(block):
                 formatted.append(convert_to_openai_data_block(block))
-            # Handle Anthropic-style image blocks
-            elif (
-                isinstance(block, dict)
-                and block.get("type") == "image"
-                and (source := block.get("source"))
-                and isinstance(source, dict)
-            ):
-                if source.get("type") == "base64":
-                    media_type = source.get("media_type")
-                    data = source.get("data")
-                    if media_type and data:
-                        formatted.append(
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:{media_type};base64,{data}"
-                                },
-                            }
-                        )
-                    else:
-                        formatted.append(block)
-                elif source.get("type") == "url" and (url := source.get("url")):
-                    formatted.append({"type": "image_url", "image_url": {"url": url}})
-                else:
-                    formatted.append(block)
             else:
                 formatted.append(block)
         return formatted

--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -40,11 +40,15 @@ from langchain_core.messages import (
     ToolCall,
     ToolMessage,
     ToolMessageChunk,
+    is_data_content_block,
 )
 from langchain_core.messages.ai import (
     InputTokenDetails,
     OutputTokenDetails,
     UsageMetadata,
+)
+from langchain_core.messages.block_translators.openai import (
+    convert_to_openai_data_block,
 )
 from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.base import OutputParserLike
@@ -1263,6 +1267,54 @@ def _is_pydantic_class(obj: Any) -> bool:
 #
 # Type conversion helpers
 #
+def _format_message_content(content: Any) -> Any:
+    """Format message content for Groq API.
+
+    Converts LangChain image content blocks to Groq's expected image_url format.
+
+    Args:
+        content: The message content (string or list of content blocks).
+
+    Returns:
+        Formatted content suitable for Groq API.
+    """
+    if content and isinstance(content, list):
+        formatted: list = []
+        for block in content:
+            # Handle LangChain standard data content blocks (image, audio, file)
+            if isinstance(block, dict) and is_data_content_block(block):
+                formatted.append(convert_to_openai_data_block(block))
+            # Handle Anthropic-style image blocks
+            elif (
+                isinstance(block, dict)
+                and block.get("type") == "image"
+                and (source := block.get("source"))
+                and isinstance(source, dict)
+            ):
+                if source.get("type") == "base64":
+                    media_type = source.get("media_type")
+                    data = source.get("data")
+                    if media_type and data:
+                        formatted.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:{media_type};base64,{data}"
+                                },
+                            }
+                        )
+                    else:
+                        formatted.append(block)
+                elif source.get("type") == "url" and (url := source.get("url")):
+                    formatted.append({"type": "image_url", "image_url": {"url": url}})
+                else:
+                    formatted.append(block)
+            else:
+                formatted.append(block)
+        return formatted
+    return content
+
+
 def _convert_message_to_dict(message: BaseMessage) -> dict:
     """Convert a LangChain message to a dictionary.
 
@@ -1277,7 +1329,10 @@ def _convert_message_to_dict(message: BaseMessage) -> dict:
     if isinstance(message, ChatMessage):
         message_dict = {"role": message.role, "content": message.content}
     elif isinstance(message, HumanMessage):
-        message_dict = {"role": "user", "content": message.content}
+        message_dict = {
+            "role": "user",
+            "content": _format_message_content(message.content),
+        }
     elif isinstance(message, AIMessage):
         # Translate v1 content
         if message.response_metadata.get("output_version") == "v1":

--- a/libs/partners/groq/tests/integration_tests/test_standard.py
+++ b/libs/partners/groq/tests/integration_tests/test_standard.py
@@ -24,7 +24,6 @@ class TestGroq(ChatModelIntegrationTests):
     def chat_model_params(self) -> dict:
         return {"model": "llama-3.3-70b-versatile", "rate_limiter": rate_limiter}
 
-    @pytest.mark.xfail(reason="Not yet implemented.")
     def test_tool_message_histories_list_content(
         self, model: BaseChatModel, my_adder_tool: BaseTool
     ) -> None:

--- a/libs/partners/groq/tests/integration_tests/test_standard.py
+++ b/libs/partners/groq/tests/integration_tests/test_standard.py
@@ -5,7 +5,6 @@ from typing import Literal
 import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.rate_limiters import InMemoryRateLimiter
-from langchain_core.tools import BaseTool
 from langchain_tests.integration_tests import (
     ChatModelIntegrationTests,
 )
@@ -23,11 +22,6 @@ class TestGroq(ChatModelIntegrationTests):
     @property
     def chat_model_params(self) -> dict:
         return {"model": "llama-3.3-70b-versatile", "rate_limiter": rate_limiter}
-
-    def test_tool_message_histories_list_content(
-        self, model: BaseChatModel, my_adder_tool: BaseTool
-    ) -> None:
-        super().test_tool_message_histories_list_content(model, my_adder_tool)
 
     @pytest.mark.xfail(
         reason="Groq models have inconsistent tool calling performance. See: "

--- a/libs/partners/groq/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/groq/tests/unit_tests/test_chat_models.py
@@ -996,40 +996,6 @@ def test_format_message_content_langchain_image_url() -> None:
     assert expected == _format_message_content([content])
 
 
-def test_format_message_content_anthropic_image_base64() -> None:
-    """Test that Anthropic-style image blocks with source are converted."""
-    content = {
-        "type": "image",
-        "source": {
-            "type": "base64",
-            "media_type": "image/jpeg",
-            "data": "<base64 data>",
-        },
-    }
-    expected = [
-        {
-            "type": "image_url",
-            "image_url": {"url": "data:image/jpeg;base64,<base64 data>"},
-        }
-    ]
-    assert expected == _format_message_content([content])
-
-
-def test_format_message_content_anthropic_image_url() -> None:
-    """Test that Anthropic-style image blocks with URL source are converted."""
-    content = {
-        "type": "image",
-        "source": {
-            "type": "url",
-            "url": "https://example.com/image.png",
-        },
-    }
-    expected = [
-        {"type": "image_url", "image_url": {"url": "https://example.com/image.png"}}
-    ]
-    assert expected == _format_message_content([content])
-
-
 def test_format_message_content_mixed() -> None:
     """Test that mixed content with text and image is handled correctly."""
     content = [


### PR DESCRIPTION
### pr description
- adds image input handling to `ChatGroq` in `chat_models.py` by converting langchain image content blocks into groq’s expected `image_url` message format.
- enables multimodal prompts (text + images) to be passed through the groq partner integration
- adds comprehensive unit test coverage for image formatting in `test_chat_models.py`

### what does it solve?
removes the xfail from test_tool_message_histories_list_content in `test_standard.py`

---

additional disclaimer : AI tools were used in assistance when forming and testing this change