### PR TITLE
docs: add example to create_message function docstring

### DIFF
--- a/libs/core/langchain_core/exceptions.py
+++ b/libs/core/langchain_core/exceptions.py
@@ -52,7 +52,7 @@ class OutputParserException(ValueError, LangChainException):  # noqa: N818
             error = create_message(
                 message=error, error_code=ErrorCode.OUTPUT_PARSING_FAILURE
             )
-            
+
         super().__init__(error)
         if send_to_llm and (observation is None or llm_output is None):
             msg = (
@@ -86,13 +86,15 @@ def create_message(*, message: str, error_code: ErrorCode) -> str:
 
     Returns:
         The full message with the troubleshooting link.
-        
+
     Example:
-        >>> create_message(
-        ...     message="Failed to parse output",
-        ...     error_code=ErrorCode.OUTPUT_PARSING_FAILURE
-        ... )
-        'Failed to parse output\\nFor troubleshooting, visit: ...'
+        ```python
+        create_message(
+            message="Failed to parse output",
+            error_code=ErrorCode.OUTPUT_PARSING_FAILURE,
+        )
+        'Failed to parse output. For troubleshooting, visit: ...'
+        ```
     """
     return (
         f"{message}\n"

--- a/libs/core/langchain_core/exceptions.py
+++ b/libs/core/langchain_core/exceptions.py
@@ -52,6 +52,7 @@ class OutputParserException(ValueError, LangChainException):  # noqa: N818
             error = create_message(
                 message=error, error_code=ErrorCode.OUTPUT_PARSING_FAILURE
             )
+            
         super().__init__(error)
         if send_to_llm and (observation is None or llm_output is None):
             msg = (
@@ -85,6 +86,13 @@ def create_message(*, message: str, error_code: ErrorCode) -> str:
 
     Returns:
         The full message with the troubleshooting link.
+        
+    Example:
+        >>> create_message(
+        ...     message="Failed to parse output",
+        ...     error_code=ErrorCode.OUTPUT_PARSING_FAILURE
+        ... )
+        'Failed to parse output\\nFor troubleshooting, visit: ...'
     """
     return (
         f"{message}\n"

--- a/libs/core/langchain_core/exceptions.py
+++ b/libs/core/langchain_core/exceptions.py
@@ -93,7 +93,7 @@ def create_message(*, message: str, error_code: ErrorCode) -> str:
             message="Failed to parse output",
             error_code=ErrorCode.OUTPUT_PARSING_FAILURE,
         )
-        'Failed to parse output. For troubleshooting, visit: ...'
+        "Failed to parse output. For troubleshooting, visit: ..."
         ```
     """
     return (


### PR DESCRIPTION
## Description
Added an example section to the `create_message` function docstring in `exceptions.py` to improve documentation completeness and follow the Google Python Style Guide.

## Changes
- Added Example section showing usage of `create_message` function with sample input and output