### PR TITLE
fix(xai): fix routing of chat completions vs. responses apis during streaming

### DIFF
--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 import openai
 from langchain_core.messages import AIMessageChunk
 from langchain_core.utils import secret_from_env
-from langchain_openai.chat_models.base import ChatOpenAI
+from langchain_openai.chat_models.base import BaseChatOpenAI
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
@@ -37,7 +37,7 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
     return default.copy()
 
 
-class ChatXAI(ChatOpenAI):  # type: ignore[override]
+class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
     r"""ChatXAI chat model.
 
     Refer to [xAI's documentation](https://docs.x.ai/docs/api-reference#chat-completions)

--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast
 import openai
 from langchain_core.messages import AIMessageChunk
 from langchain_core.utils import secret_from_env
-from langchain_openai.chat_models.base import BaseChatOpenAI
+from langchain_openai.chat_models.base import ChatOpenAI
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
@@ -37,7 +37,7 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
     return default.copy()
 
 
-class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
+class ChatXAI(ChatOpenAI):  # type: ignore[override]
     r"""ChatXAI chat model.
 
     Refer to [xAI's documentation](https://docs.x.ai/docs/api-reference#chat-completions)

--- a/libs/partners/xai/pyproject.toml
+++ b/libs/partners/xai/pyproject.toml
@@ -65,6 +65,7 @@ docstring-code-line-length = 100
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
+    "ANN401",  # Allow annotating `Any`
     "COM812",  # Messes with the formatter
     "ISC001",  # Messes with the formatter
     "PERF203", # Rarely useful


### PR DESCRIPTION
Using the web_search toolcall through the stream api would result in an error:
```python
from langchain_xai import ChatXAI
model = ChatXAI.model_validate({"model": "grok-4"})
model = model.bind_tools(tools=[{"type": "web_search"}])
async for msg in model.astream("what is the time now?"):
    print(msg)
```
Resulted in:
```
TypeError: Missing required arguments; Expected either ('messages' and 'model') or ('messages', 'model' and 'stream') arguments to be given
```

This is because the stream would try to invoke the chat completions api rather than the responses api due to it missing the logic from the OpenAi Model (https://github.com/langchain-ai/langchain/blob/11df1bedc3e496a129ab8e72cc79791378a875e0/libs/partners/openai/langchain_openai/chat_models/base.py#L3026)
```
   async def _astream(
        self, *args: Any, **kwargs: Any
    ) -> AsyncIterator[ChatGenerationChunk]:
        """Route to Chat Completions or Responses API."""
        if self._use_responses_api({**kwargs, **self.model_kwargs}):
            async for chunk in super()._astream_responses(*args, **kwargs):
                yield chunk
        else:
            async for chunk in super()._astream(*args, **kwargs):
                yield chunk
```

The toolcall would translate the message to a responses api call however as the logic was missing the astream would still make use of _astream and not _astream_responses.

Extending ChatOpenAI over BaseChatOpenAI appears to resolve this issue. However im not fully sure there is no other impacts to this.
