### PR TITLE
Fix/mustache nested variables 31976

### DIFF
--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -144,6 +144,7 @@ def mustache_template_vars(
 
     return variables
 
+
 Defs = dict[str, "Defs"]
 
 

--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -135,20 +135,14 @@ def mustache_template_vars(
         The top-level variables from the template.
     """
     variables: set[str] = set()
-    section_depth = 0
     for type_, key in mustache.tokenize(template):
-        if type_ == "end":
-            section_depth -= 1
-        elif (
-            type_ in {"variable", "section", "inverted section", "no escape"}
+        if (
+            type_ in ("variable", "section", "inverted section", "no escape")
             and key != "."
-            and section_depth == 0
         ):
             variables.add(key.split(".")[0])
-        if type_ in {"section", "inverted section"}:
-            section_depth += 1
-    return variables
 
+    return variables
 
 Defs = dict[str, "Defs"]
 


### PR DESCRIPTION
Fixes `mustache_template_vars` to extract all variables including those nested inside mustache sections.

Previously, variables inside sections like `{{#isTrue}}{{myvar}}{{/isTrue}}` were ignored because the function checked `section_depth == 0`. This change removes that restriction so all variables are extracted regardless of nesting level.

Fixes #31976