### PR TITLE
fix(core): handle empty messages in ParrotFakeChatModel

### DIFF
--- a/libs/core/langchain_core/language_models/fake_chat_models.py
+++ b/libs/core/langchain_core/language_models/fake_chat_models.py
@@ -386,6 +386,10 @@ class ParrotFakeChatModel(BaseChatModel):
         run_manager: CallbackManagerForLLMRun | None = None,
         **kwargs: Any,
     ) -> ChatResult:
+        if not messages:
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content=""))]
+            )
         return ChatResult(generations=[ChatGeneration(message=messages[-1])])
 
     @property

--- a/libs/core/tests/unit_tests/fake/test_fake_chat_model.py
+++ b/libs/core/tests/unit_tests/fake/test_fake_chat_model.py
@@ -253,3 +253,10 @@ def test_fake_messages_list_chat_model_sleep_delay() -> None:
     elapsed = time.time() - start
 
     assert elapsed >= sleep_time
+
+
+def test_parrot_fake_chat_model_empty_messages() -> None:
+    model = ParrotFakeChatModel()
+    result = model.invoke([])
+    assert isinstance(result, AIMessage)
+    assert result.content == ""


### PR DESCRIPTION
## Description
This PR fixes a bug where `ParrotFakeChatModel._generate` crashed with an `IndexError` when provided with an empty messages list. The model now asserts that the input messages list is not empty, and if it is, returns a `ChatResult` with an empty `AIMessage` content.

Fixes #34876

## Verification
I have run the following commands from `libs/core`:
- `make format` (Passed)
- `make lint` (Passed)
- `make test` (Passed, including new test case `test_parrot_fake_chat_model_empty_messages`)