### PR TITLE
feat(core): add multimodal support to count_tokens_approximately

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2192,21 +2192,22 @@ def count_tokens_approximately(
 
     - For AI messages, the token count also includes stringified tool calls.
     - For tool messages, the token count also includes the tool call ID.
+    - For multimodal messages with images, applies a fixed token penalty per image
+      instead of counting base64-encoded characters.
 
     Args:
         messages: List of messages to count tokens for.
         chars_per_token: Number of characters per token to use for the approximation.
-
             One token corresponds to ~4 chars for common English text.
-
             You can also specify `float` values for more fine-grained control.
             [See more here](https://platform.openai.com/tokenizer).
         extra_tokens_per_message: Number of extra tokens to add per message, e.g.
             special tokens, including beginning/end of message.
-
             You can also specify `float` values for more fine-grained control.
             [See more here](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb).
         count_name: Whether to include message names in the count.
+        tokens_per_image: Fixed token cost per image (default: 85, aligned with
+            OpenAI's low-resolution image token cost).
 
     Returns:
         Approximate number of tokens in the messages.
@@ -2215,8 +2216,9 @@ def count_tokens_approximately(
         This is a simple approximation that may not match the exact token count used by
         specific models. For accurate counts, use model-specific tokenizers.
 
-    Warning:
-        This function does not currently support counting image tokens.
+        For multimodal messages containing images, a fixed token penalty is applied
+        per image instead of counting base64-encoded characters, which provides a
+        more realistic approximation.
 
     !!! version-added "Added in `langchain-core` 0.3.46"
     """

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2670,9 +2670,7 @@ def test_count_tokens_approximately_with_image_content() -> None:
             {"type": "text", "text": "What's in this image?"},
             {
                 "type": "image_url",
-                "image_url": {
-                    "url": "data:image/jpeg;base64," + "A" * 100000
-                },
+                "image_url": {"url": "data:image/jpeg;base64," + "A" * 100000},
             },
         ]
     )
@@ -2709,7 +2707,8 @@ def test_count_tokens_approximately_text_only_backward_compatible() -> None:
 
     token_count = count_tokens_approximately(messages)
 
-    # "Hello world" (11 chars / 4) + "Hi there!" (9 chars / 4) + 2 * 3 (extra) = ~15 tokens
+    # Should be ~15 tokens
+    # (11 chars + 9 chars + roles + 2*3 extra)
     assert 13 <= token_count <= 17
 
 


### PR DESCRIPTION
## Summary

This PR adds multimodal support to `count_tokens_approximately` to properly handle image content blocks. Previously, base64-encoded images were counted as ~25,000 tokens; now they use a fixed penalty of ~85 tokens, providing a more accurate approximation.
Fixes #34873 

Fixes the issue where `trim_messages` and other context management tools fail with multimodal content due to massive token overestimation.

## Changes

- Added `tokens_per_image` parameter to `count_tokens_approximately` (default: 85)
- Added logic to detect and handle list-based content blocks (text, image, image_url)
- Applied fixed token penalty for image blocks instead of counting base64 characters
- Maintained full backward compatibility with string content
- Added 4 new test cases for multimodal scenarios

## Testing

Ran the following commands from `libs/core`:
- `make format` ✅
- `make test` ✅ (1635 passed, 3 skipped)

Note: `make lint` shows 1 error in `scripts/check_version.py` (line too long), but this is a pre-existing issue in a file not modified by this PR.

All 145 tests in `test_utils.py` pass, including 4 new multimodal tests.

## Breaking Changes

None. This change is fully backward compatible.

## Example
```python
from langchain_core.messages import HumanMessage
from langchain_core.messages.utils import count_tokens_approximately

message = HumanMessage(content=[
    {"type": "text", "text": "What's in this image?"},
    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}
])

# Before: ~25,000 tokens (counting base64 chars)
# After: ~92 tokens (85 for image + text)
count = count_tokens_approximately([message])
```
