### PR TITLE
test(core): add tests for approximate token counting with multimodal messages

### DIFF
--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2785,14 +2785,20 @@ def test_count_tokens_approximately_ai_tool_calls_skipped_for_list_content() -> 
     # Case 2: content is a list (e.g. Anthropic-style blocks) -> tool_calls are
     # already represented in the content and should NOT be counted again.
     ai_with_list_content = AIMessage(
-        content=[{"type": "text", "text": "do something"}],
+        content=[
+            {"type": "text", "text": "do something"},
+            {
+                "type": "tool_use",
+                "name": "foo",
+                "input": {"x": 1},
+                "id": "call_1",
+            },
+        ],
         tool_calls=tool_calls,
     )
     count_list = count_tokens_approximately([ai_with_list_content])
 
-    # The message where tool_calls are added on top of string content should
-    # be more expensive than the list-based variant.
-    assert count_text > count_list
+    assert count_text - 1 <= count_list <= count_text + 1
 
 
 def test_count_tokens_approximately_respects_count_name_flag() -> None:

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2727,6 +2727,7 @@ def test_count_tokens_approximately_with_custom_image_penalty() -> None:
     # Should be ~1600 (image) + ~1 (text) + 3 (extra) = ~1604 tokens
     assert 1600 < token_count < 1610
 
+
 def test_count_tokens_approximately_with_image_only_message() -> None:
     """Test token counting for a message that only contains an image."""
     message = HumanMessage(
@@ -2745,11 +2746,10 @@ def test_count_tokens_approximately_with_image_only_message() -> None:
     # so we expect something in the ~90-110 range.
     assert 80 < token_count < 120
 
+
 def test_count_tokens_approximately_with_unknown_block_type() -> None:
     """Test that unknown multimodal block types still contribute to token count."""
-    text_only = count_tokens_approximately(
-        [HumanMessage(content="hello")]
-    )
+    text_only = count_tokens_approximately([HumanMessage(content="hello")])
 
     message_with_unknown_block = HumanMessage(
         content=[
@@ -2764,8 +2764,9 @@ def test_count_tokens_approximately_with_unknown_block_type() -> None:
     # than the text-only version.
     assert mixed > text_only
 
+
 def test_count_tokens_approximately_ai_tool_calls_skipped_for_list_content() -> None:
-    """Test that tool_calls are not double-counted for list (Anthropic-style) content."""
+    """Test that tool_calls aren't double-counted for list (Anthropic-style) content."""
     tool_calls = [
         {
             "id": "call_1",
@@ -2792,6 +2793,7 @@ def test_count_tokens_approximately_ai_tool_calls_skipped_for_list_content() -> 
     # The message where tool_calls are added on top of string content should
     # be more expensive than the list-based variant.
     assert count_text > count_list
+
 
 def test_count_tokens_approximately_respects_count_name_flag() -> None:
     """Test that the count_name flag controls whether names are included."""

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2726,3 +2726,79 @@ def test_count_tokens_approximately_with_custom_image_penalty() -> None:
 
     # Should be ~1600 (image) + ~1 (text) + 3 (extra) = ~1604 tokens
     assert 1600 < token_count < 1610
+
+def test_count_tokens_approximately_with_image_only_message() -> None:
+    """Test token counting for a message that only contains an image."""
+    message = HumanMessage(
+        content=[
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/jpeg;base64,AAA"},
+            }
+        ]
+    )
+
+    token_count = count_tokens_approximately([message])
+
+    # Should be roughly tokens_per_image + role + extra per message.
+    # Default tokens_per_image is 85 and extra_tokens_per_message is 3,
+    # so we expect something in the ~90-110 range.
+    assert 80 < token_count < 120
+
+def test_count_tokens_approximately_with_unknown_block_type() -> None:
+    """Test that unknown multimodal block types still contribute to token count."""
+    text_only = count_tokens_approximately(
+        [HumanMessage(content="hello")]
+    )
+
+    message_with_unknown_block = HumanMessage(
+        content=[
+            {"type": "text", "text": "hello"},
+            {"type": "foo", "bar": "baz"},  # unknown type, falls back to repr(block)
+        ]
+    )
+
+    mixed = count_tokens_approximately([message_with_unknown_block])
+
+    # The message with an extra unknown block should be counted as more expensive
+    # than the text-only version.
+    assert mixed > text_only
+
+def test_count_tokens_approximately_ai_tool_calls_skipped_for_list_content() -> None:
+    """Test that tool_calls are not double-counted for list (Anthropic-style) content."""
+    tool_calls = [
+        {
+            "id": "call_1",
+            "name": "foo",
+            "args": {"x": 1},
+        }
+    ]
+
+    # Case 1: content is a string -> tool_calls should be added to the char count.
+    ai_with_text_content = AIMessage(
+        content="do something",
+        tool_calls=tool_calls,
+    )
+    count_text = count_tokens_approximately([ai_with_text_content])
+
+    # Case 2: content is a list (e.g. Anthropic-style blocks) -> tool_calls are
+    # already represented in the content and should NOT be counted again.
+    ai_with_list_content = AIMessage(
+        content=[{"type": "text", "text": "do something"}],
+        tool_calls=tool_calls,
+    )
+    count_list = count_tokens_approximately([ai_with_list_content])
+
+    # The message where tool_calls are added on top of string content should
+    # be more expensive than the list-based variant.
+    assert count_text > count_list
+
+def test_count_tokens_approximately_respects_count_name_flag() -> None:
+    """Test that the count_name flag controls whether names are included."""
+    message = HumanMessage(content="hello", name="user-name")
+
+    with_name = count_tokens_approximately([message], count_name=True)
+    without_name = count_tokens_approximately([message], count_name=False)
+
+    # When count_name is True, the name should contribute to the token count.
+    assert with_name > without_name


### PR DESCRIPTION
This PR adds additional unit tests for `count_tokens_approximately` to improve coverage around multimodal content and tool-calling behavior in `langchain-core`.

The tests help guard against regressions in image handling, unknown block types, Anthropic-style content blocks, and the `count_name` flag.

Ran `make format`, `make lint`, and `make test` locally for `libs/core`.

Note: parts of this contribution were drafted with the assistance of ChatGPT; all code and tests were reviewed, modified, and validated locally.
