### PR TITLE
fix(openai): handle proxy responses with incorrect finish_reason

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1475,11 +1475,14 @@ class BaseChatOpenAI(BaseChatModel):
                     token_usage, service_tier
                 )
             generation_info = generation_info or {}
-            generation_info["finish_reason"] = (
-                res.get("finish_reason")
-                if res.get("finish_reason") is not None
-                else generation_info.get("finish_reason")
-            )
+            if message.tool_calls:
+                 generation_info["finish_reason"] = "tool_calls"
+            else:
+                generation_info["finish_reason"] = (
+                    res.get("finish_reason")
+                    if res.get("finish_reason") is not None
+                    else generation_info.get("finish_reason")
+                )
             if "logprobs" in res:
                 generation_info["logprobs"] = res["logprobs"]
             gen = ChatGeneration(message=message, generation_info=generation_info)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1475,7 +1475,7 @@ class BaseChatOpenAI(BaseChatModel):
                     token_usage, service_tier
                 )
             generation_info = generation_info or {}
-            if message.tool_calls:
+            if isinstance(message, AIMessage) and message.tool_calls:
                 generation_info["finish_reason"] = "tool_calls"
             else:
                 generation_info["finish_reason"] = (

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -134,7 +134,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# This SSL context is equivelent to the default `verify=True`.
+# This SSL context is equivalent to the default `verify=True`.
 # https://www.python-httpx.org/advanced/ssl/#configuring-client-instances
 global_ssl_context = ssl.create_default_context(cafile=certifi.where())
 
@@ -1476,7 +1476,7 @@ class BaseChatOpenAI(BaseChatModel):
                 )
             generation_info = generation_info or {}
             if message.tool_calls:
-                 generation_info["finish_reason"] = "tool_calls"
+                generation_info["finish_reason"] = "tool_calls"
             else:
                 generation_info["finish_reason"] = (
                     res.get("finish_reason")

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_structured_output_proxy.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_structured_output_proxy.py
@@ -3,7 +3,7 @@
 import json
 from unittest.mock import MagicMock
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SecretStr
 
 from langchain_openai import ChatOpenAI
 
@@ -51,7 +51,7 @@ def test_structured_output_proxy_fix() -> None:
     }
 
     # Initialize ChatOpenAI
-    llm = ChatOpenAI(model="gpt-4", api_key="test")
+    llm = ChatOpenAI(model="gpt-4", api_key=SecretStr("test"))
 
     # Inject Mock Client directly
     # _generate calls self.client.with_raw_response.create(...).parse()

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_structured_output_proxy.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_structured_output_proxy.py
@@ -1,0 +1,74 @@
+
+"""Test structured output compatibility with proxies."""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel, Field
+
+
+class Joke(BaseModel):
+    setup: str = Field(description="the setup of the joke")
+    punchline: str = Field(description="the punchline")
+
+
+def test_structured_output_proxy_fix() -> None:
+    """Test that tool calls are respected even if finish_reason is 'stop'.
+    
+    This simulates behavior seen in some proxies (e.g. LiteLLM) where
+    finish_reason is not correctly set to 'tool_calls'.
+    """
+    # Configure response as a DICT directly to avoid Pydantic/Mock model_dump issues
+    # validation logic in base.py handles dicts natively
+    mock_response_dict = {
+        "choices": [{
+            "message": {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "Joke",
+                        "arguments": json.dumps({
+                            "setup": "Why did the chicken cross the road?",
+                            "punchline": "To get to the other side"
+                        })
+                    }
+                }]
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {"total_tokens": 10},
+         "model": "gpt-4"
+    }
+
+    # Initialize ChatOpenAI
+    llm = ChatOpenAI(
+        model="gpt-4",
+        api_key="test"
+    )
+    
+    # Inject Mock Client directly
+    # _generate calls self.client.with_raw_response.create(...).parse()
+    mock_raw_response = MagicMock()
+    mock_raw_response.parse.return_value = mock_response_dict
+    
+    llm.client = MagicMock()
+    llm.client.with_raw_response.create.return_value = mock_raw_response
+    
+    # Also mock root_client just in case logic paths change
+    llm.root_client = MagicMock()
+    llm.root_client.chat.completions.with_raw_response.parse.return_value = mock_raw_response
+
+    # Use with_structured_output
+    structured_llm = llm.with_structured_output(Joke)
+    
+    # Invoke
+    result = structured_llm.invoke("Tell me a little joke")
+    
+    # Verification
+    assert isinstance(result, Joke)
+    assert result.punchline == "To get to the other side"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_structured_output_proxy.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_structured_output_proxy.py
@@ -1,12 +1,11 @@
-
 """Test structured output compatibility with proxies."""
+
 import json
 from unittest.mock import MagicMock
 
-import pytest
-from langchain_core.messages import AIMessage
-from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, Field
+
+from langchain_openai import ChatOpenAI
 
 
 class Joke(BaseModel):
@@ -16,59 +15,64 @@ class Joke(BaseModel):
 
 def test_structured_output_proxy_fix() -> None:
     """Test that tool calls are respected even if finish_reason is 'stop'.
-    
+
     This simulates behavior seen in some proxies (e.g. LiteLLM) where
     finish_reason is not correctly set to 'tool_calls'.
     """
     # Configure response as a DICT directly to avoid Pydantic/Mock model_dump issues
     # validation logic in base.py handles dicts natively
     mock_response_dict = {
-        "choices": [{
-            "message": {
-                "role": "assistant",
-                "content": None,
-                "tool_calls": [{
-                    "id": "call_123",
-                    "type": "function",
-                    "function": {
-                        "name": "Joke",
-                        "arguments": json.dumps({
-                            "setup": "Why did the chicken cross the road?",
-                            "punchline": "To get to the other side"
-                        })
-                    }
-                }]
-            },
-            "finish_reason": "stop"
-        }],
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_123",
+                            "type": "function",
+                            "function": {
+                                "name": "Joke",
+                                "arguments": json.dumps(
+                                    {
+                                        "setup": "Why did the chicken cross the road?",
+                                        "punchline": "To get to the other side",
+                                    }
+                                ),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "stop",
+            }
+        ],
         "usage": {"total_tokens": 10},
-         "model": "gpt-4"
+        "model": "gpt-4",
     }
 
     # Initialize ChatOpenAI
-    llm = ChatOpenAI(
-        model="gpt-4",
-        api_key="test"
-    )
-    
+    llm = ChatOpenAI(model="gpt-4", api_key="test")
+
     # Inject Mock Client directly
     # _generate calls self.client.with_raw_response.create(...).parse()
     mock_raw_response = MagicMock()
     mock_raw_response.parse.return_value = mock_response_dict
-    
+
     llm.client = MagicMock()
     llm.client.with_raw_response.create.return_value = mock_raw_response
-    
+
     # Also mock root_client just in case logic paths change
     llm.root_client = MagicMock()
-    llm.root_client.chat.completions.with_raw_response.parse.return_value = mock_raw_response
+    llm.root_client.chat.completions.with_raw_response.parse.return_value = (
+        mock_raw_response
+    )
 
     # Use with_structured_output
     structured_llm = llm.with_structured_output(Joke)
-    
+
     # Invoke
     result = structured_llm.invoke("Tell me a little joke")
-    
+
     # Verification
     assert isinstance(result, Joke)
     assert result.punchline == "To get to the other side"


### PR DESCRIPTION
## Description
Fixes #34891

### The Issue
When using `ChatOpenAI` with proxies (like LiteLLM), the `finish_reason` often defaults to `"stop"` even when valid `tool_calls` are present. This causes `_create_chat_result` to ignore structured outputs, breaking agents that rely on proxies.

### The Fix
Modified `_create_chat_result` in `libs/partners/openai/langchain_openai/chat_models/base.py` to check for the existence of `tool_calls` in the message payload, rather than strictly relying on `finish_reason == "tool_calls"`.

### Verification
Added a unit test `tests/unit_tests/chat_models/test_structured_output_proxy.py` that mocks a proxy response with `finish_reason="stop"` but valid tool data. The test confirms the output is now correctly parsed.