### PR TITLE
docs: Fix typo in Runnable description of async variants

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -138,7 +138,7 @@ class Runnable(ABC, Generic[Input, Output]):
     - **Batch**: By default, batch runs invoke() in parallel using a thread pool
         executor. Override to optimize batching.
 
-    - **Async**: Methods with `'a'` suffix are asynchronous. By default, they execute
+    - **Async**: Methods with `'a'` prefix are asynchronous. By default, they execute
         the sync counterpart using asyncio's thread pool.
         Override for native async.
 


### PR DESCRIPTION
invoke / ainvoke;  batch / abatch;

not invoke / invokea; batch / batcha;