### PR TITLE
fix(core): convert None content to empty string in ToolMessage

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -100,7 +100,9 @@ class ToolMessage(BaseMessage, ToolOutputMixin):
         if isinstance(content, tuple):
             content = list(content)
 
-        if not isinstance(content, (str, list)):
+        if content is None:
+            values["content"] = ""
+        elif not isinstance(content, (str, list)):
             try:
                 values["content"] = str(content)
             except ValueError as e:

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -19,6 +19,7 @@ from langchain_core.messages import (
     RemoveMessage,
     SystemMessage,
     ToolMessage,
+    ToolMessageChunk,
     convert_to_messages,
     convert_to_openai_image_block,
     get_buffer_string,
@@ -1048,6 +1049,25 @@ def test_tool_message_tool_call_id() -> None:
     ToolMessage("foo", tool_call_id=uuid.uuid4())
     ToolMessage("foo", tool_call_id=1)
     ToolMessage("foo", tool_call_id=1.0)
+
+
+def test_tool_message_chunk_none_content() -> None:
+    """Test that ToolMessageChunk handles None content correctly."""
+    # None should be converted to empty string
+    chunk = ToolMessageChunk(tool_call_id="1", content=None)
+    assert chunk.content == ""
+
+    # Merging two chunks with None content should not produce "NoneNone"
+    chunk1 = ToolMessageChunk(tool_call_id="1", content=None)
+    chunk2 = ToolMessageChunk(tool_call_id="1", content=None)
+    result = chunk1 + chunk2
+    assert result.content == ""
+
+    # Merging None with string
+    chunk1 = ToolMessageChunk(tool_call_id="1", content=None)
+    chunk2 = ToolMessageChunk(tool_call_id="1", content="hello")
+    result = chunk1 + chunk2
+    assert result.content == "hello"
 
 
 def test_message_text() -> None:


### PR DESCRIPTION
## Summary
- Fixes #34909
- `ToolMessage.coerce_args` now converts `None` to `""` instead of `"None"`
- Prevents `None + None` from becoming `"NoneNone"` when merging chunks

## Test plan
- Added `test_tool_message_chunk_none_content` test
- All existing tool message tests pass