### PR TITLE
fix(core): handle unregistered tools gracefully in PydanticToolsParser when partial=True

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -356,8 +356,10 @@ class PydanticToolsParser(JsonOutputToolsParser):
                 )
                 raise ValueError(msg)
             try:
+                if res["type"] not in name_dict:
+                    raise KeyError(res["type"])
                 pydantic_objects.append(name_dict[res["type"]](**res["args"]))
-            except (ValidationError, ValueError):
+            except (ValidationError, ValueError, KeyError):
                 if partial:
                     continue
                 has_max_tokens_stop_reason = any(

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -355,11 +355,14 @@ class PydanticToolsParser(JsonOutputToolsParser):
                     f"{res['args']}"
                 )
                 raise ValueError(msg)
+            # Skip unregistered tools when partial=True, raise KeyError otherwise
+            if res["type"] not in name_dict:
+                if partial:
+                    continue
+                raise KeyError(res["type"])
             try:
-                if res["type"] not in name_dict:
-                    raise KeyError(res["type"])
                 pydantic_objects.append(name_dict[res["type"]](**res["args"]))
-            except (ValidationError, ValueError, KeyError):
+            except (ValidationError, ValueError):
                 if partial:
                     continue
                 has_max_tokens_stop_reason = any(


### PR DESCRIPTION
## Problem

When using `PydanticToolsParser` with `partial=True` (common in streaming scenarios), if the LLM calls a tool that isn't registered with the parser, it crashes with a `KeyError` instead of gracefully skipping it.

This is inconsistent with how other error cases (like `ValidationError` and non-dict args) are handled when `partial=True` - they get skipped rather than crashing.

Fixes #34910

## Solution

Added `KeyError` to the exception handling in `PydanticToolsParser.parse_result()`. When `partial=True` and a tool isn't found in the registered tools dict, we now skip it (just like we do for validation errors) instead of crashing.

The behavior when `partial=False` remains unchanged - a `KeyError` is raised to indicate the tool is not recognized.

## Changes

- `libs/core/langchain_core/output_parsers/openai_tools.py`: Added explicit check for tool existence and `KeyError` to the exception handling
- `libs/core/tests/unit_tests/output_parsers/test_openai_tools.py`: Added 3 tests covering:
  - Skipping unregistered tools when `partial=True`
  - Raising `KeyError` when `partial=False`
  - Graceful handling with `first_tool_only=True`

## Testing

All 41 tests in `test_openai_tools.py` pass locally.