### PR TITLE
test(deepseek): skip integration tests if API key is missing

### DIFF
--- a/libs/partners/deepseek/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/integration_tests/test_chat_models.py
@@ -1,7 +1,7 @@
 """Test ChatDeepSeek chat model."""
 
 from __future__ import annotations
-
+import os
 import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessageChunk, BaseMessageChunk
@@ -12,6 +12,10 @@ from langchain_deepseek.chat_models import ChatDeepSeek
 
 MODEL_NAME = "deepseek-chat"
 
+@pytest.mark.skipif(
+    not os.environ.get("DEEPSEEK_API_KEY"),
+    reason="Requires DEEPSEEK_API_KEY environment variable",
+)
 
 class TestChatDeepSeek(ChatModelIntegrationTests):
     """Test `ChatDeepSeek` chat model."""

--- a/libs/partners/deepseek/tests/integration_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/integration_tests/test_chat_models.py
@@ -1,7 +1,9 @@
 """Test ChatDeepSeek chat model."""
 
 from __future__ import annotations
+
 import os
+
 import pytest
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessageChunk, BaseMessageChunk
@@ -12,11 +14,11 @@ from langchain_deepseek.chat_models import ChatDeepSeek
 
 MODEL_NAME = "deepseek-chat"
 
+
 @pytest.mark.skipif(
     not os.environ.get("DEEPSEEK_API_KEY"),
     reason="Requires DEEPSEEK_API_KEY environment variable",
 )
-
 class TestChatDeepSeek(ChatModelIntegrationTests):
     """Test `ChatDeepSeek` chat model."""
 


### PR DESCRIPTION
## Description
Integration tests for `ChatDeepSeek` currently fail with `pydantic_core.ValidationError` when `DEEPSEEK_API_KEY` is not present in the environment. This causes unnecessary noise and failures for contributors running the full test suite locally without a specific DeepSeek key.

## Fix
Added a `@pytest.mark.skipif` guard to the `TestChatDeepSeek` class. The tests will now gracefully skip (mark as `s`) instead of erroring out when the API key is missing.
