### PR TITLE
fix(ollama): handle empty streaming responses without raising

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -1017,7 +1017,7 @@ class ChatOllama(BaseChatModel):
                     ),
                     generation_info={"ollama_empty_stream": True},
                 )
-            
+
         return final_chunk
 
     def _get_ls_params(

--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -977,8 +977,14 @@ class ChatOllama(BaseChatModel):
                     verbose=verbose,
                 )
         if final_chunk is None:
-            msg = "No data received from Ollama stream."
-            raise ValueError(msg)
+            # Ollama may occasionally return an empty stream; return an empty chunk instead of raising ValueError
+            log.warning("Ollama returned an empty stream; no content was generated")
+            final_chunk = ChatGenerationChunk(
+                    message=AIMessageChunk(
+                        content="",
+                    ),
+                    generation_info={"ollama_empty_stream": True},
+                )
 
         return final_chunk
 
@@ -1003,9 +1009,15 @@ class ChatOllama(BaseChatModel):
                     verbose=verbose,
                 )
         if final_chunk is None:
-            msg = "No data received from Ollama stream."
-            raise ValueError(msg)
-
+            # Ollama may occasionally return an empty stream; return an empty chunk instead of raising ValueError
+            log.warning("Ollama returned an empty stream; no content was generated")
+            final_chunk = ChatGenerationChunk(
+                    message=AIMessageChunk(
+                        content="",
+                    ),
+                    generation_info={"ollama_empty_stream": True},
+                )
+            
         return final_chunk
 
     def _get_ls_params(


### PR DESCRIPTION
### Summary

Handle cases where Ollama streaming returns no chunks by returning an empty
`ChatGenerationChunk` instead of raising a `ValueError`.

This makes streaming more robust against transient Ollama or network failures
and prevents downstream agents from crashing.

- Current behavior raises ValueError and crashes agents
- This change returns an empty ChatGenerationChunk instead
- Adds provider-scoped metadata (ollama_empty_stream)
- Applies to both sync and async streaming paths

Fixes #34918

