### PR TITLE
fix(core): raise outputparserexception for unknown tools

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -355,6 +355,17 @@ class PydanticToolsParser(JsonOutputToolsParser):
                     f"{res['args']}"
                 )
                 raise ValueError(msg)
+
+            try:
+                tool = name_dict[res["type"]]
+            except KeyError as e:
+                available = ", ".join(name_dict.keys()) or "<no_tools>"
+                msg = (
+                    f"Unknown tool type: {res['type']!r}."
+                    f"Avaibale tools: {available}"
+                )
+                raise OutputParserException(msg) from e
+
             try:
                 pydantic_objects.append(name_dict[res["type"]](**res["args"]))
             except (ValidationError, ValueError):

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -361,13 +361,12 @@ class PydanticToolsParser(JsonOutputToolsParser):
             except KeyError as e:
                 available = ", ".join(name_dict.keys()) or "<no_tools>"
                 msg = (
-                    f"Unknown tool type: {res['type']!r}."
-                    f"Avaibale tools: {available}"
+                    f"Unknown tool type: {res['type']!r}. Available tools: {available}"
                 )
                 raise OutputParserException(msg) from e
 
             try:
-                pydantic_objects.append(name_dict[res["type"]](**res["args"]))
+                pydantic_objects.append(tool(**res["args"]))
             except (ValidationError, ValueError):
                 if partial:
                     continue

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -6,6 +6,7 @@ import pydantic
 import pytest
 from pydantic import BaseModel, Field, ValidationError
 
+from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
@@ -19,7 +20,6 @@ from langchain_core.output_parsers.openai_tools import (
     parse_tool_call,
 )
 from langchain_core.outputs import ChatGeneration
-from langchain_core.exceptions import OutputParserException
 
 STREAMED_MESSAGES = [
     AIMessageChunk(content=""),
@@ -1425,9 +1425,10 @@ def test_parse_tool_call_partial_mode_with_none_arguments() -> None:
     # In partial mode, None arguments returns None (incomplete tool call)
     assert result is None
 
+
 @pytest.mark.parametrize("partial", [False, True])
 def test_pydantic_tools_parser_unknown_tool_raises_output_parser_exception(
-    partial: bool,
+    partial: bool,  # noqa: FBT001
 ) -> None:
     class KnownTool(BaseModel):
         value: int

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -19,6 +19,7 @@ from langchain_core.output_parsers.openai_tools import (
     parse_tool_call,
 )
 from langchain_core.outputs import ChatGeneration
+from langchain_core.exceptions import OutputParserException
 
 STREAMED_MESSAGES = [
     AIMessageChunk(content=""),
@@ -1423,3 +1424,30 @@ def test_parse_tool_call_partial_mode_with_none_arguments() -> None:
 
     # In partial mode, None arguments returns None (incomplete tool call)
     assert result is None
+
+@pytest.mark.parametrize("partial", [False, True])
+def test_pydantic_tools_parser_unknown_tool_raises_output_parser_exception(
+    partial: bool,
+) -> None:
+    class KnownTool(BaseModel):
+        value: int
+
+    parser = PydanticToolsParser(tools=[KnownTool])
+    message = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "id": "call_unknown",
+                "name": "UnknownTool",
+                "args": {"value": 1},
+            }
+        ],
+    )
+    generation = ChatGeneration(message=message)
+
+    with pytest.raises(OutputParserException) as excinfo:
+        parser.parse_result([generation], partial=partial)
+
+    msg = str(excinfo.value)
+    assert "Unknown tool type" in msg
+    assert "UnknownTool" in msg


### PR DESCRIPTION
# Intro
Relates to #34910

# Description
I disagree with the idea that `PydanticToolsParser` should ignore errors when `partial=True` is set. If a non-defined parameter is provided, the parser should raise an error and stop.

In my view, this behavior is correct because it would be impossible to capture or handle data that hasn't been defined in the chain. The purpose of `'Partial'` is to process data in chunks as it arrives, not to overlook schema violations or user mistakes.

The only problem I saw was that the error itself was not caught as a KeyError, after which I saw a class that complements KeyError.

# Tests:
<img width="1218" height="201" alt="image" src="https://github.com/user-attachments/assets/939a6bd5-02f2-42d8-93dc-14468a83a007" />
<img width="663" height="177" alt="image" src="https://github.com/user-attachments/assets/8fe65a2f-4526-4215-accc-927927a9ed8d" />
<img width="687" height="171" alt="image" src="https://github.com/user-attachments/assets/cd5839d5-cdfb-45d0-9d90-da282e1ba9d8" />


## Additional
AI only for explaining some things.