### PR TITLE
fix(core): handle unknown tool names in PydanticToolsParser with partial=True

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -356,8 +356,11 @@ class PydanticToolsParser(JsonOutputToolsParser):
                 )
                 raise ValueError(msg)
             try:
+                if res["type"] not in name_dict:
+                    msg = f"Unknown tool name: {res['type']}"
+                    raise KeyError(msg)
                 pydantic_objects.append(name_dict[res["type"]](**res["args"]))
-            except (ValidationError, ValueError):
+            except (ValidationError, ValueError, KeyError):
                 if partial:
                     continue
                 has_max_tokens_stop_reason = any(


### PR DESCRIPTION
When partial=True, skip unknown tool names instead of raising KeyError. When partial=False (default), raise an informative KeyError with the unknown tool name.
Fixes #34910