### PR TITLE
fix(core): allow base model annotations for empty model

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1488,7 +1488,7 @@ def get_all_basemodel_annotations(
         for name, param in inspect.signature(cls).parameters.items():
             # Exclude hidden init args added by pydantic Config. For example if
             # BaseModel(extra="allow") then "extra_data" will part of init sig.
-            if fields and name not in fields and name not in alias_map:
+            if name not in fields and name not in alias_map:
                 continue
             field_name = alias_map.get(name, name)
             annotations[field_name] = param.annotation

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2138,10 +2138,15 @@ def test__get_all_basemodel_annotations_v2(*, use_v1_namespace: bool) -> None:
         class ModelA(BaseModelV1, Generic[A], extra="allow"):
             a: A
 
+        class EmptyModel(BaseModelV1, Generic[A], extra="allow"):
+            pass
     else:
 
         class ModelA(BaseModel, Generic[A]):  # type: ignore[no-redef]
             a: A
+            model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
+
+        class EmptyModel(BaseModel, Generic[A]):  # type: ignore[no-redef]
             model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 
     class ModelB(ModelA[str]):
@@ -2191,6 +2196,10 @@ def test__get_all_basemodel_annotations_v2(*, use_v1_namespace: bool) -> None:
         "d": int | None,
     }
     actual = get_all_basemodel_annotations(ModelD[int])
+    assert actual == expected
+
+    expected = {}
+    actual = get_all_basemodel_annotations(EmptyModel)
     assert actual == expected
 
 


### PR DESCRIPTION
This fixes minimum reproduction bug:
```
class MyPydanticModel(BaseModel):
    model_config = ConfigDict(extra='allow')

tool = StructuredTool(name="Foo", args_schema=MyPydanticModel)
tool.tool_call_schema
```