### PR TITLE
feat(text-splitters): add WordTextSplitter for word-based chunking

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/__init__.py
+++ b/libs/text-splitters/langchain_text_splitters/__init__.py
@@ -16,6 +16,7 @@ from langchain_text_splitters.base import (
 from langchain_text_splitters.character import (
     CharacterTextSplitter,
     RecursiveCharacterTextSplitter,
+    WordTextSplitter,
 )
 from langchain_text_splitters.html import (
     ElementType,
@@ -65,5 +66,6 @@ __all__ = [
     "TextSplitter",
     "TokenTextSplitter",
     "Tokenizer",
+    "WordTextSplitter",
     "split_text_on_tokens",
 ]


### PR DESCRIPTION
Adds a new `WordTextSplitter` class that splits text based on word count rather than characters or tokens.

This addresses use cases where users need predictable word-based chunking, such as when working with models that have word-based context limits or when chunk size needs to be human-readable and consistent across different character encodings.

**Key features:**
- Splits text into chunks of approximately `chunk_size` words
- Supports configurable `chunk_overlap` for context preservation between chunks
- Uses regex-based word detection (default: non-whitespace sequences)
- Customizable `word_pattern` for language-specific tokenization
- Customizable `separator` for joining words

**Areas requiring careful review:**
- The default word pattern `[^\s]+` treats punctuation attached to words as part of the word. This is intentional for simplicity but may not suit all use cases.
- Overlap calculation uses simple word indexing; the actual character overlap varies based on word lengths.