### PR TITLE
feat(text-splitters): add metadata hydrator support for dynamic chunk enrichment

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/__init__.py
+++ b/libs/text-splitters/langchain_text_splitters/__init__.py
@@ -7,7 +7,9 @@
 """
 
 from langchain_text_splitters.base import (
+    BaseMetadataHydrator,
     Language,
+    SplitterContext,
     TextSplitter,
     Tokenizer,
     TokenTextSplitter,
@@ -42,6 +44,7 @@ from langchain_text_splitters.sentence_transformers import (
 from langchain_text_splitters.spacy import SpacyTextSplitter
 
 __all__ = [
+    "BaseMetadataHydrator",
     "CharacterTextSplitter",
     "ElementType",
     "ExperimentalMarkdownSyntaxTextSplitter",
@@ -62,6 +65,7 @@ __all__ = [
     "RecursiveJsonSplitter",
     "SentenceTransformersTokenTextSplitter",
     "SpacyTextSplitter",
+    "SplitterContext",
     "TextSplitter",
     "TokenTextSplitter",
     "Tokenizer",

--- a/libs/text-splitters/uv.lock
+++ b/libs/text-splitters/uv.lock
@@ -1167,7 +1167,7 @@ dependencies = [
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
-    { name = "packaging", specifier = ">=23.2.0,<26.0.0" },
+    { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
     { name = "pyyaml", specifier = ">=5.3.0,<7.0.0" },
     { name = "tenacity", specifier = ">=8.1.0,!=8.4.0,<10.0.0" },
@@ -1179,7 +1179,7 @@ requires-dist = [
 dev = [
     { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
-    { name = "setuptools", specifier = ">=67.6.1,<68.0.0" },
+    { name = "setuptools", specifier = ">=67.6.1,<79.0.0" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.14.11,<0.15.0" }]
 test = [
@@ -1202,7 +1202,7 @@ test = [
 ]
 test-integration = []
 typing = [
-    { name = "langchain-text-splitters", directory = "../text-splitters" },
+    { name = "langchain-text-splitters", directory = "." },
     { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
     { name = "types-requests", specifier = ">=2.28.11.5,<3.0.0.0" },


### PR DESCRIPTION
… enrichment

Implements support for custom metadata hydrators in TextSplitter, allowing users to dynamically enrich chunk metadata during the splitting process.

- Add SplitterContext dataclass with chunk context info
- Add BaseMetadataHydrator abstract base class
- Add metadata_hydrator parameter to TextSplitter.__init__
- Modify create_documents to invoke the hydrator for each chunk
- Add comprehensive unit tests (10 new tests)


