### PR TITLE
fix(core): handle None content in ToolMessageChunk merging

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -100,7 +100,7 @@ class BaseMessage(Serializable):
     [`SystemMessage`][langchain.messages.SystemMessage].
     """
 
-    content: str | list[str | dict]
+    content: str | list[str | dict] | None
     """The contents of the message."""
 
     additional_kwargs: dict = Field(default_factory=dict)
@@ -332,9 +332,9 @@ class BaseMessage(Serializable):
 
 
 def merge_content(
-    first_content: str | list[str | dict],
-    *contents: str | list[str | dict],
-) -> str | list[str | dict]:
+    first_content: str | list[str | dict] | None,
+    *contents: str | list[str | dict] | None,
+) -> str | list[str | dict] | None:
     """Merge multiple message contents.
 
     Args:
@@ -345,10 +345,16 @@ def merge_content(
         The merged content.
 
     """
-    merged: str | list[str | dict]
-    merged = "" if first_content is None else first_content
+    merged: str | list[str | dict] | None
+    merged = first_content
 
     for content in contents:
+        if content is None:
+            continue
+        if merged is None:
+            merged = content
+            continue
+
         # If current is a string
         if isinstance(merged, str):
             # If the next chunk is also a string, then merge them naively

--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -96,7 +96,9 @@ class ToolMessage(BaseMessage, ToolOutputMixin):
             values: The model arguments.
 
         """
-        content = values["content"]
+        content = values.get("content")
+        if content is None:
+            return values
         if isinstance(content, tuple):
             content = list(content)
 

--- a/libs/core/tests/unit_tests/messages/test_tool_chunk_merge.py
+++ b/libs/core/tests/unit_tests/messages/test_tool_chunk_merge.py
@@ -1,0 +1,52 @@
+from langchain_core.messages import ToolMessageChunk
+
+def test_tool_message_chunk_add_none_content():
+    """Test merging ToolMessageChunks with None content."""
+    chunk1 = ToolMessageChunk(
+        tool_call_id="call_123",
+        content=None,
+        id="msg1"
+    )
+    chunk2 = ToolMessageChunk(
+        tool_call_id="call_123",
+        content=None,
+        id="msg1"
+    )
+    merged = chunk1 + chunk2
+    assert merged.content is None
+
+def test_tool_message_chunk_add_none_and_str_content():
+    """Test merging ToolMessageChunks with None and string content."""
+    chunk1 = ToolMessageChunk(
+        tool_call_id="call_123",
+        content=None,
+        id="msg1"
+    )
+    chunk2 = ToolMessageChunk(
+        tool_call_id="call_123",
+        content="hello",
+        id="msg1"
+    )
+    
+    # None + Str
+    merged1 = chunk1 + chunk2
+    assert merged1.content == "hello"
+    
+    # Str + None
+    merged2 = chunk2 + chunk1
+    assert merged2.content == "hello"
+
+def test_tool_message_chunk_add_str_content():
+    """Test merging ToolMessageChunks with string content (ensure no regression)."""
+    chunk1 = ToolMessageChunk(
+        tool_call_id="call_123",
+        content="hello",
+        id="msg1"
+    )
+    chunk2 = ToolMessageChunk(
+        tool_call_id="call_123",
+        content=" world",
+        id="msg1"
+    )
+    merged = chunk1 + chunk2
+    assert merged.content == "hello world"


### PR DESCRIPTION
Fixes #34909. This PR ensures that merging ToolMessageChunks with None content does not result in 'NoneNone' strings. It updates merge_content to safely handle None values and ensures ToolMessage correctly allows None content. This is a fix for the regression identified in the issue.