### PR TITLE
fix(core): prevent crash in ParrotFakeChatModel when messages list is empty

### DIFF
--- a/libs/core/langchain_core/language_models/fake_chat_models.py
+++ b/libs/core/langchain_core/language_models/fake_chat_models.py
@@ -386,6 +386,9 @@ class ParrotFakeChatModel(BaseChatModel):
         run_manager: CallbackManagerForLLMRun | None = None,
         **kwargs: Any,
     ) -> ChatResult:
+        if not messages:
+            msg = "messages list cannot be empty."
+            raise ValueError(msg)
         return ChatResult(generations=[ChatGeneration(message=messages[-1])])
 
     @property


### PR DESCRIPTION
Fixes #34876. This PR adds a check for empty message lists in ParrotFakeChatModel._generate. Previously, it would crash with a cryptic IndexError. It now raises a more descriptive ValueError.