### PR TITLE
docs(docs): add uv sync step to local setup instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@ langchain/
 This monorepo uses `uv` for dependency management. Local development uses editable installs: `[tool.uv.sources]`
 
 Each package in `libs/` has its own `pyproject.toml` and `uv.lock`.
+Before running your tests, setup all packages by
+```bash
+# For all groups
+uv sync --all-groups
+
+# or, to install a specific group only:
+uv sync --group test
+```
 
 ```bash
 # Run unit tests (no network)


### PR DESCRIPTION
### Why

The LangChain monorepo relies on `uv` for dependency resolution and editable installs, but the initial setup instructions do not explicitly mention running `uv sync` after cloning the repository.

New contributors may encounter missing dependencies, import errors, or failing tests if this step is skipped.

### What

- Adds  `uv sync` step before the local development setup instructions.
- Does not change any runtime behaviour, APIs, or tooling.

### Review notes

- This change is documentation-only and does not affect code paths.
- Placement was chosen to align with existing "Development tools & commands" guidance.