### PR TITLE
fix(core): handle None content in ToolMessage to prevent NoneNone merge

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -96,7 +96,12 @@ class ToolMessage(BaseMessage, ToolOutputMixin):
             values: The model arguments.
 
         """
-        content = values["content"]
+        content = values.get("content")
+        if content is None:
+            # Preserve None as empty string to avoid "NoneNone" when merging chunks
+            values["content"] = ""
+            return values
+
         if isinstance(content, tuple):
             content = list(content)
 


### PR DESCRIPTION
## Summary
This PR fixes issue #34909 where merging two `ToolMessageChunk` instances with `content=None` resulted in the string `"NoneNone"` instead of an empty string.

## Problem
When creating `ToolMessageChunk` with `content=None`:
```python
chunk1 = ToolMessageChunk(tool_call_id="call_123", content=None, ...)
chunk2 = ToolMessageChunk(tool_call_id="call_123", content=None, ...)
result = chunk1 + chunk2
print(result.content)  # Output: "NoneNone" (incorrect)
```

## Root Cause
The `model_validator` in `ToolMessage` was coercing non-string/non-list content to string using `str(content)`. When `content=None`, this produced `"None"`, and merging two such chunks concatenated the strings: `"None" + "None" = "NoneNone"`.

## Solution
Explicitly check for `None` content before other coercion logic and convert it to an empty string `""`.

## After Fix
```python
chunk1 = ToolMessageChunk(tool_call_id="call_123", content=None, ...)
chunk2 = ToolMessageChunk(tool_call_id="call_123", content=None, ...)
result = chunk1 + chunk2
print(result.content)  # Output: "" (correct)
```

Fixes #34909