### PR TITLE
feat(text-splitters): Add metadata_hydrator hook to enrich chunk metadata #34954

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/base.py
+++ b/libs/text-splitters/langchain_text_splitters/base.py
@@ -52,7 +52,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         keep_separator: bool | Literal["start", "end"] = False,  # noqa: FBT001,FBT002
         add_start_index: bool = False,  # noqa: FBT001,FBT002
         strip_whitespace: bool = True,  # noqa: FBT001,FBT002
-        metadata_hydrator: Callable[[Document, int], dict] | None = None,
+        metadata_hydrator: Callable[[Document, int], dict[str, Any]] | None = None,
     ) -> None:
         """Create a new `TextSplitter`.
 

--- a/libs/text-splitters/langchain_text_splitters/base.py
+++ b/libs/text-splitters/langchain_text_splitters/base.py
@@ -52,7 +52,7 @@ class TextSplitter(BaseDocumentTransformer, ABC):
         keep_separator: bool | Literal["start", "end"] = False,  # noqa: FBT001,FBT002
         add_start_index: bool = False,  # noqa: FBT001,FBT002
         strip_whitespace: bool = True,  # noqa: FBT001,FBT002
-        metadata_hydrator: Callable[[Document, int], dict] | None = None
+        metadata_hydrator: Callable[[Document, int], dict] | None = None,
     ) -> None:
         """Create a new `TextSplitter`.
 

--- a/libs/text-splitters/tests/unit_tests/test_metadata_hydration.py
+++ b/libs/text-splitters/tests/unit_tests/test_metadata_hydration.py
@@ -1,7 +1,9 @@
 """Unit tests for metadata hydration in TextSplitter."""
-from typing import Any, Dict
+
+from typing import Any
 
 from langchain_core.documents import Document
+
 from langchain_text_splitters import CharacterTextSplitter
 
 
@@ -9,15 +11,17 @@ def test_metadata_hydration_adds_index() -> None:
     """Test that the hydrator can add a simple chunk index."""
 
     # 1. Define the logic: Add index to metadata
-    def add_index_logic(doc: Document, index: int) -> Dict[str, Any]:
+    # NOTE: '_doc' means we are ignoring this argument intentionally
+    def add_index_logic(_doc: Document, index: int) -> dict[str, Any]:
         return {"chunk_index": index}
 
     # 2. Setup Splitter with the hook
+    # chunk_size=1 ensures every word is split
     splitter = CharacterTextSplitter(
         separator=" ",
         chunk_size=1,
         chunk_overlap=0,
-        metadata_hydrator=add_index_logic
+        metadata_hydrator=add_index_logic,
     )
 
     # 3. Create documents
@@ -39,14 +43,14 @@ def test_metadata_hydration_adds_index() -> None:
 def test_metadata_hydration_preserves_existing_metadata() -> None:
     """Test that existing metadata passed to create_documents is not lost."""
 
-    def add_version(doc: Document, index: int) -> Dict[str, Any]:
+    def add_version(_doc: Document, index: int) -> dict[str, Any]:
         return {"version": "v1.0", "chunk_id": index}
 
     splitter = CharacterTextSplitter(
         separator=" ",
         chunk_size=1,
         chunk_overlap=0,
-        metadata_hydrator=add_version
+        metadata_hydrator=add_version,
     )
 
     text = "Alpha Beta"
@@ -58,19 +62,20 @@ def test_metadata_hydration_preserves_existing_metadata() -> None:
     assert len(docs) == 2
 
     # Check First Chunk
-    # "source" and "author" should come from original_metadata
-    # "version" and "chunk_id" should come from hydration
     assert docs[0].metadata["source"] == "file.txt"
     assert docs[0].metadata["author"] == "Kamran"
     assert docs[0].metadata["version"] == "v1.0"
     assert docs[0].metadata["chunk_id"] == 0
 
+    # Check Second Chunk
+    assert docs[1].metadata["source"] == "file.txt"
+    assert docs[1].metadata["chunk_id"] == 1
+
 
 def test_metadata_hydration_conditional_logic() -> None:
     """Test that hydrator can use document content to make decisions."""
 
-    def tag_important(doc: Document, index: int) -> Dict[str, Any]:
-        # Logic: If content is "Urgent", add a priority tag
+    def tag_important(doc: Document, _index: int) -> dict[str, Any]:
         if "Urgent" in doc.page_content:
             return {"priority": "high"}
         return {"priority": "normal"}
@@ -79,7 +84,7 @@ def test_metadata_hydration_conditional_logic() -> None:
         separator=" ",
         chunk_size=20,
         chunk_overlap=0,
-        metadata_hydrator=tag_important
+        metadata_hydrator=tag_important,
     )
 
     texts = ["This is Normal.", "This is Urgent!"]

--- a/libs/text-splitters/tests/unit_tests/test_metadata_hydration.py
+++ b/libs/text-splitters/tests/unit_tests/test_metadata_hydration.py
@@ -1,0 +1,90 @@
+"""Unit tests for metadata hydration in TextSplitter."""
+from typing import Any, Dict
+
+from langchain_core.documents import Document
+from langchain_text_splitters import CharacterTextSplitter
+
+
+def test_metadata_hydration_adds_index() -> None:
+    """Test that the hydrator can add a simple chunk index."""
+
+    # 1. Define the logic: Add index to metadata
+    def add_index_logic(doc: Document, index: int) -> Dict[str, Any]:
+        return {"chunk_index": index}
+
+    # 2. Setup Splitter with the hook
+    splitter = CharacterTextSplitter(
+        separator=" ",
+        chunk_size=1,
+        chunk_overlap=0,
+        metadata_hydrator=add_index_logic
+    )
+
+    # 3. Create documents
+    text = "One Two Three"
+    docs = splitter.create_documents([text])
+
+    # 4. Assertions (Check results)
+    assert len(docs) == 3
+    assert docs[0].page_content == "One"
+    assert docs[0].metadata["chunk_index"] == 0
+
+    assert docs[1].page_content == "Two"
+    assert docs[1].metadata["chunk_index"] == 1
+
+    assert docs[2].page_content == "Three"
+    assert docs[2].metadata["chunk_index"] == 2
+
+
+def test_metadata_hydration_preserves_existing_metadata() -> None:
+    """Test that existing metadata passed to create_documents is not lost."""
+
+    def add_version(doc: Document, index: int) -> Dict[str, Any]:
+        return {"version": "v1.0", "chunk_id": index}
+
+    splitter = CharacterTextSplitter(
+        separator=" ",
+        chunk_size=1,
+        chunk_overlap=0,
+        metadata_hydrator=add_version
+    )
+
+    text = "Alpha Beta"
+    # User passes existing metadata (e.g., source file name)
+    original_metadata = [{"source": "file.txt", "author": "Kamran"}]
+
+    docs = splitter.create_documents([text], metadatas=original_metadata)
+
+    assert len(docs) == 2
+
+    # Check First Chunk
+    # "source" and "author" should come from original_metadata
+    # "version" and "chunk_id" should come from hydration
+    assert docs[0].metadata["source"] == "file.txt"
+    assert docs[0].metadata["author"] == "Kamran"
+    assert docs[0].metadata["version"] == "v1.0"
+    assert docs[0].metadata["chunk_id"] == 0
+
+
+def test_metadata_hydration_conditional_logic() -> None:
+    """Test that hydrator can use document content to make decisions."""
+
+    def tag_important(doc: Document, index: int) -> Dict[str, Any]:
+        # Logic: If content is "Urgent", add a priority tag
+        if "Urgent" in doc.page_content:
+            return {"priority": "high"}
+        return {"priority": "normal"}
+
+    splitter = CharacterTextSplitter(
+        separator=" ",
+        chunk_size=20,
+        chunk_overlap=0,
+        metadata_hydrator=tag_important
+    )
+
+    texts = ["This is Normal.", "This is Urgent!"]
+    docs = splitter.create_documents(texts)
+
+    # Check logic
+    assert docs[0].metadata["priority"] == "normal"
+    assert docs[1].metadata["priority"] == "high"


### PR DESCRIPTION
## Description
This PR addresses issue #34954 by introducing an optional `metadata_hydrator` hook in `TextSplitter`. 

Currently, adding dynamic metadata (like chunk index, offsets, or custom tags) requires post-processing loops after splitting. This PR allows users to inject this logic directly during the splitting process via a callback function.

## Changes
- Modified `libs/text-splitters/langchain_text_splitters/base.py`:
  - Added `metadata_hydrator` parameter to `__init__`.
  - Updated `create_documents` to invoke the hydrator (if provided) and merge the returned dictionary into the chunk's metadata.
- Added unit tests in `libs/text-splitters/tests/unit_tests/test_metadata_hydration.py` to verify:
  - Simple index addition.
  - Preservation of existing metadata.
  - Conditional logic based on content.

## Motivation
In RAG pipelines, maintaining chunk lineage (e.g., `chunk_id: 0`, `chunk_id: 1`) is essential for advanced retrieval techniques like window retrieval. This change enables cleaner, functional pipelines without manual post-processing.

## Testing
- Added new unit tests covering the feature.
- Ran existing tests to ensure no regression.