### PR TITLE
fix(core): preserve tool_calls in InMemoryChatMessageHistory serialization

### DIFF
--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, SerializeAsAny
 
 from langchain_core.messages import (
     AIMessage,
@@ -205,7 +205,7 @@ class InMemoryChatMessageHistory(BaseChatMessageHistory, BaseModel):
     Stores messages in a memory list.
     """
 
-    messages: list[BaseMessage] = Field(default_factory=list)
+    messages: list[SerializeAsAny[BaseMessage]] = Field(default_factory=list)
     """A list of messages stored in memory."""
 
     async def aget_messages(self) -> list[BaseMessage]:


### PR DESCRIPTION
When using `InMemoryChatMessageHistory` with Pydantic v2, `tool_calls` and other subclass-specific fields of `AIMessage` are lost during serialization because the `messages` field is typed as `list[BaseMessage]`. Using `SerializeAsAny` ensures that the actual subclass fields are preserved in the output.

Fixes an issue where persisting chat history with tool calls resulted in data loss.