### PR TITLE
chore(core): fix docstring format

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -51,14 +51,22 @@ class LangSmithParams(TypedDict, total=False):
 
     ls_provider: str
     """Provider of the model."""
+
     ls_model_name: str
     """Name of the model."""
+
     ls_model_type: Literal["chat", "llm"]
-    """Type of the model. Should be 'chat' or 'llm'."""
+    """Type of the model.
+
+    Should be `'chat'` or `'llm'`.
+    """
+
     ls_temperature: float | None
     """Temperature for generation."""
+
     ls_max_tokens: int | None
     """Max tokens for generation."""
+
     ls_stop: list[str] | None
     """Stop words for generation."""
 

--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -94,9 +94,10 @@ def tool(
     unless disabled.
 
     !!! note "Requirements"
+
         - Functions should have type hints for proper schema inference.
         - Functions may accept multiple arguments and return types are flexible;
-        outputs will be serialized if needed.
+            outputs will be serialized if needed.
         - When using with `Runnable`, a string name must be provided.
 
     Args:


### PR DESCRIPTION
following #34860

list continuations must be indented for proper rendering in reference docs