### PR TITLE
fix(langchain-classic): make deprecated imports safer and more user friendly

### DIFF
--- a/libs/langchain/langchain_classic/chat_loaders/facebook_messenger.py
+++ b/libs/langchain/langchain_classic/chat_loaders/facebook_messenger.py
@@ -26,7 +26,14 @@ import_lookup = create_importer(
 
 
 def __getattr__(name: str) -> Any:
+    if name not in module_lookup:
+        raise AttributeError(
+            f"module '{__name__}' has no attribute '{name}'. "
+            f"Available: {list(module_lookup.keys())}"
+        )
     return import_lookup(name)
+
+# ...existing code...
 
 
 __all__ = ["FolderFacebookMessengerChatLoader", "SingleFileFacebookMessengerChatLoader"]


### PR DESCRIPTION
PR title:fix(langchain-classic): make deprecated imports safer and more user friendly


PR description:

This PR tightens the deprecated import shim by validating attribute access in __getattr__. Unsupported attribute names now raise a clear AttributeError listing the available deprecated loader names, while valid names continue to be resolved via create_importer`.

Breaking changes: None.
Fixes: N/A.
Depends on: N/A.

Testing:

make format

make lint

make test

AI disclaimer: N/A
