### PR TITLE
fix(deepseek): with_structured_output input validation

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable, Iterator, Sequence
+from inspect import isclass
 from json import JSONDecodeError
 from typing import Any, Literal, TypeAlias, cast
 
@@ -516,6 +517,26 @@ class ChatDeepSeek(BaseChatOpenAI):
                     depends on the `schema` as described above.
                 - `'parsing_error'`: `BaseException | None`
         """
+        if schema is not None and not (
+            isinstance(schema, dict)
+            or (
+                isclass(schema)
+                and (
+                    issubclass(schema, BaseModel)
+                    or (
+                        hasattr(schema, "__annotations__")
+                        and hasattr(schema, "__total__")
+                    )
+                )
+            )
+        ):
+            error_str = (
+                "schema must be a dict, TypedDict class, or "
+                "Pydantic BaseModel subclass; "
+                f"got {schema!r} ({type(schema).__name__})"
+            )
+            raise TypeError(error_str)
+
         # Some applications require that incompatible parameters (e.g., unsupported
         # methods) be handled.
         if method == "json_schema":

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -15,7 +15,6 @@ from pydantic import Field, SecretStr
 
 from langchain_deepseek.chat_models import DEFAULT_API_BASE, ChatDeepSeek
 
-DEEPSEEK_API_KEY = "abc"
 MODEL_NAME = "deepseek-chat"
 
 

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from enum import Enum
+from typing import Any, Literal, cast
 from unittest.mock import MagicMock
 
 from langchain_core.messages import AIMessageChunk, ToolMessage
@@ -309,17 +310,25 @@ class TestChatDeepSeekStrictMode:
         assert structured_model is not None
 
     def test_with_structured_output_typing_schema_raises(self) -> None:
+        """Test that invalid typing-based schemas raise a TypeError."""
         llm = ChatDeepSeek(
             model="deepseek-chat",
             api_key=SecretStr("test_key"),
         )
 
+        class InvalidSchemaEnum(Enum):
+            A = "a"
+            B = "b"
+
+        invalid_schema = cast("Any", InvalidSchemaEnum)
+
         try:
-            llm.with_structured_output(list[int])
-        except TypeError as exc:
-            assert "schema must be a dict" in str(exc)
-        else:
-            assert False, "TypeError was not raised"
+            llm.with_structured_output(invalid_schema)
+        except TypeError:
+            return
+
+        assertion_str = "TypeError was not raised for invalid schema type"
+        raise AssertionError(assertion_str)
 
 
 def test_profile() -> None:

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -15,6 +15,7 @@ from pydantic import Field, SecretStr
 
 from langchain_deepseek.chat_models import DEFAULT_API_BASE, ChatDeepSeek
 
+DEEPSEEK_API_KEY = "abc"
 MODEL_NAME = "deepseek-chat"
 
 

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -308,6 +308,19 @@ class TestChatDeepSeekStrictMode:
         # The structured model should work with beta endpoint
         assert structured_model is not None
 
+    def test_with_structured_output_typing_schema_raises(self) -> None:
+        llm = ChatDeepSeek(
+            model="deepseek-chat",
+            api_key=SecretStr("test_key"),
+        )
+
+        try:
+            llm.with_structured_output(list[int])
+        except TypeError as exc:
+            assert "schema must be a dict" in str(exc)
+        else:
+            assert False, "TypeError was not raised"
+
 
 def test_profile() -> None:
     """Test that model profile is loaded correctly."""


### PR DESCRIPTION
Fixes #34970

This PR adds explicit validation for the schema argument in with_structured_output, raising a clear TypeError when an unsupported schema type is provided instead of failing later in the pipeline. It also introduces a unit test to ensure invalid schema types are rejected early and consistently.