### PR TITLE
fix(core): reject Enum schemas in with_structured_output

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import inspect
+from enum import Enum
+
 import asyncio
 import inspect
 import json
@@ -1691,6 +1694,12 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         if type(self).bind_tools is BaseChatModel.bind_tools:
             msg = "with_structured_output is not implemented for this model."
             raise NotImplementedError(msg)
+
+        if inspect.isclass(schema) and issubclass(schema, Enum):
+            raise ValueError(
+                "Enum is not a valid schema for with_structured_output. "
+                "Wrap the Enum inside a Pydantic BaseModel instead."
+            )
 
         llm = self.bind_tools(
             [schema],

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_with_structured_output_rejects_enum.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_with_structured_output_rejects_enum.py
@@ -1,0 +1,35 @@
+import pytest
+from enum import Enum
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.runnables import Runnable
+
+
+class DummyChatModel(BaseChatModel):
+    @property
+    def _llm_type(self) -> str:
+        return "dummy"
+
+    def bind_tools(self, tools, **kwargs) -> Runnable:
+        return self
+
+    def _generate(self, messages, stop=None, **kwargs):
+        raise RuntimeError("Should never be called")
+
+    async def _agenerate(self, messages, stop=None, **kwargs):
+        raise RuntimeError("Should never be called")
+
+
+class MyStatus(Enum):
+    TODO = "To Do"
+    SUCCESSFUL = "Successful"
+    FAILED = "Failed"
+
+
+def test_with_structured_output_rejects_enum_schema():
+    model = DummyChatModel()
+
+    with pytest.raises(ValueError) as exc_info:
+        model.with_structured_output(MyStatus)
+
+    assert "Enum is not a valid schema" in str(exc_info.value)


### PR DESCRIPTION
with_structured_output currently accepts Enum classes as schemas, silently treating them as callables and producing invalid structured outputs (e.g. empty parameter schemas) instead of failing fast.

This change adds early validation in BaseChatModel.with_structured_output to reject Enum schemas with a clear error message, and includes a regression test to prevent future regressions.

Fixes #34970


