### PR TITLE
fix: support tools parameter in with_structured_output function_calling mode

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2101,7 +2101,11 @@ class BaseChatOpenAI(BaseChatModel):
                 }
             )
 
-            llm = self.bind_tools([schema], **bind_kwargs)
+            tools_to_bind = [schema]
+            if tools:
+                tools_to_bind.extend(tools)
+
+            llm = self.bind_tools(tools_to_bind, **bind_kwargs)
             if is_pydantic_schema:
                 output_parser: Runnable = PydanticToolsParser(
                     tools=[schema],  # type: ignore[list-item]


### PR DESCRIPTION
## Problem
When using `with_structured_output(method="function_calling")`, the `tools` parameter is ignored, causing previously bound tools to be lost.

## Solution
Modified `with_structured_output` to merge additional tools when provided via the `tools` parameter, similar to how `method="json_schema"` already works.

## Changes
- Modified `with_structured_output()` to extend tools list instead of replacing it

## Example
```python
llm = ChatOpenAI(model="gpt-4o")

# Now works - tools are preserved
llm = llm.with_structured_output(
    Schema,
    method="function_calling",
    tools=[{"type": "web_search"}]
)
```



  