### PR TITLE
feat(core): allow scaling by reported usage when counting tokens approximately

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2227,6 +2227,13 @@ def count_tokens_approximately(
     """
     token_count = 0.0
     for message in convert_to_messages(messages):
+        if (
+            isinstance(message, AIMessage)
+            and message.usage_metadata
+            and (output_tokens := message.usage_metadata.get("output_tokens"))
+        ):
+            token_count += output_tokens
+            continue
         message_chars = 0
 
         if isinstance(message.content, str):

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2319,7 +2319,8 @@ def count_tokens_approximately(
         and approx_at_last_ai
         and approx_at_last_ai > 0
     ):
-        token_count *= last_ai_total_tokens / approx_at_last_ai
+        scale_factor = last_ai_total_tokens / approx_at_last_ai
+        token_count *= max(1.0, scale_factor)
 
     # round up once more time in case extra_tokens_per_message is a float
     return math.ceil(token_count)

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1594,6 +1594,19 @@ def test_count_tokens_approximately_mixed_content_types() -> None:
     assert sum(count_tokens_approximately([m]) for m in messages) == token_count
 
 
+def test_count_tokens_approximately_usage_metadata() -> None:
+    messages = [
+        HumanMessage("Hello"),
+        AIMessage(
+            [],
+            usage_metadata={"input_tokens": 6, "output_tokens": 50, "total_tokens": 56},
+        ),
+        AIMessage("Hello"),
+    ]
+    min_expected = 60
+    assert count_tokens_approximately(messages) > min_expected
+
+
 def test_get_buffer_string_with_structured_content() -> None:
     """Test get_buffer_string with structured content in messages."""
     messages = [

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1673,6 +1673,25 @@ def test_count_tokens_approximately_usage_metadata_scaling_total_tokens() -> Non
     assert scaled == unscaled
 
 
+def test_count_tokens_approximately_usage_metadata_scaling_floor_at_one() -> None:
+    messages = [
+        HumanMessage("text"),
+        AIMessage(
+            "text",
+            response_metadata={"model_provider": "openai"},
+            # Set total_tokens lower than the approximate count up through this message.
+            usage_metadata={"input_tokens": 0, "output_tokens": 0, "total_tokens": 1},
+        ),
+        HumanMessage("text"),
+    ]
+
+    unscaled = count_tokens_approximately(messages)
+    scaled = count_tokens_approximately(messages, use_usage_metadata_scaling=True)
+
+    # scale factor would be < 1, but we floor it at 1.0 to avoid decreasing counts
+    assert scaled == unscaled
+
+
 def test_get_buffer_string_with_structured_content() -> None:
     """Test get_buffer_string with structured content in messages."""
     messages = [


### PR DESCRIPTION
```
user message
ai message <-- approx says 75 tokens total, usage_metadata says 100
tool message
tool message
ai message <-- approx says 200 tokens total, usage_metadata says 400
tool message <-- approx says 250 tokens total
```
Here we add a boolean kwarg to `count_tokens_approximately`. When enabled, we scale token counts by comparing the approximate token counts as of the most recent AIMessage with the reported total in that message.

So in the above example, we'd compute `ratio = 400 / 200 = 2` and scale the total approximate token counts: `250 * 2 = 500`.

**Important consideration**: after summarization, these counts will no longer monotonically increase. So we will see:
```
summarization message
ai message <-- approx says 20 tokens total, usage_metadata says 100
tool message
ai message <-- approx says 30 tokens total, usage_metadata says 50
```
We only ever take reported token counts from the most recent AIMessage. Because summarization happens in `before_model`, we should always get an AIMessage appended to the message history with valid counts after it.

Also, we only engage this if all AIMessages have consistent values for `model_provider`, as a precaution against mixing models. Although there are edge cases where we could scale by the tokens reported for another provider.