### PR TITLE
fix(chroma): remove Python 3.14 classifier until Chroma supports it

### DIFF
--- a/libs/partners/chroma/pyproject.toml
+++ b/libs/partners/chroma/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 requires-python = ">=3.10.0,<4.0.0"


### PR DESCRIPTION
## Description

Removes the Python 3.14 classifier from `langchain-chroma` since Chroma doesn't officially support Python 3.14 yet.

## Issue

Fixes #34995

## Context

- Chroma's Python 3.14 support is still in progress: https://github.com/chroma-core/chroma/issues/4029
- The classifier was mistakenly added in #34980

## Changes

- Removed `Programming Language :: Python :: 3.14` from `libs/partners/chroma/pyproject.toml`