### PR TITLE
revert: use usage metadata scaling in SummarizationMiddleware default token counter

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -144,10 +144,8 @@ def _get_approximate_token_counter(model: BaseChatModel) -> TokenCounter:
     if model._llm_type == "anthropic-chat":  # noqa: SLF001
         # 3.3 was estimated in an offline experiment, comparing with Claude's token-counting
         # API: https://platform.claude.com/docs/en/build-with-claude/token-counting
-        return partial(
-            count_tokens_approximately, chars_per_token=3.3, use_usage_metadata_scaling=True
-        )
-    return partial(count_tokens_approximately, use_usage_metadata_scaling=True)
+        return partial(count_tokens_approximately, chars_per_token=3.3)
+    return count_tokens_approximately
 
 
 class SummarizationMiddleware(AgentMiddleware):


### PR DESCRIPTION
Reverts langchain-ai/langchain#35001

Need to get system message into messages for which we count tokens.
```
(system message hidden)
user message
ai message  <-- approximate 50 tokens, reported 10,000 tokens
```
this causes the scale factor to be very large (~200), which could cause us to prematurely summarize.