### PR TITLE
fix(core): handle None content in ToolMessageChunk merge

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -96,7 +96,9 @@ class ToolMessage(BaseMessage, ToolOutputMixin):
             values: The model arguments.
 
         """
-        content = values["content"]
+        content = values.get("content")
+        if content is None:
+            return values
         if isinstance(content, tuple):
             content = list(content)
 


### PR DESCRIPTION
## Summary
- Fixes issue where merging two `ToolMessageChunk` instances with `content=None` resulted in `"NoneNone"` string instead of `None`
- The `coerce_args` validator was converting `None` to `"None"` string before the merge

## Changes
- Added early return in `coerce_args` when content is `None` to preserve the value

## Test
```python
from langchain_core.messages import ToolMessageChunk

chunk1 = ToolMessageChunk(tool_call_id="call_123", content=None)
chunk2 = ToolMessageChunk(tool_call_id="call_123", content=None)

result = chunk1 + chunk2
print(result.content)  # Now correctly prints: None (was: "NoneNone")
```

Fixes #34909

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)