### PR TITLE
chore(standard-tests): bump down to 1.1.3

### DIFF
--- a/libs/standard-tests/pyproject.toml
+++ b/libs/standard-tests/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.1.4"
+version = "1.1.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.2.7,<2.0.0",

--- a/libs/standard-tests/uv.lock
+++ b/libs/standard-tests/uv.lock
@@ -381,7 +381,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.4"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
We didn't release 1.1.3 yet, so bumping down so we can release.