### PR TITLE
fix(core): make `self` positional-only in `_run`/`_arun` to allow "self" as tool input key

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -775,21 +775,29 @@ class ChildTool(BaseTool):
         return tool_input
 
     @abstractmethod
-    def _run(self, *args: Any, **kwargs: Any) -> Any:
+    def _run(self, /, *args: Any, **kwargs: Any) -> Any:
         """Use the tool.
 
         Add `run_manager: CallbackManagerForToolRun | None = None` to child
         implementations to enable tracing.
 
+        Note: ``self`` is positional-only so that callers can pass a keyword
+        argument named ``"self"`` (e.g. from user-supplied tool input) without
+        colliding with the method receiver.
+
         Returns:
             The result of the tool execution.
         """
 
-    async def _arun(self, *args: Any, **kwargs: Any) -> Any:
+    async def _arun(self, /, *args: Any, **kwargs: Any) -> Any:
         """Use the tool asynchronously.
 
         Add `run_manager: AsyncCallbackManagerForToolRun | None = None` to child
         implementations to enable tracing.
+
+        Note: ``self`` is positional-only so that callers can pass a keyword
+        argument named ``"self"`` (e.g. from user-supplied tool input) without
+        colliding with the method receiver.
 
         Returns:
             The result of the tool execution.

--- a/libs/core/langchain_core/tools/simple.py
+++ b/libs/core/langchain_core/tools/simple.py
@@ -98,6 +98,7 @@ class Tool(BaseTool):
 
     def _run(
         self,
+        /,
         *args: Any,
         config: RunnableConfig,
         run_manager: CallbackManagerForToolRun | None = None,
@@ -125,6 +126,7 @@ class Tool(BaseTool):
 
     async def _arun(
         self,
+        /,
         *args: Any,
         config: RunnableConfig,
         run_manager: AsyncCallbackManagerForToolRun | None = None,

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -73,6 +73,7 @@ class StructuredTool(BaseTool):
 
     def _run(
         self,
+        /,
         *args: Any,
         config: RunnableConfig,
         run_manager: CallbackManagerForToolRun | None = None,
@@ -100,6 +101,7 @@ class StructuredTool(BaseTool):
 
     async def _arun(
         self,
+        /,
         *args: Any,
         config: RunnableConfig,
         run_manager: AsyncCallbackManagerForToolRun | None = None,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3654,6 +3654,7 @@ def test_tool_default_factory_not_required() -> None:
     params = schema["function"]["parameters"]
     assert "names" not in params.get("required", [])
 
+
 def test_tool_invoke_with_self_keyword_in_input() -> None:
     """Tool invocation should not fail when input contains a key named 'self'.
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3702,4 +3702,3 @@ async def test_tool_ainvoke_with_self_keyword_in_input() -> None:
     # Should not raise TypeError about multiple values for 'self'
     result = await structured.ainvoke(tool_input)
     assert result == repr(tool_input)
-

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3653,3 +3653,53 @@ def test_tool_default_factory_not_required() -> None:
     schema = convert_to_openai_tool(some_func)
     params = schema["function"]["parameters"]
     assert "names" not in params.get("required", [])
+
+def test_tool_invoke_with_self_keyword_in_input() -> None:
+    """Tool invocation should not fail when input contains a key named 'self'.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/34900.
+    """
+
+    def func(**kwargs: Any) -> str:
+        return repr(kwargs)
+
+    structured = StructuredTool(
+        name="test_tool",
+        func=func,
+        args_schema={
+            "type": "object",
+            "properties": {},
+        },
+    )
+
+    tool_input = {"self": 2, "other": 3}
+
+    # Should not raise TypeError about multiple values for 'self'
+    result = structured.invoke(tool_input)
+    assert result == repr(tool_input)
+
+
+async def test_tool_ainvoke_with_self_keyword_in_input() -> None:
+    """Async tool invocation should not fail when input contains a key named 'self'.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/34900.
+    """
+
+    async def async_func(**kwargs: Any) -> str:
+        return repr(kwargs)
+
+    structured = StructuredTool(
+        name="test_tool",
+        coroutine=async_func,
+        args_schema={
+            "type": "object",
+            "properties": {},
+        },
+    )
+
+    tool_input = {"self": 2, "other": 3}
+
+    # Should not raise TypeError about multiple values for 'self'
+    result = await structured.ainvoke(tool_input)
+    assert result == repr(tool_input)
+


### PR DESCRIPTION
## Summary

- Fixes `BaseTool` failing with `TypeError: got multiple values for argument 'self'` when tool input contains a key named `"self"` (e.g. `tool.invoke({"self": 2})`)
- Adds the positional-only parameter marker (`/`) after `self` in `_run` and `_arun` across `BaseTool`, `StructuredTool`, and `Tool`, so Python routes user-supplied `"self"` into `**kwargs` instead of conflicting with the method receiver
- Adds sync and async regression tests

Closes #34900

## Test plan

- [x] New unit test `test_tool_invoke_with_self_keyword_in_input` verifies sync invocation with `"self"` in input
- [x] New unit test `test_tool_ainvoke_with_self_keyword_in_input` verifies async invocation with `"self"` in input
- [x] Full existing test suite passes (157 passed, 4 skipped) with no regressions

## Review notes

The change is minimal -- just adding `/` after `self` in the method signatures. This is a non-breaking change: all existing subclass overrides of `_run`/`_arun` continue to work exactly as before. The positional-only marker only affects whether Python allows `self=...` as a keyword argument at the call site; it does not change how the method is dispatched or overridden.

Note that user-defined `BaseTool` subclasses that override `_run` without `self, /` will still hit this issue if they receive `"self"` as a keyword argument. However, the built-in tool classes (`StructuredTool`, `Tool`) and the `@tool` decorator -- which cover the vast majority of usage -- are all fixed.