### PR TITLE
docs(langchain-classic): clarify MultiVectorRetriever usage

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/multi_vector.py
+++ b/libs/langchain/langchain_classic/retrievers/multi_vector.py
@@ -41,9 +41,6 @@ class MultiVectorRetriever(BaseRetriever):
     This pattern is commonly used in RAG pipelines to improve answer grounding
     while preserving full document context.
     """
-
-
-
     vectorstore: VectorStore
     """The underlying `VectorStore` to use to store small chunks
     and their embedding vectors"""

--- a/libs/langchain/langchain_classic/retrievers/multi_vector.py
+++ b/libs/langchain/langchain_classic/retrievers/multi_vector.py
@@ -27,21 +27,22 @@ class SearchType(str, Enum):
 
 
 class MultiVectorRetriever(BaseRetriever):
+  class MultiVectorRetriever(BaseRetriever):
+    """Retriever that supports multiple embeddings per parent document.
+
+    This retriever is designed for scenarios where documents are split into
+    smaller chunks for embedding and vector search, but retrieval returns
+    the original parent documents rather than individual chunks.
+
+    It works by:
+    - Performing similarity (or MMR) search over embedded child chunks
+    - Collecting unique parent document IDs from chunk metadata
+    - Fetching and returning the corresponding parent documents from the docstore
+
+    This pattern is commonly used in RAG pipelines to improve answer grounding
+    while preserving full document context.
     """
-Retriever that supports multiple embeddings per parent document.
 
-This retriever is designed for scenarios where documents are split into
-smaller chunks for embedding and vector search, but retrieval should return
-the original parent documents rather than individual chunks.
-
-It works by:
-- Performing similarity (or MMR) search over embedded child chunks
-- Collecting unique parent document IDs from chunk metadata
-- Fetching and returning the corresponding parent documents from the docstore
-
-This pattern is commonly used in RAG pipelines to improve answer grounding
-while preserving full document context.
-"""
 
 
     vectorstore: VectorStore

--- a/libs/langchain/langchain_classic/retrievers/multi_vector.py
+++ b/libs/langchain/langchain_classic/retrievers/multi_vector.py
@@ -27,7 +27,6 @@ class SearchType(str, Enum):
 
 
 class MultiVectorRetriever(BaseRetriever):
-  class MultiVectorRetriever(BaseRetriever):
     """Retriever that supports multiple embeddings per parent document.
 
     This retriever is designed for scenarios where documents are split into

--- a/libs/langchain/langchain_classic/retrievers/multi_vector.py
+++ b/libs/langchain/langchain_classic/retrievers/multi_vector.py
@@ -41,6 +41,7 @@ class MultiVectorRetriever(BaseRetriever):
     This pattern is commonly used in RAG pipelines to improve answer grounding
     while preserving full document context.
     """
+
     vectorstore: VectorStore
     """The underlying `VectorStore` to use to store small chunks
     and their embedding vectors"""

--- a/libs/langchain/langchain_classic/retrievers/multi_vector.py
+++ b/libs/langchain/langchain_classic/retrievers/multi_vector.py
@@ -27,7 +27,22 @@ class SearchType(str, Enum):
 
 
 class MultiVectorRetriever(BaseRetriever):
-    """Retrieve from a set of multiple embeddings for the same document."""
+    """
+Retriever that supports multiple embeddings per parent document.
+
+This retriever is designed for scenarios where documents are split into
+smaller chunks for embedding and vector search, but retrieval should return
+the original parent documents rather than individual chunks.
+
+It works by:
+- Performing similarity (or MMR) search over embedded child chunks
+- Collecting unique parent document IDs from chunk metadata
+- Fetching and returning the corresponding parent documents from the docstore
+
+This pattern is commonly used in RAG pipelines to improve answer grounding
+while preserving full document context.
+"""
+
 
     vectorstore: VectorStore
     """The underlying `VectorStore` to use to store small chunks


### PR DESCRIPTION
### Summary
Improves the class-level documentation for `MultiVectorRetriever` by expanding
the docstring to clearly explain its purpose, behavior, and common usage
patterns.

### Details
The previous docstring was very minimal for a retriever that is frequently used
in RAG pipelines. This update adds context around when and why
`MultiVectorRetriever` should be used, without changing any runtime behavior.

### Verification
Documentation-only change. No functional logic was modified.

### Notes
No breaking changes.
