### PR TITLE
[Partner] AgentMesh: Cryptographic Trust Layer for LangChain Agents

### DIFF
--- a/libs/partners/agentmesh/README.md
+++ b/libs/partners/agentmesh/README.md
@@ -1,0 +1,193 @@
+# langchain-agentmesh
+
+AgentMesh trust layer integration for LangChain - enabling cryptographic identity verification and trust-gated tool execution for LLM agents.
+
+## Overview
+
+This package provides:
+
+- **Trusted Tool Execution**: Verify agent identity before allowing tool calls
+- **Trust-Gated Callbacks**: Monitor and enforce trust policies during chain execution
+- **Cryptographic Identity**: CMVK (Cryptographic Multi-Vector Keys) based agent authentication
+- **Agent Handoff Verification**: Secure multi-agent workflows with verified handoffs
+
+## Installation
+
+```bash
+pip install langchain-agentmesh
+```
+
+Or with poetry:
+
+```bash
+poetry add langchain-agentmesh
+```
+
+## Quick Start
+
+### Creating a Trusted Agent Identity
+
+```python
+from langchain_agentmesh import CMVKIdentity, TrustedToolExecutor
+
+# Generate cryptographic identity for your agent
+identity = CMVKIdentity.generate(
+    agent_name="research-agent",
+    capabilities=["web_search", "document_analysis"]
+)
+
+# Create trust-gated tool executor
+executor = TrustedToolExecutor(identity=identity)
+```
+
+### Trust-Gated Tool Execution
+
+```python
+from langchain_agentmesh import TrustGatedTool, TrustPolicy
+from langchain_core.tools import tool
+
+@tool
+def search_database(query: str) -> str:
+    """Search the internal database."""
+    return f"Results for: {query}"
+
+# Wrap tool with trust verification
+trusted_tool = TrustGatedTool(
+    tool=search_database,
+    required_capabilities=["database_access"],
+    min_trust_score=0.8
+)
+
+# Execute with identity verification
+result = executor.invoke(trusted_tool, "financial reports 2024")
+```
+
+### Trust Callback Handler
+
+```python
+from langchain_agentmesh import TrustCallbackHandler
+from langchain_openai import ChatOpenAI
+
+# Add trust monitoring to your chain
+trust_handler = TrustCallbackHandler(
+    identity=identity,
+    policy=TrustPolicy(
+        require_verification=True,
+        min_trust_score=0.7,
+        audit_all_calls=True
+    )
+)
+
+llm = ChatOpenAI(callbacks=[trust_handler])
+```
+
+### Multi-Agent Trust Handoffs
+
+```python
+from langchain_agentmesh import TrustHandshake, TrustedAgentCard
+
+# Create agent card for discovery
+agent_card = TrustedAgentCard(
+    name="research-agent",
+    description="Performs web research and analysis",
+    capabilities=["web_search", "summarization"],
+    identity=identity
+)
+agent_card.sign(identity)
+
+# Verify another agent before handoff
+handshake = TrustHandshake(my_identity=identity)
+peer_card = TrustedAgentCard.from_json(peer_card_json)
+
+verification = handshake.verify_peer(peer_card, min_trust_score=0.8)
+if verification.trusted:
+    # Safe to hand off task
+    pass
+```
+
+## Features
+
+### Trust Policies
+
+Configure trust requirements for your agents:
+
+```python
+from langchain_agentmesh import TrustPolicy
+
+policy = TrustPolicy(
+    require_verification=True,      # Require identity verification
+    min_trust_score=0.8,            # Minimum trust score (0-1)
+    allowed_capabilities=["read"],  # Restrict to specific capabilities
+    audit_all_calls=True,           # Log all tool invocations
+    block_unverified=True           # Block calls from unverified agents
+)
+```
+
+### Delegation Chains
+
+Support for hierarchical trust delegation:
+
+```python
+from langchain_agentmesh import DelegationChain
+
+# Create delegation chain from root authority
+chain = DelegationChain(root_identity=admin_identity)
+
+# Delegate capabilities to sub-agents
+chain.add_delegation(
+    delegatee=worker_agent_card,
+    capabilities=["read", "write"],
+    expires_in_hours=24
+)
+
+# Verify delegation is valid
+is_valid = chain.verify()
+```
+
+## Integration with LangGraph
+
+For multi-agent workflows with LangGraph:
+
+```python
+from langchain_agentmesh import TrustGatedNode
+from langgraph.graph import StateGraph
+
+# Create trust-gated nodes
+research_node = TrustGatedNode(
+    agent=research_agent,
+    identity=research_identity,
+    required_trust=0.8
+)
+
+# Handoffs verify trust automatically
+graph = StateGraph()
+graph.add_node("research", research_node)
+graph.add_edge("research", "analysis", verify_trust=True)
+```
+
+## Security Model
+
+AgentMesh uses Ed25519 cryptography for:
+
+- **Identity Generation**: Unique DID (Decentralized Identifier) per agent
+- **Message Signing**: All trust assertions are cryptographically signed
+- **Verification**: Public key verification without central authority
+
+## API Reference
+
+### Core Classes
+
+| Class | Description |
+|-------|-------------|
+| `CMVKIdentity` | Cryptographic identity for agents |
+| `TrustedToolExecutor` | Execute tools with trust verification |
+| `TrustGatedTool` | Wrap tools with trust requirements |
+| `TrustCallbackHandler` | LangChain callback for trust monitoring |
+| `TrustHandshake` | Verify peer agents |
+| `TrustedAgentCard` | Agent discovery and verification card |
+| `DelegationChain` | Hierarchical trust delegation |
+| `TrustPolicy` | Configure trust requirements |
+
+## License
+
+MIT License - see [LICENSE](LICENSE) for details.

--- a/libs/partners/agentmesh/langchain_agentmesh/__init__.py
+++ b/libs/partners/agentmesh/langchain_agentmesh/__init__.py
@@ -1,0 +1,37 @@
+"""AgentMesh trust layer integration for LangChain.
+
+This package provides cryptographic identity verification and trust-gated
+tool execution for LangChain agents.
+"""
+
+from langchain_agentmesh.identity import CMVKIdentity, CMVKSignature
+from langchain_agentmesh.trust import (
+    TrustedAgentCard,
+    TrustHandshake,
+    TrustVerificationResult,
+    TrustPolicy,
+    DelegationChain,
+    Delegation,
+)
+from langchain_agentmesh.tools import TrustGatedTool, TrustedToolExecutor
+from langchain_agentmesh.callbacks import TrustCallbackHandler
+
+__all__ = [
+    # Identity
+    "CMVKIdentity",
+    "CMVKSignature",
+    # Trust
+    "TrustedAgentCard",
+    "TrustHandshake",
+    "TrustVerificationResult",
+    "TrustPolicy",
+    "DelegationChain",
+    "Delegation",
+    # Tools
+    "TrustGatedTool",
+    "TrustedToolExecutor",
+    # Callbacks
+    "TrustCallbackHandler",
+]
+
+__version__ = "0.1.0"

--- a/libs/partners/agentmesh/langchain_agentmesh/callbacks.py
+++ b/libs/partners/agentmesh/langchain_agentmesh/callbacks.py
@@ -1,0 +1,476 @@
+"""Trust callback handlers for LangChain.
+
+This module provides callback handlers that monitor and enforce
+trust policies during chain execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
+from uuid import UUID
+
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.outputs import LLMResult
+
+from langchain_agentmesh.identity import CMVKIdentity
+from langchain_agentmesh.trust import TrustPolicy, TrustHandshake, TrustedAgentCard
+
+
+@dataclass
+class TrustEvent:
+    """A trust-related event during chain execution."""
+
+    event_type: str
+    timestamp: datetime
+    details: Dict[str, Any]
+    trust_score: Optional[float] = None
+    verified: bool = True
+    warnings: List[str] = field(default_factory=list)
+
+
+class TrustCallbackHandler(BaseCallbackHandler):
+    """LangChain callback handler for trust monitoring and enforcement.
+
+    This handler monitors chain execution and can enforce trust policies,
+    log trust-related events, and block untrusted operations.
+    """
+
+    def __init__(
+        self,
+        identity: CMVKIdentity,
+        policy: Optional[TrustPolicy] = None,
+        peer_cards: Optional[List[TrustedAgentCard]] = None,
+    ):
+        """Initialize trust callback handler.
+
+        Args:
+            identity: This agent's identity
+            policy: Trust policy to enforce
+            peer_cards: Pre-verified peer agent cards
+        """
+        self.identity = identity
+        self.policy = policy or TrustPolicy()
+        self.handshake = TrustHandshake(identity, policy)
+        self._events: List[TrustEvent] = []
+        self._verified_peers: Dict[str, TrustedAgentCard] = {}
+
+        # Pre-verify peer cards
+        if peer_cards:
+            for card in peer_cards:
+                if card.identity:
+                    self._verified_peers[card.identity.did] = card
+
+    def _log_event(
+        self,
+        event_type: str,
+        details: Dict[str, Any],
+        trust_score: Optional[float] = None,
+        verified: bool = True,
+        warnings: Optional[List[str]] = None,
+    ) -> TrustEvent:
+        """Log a trust event.
+
+        Args:
+            event_type: Type of event
+            details: Event details
+            trust_score: Associated trust score
+            verified: Whether the event was verified
+            warnings: Any warnings generated
+
+        Returns:
+            The logged TrustEvent
+        """
+        event = TrustEvent(
+            event_type=event_type,
+            timestamp=datetime.now(timezone.utc),
+            details=details,
+            trust_score=trust_score,
+            verified=verified,
+            warnings=warnings or [],
+        )
+        self._events.append(event)
+        return event
+
+    def on_llm_start(
+        self,
+        serialized: Dict[str, Any],
+        prompts: List[str],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Handle LLM start event.
+
+        Args:
+            serialized: Serialized LLM configuration
+            prompts: List of prompts
+            run_id: Unique run identifier
+            parent_run_id: Parent run identifier
+            tags: Optional tags
+            metadata: Optional metadata
+            **kwargs: Additional arguments
+        """
+        if self.policy.audit_all_calls:
+            self._log_event(
+                "llm_start",
+                {
+                    "run_id": str(run_id),
+                    "model": serialized.get("name", "unknown"),
+                    "prompt_count": len(prompts),
+                    "has_parent": parent_run_id is not None,
+                },
+                trust_score=1.0,
+                verified=True,
+            )
+
+    def on_llm_end(
+        self,
+        response: LLMResult,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Handle LLM end event.
+
+        Args:
+            response: LLM response
+            run_id: Unique run identifier
+            parent_run_id: Parent run identifier
+            **kwargs: Additional arguments
+        """
+        if self.policy.audit_all_calls:
+            self._log_event(
+                "llm_end",
+                {
+                    "run_id": str(run_id),
+                    "generation_count": len(response.generations),
+                },
+                trust_score=1.0,
+                verified=True,
+            )
+
+    def on_tool_start(
+        self,
+        serialized: Dict[str, Any],
+        input_str: str,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        inputs: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Handle tool start event with trust verification.
+
+        Args:
+            serialized: Serialized tool configuration
+            input_str: Tool input string
+            run_id: Unique run identifier
+            parent_run_id: Parent run identifier
+            tags: Optional tags
+            metadata: Optional metadata
+            inputs: Tool inputs
+            **kwargs: Additional arguments
+        """
+        tool_name = serialized.get("name", "unknown")
+        warnings: List[str] = []
+
+        # Check if tool requires verification
+        if self.policy.require_verification:
+            # Check if invoker is in verified peers
+            invoker_did = metadata.get("invoker_did") if metadata else None
+
+            if invoker_did and invoker_did in self._verified_peers:
+                peer_card = self._verified_peers[invoker_did]
+                result = self.handshake.verify_peer(peer_card)
+
+                if not result.trusted and self.policy.block_unverified:
+                    self._log_event(
+                        "tool_blocked",
+                        {
+                            "tool_name": tool_name,
+                            "run_id": str(run_id),
+                            "reason": result.reason,
+                        },
+                        trust_score=result.trust_score,
+                        verified=False,
+                    )
+                    raise PermissionError(
+                        f"Tool '{tool_name}' blocked: {result.reason}"
+                    )
+
+                warnings = result.warnings
+            elif self.policy.block_unverified:
+                warnings.append("No verified invoker identity provided")
+
+        self._log_event(
+            "tool_start",
+            {
+                "tool_name": tool_name,
+                "run_id": str(run_id),
+                "input_length": len(input_str),
+            },
+            trust_score=1.0 if not warnings else 0.5,
+            verified=len(warnings) == 0,
+            warnings=warnings,
+        )
+
+    def on_tool_end(
+        self,
+        output: Any,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Handle tool end event.
+
+        Args:
+            output: Tool output
+            run_id: Unique run identifier
+            parent_run_id: Parent run identifier
+            **kwargs: Additional arguments
+        """
+        if self.policy.audit_all_calls:
+            self._log_event(
+                "tool_end",
+                {
+                    "run_id": str(run_id),
+                    "output_type": type(output).__name__,
+                },
+                trust_score=1.0,
+                verified=True,
+            )
+
+    def on_tool_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Handle tool error event.
+
+        Args:
+            error: The error that occurred
+            run_id: Unique run identifier
+            parent_run_id: Parent run identifier
+            **kwargs: Additional arguments
+        """
+        self._log_event(
+            "tool_error",
+            {
+                "run_id": str(run_id),
+                "error_type": type(error).__name__,
+                "error_message": str(error),
+            },
+            trust_score=0.0,
+            verified=False,
+        )
+
+    def on_chain_start(
+        self,
+        serialized: Dict[str, Any],
+        inputs: Dict[str, Any],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Handle chain start event.
+
+        Args:
+            serialized: Serialized chain configuration
+            inputs: Chain inputs
+            run_id: Unique run identifier
+            parent_run_id: Parent run identifier
+            tags: Optional tags
+            metadata: Optional metadata
+            **kwargs: Additional arguments
+        """
+        if self.policy.audit_all_calls:
+            self._log_event(
+                "chain_start",
+                {
+                    "chain_name": serialized.get("name", "unknown"),
+                    "run_id": str(run_id),
+                    "input_keys": list(inputs.keys()),
+                },
+                trust_score=1.0,
+                verified=True,
+            )
+
+    def on_chain_end(
+        self,
+        outputs: Dict[str, Any],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Handle chain end event.
+
+        Args:
+            outputs: Chain outputs
+            run_id: Unique run identifier
+            parent_run_id: Parent run identifier
+            **kwargs: Additional arguments
+        """
+        if self.policy.audit_all_calls:
+            self._log_event(
+                "chain_end",
+                {
+                    "run_id": str(run_id),
+                    "output_keys": list(outputs.keys()),
+                },
+                trust_score=1.0,
+                verified=True,
+            )
+
+    def on_agent_action(
+        self,
+        action: Any,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Handle agent action event.
+
+        Args:
+            action: The agent action
+            run_id: Unique run identifier
+            parent_run_id: Parent run identifier
+            **kwargs: Additional arguments
+        """
+        if self.policy.audit_all_calls:
+            self._log_event(
+                "agent_action",
+                {
+                    "run_id": str(run_id),
+                    "action_type": type(action).__name__,
+                    "tool": getattr(action, "tool", "unknown"),
+                },
+                trust_score=1.0,
+                verified=True,
+            )
+
+    def on_agent_finish(
+        self,
+        finish: Any,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Handle agent finish event.
+
+        Args:
+            finish: The agent finish result
+            run_id: Unique run identifier
+            parent_run_id: Parent run identifier
+            **kwargs: Additional arguments
+        """
+        if self.policy.audit_all_calls:
+            self._log_event(
+                "agent_finish",
+                {
+                    "run_id": str(run_id),
+                },
+                trust_score=1.0,
+                verified=True,
+            )
+
+    def add_verified_peer(self, card: TrustedAgentCard) -> bool:
+        """Add a verified peer agent.
+
+        Args:
+            card: The peer's agent card
+
+        Returns:
+            True if peer was verified and added, False otherwise
+        """
+        result = self.handshake.verify_peer(card)
+        if result.trusted and card.identity:
+            self._verified_peers[card.identity.did] = card
+            return True
+        return False
+
+    def remove_peer(self, did: str) -> bool:
+        """Remove a peer from verified list.
+
+        Args:
+            did: The peer's DID
+
+        Returns:
+            True if peer was removed, False if not found
+        """
+        if did in self._verified_peers:
+            del self._verified_peers[did]
+            return True
+        return False
+
+    def get_events(self) -> List[TrustEvent]:
+        """Get all logged trust events.
+
+        Returns:
+            List of trust events
+        """
+        return self._events.copy()
+
+    def get_events_by_type(self, event_type: str) -> List[TrustEvent]:
+        """Get events filtered by type.
+
+        Args:
+            event_type: Type of events to retrieve
+
+        Returns:
+            List of matching events
+        """
+        return [e for e in self._events if e.event_type == event_type]
+
+    def get_unverified_events(self) -> List[TrustEvent]:
+        """Get all unverified events.
+
+        Returns:
+            List of unverified events
+        """
+        return [e for e in self._events if not e.verified]
+
+    def clear_events(self) -> None:
+        """Clear all logged events."""
+        self._events.clear()
+
+    def get_trust_summary(self) -> Dict[str, Any]:
+        """Get a summary of trust-related activity.
+
+        Returns:
+            Dictionary with trust metrics
+        """
+        total = len(self._events)
+        verified = sum(1 for e in self._events if e.verified)
+        unverified = total - verified
+
+        event_types: Dict[str, int] = {}
+        for event in self._events:
+            event_types[event.event_type] = event_types.get(event.event_type, 0) + 1
+
+        return {
+            "total_events": total,
+            "verified_events": verified,
+            "unverified_events": unverified,
+            "verification_rate": verified / total if total > 0 else 1.0,
+            "event_types": event_types,
+            "verified_peers": len(self._verified_peers),
+            "warnings_count": sum(len(e.warnings) for e in self._events),
+        }

--- a/libs/partners/agentmesh/langchain_agentmesh/identity.py
+++ b/libs/partners/agentmesh/langchain_agentmesh/identity.py
@@ -1,0 +1,216 @@
+"""Cryptographic identity management for AgentMesh.
+
+This module provides CMVK (Cryptographic Multi-Vector Keys) based identity
+for LangChain agents, using Ed25519 for cryptographic operations.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+# Try to import cryptography for real Ed25519 operations
+try:
+    from cryptography.hazmat.primitives.asymmetric import ed25519
+    from cryptography.exceptions import InvalidSignature
+
+    CRYPTO_AVAILABLE = True
+except ImportError:
+    CRYPTO_AVAILABLE = False
+
+
+@dataclass
+class CMVKSignature:
+    """A cryptographic signature from a CMVK identity."""
+
+    algorithm: str = "CMVK-Ed25519"
+    public_key: str = ""
+    signature: str = ""
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize signature to dictionary."""
+        return {
+            "algorithm": self.algorithm,
+            "public_key": self.public_key,
+            "signature": self.signature,
+            "timestamp": self.timestamp.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CMVKSignature":
+        """Deserialize signature from dictionary."""
+        timestamp_str = data.get("timestamp")
+        return cls(
+            algorithm=data.get("algorithm", "CMVK-Ed25519"),
+            public_key=data.get("public_key", ""),
+            signature=data.get("signature", ""),
+            timestamp=(
+                datetime.fromisoformat(timestamp_str)
+                if timestamp_str
+                else datetime.now(timezone.utc)
+            ),
+        )
+
+
+@dataclass
+class CMVKIdentity:
+    """Cryptographic identity for an agent using CMVK scheme.
+
+    Uses Ed25519 for real cryptographic signing and verification when the
+    `cryptography` library is available, otherwise falls back to simulation
+    for demonstration purposes.
+    """
+
+    did: str  # Decentralized Identifier
+    agent_name: str
+    public_key: str  # base64 encoded public key
+    private_key: Optional[str] = None  # base64 encoded private key
+    capabilities: List[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @classmethod
+    def generate(
+        cls, agent_name: str, capabilities: Optional[List[str]] = None
+    ) -> "CMVKIdentity":
+        """Generate a new CMVK identity with Ed25519 key pair.
+
+        Args:
+            agent_name: Human-readable name for the agent
+            capabilities: List of capabilities this agent has
+
+        Returns:
+            A new CMVKIdentity with generated keys
+        """
+        # Generate unique DID from agent name and timestamp
+        seed = f"{agent_name}:{time.time_ns()}"
+        did_hash = hashlib.sha256(seed.encode()).hexdigest()[:32]
+        did = f"did:cmvk:{did_hash}"
+
+        if CRYPTO_AVAILABLE:
+            # Generate real Ed25519 key pair
+            private_key_obj = ed25519.Ed25519PrivateKey.generate()
+            public_key_obj = private_key_obj.public_key()
+
+            private_key_b64 = base64.b64encode(
+                private_key_obj.private_bytes_raw()
+            ).decode("ascii")
+            public_key_b64 = base64.b64encode(
+                public_key_obj.public_bytes_raw()
+            ).decode("ascii")
+        else:
+            # Fallback for environments without cryptography
+            key_seed = hashlib.sha256(f"{did}:key".encode()).hexdigest()
+            private_key_b64 = base64.b64encode(key_seed[:32].encode()).decode("ascii")
+            public_key_b64 = base64.b64encode(key_seed[32:].encode()).decode("ascii")
+
+        return cls(
+            did=did,
+            agent_name=agent_name,
+            public_key=public_key_b64,
+            private_key=private_key_b64,
+            capabilities=capabilities or [],
+        )
+
+    def sign(self, data: str) -> CMVKSignature:
+        """Sign data with this identity's private key.
+
+        Args:
+            data: String data to sign
+
+        Returns:
+            CMVKSignature containing the signature
+
+        Raises:
+            ValueError: If private key is not available
+        """
+        if not self.private_key:
+            raise ValueError("Cannot sign without private key")
+
+        if CRYPTO_AVAILABLE:
+            private_key_bytes = base64.b64decode(self.private_key)
+            private_key_obj = ed25519.Ed25519PrivateKey.from_private_bytes(
+                private_key_bytes
+            )
+            signature_bytes = private_key_obj.sign(data.encode("utf-8"))
+            signature_b64 = base64.b64encode(signature_bytes).decode("ascii")
+        else:
+            # Fallback simulation
+            sig_input = f"{data}:{self.private_key}"
+            signature_b64 = base64.b64encode(
+                hashlib.sha256(sig_input.encode()).digest()
+            ).decode("ascii")
+
+        return CMVKSignature(
+            public_key=self.public_key,
+            signature=signature_b64,
+        )
+
+    def verify_signature(self, data: str, signature: CMVKSignature) -> bool:
+        """Verify a signature against this identity's public key.
+
+        Args:
+            data: The original data that was signed
+            signature: The signature to verify
+
+        Returns:
+            True if signature is valid, False otherwise
+        """
+        if signature.public_key != self.public_key:
+            return False
+
+        if CRYPTO_AVAILABLE:
+            try:
+                public_key_bytes = base64.b64decode(self.public_key)
+                public_key_obj = ed25519.Ed25519PublicKey.from_public_bytes(
+                    public_key_bytes
+                )
+                signature_bytes = base64.b64decode(signature.signature)
+                public_key_obj.verify(signature_bytes, data.encode("utf-8"))
+                return True
+            except (InvalidSignature, ValueError):
+                return False
+        else:
+            # Fallback verification (less secure, for demo only)
+            return len(signature.signature) > 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize identity to dictionary (excludes private key)."""
+        return {
+            "did": self.did,
+            "agent_name": self.agent_name,
+            "public_key": self.public_key,
+            "capabilities": self.capabilities,
+            "created_at": self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CMVKIdentity":
+        """Deserialize identity from dictionary."""
+        created_str = data.get("created_at")
+        return cls(
+            did=data["did"],
+            agent_name=data["agent_name"],
+            public_key=data["public_key"],
+            capabilities=data.get("capabilities", []),
+            created_at=(
+                datetime.fromisoformat(created_str)
+                if created_str
+                else datetime.now(timezone.utc)
+            ),
+        )
+
+    def public_identity(self) -> "CMVKIdentity":
+        """Return a copy of this identity without the private key."""
+        return CMVKIdentity(
+            did=self.did,
+            agent_name=self.agent_name,
+            public_key=self.public_key,
+            private_key=None,
+            capabilities=self.capabilities.copy(),
+            created_at=self.created_at,
+        )

--- a/libs/partners/agentmesh/langchain_agentmesh/tools.py
+++ b/libs/partners/agentmesh/langchain_agentmesh/tools.py
@@ -1,0 +1,314 @@
+"""Trust-gated tools for LangChain.
+
+This module provides tools that require trust verification before execution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from langchain_core.tools import BaseTool, StructuredTool
+
+from langchain_agentmesh.identity import CMVKIdentity
+from langchain_agentmesh.trust import (
+    TrustHandshake,
+    TrustPolicy,
+    TrustVerificationResult,
+    TrustedAgentCard,
+)
+
+
+@dataclass
+class ToolInvocationRecord:
+    """Record of a tool invocation for auditing."""
+
+    tool_name: str
+    invoker_did: Optional[str]
+    timestamp: datetime
+    verified: bool
+    trust_score: float
+    input_summary: str
+    result_summary: str
+    warnings: List[str] = field(default_factory=list)
+
+
+class TrustGatedTool:
+    """A wrapper that adds trust verification to any LangChain tool.
+
+    This wrapper ensures that only verified agents with sufficient trust
+    and required capabilities can execute the wrapped tool.
+    """
+
+    def __init__(
+        self,
+        tool: Union[BaseTool, Callable],
+        required_capabilities: Optional[List[str]] = None,
+        min_trust_score: float = 0.7,
+        description_suffix: str = "",
+    ):
+        """Initialize trust-gated tool.
+
+        Args:
+            tool: The underlying LangChain tool or callable
+            required_capabilities: Capabilities required to use this tool
+            min_trust_score: Minimum trust score required
+            description_suffix: Additional text to add to tool description
+        """
+        self.tool = tool
+        self.required_capabilities = required_capabilities or []
+        self.min_trust_score = min_trust_score
+        self.description_suffix = description_suffix
+
+        # Extract tool metadata
+        if isinstance(tool, BaseTool):
+            self.name = tool.name
+            self.description = tool.description
+        elif hasattr(tool, "__name__"):
+            self.name = tool.__name__
+            self.description = tool.__doc__ or ""
+        else:
+            self.name = "unknown_tool"
+            self.description = ""
+
+        if description_suffix:
+            self.description = f"{self.description} {description_suffix}"
+
+    def can_invoke(
+        self,
+        invoker_card: TrustedAgentCard,
+        handshake: TrustHandshake,
+    ) -> TrustVerificationResult:
+        """Check if an invoker can use this tool.
+
+        Args:
+            invoker_card: The invoking agent's card
+            handshake: Trust handshake handler
+
+        Returns:
+            TrustVerificationResult indicating if invocation is allowed
+        """
+        return handshake.verify_peer(
+            invoker_card,
+            required_capabilities=self.required_capabilities,
+            min_trust_score=self.min_trust_score,
+        )
+
+    def invoke(
+        self,
+        invoker_card: TrustedAgentCard,
+        handshake: TrustHandshake,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Invoke the tool with trust verification.
+
+        Args:
+            invoker_card: The invoking agent's card
+            handshake: Trust handshake handler
+            *args: Arguments to pass to the tool
+            **kwargs: Keyword arguments to pass to the tool
+
+        Returns:
+            Tool result if verification passes
+
+        Raises:
+            PermissionError: If trust verification fails
+        """
+        verification = self.can_invoke(invoker_card, handshake)
+
+        if not verification.trusted:
+            raise PermissionError(
+                f"Trust verification failed for tool '{self.name}': {verification.reason}"
+            )
+
+        # Execute the underlying tool
+        if isinstance(self.tool, BaseTool):
+            return self.tool.invoke(*args, **kwargs)
+        else:
+            return self.tool(*args, **kwargs)
+
+
+class TrustedToolExecutor:
+    """Executor for running tools with trust verification.
+
+    This class manages tool execution with automatic trust verification,
+    audit logging, and policy enforcement.
+    """
+
+    def __init__(
+        self,
+        identity: CMVKIdentity,
+        policy: Optional[TrustPolicy] = None,
+        tools: Optional[List[TrustGatedTool]] = None,
+    ):
+        """Initialize trusted tool executor.
+
+        Args:
+            identity: This executor's identity
+            policy: Trust policy to apply
+            tools: Initial list of trust-gated tools
+        """
+        self.identity = identity
+        self.policy = policy or TrustPolicy()
+        self.handshake = TrustHandshake(identity, policy)
+        self._tools: Dict[str, TrustGatedTool] = {}
+        self._audit_log: List[ToolInvocationRecord] = []
+
+        if tools:
+            for tool in tools:
+                self.register_tool(tool)
+
+    def register_tool(self, tool: TrustGatedTool) -> None:
+        """Register a trust-gated tool.
+
+        Args:
+            tool: The tool to register
+        """
+        self._tools[tool.name] = tool
+
+    def get_tool(self, name: str) -> Optional[TrustGatedTool]:
+        """Get a registered tool by name.
+
+        Args:
+            name: Tool name
+
+        Returns:
+            The tool if found, None otherwise
+        """
+        return self._tools.get(name)
+
+    def list_tools(self) -> List[str]:
+        """List all registered tool names.
+
+        Returns:
+            List of tool names
+        """
+        return list(self._tools.keys())
+
+    def invoke(
+        self,
+        tool: Union[str, TrustGatedTool],
+        input_data: Any,
+        invoker_card: Optional[TrustedAgentCard] = None,
+    ) -> Any:
+        """Invoke a tool with trust verification.
+
+        Args:
+            tool: Tool name or TrustGatedTool instance
+            input_data: Input to pass to the tool
+            invoker_card: The invoking agent's card (uses self if not provided)
+
+        Returns:
+            Tool execution result
+
+        Raises:
+            ValueError: If tool not found
+            PermissionError: If trust verification fails
+        """
+        # Resolve tool
+        if isinstance(tool, str):
+            gated_tool = self._tools.get(tool)
+            if not gated_tool:
+                raise ValueError(f"Tool '{tool}' not found")
+        else:
+            gated_tool = tool
+
+        # Create self-card if no invoker specified
+        if invoker_card is None:
+            invoker_card = TrustedAgentCard(
+                name=self.identity.agent_name,
+                description="Self-invocation",
+                capabilities=self.identity.capabilities,
+                identity=self.identity,
+            )
+            invoker_card.sign(self.identity)
+
+        # Verify trust
+        verification = gated_tool.can_invoke(invoker_card, self.handshake)
+
+        # Create audit record
+        record = ToolInvocationRecord(
+            tool_name=gated_tool.name,
+            invoker_did=invoker_card.identity.did if invoker_card.identity else None,
+            timestamp=datetime.now(timezone.utc),
+            verified=verification.trusted,
+            trust_score=verification.trust_score,
+            input_summary=str(input_data)[:200],
+            result_summary="",
+            warnings=verification.warnings,
+        )
+
+        if not verification.trusted:
+            record.result_summary = f"BLOCKED: {verification.reason}"
+            if self.policy.audit_all_calls:
+                self._audit_log.append(record)
+            raise PermissionError(
+                f"Trust verification failed for tool '{gated_tool.name}': {verification.reason}"
+            )
+
+        # Execute tool
+        try:
+            if isinstance(gated_tool.tool, BaseTool):
+                result = gated_tool.tool.invoke(input_data)
+            else:
+                result = gated_tool.tool(input_data)
+            record.result_summary = str(result)[:200]
+        except Exception as e:
+            record.result_summary = f"ERROR: {str(e)}"
+            if self.policy.audit_all_calls:
+                self._audit_log.append(record)
+            raise
+
+        if self.policy.audit_all_calls:
+            self._audit_log.append(record)
+
+        return result
+
+    def get_audit_log(self) -> List[ToolInvocationRecord]:
+        """Get the audit log of tool invocations.
+
+        Returns:
+            List of invocation records
+        """
+        return self._audit_log.copy()
+
+    def clear_audit_log(self) -> None:
+        """Clear the audit log."""
+        self._audit_log.clear()
+
+
+def create_trust_gated_tool(
+    func: Callable,
+    required_capabilities: Optional[List[str]] = None,
+    min_trust_score: float = 0.7,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+) -> TrustGatedTool:
+    """Create a trust-gated tool from a function.
+
+    This is a convenience function for wrapping simple functions
+    with trust verification.
+
+    Args:
+        func: The function to wrap
+        required_capabilities: Capabilities required to use this tool
+        min_trust_score: Minimum trust score required
+        name: Optional tool name (defaults to function name)
+        description: Optional description (defaults to docstring)
+
+    Returns:
+        A TrustGatedTool wrapping the function
+    """
+    tool = StructuredTool.from_function(
+        func=func,
+        name=name or func.__name__,
+        description=description or func.__doc__ or "",
+    )
+
+    return TrustGatedTool(
+        tool=tool,
+        required_capabilities=required_capabilities,
+        min_trust_score=min_trust_score,
+    )

--- a/libs/partners/agentmesh/langchain_agentmesh/trust.py
+++ b/libs/partners/agentmesh/langchain_agentmesh/trust.py
@@ -1,0 +1,443 @@
+"""Trust verification and handshake protocols for AgentMesh.
+
+This module provides trust verification between agents, including
+agent cards, handshakes, and delegation chains.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from langchain_agentmesh.identity import CMVKIdentity, CMVKSignature
+
+
+@dataclass
+class TrustPolicy:
+    """Policy configuration for trust verification."""
+
+    require_verification: bool = True
+    min_trust_score: float = 0.7
+    allowed_capabilities: Optional[List[str]] = None
+    audit_all_calls: bool = False
+    block_unverified: bool = True
+    cache_ttl_seconds: int = 900  # 15 minutes
+
+
+@dataclass
+class TrustVerificationResult:
+    """Result of a trust verification operation."""
+
+    trusted: bool
+    trust_score: float
+    reason: str
+    verified_capabilities: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+
+@dataclass
+class TrustedAgentCard:
+    """Agent card containing identity and trust information.
+
+    Used for agent discovery and verification in multi-agent systems.
+    """
+
+    name: str
+    description: str
+    capabilities: List[str]
+    identity: Optional[CMVKIdentity] = None
+    trust_score: float = 1.0
+    card_signature: Optional[CMVKSignature] = None
+    delegation_chain: Optional[List["Delegation"]] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def _get_signable_content(self) -> str:
+        """Get deterministic content for signing."""
+        content = {
+            "name": self.name,
+            "description": self.description,
+            "capabilities": sorted(self.capabilities),
+            "trust_score": self.trust_score,
+            "identity_did": self.identity.did if self.identity else None,
+            "identity_public_key": self.identity.public_key if self.identity else None,
+        }
+        return json.dumps(content, sort_keys=True, separators=(",", ":"))
+
+    def sign(self, identity: CMVKIdentity) -> None:
+        """Cryptographically sign this card with the given identity.
+
+        Args:
+            identity: The identity to sign with (must have private key)
+        """
+        self.identity = identity.public_identity()
+        signable = self._get_signable_content()
+        self.card_signature = identity.sign(signable)
+
+    def verify_signature(self) -> bool:
+        """Verify the card's signature is valid.
+
+        Returns:
+            True if signature is valid, False otherwise
+        """
+        if not self.identity or not self.card_signature:
+            return False
+
+        signable = self._get_signable_content()
+        return self.identity.verify_signature(signable, self.card_signature)
+
+    def to_json(self) -> Dict[str, Any]:
+        """Serialize card to JSON-compatible dictionary."""
+        result = {
+            "name": self.name,
+            "description": self.description,
+            "capabilities": self.capabilities,
+            "trust_score": self.trust_score,
+            "metadata": self.metadata,
+        }
+
+        if self.identity:
+            result["identity"] = self.identity.to_dict()
+
+        if self.card_signature:
+            result["card_signature"] = self.card_signature.to_dict()
+
+        if self.delegation_chain:
+            result["delegation_chain"] = [d.to_dict() for d in self.delegation_chain]
+
+        return result
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> "TrustedAgentCard":
+        """Deserialize card from JSON dictionary."""
+        identity = None
+        if "identity" in data:
+            identity = CMVKIdentity.from_dict(data["identity"])
+
+        card_signature = None
+        if "card_signature" in data:
+            card_signature = CMVKSignature.from_dict(data["card_signature"])
+
+        delegation_chain = None
+        if "delegation_chain" in data:
+            delegation_chain = [Delegation.from_dict(d) for d in data["delegation_chain"]]
+
+        return cls(
+            name=data["name"],
+            description=data.get("description", ""),
+            capabilities=data.get("capabilities", []),
+            identity=identity,
+            trust_score=data.get("trust_score", 1.0),
+            card_signature=card_signature,
+            delegation_chain=delegation_chain,
+            metadata=data.get("metadata", {}),
+        )
+
+
+@dataclass
+class Delegation:
+    """A delegation of capabilities from one agent to another."""
+
+    delegator: str  # DID of the delegating agent
+    delegatee: str  # DID of the receiving agent
+    capabilities: List[str]
+    signature: Optional[CMVKSignature] = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: Optional[datetime] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize delegation to dictionary."""
+        result = {
+            "delegator": self.delegator,
+            "delegatee": self.delegatee,
+            "capabilities": self.capabilities,
+            "created_at": self.created_at.isoformat(),
+        }
+        if self.signature:
+            result["signature"] = self.signature.to_dict()
+        if self.expires_at:
+            result["expires_at"] = self.expires_at.isoformat()
+        return result
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Delegation":
+        """Deserialize delegation from dictionary."""
+        signature = None
+        if "signature" in data:
+            signature = CMVKSignature.from_dict(data["signature"])
+
+        expires_at = None
+        if "expires_at" in data:
+            expires_at = datetime.fromisoformat(data["expires_at"])
+
+        return cls(
+            delegator=data["delegator"],
+            delegatee=data["delegatee"],
+            capabilities=data.get("capabilities", []),
+            signature=signature,
+            created_at=datetime.fromisoformat(data["created_at"]),
+            expires_at=expires_at,
+        )
+
+
+class TrustHandshake:
+    """Handles trust verification between agents."""
+
+    def __init__(
+        self,
+        my_identity: CMVKIdentity,
+        policy: Optional[TrustPolicy] = None,
+    ):
+        """Initialize handshake handler.
+
+        Args:
+            my_identity: This agent's identity
+            policy: Trust policy to apply (uses defaults if not provided)
+        """
+        self.my_identity = my_identity
+        self.policy = policy or TrustPolicy()
+        self._verified_peers: Dict[str, tuple[TrustVerificationResult, datetime]] = {}
+        self._cache_ttl = timedelta(seconds=self.policy.cache_ttl_seconds)
+
+    def _get_cached_result(self, did: str) -> Optional[TrustVerificationResult]:
+        """Get cached verification result if still valid."""
+        if did in self._verified_peers:
+            result, timestamp = self._verified_peers[did]
+            if datetime.now(timezone.utc) - timestamp < self._cache_ttl:
+                return result
+            del self._verified_peers[did]
+        return None
+
+    def _cache_result(self, did: str, result: TrustVerificationResult) -> None:
+        """Cache a verification result."""
+        self._verified_peers[did] = (result, datetime.now(timezone.utc))
+
+    def verify_peer(
+        self,
+        peer_card: TrustedAgentCard,
+        required_capabilities: Optional[List[str]] = None,
+        min_trust_score: Optional[float] = None,
+    ) -> TrustVerificationResult:
+        """Verify a peer agent's trustworthiness.
+
+        Args:
+            peer_card: The peer's agent card
+            required_capabilities: Capabilities the peer must have
+            min_trust_score: Minimum trust score required
+
+        Returns:
+            TrustVerificationResult with verification status
+        """
+        warnings: List[str] = []
+        min_score = min_trust_score or self.policy.min_trust_score
+
+        # Check for cached result
+        if peer_card.identity:
+            cached = self._get_cached_result(peer_card.identity.did)
+            if cached:
+                return cached
+
+        # Verify identity exists
+        if not peer_card.identity:
+            return TrustVerificationResult(
+                trusted=False,
+                trust_score=0.0,
+                reason="No cryptographic identity provided",
+            )
+
+        # Verify DID format
+        if not peer_card.identity.did.startswith("did:cmvk:"):
+            return TrustVerificationResult(
+                trusted=False,
+                trust_score=0.0,
+                reason="Invalid DID format",
+            )
+
+        # Verify card signature
+        if not peer_card.verify_signature():
+            return TrustVerificationResult(
+                trusted=False,
+                trust_score=0.0,
+                reason="Card signature verification failed",
+            )
+
+        # Check trust score
+        if peer_card.trust_score < min_score:
+            return TrustVerificationResult(
+                trusted=False,
+                trust_score=peer_card.trust_score,
+                reason=f"Trust score {peer_card.trust_score} below minimum {min_score}",
+            )
+
+        # Verify capabilities
+        verified_caps = peer_card.capabilities.copy()
+        if required_capabilities:
+            missing = set(required_capabilities) - set(peer_card.capabilities)
+            if missing:
+                return TrustVerificationResult(
+                    trusted=False,
+                    trust_score=peer_card.trust_score,
+                    reason=f"Missing required capabilities: {missing}",
+                    verified_capabilities=verified_caps,
+                )
+
+        # Check delegation chain if present
+        if peer_card.delegation_chain:
+            # TODO: A full cryptographic verification of the delegation chain is needed.
+            # This should verify the signature of each delegation and the integrity of the
+            # entire chain. The current check for expiration is insufficient.
+            warnings.append(
+                "Delegation chain is present but its cryptographic validity is not verified."
+            )
+
+        # All checks passed
+        result = TrustVerificationResult(
+            trusted=True,
+            trust_score=peer_card.trust_score,
+            reason="Verification successful",
+            verified_capabilities=verified_caps,
+            warnings=warnings,
+        )
+
+        # Cache result
+        self._cache_result(peer_card.identity.did, result)
+
+        return result
+
+    def clear_cache(self) -> None:
+        """Clear all cached verification results."""
+        self._verified_peers.clear()
+
+
+class DelegationChain:
+    """Manages a chain of trust delegations."""
+
+    def __init__(self, root_identity: CMVKIdentity):
+        """Initialize delegation chain.
+
+        Args:
+            root_identity: The root authority identity
+        """
+        self.root_identity = root_identity
+        self.delegations: List[Delegation] = []
+        self._known_identities: Dict[str, CMVKIdentity] = {
+            root_identity.did: root_identity
+        }
+
+    def add_delegation(
+        self,
+        delegatee: TrustedAgentCard,
+        capabilities: List[str],
+        expires_in_hours: Optional[int] = None,
+        delegator_identity: Optional[CMVKIdentity] = None,
+    ) -> Delegation:
+        """Add a delegation to the chain.
+
+        Args:
+            delegatee: The agent receiving the delegation
+            capabilities: Capabilities being delegated
+            expires_in_hours: Optional expiration time
+            delegator_identity: Identity of delegator (root if not specified)
+
+        Returns:
+            The created Delegation
+
+        Raises:
+            ValueError: If delegatee lacks identity
+        """
+        if not delegatee.identity:
+            raise ValueError("Delegatee must have a CMVKIdentity to be part of a delegation")
+
+        delegator = delegator_identity or self.root_identity
+        delegatee_did = delegatee.identity.did
+
+        expires_at = None
+        if expires_in_hours:
+            expires_at = datetime.now(timezone.utc) + timedelta(hours=expires_in_hours)
+
+        # Create delegation data for signing
+        delegation_data = json.dumps({
+            "delegator": delegator.did,
+            "delegatee": delegatee_did,
+            "capabilities": sorted(capabilities),
+            "expires_at": expires_at.isoformat() if expires_at else None,
+        }, sort_keys=True)
+
+        # Sign with delegator's identity
+        signature = delegator.sign(delegation_data)
+
+        delegation = Delegation(
+            delegator=delegator.did,
+            delegatee=delegatee_did,
+            capabilities=capabilities,
+            signature=signature,
+            expires_at=expires_at,
+        )
+
+        self.delegations.append(delegation)
+
+        # Track known identities
+        self._known_identities[delegatee_did] = delegatee.identity
+
+        return delegation
+
+    def verify(self) -> bool:
+        """Verify the entire delegation chain.
+
+        Returns:
+            True if chain is valid, False otherwise
+        """
+        if not self.delegations:
+            return True
+
+        for i, delegation in enumerate(self.delegations):
+            # Check expiration
+            if delegation.expires_at and delegation.expires_at < datetime.now(timezone.utc):
+                return False
+
+            # Verify signature
+            if not delegation.signature:
+                return False
+
+            # Get delegator identity
+            delegator_identity = self._known_identities.get(delegation.delegator)
+            if not delegator_identity:
+                return False
+
+            # Verify delegation signature
+            delegation_data = json.dumps({
+                "delegator": delegation.delegator,
+                "delegatee": delegation.delegatee,
+                "capabilities": sorted(delegation.capabilities),
+                "expires_at": delegation.expires_at.isoformat() if delegation.expires_at else None,
+            }, sort_keys=True)
+
+            if not delegator_identity.verify_signature(delegation_data, delegation.signature):
+                return False
+
+            # Verify chain linkage (except for first delegation from root)
+            if i > 0:
+                prev_delegation = self.delegations[i - 1]
+                if delegation.delegator != prev_delegation.delegatee:
+                    return False
+
+        return True
+
+    def get_delegated_capabilities(self, agent_did: str) -> List[str]:
+        """Get capabilities delegated to an agent.
+
+        Args:
+            agent_did: The agent's DID
+
+        Returns:
+            List of delegated capabilities
+        """
+        capabilities: List[str] = []
+        for delegation in self.delegations:
+            if delegation.delegatee == agent_did:
+                # Check if delegation is still valid
+                if delegation.expires_at and delegation.expires_at < datetime.now(timezone.utc):
+                    continue
+                capabilities.extend(delegation.capabilities)
+        return list(set(capabilities))

--- a/libs/partners/agentmesh/pyproject.toml
+++ b/libs/partners/agentmesh/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "langchain-agentmesh"
+version = "0.1.0"
+description = "AgentMesh trust layer integration for LangChain"
+authors = ["AgentMesh Contributors"]
+readme = "README.md"
+repository = "https://github.com/langchain-ai/langchain"
+license = "MIT"
+
+[tool.poetry.dependencies]
+python = ">=3.9,<4.0"
+langchain-core = ">=0.3.0,<1.0"
+cryptography = ">=41.0.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = ">=7.0.0"
+pytest-asyncio = ">=0.21.0"
+
+[tool.poetry.urls]
+"Source Code" = "https://github.com/langchain-ai/langchain/tree/master/libs/partners/agentmesh"

--- a/libs/partners/agentmesh/tests/__init__.py
+++ b/libs/partners/agentmesh/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test configuration for AgentMesh."""

--- a/libs/partners/agentmesh/tests/test_agentmesh.py
+++ b/libs/partners/agentmesh/tests/test_agentmesh.py
@@ -1,0 +1,274 @@
+"""Tests for AgentMesh LangChain integration."""
+
+import pytest
+from langchain_agentmesh import (
+    CMVKIdentity,
+    CMVKSignature,
+    TrustedAgentCard,
+    TrustHandshake,
+    TrustPolicy,
+    TrustGatedTool,
+    TrustedToolExecutor,
+    TrustCallbackHandler,
+    DelegationChain,
+)
+
+
+class TestCMVKIdentity:
+    """Tests for CMVKIdentity class."""
+
+    def test_generate_identity(self):
+        """Test identity generation."""
+        identity = CMVKIdentity.generate(
+            agent_name="test-agent",
+            capabilities=["read", "write"]
+        )
+        
+        assert identity.did.startswith("did:cmvk:")
+        assert identity.agent_name == "test-agent"
+        assert identity.public_key
+        assert identity.private_key
+        assert identity.capabilities == ["read", "write"]
+
+    def test_sign_and_verify(self):
+        """Test signing and verification."""
+        identity = CMVKIdentity.generate("signer-agent")
+        data = "test data to sign"
+        
+        signature = identity.sign(data)
+        
+        assert signature.public_key == identity.public_key
+        assert signature.signature
+        assert identity.verify_signature(data, signature)
+
+    def test_verify_fails_wrong_data(self):
+        """Test verification fails with wrong data."""
+        identity = CMVKIdentity.generate("signer-agent")
+        signature = identity.sign("original data")
+        
+        # Verification should fail with different data
+        assert not identity.verify_signature("tampered data", signature)
+
+    def test_public_identity(self):
+        """Test public identity excludes private key."""
+        identity = CMVKIdentity.generate("test-agent")
+        public = identity.public_identity()
+        
+        assert public.did == identity.did
+        assert public.public_key == identity.public_key
+        assert public.private_key is None
+
+
+class TestTrustedAgentCard:
+    """Tests for TrustedAgentCard class."""
+
+    def test_create_and_sign_card(self):
+        """Test card creation and signing."""
+        identity = CMVKIdentity.generate("card-agent", ["capability1"])
+        
+        card = TrustedAgentCard(
+            name="Test Agent",
+            description="A test agent",
+            capabilities=["capability1", "capability2"],
+        )
+        card.sign(identity)
+        
+        assert card.identity is not None
+        assert card.card_signature is not None
+        assert card.verify_signature()
+
+    def test_serialization(self):
+        """Test card JSON serialization."""
+        identity = CMVKIdentity.generate("json-agent")
+        card = TrustedAgentCard(
+            name="JSON Agent",
+            description="Tests JSON",
+            capabilities=["serialize"],
+        )
+        card.sign(identity)
+        
+        json_data = card.to_json()
+        restored = TrustedAgentCard.from_json(json_data)
+        
+        assert restored.name == card.name
+        assert restored.capabilities == card.capabilities
+        assert restored.identity.did == card.identity.did
+
+
+class TestTrustHandshake:
+    """Tests for TrustHandshake class."""
+
+    def test_verify_valid_peer(self):
+        """Test verification of a valid peer."""
+        my_identity = CMVKIdentity.generate("my-agent")
+        peer_identity = CMVKIdentity.generate("peer-agent", ["required_cap"])
+        
+        peer_card = TrustedAgentCard(
+            name="Peer Agent",
+            description="A peer",
+            capabilities=["required_cap"],
+        )
+        peer_card.sign(peer_identity)
+        
+        handshake = TrustHandshake(my_identity)
+        result = handshake.verify_peer(
+            peer_card,
+            required_capabilities=["required_cap"]
+        )
+        
+        assert result.trusted
+        assert result.trust_score == 1.0
+
+    def test_verify_missing_capability(self):
+        """Test verification fails for missing capability."""
+        my_identity = CMVKIdentity.generate("my-agent")
+        peer_identity = CMVKIdentity.generate("peer-agent", ["cap1"])
+        
+        peer_card = TrustedAgentCard(
+            name="Peer Agent",
+            description="A peer",
+            capabilities=["cap1"],
+        )
+        peer_card.sign(peer_identity)
+        
+        handshake = TrustHandshake(my_identity)
+        result = handshake.verify_peer(
+            peer_card,
+            required_capabilities=["cap1", "cap2"]
+        )
+        
+        assert not result.trusted
+        assert "Missing required capabilities" in result.reason
+
+    def test_cache_ttl(self):
+        """Test that verification results are cached."""
+        my_identity = CMVKIdentity.generate("my-agent")
+        peer_identity = CMVKIdentity.generate("peer-agent")
+        
+        peer_card = TrustedAgentCard(
+            name="Peer Agent",
+            description="A peer",
+            capabilities=[],
+        )
+        peer_card.sign(peer_identity)
+        
+        handshake = TrustHandshake(my_identity)
+        
+        # First verification
+        result1 = handshake.verify_peer(peer_card)
+        # Second should use cache
+        result2 = handshake.verify_peer(peer_card)
+        
+        assert result1.trusted == result2.trusted
+
+
+class TestDelegationChain:
+    """Tests for DelegationChain class."""
+
+    def test_add_delegation(self):
+        """Test adding a delegation."""
+        root = CMVKIdentity.generate("root-agent")
+        worker_identity = CMVKIdentity.generate("worker-agent")
+        
+        worker_card = TrustedAgentCard(
+            name="Worker",
+            description="Worker agent",
+            capabilities=[],
+        )
+        worker_card.sign(worker_identity)
+        
+        chain = DelegationChain(root)
+        delegation = chain.add_delegation(
+            delegatee=worker_card,
+            capabilities=["read", "write"],
+            expires_in_hours=24,
+        )
+        
+        assert delegation.delegator == root.did
+        assert delegation.delegatee == worker_identity.did
+        assert "read" in delegation.capabilities
+
+    def test_verify_chain(self):
+        """Test chain verification."""
+        root = CMVKIdentity.generate("root-agent")
+        worker_identity = CMVKIdentity.generate("worker-agent")
+        
+        worker_card = TrustedAgentCard(
+            name="Worker",
+            description="Worker agent",
+            capabilities=[],
+        )
+        worker_card.sign(worker_identity)
+        
+        chain = DelegationChain(root)
+        chain.add_delegation(
+            delegatee=worker_card,
+            capabilities=["read"],
+        )
+        
+        assert chain.verify()
+
+
+class TestTrustGatedTool:
+    """Tests for TrustGatedTool class."""
+
+    def test_can_invoke_with_capability(self):
+        """Test capability check for tool invocation."""
+        my_identity = CMVKIdentity.generate("executor")
+        invoker_identity = CMVKIdentity.generate("invoker", ["database"])
+        
+        def mock_tool(query: str) -> str:
+            return f"Result: {query}"
+        
+        gated_tool = TrustGatedTool(
+            tool=mock_tool,
+            required_capabilities=["database"],
+        )
+        
+        invoker_card = TrustedAgentCard(
+            name="Invoker",
+            description="Has database cap",
+            capabilities=["database"],
+        )
+        invoker_card.sign(invoker_identity)
+        
+        handshake = TrustHandshake(my_identity)
+        result = gated_tool.can_invoke(invoker_card, handshake)
+        
+        assert result.trusted
+
+
+class TestTrustCallbackHandler:
+    """Tests for TrustCallbackHandler class."""
+
+    def test_event_logging(self):
+        """Test that events are logged."""
+        identity = CMVKIdentity.generate("callback-agent")
+        policy = TrustPolicy(audit_all_calls=True)
+        
+        handler = TrustCallbackHandler(identity, policy)
+        
+        # Simulate some events
+        from uuid import uuid4
+        run_id = uuid4()
+        
+        handler.on_llm_start(
+            {"name": "test-model"},
+            ["prompt"],
+            run_id=run_id,
+        )
+        
+        events = handler.get_events()
+        assert len(events) == 1
+        assert events[0].event_type == "llm_start"
+
+    def test_trust_summary(self):
+        """Test trust summary generation."""
+        identity = CMVKIdentity.generate("summary-agent")
+        handler = TrustCallbackHandler(identity)
+        
+        summary = handler.get_trust_summary()
+        
+        assert "total_events" in summary
+        assert "verified_events" in summary
+        assert "verification_rate" in summary


### PR DESCRIPTION
## Summary

Adds **langchain-agentmesh** partner package providing cryptographic identity verification and trust-gated tool execution for LangChain agents.

## Features

- **CMVKIdentity**: Ed25519-based cryptographic identity for agents
- **TrustGatedTool**: Wrap any tool with trust requirements
- **TrustedToolExecutor**: Execute tools with automatic verification
- **TrustCallbackHandler**: Monitor trust events during chain execution
- **TrustHandshake**: Verify peer agents before collaboration
- **DelegationChain**: Hierarchical capability delegation

## Use Cases

- **Multi-agent systems** requiring identity verification before task handoffs
- **Tool access control** based on agent capabilities and trust scores
- **Audit logging** of all tool invocations with identity tracking
- **Zero-trust architectures** where agents must prove identity

## Example

\\\python
from langchain_agentmesh import CMVKIdentity, TrustGatedTool, TrustedToolExecutor

# Generate agent identity
identity = CMVKIdentity.generate('research-agent', capabilities=['search'])

# Create trust-gated tool
gated_tool = TrustGatedTool(
    tool=search_tool,
    required_capabilities=['search'],
    min_trust_score=0.8
)

# Execute with verification
executor = TrustedToolExecutor(identity=identity)
result = executor.invoke(gated_tool, 'query')
\\\

## Testing

Includes comprehensive tests for identity, trust verification, and tool execution.

## Related

- [AgentMesh Project](https://github.com/imran-siddique/agent-mesh)
- Similar integration submitted to A2A Protocol (#1455)