### PR TITLE
chore(core): clean up docstring mismatch and redundant logic in langchain-core

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -234,7 +234,7 @@ class Blob(BaseMedia):
             `Blob` instance
         """
         if mime_type is None and guess_type:
-            mimetype = mimetypes.guess_type(path)[0] if guess_type else None
+            mimetype = mimetypes.guess_type(path)[0]
         else:
             mimetype = mime_type
         # We do not load the data immediately, instead we treat the blob as a

--- a/libs/core/langchain_core/utils/mustache.py
+++ b/libs/core/langchain_core/utils/mustache.py
@@ -481,14 +481,6 @@ def render(
     Args:
         template: A file-like object or a string containing the template.
         data: A python dictionary with your data scope.
-        partials_path: The path to where your partials are stored.
-
-            If set to None, then partials won't be loaded from the file system
-
-            Defaults to `'.'`.
-        partials_ext: The extension that you want the parser to look for
-
-            Defaults to `'mustache'`.
         partials_dict: A python dictionary which will be search for partials
             before the filesystem is.
 


### PR DESCRIPTION
## Description

Fixes #35046

Two minor cleanups in `langchain-core`:

1. **Fix docstring mismatch in `mustache.render()`**: The docstring incorrectly documented `partials_path` and `partials_ext` parameters that do not exist in the function signature. These were likely carried over from the original [chevron](https://github.com/noahmorrison/chevron) library but were never part of this adapted implementation.

2. **Remove redundant logic in `Blob.from_path()`**: The expression `mimetypes.guess_type(path)[0] if guess_type else None` had a redundant `if guess_type` ternary since the outer condition `if mime_type is None and guess_type:` already guarantees `guess_type` is `True` at that point. Simplified to just `mimetypes.guess_type(path)[0]`.

## AI Disclaimer

An AI coding assistant was used to help identify and implement these changes.
