### PR TITLE
fix(core): prevent tool docstrings from inheriting parent class descriptions

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -167,7 +167,7 @@ def _parse_python_function_docstring(
     Returns:
         A tuple containing the function description and argument descriptions.
     """
-    docstring = inspect.getdoc(function)
+    docstring = inspect.cleandoc(function.__doc__) if function.__doc__ else None
     return _parse_google_docstring(
         docstring,
         list(annotations),
@@ -215,7 +215,7 @@ def _infer_arg_descriptions(
             fn, annotations, error_on_invalid_docstring=error_on_invalid_docstring
         )
     else:
-        description = inspect.getdoc(fn) or ""
+        description = inspect.cleandoc(fn.__doc__) if fn.__doc__ else ""
         arg_descriptions = {}
     if parse_docstring:
         _validate_docstring_args_against_annotations(arg_descriptions, annotations)

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import textwrap
 from collections.abc import Awaitable, Callable
 from inspect import signature
@@ -231,8 +232,11 @@ class StructuredTool(BaseTool):
                 )
                 raise TypeError(msg)
         if description_ is None:
-            msg = "Function must have a docstring if description not provided."
-            raise ValueError(msg)
+            if inspect.isclass(source_function):
+                description_ = ""
+            else:
+                msg = "Function must have a docstring if description not provided."
+                raise ValueError(msg)
         if description is None:
             # Only apply if using the function's docstring
             description_ = textwrap.dedent(description_).strip()

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -224,7 +224,8 @@ def _create_subset_model_v1(
         fields[field_name] = (t, field.field_info)
 
     rtn = cast("type[BaseModelV1]", create_model_v1(name, **fields))  # type: ignore[call-overload]
-    rtn.__doc__ = textwrap.dedent(fn_description or model.__doc__ or "")
+    doc = fn_description if fn_description is not None else (model.__doc__ or "")
+    rtn.__doc__ = textwrap.dedent(doc)
     return rtn
 
 
@@ -265,7 +266,8 @@ def _create_subset_model_v2(
     ]
 
     rtn.__annotations__ = dict(selected_annotations)
-    rtn.__doc__ = textwrap.dedent(fn_description or model.__doc__ or "")
+    doc = fn_description if fn_description is not None else (model.__doc__ or "")
+    rtn.__doc__ = textwrap.dedent(doc)
     return rtn
 
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -733,6 +733,32 @@ def test_missing_docstring() -> None:
     assert not MyTool.description  # type: ignore[attr-defined]
 
 
+def test_docstring_no_inheritance_from_parent() -> None:
+    """Test that child classes do not inherit docstrings from parents."""
+
+    class ParentModel(BaseModel):
+        """Parent docstring."""
+
+        foo: str
+
+    @tool
+    class ChildTool(ParentModel):
+        bar: str
+
+    # Child should not inherit parent's docstring
+    assert ChildTool.description != "Parent docstring."  # type: ignore[attr-defined]
+    assert not ChildTool.description  # type: ignore[attr-defined]
+
+    @tool
+    class ChildWithOwnDoc(ParentModel):
+        """Child's own docstring."""
+
+        bar: str
+
+    # Child with own docstring should use it
+    assert ChildWithOwnDoc.description == "Child's own docstring."  # type: ignore[attr-defined]
+
+
 def test_create_tool_positional_args() -> None:
     """Test that positional arguments are allowed."""
     test_tool = Tool("test_name", lambda x: x, "test_description")


### PR DESCRIPTION
## Summary

Fixes #32066

- Replace `inspect.getdoc()` with direct `__doc__` access in `_infer_arg_descriptions` and `_parse_python_function_docstring` to prevent child classes from inheriting parent docstrings via MRO traversal
- Update `_create_subset_model_v1`/`_create_subset_model_v2` to use `is not None` check instead of truthiness, so an explicitly empty `fn_description` is preserved rather than falling through to the parent model's docstring
- Allow classes without docstrings to get an empty description in `StructuredTool.from_function` instead of raising `ValueError` (functions without docstrings still raise)

### Before
```python
from langchain_core.tools import tool
from pydantic import BaseModel

class MyTool(BaseModel):
    """Parent Tool"""
    foo: str

@tool
class ChildTool(MyTool):
    bar: str

print(ChildTool.description)  # "Parent Tool" (inherited from parent)
```

### After
```python
print(ChildTool.description)  # "" (no inheritance)
```

## Test plan
- [x] Added `test_docstring_no_inheritance_from_parent` covering child without docstring and child with own docstring
- [x] All 156 tool tests pass (`tests/unit_tests/test_tools.py`)
- [x] All 164 tests pass across tools + pydantic utils
- [x] Full unit test suite (1636 tests) passes with no regressions
- [x] Linting and formatting checks pass