### PR TITLE
feat(text-splitters): add model_kwargs to SentenceTransformersTokenTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/sentence_transformers.py
+++ b/libs/text-splitters/langchain_text_splitters/sentence_transformers.py
@@ -25,6 +25,7 @@ class SentenceTransformersTokenTextSplitter(TextSplitter):
         chunk_overlap: int = 50,
         model_name: str = "sentence-transformers/all-mpnet-base-v2",
         tokens_per_chunk: int | None = None,
+        model_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """Create a new `TextSplitter`.
@@ -35,6 +36,9 @@ class SentenceTransformersTokenTextSplitter(TextSplitter):
             tokens_per_chunk: The number of tokens per chunk.
 
                 If `None`, uses the maximum tokens allowed by the model.
+            model_kwargs: Additional keyword arguments to pass to the
+                SentenceTransformer constructor. For example, use
+                `{"trust_remote_code": True}` for models that require it.
 
         Raises:
             ImportError: If the `sentence_transformers` package is not installed.
@@ -50,7 +54,8 @@ class SentenceTransformersTokenTextSplitter(TextSplitter):
             raise ImportError(msg)
 
         self.model_name = model_name
-        self._model = SentenceTransformer(self.model_name)
+        _model_kwargs = model_kwargs or {}
+        self._model = SentenceTransformer(self.model_name, **_model_kwargs)
         self.tokenizer = self._model.tokenizer
         self._initialize_chunk_configuration(tokens_per_chunk=tokens_per_chunk)
 

--- a/libs/text-splitters/tests/integration_tests/test_text_splitter.py
+++ b/libs/text-splitters/tests/integration_tests/test_text_splitter.py
@@ -112,3 +112,19 @@ def test_sentence_transformers_multiple_tokens() -> None:
         - splitter.maximum_tokens_per_chunk
     )
     assert expected == actual
+
+
+def test_sentence_transformers_with_model_kwargs() -> None:
+    """Test that model_kwargs are passed to SentenceTransformer."""
+    splitter = SentenceTransformersTokenTextSplitter(
+        model_name="sentence-transformers/all-MiniLM-L6-v2",
+        model_kwargs={"device": "cpu"},
+        tokens_per_chunk=100,
+    )
+
+    text = "This is a test sentence. " * 10
+    chunks = splitter.split_text(text)
+    assert len(chunks) > 0
+
+    token_count = splitter.count_tokens(text=text)
+    assert token_count > 0


### PR DESCRIPTION
## Description

Adds `model_kwargs` parameter to `SentenceTransformersTokenTextSplitter` to support passing additional keyword arguments to the underlying `SentenceTransformer` constructor.

This allows users to work with models that require special parameters like `trust_remote_code=True`, specify device placement, configure caching, or use any other `SentenceTransformer` parameters.



## Changes
- Added optional `model_kwargs` parameter (type: `dict[str, Any] | None`) to `__init__` method
- Updated docstring with parameter description and usage example
- Added integration test to verify functionality
- Maintained full backward compatibility (defaults to empty dict)

## Example Usage
```python
from langchain_text_splitters import SentenceTransformersTokenTextSplitter

# Using models that require trust_remote_code
splitter = SentenceTransformersTokenTextSplitter(
    model_name="nomic-ai/nomic-embed-text-v1.5",
    model_kwargs={"trust_remote_code": True}
)

# Specifying device
splitter = SentenceTransformersTokenTextSplitter(
    model_name="sentence-transformers/all-mpnet-base-v2",
    model_kwargs={"device": "cuda"}
)

# Multiple parameters
splitter = SentenceTransformersTokenTextSplitter(
    model_name="custom-model",
    model_kwargs={
        "trust_remote_code": True,
        "cache_folder": "/path/to/cache",
        "device": "cpu"
    }
)
```

## Testing
Ran from `libs/text-splitters/`:
- ✅ `make format`
- ✅ `make lint`
- ✅ `make test`

Added integration test that verifies `model_kwargs` are correctly passed to `SentenceTransformer`.

