### PR TITLE
fix(langchain-classic): validate ensemble retriever weights

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -80,8 +80,12 @@ class EnsembleRetriever(BaseRetriever):
     @model_validator(mode="before")
     @classmethod
     def _set_weights(cls, values: dict[str, Any]) -> Any:
-        retrievers = values.get("retrievers", [])
+        retrievers = values.get("retrievers")
         weights = values.get("weights")
+
+        # If retrievers are not yet set, defer validation
+        if not retrievers:
+            return values
 
         if not weights:
             n_retrievers = len(retrievers)
@@ -93,7 +97,7 @@ class EnsembleRetriever(BaseRetriever):
                 "Length of weights must match number of retrievers "
                 f"(got {len(weights)} weights for {len(retrievers)} retrievers)."
         )
-        raise ValueError(msg)
+            raise ValueError(msg)
 
         if not any(w > 0 for w in weights):
             msg = "At least one ensemble weight must be greater than zero."

--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -91,15 +91,15 @@ class EnsembleRetriever(BaseRetriever):
         if len(weights) != len(retrievers):
             msg = (
                 "Length of weights must match number of retrievers "
-                 f"(got {len(weights)} weights for {len(retrievers)} retrievers)."
-            )
-            raise ValueError(msg)
+                f"(got {len(weights)} weights for {len(retrievers)} retrievers)."
+        )
+        raise ValueError(msg)
 
         if not any(w > 0 for w in weights):
-             msg = "At least one ensemble weight must be greater than zero."
-             raise ValueError(msg)
+            msg = "At least one ensemble weight must be greater than zero."
+            raise ValueError(msg)
 
-             return values
+        return values
 
     @override
     def invoke(

--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -80,9 +80,25 @@ class EnsembleRetriever(BaseRetriever):
     @model_validator(mode="before")
     @classmethod
     def _set_weights(cls, values: dict[str, Any]) -> Any:
-        if not values.get("weights"):
-            n_retrievers = len(values["retrievers"])
+        retrievers = values.get("retrievers", [])
+        weights = values.get("weights")
+
+        if not weights:
+            n_retrievers = len(retrievers)
             values["weights"] = [1 / n_retrievers] * n_retrievers
+            return values
+
+        if len(weights) != len(retrievers):
+            raise ValueError(
+                "Length of weights must match number of retrievers "
+                f"(got {len(weights)} weights for {len(retrievers)} retrievers)."
+            )
+
+        if not any(w > 0 for w in weights):
+            raise ValueError(
+                "At least one ensemble weight must be greater than zero."
+            )
+
         return values
 
     @override

--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -96,13 +96,12 @@ class EnsembleRetriever(BaseRetriever):
             msg = (
                 "Length of weights must match number of retrievers "
                 f"(got {len(weights)} weights for {len(retrievers)} retrievers)."
-        )
+                    )
             raise ValueError(msg)
 
         if not any(w > 0 for w in weights):
             msg = "At least one ensemble weight must be greater than zero."
             raise ValueError(msg)
-
         return values
 
     @override

--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -89,17 +89,17 @@ class EnsembleRetriever(BaseRetriever):
             return values
 
         if len(weights) != len(retrievers):
-            raise ValueError(
+            msg = (
                 "Length of weights must match number of retrievers "
-                f"(got {len(weights)} weights for {len(retrievers)} retrievers)."
+                 f"(got {len(weights)} weights for {len(retrievers)} retrievers)."
             )
+            raise ValueError(msg)
 
         if not any(w > 0 for w in weights):
-            raise ValueError(
-                "At least one ensemble weight must be greater than zero."
-            )
+             msg = "At least one ensemble weight must be greater than zero."
+             raise ValueError(msg)
 
-        return values
+             return values
 
     @override
     def invoke(

--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -80,28 +80,25 @@ class EnsembleRetriever(BaseRetriever):
     @model_validator(mode="before")
     @classmethod
     def _set_weights(cls, values: dict[str, Any]) -> Any:
-        retrievers = values.get("retrievers")
         weights = values.get("weights")
 
-        # If retrievers are not yet set, defer validation
-        if not retrievers:
-            return values
-
         if not weights:
-            n_retrievers = len(retrievers)
+            n_retrievers = len(values["retrievers"])
             values["weights"] = [1 / n_retrievers] * n_retrievers
             return values
 
+        retrievers = values["retrievers"]
         if len(weights) != len(retrievers):
             msg = (
                 "Length of weights must match number of retrievers "
                 f"(got {len(weights)} weights for {len(retrievers)} retrievers)."
-                    )
+            )
             raise ValueError(msg)
 
         if not any(w > 0 for w in weights):
             msg = "At least one ensemble weight must be greater than zero."
             raise ValueError(msg)
+
         return values
 
     @override


### PR DESCRIPTION
### Summary
Adds validation for ensemble retriever weights to prevent common
misconfigurations.

### Details
Ensures the number of weights matches the number of retrievers and that
at least one weight is greater than zero. This avoids silent failures
while preserving existing behavior for valid inputs.

### Notes
No breaking changes.
