### PR TITLE
fix(anthropic): fix AttributeError in AnthropicPromptCachingMiddleware

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/prompt_caching.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/prompt_caching.py
@@ -91,10 +91,13 @@ class AnthropicPromptCachingMiddleware(AgentMiddleware):
                 warn(msg, stacklevel=3)
             return False
 
+        # ModelRequest uses `system_prompt`, not `system_message`.
+        # Check both via getattr for forward compatibility.
+        has_system = getattr(request, "system_prompt", None) or getattr(
+            request, "system_message", None
+        )
         messages_count = (
-            len(request.messages) + 1
-            if request.system_message
-            else len(request.messages)
+            len(request.messages) + 1 if has_system else len(request.messages)
         )
         return messages_count >= self.min_messages_to_cache
 


### PR DESCRIPTION
## Description

One-line fix: `request.system_message` → `request.system_prompt` in `AnthropicPromptCachingMiddleware._should_apply_caching()`.

`ModelRequest` uses `system_prompt`, not `system_message`. Accessing the wrong attribute causes an `AttributeError` at runtime when prompt caching is used with a `ChatAnthropic` model.

### Why this wasn't caught earlier

The bug is masked when the model is pre-wrapped via `.bind_tools()` before being passed to `create_agent()`. `bind_tools()` returns a `RunnableBinding`, so the `isinstance(request.model, ChatAnthropic)` check on [line 83](https://github.com/langchain-ai/langchain/blob/master/libs/partners/anthropic/langchain_anthropic/middleware/prompt_caching.py#L83) fails first and returns `False` — **silently disabling prompt caching** without ever reaching the buggy line.

When the model is correctly passed as a raw `ChatAnthropic` (since `create_agent()` handles tool binding internally), the isinstance check passes and the `AttributeError` is raised.

### Error

```
File "langchain_anthropic/middleware/prompt_caching.py", line 96, in _should_apply_caching
    if request.system_message
       ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ModelRequest' object has no attribute 'system_message'
```

## Issue

Fixes #35082

## Dependencies

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)