### PR TITLE
Fixed ChatAnthropic fails

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1167,6 +1167,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 msg = "Asked to cache, but no cache found at `langchain.cache`."
                 raise ValueError(msg)
 
+        # Validate messages before making API calls (provider-specific validation)
+        self._validate_messages(messages)
+
         # Apply the rate limiter after checking the cache, since
         # we usually don't want to rate limit cache lookups, but
         # we do want to rate limit API requests.
@@ -1293,6 +1296,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 msg = "Asked to cache, but no cache found at `langchain.cache`."
                 raise ValueError(msg)
 
+        # Validate messages before making API calls (provider-specific validation)
+        self._validate_messages(messages)
+
         # Apply the rate limiter after checking the cache, since
         # we usually don't want to rate limit cache lookups, but
         # we do want to rate limit API requests.
@@ -1384,6 +1390,26 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         if check_cache and llm_cache:
             await llm_cache.aupdate(prompt, llm_string, result.generations)
         return result
+
+    def _validate_messages(self, messages: list[BaseMessage]) -> None:
+        """Validate messages before sending to the model provider.
+
+        This method can be overridden by subclasses to implement provider-specific
+        validation rules. By default, no validation is performed, allowing all
+        providers to maintain backward compatibility.
+
+        Args:
+            messages: The messages to validate.
+
+        Raises:
+            ValueError: If messages violate provider-specific validation rules.
+
+        Note:
+            This validation occurs before any API calls are made, ensuring
+            fast failure for invalid input.
+        """
+        # Default implementation: no validation (backward compatible)
+        pass
 
     @abstractmethod
     def _generate(

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1409,7 +1409,6 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             fast failure for invalid input.
         """
         # Default implementation: no validation (backward compatible)
-        pass
 
     @abstractmethod
     def _generate(

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1303,6 +1303,8 @@ class ChatAnthropic(BaseChatModel):
         if stream_usage is None:
             stream_usage = self.stream_usage
         kwargs["stream"] = True
+        # Validate messages before making API calls
+        self._validate_messages(messages)
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
         try:
             stream = self._create(payload)
@@ -1340,6 +1342,8 @@ class ChatAnthropic(BaseChatModel):
         if stream_usage is None:
             stream_usage = self.stream_usage
         kwargs["stream"] = True
+        # Validate messages before making API calls
+        self._validate_messages(messages)
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
         try:
             stream = await self._acreate(payload)

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2603,12 +2603,9 @@ def test_chat_anthropic_validation_streaming() -> None:
     llm = ChatAnthropic(model=MODEL_NAME, streaming=True)
 
     # Empty message should raise before streaming
-    with pytest.raises(ValueError, match="Anthropic models do not allow empty"):
-        with patch.object(llm, "_create") as mock_create:
-            # This should fail before any stream setup
-            try:
-                list(llm.stream([HumanMessage(content="")]))  # type: ignore[misc]
-            except ValueError:
-                pass
-            # Verify no API call was made
-            mock_create.assert_not_called()
+    with patch.object(llm, "_create") as mock_create:
+        # This should fail before any stream setup
+        with pytest.raises(ValueError, match="Anthropic models do not allow empty"):
+            list(llm.stream([HumanMessage(content="")]))  # type: ignore[misc]
+        # Verify no API call was made
+        mock_create.assert_not_called()

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -508,7 +508,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
+    { name = "langchain-anthropic", marker = "extra == 'anthropic'", editable = "." },
     { name = "langchain-aws", marker = "extra == 'aws'" },
     { name = "langchain-azure-ai", marker = "extra == 'azure-ai'" },
     { name = "langchain-community", marker = "extra == 'community'" },


### PR DESCRIPTION
(Replace this entire block of text)

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview
If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangChain! Follow these steps to have your pull request considered as ready for review.

1. PR title: fix(anthropic): validate empty message content before API calls
2. PR description:

Fixes #35081

This PR implements a layered validation system to catch empty HumanMessage and SystemMessage content before sending requests to the Anthropic API. Previously, empty message content would be forwarded directly to the API, resulting in a cryptic BadRequestError. The fix provides clear, actionable error messages and prevents unnecessary API calls.

The implementation follows LangChain's architectural patterns by adding validation at three levels:

1. **Core validation utility** (`langchain_core/messages/utils.py`): Added `_is_message_content_empty()` and `validate_message_content()` functions that detect empty or whitespace-only content across different message types and content formats (strings, lists, mixed content blocks).

2. **Base model validation hook** (`langchain_core/language_models/chat_models.py`): Added `_validate_messages()` method to `BaseChatModel` that providers can override. The hook is called in `_generate_with_cache()` and `_agenerate_with_cache()` after cache checks but before API calls, ensuring fast failure for invalid input.

3. **Anthropic-specific enforcement** (`langchain_anthropic/chat_models.py`): Overrode `_validate_messages()` in `ChatAnthropic` to enforce Anthropic's requirement that all messages must have non-empty content except for the optional final assistant message. The validation provides clear error messages that guide developers to fix issues in agent/tool pipelines where tools might return empty strings.

The validation correctly handles edge cases including:
- Empty string and list content
- Whitespace-only content
- Mixed content blocks (empty text + non-empty blocks)
- AIMessages with tool_calls (considered non-empty as tool_calls become content blocks)
- Different message types (HumanMessage, SystemMessage, ChatMessage, ToolMessage, FunctionMessage)

This change maintains backward compatibility for all non-Anthropic providers, as the default `_validate_messages()` implementation is a no-op. Only Anthropic models enforce these validation rules.

Comprehensive test coverage has been added for both the core validation utilities and the Anthropic-specific implementation, including unit tests, integration tests, and edge case scenarios.

**How I verified the code works:**
- Added unit tests for core validation utilities covering all content types and edge cases
- Added integration tests verifying validation occurs in `invoke()`, `generate()`, and `stream()` paths before API calls
- Verified that empty messages raise clear ValueError with helpful messages
- Confirmed that valid messages (including those with tool_calls) pass validation
- Tested that non-Anthropic providers are unaffected (backward compatibility maintained)
- All tests pass and linting/formatting checks pass

**AI Disclosure:** This contribution was developed with assistance from AI coding tools. The architectural design, implementation approach, and test coverage were developed collaboratively.
