### PR TITLE
Fix Blob MIME guessing defaults and align mustache render docs

### DIFF
--- a/libs/core/langchain_core/documents/__init__.py
+++ b/libs/core/langchain_core/documents/__init__.py
@@ -31,14 +31,15 @@ from typing import TYPE_CHECKING
 from langchain_core._import_utils import import_attr
 
 if TYPE_CHECKING:
-    from langchain_core.documents.base import Document
+    from langchain_core.documents.base import Blob, Document
     from langchain_core.documents.compressor import BaseDocumentCompressor
     from langchain_core.documents.transformers import BaseDocumentTransformer
 
-__all__ = ("BaseDocumentCompressor", "BaseDocumentTransformer", "Document")
+__all__ = ("BaseDocumentCompressor", "BaseDocumentTransformer", "Blob", "Document")
 
 _dynamic_imports = {
     "Document": "base",
+    "Blob": "base",
     "BaseDocumentCompressor": "compressor",
     "BaseDocumentTransformer": "transformers",
 }

--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -234,7 +234,7 @@ class Blob(BaseMedia):
             `Blob` instance
         """
         if mime_type is None and guess_type:
-            mimetype = mimetypes.guess_type(path)[0] if guess_type else None
+            mimetype = mimetypes.guess_type(path)[0]
         else:
             mimetype = mime_type
         # We do not load the data immediately, instead we treat the blob as a

--- a/libs/core/langchain_core/utils/mustache.py
+++ b/libs/core/langchain_core/utils/mustache.py
@@ -479,31 +479,18 @@ def render(
     Renders a mustache template with a data scope and inline partial capability.
 
     Args:
-        template: A file-like object or a string containing the template.
-        data: A python dictionary with your data scope.
-        partials_path: The path to where your partials are stored.
+        template: A tokenized template or raw template string to render.
+        data: A dictionary providing the rendering scope.
+        partials_dict: In-memory partials to check before falling back to the
+            filesystem lookup.
 
-            If set to None, then partials won't be loaded from the file system
-
-            Defaults to `'.'`.
-        partials_ext: The extension that you want the parser to look for
-
-            Defaults to `'mustache'`.
-        partials_dict: A python dictionary which will be search for partials
-            before the filesystem is.
-
-            `{'include': 'foo'}` is the same as a file called include.mustache
-            (defaults to `{}`).
-        padding: This is for padding partials, and shouldn't be used
-            (but can be if you really want to).
-        def_ldel: The default left delimiter
-
-            (`'{{'` by default, as in spec compliant mustache).
-        def_rdel: The default right delimiter
-
-            (`'}}'` by default, as in spec compliant mustache).
-        scopes: The list of scopes that `get_key` will look through.
-        warn: Log a warning when a template substitution isn't found in the data
+            `{'include': 'foo'}` behaves the same as a file called
+            `include.mustache` (defaults to `{}`).
+        padding: Optional padding prefixed to newlines when rendering partials.
+        def_ldel: The default left delimiter (`'{{'` by default).
+        def_rdel: The default right delimiter (`'}}'` by default).
+        scopes: Seed scopes for nested renders (primarily internal reuse).
+        warn: Log a warning when a template substitution isn't found in the data.
         keep: Keep unreplaced tags when a substitution isn't found in the data.
 
     Returns:

--- a/libs/core/tests/unit_tests/documents/test_blob.py
+++ b/libs/core/tests/unit_tests/documents/test_blob.py
@@ -26,9 +26,7 @@ def test_blob_from_path_prefers_explicit_mimetype(tmp_path: Path) -> None:
     file_path = tmp_path / "data.unknown"
     file_path.write_bytes(b"{}")
 
-    blob = Blob.from_path(
-        file_path, mime_type="application/custom", guess_type=True
-    )
+    blob = Blob.from_path(file_path, mime_type="application/custom", guess_type=True)
 
     assert blob.mimetype == "application/custom"
 

--- a/libs/core/tests/unit_tests/documents/test_blob.py
+++ b/libs/core/tests/unit_tests/documents/test_blob.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+from langchain_core.documents import Blob
+
+
+def test_blob_from_path_guesses_mimetype(tmp_path: Path) -> None:
+    file_path = tmp_path / "sample.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    blob = Blob.from_path(file_path)
+
+    assert blob.mimetype == "text/plain"
+    assert blob.path == file_path
+
+
+def test_blob_from_path_skips_guessing(tmp_path: Path) -> None:
+    file_path = tmp_path / "data.bin"
+    file_path.write_bytes(b"\x00\x01")
+
+    blob = Blob.from_path(file_path, guess_type=False)
+
+    assert blob.mimetype is None
+
+
+def test_blob_from_path_prefers_explicit_mimetype(tmp_path: Path) -> None:
+    file_path = tmp_path / "data.unknown"
+    file_path.write_bytes(b"{}")
+
+    blob = Blob.from_path(
+        file_path, mime_type="application/custom", guess_type=True
+    )
+
+    assert blob.mimetype == "application/custom"
+
+
+def test_blob_reads_string_from_path(tmp_path: Path) -> None:
+    file_path = tmp_path / "note.txt"
+    file_path.write_text("hello", encoding="utf-8")
+
+    blob = Blob.from_path(file_path)
+
+    assert blob.as_string() == "hello"


### PR DESCRIPTION
## Summary
- normalize Blob.from_path MIME detection and add unit coverage for guess_type, explicit mimetype, and path reads
- align mustache.render docstring with its actual parameters

Closes #35046

## Testing
- Not run (pytest not installed in this environment)