### PR TITLE
Validate Anthropic messages before request

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -283,7 +283,6 @@ def _merge_messages(
 
 def _is_empty_content(content: Any) -> bool:
     """Check if message content is empty."""
-
     if isinstance(content, str):
         return content == ""
     if isinstance(content, list):

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -430,7 +430,11 @@ def _format_messages(
             message.type == "ai" and _i == total_messages - 1
         )
 
-        if _is_empty_content(message.content) and not is_final_assistant_message:
+        if (
+            _is_empty_content(message.content)
+            and not is_final_assistant_message
+            and not (isinstance(message, AIMessage) and message.tool_calls)
+        ):
             msg = (
                 "Anthropic requires non-empty message content for all messages "
                 "except the optional final assistant message; received an empty "

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -428,11 +428,14 @@ def _format_messages(
         is_final_assistant_message = (
             message.type == "ai" and _i == total_messages - 1
         )
+        is_empty = _is_empty_content(message.content)
+        has_tool_calls = bool(getattr(message, "tool_calls", None))
 
         if (
-            _is_empty_content(message.content)
+            is_empty
+            and message.type != "system"
             and not is_final_assistant_message
-            and not (isinstance(message, AIMessage) and message.tool_calls)
+            and not has_tool_calls
         ):
             msg = (
                 "Anthropic requires non-empty message content for all messages "

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2322,6 +2322,25 @@ def test_extras_with_multiple_fields() -> None:
     assert "input_examples" in tool_def
 
 
+def test__format_messages_rejects_empty_non_final_message() -> None:
+    human_empty = HumanMessage("")  # type: ignore[misc]
+
+    with pytest.raises(ValueError, match="non-empty message content"):
+        _format_messages([human_empty])
+
+    with pytest.raises(ValueError, match="non-empty message content"):
+        _format_messages([HumanMessage("foo"), HumanMessage("")])  # type: ignore[misc]
+
+
+def test__format_messages_allows_empty_final_assistant_message() -> None:
+    human = HumanMessage("foo")  # type: ignore[misc]
+    ai_empty = AIMessage("")  # type: ignore[misc]
+
+    _, anthropic_messages = _format_messages([human, ai_empty])
+
+    assert anthropic_messages[-1]["content"] == ""
+
+
 def test__format_messages_trailing_whitespace() -> None:
     """Test that trailing whitespace is trimmed from the final assistant message."""
     human = HumanMessage("foo")  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- raise a clear ValueError when Anthropic message content is empty instead of sending a 400-inducing payload
- keep the optional final assistant message exempt per Anthropic API semantics
- add unit coverage to guard against empty human content and keep an empty final assistant message valid

Fixes #35081.

## Testing
- not run (deps not available in this environment)
