### PR TITLE
fix: filter duplicates in BaseChatMemory list_messages

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -366,10 +366,7 @@ class BaseMessage(Serializable):
                     if html and (url or file_id):
                         if url:
                             return f'<img src="{escape(str(url))}" alt="image" />'
-                        return (
-                            f'<img data-file-id="{escape(str(file_id))}" '
-                            'alt="image" />'
-                        )
+                        return f'<img data-file-id="{escape(str(file_id))}" alt="image" />'
                     if url or file_id:
                         return str(url or file_id)
 

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -345,7 +345,7 @@ class BaseMessage(Serializable):
             if isinstance(block, dict):
                 block_type = block.get("type")
                 if block_type == "text" and isinstance(block.get("text"), str):
-                    text_value = block["text"]
+                    text_value = cast(str, block["text"])
                     return escape(text_value) if html else text_value
 
                 if block_type == "reasoning":
@@ -354,7 +354,7 @@ class BaseMessage(Serializable):
                         reasoning = json.dumps(reasoning, ensure_ascii=False)
                     if html:
                         return f'<pre class="lc-reasoning">{escape(reasoning)}</pre>'
-                    return cast("str", reasoning)
+                    return reasoning
 
                 if block_type in {"image", "image_url"}:
                     url = block.get("url")
@@ -369,7 +369,7 @@ class BaseMessage(Serializable):
                         img_id = escape(str(file_id))
                         return f'<img data-file-id="{img_id}" alt="image" />'
                     if url or file_id:
-                        return cast("str", url or file_id)
+                        return str(url or file_id)
 
             try:
                 serialized = json.dumps(block, ensure_ascii=False)

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -366,7 +366,8 @@ class BaseMessage(Serializable):
                     if html and (url or file_id):
                         if url:
                             return f'<img src="{escape(str(url))}" alt="image" />'
-                        return f'<img data-file-id="{escape(str(file_id))}" alt="image" />'
+                        img_id = escape(str(file_id))
+                        return f'<img data-file-id="{img_id}" alt="image" />'
                     if url or file_id:
                         return str(url or file_id)
 

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -354,7 +354,7 @@ class BaseMessage(Serializable):
                         reasoning = json.dumps(reasoning, ensure_ascii=False)
                     if html:
                         return f'<pre class="lc-reasoning">{escape(reasoning)}</pre>'
-                    return cast(str, reasoning)
+                    return cast("str", reasoning)
 
                 if block_type in {"image", "image_url"}:
                     url = block.get("url")
@@ -369,7 +369,7 @@ class BaseMessage(Serializable):
                         img_id = escape(str(file_id))
                         return f'<img data-file-id="{img_id}" alt="image" />'
                     if url or file_id:
-                        return cast(str, url or file_id)
+                        return cast("str", url or file_id)
 
             try:
                 serialized = json.dumps(block, ensure_ascii=False)

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -354,7 +354,7 @@ class BaseMessage(Serializable):
                         reasoning = json.dumps(reasoning, ensure_ascii=False)
                     if html:
                         return f'<pre class="lc-reasoning">{escape(reasoning)}</pre>'
-                    return reasoning
+                    return cast(str, reasoning)
 
                 if block_type in {"image", "image_url"}:
                     url = block.get("url")
@@ -369,7 +369,7 @@ class BaseMessage(Serializable):
                         img_id = escape(str(file_id))
                         return f'<img data-file-id="{img_id}" alt="image" />'
                     if url or file_id:
-                        return str(url or file_id)
+                        return cast(str, url or file_id)
 
             try:
                 serialized = json.dumps(block, ensure_ascii=False)

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -394,9 +394,9 @@ class BaseMessage(Serializable):
             content_repr = _format_content(html=True)
             return (
                 '<div class="lc-message">'
-                f"\n  <div class=\"lc-message-title\"><strong>{title}</strong></div>"
+                f'\n  <div class="lc-message-title"><strong>{title}</strong></div>'
                 f"{name_line}"
-                f"\n  <div class=\"lc-message-body\">{content_repr}</div>"
+                f'\n  <div class="lc-message-body">{content_repr}</div>'
                 "\n</div>"
             )
 

--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -366,7 +366,10 @@ class BaseMessage(Serializable):
                     if html and (url or file_id):
                         if url:
                             return f'<img src="{escape(str(url))}" alt="image" />'
-                        return f'<img data-file-id="{escape(str(file_id))}" alt="image" />'
+                        return (
+                            f'<img data-file-id="{escape(str(file_id))}" '
+                            'alt="image" />'
+                        )
                     if url or file_id:
                         return str(url or file_id)
 

--- a/libs/core/tests/unit_tests/messages/test_base_message.py
+++ b/libs/core/tests/unit_tests/messages/test_base_message.py
@@ -1,0 +1,24 @@
+from langchain_core.messages import BaseMessage
+
+
+def test_pretty_repr_html_formats_blocks_as_html() -> None:
+    message = BaseMessage(content=["First", {"type": "text", "text": "Second"}], type="ai", name="bot")
+
+    rendered = message.pretty_repr(html=True)
+
+    assert '<div class="lc-message"' in rendered
+    assert "First" in rendered
+    assert "Second" in rendered
+    # Ensure we don't fall back to Python list repr
+    assert "['First'" not in rendered
+
+
+def test_pretty_repr_formats_reasoning_block() -> None:
+    message = BaseMessage(content=[{"type": "reasoning", "reasoning": "step one"}], type="ai")
+
+    rendered_html = message.pretty_repr(html=True)
+    assert "<pre" in rendered_html
+    assert "step one" in rendered_html
+
+    rendered_text = message.pretty_repr()
+    assert "step one" in rendered_text

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- render BaseMessage.pretty_repr with HTML tags and escape content blocks instead of falling back to Python list repr
- handle structured blocks (text, reasoning, image) when rendering to HTML/plain text so multi-part content stays readable
- add regression tests for HTML and text pretty representations

## Testing
- Not run (local test deps like blockbuster unavailable in env)
