### PR TITLE
fix(core): treat empty list from tool return as non-message-content

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1291,7 +1291,9 @@ def _is_message_content_type(obj: Any) -> bool:
         `True` if the object is valid message content, `False` otherwise.
     """
     return isinstance(obj, str) or (
-        isinstance(obj, list) and all(_is_message_content_block(e) for e in obj)
+        isinstance(obj, list)
+        and bool(obj)
+        and all(_is_message_content_block(e) for e in obj)
     )
 
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2133,10 +2133,32 @@ def test__is_message_content_block(obj: Any, *, expected: bool) -> None:
         ("foo", True),
         (valid_tool_result_blocks, True),
         (invalid_tool_result_blocks, False),
+        ([], False),
     ],
 )
 def test__is_message_content_type(obj: Any, *, expected: bool) -> None:
     assert _is_message_content_type(obj) is expected
+
+
+def test_tool_returning_empty_list_is_stringified() -> None:
+    """Empty list returned by tool should be JSON-stringified, not passed as-is."""
+
+    @tool
+    def returns_empty(x: str) -> list:
+        """A tool that returns an empty list."""
+        return []
+
+    result = returns_empty.invoke(
+        {
+            "name": "returns_empty",
+            "args": {"x": "test"},
+            "id": "call_123",
+            "type": "tool_call",
+        }
+    )
+    assert isinstance(result, ToolMessage)
+    assert result.content == "[]"
+    assert result.tool_call_id == "call_123"
 
 
 @pytest.mark.parametrize("use_v1_namespace", [True, False])


### PR DESCRIPTION
`_is_message_content_type()` incorrectly returns `True` for empty lists because `all()` evaluates to `True` on empty iterables (vacuous truth). This causes `[]` returned by a tool to be passed directly as `ToolMessage.content` instead of being JSON-stringified to `"[]"`, inconsistent with how non-empty non-content-block lists are handled.

Added `bool(obj)` check to short-circuit on empty lists and added corresponding unit tests.

Fixes #30578

Verified by running lint and tests from `libs/core/`. 