### PR TITLE
fix: handle empty HumanMessage content in ChatAnthropic

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -654,10 +654,15 @@ def _format_messages(
             ):
                 content[-1]["text"] = content[-1]["text"].rstrip()
 
-        if not content and role == "assistant" and _i < len(merged_messages) - 1:
-            # anthropic.BadRequestError: Error code: 400: all messages must have
-            # non-empty content except for the optional final assistant message
-            continue
+        if not content:
+            if role == "assistant" and _i < len(merged_messages) - 1:
+                # anthropic.BadRequestError: Error code: 400: all messages must have
+                # non-empty content except for the optional final assistant message
+                continue
+            elif role == "user":
+                # Anthropic API rejects user messages with empty content
+                # Skip empty human messages rather than sending them
+                continue
         formatted_messages.append({"role": role, "content": content})
     return system, formatted_messages
 


### PR DESCRIPTION
## Summary

Fixes #35081

When a `HumanMessage` with empty content (`""`) is passed to `ChatAnthropic`, the Anthropic API rejects it with:
```
BadRequestError: Error code: 400 - all messages must have non-empty content
```

The existing code already handles empty `assistant` messages by skipping them (line 657-660), but doesn't do the same for `user` messages.

## Changes

Extended the empty content check in `_format_messages()` to also skip `user` messages with empty content, consistent with how empty `assistant` messages are handled.

## Notes

This only affects messages where content is an empty string after all processing. Messages with list content (images, tool results) go through a separate code path and are not affected.