### PR TITLE
fix(anthropic): hoist cache_control from tool_result content sub-blocks to tool_result level

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -250,15 +250,33 @@ def _merge_messages(
             ):
                 curr = HumanMessage(curr.content)  # type: ignore[misc]
             else:
+                tool_content = curr.content
+                cache_ctrl = None
+                # Extract cache_control from content blocks and hoist it
+                # to the tool_result level.  Anthropic's API does not
+                # support cache_control on tool_result content sub-blocks.
+                if isinstance(tool_content, list):
+                    cleaned = []
+                    for block in tool_content:
+                        if isinstance(block, dict) and "cache_control" in block:
+                            cache_ctrl = block["cache_control"]
+                            block = {
+                                k: v
+                                for k, v in block.items()
+                                if k != "cache_control"
+                            }
+                        cleaned.append(block)
+                    tool_content = cleaned
+                tool_result: dict = {
+                    "type": "tool_result",
+                    "content": tool_content,
+                    "tool_use_id": curr.tool_call_id,
+                    "is_error": curr.status == "error",
+                }
+                if cache_ctrl:
+                    tool_result["cache_control"] = cache_ctrl
                 curr = HumanMessage(  # type: ignore[misc]
-                    [
-                        {
-                            "type": "tool_result",
-                            "content": curr.content,
-                            "tool_use_id": curr.tool_call_id,
-                            "is_error": curr.status == "error",
-                        },
-                    ],
+                    [tool_result],
                 )
         last = merged[-1] if merged else None
         if any(

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -261,9 +261,7 @@ def _merge_messages(
                         if isinstance(block, dict) and "cache_control" in block:
                             cache_ctrl = block["cache_control"]
                             block = {
-                                k: v
-                                for k, v in block.items()
-                                if k != "cache_control"
+                                k: v for k, v in block.items() if k != "cache_control"
                             }
                         cleaned.append(block)
                     tool_content = cleaned


### PR DESCRIPTION
## Summary

Fixes #34920

When `cache_control` is specified inside a `ToolMessage` content block (e.g., `[{"type": "text", "text": "result", "cache_control": {"type": "ephemeral"}}]`), `langchain-anthropic` passes it through to `tool_result.content[].cache_control`. However, Anthropic's API **does not support** `cache_control` at this level — it must be placed directly on the `tool_result` object.

## Root Cause

In `_merge_messages`, the `ToolMessage` content is passed through as-is:

```python
{
    "type": "tool_result",
    "content": curr.content,  # cache_control inside blocks is preserved
    ...
}
```

Anthropic rejects this with: `invalid_cache: cache_control is not supported at messages.N.content.M.content.K.cache_control`

## Fix

Extract `cache_control` from content sub-blocks and hoist it to the `tool_result` level during message merging. This matches Anthropic's API requirement that `cache_control` be placed on the `tool_result` object itself.

## Test plan

- [ ] Verify that `ToolMessage` with `cache_control` inside content blocks no longer causes API errors
- [ ] Verify that the extracted `cache_control` is correctly placed on the `tool_result` level
- [ ] Verify that `ToolMessage` without `cache_control` continues to work unchanged