### PR TITLE
feat(core): allow overriding tool_choice in with_structured_output

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1576,6 +1576,13 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
 
                 The final output is always a `dict` with keys `'raw'`, `'parsed'`, and
                 `'parsing_error'`.
+            kwargs:
+                Additional keyword arguments for structured output.
+
+                - `tool_choice`: Tool choice forwarded to `bind_tools`. Defaults to
+                    `"any"` for backwards compatibility.
+                - `method`: Currently ignored.
+                - `strict`: Currently ignored.
 
         Raises:
             ValueError: If there are any unsupported `kwargs`.
@@ -1684,6 +1691,10 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         """  # noqa: E501
         _ = kwargs.pop("method", None)
         _ = kwargs.pop("strict", None)
+        tool_choice = kwargs.pop("tool_choice", "any")
+        if not isinstance(tool_choice, (str, type(None))):
+            msg = "tool_choice must be a string or None."
+            raise TypeError(msg)
         if kwargs:
             msg = f"Received unsupported arguments {kwargs}"
             raise ValueError(msg)
@@ -1694,7 +1705,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
 
         llm = self.bind_tools(
             [schema],
-            tool_choice="any",
+            tool_choice=tool_choice,
             ls_structured_output_format={
                 "kwargs": {"method": "function_calling"},
                 "schema": schema,


### PR DESCRIPTION
## Summary
This removes the hardcoded `tool_choice="any"` in `BaseChatModel.with_structured_output()` and allows callers to override it via `tool_choice=...`.

Fixes langchain-ai/langchain-google#1582.

## Why
Some providers reject `tool_choice="any"` (e.g. Meta via Vertex Model Garden), which causes structured output calls to fail even when tool calling itself is supported.

By allowing an explicit override, callers can use provider-compatible values such as `"auto"`, `"required"`, or provider-specific accepted choices.

## Changes
- `with_structured_output(..., **kwargs)` now accepts:
  - `tool_choice` (default remains `"any"` for backward compatibility)
- Added runtime type validation for `tool_choice` (`str | None`, otherwise `TypeError`)
- Updated docstring to document supported kwargs (`tool_choice`, `method`, `strict`)
- Added unit tests for:
  - default behavior (`"any"`)
  - override behavior (e.g. `"auto"`)
  - invalid type error path

## Testing
From `libs/core`:
- `uv run --group lint ruff check langchain_core/language_models/chat_models.py tests/unit_tests/language_models/chat_models/test_base.py`
- `uv run --group test pytest -q tests/unit_tests/language_models/chat_models/test_base.py -k "with_structured_output_uses_default_tool_choice_any or with_structured_output_accepts_tool_choice_override or with_structured_output_rejects_invalid_tool_choice_type"`
- `uv run --group typing mypy langchain_core/language_models/chat_models.py tests/unit_tests/language_models/chat_models/test_base.py`
- `uv run --group test python -m trace --count --coverdir /tmp/langchain_35132_trace_1770722619 --module pytest -q tests/unit_tests/language_models/chat_models/test_base.py -k "with_structured_output_uses_default_tool_choice_any or with_structured_output_accepts_tool_choice_override or with_structured_output_rejects_invalid_tool_choice_type"`

Trace output confirms execution of all newly added tool-choice code paths in `with_structured_output`.
