### PR TITLE
fix(core): avoid blocking source scans in runnablelambda deps (#29530)

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_utils.py
+++ b/libs/core/tests/unit_tests/runnables/test_utils.py
@@ -82,7 +82,10 @@ def test_runnable_lambda_deps_fast_path_without_nonlocals(
         msg = "get_function_nonlocals should not be called for no-closure functions"
         raise AssertionError(msg)
 
-    monkeypatch.setattr("langchain_core.runnables.base.get_function_nonlocals", _explode)
+    monkeypatch.setattr(
+        "langchain_core.runnables.base.get_function_nonlocals",
+        _explode,
+    )
     assert RunnableLambda(lambda x: x + 1).deps == []
 
 
@@ -98,5 +101,8 @@ def test_runnable_lambda_deps_fast_path_with_direct_runnable(
     def my_func(value: str) -> str:
         return agent.invoke(value)
 
-    monkeypatch.setattr("langchain_core.runnables.base.get_function_nonlocals", _explode)
+    monkeypatch.setattr(
+        "langchain_core.runnables.base.get_function_nonlocals",
+        _explode,
+    )
     assert RunnableLambda(my_func).deps == [agent]


### PR DESCRIPTION
## Problem
`RunnableLambda.deps` can trigger source-based nonlocal inspection, which may perform blocking file I/O (`inspect.getsource`) in async execution paths where config specs are materialized.

## Reproduction
Calling dependency/config-spec paths for `RunnableLambda` in async contexts can reach `get_function_nonlocals` and source inspection even when dependencies are trivially resolvable from closure vars.

## Solution
- Added a non-blocking fast path in `RunnableLambda.deps`:
  - inspect closure vars directly,
  - extract direct runnable deps without source reads,
  - fall back to `get_function_nonlocals` only when closure candidates exist but no direct runnable deps were found.
- Added regression tests ensuring fast path avoids source-scan fallback for:
  - no-closure functions,
  - direct runnable closure references.

## Tests
Ran:
- `PYTHONPATH=libs/core python -m pytest libs/core/tests/unit_tests/runnables/test_utils.py -q`

## Backward Compatibility
No API changes. Fallback path is retained for complex nested attribute cases.

Closes #29530