### PR TITLE
fix(openai): support bind_tools after with_structured_output (#28848)

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2273,9 +2273,10 @@ class BaseChatOpenAI(BaseChatModel):
                 [parser_none], exception_key="parsing_error"
             )
             return _StructuredOutputRunnableSequence(
-                RunnableMap(raw=llm), parser_with_fallback
+                first=RunnableMap(raw=llm),
+                last=parser_with_fallback,
             )
-        return _StructuredOutputRunnableSequence(llm, output_parser)
+        return _StructuredOutputRunnableSequence(first=llm, last=output_parser)
 
     def _filter_disabled_params(self, **kwargs: Any) -> dict[str, Any]:
         if not self.disabled_params:


### PR DESCRIPTION
## Problem
`ChatOpenAI.with_structured_output(...)` returns a runnable sequence, so calling `.bind_tools(...)` on that result raises an attribute error. This prevents the chaining pattern reported in #28848.

## Reproduction
```python
structured_llm = llm.with_structured_output(ResponseModel)
structured_llm.bind_tools([a_tool])
```
Before this change, the second line fails because the returned sequence had no `bind_tools` method.

## Solution
- Added `_StructuredOutputRunnableSequence`, a small `RunnableSequence` wrapper used by `with_structured_output`.
- Added `bind_tools(...)` on that wrapper so chained tool binding works for structured output runnables.
- The wrapper preserves existing bound kwargs/tools from the structured-output sequence and appends newly provided tools.
- For `include_raw=True` shape (where the first step is not a direct binding), it raises a clear `ValueError`.

## Tests
- Added `test_with_structured_output_bind_tools` to verify chaining works and preserves the structured-output tool choice.
- Added `test_with_structured_output_bind_tools_include_raw_unsupported` to verify explicit error behavior for unsupported shape.
- Ran:
  - `PYTHONPATH=libs/core;libs/partners/openai;libs/standard-tests python -m pytest libs/partners/openai/tests/unit_tests/chat_models/test_base.py -k with_structured_output_bind_tools -q`

## Backward Compatibility
- No public API removals or signature changes.
- Existing `with_structured_output` behavior is preserved; this adds chained `bind_tools` support to the returned runnable sequence.

Closes #28848