### PR TITLE
fix(core): replace bare except with Exception in tracer

### DIFF
--- a/libs/core/langchain_core/tracers/core.py
+++ b/libs/core/langchain_core/tracers/core.py
@@ -102,7 +102,7 @@ class _TracerCore(ABC):
         try:
             tb = traceback.format_exception(error)
             return (msg + "\n\n".join(tb)).strip()
-        except:  # noqa: E722
+        except Exception:
             return msg
 
     def _start_trace(self, run: Run) -> Coroutine[Any, Any, None] | None:  # type: ignore[return]


### PR DESCRIPTION
## Description

This PR replaces a bare `except:` clause with `except Exception:` in `libs/core/langchain_core/tracers/core.py`.

The previous implementation caught `BaseException`, which includes `SystemExit` and `KeyboardInterrupt`. This meant that if a user tried to interrupt the program (Ctrl+C) during a traceback formatting error, the signal would be suppressed, potentially making the process un-killable.

This change ensures that standard runtime errors are still caught and logged, but system control signals are allowed to propagate correctly.

## Verification

- Verified via code inspection.
- This is a standard safety fix for exception handling patterns in Python to avoid suppressing system exit signals.