### PR TITLE
fix(openai): reuse cached httpx clients in AzureChatOpenAI

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -17,6 +17,10 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 from langchain_openai.chat_models.base import BaseChatOpenAI, _get_default_model_profile
 
 logger = logging.getLogger(__name__)
@@ -683,11 +687,19 @@ class AzureChatOpenAI(BaseChatOpenAI):
             client_params["max_retries"] = self.max_retries
 
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(self.azure_endpoint, self.request_timeout),
+            }
             self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
             self.client = self.root_client.chat.completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                ),
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (


### PR DESCRIPTION
Fixes #32489

`AzureChatOpenAI` was creating fresh `httpx.Client` / `httpx.AsyncClient` instances on every instantiation. The base `BaseChatOpenAI` class already caches these via `_get_default_httpx_client` / `_get_default_async_httpx_client` (keyed on base_url + timeout), but `AzureChatOpenAI` was passing `self.http_client` directly without the fallback.

This just wires up the same caching pattern, using `azure_endpoint` as the cache key instead of `openai_api_base`.

**Before:** 5 instances = 5 sync + 5 async clients  
**After:** 5 instances = 1 sync + 1 async client (cached)

Added a unit test following the same pattern as `test_openai_client_caching` in `test_base.py`.

All existing tests pass, `make lint` and `make format` are clean.