### PR TITLE
fix(openai): validate message and tool names before API call

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3547,7 +3547,8 @@ def _lc_tool_call_to_openai_tool_call(tool_call: ToolCall) -> dict:
 def _lc_invalid_tool_call_to_openai_tool_call(
     invalid_tool_call: InvalidToolCall,
 ) -> dict:
-    _validate_openai_name(invalid_tool_call["name"], context="tool")
+    if name := invalid_tool_call["name"]:
+        _validate_openai_name(name, context="tool")
     return {
         "type": "function",
         "id": invalid_tool_call["id"],


### PR DESCRIPTION
## Summary
This PR adds OpenAI-specific name validation before request serialization in `langchain-openai`.

It catches invalid names early (for example names containing spaces like `"User Onboarding Agent"`) and raises a clear `ValueError` instead of letting the request fail later with an opaque OpenAI `400`.

Fixes #35054.

## What changed
- Added `_validate_openai_name(...)` in `langchain_openai/chat_models/base.py`.
- Applied validation at serialization/binding points:
  - message `name` in `_convert_message_to_dict(...)`
  - tool call names in `_lc_tool_call_to_openai_tool_call(...)`
  - invalid tool call names in `_lc_invalid_tool_call_to_openai_tool_call(...)`
  - tool names during `bind_tools(...)`
  - tool names from `tool_choice` (`str` and function `dict` forms)
  - names in `additional_kwargs["tool_calls"]` when present
- Added regression tests for all new validation paths in
  `tests/unit_tests/chat_models/test_base.py`.

## Why this is the right layer
The restriction is OpenAI API specific (`messages[*].name`/tool names). Validating in `langchain-openai` keeps this behavior provider-scoped and avoids changing cross-provider core behavior.

## Local verification
Run from `libs/partners/openai`:

```bash
env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy OPENAI_API_KEY=test uv run ruff check langchain_openai/chat_models/base.py tests/unit_tests/chat_models/test_base.py
env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy OPENAI_API_KEY=test uv run ruff format --check langchain_openai/chat_models/base.py tests/unit_tests/chat_models/test_base.py
env -u ALL_PROXY -u all_proxy -u HTTPS_PROXY -u https_proxy -u HTTP_PROXY -u http_proxy -u NO_PROXY -u no_proxy OPENAI_API_KEY=test uv run python -m pytest -q tests/unit_tests/chat_models/test_base.py
```

All passed locally.

## AI assistance disclosure
AI assistance was intentionally limited to unit test drafting/refinement, review support, and formatting checks. Final implementation decisions and code changes were reviewed and applied manually.
