### PR TITLE
fix: ChatOpenAI silently drops reasoning_content

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -191,6 +191,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
                     )
         if audio := _dict.get("audio"):
             additional_kwargs["audio"] = audio
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = reasoning_content
         return AIMessage(
             content=content,
             additional_kwargs=additional_kwargs,
@@ -397,6 +399,8 @@ def _convert_delta_to_message_chunk(
     if role == "user" or default_class == HumanMessageChunk:
         return HumanMessageChunk(content=content, id=id_)
     if role == "assistant" or default_class == AIMessageChunk:
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = reasoning_content
         return AIMessageChunk(
             content=content,
             additional_kwargs=additional_kwargs,
@@ -1543,6 +1547,13 @@ class BaseChatOpenAI(BaseChatModel):
                 generations[0].message.additional_kwargs["parsed"] = message.parsed
             if hasattr(message, "refusal"):
                 generations[0].message.additional_kwargs["refusal"] = message.refusal
+            if (
+                hasattr(message, "reasoning_content")
+                and message.reasoning_content
+            ):
+                generations[0].message.additional_kwargs["reasoning_content"] = (
+                    message.reasoning_content
+                )
 
         return ChatResult(generations=generations, llm_output=llm_output)
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1547,10 +1547,7 @@ class BaseChatOpenAI(BaseChatModel):
                 generations[0].message.additional_kwargs["parsed"] = message.parsed
             if hasattr(message, "refusal"):
                 generations[0].message.additional_kwargs["refusal"] = message.refusal
-            if (
-                hasattr(message, "reasoning_content")
-                and message.reasoning_content
-            ):
+            if hasattr(message, "reasoning_content") and message.reasoning_content:
                 generations[0].message.additional_kwargs["reasoning_content"] = (
                     message.reasoning_content
                 )


### PR DESCRIPTION
# fix: ChatOpenAI silently drops `reasoning_content`

## Description
This PR fixes an issue where `ChatOpenAI` silently drops the `reasoning_content` field from API responses. This field is crucial for obtaining the "thought process" from reasoning models like DeepSeek-R1 or similar models served via vLLM/OpenAI-compatible endpoints.

The fix involves extracting `reasoning_content` and adding it to `additional_kwargs` in:
1. `_convert_dict_to_message` (for non-streaming responses).
2. `_convert_delta_to_message_chunk` (for streaming responses).
3. `_create_chat_result` (handling `reasoning_content` attribute on `BaseModel` responses).

This ensures consistent behavior with `ChatDeepSeek` and allows users to access reasoning data regardless of the provider.

## Issue
Fixes #35059

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## General Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make test` and `make lint` locally
- [x] I have added necessary documentation (if appropriate)

## Verification
Added 4 new unit tests in `libs/partners/openai/tests/unit_tests/chat_models/test_base.py`:
- `test_convert_dict_to_message_with_reasoning_content`
- `test_convert_dict_to_message_without_reasoning_content`
- `test_convert_delta_to_message_chunk_with_reasoning_content`
- `test_convert_delta_to_message_chunk_without_reasoning_content`

Ran tests with:
```bash
pytest libs/partners/openai/tests/unit_tests/chat_models/test_base.py -v -k reasoning
```
Result: 4 passed.
