### PR TITLE
fix(core): correct misleading jinja2 sandboxing comment

### DIFF
--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -64,9 +64,11 @@ def jinja2_formatter(template: str, /, **kwargs: Any) -> str:
         )
         raise ImportError(msg)
 
-    # Use a restricted sandbox that blocks ALL attribute/method access
-    # Only simple variable lookups like {{variable}} are allowed
-    # Attribute access like {{variable.attr}} or {{variable.method()}} is blocked
+    # Use Jinja2's SandboxedEnvironment which blocks access to dunder attributes
+    # (e.g., __class__, __globals__) to prevent sandbox escapes.
+    # Note: regular attribute access (e.g., {{obj.attr}}) and method calls are
+    # still allowed. This is a best-effort measure — do not use with untrusted
+    # templates.
     return SandboxedEnvironment().from_string(template).render(**kwargs)
 
 


### PR DESCRIPTION
## Summary
- The inline comment at `langchain_core/prompts/string.py:67-69` incorrectly states that `SandboxedEnvironment` "blocks ALL attribute/method access" and that "only simple variable lookups like `{{variable}}` are allowed."
- In reality, Jinja2's `SandboxedEnvironment` only blocks access to dunder attributes (`__class__`, `__globals__`, etc.) to prevent sandbox escapes. Regular attribute access like `{{obj.content}}` and method calls remain allowed.
- This misleading comment was left behind when a `_RestrictedSandboxedEnvironment` class was reverted in commit 395c8d0bd4. Updated to accurately describe the actual behavior.

## Why this matters
The comment could mislead developers into trusting partially-untrusted templates, believing attribute access is blocked when it is not. The function's docstring already correctly warns against untrusted templates.

## Test plan
- [ ] No behavioral change — comment-only fix
- [ ] Verified `SandboxedEnvironment` behavior matches updated comment

> This PR was authored with the help of AI tools.