### PR TITLE
fix(core): handle `NameError` in `RunnableWithFallbacks.__getattr__`

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -649,7 +649,12 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
 def _returns_runnable(attr: Any) -> bool:
     if not callable(attr):
         return False
-    return_type = typing.get_type_hints(attr).get("return")
+    try:
+        return_type = typing.get_type_hints(attr).get("return")
+    except NameError:
+        # get_type_hints() raises NameError when annotations reference names
+        # only available in TYPE_CHECKING blocks (forward references).
+        return False
     return bool(return_type and _is_runnable_type(return_type))
 
 

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -385,6 +385,7 @@ def test_returns_runnable_handles_nameerror() -> None:
     typing.get_type_hints() raises NameError when annotations reference names
     only available in TYPE_CHECKING blocks. This should not crash.
     """
+
     # Simulate a callable whose annotations reference an undefined name
     def func_with_bad_annotation() -> "UndefinedType":  # type: ignore[name-defined]  # noqa: F821
         pass

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -27,6 +27,7 @@ from langchain_core.runnables import (
     RunnablePassthrough,
     RunnableWithFallbacks,
 )
+from langchain_core.runnables.fallbacks import _returns_runnable
 from langchain_core.tools import BaseTool
 
 
@@ -384,8 +385,6 @@ def test_returns_runnable_handles_nameerror() -> None:
     typing.get_type_hints() raises NameError when annotations reference names
     only available in TYPE_CHECKING blocks. This should not crash.
     """
-    from langchain_core.runnables.fallbacks import _returns_runnable
-
     # Simulate a callable whose annotations reference an undefined name
     def func_with_bad_annotation() -> "UndefinedType":  # type: ignore[name-defined]  # noqa: F821
         pass

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -378,6 +378,22 @@ class FakeModel(BaseChatModel):
         return "fake2"
 
 
+def test_returns_runnable_handles_nameerror() -> None:
+    """Test that _returns_runnable handles NameError from get_type_hints.
+
+    typing.get_type_hints() raises NameError when annotations reference names
+    only available in TYPE_CHECKING blocks. This should not crash.
+    """
+    from langchain_core.runnables.fallbacks import _returns_runnable
+
+    # Simulate a callable whose annotations reference an undefined name
+    def func_with_bad_annotation() -> "UndefinedType":  # type: ignore[name-defined]  # noqa: F821
+        pass
+
+    # Should return False instead of raising NameError
+    assert _returns_runnable(func_with_bad_annotation) is False
+
+
 def test_fallbacks_getattr() -> None:
     llm_with_fallbacks = FakeStructuredOutputModel(foo=3).with_fallbacks(
         [FakeModel(bar=4)]


### PR DESCRIPTION
## Summary
- `_returns_runnable()` in `fallbacks.py` calls `typing.get_type_hints()` without handling `NameError`, which is raised when annotations reference names only available in `TYPE_CHECKING` blocks (forward references).
- This causes unexpected crashes when using `.with_fallbacks()` on runnables whose methods have such type annotations.
- Added a `try/except NameError` that gracefully returns `False` (the safe default — the method won't be wrapped as returning a `Runnable`).

## Test plan
- [x] Added `test_returns_runnable_handles_nameerror` that verifies the fix
- [x] Existing `test_fallbacks_getattr` and `test_fallbacks_getattr_runnable_output` still pass

> This PR was authored with the help of AI tools.