### PR TITLE
fix(core): add path traversal protection to chat history docstring example

### DIFF
--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -63,17 +63,15 @@ class BaseChatMessageHistory(ABC):
                 # Sanitize session_id to prevent path traversal
                 safe_id = os.path.basename(self.session_id)
                 if not safe_id or safe_id != self.session_id:
-                    raise ValueError(
-                        f"Invalid session_id: {self.session_id!r}"
-                    )
+                    raise ValueError(f"Invalid session_id: {self.session_id!r}")
                 file_path = os.path.join(self.storage_path, safe_id)
                 # Verify the resolved path is within storage_path
-                if not Path(file_path).resolve().is_relative_to(
-                    Path(self.storage_path).resolve()
+                if (
+                    not Path(file_path)
+                    .resolve()
+                    .is_relative_to(Path(self.storage_path).resolve())
                 ):
-                    raise ValueError(
-                        f"Invalid session_id: {self.session_id!r}"
-                    )
+                    raise ValueError(f"Invalid session_id: {self.session_id!r}")
                 return file_path
 
             @property


### PR DESCRIPTION
## Summary
- The `FileChatMessageHistory` example in the `BaseChatMessageHistory` docstring passes `session_id` directly into `os.path.join()` without any validation.
- Since developers commonly copy docstring examples, this creates a risk of path traversal if `session_id` comes from user input (e.g., `../../etc/passwd`).
- Added a `_get_file_path()` helper to the example that:
  - Strips path components using `os.path.basename()`
  - Rejects `session_id` values containing path separators
  - Verifies the resolved path stays within `storage_path` using `Path.is_relative_to()`

## Why this matters
Docstring examples serve as reference implementations that developers copy. This example is the primary guidance for implementing file-based chat history, and in RAG/chatbot applications `session_id` often comes from user input (URL parameters, cookies, etc.).

## Test plan
- [ ] No behavioral change — docstring-only fix
- [ ] Verified the example code is syntactically valid

> This PR was authored with the help of AI tools.