### PR TITLE
fix(openai): mitigate SSRF TOCTOU in image token counter

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3566,7 +3566,7 @@ def _url_to_size(image_source: str) -> tuple[int, int] | None:
                 return None
 
             for result in addr_info:
-                ip_str: str = result[4][0]
+                ip_str = str(result[4][0])
                 if is_cloud_metadata(hostname, ip_str):
                     logger.warning(
                         "Image URL resolves to cloud metadata IP: %s", ip_str

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3573,14 +3573,10 @@ def _url_to_size(image_source: str) -> tuple[int, int] | None:
                     )
                     return None
                 if is_localhost(hostname, ip_str):
-                    logger.warning(
-                        "Image URL resolves to localhost: %s", ip_str
-                    )
+                    logger.warning("Image URL resolves to localhost: %s", ip_str)
                     return None
                 if is_private_ip(ip_str):
-                    logger.warning(
-                        "Image URL resolves to private IP: %s", ip_str
-                    )
+                    logger.warning("Image URL resolves to private IP: %s", ip_str)
                     return None
         except ImportError:
             logger.warning(


### PR DESCRIPTION
## Summary
- The SSRF protection in `_url_to_size()` previously called `validate_safe_url()` which resolved DNS, then `httpx.get()` resolved DNS independently. This created a Time-of-Check-Time-of-Use gap (CWE-367) where DNS rebinding could bypass validation.
- Now resolves DNS manually via `socket.getaddrinfo()` and validates **all** resolved IPs directly against blocklists (private ranges, cloud metadata endpoints, localhost). The httpx request follows immediately, relying on OS DNS cache to minimize the rebinding window.
- Practical impact was limited to blind SSRF (response data is only used for image dimensions via PIL, not returned to the caller).

## Why this approach
A complete fix would require IP-pinned transport support in httpx (connecting to a pre-resolved IP while maintaining TLS hostname verification), which httpx does not currently support. This approach narrows the TOCTOU window by:
1. Resolving DNS once and validating all returned IPs
2. Making the httpx request immediately after, when OS DNS cache still holds the validated addresses

This is documented in code comments for future improvement.

## Test plan
- [x] Added `test_url_to_size_blocks_private_ips` — verifies cloud metadata IPs are blocked
- [x] Added `test_url_to_size_blocks_localhost` — verifies localhost IPs are blocked
- [x] Existing tests still pass

> This PR was authored with the help of AI tools.