### PR TITLE
fix(core): prevent IndexError in handle_event when NotImplementedError is raised

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -284,7 +284,7 @@ def handle_event(
                     if asyncio.iscoroutine(event):
                         coros.append(event)
             except NotImplementedError as e:
-                if event_name == "on_chat_model_start":
+                if event_name == "on_chat_model_start" and len(args) >= 2:
                     if message_strings is None:
                         message_strings = [get_buffer_string(m) for m in args[1]]
                     handle_event(

--- a/libs/core/tests/unit_tests/callbacks/test_handle_event.py
+++ b/libs/core/tests/unit_tests/callbacks/test_handle_event.py
@@ -1,0 +1,43 @@
+"""Tests for handle_event in callback manager."""
+
+from unittest.mock import Mock
+
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.callbacks.manager import handle_event
+
+
+class _RaisingHandler(BaseCallbackHandler):
+    """Handler that raises NotImplementedError on on_chat_model_start."""
+
+    def on_chat_model_start(self, *args, **kwargs):
+        raise NotImplementedError("not implemented")
+
+
+def test_handle_event_not_implemented_error_no_args():
+    """Test that handle_event does not raise IndexError when a handler raises
+    NotImplementedError for on_chat_model_start and no positional args are given.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/31576
+    """
+    handler = _RaisingHandler()
+    # Should not raise IndexError — should log a warning instead
+    handle_event(
+        [handler],
+        "on_chat_model_start",
+        ignore_condition_name=None,
+    )
+
+
+def test_handle_event_generic_exception_is_logged():
+    """Test that generic exceptions in handlers are caught and logged."""
+    handler = Mock(spec=BaseCallbackHandler)
+    handler.on_llm_start = Mock(side_effect=KeyError("test"))
+    handler.raise_error = False
+    handler.ignore_llm = False
+
+    # Should not raise — the KeyError should be caught and logged
+    handle_event(
+        [handler],
+        "on_llm_start",
+        "ignore_llm",
+    )


### PR DESCRIPTION
## Summary

Fixes `IndexError: tuple index out of range` in `handle_event()` when a callback handler raises `NotImplementedError` for `on_chat_model_start` without positional arguments.

## Problem

When a handler raises `NotImplementedError` for the `on_chat_model_start` event, `handle_event` tries to access `args[1]` to convert messages for a fallback `on_llm_start` call. If insufficient positional arguments were passed, this produces an `IndexError` that masks the original `NotImplementedError`.

```python
# Reproduces the bug:
handler = Mock()
handler.on_chat_model_start = Mock(side_effect=NotImplementedError)
handle_event([handler], "on_chat_model_start", None)
# IndexError: tuple index out of range
```

## Fix

Added a bounds check `len(args) >= 2` before accessing `args[1]`. When there aren't enough args to perform the fallback conversion, the handler falls through to the warning log path instead of crashing.

## Test plan

- [x] Added `test_handle_event_not_implemented_error_no_args` — verifies no `IndexError` on `NotImplementedError` with no args
- [x] Added `test_handle_event_generic_exception_is_logged` — verifies other exceptions are caught normally

Fixes #31576