### PR TITLE
feat(core): implement .save() for ChatPromptTemplate

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from pathlib import Path
@@ -14,6 +15,7 @@ from typing import (
     overload,
 )
 
+import yaml
 from pydantic import (
     Field,
     PositiveInt,
@@ -1306,12 +1308,32 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
         return "chat"
 
     def save(self, file_path: Path | str) -> None:
-        """Save prompt to file.
+        """Save the prompt to a file.
 
         Args:
             file_path: path to file.
         """
-        raise NotImplementedError
+        path = Path(file_path)
+        if path.suffix not in [".json", ".yaml"]:
+            msg = (
+                f"Got unsupported file extension {path.suffix}. "
+                "Please use .json or .yaml"
+            )
+            raise ValueError(msg)
+
+        # Convert to dict for serialization
+        prompt_dict = self.dict()
+
+        # Ensure the loader knows this is a chat prompt
+        if "_type" not in prompt_dict:
+            prompt_dict["_type"] = "chat"
+
+        if path.suffix == ".json":
+            with path.open("w") as f:
+                json.dump(prompt_dict, f, indent=2)
+        else:
+            with path.open("w") as f:
+                yaml.dump(prompt_dict, f)
 
     @override
     def pretty_repr(self, html: bool = False) -> str:

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -1,3 +1,4 @@
+import json
 import re
 import warnings
 from pathlib import Path
@@ -1983,3 +1984,22 @@ def test_mustache_template_attribute_access_vulnerability() -> None:
     )
     result_dict = prompt_dict.invoke({"person": {"name": "Alice"}})
     assert result_dict.messages[0].content == "Alice"  # type: ignore[attr-defined]
+
+
+def test_chat_prompt_template_save(tmp_path: Path) -> None:
+    """Test saving a chat prompt template."""
+    file_path = tmp_path / "chat_prompt.json"
+    template = ChatPromptTemplate.from_messages(
+        [
+            ("system", "You are a helpful assistant."),
+            ("human", "Tell me a joke about {topic}"),
+        ]
+    )
+    template.save(file_path)
+    assert file_path.exists()
+
+    # Verify the saved content contains the correct type for the loader
+    with file_path.open("r") as f:
+        data = json.load(f)
+    assert data["_type"] == "chat"
+    assert "messages" in data


### PR DESCRIPTION
1. feat(core) : implement .save() for ChatPromptTemplate
 

2. PR description:

- Implements the missing .save() method in ChatPromptTemplate to support serialization to JSON and YAML.
- Fixes #32637 

3. How did you verify your code works?

  - Added a unit test in tests/unit_tests/prompts/test_chat.py 
  - Also confirmed that make format, make linkt and pytests all passes.

  - **Disclaimer**: Note that this contribution was assisted by AI.

LinkedIn: [rithvikms](https://www.linkedin.com/in/rithvikms/)
