### PR TITLE
fix(anthropic): pass metadata.user_id from config to API

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1291,6 +1291,10 @@ class ChatAnthropic(BaseChatModel):
     ) -> dict:
         messages = self._convert_input(input_).to_messages()
         system, formatted_messages = _format_messages(messages)
+        
+        # Extract metadata from kwargs if present
+        metadata = kwargs.pop("metadata", None)
+        
         payload = {
             "model": self.model,
             "max_tokens": self.max_tokens,
@@ -1305,6 +1309,11 @@ class ChatAnthropic(BaseChatModel):
             **self.model_kwargs,
             **kwargs,
         }
+        
+        # Add metadata to payload if user_id is present
+        if metadata and "user_id" in metadata:
+            payload["metadata"] = {"user_id": metadata["user_id"]}
+        
         if self.thinking is not None:
             payload["thinking"] = self.thinking
         return {k: v for k, v in payload.items() if v is not None}


### PR DESCRIPTION
## Summary
Fixes an issue where `metadata.user_id` from the config parameter was not being passed to the Anthropic API, preventing prompt caching from working correctly with third-party agents that require user identification.

## Changes
- Modified `_get_request_payload` method in `ChatAnthropic` to extract metadata from kwargs
- Added logic to include metadata with user_id in the API payload when present
- Maintains backward compatibility - metadata is only added when explicitly provided

## How I verified this works
Created and ran unit tests verifying:
- metadata is correctly passed to API payload when provided
- metadata is absent from payload when not provided  
- metadata without user_id doesn't trigger inclusion

Fixes #35219
