### PR TITLE
fix(infra): create GitHub releases for partner package releases

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -586,6 +586,8 @@ jobs:
       - test-pypi-publish
       - pre-release-checks
       - publish
+    # Run if all needed jobs succeeded or were skipped (test-dependents only runs for core/langchain_v1)
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     permissions:
       # This permission is needed by `ncipollo/release-action` to

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -219,6 +219,7 @@ jobs:
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
           NOMIC_API_KEY: ${{ secrets.NOMIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           PPLX_API_KEY: ${{ secrets.PPLX_API_KEY }}
           XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
         with:

--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -239,7 +239,7 @@ class ChatOpenRouter(BaseChatModel):
     """
 
     route: str | None = None
-    """Route preference for OpenRouter. E.g. `'fallback'`."""
+    """Route preference for OpenRouter, e.g. `'fallback'`."""
 
     plugins: list[dict[str, Any]] | None = None
     """Plugins configuration for OpenRouter."""


### PR DESCRIPTION
- GitHub releases have not been created for partner package releases since #34784 (Jan 16). PyPI publishes were unaffected.

#34784 added `test-dependents` to the `publish` job's dependency chain. `test-dependents` only runs for core/langchain releases, so it's skipped for everything else. `publish` handles this with `if: ${{ !cancelled() && !failure() }}`, but `mark-release` (which creates the GitHub release) doesn't have the same guard — so GitHub Actions skips it whenever `test-dependents` is skipped.

## Missing GitHub releases
`langchain-xai==1.2.2`, `langchain-standard-tests==1.1.3`, `langchain-groq==1.1.2`, `langchain-anthropic==1.3.2`, `langchain-standard-tests==1.1.4`, `langchain-openai==1.1.8`, `langchain-openai==1.1.9`, `langchain-anthropic==1.3.3`, `langchain-openrouter==0.0.2`