### PR TITLE
core: implement ChatPromptTemplate.save() by delegating to base class

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -1310,8 +1310,16 @@ class ChatPromptTemplate(BaseChatPromptTemplate):
 
         Args:
             file_path: path to file.
+
+        Raises:
+            ValueError: If the file path is not json or yaml.
+
+        Example:
+            .. code-block:: python
+
+                prompt.save(file_path="path/prompt.json")
         """
-        raise NotImplementedError
+        super().save(file_path)
 
     @override
     def pretty_repr(self, html: bool = False) -> str:


### PR DESCRIPTION
## Description

Implements `ChatPromptTemplate.save()` by delegating to the base class `BasePromptTemplate.save()`, which already supports serialization to JSON/YAML.

Previously, `ChatPromptTemplate.save()` unconditionally raised `NotImplementedError`, even though:
- `BasePromptTemplate.save()` already handles serialization via `self.dict()`
- `ChatPromptTemplate` correctly implements `_prompt_type` (returns `"chat"`)
- `BasePromptTemplate.dict()` already includes `_type` from `_prompt_type`

The fix simply delegates to the parent class implementation.

### Example

```python
from langchain_core.prompts import ChatPromptTemplate

prompt = ChatPromptTemplate.from_messages([
    ("system", "You are a helpful assistant."),
    ("human", "{input}"),
])

# Previously raised NotImplementedError
prompt.save("prompt.json")  # Now works
prompt.save("prompt.yaml")  # Now works
```

Closes #32637