### PR TITLE
fix(openai): improve error message for null choices in OpenAI-compatible APIs

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1520,7 +1520,15 @@ class BaseChatOpenAI(BaseChatModel):
             raise KeyError(msg) from e
 
         if choices is None:
-            msg = "Received response with null value for `choices`."
+            # Some OpenAI-compatible APIs (e.g., vLLM) may return null choices
+            # when the response format differs or an error occurs without
+            # populating the error field. Provide a more helpful error message.
+            msg = (
+                "Received response with null value for `choices`. "
+                "This can happen when using OpenAI-compatible APIs (e.g., vLLM) "
+                "that return a response in an unexpected format. "
+                f"Full response keys: {list(response_dict.keys())}"
+            )
             raise TypeError(msg)
 
         token_usage = response_dict.get("usage")


### PR DESCRIPTION
## Description

Improves the error message when `choices` is `null` in the response from OpenAI-compatible APIs (e.g., vLLM).

Previously the error was:
```
TypeError: Received response with null value for `choices`.
```

This is unhelpful when debugging vLLM or other compatible API issues. The new message:
- Mentions that this commonly happens with OpenAI-compatible APIs like vLLM
- Includes the response keys so users can see what the API actually returned
- Helps users identify if the response was in a different format (e.g., Responses API)

### Context

When using vLLM's OpenAI-compatible API with multimodal inputs, the server may return a response with `choices: null` instead of the expected format. The current error message gives no indication of what went wrong or how to debug it.

Related to #32252