### PR TITLE
openai: reuse cached httpx clients in AzureChatOpenAI

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -17,6 +17,10 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 from langchain_openai.chat_models.base import BaseChatOpenAI, _get_default_model_profile
 
 logger = logging.getLogger(__name__)
@@ -683,11 +687,21 @@ class AzureChatOpenAI(BaseChatOpenAI):
             client_params["max_retries"] = self.max_retries
 
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(
+                    self.openai_api_base, self.request_timeout
+                ),
+            }
             self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
             self.client = self.root_client.chat.completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.openai_api_base, self.request_timeout
+                ),
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (


### PR DESCRIPTION
## Description

Fixes `AzureChatOpenAI` creating a new `httpx.Client`/`httpx.AsyncClient` on every instantiation.

### Problem

`BaseChatOpenAI` correctly falls back to cached httpx clients via `_get_default_httpx_client()` / `_get_default_async_httpx_client()` (which use `lru_cache`). However, `AzureChatOpenAI` passes `self.http_client` directly (which is `None` by default), causing the underlying `openai.AzureOpenAI` to create a new httpx client each time.

### Fix

Apply the same fallback pattern used in `BaseChatOpenAI`:
```python
"http_client": self.http_client or _get_default_httpx_client(...)
```

This ensures httpx clients are reused across `AzureChatOpenAI` instances with the same base URL and timeout.

### Verification

```python
import httpx
from langchain_openai import AzureChatOpenAI

original_init = httpx.AsyncClient.__init__
counter = {"count": 0}
def counting_init(self, *args, **kwargs):
    counter["count"] += 1
    original_init(self, *args, **kwargs)
httpx.AsyncClient.__init__ = counting_init

# Before fix: 5 clients created
# After fix: 1 client created (cached)
llms = [AzureChatOpenAI(azure_endpoint="https://test.openai.azure.com/", deployment_name="gpt-4") for _ in range(5)]
print(f"Clients created: {counter['count']}")
```

Fixes #32489