### PR TITLE
fix(core): ensure pretty_repr handles partial variables

### DIFF
--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -360,6 +360,13 @@ class StringPromptTemplate(BasePromptTemplate, ABC):
         dummy_vars = {
             input_var: "{" + f"{input_var}" + "}" for input_var in self.input_variables
         }
+        if hasattr(self, "partial_variables"):
+            dummy_vars.update(
+                {
+                    k: "{" + f"{k}" + "}"
+                    for k in self.partial_variables.keys()
+                }
+            )
         if html:
             dummy_vars = {
                 k: get_colored_text(v, "yellow") for k, v in dummy_vars.items()

--- a/libs/core/tests/unit_tests/prompts/test_string.py
+++ b/libs/core/tests/unit_tests/prompts/test_string.py
@@ -39,3 +39,15 @@ def test_get_template_variables_mustache_nested() -> None:
     expected = ["user"]
     actual = get_template_variables(template, template_format)
     assert actual == expected
+
+
+def test_pretty_repr_with_partial_variables() -> None:
+    from langchain_core.prompts import PromptTemplate
+
+    prompt = PromptTemplate(
+        template="Hello {name}, welcome to {place}!",
+        input_variables=["name", "place"],
+        partial_variables={"place": "World"},
+    )
+    # We want the partial variable to be displayed as a placeholder, not its value.
+    assert "welcome to {place}" in prompt.pretty_repr()


### PR DESCRIPTION
## Description

 was previously resolving partial variables, which made the string representation inaccurate for prompt templates that use them. This PR updates  to display partial variables as placeholders (e.g. ) instead of their resolved values.

## Changes
- Updated  to include partial variables in .
- Added a test case in  to verify the fix.

## Verification
- Verified manually with a reproduction script.
- Verified with the new unit test.