### PR TITLE
fix(core): improve BaseMessage.pretty_repr for list content

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -336,10 +336,34 @@ class BaseMessage(Serializable):
             ```
         """  # noqa: E501
         title = get_msg_title_repr(self.type.title() + " Message", bold=html)
-        # TODO: handle non-string content.
         if self.name is not None:
             title += f"\nName: {self.name}"
-        return f"{title}\n\n{self.content}"
+
+        if isinstance(self.content, str):
+            val = self.content
+        elif isinstance(self.content, list):
+            val_parts = []
+            for block in self.content:
+                if isinstance(block, str):
+                    val_parts.append(block)
+                elif isinstance(block, dict):
+                    block_type = block.get("type")
+                    if block_type == "text":
+                        val_parts.append(block.get("text", ""))
+                    elif block_type in ("image_url", "image"):
+                        val_parts.append(f"[{block_type}]")
+                    elif block_type in ("tool_use", "tool_call"):
+                        name = block.get("name", "")
+                        val_parts.append(f"[{block_type}: {name}]")
+                    else:
+                        val_parts.append(str(block))
+                else:
+                    val_parts.append(str(block))
+            val = "".join(val_parts)
+        else:
+            val = str(self.content)
+
+        return f"{title}\n\n{val}"
 
     def pretty_print(self) -> None:
         """Print a pretty representation of the message.

--- a/libs/core/tests/unit_tests/messages/test_pretty_repr.py
+++ b/libs/core/tests/unit_tests/messages/test_pretty_repr.py
@@ -1,0 +1,41 @@
+
+import pytest
+from langchain_core.messages import HumanMessage, AIMessage
+
+def test_pretty_repr_string_content() -> None:
+    msg = HumanMessage(content="Hello World")
+    assert "Hello World" in msg.pretty_repr()
+
+def test_pretty_repr_list_text_content() -> None:
+    msg = HumanMessage(content=[
+        {"type": "text", "text": "Hello"},
+        {"type": "text", "text": " World"}
+    ])
+    assert "Hello World" in msg.pretty_repr()
+
+def test_pretty_repr_mixed_content() -> None:
+    msg = HumanMessage(content=[
+        {"type": "text", "text": "Look at this: "},
+        {"type": "image_url", "image_url": {"url": "http://example.com/image.png"}}
+    ])
+    repr_output = msg.pretty_repr()
+    assert "Look at this: " in repr_output
+    assert "[image_url]" in repr_output
+
+def test_pretty_repr_tool_call_content() -> None:
+    # content block style tool call (e.g. Anthropic)
+    msg = AIMessage(content=[
+        {"type": "text", "text": "I will use a tool."},
+        {"type": "tool_use", "name": "calculator", "id": "123"}
+    ])
+    repr_output = msg.pretty_repr()
+    assert "I will use a tool." in repr_output
+    assert "[tool_use: calculator]" in repr_output
+
+
+def test_pretty_repr_unknown_block_content() -> None:
+    msg = AIMessage(content=[
+        {"type": "unknown_type", "value": "mystery"}
+    ])
+    # Should fallback to string representation of the dict
+    assert "{'type': 'unknown_type', 'value': 'mystery'}" in msg.pretty_repr()


### PR DESCRIPTION
## Description

 previously printed the raw list representation for messages with list content (e.g. multimodal messages or tool usage), which was hard to read. This PR updates  to format list content in a human-readable way.

## Changes
- Updated  to iterate over content blocks and format them.
  - Text blocks are joined.
  - Image and tool call blocks are represented with markers like `[image_url]` and `[tool_use: name]`.
  - Fallback to string representation for unknown blocks.
- Added  with tests for:
  - String content.
  - List of text blocks.
  - Mixed content (text + image).
  - Tool calls.
  - Unknown block types.

## Verification
- Verified with new unit tests.