### PR TITLE
chore: add deprecation warning to root readme [closes LC-479]

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
   <a href="https://x.com/langchain" target="_blank"><img src="https://img.shields.io/twitter/url/https/twitter.com/langchain.svg?style=social&label=Follow%20%40LangChain" alt="Twitter / X"></a>
 </div>
 
+> [!CAUTION]
+> **This repository is deprecated.** The `langchain` package is no longer actively maintained. We recommend migrating to [LangGraph](https://github.com/langchain-ai/langgraph) for building agents and LLM-powered applications. See the [LangGraph documentation](https://docs.langchain.com/oss/python/langgraph/overview) for more details.
+
 LangChain is a framework for building agents and LLM-powered applications. It helps you chain together interoperable components and third-party integrations to simplify AI application development – all while future-proofing decisions as the underlying technology evolves.
 
 ```bash


### PR DESCRIPTION
## Description
Adds a prominent deprecation warning to the root README to inform users that this repository is deprecated and they should not use it. The warning recommends migrating to LangGraph and links to the LangGraph repository and documentation.

Changes:
- Added a `[!CAUTION]` admonition block at the top of `README.md` (before the description text) stating the repo is deprecated

Resolves LC-479

## Test Plan
- [ ] Verify the deprecation warning renders correctly on GitHub (red CAUTION box)
- [ ] Verify the warning is visible immediately when viewing the repository README
- [ ] Verify the LangGraph links in the warning are correct