### PR TITLE
fix(openai): enhance error message for non-OpenAI embedding providers

### DIFF
--- a/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_base.py
@@ -1,6 +1,6 @@
 import os
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from pydantic import SecretStr
@@ -148,3 +148,116 @@ def test_embeddings_respects_token_limit() -> None:
     # Verify each call respected the limit
     for count in call_counts:
         assert count <= 300000, f"Batch exceeded limit: {count}"
+
+
+class TestNonOpenAIProviderErrorGuidance:
+    """Tests for enhanced error messages when using non-OpenAI providers."""
+
+    def test_non_openai_url_valueerror_gives_enhanced_message_sync_tokenized(
+        self,
+    ) -> None:
+        """Sync tokenized path: non-OpenAI URL + ValueError gives guidance."""
+        embeddings = OpenAIEmbeddings(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",  # type: ignore[arg-type]
+        )
+        with patch.object(embeddings.client, "create") as mock_create:
+            mock_create.side_effect = ValueError("No embedding data received")
+            with pytest.raises(ValueError, match="check_embedding_ctx_length=False"):
+                embeddings.embed_documents(["hello"])
+
+    def test_non_openai_url_valueerror_gives_enhanced_message_sync_plain(
+        self,
+    ) -> None:
+        """Sync plain-text path: non-OpenAI URL + ValueError gives guidance."""
+        embeddings = OpenAIEmbeddings(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",  # type: ignore[arg-type]
+            check_embedding_ctx_length=False,
+        )
+        with patch.object(embeddings.client, "create") as mock_create:
+            mock_create.side_effect = ValueError("No embedding data received")
+            with pytest.raises(ValueError, match="encoding_format"):
+                embeddings.embed_documents(["hello"])
+
+    async def test_non_openai_url_valueerror_gives_enhanced_message_async_tokenized(
+        self,
+    ) -> None:
+        """Async tokenized path: non-OpenAI URL + ValueError gives guidance."""
+        embeddings = OpenAIEmbeddings(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",  # type: ignore[arg-type]
+        )
+        with patch.object(embeddings.async_client, "create") as mock_create:
+            mock_create.side_effect = ValueError("No embedding data received")
+            with pytest.raises(ValueError, match="check_embedding_ctx_length=False"):
+                await embeddings.aembed_documents(["hello"])
+
+    async def test_non_openai_url_valueerror_gives_enhanced_message_async_plain(
+        self,
+    ) -> None:
+        """Async plain-text path: non-OpenAI URL + ValueError gives guidance."""
+        embeddings = OpenAIEmbeddings(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",  # type: ignore[arg-type]
+            check_embedding_ctx_length=False,
+        )
+        with patch.object(embeddings.async_client, "create") as mock_create:
+            mock_create.side_effect = ValueError("No embedding data received")
+            with pytest.raises(ValueError, match="encoding_format"):
+                await embeddings.aembed_documents(["hello"])
+
+    def test_openai_url_valueerror_passes_through_unchanged(self) -> None:
+        """Default OpenAI URL: ValueError passes through without modification."""
+        embeddings = OpenAIEmbeddings(
+            api_key="test-key",  # type: ignore[arg-type]
+        )
+        with patch.object(embeddings.client, "create") as mock_create:
+            mock_create.side_effect = ValueError("No embedding data received")
+            with pytest.raises(ValueError, match="^No embedding data received$"):
+                embeddings.embed_documents(["hello"])
+
+    def test_non_openai_url_other_valueerror_passes_through(self) -> None:
+        """Non-OpenAI URL but different ValueError message passes through."""
+        embeddings = OpenAIEmbeddings(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",  # type: ignore[arg-type]
+            check_embedding_ctx_length=False,
+        )
+        with patch.object(embeddings.client, "create") as mock_create:
+            mock_create.side_effect = ValueError("Some other error")
+            with pytest.raises(ValueError, match="^Some other error$"):
+                embeddings.embed_documents(["hello"])
+
+    def test_is_openai_url_default(self) -> None:
+        """Default config (no base_url) is detected as OpenAI."""
+        embeddings = OpenAIEmbeddings(api_key="test-key")  # type: ignore[arg-type]
+        assert embeddings._is_openai_url is True
+
+    def test_is_openai_url_explicit_openai(self) -> None:
+        """Explicit api.openai.com URL is detected as OpenAI."""
+        embeddings = OpenAIEmbeddings(
+            base_url="https://api.openai.com/v1",
+            api_key="test-key",  # type: ignore[arg-type]
+        )
+        assert embeddings._is_openai_url is True
+
+    def test_is_openai_url_non_openai(self) -> None:
+        """Non-OpenAI URL is detected as non-OpenAI."""
+        embeddings = OpenAIEmbeddings(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",  # type: ignore[arg-type]
+        )
+        assert embeddings._is_openai_url is False
+
+    def test_enhanced_error_includes_base_url(self) -> None:
+        """Enhanced error message includes the actual base_url for debugging."""
+        embeddings = OpenAIEmbeddings(
+            base_url="https://openrouter.ai/api/v1",
+            api_key="test-key",  # type: ignore[arg-type]
+            check_embedding_ctx_length=False,
+        )
+        with patch.object(embeddings.client, "create") as mock_create:
+            mock_create.side_effect = ValueError("No embedding data received")
+            with pytest.raises(ValueError, match="openrouter.ai"):
+                embeddings.embed_documents(["hello"])


### PR DESCRIPTION
## Summary

Fixes #35204 (umbrella: #34328)

When using `OpenAIEmbeddings` with a non-OpenAI `base_url` (e.g. OpenRouter, Ollama, vLLM), the call fails with an unhelpful `ValueError: No embedding data received`. Root causes:

1. **Token arrays as input** - the default path tokenizes text via tiktoken and sends `list[int]`, which non-OpenAI providers do not support.
2. **Base64 encoding** - the openai SDK auto-sets `encoding_format="base64"`, which non-OpenAI providers do not support.

This PR:

- **Enhanced error message**: Wraps the 4 `client.create()` call sites (sync/async, tokenized/plain) to detect `"No embedding data received"` when `base_url` is non-OpenAI, and re-raises with actionable guidance:
  > `check_embedding_ctx_length=False` to send raw text instead of tokens, and/or `model_kwargs={"encoding_format": "float"}` to avoid base64 encoding.
- **Updated docstrings**: Adds an "OpenAI-compatible APIs" section to the class docstring with a working example, and clarifies `check_embedding_ctx_length` and `tiktoken_enabled` for non-OpenAI providers.
- **Unit tests**: 10 new tests covering all 4 call paths, passthrough for OpenAI URLs, passthrough for unrelated errors, and `_is_openai_url` property.

## Test plan

- [x] All 17 unit tests pass (`pytest libs/partners/openai/tests/unit_tests/embeddings/test_base.py`)
- [x] Existing tests unaffected (no changes to OpenAI-native code paths)
- [ ] Verify enhanced error triggers with actual OpenRouter endpoint (manual)