### PR TITLE
fix(openai): replace KeyError with clear ValueError for missing role in Responses API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4202,6 +4202,16 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
         # "name" parameter unsupported
         if "name" in msg:
             msg.pop("name")
+        if "role" not in msg:
+            err_msg = (
+                f"Expected a 'role' key in message dict when constructing "
+                f"Responses API payload, but none was found. "
+                f"Message type: {type(lc_msg).__name__}, "
+                f"available keys: {sorted(msg.keys())}. "
+                f"This can happen when middleware or checkpoint state produces "
+                f"messages that are not properly constructed BaseMessage objects."
+            )
+            raise ValueError(err_msg)
         if msg["role"] == "tool":
             tool_output = msg["content"]
             computer_call_output = _make_computer_call_output_from_message(

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2462,6 +2462,19 @@ def test__construct_responses_api_input_multiple_message_types() -> None:
     ]
 
 
+def test__construct_responses_api_input_missing_role_raises_error() -> None:
+    """Test that a message dict missing 'role' raises ValueError with guidance."""
+    msg = HumanMessage(content="hello")
+    with (
+        patch(
+            "langchain_openai.chat_models.base._convert_message_to_dict",
+            return_value={"content": "hello"},
+        ),
+        pytest.raises(ValueError, match="Expected a 'role' key in message dict"),
+    ):
+        _construct_responses_api_input([msg])
+
+
 def test_service_tier() -> None:
     llm = ChatOpenAI(model="o4-mini", service_tier="flex")
     payload = llm._get_request_payload([HumanMessage("Hello")])


### PR DESCRIPTION
  ## Summary
  - Fix #34748: Replace cryptic `KeyError: 'role'` in
  `_construct_responses_api_input` with a clear `ValueError` that includes
   the message type, available keys, and likely causes
  (middleware/checkpoint state producing improperly constructed messages)

  ## Test plan
  - Added `test__construct_responses_api_input_missing_role_raises_error`
  to verify the new error message
  - All existing `_construct_responses_api_input` tests pass with no
  regressions