### PR TITLE
fix(core): prevent recursion error when args_schema is dict

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -819,7 +819,8 @@ class ChildTool(BaseTool):
         filtered_keys.update(self._injected_args_keys)
 
         # If we have an args_schema, use it to identify injected args
-        if self.args_schema is not None:
+        # Skip if args_schema is a dict (JSON Schema) as it's not a Pydantic model
+        if self.args_schema is not None and not isinstance(self.args_schema, dict):
             try:
                 annotations = get_all_basemodel_annotations(self.args_schema)
                 for field_name, field_type in annotations.items():

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3632,3 +3632,39 @@ def test_tool_args_schema_falsy_defaults() -> None:
     # Invoke with only required argument - falsy defaults should be applied
     result = config_tool.invoke({"name": "test"})
     assert result == "name=test, enabled=False, count=0, prefix=''"
+
+
+def test_tool_with_dict_args_schema() -> None:
+    """Test that StructuredTool works with dict (JSON Schema) args_schema.
+
+    Regression test for issue #35258: When args_schema is a dict instead of
+    a Pydantic BaseModel, _filter_injected_args should not cause a RecursionError.
+    """
+    # Create a tool with dict args_schema (JSON Schema format)
+    tool = StructuredTool(
+        name="example_tool",
+        description="Example tool with JSON Schema",
+        func=lambda x: f"received: {x}",
+        args_schema={"type": "object", "properties": {"x": {"type": "string"}}},
+    )
+
+    # Invoking the tool should work without RecursionError
+    result = tool.invoke({"x": "test"})
+    assert result == "received: test"
+
+    # Test with multiple parameters
+    multi_param_tool = StructuredTool(
+        name="multi_param_tool",
+        description="Tool with multiple parameters",
+        func=lambda x, y: f"x={x}, y={y}",
+        args_schema={
+            "type": "object",
+            "properties": {
+                "x": {"type": "string"},
+                "y": {"type": "integer"},
+            },
+        },
+    )
+
+    result = multi_param_tool.invoke({"x": "hello", "y": 42})
+    assert result == "x=hello, y=42"


### PR DESCRIPTION
## fix(core): prevent recursion error when args_schema is dict

Fixes #35258
Added type check in `_filter_injected_args` to skip annotation filtering when `args_schema` is a dict (JSON Schema) instead of a Pydantic BaseModel. This prevents infinite recursion in `get_all_basemodel_annotations` which was causing RecursionError logs on every tool invocation for MCP-integrated tools.

**Changes:**
- Added `isinstance(self.args_schema, dict)` check before calling `get_all_basemodel_annotations`
- Added regression test `test_tool_with_dict_args_schema` to verify dict args_schema works correctly


**Testing:**
- All existing tests pass (161 passed)
- New test verifies tools with dict args_schema invoke successfully
- Verified original reproduction case no longer logs RecursionError


## Social handles
LinkedIn: https://www.linkedin.com/in/karthik-reddy-jannupalli/
