### PR TITLE
fix: RecursionError when initializing StructuredTool with dict schema

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -819,7 +819,7 @@ class ChildTool(BaseTool):
         filtered_keys.update(self._injected_args_keys)
 
         # If we have an args_schema, use it to identify injected args
-        if self.args_schema is not None:
+        if self.args_schema is not None and is_basemodel_subclass(self.args_schema):
             try:
                 annotations = get_all_basemodel_annotations(self.args_schema)
                 for field_name, field_type in annotations.items():

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -819,7 +819,11 @@ class ChildTool(BaseTool):
         filtered_keys.update(self._injected_args_keys)
 
         # If we have an args_schema, use it to identify injected args
-        if self.args_schema is not None and is_basemodel_subclass(self.args_schema):
+        if (
+            self.args_schema is not None
+            and isinstance(self.args_schema, type)
+            and is_basemodel_subclass(self.args_schema)
+        ):
             try:
                 annotations = get_all_basemodel_annotations(self.args_schema)
                 for field_name, field_type in annotations.items():

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3632,3 +3632,29 @@ def test_tool_args_schema_falsy_defaults() -> None:
     # Invoke with only required argument - falsy defaults should be applied
     result = config_tool.invoke({"name": "test"})
     assert result == "name=test, enabled=False, count=0, prefix=''"
+
+
+def test_structured_tool_recursion_with_dict_schema() -> None:
+    """Test that a StructuredTool with a dict schema does not cause recursion error."""
+
+    def foo(bar: int) -> int:
+        return bar
+
+    json_schema = {
+        "title": "foo",
+        "description": "foo",
+        "type": "object",
+        "properties": {"bar": {"title": "Bar", "type": "integer"}},
+        "required": ["bar"],
+    }
+
+    tool = StructuredTool.from_function(
+        func=foo,
+        name="TestTool",
+        description="Test Tool",
+        args_schema=json_schema,
+    )
+
+    # This should not raise RecursionError
+    result = tool.invoke({"bar": 1})
+    assert result == 1


### PR DESCRIPTION
Fixes #35258

## Description
This PR fixes a RecursionError that occurred when initializing a StructuredTool with a dictionary args_schema (JSON Schema) instead of a Pydantic BaseModel.

## Changes
- Modified  in  to check if  is a BaseModel subclass before calling 
- Added regression test  to prevent future regressions

## Testing
- All existing tests pass (161 passed)
- New regression test verifies the fix