### PR TITLE
docs(perplexity): Fix docstring of `output_parsers.strip_think_tags()`

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/output_parsers.py
+++ b/libs/partners/perplexity/langchain_perplexity/output_parsers.py
@@ -10,7 +10,7 @@ def strip_think_tags(text: str) -> str:
     """Removes all <think>...</think> tags and their content from text.
 
     This function removes all occurrences of think tags, preserving text
-    before, between, and after the tags. It also handles markdown code fences.
+    before and after the tags. It also handles markdown code fences.
 
     Args:
         text: The input text that may contain think tags.


### PR DESCRIPTION
Function `strip_think_tags()` removes all `<think>...</think>` tags and their content from the text, but in the docstring it states:
"[...] preserving text before, between, and after the tags [...]".
This "between" is wrong here and this PR removes it.