### PR TITLE
fix(anthropic): replace empty non-assistant message content with space

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -674,6 +674,14 @@ def _format_messages(
             # anthropic.BadRequestError: Error code: 400: all messages must have
             # non-empty content except for the optional final assistant message
             continue
+        if not content and role != "assistant":
+            # anthropic.BadRequestError: Error code: 400: all messages must have
+            # non-empty content except for the optional final assistant message.
+            # Replace empty content with a single space to avoid API rejection
+            # while preserving the message in the conversation (e.g., in
+            # multi-agent pipelines where an upstream agent may produce empty
+            # output).
+            content = " "
         formatted_messages.append({"role": role, "content": content})
     return system, formatted_messages
 

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -755,6 +755,24 @@ def test__format_messages_with_tool_calls() -> None:
             "user",
         ]
 
+    # Check handling of empty HumanMessage
+    # Empty content should be replaced with " " to avoid API rejection
+    _, anthropic_messages = _format_messages([HumanMessage(content="")])
+    assert anthropic_messages == [{"role": "user", "content": " "}]
+
+    # Empty content in non-final position
+    _, anthropic_messages = _format_messages(
+        [HumanMessage(content=""), AIMessage(content="response")]
+    )
+    assert anthropic_messages == [
+        {"role": "user", "content": " "},
+        {"role": "assistant", "content": "response"},
+    ]
+
+    # Empty list content should also be replaced
+    _, anthropic_messages = _format_messages([HumanMessage(content=[])])
+    assert anthropic_messages == [{"role": "user", "content": " "}]
+
 
 def test__format_tool_use_block() -> None:
     # Test we correctly format tool_use blocks when there is no corresponding tool_call.


### PR DESCRIPTION
## Description

Fixes #35081

When using `ChatAnthropic` with a `HumanMessage` that has empty content (`content=""`), the Anthropic API returns a 400 error:

> all messages must have non-empty content except for the optional final assistant message

This can happen in multi-agent pipelines where an upstream agent produces empty output that becomes the user input for the next agent (as described by @Mary904 in the issue discussion).

## Approach

Replace empty content with a single space `" "` for non-assistant message roles, following the same approach used by [Microsoft AutoGen](https://github.com/microsoft/autogen/pull/6063) for the same Anthropic API constraint.

This approach:
- **Preserves the message** in the conversation (unlike skipping/dropping it)
- **Avoids breaking pipelines** (unlike raising a ValueError)
- **Satisfies the API constraint** (non-empty content)
- **Is consistent** with how other frameworks handle this edge case

The existing behavior for empty assistant messages is unchanged — they are still skipped when not in the final position, and permitted in the final position (for pre-filling).

## Changes

- `langchain_anthropic/chat_models.py`: Added guard after the existing empty-assistant-message handling to replace empty content with `" "` for non-assistant roles
- `tests/unit_tests/test_chat_models.py`: Added 3 test cases for empty `HumanMessage` handling (empty string, empty string with following message, empty list content)

## Dependencies

None
