### PR TITLE
fix(mistralai): update test

### DIFF
--- a/libs/partners/mistralai/tests/integration_tests/test_embeddings.py
+++ b/libs/partners/mistralai/tests/integration_tests/test_embeddings.py
@@ -40,7 +40,7 @@ async def test_mistralai_embedding_documents_tenacity_error_async() -> None:
     documents = ["foo bar", "test document"]
     embedding = MistralAIEmbeddings(max_retries=0)
     mock_response = httpx.Response(
-        status_code=400,
+        status_code=429,
         request=httpx.Request("POST", url=embedding.async_client.base_url),
     )
     with (


### PR DESCRIPTION
Following #35238

We (correctly) no longer retry on 400 error. Update test to reflect this.