### PR TITLE
fix: TypeError in merge_lists with mixed content types & pretty_repr HTML for non-string content

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -110,7 +110,9 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                     to_merge = [
                         i
                         for i, e_left in enumerate(merged)
-                        if "index" in e_left and e_left["index"] == e["index"]
+                        if isinstance(e_left, dict)
+                        and "index" in e_left
+                        and e_left["index"] == e["index"]
                     ]
                     if to_merge:
                         # TODO: Remove this once merge_dict is updated with special


### PR DESCRIPTION
## Fixes

### 1. TypeError in `merge_lists` when streaming Mistral responses with inline citations (#35259)

**Problem:** When `merge_lists` processes a list containing both strings and dicts with `"index"` keys, the list comprehension tries to access `e_left["index"]` on string elements, causing `TypeError: string indices must be integers, not 'str'`.

**Fix:** Added `isinstance(e_left, dict)` guard before checking for `"index"` key in the list comprehension.

### 2. `pretty_repr(html=True)` does not return HTML for non-string content (#34875)

**Problem:** When `BaseMessage.content` is a list (valid type), `pretty_repr(html=True)` returns the raw Python repr with no HTML formatting, despite the docstring promising HTML output.

**Fix:** 
- Parse list content blocks (text, image_url, plain strings) into readable text
- Apply HTML escaping and line break conversion when `html=True`
- Resolves the existing TODO comment in the code