### PR TITLE
fixes/33504-agent-not-handle-invalid-tool-calls

### DIFF
--- a/libs/core/langchain_core/messages/__init__.py
+++ b/libs/core/langchain_core/messages/__init__.py
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
         ToolCallChunk,
         ToolMessage,
         ToolMessageChunk,
+        tool_messages_from_invalid_tool_calls,
     )
     from langchain_core.messages.utils import (
         AnyMessage,
@@ -126,6 +127,7 @@ __all__ = (
     "message_to_dict",
     "messages_from_dict",
     "messages_to_dict",
+    "tool_messages_from_invalid_tool_calls",
     "trim_messages",
 )
 
@@ -170,6 +172,7 @@ _dynamic_imports = {
     "ToolMessageChunk": "tool",
     "UsageMetadata": "ai",
     "VideoContentBlock": "content",
+    "tool_messages_from_invalid_tool_calls": "tool",
     "AnyMessage": "utils",
     "MessageLikeRepresentation": "utils",
     "_message_from_dict": "utils",

--- a/libs/core/tests/unit_tests/messages/test_imports.py
+++ b/libs/core/tests/unit_tests/messages/test_imports.py
@@ -58,6 +58,7 @@ EXPECTED_ALL = [
     "UsageMetadata",
     "InputTokenDetails",
     "OutputTokenDetails",
+    "tool_messages_from_invalid_tool_calls",
 ]
 
 

--- a/libs/core/tests/unit_tests/messages/test_tool.py
+++ b/libs/core/tests/unit_tests/messages/test_tool.py
@@ -1,0 +1,121 @@
+"""Tests for langchain_core.messages.tool utilities."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from langchain_core.messages import ToolMessage
+from langchain_core.messages.tool import tool_messages_from_invalid_tool_calls
+
+if TYPE_CHECKING:
+    from langchain_core.messages.content import InvalidToolCall
+
+
+class TestToolMessagesFromInvalidToolCalls:
+    """Tests for tool_messages_from_invalid_tool_calls utility."""
+
+    def test_basic_conversion(self) -> None:
+        """Single invalid tool call produces correct error ToolMessage."""
+        invalid_calls: list[InvalidToolCall] = [
+            {
+                "type": "invalid_tool_call",
+                "name": "get_weather",
+                "args": "{bad json",
+                "id": "call_1",
+                "error": "JSON parse error",
+            }
+        ]
+        result = tool_messages_from_invalid_tool_calls(invalid_calls)
+
+        assert len(result) == 1
+        msg = result[0]
+        assert isinstance(msg, ToolMessage)
+        assert msg.status == "error"
+        assert msg.tool_call_id == "call_1"
+        assert msg.name == "get_weather"
+        assert "get_weather" in msg.content
+        assert "JSON parse error" in msg.content
+        assert "Please fix your mistakes" in msg.content
+
+    def test_empty_list_returns_empty(self) -> None:
+        """Empty input produces empty output."""
+        result = tool_messages_from_invalid_tool_calls([])
+        assert result == []
+
+    def test_none_id_defaults_to_empty_string(self) -> None:
+        """InvalidToolCall with id=None produces tool_call_id=''."""
+        invalid_calls: list[InvalidToolCall] = [
+            {
+                "type": "invalid_tool_call",
+                "name": "my_tool",
+                "args": "bad",
+                "id": None,
+                "error": None,
+            }
+        ]
+        result = tool_messages_from_invalid_tool_calls(invalid_calls)
+
+        assert len(result) == 1
+        assert result[0].tool_call_id == ""
+
+    def test_none_name_defaults_to_unknown(self) -> None:
+        """InvalidToolCall with name=None produces name='unknown'."""
+        invalid_calls: list[InvalidToolCall] = [
+            {
+                "type": "invalid_tool_call",
+                "name": None,
+                "args": "bad",
+                "id": "call_1",
+                "error": None,
+            }
+        ]
+        result = tool_messages_from_invalid_tool_calls(invalid_calls)
+
+        assert len(result) == 1
+        assert result[0].name == "unknown"
+        assert "unknown" in result[0].content
+
+    def test_none_error_omits_details_line(self) -> None:
+        """When error is None, the 'Details:' line should not appear."""
+        invalid_calls: list[InvalidToolCall] = [
+            {
+                "type": "invalid_tool_call",
+                "name": "my_tool",
+                "args": "bad",
+                "id": "call_1",
+                "error": None,
+            }
+        ]
+        result = tool_messages_from_invalid_tool_calls(invalid_calls)
+
+        assert len(result) == 1
+        assert "Details:" not in result[0].content
+
+    def test_multiple_invalid_tool_calls(self) -> None:
+        """Multiple invalid tool calls each produce an error ToolMessage."""
+        invalid_calls: list[InvalidToolCall] = [
+            {
+                "type": "invalid_tool_call",
+                "name": "tool_a",
+                "args": "{bad",
+                "id": "call_1",
+                "error": "parse error 1",
+            },
+            {
+                "type": "invalid_tool_call",
+                "name": "tool_b",
+                "args": "{also bad",
+                "id": "call_2",
+                "error": "parse error 2",
+            },
+        ]
+        result = tool_messages_from_invalid_tool_calls(invalid_calls)
+
+        assert len(result) == 2
+        assert result[0].tool_call_id == "call_1"
+        assert result[0].name == "tool_a"
+        assert "tool_a" in result[0].content
+        assert result[1].tool_call_id == "call_2"
+        assert result[1].name == "tool_b"
+        assert "tool_b" in result[1].content
+        assert all(msg.status == "error" for msg in result)

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -1,5 +1,9 @@
 """Utils file included for backwards compat imports."""
 
+import logging
+
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.messages.tool import tool_messages_from_invalid_tool_calls
 from langgraph.prebuilt import InjectedState, InjectedStore, ToolRuntime
 from langgraph.prebuilt.tool_node import (
     ToolCallRequest,
@@ -10,6 +14,8 @@ from langgraph.prebuilt.tool_node import (
     ToolNode as _ToolNode,  # noqa: F401
 )
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "InjectedState",
     "InjectedStore",
@@ -17,4 +23,29 @@ __all__ = [
     "ToolCallWithContext",
     "ToolCallWrapper",
     "ToolRuntime",
+    "convert_invalid_tool_calls",
 ]
+
+
+def convert_invalid_tool_calls(ai_message: AIMessage) -> list[ToolMessage]:
+    """Convert invalid tool calls from an ``AIMessage`` to error ``ToolMessage`` objects.
+
+    If the ``AIMessage`` has no ``invalid_tool_calls``, returns an empty list.
+
+    This is used by the agent loop to surface JSON parsing errors back to the
+    LLM so it can self-correct, rather than silently terminating.
+
+    Args:
+        ai_message: The AI message potentially containing invalid tool calls.
+
+    Returns:
+        List of error ``ToolMessage`` objects, one per invalid tool call.
+    """
+    if not ai_message.invalid_tool_calls:
+        return []
+
+    logger.debug(
+        "Converting %d invalid tool call(s) to error messages",
+        len(ai_message.invalid_tool_calls),
+    )
+    return tool_messages_from_invalid_tool_calls(ai_message.invalid_tool_calls)

--- a/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_return_direct_graph.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_return_direct_graph.ambr
@@ -16,6 +16,7 @@
   	model -.-> tools;
   	tools -.-> __end__;
   	tools -.-> model;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -39,6 +40,7 @@
   	model -.-> tools;
   	tools -.-> __end__;
   	tools -.-> model;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -61,6 +63,7 @@
   	model -.-> __end__;
   	model -.-> tools;
   	tools -.-> model;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
@@ -22,6 +22,7 @@
   	model -.-> tools;
   	tools -.-> model;
   	NoopOne\2eafter_agent --> __end__;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -29,134 +30,6 @@
   '''
 # ---
 # name: test_create_agent_jump[memory]
-  '''
-  ---
-  config:
-    flowchart:
-      curve: linear
-  ---
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	model(model)
-  	tools(tools)
-  	NoopSeven\2ebefore_model(NoopSeven.before_model)
-  	NoopSeven\2eafter_model(NoopSeven.after_model)
-  	NoopEight\2ebefore_model(NoopEight.before_model)
-  	NoopEight\2eafter_model(NoopEight.after_model)
-  	__end__([<p>__end__</p>]):::last
-  	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
-  	NoopEight\2ebefore_model -.-> model;
-  	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
-  	NoopSeven\2eafter_model -.-> tools;
-  	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
-  	__start__ --> NoopSeven\2ebefore_model;
-  	model --> NoopEight\2eafter_model;
-  	tools -.-> NoopSeven\2ebefore_model;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_create_agent_jump[postgres]
-  '''
-  ---
-  config:
-    flowchart:
-      curve: linear
-  ---
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	model(model)
-  	tools(tools)
-  	NoopSeven\2ebefore_model(NoopSeven.before_model)
-  	NoopSeven\2eafter_model(NoopSeven.after_model)
-  	NoopEight\2ebefore_model(NoopEight.before_model)
-  	NoopEight\2eafter_model(NoopEight.after_model)
-  	__end__([<p>__end__</p>]):::last
-  	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
-  	NoopEight\2ebefore_model -.-> model;
-  	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
-  	NoopSeven\2eafter_model -.-> tools;
-  	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
-  	__start__ --> NoopSeven\2ebefore_model;
-  	model --> NoopEight\2eafter_model;
-  	tools -.-> NoopSeven\2ebefore_model;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_create_agent_jump[postgres_pipe]
-  '''
-  ---
-  config:
-    flowchart:
-      curve: linear
-  ---
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	model(model)
-  	tools(tools)
-  	NoopSeven\2ebefore_model(NoopSeven.before_model)
-  	NoopSeven\2eafter_model(NoopSeven.after_model)
-  	NoopEight\2ebefore_model(NoopEight.before_model)
-  	NoopEight\2eafter_model(NoopEight.after_model)
-  	__end__([<p>__end__</p>]):::last
-  	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
-  	NoopEight\2ebefore_model -.-> model;
-  	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
-  	NoopSeven\2eafter_model -.-> tools;
-  	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
-  	__start__ --> NoopSeven\2ebefore_model;
-  	model --> NoopEight\2eafter_model;
-  	tools -.-> NoopSeven\2ebefore_model;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_create_agent_jump[postgres_pool]
-  '''
-  ---
-  config:
-    flowchart:
-      curve: linear
-  ---
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	model(model)
-  	tools(tools)
-  	NoopSeven\2ebefore_model(NoopSeven.before_model)
-  	NoopSeven\2eafter_model(NoopSeven.after_model)
-  	NoopEight\2ebefore_model(NoopEight.before_model)
-  	NoopEight\2eafter_model(NoopEight.after_model)
-  	__end__([<p>__end__</p>]):::last
-  	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
-  	NoopEight\2ebefore_model -.-> model;
-  	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
-  	NoopSeven\2eafter_model -.-> tools;
-  	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
-  	__start__ --> NoopSeven\2ebefore_model;
-  	model --> NoopEight\2eafter_model;
-  	tools -.-> NoopSeven\2ebefore_model;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_create_agent_jump[sqlite]
   '''
   ---
   config:
@@ -204,6 +77,7 @@
   	model -.-> __end__;
   	model -.-> tools;
   	tools -.-> model;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langchain_v1/tests/unit_tests/agents/test_invalid_tool_calls.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_invalid_tool_calls.py
@@ -1,0 +1,254 @@
+"""Tests for invalid_tool_calls handling in create_agent.
+
+Verifies that agents do not silently terminate when the LLM produces malformed
+JSON for tool calls, and instead surface the error back to the LLM for retry.
+"""
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.messages.content import InvalidToolCall
+from langgraph.errors import GraphRecursionError
+
+from langchain.agents import create_agent
+from langchain.tools import tool as dec_tool
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+@dec_tool
+def get_weather(city: str) -> str:
+    """Get weather for a city.
+
+    Args:
+        city: The city name.
+    """
+    return f"Sunny in {city}"
+
+
+class TestInvalidToolCallRetry:
+    """Tests that invalid_tool_calls trigger error feedback and retry."""
+
+    def test_invalid_tool_call_retries_and_succeeds(self) -> None:
+        """Agent retries after invalid tool call and eventually succeeds.
+
+        Flow:
+        1. Model emits invalid_tool_calls (malformed JSON)
+        2. Agent converts to error ToolMessage and routes back to model
+        3. Model retries with valid tool_call
+        4. Tool executes successfully
+        5. Model returns final text answer
+        """
+        model = FakeToolCallingModel(
+            tool_calls=[
+                [],  # Round 0: no valid tool_calls (only invalid)
+                [{"name": "get_weather", "args": {"city": "SF"}, "id": "call_2"}],
+                [],  # Round 2: final text response
+            ],
+            invalid_tool_calls=[
+                [
+                    InvalidToolCall(
+                        type="invalid_tool_call",
+                        name="get_weather",
+                        args='{city: "SF"}',
+                        id="call_1",
+                        error="JSON parse error",
+                    )
+                ],
+                [],  # Round 1: no invalid calls
+                [],  # Round 2: no invalid calls
+            ],
+        )
+
+        agent = create_agent(model, tools=[get_weather])
+        result = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        messages = result["messages"]
+
+        # Model should have been called more than once
+        ai_messages = [m for m in messages if isinstance(m, AIMessage)]
+        assert len(ai_messages) >= 2, "Model should be called at least twice (initial + retry)"
+
+        # There should be an error ToolMessage from the invalid tool call
+        tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+        error_tool_messages = [m for m in tool_messages if m.status == "error"]
+        assert len(error_tool_messages) >= 1, (
+            "At least one error ToolMessage should exist for the invalid tool call"
+        )
+
+        # The error message should reference the tool name
+        assert any("get_weather" in m.content for m in error_tool_messages), (
+            "Error ToolMessage should mention the tool name"
+        )
+
+        # There should also be a successful tool execution
+        success_tool_messages = [m for m in tool_messages if m.status == "success"]
+        assert len(success_tool_messages) >= 1, (
+            "At least one successful ToolMessage should exist from the retry"
+        )
+
+    def test_multiple_invalid_tool_calls_all_get_error_messages(self) -> None:
+        """Each invalid tool call produces its own error ToolMessage."""
+        model = FakeToolCallingModel(
+            tool_calls=[
+                [],  # Round 0: no valid calls
+                [],  # Round 1: final response (end loop)
+            ],
+            invalid_tool_calls=[
+                [
+                    InvalidToolCall(
+                        type="invalid_tool_call",
+                        name="get_weather",
+                        args="{bad json 1",
+                        id="call_1",
+                        error="parse error 1",
+                    ),
+                    InvalidToolCall(
+                        type="invalid_tool_call",
+                        name="get_weather",
+                        args="{bad json 2",
+                        id="call_2",
+                        error="parse error 2",
+                    ),
+                ],
+                [],  # Round 1: no invalid calls
+            ],
+        )
+
+        agent = create_agent(model, tools=[get_weather])
+        result = agent.invoke({"messages": [HumanMessage("Weather?")]})
+
+        messages = result["messages"]
+        error_tool_messages = [
+            m for m in messages if isinstance(m, ToolMessage) and m.status == "error"
+        ]
+        assert len(error_tool_messages) == 2, (
+            "Each invalid tool call should produce its own error ToolMessage"
+        )
+
+    def test_invalid_tool_call_with_none_id(self) -> None:
+        """InvalidToolCall with id=None does not crash the agent."""
+        model = FakeToolCallingModel(
+            tool_calls=[
+                [],  # Round 0: only invalid
+                [],  # Round 1: end loop
+            ],
+            invalid_tool_calls=[
+                [
+                    InvalidToolCall(
+                        type="invalid_tool_call",
+                        name="get_weather",
+                        args="{bad",
+                        id=None,
+                        error=None,
+                    )
+                ],
+                [],
+            ],
+        )
+
+        agent = create_agent(model, tools=[get_weather])
+        result = agent.invoke({"messages": [HumanMessage("Weather?")]})
+
+        error_messages = [
+            m for m in result["messages"] if isinstance(m, ToolMessage) and m.status == "error"
+        ]
+        assert len(error_messages) == 1
+        # Should not crash; tool_call_id defaults to ""
+        assert error_messages[0].tool_call_id == ""
+
+    def test_invalid_tool_call_with_none_name(self) -> None:
+        """InvalidToolCall with name=None does not crash the agent."""
+        model = FakeToolCallingModel(
+            tool_calls=[
+                [],  # Round 0: only invalid
+                [],  # Round 1: end loop
+            ],
+            invalid_tool_calls=[
+                [
+                    InvalidToolCall(
+                        type="invalid_tool_call",
+                        name=None,
+                        args="{bad",
+                        id="call_1",
+                        error=None,
+                    )
+                ],
+                [],
+            ],
+        )
+
+        agent = create_agent(model, tools=[get_weather])
+        result = agent.invoke({"messages": [HumanMessage("Weather?")]})
+
+        error_messages = [
+            m for m in result["messages"] if isinstance(m, ToolMessage) and m.status == "error"
+        ]
+        assert len(error_messages) == 1
+        assert error_messages[0].name == "unknown"
+
+
+class TestInvalidToolCallBackwardCompat:
+    """Tests that existing behavior is preserved."""
+
+    def test_valid_tool_calls_unchanged(self) -> None:
+        """Normal valid tool calls work exactly as before."""
+        model = FakeToolCallingModel(
+            tool_calls=[
+                [{"name": "get_weather", "args": {"city": "NYC"}, "id": "call_1"}],
+                [],  # End loop
+            ],
+        )
+
+        agent = create_agent(model, tools=[get_weather])
+        result = agent.invoke({"messages": [HumanMessage("Weather in NYC?")]})
+
+        messages = result["messages"]
+        tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].status == "success"
+        assert "Sunny in NYC" in tool_messages[0].content
+
+    def test_no_tool_calls_exits_normally(self) -> None:
+        """Agent exits normally when model produces no tool calls at all."""
+        model = FakeToolCallingModel(
+            tool_calls=[[]],  # No tool calls, should exit
+        )
+
+        agent = create_agent(model, tools=[get_weather])
+        result = agent.invoke({"messages": [HumanMessage("Hello")]})
+
+        messages = result["messages"]
+        ai_messages = [m for m in messages if isinstance(m, AIMessage)]
+        # Should exit after single model call with no tool calls
+        assert len(ai_messages) == 1
+        assert len(ai_messages[0].tool_calls) == 0
+        assert len(ai_messages[0].invalid_tool_calls) == 0
+
+
+class TestInvalidToolCallRecursionLimit:
+    """Tests that persistent invalid tool calls hit the recursion limit."""
+
+    def test_persistent_invalid_calls_hit_recursion_limit(self) -> None:
+        """If model always produces invalid tool calls, recursion limit is hit."""
+        # Model always returns invalid tool calls (never corrects itself)
+        model = FakeToolCallingModel(
+            tool_calls=[[]],  # Always empty valid calls (cycles)
+            invalid_tool_calls=[
+                [
+                    InvalidToolCall(
+                        type="invalid_tool_call",
+                        name="get_weather",
+                        args="{always bad",
+                        id="call_loop",
+                        error="persistent parse error",
+                    )
+                ]
+            ],  # Always invalid (cycles)
+        )
+
+        agent = create_agent(model, tools=[get_weather])
+
+        with pytest.raises(GraphRecursionError):
+            agent.invoke(
+                {"messages": [HumanMessage("Weather?")]},
+                {"recursion_limit": 5},
+            )

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2028,7 +2028,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.75.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.78.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2404,7 +2404,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Summary
create_agent silently terminates when the LLM produces malformed JSON tool calls (invalid_tool_calls), because the routing logic only checks tool_calls and exits when it's empty. This fix converts invalid tool calls into error ToolMessage(status="error") objects and routes the agent back to the model, restoring retry behavior that existed in the deprecated AgentExecutor(handle_parsing_errors=True).

Fixes #33504

Why this touches two packages
The fix requires a core-level utility (tool_messages_from_invalid_tool_calls) because both InvalidToolCall and ToolMessage are defined in langchain-core, and the conversion between them is a general-purpose operation useful beyond create_agent. The routing and model-output fixes live in langchain.

What changed
libs/core/langchain_core/messages/tool.py — Added tool_messages_from_invalid_tool_calls() that converts InvalidToolCall dicts into ToolMessage(status="error") objects with structured error content. Handles None id/name/error gracefully.

libs/langchain_v1/langchain/tools/tool_node.py — Added convert_invalid_tool_calls() wrapper that accepts an AIMessage and delegates to the core utility. This is the tool-layer API imported by factory.py.

libs/langchain_v1/langchain/agents/factory.py — Three changes:

_handle_model_output(): detects invalid_tool_calls on the model output and appends error ToolMessages to state (same pattern as structured output validation errors on lines 1038-1046)
_make_model_to_tools_edge(): when tool_calls is empty but invalid_tool_calls is present, routes back to model instead of exiting
Graph construction: always includes loop_entry_node in conditional edge destinations so the model-loop-back route is valid in all configurations (not just when response_format or after_model middleware exists)

Fixes #33504 

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/
