### PR TITLE
fix: Fix IndexError in handle_event when handler raises NotImplementedError

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -284,7 +284,7 @@ def handle_event(
                     if asyncio.iscoroutine(event):
                         coros.append(event)
             except NotImplementedError as e:
-                if event_name == "on_chat_model_start":
+                if event_name == "on_chat_model_start" and len(args) >= 2:
                     if message_strings is None:
                         message_strings = [get_buffer_string(m) for m in args[1]]
                     handle_event(
@@ -388,7 +388,7 @@ async def _ahandle_event_for_handler(
                     ),
                 )
     except NotImplementedError as e:
-        if event_name == "on_chat_model_start":
+        if event_name == "on_chat_model_start" and len(args) >= 2:
             message_strings = [get_buffer_string(m) for m in args[1]]
             await _ahandle_event_for_handler(
                 handler,

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -29,7 +29,6 @@ from langchain_core.callbacks.base import (
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.globals import get_debug
 
-_MIN_ARGS_FOR_CHAT_MODEL_FALLBACK = 2
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.tracers.context import (
     _configure_hooks,
@@ -42,6 +41,8 @@ from langchain_core.tracers.langchain import LangChainTracer
 from langchain_core.tracers.stdout import ConsoleCallbackHandler
 from langchain_core.utils.env import env_var_is_set
 from langchain_core.utils.uuid import uuid7
+
+_MIN_ARGS_FOR_CHAT_MODEL_FALLBACK = 2
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Coroutine, Generator, Sequence
@@ -286,7 +287,10 @@ def handle_event(
                     if asyncio.iscoroutine(event):
                         coros.append(event)
             except NotImplementedError as e:
-                if event_name == "on_chat_model_start" and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK:
+                if (
+                    event_name == "on_chat_model_start"
+                    and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK
+                ):
                     if message_strings is None:
                         message_strings = [get_buffer_string(m) for m in args[1]]
                     handle_event(
@@ -390,7 +394,10 @@ async def _ahandle_event_for_handler(
                     ),
                 )
     except NotImplementedError as e:
-        if event_name == "on_chat_model_start" and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK:
+        if (
+            event_name == "on_chat_model_start"
+            and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK
+        ):
             message_strings = [get_buffer_string(m) for m in args[1]]
             await _ahandle_event_for_handler(
                 handler,

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -28,7 +28,6 @@ from langchain_core.callbacks.base import (
 )
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.globals import get_debug
-
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.tracers.context import (
     _configure_hooks,

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -28,6 +28,8 @@ from langchain_core.callbacks.base import (
 )
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.globals import get_debug
+
+_MIN_ARGS_FOR_CHAT_MODEL_FALLBACK = 2
 from langchain_core.messages import BaseMessage, get_buffer_string
 from langchain_core.tracers.context import (
     _configure_hooks,
@@ -284,7 +286,7 @@ def handle_event(
                     if asyncio.iscoroutine(event):
                         coros.append(event)
             except NotImplementedError as e:
-                if event_name == "on_chat_model_start" and len(args) >= 2:
+                if event_name == "on_chat_model_start" and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK:
                     if message_strings is None:
                         message_strings = [get_buffer_string(m) for m in args[1]]
                     handle_event(
@@ -388,7 +390,7 @@ async def _ahandle_event_for_handler(
                     ),
                 )
     except NotImplementedError as e:
-        if event_name == "on_chat_model_start" and len(args) >= 2:
+        if event_name == "on_chat_model_start" and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK:
             message_strings = [get_buffer_string(m) for m in args[1]]
             await _ahandle_event_for_handler(
                 handler,


### PR DESCRIPTION
## Issue

Fixes #31576

## Problem

When `on_chat_model_start` handlers raise `NotImplementedError`, the fallback code in both `handle_event` (sync) and `_ahandle_event_for_handler` (async) unconditionally accesses `args[1]` to convert messages to strings for the `on_llm_start` fallback. If the handler was called without positional arguments (or with fewer than 2), this raises an `IndexError`, masking the original `NotImplementedError`.

## Fix

Added a `len(args) >= 2` guard to both the sync and async code paths. When args are insufficient for the `on_llm_start` fallback, it falls through to the else branch which logs a warning instead of crashing.