### PR TITLE
core: prevent docstring inheritance from parent classes in tools

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -170,9 +170,8 @@ def _get_own_docstring(obj: Any) -> str | None:
         return None
     # For classes, check if the docstring was actually defined on this class
     # rather than inherited from a parent.
-    if isinstance(obj, type):
-        if "__doc__" not in obj.__dict__:
-            return None
+    if isinstance(obj, type) and "__doc__" not in obj.__dict__:
+        return None
     return inspect.cleandoc(doc)
 
 

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -211,10 +211,24 @@ class StructuredTool(BaseTool):
             )
         description_ = description
         if description is None and not parse_docstring:
-            description_ = source_function.__doc__ or None
+            # Only use docstring if directly defined, not inherited from parent
+            if isinstance(source_function, type):
+                description_ = (
+                    source_function.__doc__
+                    if "__doc__" in source_function.__dict__
+                    else None
+                )
+            else:
+                description_ = source_function.__doc__ or None
         if description_ is None and args_schema:
             if isinstance(args_schema, type) and is_basemodel_subclass(args_schema):
-                description_ = args_schema.__doc__
+                # Only use docstring if directly defined on this class,
+                # not inherited from a parent.
+                description_ = (
+                    args_schema.__doc__
+                    if "__doc__" in args_schema.__dict__
+                    else None
+                )
                 if (
                     description_
                     and "A base class for creating Pydantic models" in description_

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -245,8 +245,12 @@ class StructuredTool(BaseTool):
                 )
                 raise TypeError(msg)
         if description_ is None:
-            msg = "Function must have a docstring if description not provided."
-            raise ValueError(msg)
+            if isinstance(source_function, type):
+                # Classes without docstrings get an empty description
+                description_ = ""
+            else:
+                msg = "Function must have a docstring if description not provided."
+                raise ValueError(msg)
         if description is None:
             # Only apply if using the function's docstring
             description_ = textwrap.dedent(description_).strip()

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3632,3 +3632,40 @@ def test_tool_args_schema_falsy_defaults() -> None:
     # Invoke with only required argument - falsy defaults should be applied
     result = config_tool.invoke({"name": "test"})
     assert result == "name=test, enabled=False, count=0, prefix=''"
+
+
+def test_docstring_not_inherited_from_parent() -> None:
+    """Test that child classes don't inherit docstrings from parents."""
+    from pydantic import BaseModel
+
+    from langchain_core.tools import tool
+
+    class ParentModel(BaseModel):
+        """Parent description that should not be inherited."""
+
+        foo: str
+
+    class ChildWithoutDocstring(ParentModel):
+        bar: str
+
+    class ChildWithDocstring(ParentModel):
+        """Child's own description."""
+
+        bar: str
+
+    # When a child class has no docstring, it should NOT inherit parent's
+    @tool
+    class ToolWithoutDocstring(ParentModel):
+        bar: str
+
+    # The description should not be "Parent description that should not be inherited."
+    assert "Parent description" not in (ToolWithoutDocstring.description or "")
+
+    # When a child class has its own docstring, it should use it
+    @tool
+    class ToolWithDocstring(ParentModel):
+        """Child tool description."""
+
+        bar: str
+
+    assert ToolWithDocstring.description == "Child tool description."


### PR DESCRIPTION
## Description

Fixes #32066.

When using the `@tool` decorator with a class that inherits from a parent with a docstring, the parent's docstring was incorrectly used as the tool description. This happened because `inspect.getdoc()` walks the MRO to find docstrings.

## Changes

- **`libs/core/langchain_core/tools/base.py`**: Added `_get_own_docstring()` helper that retrieves only directly-defined docstrings (no MRO traversal). Updated `_parse_python_function_docstring` and `_infer_arg_descriptions` to use this helper instead of `inspect.getdoc()`.
- **`libs/core/langchain_core/tools/structured.py`**: Updated `StructuredTool.from_function` to check `__dict__` for own docstrings on class-based schemas and source functions, preventing inherited docstring usage.
- **`libs/core/tests/unit_tests/test_tools.py`**: Added test verifying that child classes without their own docstrings do not inherit the parent's docstring as the tool description.

## Example

```python
from langchain_core.tools import tool
from pydantic import BaseModel

class MyTool(BaseModel):
    """Parent Tool"""
    foo: str

@tool
class ChildTool(MyTool):
    bar: str

# Before: ChildTool.description == 'Parent Tool'
# After:  ChildTool.description != 'Parent Tool'
```