### PR TITLE
fix(openai): add `model` property

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -901,6 +901,10 @@ class BaseChatOpenAI(BaseChatModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
+    @property
+    def model(self) -> str:
+        return self.model_name
+
     @model_validator(mode="before")
     @classmethod
     def build_extra(cls, values: dict[str, Any]) -> Any:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -903,6 +903,7 @@ class BaseChatOpenAI(BaseChatModel):
 
     @property
     def model(self) -> str:
+        """Same as model_name."""
         return self.model_name
 
     @model_validator(mode="before")

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -86,8 +86,10 @@ from langchain_openai.chat_models.base import (
 def test_openai_model_param() -> None:
     llm = ChatOpenAI(model="foo")
     assert llm.model_name == "foo"
+    assert llm.model == "foo"
     llm = ChatOpenAI(model_name="foo")  # type: ignore[call-arg]
     assert llm.model_name == "foo"
+    assert llm.model == "foo"
 
     llm = ChatOpenAI(max_tokens=10)  # type: ignore[call-arg]
     assert llm.max_tokens == 10


### PR DESCRIPTION
Same as `model_name`. For consistency with prevailing norms (langchain-anthropic, langchain-google-genai).