### PR TITLE
fix(core): remove str() cast in get_from_dict_or_env to preserve original types

### DIFF
--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -28,7 +28,7 @@ def get_from_dict_or_env(
     key: str | list[str],
     env_key: str,
     default: str | None = None,
-) -> str:
+) -> Any:
     """Get a value from a dictionary or an environment variable.
 
     Args:
@@ -47,10 +47,10 @@ def get_from_dict_or_env(
     if isinstance(key, (list, tuple)):
         for k in key:
             if value := data.get(k):
-                return str(value)
+                return value
 
     if isinstance(key, str) and key in data and data[key]:
-        return str(data[key])
+        return data[key]
 
     key_for_err = key[0] if isinstance(key, (list, tuple)) else key
 


### PR DESCRIPTION
## Description

Fixes #35285.

`get_from_dict_or_env` accepts `dict[str, Any]` but was casting all dictionary values to `str` via `str()`, which breaks code storing non-string types (e.g., enums) as dict values.

## Changes

- Removed `str()` wrapping when returning values from the dictionary
- Updated return type annotation from `str` to `Any` to match the input type
- Environment variable lookups still return strings as expected (via `get_from_env`)

## Testing

The change is backwards-compatible: string values remain strings, but non-string types (enums, ints, etc.) are no longer incorrectly cast.