### PR TITLE
fix(core): fix TypeError in merge_lists when merged list contains non-dict elements

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -110,7 +110,9 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                     to_merge = [
                         i
                         for i, e_left in enumerate(merged)
-                        if "index" in e_left and e_left["index"] == e["index"]
+                        if isinstance(e_left, dict)
+                        and "index" in e_left
+                        and e_left["index"] == e["index"]
                     ]
                     if to_merge:
                         # TODO: Remove this once merge_dict is updated with special


### PR DESCRIPTION
## Description

Fixes #35259.

When streaming Mistral responses with inline citations, `merge_lists` can encounter a mixed list of strings and dicts. The list comprehension that searches for matching `index` values assumed all elements in `merged` were dicts, causing:

```
TypeError: string indices must be integers, not 'str'
```

## Changes

Added `isinstance(e_left, dict)` check in the list comprehension before accessing dict keys, so string elements are safely skipped.

## Testing

Reproduces with the exact example from the issue:
```python
from langchain_core.utils._merge import merge_lists
merged = ["start answer...", {"type": "reference", "index": 0, "reference_ids": ["iKcb2CAQ7"]}, "other answer..."]
other = [{"type": "reference", "index": 0, "reference_ids": ["DGqzzmqc3"]}]
result = merge_lists(merged, other)  # no longer raises TypeError
```