### PR TITLE
fix(core): fix RecursionError in _filter_injected_args when args_schema is a dict

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -818,8 +818,10 @@ class ChildTool(BaseTool):
         # Add injected args from function signature (e.g., ToolRuntime parameters)
         filtered_keys.update(self._injected_args_keys)
 
-        # If we have an args_schema, use it to identify injected args
-        if self.args_schema is not None:
+        # If we have an args_schema, use it to identify injected args.
+        # Skip dict schemas (JSON Schema) since they don't have type annotations
+        # and passing them to get_all_basemodel_annotations causes a RecursionError.
+        if self.args_schema is not None and not isinstance(self.args_schema, dict):
             try:
                 annotations = get_all_basemodel_annotations(self.args_schema)
                 for field_name, field_type in annotations.items():


### PR DESCRIPTION
## Description

Fixes #35258.

When `args_schema` is a plain dict (JSON Schema) instead of a Pydantic BaseModel, calling `get_all_basemodel_annotations()` on it causes a `RecursionError`. While the existing try/except catches this, it generates noisy debug logs and is unnecessary since dict schemas cannot have injected args.

## Changes

Added `not isinstance(self.args_schema, dict)` guard before attempting to extract annotations, consistent with other dict-schema checks already in the codebase (e.g., lines 574, 593).

## Testing

```python
from langchain_core.tools import StructuredTool
tool = StructuredTool(
    name="example", description="Example", func=lambda x: x,
    args_schema={"type": "object", "properties": {"x": {"type": "string"}}}
)
tool.invoke({"x": "test"})  # no more RecursionError in debug logs
```