### PR TITLE
feat(langchain, core): add provenance-based execution guard for side-effecting tools

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -512,6 +512,17 @@ class ChildTool(BaseTool):
     two-tuple corresponding to the `(content, artifact)` of a `ToolMessage`.
     """
 
+    side_effects: bool = False
+    """Whether this tool performs side effects (e.g., writes, deletes, sends).
+
+    When `True`, provenance-based execution guards (such as
+    `ProvenanceMiddleware`) may require that arguments be traceable to prior
+    trusted tool outputs in the same session before allowing execution.
+
+    Tools that only read or query data should leave this as `False` (the
+    default).
+    """
+
     extras: dict[str, Any] | None = None
     """Optional provider-specific extra fields for the tool.
 

--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -24,6 +24,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    side_effects: bool = False,
 ) -> Callable[[Callable | Runnable], BaseTool]: ...
 
 
@@ -40,6 +41,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    side_effects: bool = False,
 ) -> BaseTool: ...
 
 
@@ -55,6 +57,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    side_effects: bool = False,
 ) -> BaseTool: ...
 
 
@@ -70,6 +73,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    side_effects: bool = False,
 ) -> Callable[[Callable | Runnable], BaseTool]: ...
 
 
@@ -85,6 +89,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    side_effects: bool = False,
 ) -> BaseTool | Callable[[Callable | Runnable], BaseTool]:
     """Convert Python functions and `Runnables` to LangChain tools.
 
@@ -150,6 +155,10 @@ def tool(
 
                 For example, Anthropic-specific fields like `cache_control`,
                 `defer_loading`, or `input_examples`.
+        side_effects: Whether this tool performs side effects (e.g., writes, deletes,
+            sends). When `True`, provenance-based execution guards (such as
+            `ProvenanceMiddleware`) may require that arguments be traceable to prior
+            trusted tool outputs before allowing execution.
 
     Raises:
         ValueError: If too many positional arguments are provided (e.g. violating the
@@ -313,6 +322,7 @@ def tool(
                     parse_docstring=parse_docstring,
                     error_on_invalid_docstring=error_on_invalid_docstring,
                     extras=extras,
+                    side_effects=side_effects,
                 )
             # If someone doesn't want a schema applied, we must treat it as
             # a simple string->string function
@@ -330,6 +340,7 @@ def tool(
                 coroutine=coroutine,
                 response_format=response_format,
                 extras=extras,
+                side_effects=side_effects,
             )
 
         return _tool_factory

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3631,3 +3631,52 @@ def test_tool_args_schema_falsy_defaults() -> None:
     # Invoke with only required argument - falsy defaults should be applied
     result = config_tool.invoke({"name": "test"})
     assert result == "name=test, enabled=False, count=0, prefix=''"
+
+
+def test_tool_decorator_side_effects_default() -> None:
+    """Test that @tool defaults side_effects to False."""
+
+    @tool
+    def read_data(query: str) -> str:
+        """Read some data."""
+        return query
+
+    assert isinstance(read_data, BaseTool)
+    assert read_data.side_effects is False
+
+
+def test_tool_decorator_side_effects_true() -> None:
+    """Test that @tool(side_effects=True) sets the field."""
+
+    @tool(side_effects=True)
+    def delete_record(record_id: str) -> str:
+        """Delete a record by ID."""
+        return f"Deleted {record_id}"
+
+    assert isinstance(delete_record, BaseTool)
+    assert delete_record.side_effects is True
+
+
+def test_tool_decorator_side_effects_with_name() -> None:
+    """Test that @tool('name', side_effects=True) works."""
+
+    @tool("delete", side_effects=True)
+    def delete_record(record_id: str) -> str:
+        """Delete a record by ID."""
+        return f"Deleted {record_id}"
+
+    assert isinstance(delete_record, BaseTool)
+    assert delete_record.name == "delete"
+    assert delete_record.side_effects is True
+
+
+def test_tool_decorator_side_effects_false_explicit() -> None:
+    """Test that @tool(side_effects=False) explicitly sets False."""
+
+    @tool(side_effects=False)
+    def search(query: str) -> str:
+        """Search for things."""
+        return query
+
+    assert isinstance(search, BaseTool)
+    assert search.side_effects is False

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -10,6 +10,7 @@ from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddlewar
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
+from langchain.agents.middleware.provenance import ProvenanceMiddleware
 from langchain.agents.middleware.shell_tool import (
     CodexSandboxExecutionPolicy,
     DockerExecutionPolicy,
@@ -63,6 +64,7 @@ __all__ = [
     "ModelRetryMiddleware",
     "PIIDetectionError",
     "PIIMiddleware",
+    "ProvenanceMiddleware",
     "RedactionRule",
     "ShellToolMiddleware",
     "SummarizationMiddleware",

--- a/libs/langchain_v1/langchain/agents/middleware/provenance.py
+++ b/libs/langchain_v1/langchain/agents/middleware/provenance.py
@@ -1,0 +1,305 @@
+"""Provenance-based execution guard for side-effecting tools.
+
+Implements the STTI-001 invariant: "No tool with side effects should execute
+unless every argument can be traced to a value produced by a prior trusted
+tool output in the same session."
+
+See: https://github.com/langchain-ai/langchain/issues/34469
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import HumanMessage, ToolMessage
+from langgraph.typing import ContextT
+from typing_extensions import override
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ResponseT,
+    ToolCallRequest,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from langgraph.types import Command
+
+logger = logging.getLogger(__name__)
+
+PROVENANCE_ERROR_TEMPLATE = (
+    "Execution blocked by provenance guard: tool '{tool_name}' has side effects "
+    "but the following arguments could not be traced to any prior tool output or "
+    "user input in this session:\n{details}\n"
+    "Please use a read/query tool first to obtain the correct values, then retry."
+)
+
+
+def _build_provenance_error(tool_name: str, ungrounded: list[str]) -> str:
+    """Build an error message for ungrounded arguments.
+
+    Args:
+        tool_name: The name of the tool that was blocked.
+        ungrounded: List of ``"key=value"`` strings for ungrounded arguments.
+
+    Returns:
+        A formatted error message suitable for a ``ToolMessage``.
+    """
+    details = "\n".join(f"  - {item}" for item in ungrounded)
+    return PROVENANCE_ERROR_TEMPLATE.format(tool_name=tool_name, details=details)
+
+
+class ProvenanceMiddleware(AgentMiddleware[Any, ContextT, ResponseT]):
+    """Enforce argument provenance for side-effecting tools.
+
+    Tracks values from trusted tool outputs and user inputs during a session.
+    Side-effecting tools (``side_effects=True``) can only execute if their
+    arguments are grounded in previously observed values. If provenance cannot
+    be established, execution is blocked and an error ``ToolMessage`` is
+    returned.
+
+    This middleware is **optional and disabled by default**. Existing agents
+    are unaffected unless this middleware is explicitly added.
+
+    Configuration:
+        - ``include_user_inputs``: Whether ``HumanMessage`` content counts as
+            trusted provenance (default ``True``).
+        - ``min_value_length``: Minimum string length for a value to require
+            provenance checking. Values shorter than this are considered
+            trivially common and skipped (default ``3``).
+
+    Examples:
+        !!! example "Basic usage"
+
+            ```python
+            from langchain.agents import create_agent
+            from langchain.agents.middleware import ProvenanceMiddleware
+            from langchain.tools import tool
+
+            @tool
+            def search(query: str) -> str:
+                \"\"\"Search for information.\"\"\"
+                return f"Found record: id=abc-123"
+
+            @tool(side_effects=True)
+            def delete_record(record_id: str) -> str:
+                \"\"\"Delete a record by ID.\"\"\"
+                return f"Deleted {record_id}"
+
+            agent = create_agent(
+                "openai:gpt-4o",
+                tools=[search, delete_record],
+                middleware=[ProvenanceMiddleware()],
+            )
+            ```
+
+        !!! example "Strict mode (no user inputs as provenance)"
+
+            ```python
+            guard = ProvenanceMiddleware(include_user_inputs=False)
+            agent = create_agent("openai:gpt-4o", tools=[...], middleware=[guard])
+            ```
+    """
+
+    def __init__(
+        self,
+        *,
+        include_user_inputs: bool = True,
+        min_value_length: int = 3,
+    ) -> None:
+        """Initialize the provenance middleware.
+
+        Args:
+            include_user_inputs: Whether ``HumanMessage`` content counts as
+                trusted provenance. When ``True`` (default), values provided
+                by the user are treated as trusted.
+            min_value_length: Minimum string length for a value to require
+                provenance. Values shorter than this threshold are considered
+                trivially common (e.g., ``"ok"``, ``"1"``) and are not checked.
+        """
+        super().__init__()
+        self.include_user_inputs = include_user_inputs
+        self.min_value_length = min_value_length
+
+    @override
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Check argument provenance before executing side-effecting tools.
+
+        Non-side-effecting tools are passed through without any checks.
+        Side-effecting tools have their arguments validated against the
+        accumulated provenance from the session's message history.
+
+        Args:
+            request: The tool call request containing the tool, arguments,
+                and agent state.
+            handler: The next handler in the middleware chain.
+
+        Returns:
+            A ``ToolMessage`` (either from successful execution or an error
+            if provenance check fails) or a ``Command``.
+        """
+        tool = request.tool
+        if tool is None or not getattr(tool, "side_effects", False):
+            return handler(request)
+
+        messages = request.state.get("messages", [])
+        trusted_texts = self._collect_trusted_texts(messages)
+
+        ungrounded = self._find_ungrounded_args(request.tool_call.get("args", {}), trusted_texts)
+
+        if ungrounded:
+            tool_name = request.tool_call.get("name", "unknown")
+            logger.warning(
+                "Provenance check failed for tool '%s': ungrounded args %s",
+                tool_name,
+                ungrounded,
+            )
+            return ToolMessage(
+                content=_build_provenance_error(tool_name, ungrounded),
+                tool_call_id=request.tool_call.get("id", ""),
+                name=tool_name,
+                status="error",
+            )
+
+        return handler(request)
+
+    @override
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Any],
+    ) -> ToolMessage | Command[Any]:
+        """Async version of ``wrap_tool_call``.
+
+        The provenance check itself is synchronous (string matching on message
+        history), so this delegates to the same logic and only awaits the
+        handler if the check passes.
+
+        Args:
+            request: The tool call request.
+            handler: The next async handler in the middleware chain.
+
+        Returns:
+            A ``ToolMessage`` or ``Command``.
+        """
+        tool = request.tool
+        if tool is None or not getattr(tool, "side_effects", False):
+            return await handler(request)
+
+        messages = request.state.get("messages", [])
+        trusted_texts = self._collect_trusted_texts(messages)
+
+        ungrounded = self._find_ungrounded_args(request.tool_call.get("args", {}), trusted_texts)
+
+        if ungrounded:
+            tool_name = request.tool_call.get("name", "unknown")
+            logger.warning(
+                "Provenance check failed for tool '%s': ungrounded args %s",
+                tool_name,
+                ungrounded,
+            )
+            return ToolMessage(
+                content=_build_provenance_error(tool_name, ungrounded),
+                tool_call_id=request.tool_call.get("id", ""),
+                name=tool_name,
+                status="error",
+            )
+
+        return await handler(request)
+
+    def _collect_trusted_texts(self, messages: list[Any]) -> list[str]:
+        """Extract text content from trusted message sources.
+
+        Trusted sources are:
+        - ``ToolMessage`` with ``status="success"`` (tool outputs)
+        - ``HumanMessage`` (user inputs, if ``include_user_inputs`` is True)
+
+        Args:
+            messages: The agent's message history.
+
+        Returns:
+            List of trusted text strings.
+        """
+        texts: list[str] = []
+        for msg in messages:
+            if (isinstance(msg, ToolMessage) and msg.status == "success") or (
+                self.include_user_inputs and isinstance(msg, HumanMessage)
+            ):
+                self._extract_text(msg.content, texts)
+        return texts
+
+    @staticmethod
+    def _extract_text(content: str | list[Any], out: list[str]) -> None:
+        """Extract plain text from message content.
+
+        Handles both string content and structured content block lists.
+
+        Args:
+            content: The message content (string or list of blocks).
+            out: Output list to append extracted text to.
+        """
+        if isinstance(content, str):
+            out.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, str):
+                    out.append(block)
+                elif isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text", "")
+                    if text:
+                        out.append(text)
+
+    def _find_ungrounded_args(self, args: dict[str, Any], trusted_texts: list[str]) -> list[str]:
+        """Check each argument value for provenance in trusted texts.
+
+        Args:
+            args: The tool call arguments dict.
+            trusted_texts: List of trusted text strings to search.
+
+        Returns:
+            List of ``"key=value"`` strings for arguments that lack provenance.
+        """
+        if not trusted_texts:
+            # No trusted text at all — every non-trivial argument is ungrounded
+            return [
+                f"{key}={value!r}"
+                for key, value in args.items()
+                if not self._should_skip_value(value, self.min_value_length)
+            ]
+
+        combined = "\n".join(trusted_texts)
+        ungrounded: list[str] = []
+        for key, value in args.items():
+            if self._should_skip_value(value, self.min_value_length):
+                continue
+            str_value = str(value)
+            if str_value not in combined:
+                ungrounded.append(f"{key}={value!r}")
+        return ungrounded
+
+    @staticmethod
+    def _should_skip_value(value: Any, min_length: int) -> bool:
+        """Determine if a value is trivial and should skip provenance checking.
+
+        Trivial values include: None, booleans, empty strings, and strings
+        shorter than ``min_length``.
+
+        Args:
+            value: The argument value to check.
+            min_length: Minimum string length to require provenance.
+
+        Returns:
+            ``True`` if the value should be skipped (not checked).
+        """
+        if value is None:
+            return True
+        if isinstance(value, bool):
+            return True
+        str_value = str(value)
+        return len(str_value) < min_length

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_provenance.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_provenance.py
@@ -1,0 +1,400 @@
+"""Tests for ProvenanceMiddleware functionality."""
+
+from langchain_core.messages import HumanMessage, ToolCall, ToolMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware.provenance import ProvenanceMiddleware
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+@tool
+def search(query: str) -> str:
+    """Search for information."""
+    return f"Found record: id=abc-123, name={query}"
+
+
+@tool(side_effects=True)
+def delete_record(record_id: str) -> str:
+    """Delete a record by ID."""
+    return f"Deleted {record_id}"
+
+
+@tool(side_effects=True)
+def send_email(to: str, body: str) -> str:
+    """Send an email."""
+    return f"Email sent to {to}"
+
+
+@tool
+def lookup(key: str) -> str:
+    """Look up a value by key."""
+    return f"value-for-{key}"
+
+
+def test_provenance_initialization_defaults() -> None:
+    """Test ProvenanceMiddleware initialization with default values."""
+    guard = ProvenanceMiddleware()
+    assert guard.include_user_inputs is True
+    assert guard.min_value_length == 3
+
+
+def test_provenance_initialization_custom() -> None:
+    """Test ProvenanceMiddleware initialization with custom values."""
+    guard = ProvenanceMiddleware(include_user_inputs=False, min_value_length=5)
+    assert guard.include_user_inputs is False
+    assert guard.min_value_length == 5
+
+
+def test_side_effecting_tool_blocked_without_provenance() -> None:
+    """Side-effecting tool is blocked when args lack provenance."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            # Agent immediately tries to delete with a hallucinated ID
+            # (the ID does NOT appear in the user message)
+            [ToolCall(name="delete_record", args={"record_id": "hallucinated-id-999"}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[search, delete_record],
+        middleware=[ProvenanceMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Please delete that record")]},
+        {"configurable": {"thread_id": "test-blocked"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) >= 1
+
+    # The delete_record call should be blocked
+    delete_msg = next(m for m in tool_messages if m.name == "delete_record")
+    assert delete_msg.status == "error"
+    assert "provenance" in delete_msg.content.lower()
+    assert "record_id" in delete_msg.content
+
+
+def test_side_effecting_tool_allowed_with_provenance() -> None:
+    """Side-effecting tool succeeds when args come from prior tool output."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            # Step 1: agent calls search tool (non-side-effecting, passes through)
+            [ToolCall(name="search", args={"query": "test"}, id="1")],
+            # Step 2: agent uses the ID from search output to delete
+            [ToolCall(name="delete_record", args={"record_id": "abc-123"}, id="2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[search, delete_record],
+        middleware=[ProvenanceMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Search then delete")]},
+        {"configurable": {"thread_id": "test-allowed"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+
+    # search should succeed
+    search_msg = next(m for m in tool_messages if m.name == "search")
+    assert "abc-123" in search_msg.content
+
+    # delete should succeed (abc-123 is in the search output)
+    delete_msg = next(m for m in tool_messages if m.name == "delete_record")
+    assert delete_msg.status != "error"
+    assert "Deleted abc-123" in delete_msg.content
+
+
+def test_non_side_effecting_tools_unaffected() -> None:
+    """Non-side-effecting tools execute normally regardless of provenance."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            # search is not side-effecting, should pass through even with no provenance
+            [ToolCall(name="search", args={"query": "hallucinated-query-xyz"}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[search, delete_record],
+        middleware=[ProvenanceMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Search something")]},
+        {"configurable": {"thread_id": "test-non-side-effect"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].status != "error"
+    assert "Found record" in tool_messages[0].content
+
+
+def test_disabled_by_default_without_middleware() -> None:
+    """Agent without ProvenanceMiddleware executes side-effecting tools freely."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            # No prior search — directly delete with hallucinated ID
+            [ToolCall(name="delete_record", args={"record_id": "hallucinated-id"}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[search, delete_record],
+        # No middleware
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Delete something")]},
+        {"configurable": {"thread_id": "test-no-middleware"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    # Should succeed because no middleware is enforcing provenance
+    assert tool_messages[0].status != "error"
+    assert "Deleted hallucinated-id" in tool_messages[0].content
+
+
+def test_user_input_as_provenance() -> None:
+    """User message content counts as trusted provenance when include_user_inputs=True."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            # Agent uses a value that the user provided in their message
+            [ToolCall(name="delete_record", args={"record_id": "user-provided-id-42"}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[search, delete_record],
+        middleware=[ProvenanceMiddleware(include_user_inputs=True)],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Please delete user-provided-id-42")]},
+        {"configurable": {"thread_id": "test-user-provenance"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    # Should succeed because the ID is in the user's message
+    assert tool_messages[0].status != "error"
+    assert "Deleted user-provided-id-42" in tool_messages[0].content
+
+
+def test_user_input_provenance_disabled() -> None:
+    """User messages do NOT count when include_user_inputs=False."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="delete_record", args={"record_id": "user-provided-id-42"}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[search, delete_record],
+        middleware=[ProvenanceMiddleware(include_user_inputs=False)],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Please delete user-provided-id-42")]},
+        {"configurable": {"thread_id": "test-no-user-provenance"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) >= 1
+
+    delete_msg = next(m for m in tool_messages if m.name == "delete_record")
+    # Should be blocked — user input is not trusted
+    assert delete_msg.status == "error"
+    assert "provenance" in delete_msg.content.lower()
+
+
+def test_trivial_values_skip_provenance_check() -> None:
+    """Boolean, None, and short string values are not provenance-checked."""
+
+    @tool(side_effects=True)
+    def update_setting(name: str, *, enabled: bool, value: str) -> str:
+        """Update a setting."""
+        return f"Updated {name}: enabled={enabled}, value={value}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            # "name" is from user message, "enabled" is bool (skipped), "ok" is short (skipped)
+            [
+                ToolCall(
+                    name="update_setting",
+                    args={"name": "my-setting", "enabled": True, "value": "ok"},
+                    id="1",
+                )
+            ],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[update_setting],
+        middleware=[ProvenanceMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Update my-setting")]},
+        {"configurable": {"thread_id": "test-trivial"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    # "enabled" (bool) and "ok" (len < 3) are skipped
+    # "my-setting" appears in user message
+    assert tool_messages[0].status != "error"
+
+
+def test_full_read_then_write_flow() -> None:
+    """Full agent flow: read tool returns ID, write tool uses it."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            # Step 1: lookup returns a value
+            [ToolCall(name="lookup", args={"key": "project"}, id="1")],
+            # Step 2: delete uses the looked-up value
+            [ToolCall(name="delete_record", args={"record_id": "value-for-project"}, id="2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[lookup, delete_record],
+        middleware=[ProvenanceMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Lookup then delete")]},
+        {"configurable": {"thread_id": "test-flow"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+
+    lookup_msg = next(m for m in tool_messages if m.name == "lookup")
+    assert "value-for-project" in lookup_msg.content
+
+    delete_msg = next(m for m in tool_messages if m.name == "delete_record")
+    assert delete_msg.status != "error"
+    assert "Deleted value-for-project" in delete_msg.content
+
+
+def test_multiple_args_partial_provenance_blocked() -> None:
+    """If some args have provenance but others don't, execution is blocked."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            # Search returns known data
+            [ToolCall(name="search", args={"query": "test"}, id="1")],
+            # send_email: "to" is hallucinated, "body" references known content
+            [
+                ToolCall(
+                    name="send_email",
+                    args={"to": "hallucinated@evil.com", "body": "abc-123"},
+                    id="2",
+                )
+            ],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[search, send_email],
+        middleware=[ProvenanceMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Search then email")]},
+        {"configurable": {"thread_id": "test-partial"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+
+    email_msg = next(m for m in tool_messages if m.name == "send_email")
+    # Should be blocked because "to" arg is not in any trusted text
+    assert email_msg.status == "error"
+    assert "to=" in email_msg.content
+
+
+async def test_provenance_async_blocked() -> None:
+    """Async execution also blocks side-effecting tools without provenance."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="delete_record", args={"record_id": "async-hallucinated"}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[search, delete_record],
+        middleware=[ProvenanceMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage("Please delete that record")]},
+        {"configurable": {"thread_id": "test-async-blocked"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    delete_msg = next(m for m in tool_messages if m.name == "delete_record")
+    assert delete_msg.status == "error"
+    assert "provenance" in delete_msg.content.lower()
+
+
+async def test_provenance_async_allowed() -> None:
+    """Async execution allows side-effecting tools when provenance exists."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="search", args={"query": "test"}, id="1")],
+            [ToolCall(name="delete_record", args={"record_id": "abc-123"}, id="2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[search, delete_record],
+        middleware=[ProvenanceMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage("Search then delete")]},
+        {"configurable": {"thread_id": "test-async-allowed"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    delete_msg = next(m for m in tool_messages if m.name == "delete_record")
+    assert delete_msg.status != "error"
+    assert "Deleted abc-123" in delete_msg.content

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2028,7 +2028,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.75.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.78.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2404,7 +2404,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Description:

Fixes #34469

Adds an optional, deterministic provenance guard that prevents side-effecting tools from executing with hallucinated arguments. The invariant: no tool with side_effects=True should execute unless every argument can be traced to a value from a prior trusted tool output or user input in the same session.

Changes:

Add side_effects: bool = False field to BaseTool in langchain-core for first-class side-effect classification
Expose side_effects parameter on the @tool decorator across all overload signatures
Implement ProvenanceMiddleware using the wrap_tool_call hook — scans message history for trusted text (successful ToolMessage outputs + HumanMessage inputs), blocks execution if any argument value can't be found via substring match, returns error ToolMessage without executing
Export ProvenanceMiddleware from langchain.agents.middleware
Design decisions worth reviewing:

Provenance is stateless — rebuilt from message history each call, no custom state schema needed
Enforcement uses substring matching (str(value) in combined_trusted_text) — simple, deterministic, no heuristics
Trivial values (booleans, None, strings shorter than min_value_length) are skipped
Fully opt-in: side_effects defaults to False, middleware must be explicitly added. Zero behavior change for existing users
include_user_inputs (default True) and min_value_length (default 3) are configurable
Verification:

make format, make lint, make test pass for both libs/core (1650 passed) and libs/langchain_v1 (793 passed)
4 new tests in libs/core for side_effects on the @tool decorator
13 new tests in libs/langchain_v1 covering: blocked execution without provenance, allowed execution with provenance, non-side-effecting tools unaffected, backward compat without middleware, user input as provenance (enabled/disabled), trivial value skipping, partial provenance blocking, full read-then-write flow, async variants
