### PR TITLE
feat(core,openai): add client-side rate limiting for embedding models

### DIFF
--- a/libs/core/langchain_core/embeddings/embeddings.py
+++ b/libs/core/langchain_core/embeddings/embeddings.py
@@ -1,8 +1,14 @@
 """**Embeddings** interface."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from langchain_core.runnables.config import run_in_executor
+
+if TYPE_CHECKING:
+    from langchain_core.rate_limiters import BaseRateLimiter
 
 
 class Embeddings(ABC):
@@ -76,3 +82,89 @@ class Embeddings(ABC):
             Embedding.
         """
         return await run_in_executor(None, self.embed_query, text)
+
+    def with_rate_limiter(self, rate_limiter: BaseRateLimiter) -> Embeddings:
+        """Create a rate-limited wrapper around this embeddings instance.
+
+        The returned wrapper acquires the rate limiter before each embedding
+        call, throttling requests to stay within configured limits. This is
+        consistent with the rate limiting support on chat models.
+
+        Args:
+            rate_limiter: The rate limiter to use (e.g., `InMemoryRateLimiter`).
+
+        Returns:
+            A new `Embeddings` instance that rate-limits all calls.
+
+        Examples:
+            ```python
+            from langchain_core.embeddings import FakeEmbeddings
+            from langchain_core.rate_limiters import InMemoryRateLimiter
+
+            embeddings = FakeEmbeddings(size=10).with_rate_limiter(
+                InMemoryRateLimiter(requests_per_second=5, max_bucket_size=10)
+            )
+            embeddings.embed_documents(["hello", "world"])
+            ```
+        """
+        return _RateLimitedEmbeddings(self, rate_limiter)
+
+
+class _RateLimitedEmbeddings(Embeddings):
+    """Transparent wrapper that rate-limits all embedding calls.
+
+    This class is not part of the public API. Use
+    ``Embeddings.with_rate_limiter()`` to create instances.
+    """
+
+    def __init__(self, base: Embeddings, rate_limiter: BaseRateLimiter) -> None:
+        self._base = base
+        self._rate_limiter = rate_limiter
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        """Rate-limit then delegate to the underlying embeddings.
+
+        Args:
+            texts: List of text to embed.
+
+        Returns:
+            List of embeddings.
+        """
+        self._rate_limiter.acquire(blocking=True)
+        return self._base.embed_documents(texts)
+
+    def embed_query(self, text: str) -> list[float]:
+        """Rate-limit then delegate to the underlying embeddings.
+
+        Args:
+            text: Text to embed.
+
+        Returns:
+            Embedding.
+        """
+        self._rate_limiter.acquire(blocking=True)
+        return self._base.embed_query(text)
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        """Async rate-limit then delegate to the underlying embeddings.
+
+        Args:
+            texts: List of text to embed.
+
+        Returns:
+            List of embeddings.
+        """
+        await self._rate_limiter.aacquire(blocking=True)
+        return await self._base.aembed_documents(texts)
+
+    async def aembed_query(self, text: str) -> list[float]:
+        """Async rate-limit then delegate to the underlying embeddings.
+
+        Args:
+            text: Text to embed.
+
+        Returns:
+            Embedding.
+        """
+        await self._rate_limiter.aacquire(blocking=True)
+        return await self._base.aembed_query(text)

--- a/libs/core/tests/unit_tests/embeddings/test_rate_limiting.py
+++ b/libs/core/tests/unit_tests/embeddings/test_rate_limiting.py
@@ -1,0 +1,258 @@
+"""Tests for embedding model rate limiting."""
+
+import asyncio
+import threading
+import time
+
+import pytest
+from blockbuster import BlockBuster
+
+from langchain_core.embeddings import DeterministicFakeEmbedding, FakeEmbeddings
+from langchain_core.rate_limiters import InMemoryRateLimiter
+
+
+@pytest.fixture(autouse=True)
+def deactivate_blockbuster(blockbuster: BlockBuster) -> None:
+    # Deactivate BlockBuster to not disturb the rate limiter timings
+    blockbuster.deactivate()
+
+
+def test_rate_limit_embed_documents() -> None:
+    """Test that embed_documents respects rate limiter timing."""
+    model = FakeEmbeddings(
+        size=10,
+        rate_limiter=InMemoryRateLimiter(
+            requests_per_second=20,
+            check_every_n_seconds=0.1,
+            max_bucket_size=10,
+        ),
+    )
+    tic = time.time()
+    result = model.embed_documents(["hello", "world"])
+    toc = time.time()
+    # Should wait for rate limiter token (bucket starts empty)
+    assert 0.10 < toc - tic < 0.20
+    assert len(result) == 2
+    assert len(result[0]) == 10
+
+
+def test_rate_limit_embed_query() -> None:
+    """Test that embed_query respects rate limiter timing."""
+    model = FakeEmbeddings(
+        size=10,
+        rate_limiter=InMemoryRateLimiter(
+            requests_per_second=20,
+            check_every_n_seconds=0.1,
+            max_bucket_size=10,
+        ),
+    )
+    tic = time.time()
+    result = model.embed_query("hello")
+    toc = time.time()
+    assert 0.10 < toc - tic < 0.20
+    assert len(result) == 10
+
+
+async def test_rate_limit_aembed_documents() -> None:
+    """Test that aembed_documents respects rate limiter timing."""
+    model = FakeEmbeddings(
+        size=10,
+        rate_limiter=InMemoryRateLimiter(
+            requests_per_second=20,
+            check_every_n_seconds=0.1,
+            max_bucket_size=10,
+        ),
+    )
+    tic = time.time()
+    result = await model.aembed_documents(["hello", "world"])
+    toc = time.time()
+    assert 0.10 < toc - tic < 0.20
+    assert len(result) == 2
+
+
+async def test_rate_limit_aembed_query() -> None:
+    """Test that aembed_query respects rate limiter timing."""
+    model = FakeEmbeddings(
+        size=10,
+        rate_limiter=InMemoryRateLimiter(
+            requests_per_second=20,
+            check_every_n_seconds=0.1,
+            max_bucket_size=10,
+        ),
+    )
+    tic = time.time()
+    result = await model.aembed_query("hello")
+    toc = time.time()
+    assert 0.10 < toc - tic < 0.20
+    assert len(result) == 10
+
+
+def test_no_rate_limit_by_default() -> None:
+    """Test that embeddings work normally without rate limiter."""
+    model = FakeEmbeddings(size=10)
+    tic = time.time()
+    result = model.embed_documents(["hello", "world"])
+    toc = time.time()
+    # Should be fast without rate limiting
+    assert toc - tic < 0.05
+    assert len(result) == 2
+
+
+def test_with_rate_limiter_wrapper() -> None:
+    """Test with_rate_limiter() creates a working rate-limited wrapper."""
+    base = DeterministicFakeEmbedding(size=10)
+    limiter = InMemoryRateLimiter(
+        requests_per_second=20,
+        check_every_n_seconds=0.1,
+        max_bucket_size=10,
+    )
+    wrapped = base.with_rate_limiter(limiter)
+
+    # First call should wait for token
+    tic = time.time()
+    result = wrapped.embed_documents(["hello"])
+    toc = time.time()
+    assert 0.10 < toc - tic < 0.20
+    assert len(result) == 1
+    assert len(result[0]) == 10
+
+
+async def test_with_rate_limiter_wrapper_async() -> None:
+    """Test with_rate_limiter() works for async methods."""
+    base = DeterministicFakeEmbedding(size=10)
+    limiter = InMemoryRateLimiter(
+        requests_per_second=20,
+        check_every_n_seconds=0.1,
+        max_bucket_size=10,
+    )
+    wrapped = base.with_rate_limiter(limiter)
+
+    tic = time.time()
+    result = await wrapped.aembed_query("hello")
+    toc = time.time()
+    assert 0.10 < toc - tic < 0.20
+    assert len(result) == 10
+
+
+def test_with_rate_limiter_preserves_results() -> None:
+    """Test that the wrapper produces the same results as the base embeddings."""
+    base = DeterministicFakeEmbedding(size=10)
+    limiter = InMemoryRateLimiter(
+        requests_per_second=100,
+        check_every_n_seconds=0.01,
+        max_bucket_size=100,
+    )
+    wrapped = base.with_rate_limiter(limiter)
+
+    # Allow rate limiter to warm up
+    time.sleep(0.05)
+
+    base_result = base.embed_query("test text")
+    wrapped_result = wrapped.embed_query("test text")
+    assert base_result == wrapped_result
+
+    base_docs = base.embed_documents(["doc1", "doc2"])
+    wrapped_docs = wrapped.embed_documents(["doc1", "doc2"])
+    assert base_docs == wrapped_docs
+
+
+def test_concurrent_rate_limiting() -> None:
+    """Test that rate limiting works under concurrent access."""
+    model = FakeEmbeddings(
+        size=10,
+        rate_limiter=InMemoryRateLimiter(
+            requests_per_second=10,
+            check_every_n_seconds=0.01,
+            max_bucket_size=1,
+        ),
+    )
+
+    results: list[list[list[float]]] = []
+    errors: list[Exception] = []
+
+    def embed_worker() -> None:
+        try:
+            result = model.embed_documents(["text"])
+            results.append(result)
+        except Exception as e:
+            errors.append(e)
+
+    tic = time.time()
+    threads = [threading.Thread(target=embed_worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    toc = time.time()
+
+    assert len(errors) == 0
+    assert len(results) == 3
+    # 3 calls at 10 req/s with bucket size 1 → ~0.2s minimum
+    assert toc - tic >= 0.15
+
+
+async def test_concurrent_async_rate_limiting() -> None:
+    """Test that async rate limiting works under concurrent access."""
+    model = FakeEmbeddings(
+        size=10,
+        rate_limiter=InMemoryRateLimiter(
+            requests_per_second=10,
+            check_every_n_seconds=0.01,
+            max_bucket_size=1,
+        ),
+    )
+
+    tic = time.time()
+    results = await asyncio.gather(
+        model.aembed_documents(["text1"]),
+        model.aembed_documents(["text2"]),
+        model.aembed_documents(["text3"]),
+    )
+    toc = time.time()
+
+    assert len(results) == 3
+    for result in results:
+        assert len(result) == 1
+    # 3 concurrent calls at 10 req/s with bucket size 1
+    assert toc - tic >= 0.15
+
+
+def test_deterministic_fake_with_rate_limiter() -> None:
+    """Test DeterministicFakeEmbedding with rate limiter field."""
+    model = DeterministicFakeEmbedding(
+        size=10,
+        rate_limiter=InMemoryRateLimiter(
+            requests_per_second=20,
+            check_every_n_seconds=0.1,
+            max_bucket_size=10,
+        ),
+    )
+    tic = time.time()
+    result = model.embed_documents(["hello"])
+    toc = time.time()
+    assert 0.10 < toc - tic < 0.20
+    assert len(result) == 1
+
+
+def test_second_call_faster() -> None:
+    """Test that second call is faster due to token accumulation."""
+    model = FakeEmbeddings(
+        size=10,
+        rate_limiter=InMemoryRateLimiter(
+            requests_per_second=20,
+            check_every_n_seconds=0.1,
+            max_bucket_size=10,
+        ),
+    )
+
+    # First call waits for token
+    tic = time.time()
+    model.embed_documents(["hello"])
+    toc = time.time()
+    assert 0.10 < toc - tic < 0.20
+
+    # Second call should be faster (token accumulated during first call)
+    tic = time.time()
+    model.embed_documents(["world"])
+    toc = time.time()
+    assert toc - tic < 0.10

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.7"
+version = "1.2.9"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },
@@ -557,7 +557,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
+    { name = "langchain-anthropic", marker = "extra == 'anthropic'", editable = "../anthropic" },
     { name = "langchain-aws", marker = "extra == 'aws'" },
     { name = "langchain-azure-ai", marker = "extra == 'azure-ai'" },
     { name = "langchain-community", marker = "extra == 'community'" },
@@ -610,7 +610,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.7"
+version = "1.2.9"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -757,7 +757,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.2"
+version = "1.1.4"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Summary
Closes #34417

Add with_rate_limiter() method to the Embeddings base class that returns a transparent rate-limited wrapper, working with any provider out of the box
Add rate_limiter field to OpenAIEmbeddings (inherited by AzureOpenAIEmbeddings) matching the existing chat model constructor pattern
Add rate_limiter field to FakeEmbeddings and DeterministicFakeEmbedding for testing rate-limited embedding scenarios
Why
Embedding-heavy workloads (parallel document ingestion, batch processing) frequently hit provider rate limits with no framework-level mitigation. Chat models already support client-side rate limiting via BaseChatModel.rate_limiter, but embedding models have no equivalent.

The core design challenge is that Embeddings.embed_documents / embed_query are @abstractmethod — there is no concrete public layer to insert rate limiting (unlike chat models which have _generate_with_cache wrapping _generate). Making them non-abstract would break every existing provider.

The solution uses two complementary mechanisms:

with_rate_limiter() wrapper — provider-agnostic, works with any Embeddings subclass
rate_limiter field on OpenAIEmbeddings — constructor-based, consistent with BaseChatModel API
Review focus
[embeddings.py](vscode-webview://1p8iial8l117g576fjtmhaf7o6blocc58e6mq261pvn7dmoshq3s/libs/core/langchain_core/embeddings/embeddings.py) — _RateLimitedEmbeddings is intentionally private; users interact only via with_rate_limiter()
[base.py](vscode-webview://1p8iial8l117g576fjtmhaf7o6blocc58e6mq261pvn7dmoshq3s/libs/partners/openai/langchain_openai/embeddings/base.py) — Rate limiting is applied once in embed_documents / aembed_documents only, since embed_query / aembed_query delegate to them internally (avoids double-rate-limiting)