### PR TITLE
fix(core): accept int temperature in _get_ls_params for LangSmith tracing

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -812,9 +812,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             ls_params["ls_model_name"] = self.model_name
 
         # temperature
-        if "temperature" in kwargs and isinstance(kwargs["temperature"], float):
+        if "temperature" in kwargs and isinstance(kwargs["temperature"], (int, float)):
             ls_params["ls_temperature"] = kwargs["temperature"]
-        elif hasattr(self, "temperature") and isinstance(self.temperature, float):
+        elif hasattr(self, "temperature") and isinstance(self.temperature, (int, float)):
             ls_params["ls_temperature"] = self.temperature
 
         # max_tokens

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -814,7 +814,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         # temperature
         if "temperature" in kwargs and isinstance(kwargs["temperature"], (int, float)):
             ls_params["ls_temperature"] = kwargs["temperature"]
-        elif hasattr(self, "temperature") and isinstance(self.temperature, (int, float)):
+        elif hasattr(self, "temperature") and isinstance(
+            self.temperature, (int, float)
+        ):
             ls_params["ls_temperature"] = self.temperature
 
         # max_tokens

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -353,7 +353,9 @@ class BaseLLM(BaseLanguageModel[str], ABC):
         # temperature
         if "temperature" in kwargs and isinstance(kwargs["temperature"], (int, float)):
             ls_params["ls_temperature"] = kwargs["temperature"]
-        elif hasattr(self, "temperature") and isinstance(self.temperature, (int, float)):
+        elif hasattr(self, "temperature") and isinstance(
+            self.temperature, (int, float)
+        ):
             ls_params["ls_temperature"] = self.temperature
 
         # max_tokens

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -351,9 +351,9 @@ class BaseLLM(BaseLanguageModel[str], ABC):
             ls_params["ls_model_name"] = self.model_name
 
         # temperature
-        if "temperature" in kwargs and isinstance(kwargs["temperature"], float):
+        if "temperature" in kwargs and isinstance(kwargs["temperature"], (int, float)):
             ls_params["ls_temperature"] = kwargs["temperature"]
-        elif hasattr(self, "temperature") and isinstance(self.temperature, float):
+        elif hasattr(self, "temperature") and isinstance(self.temperature, (int, float)):
             ls_params["ls_temperature"] = self.temperature
 
         # max_tokens

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -1206,6 +1206,13 @@ def test_get_ls_params() -> None:
     ls_params = llm._get_ls_params(temperature=0.2)
     assert ls_params["ls_temperature"] == 0.2
 
+    # Test integer temperature values (regression test for issue #35300)
+    ls_params = llm._get_ls_params(temperature=0)
+    assert ls_params["ls_temperature"] == 0
+
+    ls_params = llm._get_ls_params(temperature=1)
+    assert ls_params["ls_temperature"] == 1
+
     ls_params = llm._get_ls_params(max_tokens=2048)
     assert ls_params["ls_max_tokens"] == 2048
 

--- a/libs/core/tests/unit_tests/language_models/llms/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/llms/test_base.py
@@ -272,6 +272,13 @@ def test_get_ls_params() -> None:
     ls_params = llm._get_ls_params(temperature=0.2)
     assert ls_params["ls_temperature"] == 0.2
 
+    # Test integer temperature values (regression test for issue #35300)
+    ls_params = llm._get_ls_params(temperature=0)
+    assert ls_params["ls_temperature"] == 0
+
+    ls_params = llm._get_ls_params(temperature=1)
+    assert ls_params["ls_temperature"] == 1
+
     ls_params = llm._get_ls_params(max_tokens=2048)
     assert ls_params["ls_max_tokens"] == 2048
 


### PR DESCRIPTION
## Description

Fixes #35300

`BaseChatModel._get_ls_params()` and `BaseLLM._get_ls_params()` use `isinstance(kwargs["temperature"], float)` to check the temperature parameter before adding it to LangSmith tracing metadata. 

`isinstance(0, float)` is `False` so integer temperature values like `temperature=0` or `temperature=1` are silently dropped from traces. 

Changed to `isinstance(..., (int, float))` in all 4 locations. 

Added regression tests covering integer temperature kwargs.