### PR TITLE
fix(langchain): use profile-based check for structured output with tools

### DIFF
--- a/libs/core/langchain_core/language_models/model_profile.py
+++ b/libs/core/langchain_core/language_models/model_profile.py
@@ -80,6 +80,14 @@ class ModelProfile(TypedDict, total=False):
     """Whether the model supports a native [structured output](https://docs.langchain.com/oss/python/langchain/models#structured-outputs)
     feature"""
 
+    structured_output_with_tools: bool
+    """Whether the model supports structured output simultaneously with tool calling.
+
+    When `False`, the agent framework falls back to tool-based structured output
+    when tools are present. When absent or `True`, structured output with tools
+    is assumed to be supported if `structured_output` is `True`.
+    """
+
 
 ModelProfileRegistry = dict[str, ModelProfile]
 """Registry mapping model identifiers or names to their ModelProfile."""

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -492,14 +492,10 @@ def _supports_provider_strategy(
             or getattr(model, "model_id", "")
         )
         model_profile = model.profile
-        if (
-            model_profile is not None
-            and model_profile.get("structured_output")
-            # We make an exception for Gemini models, which currently do not support
-            # simultaneous tool use with structured output
-            and not (tools and isinstance(model_name, str) and "gemini" in model_name.lower())
-        ):
-            return True
+        if model_profile is not None and model_profile.get("structured_output"):
+            # When tools are present, check if model explicitly blocks
+            # structured output with tools (e.g. pre-Gemini 3 models)
+            return not (tools and model_profile.get("structured_output_with_tools") is False)
 
     return (
         any(part in model_name.lower() for part in FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT)

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2028,7 +2028,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.75.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.78.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2404,7 +2404,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/model-profiles/langchain_model_profiles/cli.py
+++ b/libs/model-profiles/langchain_model_profiles/cli.py
@@ -118,6 +118,7 @@ def _model_data_to_profile(model_data: dict[str, Any]) -> dict[str, Any]:
         "tool_calling": model_data.get("tool_call"),
         "tool_choice": model_data.get("tool_choice"),
         "structured_output": model_data.get("structured_output"),
+        "structured_output_with_tools": model_data.get("structured_output_with_tools"),
         "image_url_inputs": model_data.get("image_url_inputs"),
         "image_tool_message": model_data.get("image_tool_message"),
         "pdf_tool_message": model_data.get("pdf_tool_message"),


### PR DESCRIPTION
Summary
Replace the hardcoded "gemini" in model_name.lower() check in _supports_provider_strategy() with a new structured_output_with_tools field on ModelProfile, allowing Gemini 3 models to use provider-native structured output when tools are present
Add the structured_output_with_tools field to ModelProfile TypedDict in langchain-core and to the model-profiles CLI generator
Add 5 unit tests covering Gemini 3, old Gemini, non-Gemini backward compat, no-tools, and no-structured-output scenarios

Closes #34463