### PR TITLE
fix(openai): accept valid responses that are falsy at runtime

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3765,7 +3765,7 @@ def _convert_to_openai_response_format(
 def _oai_structured_outputs_parser(
     ai_msg: AIMessage, schema: type[_BM]
 ) -> PydanticBaseModel | None:
-    if parsed := ai_msg.additional_kwargs.get("parsed"):
+    if (parsed := ai_msg.additional_kwargs.get("parsed")) is not None:
         if isinstance(parsed, dict):
             return schema(**parsed)
         return parsed

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1388,6 +1388,26 @@ def test_structured_outputs_parser() -> None:
     assert result == parsed_response
 
 
+def test_structured_outputs_parser_valid_falsy_response() -> None:
+    class LunchBox(BaseModel):
+        sandwiches: list[str]
+
+        def __len__(self) -> int:
+            return len(self.sandwiches)
+
+    # prepare a valid *but falsy* response object, an empty LunchBox
+    parsed_response = LunchBox(sandwiches=[])
+    assert len(parsed_response) == 0
+    llm_output = AIMessage(
+        content='{"sandwiches": []}', additional_kwargs={"parsed": parsed_response}
+    )
+    output_parser = RunnableLambda(
+        partial(_oai_structured_outputs_parser, schema=LunchBox)
+    )
+    result = output_parser.invoke(llm_output)
+    assert result == parsed_response
+
+
 def test__construct_lc_result_from_responses_api_error_handling() -> None:
     """Test that errors in the response are properly raised."""
     response = Response(


### PR DESCRIPTION
When using structured output through `model.with_structured_output(MyModel)` using a `MyModel` class definition that happens to implement magic methods that influence the truthiness of an instance, a valid response that evaluates to `False` causes `_oai_structured_outputs_parser` to fall through all of the options reading the response, concluding that the response must be faulty. Moving from a truthiness check to a presence check (`is not None`) fixes this; valid responses of my model class that happen to have length 0 are now returned as expected. 

See the added test for a minimal example of this behaviour (the test fails without the single line change in `langchain_openai/chat_models/base.py`).