### PR TITLE
fix(langchain-classic): prevent duplicate output in TodoListMiddleware when model returns text and write_todos simultaneously

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -317,14 +317,15 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
 
     @staticmethod
     def _has_text_content(msg: AIMessage) -> bool:
-        if isinstance(msg.content, str):
-            return bool(msg.content.strip())
-        if isinstance(msg.content, list):
+        content = msg.content
+        if isinstance(content, str):
+            return bool(content.strip())
+        if isinstance(content, list):
             return any(
                 isinstance(block, dict)
                 and block.get("type") == "text"
                 and block.get("text", "").strip()
-                for block in msg.content
+                for block in content
             )
         return False
 

--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -320,14 +320,12 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
         content = msg.content
         if isinstance(content, str):
             return bool(content.strip())
-        if isinstance(content, list):
-            return any(
-                isinstance(block, dict)
-                and block.get("type") == "text"
-                and block.get("text", "").strip()
-                for block in content
+        return any(
+            isinstance(block, dict)
+            and block.get("type") == "text"
+            and block.get("text", "").strip()
+            for block in content
             )
-        return False
 
     @override
     async def aafter_model(

--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -301,7 +301,8 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
             # Keep the tool calls in the AI message but return error messages
             # This follows the same pattern as HumanInTheLoopMiddleware
             return {"messages": error_messages}
-        if len(write_todos_calls) == 1 and _has_text_content(last_ai_msg):
+
+        if len(write_todos_calls) == 1 and self._has_text_content(last_ai_msg):
             todos = write_todos_calls[0].get("args", {}).get("todos", [])
             if todos and all(t.get("status") == "completed" for t in todos):
                 # Strip write_todos tool call, update todos directly in state
@@ -314,6 +315,7 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
 
         return None
 
+    @staticmethod
     def _has_text_content(msg: AIMessage) -> bool:
         if isinstance(msg.content, str):
             return bool(msg.content.strip())

--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -321,7 +321,9 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
             return bool(msg.content.strip())
         if isinstance(msg.content, list):
             return any(
-                isinstance(block, dict) and block.get("type") == "text" and block.get("text", "").strip()
+                isinstance(block, dict)
+                and block.get("type") == "text"
+                and block.get("text", "").strip()
                 for block in msg.content
             )
         return False

--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -325,7 +325,7 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
             and block.get("type") == "text"
             and block.get("text", "").strip()
             for block in content
-            )
+        )
 
     @override
     async def aafter_model(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -809,7 +810,6 @@ async def test_handler_called_with_modified_request_async() -> None:
 
 def test_aafter_model_delegates_to_after_model() -> None:
     """aafter_model should return the same result as after_model."""
-    import asyncio
     middleware = TodoListMiddleware()
     ai_message = AIMessage(
         content="Task completed!",

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
@@ -805,3 +805,24 @@ async def test_handler_called_with_modified_request_async() -> None:
     assert received_prompt["value"] is not None
     assert "Original" in received_prompt["value"]
     assert "write_todos" in received_prompt["value"]
+
+
+def test_aafter_model_delegates_to_after_model() -> None:
+    """aafter_model should return the same result as after_model."""
+    import asyncio
+    middleware = TodoListMiddleware()
+    ai_message = AIMessage(
+        content="Here is your answer.",
+        tool_calls=[{
+            "name": "write_todos",
+            "args": {"todos": [{"content": "Task A", "status": "completed"}]},
+            "id": "call_123",
+            "type": "tool_call",
+        }],
+    )
+    state: PlanningState = {"messages": [HumanMessage(content="Hello"), ai_message]}
+
+    sync_result = middleware.after_model(state, _fake_runtime())
+    async_result = asyncio.run(middleware.aafter_model(state, _fake_runtime()))
+
+    assert sync_result == async_result

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
@@ -410,7 +410,7 @@ def test_todo_middleware_agent_creation_with_middleware() -> None:
     # ai message (6) - complete todo
     # tool message (7)
     # ai message (8) - no tool calls
-    assert len(result["messages"]) == 8
+    assert len(result["messages"]) == 6
 
 
 def test_todo_middleware_custom_system_prompt_in_agent() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
@@ -814,16 +814,16 @@ def test_aafter_model_delegates_to_after_model() -> None:
     ai_message = AIMessage(
         content="Task completed!",
         id="unique_msg_id",
-        tool_calls=[{
-            "name": "write_todos",
-            "args": {"todos": [{"content": "Task A", "status": "completed"}]},
-            "id": "call_123",
-            "type": "tool_call",
-        }],
+        tool_calls=[
+            {
+                "name": "write_todos",
+                "args": {"todos": [{"content": "Task A", "status": "completed"}]},
+                "id": "call_123",
+                "type": "tool_call",
+            }
+        ],
     )
-    state: PlanningState = {
-        "messages": [HumanMessage(content="Hello"), ai_message]
-    }
+    state: PlanningState = {"messages": [HumanMessage(content="Hello"), ai_message]}
     fake_runtime = _fake_runtime()
     sync_result = middleware.after_model(state, fake_runtime)
     async_result = asyncio.run(middleware.aafter_model(state, fake_runtime))


### PR DESCRIPTION
When the model generates a final text answer and a `write_todos(all completed)` tool call in the same response, the agent loop continues due to the presence of a tool call, causing the model to regenerate the answer. This fix detects that case in `after_model` and strips the `write_todos` tool call from the AI message, updating todos directly in state so the agent terminates normally.

Fixes #35310