### PR TITLE
fix(core, openai): surface reasoning traces via Chat Completions API …

### DIFF
--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -190,6 +190,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
                     )
         if audio := _dict.get("audio"):
             additional_kwargs["audio"] = audio
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = reasoning_content
         return AIMessage(
             content=content,
             additional_kwargs=additional_kwargs,
@@ -373,6 +375,8 @@ def _convert_delta_to_message_chunk(
     role = cast(str, _dict.get("role"))
     content = cast(str, _dict.get("content") or "")
     additional_kwargs: dict = {}
+    if reasoning_content := _dict.get("reasoning_content"):
+        additional_kwargs["reasoning_content"] = reasoning_content
     if _dict.get("function_call"):
         function_call = dict(_dict["function_call"])
         if "name" in function_call and function_call["name"] is None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -201,6 +201,32 @@ def test__convert_dict_to_message_ai_with_name() -> None:
     assert _convert_message_to_dict(expected_output) == message
 
 
+def test__convert_dict_to_message_ai_with_reasoning_content() -> None:
+    """Test that reasoning_content from Chat Completions is captured."""
+    message = {
+        "role": "assistant",
+        "content": "The capital is Paris.",
+        "reasoning_content": "Let me think about geography...",
+    }
+    result = _convert_dict_to_message(message)
+    assert isinstance(result, AIMessage)
+    assert result.content == "The capital is Paris."
+    assert result.additional_kwargs["reasoning_content"] == (
+        "Let me think about geography..."
+    )
+
+
+def test__convert_delta_to_message_chunk_with_reasoning_content() -> None:
+    """Test that reasoning_content from Chat Completions streaming is captured."""
+    from langchain_openai.chat_models.base import _convert_delta_to_message_chunk
+
+    delta = {"role": "assistant", "reasoning_content": "Let me reason..."}
+    result = _convert_delta_to_message_chunk(delta, AIMessageChunk)
+    assert isinstance(result, AIMessageChunk)
+    assert result.additional_kwargs["reasoning_content"] == "Let me reason..."
+    assert result.content == ""
+
+
 def test__convert_dict_to_message_system() -> None:
     message = {"role": "system", "content": "foo"}
     result = _convert_dict_to_message(message)

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.7"
+version = "1.2.9"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },
@@ -557,7 +557,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
+    { name = "langchain-anthropic", marker = "extra == 'anthropic'", editable = "../anthropic" },
     { name = "langchain-aws", marker = "extra == 'aws'" },
     { name = "langchain-azure-ai", marker = "extra == 'azure-ai'" },
     { name = "langchain-community", marker = "extra == 'community'" },
@@ -610,7 +610,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.7"
+version = "1.2.9"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -757,7 +757,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.2"
+version = "1.1.4"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Extract `reasoning_content` from Chat Completions responses in both
  streaming (`_convert_delta_to_message_chunk`) and non-streaming
  (`_convert_dict_to_message`) paths in langchain-openai
- Include reasoning blocks from `additional_kwargs["reasoning_content"]`
  in the OpenAI block translator's Chat Completions converters
  (`_convert_to_v1_from_chat_completions` and
  `_convert_to_v1_from_chat_completions_chunk`) in langchain-core

Fixes #34439

## Why
The Responses API path already handled reasoning traces correctly, but
the Chat Completions path (used by AzureChatOpenAI, DeepSeek, etc.) had
two gaps: reasoning data wasn't extracted from the raw response delta,
and even when present in `additional_kwargs`, the OpenAI block translator
didn't include it in `content_blocks`. Since the provider-specific
translator returns early, the generic fallback
`_extract_reasoning_from_additional_kwargs` never ran.

## Test plan
- [x] 4 new tests in `libs/core/tests/unit_tests/messages/block_translators/test_openai.py`
  for reasoning content in `content_blocks` (message, chunk, absent, accumulation)
- [x] 2 new tests in `libs/partners/openai/tests/unit_tests/chat_models/test_base.py`
  for `reasoning_content` extraction in `_convert_dict_to_message` and
  `_convert_delta_to_message_chunk`
- [x] Full test suites pass for both langchain-core (1649 passed) and
  langchain-openai (299 passed)
- [x] Lint + mypy pass for both packages