### PR TITLE
fix(text-splitters): prevent JSFrameworkTextSplitter from mutating self._separators on each split_text() call

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/jsx.py
+++ b/libs/text-splitters/langchain_text_splitters/jsx.py
@@ -92,11 +92,15 @@ class JSFrameworkTextSplitter(RecursiveCharacterTextSplitter):
             "\ndefault ",
             " default ",
         ]
+        # Build the effective separator list for this call only.
+        # Do NOT assign back to self._separators: doing so would permanently
+        # append js_separators + component_separators on every invocation,
+        # causing the list to grow unboundedly when split_text() is called
+        # multiple times on the same instance.
         separators = (
             self._separators
             + js_separators
             + component_separators
             + ["<>", "\n\n", "&&\n", "||\n"]
         )
-        self._separators = separators
-        return super().split_text(text)
+        return self._split_text(text, separators)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -624,6 +624,29 @@ def test_svelte_text_splitter() -> None:
     assert [s.strip() for s in splits] == [s.strip() for s in expected_splits]
 
 
+def test_jsx_splitter_separator_not_mutated_across_calls() -> None:
+    """Regression test: calling split_text() multiple times on the same
+    JSFrameworkTextSplitter instance must not grow the internal separator
+    list between calls.  Before the fix, self._separators was overwritten
+    with the full expanded list on every invocation, so a second call would
+    start with the already-expanded list and append even more separators."""
+    splitter = JSFrameworkTextSplitter(chunk_size=30, chunk_overlap=0)
+
+    # Record separator count after constructing (should be 0 – no custom separators)
+    initial_sep_count = len(splitter._separators)
+
+    # Call split_text twice; the results should be identical for identical input
+    splits_first = splitter.split_text(FAKE_JSX_TEXT)
+    splits_second = splitter.split_text(FAKE_JSX_TEXT)
+
+    assert splits_first == splits_second, (
+        "split_text() must return identical results on repeated calls with the same input"
+    )
+    assert len(splitter._separators) == initial_sep_count, (
+        "split_text() must not mutate self._separators between calls"
+    )
+
+
 CHUNK_SIZE = 16
 
 

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -625,14 +625,18 @@ def test_svelte_text_splitter() -> None:
 
 
 def test_jsx_splitter_separator_not_mutated_across_calls() -> None:
-    """Regression test: calling split_text() multiple times on the same
-    JSFrameworkTextSplitter instance must not grow the internal separator
-    list between calls.  Before the fix, self._separators was overwritten
-    with the full expanded list on every invocation, so a second call would
-    start with the already-expanded list and append even more separators."""
+    """Regression test: repeated split_text() calls must not mutate separators.
+
+    Calling split_text() multiple times on the same JSFrameworkTextSplitter
+    instance must not grow the internal separator list between calls.
+
+    Before the fix, self._separators was overwritten with the full expanded list
+    on every invocation, so a second call would start with the already-expanded
+    list and append even more separators.
+    """
     splitter = JSFrameworkTextSplitter(chunk_size=30, chunk_overlap=0)
 
-    # Record separator count after constructing (should be 0 – no custom separators)
+    # Record separator count after constructing (should be 0 - no custom separators)
     initial_sep_count = len(splitter._separators)
 
     # Call split_text twice; the results should be identical for identical input
@@ -640,7 +644,8 @@ def test_jsx_splitter_separator_not_mutated_across_calls() -> None:
     splits_second = splitter.split_text(FAKE_JSX_TEXT)
 
     assert splits_first == splits_second, (
-        "split_text() must return identical results on repeated calls with the same input"
+        "split_text() must return identical results on repeated calls with the "
+        "same input"
     )
     assert len(splitter._separators) == initial_sep_count, (
         "split_text() must not mutate self._separators between calls"


### PR DESCRIPTION
## What

Fix a bug in `JSFrameworkTextSplitter.split_text()` where `self._separators` was permanently overwritten with the expanded separator list on every call, causing the list to grow unboundedly and producing inconsistent results across multiple calls.

## Why

In `libs/text-splitters/langchain_text_splitters/jsx.py`, `split_text()` builds a `separators` list by concatenating:
- `self._separators` (user-provided)
- `js_separators` (fixed list of JS keywords)
- `component_separators` (extracted from the current text)
- trailing markers (`"<>"`, etc.)

Then it does:
```python
self._separators = separators  # ← permanent mutation
return super().split_text(text)
```

On the **next** call to `split_text()`, `self._separators` already contains all the JS keywords and the previous call's component tags. The method then appends another full set of JS keywords and the new call's component tags. Every call makes the list longer.

**Consequences:**
1. **Memory leak** – `self._separators` grows O(N) in the number of `split_text` calls
2. **Inconsistent results** – Component tags from a previous document bleed into the splitting of a later document
3. **Duplicate separators** – JS keyword separators are duplicated on every call

## How

Replace:
```python
self._separators = separators
return super().split_text(text)
```

With:
```python
return self._split_text(text, separators)
```

This passes the locally computed separator list to the recursive splitting algorithm without touching `self._separators`. The instance state is preserved exactly as the user configured it at construction time.

Also adds a regression test (`test_jsx_splitter_separator_not_mutated_across_calls`) that:
- Calls `split_text()` twice on the same instance
- Asserts results are identical for identical input
- Asserts `len(self._separators)` is unchanged after calls

## Testing

```bash
cd libs/text-splitters
uv run pytest tests/unit_tests/test_text_splitters.py::test_jsx_splitter_separator_not_mutated_across_calls -v
uv run pytest tests/unit_tests/test_text_splitters.py -k jsx -v
```

All existing JSX/Vue/Svelte tests still pass because the fix only changes `self._separators` mutation behavior, not the splitting logic itself.

## Checklist

- [x] Fixes the separator mutation bug in `JSFrameworkTextSplitter`
- [x] Adds regression test to prevent future regressions
- [x] Existing tests (JSX, Vue, Svelte splitter tests) unaffected
- [x] No API surface changes — purely internal fix