### PR TITLE
fix(core): prevent IndexError in handle_event when on_chat_model_start fallback lacks args

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -253,6 +253,11 @@ def shielded(func: Func) -> Func:
     return cast("Func", wrapped)
 
 
+# Minimum positional args required to fall back from on_chat_model_start to
+# on_llm_start: args[0] = serialized, args[1] = messages.
+_MIN_ARGS_FOR_CHAT_MODEL_FALLBACK = 2
+
+
 def handle_event(
     handlers: list[BaseCallbackHandler],
     event_name: str,
@@ -284,7 +289,10 @@ def handle_event(
                     if asyncio.iscoroutine(event):
                         coros.append(event)
             except NotImplementedError as e:
-                if event_name == "on_chat_model_start":
+                if (
+                    event_name == "on_chat_model_start"
+                    and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK
+                ):
                     if message_strings is None:
                         message_strings = [get_buffer_string(m) for m in args[1]]
                     handle_event(
@@ -388,7 +396,10 @@ async def _ahandle_event_for_handler(
                     ),
                 )
     except NotImplementedError as e:
-        if event_name == "on_chat_model_start":
+        if (
+            event_name == "on_chat_model_start"
+            and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK
+        ):
             message_strings = [get_buffer_string(m) for m in args[1]]
             await _ahandle_event_for_handler(
                 handler,

--- a/libs/core/tests/unit_tests/callbacks/test_handle_event.py
+++ b/libs/core/tests/unit_tests/callbacks/test_handle_event.py
@@ -1,0 +1,170 @@
+"""Tests for handle_event and _ahandle_event_for_handler fallback behavior.
+
+Specifically covers the NotImplementedError fallback from on_chat_model_start
+to on_llm_start, ensuring no IndexError when args are insufficient.
+
+See: https://github.com/langchain-ai/langchain/issues/31576
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.callbacks.manager import (
+    _ahandle_event_for_handler,
+    handle_event,
+)
+from langchain_core.messages import HumanMessage
+
+
+class _NotImplementedChatHandler(BaseCallbackHandler):
+    """Handler that raises NotImplementedError for on_chat_model_start."""
+
+    def on_chat_model_start(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError
+
+    def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class _NotImplementedChatHandlerAsync(BaseCallbackHandler):
+    """Async-compatible handler that raises NotImplementedError."""
+
+    run_inline = True
+
+    def on_chat_model_start(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError
+
+    def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+def test_handle_event_chat_model_start_fallback_with_args() -> None:
+    """on_chat_model_start falls back to on_llm_start when args are provided."""
+    handler = _NotImplementedChatHandler()
+    handler.on_llm_start = MagicMock()  # type: ignore[method-assign]
+
+    serialized = {"name": "test"}
+    messages = [[HumanMessage(content="hello")]]
+
+    handle_event(
+        [handler],
+        "on_chat_model_start",
+        "ignore_chat_model",
+        serialized,
+        messages,
+    )
+
+    handler.on_llm_start.assert_called_once()
+
+
+def test_handle_event_chat_model_start_no_args_no_crash() -> None:
+    """on_chat_model_start with no positional args should not raise IndexError."""
+    handler = _NotImplementedChatHandler()
+
+    # Before the fix, this would raise IndexError: tuple index out of range
+    handle_event(
+        [handler],
+        "on_chat_model_start",
+        "ignore_chat_model",
+    )
+
+
+def test_handle_event_chat_model_start_one_arg_no_crash() -> None:
+    """on_chat_model_start with only one positional arg should not raise IndexError."""
+    handler = _NotImplementedChatHandler()
+
+    handle_event(
+        [handler],
+        "on_chat_model_start",
+        "ignore_chat_model",
+        {"name": "test"},
+    )
+
+
+def test_handle_event_other_event_not_implemented() -> None:
+    """Non-chat_model_start events that raise NotImplementedError log a warning."""
+
+    class _Handler(BaseCallbackHandler):
+        def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError
+
+    handler = _Handler()
+
+    # Should not raise — logs a warning instead
+    handle_event(
+        [handler],
+        "on_llm_start",
+        "ignore_llm",
+        {"name": "test"},
+        ["prompt"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_ahandle_event_chat_model_start_fallback_with_args() -> None:
+    """Async: on_chat_model_start falls back to on_llm_start with proper args."""
+    handler = _NotImplementedChatHandlerAsync()
+    handler.on_llm_start = MagicMock()  # type: ignore[method-assign]
+
+    serialized = {"name": "test"}
+    messages = [[HumanMessage(content="hello")]]
+
+    await _ahandle_event_for_handler(
+        handler,
+        "on_chat_model_start",
+        "ignore_chat_model",
+        serialized,
+        messages,
+    )
+
+    handler.on_llm_start.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ahandle_event_chat_model_start_no_args_no_crash() -> None:
+    """Async: on_chat_model_start with no args should not raise IndexError."""
+    handler = _NotImplementedChatHandlerAsync()
+
+    # Before the fix, this would raise IndexError: tuple index out of range
+    await _ahandle_event_for_handler(
+        handler,
+        "on_chat_model_start",
+        "ignore_chat_model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ahandle_event_chat_model_start_one_arg_no_crash() -> None:
+    """Async: on_chat_model_start with one arg should not raise IndexError."""
+    handler = _NotImplementedChatHandlerAsync()
+
+    await _ahandle_event_for_handler(
+        handler,
+        "on_chat_model_start",
+        "ignore_chat_model",
+        {"name": "test"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_ahandle_event_other_event_not_implemented() -> None:
+    """Async: non-chat_model_start events log warning on NotImplementedError."""
+
+    class _Handler(BaseCallbackHandler):
+        run_inline = True
+
+        def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError
+
+    handler = _Handler()
+
+    await _ahandle_event_for_handler(
+        handler,
+        "on_llm_start",
+        "ignore_llm",
+        {"name": "test"},
+        ["prompt"],
+    )


### PR DESCRIPTION
## Summary

- Fixes the `IndexError: tuple index out of range` crash in both sync `handle_event()` and async `_ahandle_event_for_handler()` when a callback handler raises `NotImplementedError` for `on_chat_model_start` but insufficient positional args are provided
- Adds a `len(args) >= 2` guard before accessing `args[1]` (messages) in the fallback path, logging a warning instead of crashing when args are missing
- Adds 8 unit tests covering both sync and async paths: fallback with proper args, no args, one arg, and other event names

Closes #31576

## Why

When a custom callback handler doesn't implement `on_chat_model_start` (raises `NotImplementedError`), LangChain's callback system is designed to gracefully fall back to `on_llm_start`. However, the fallback code accesses `args[1]` without checking if sufficient args exist, causing an `IndexError` that **masks the original `NotImplementedError`** — making debugging harder for users writing custom callback handlers.

## Test plan

- [x] 8 new unit tests covering both sync and async paths
- [x] Full callbacks test suite passes (21 tests)
- [x] `ruff check` and `ruff format` pass on changed files
- [x] Existing fallback behavior (with proper args) still works correctly

> [!NOTE]
> This PR was developed with assistance from Claude Code (AI agent). All changes were reviewed and verified by the contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)