### PR TITLE
fix(core): improve typing/docs for on_chat_model_start to clarify required positional args

### DIFF
--- a/libs/core/langchain_core/callbacks/base.py
+++ b/libs/core/langchain_core/callbacks/base.py
@@ -285,9 +285,29 @@ class CallbackManagerMixin:
             This method is called for chat models. If you're implementing a handler for
             a non-chat model, you should use `on_llm_start` instead.
 
+        !!! note
+
+            When overriding this method, the signature **must** include the two
+            required positional arguments ``serialized`` and ``messages``.  Avoid
+            using ``*args`` in your override — doing so causes an ``IndexError``
+            in the fallback path when the callback system converts ``messages``
+            to prompt strings for ``on_llm_start``.  Always declare the
+            signature explicitly:
+
+            .. code-block:: python
+
+                def on_chat_model_start(
+                    self,
+                    serialized: dict[str, Any],
+                    messages: list[list[BaseMessage]],
+                    **kwargs: Any,
+                ) -> None:
+                    raise NotImplementedError  # triggers fallback to on_llm_start
+
         Args:
             serialized: The serialized chat model.
-            messages: The messages.
+            messages: The messages. Must be a list of message lists — this is a
+                required positional argument and must be present in any override.
             run_id: The ID of the current run.
             parent_run_id: The ID of the parent run.
             tags: The tags.
@@ -295,7 +315,7 @@ class CallbackManagerMixin:
             **kwargs: Additional keyword arguments.
         """
         # NotImplementedError is thrown intentionally
-        # Callback handler will fall back to on_llm_start if this is exception is thrown
+        # Callback handler will fall back to on_llm_start if this exception is thrown
         msg = f"{self.__class__.__name__} does not implement `on_chat_model_start`"
         raise NotImplementedError(msg)
 
@@ -534,9 +554,29 @@ class AsyncCallbackHandler(BaseCallbackHandler):
             This method is called for chat models. If you're implementing a handler for
             a non-chat model, you should use `on_llm_start` instead.
 
+        !!! note
+
+            When overriding this method, the signature **must** include the two
+            required positional arguments ``serialized`` and ``messages``.  Avoid
+            using ``*args`` in your override — doing so causes an ``IndexError``
+            in the fallback path when the callback system converts ``messages``
+            to prompt strings for ``on_llm_start``.  Always declare the
+            signature explicitly:
+
+            .. code-block:: python
+
+                async def on_chat_model_start(
+                    self,
+                    serialized: dict[str, Any],
+                    messages: list[list[BaseMessage]],
+                    **kwargs: Any,
+                ) -> None:
+                    raise NotImplementedError  # triggers fallback to on_llm_start
+
         Args:
             serialized: The serialized chat model.
-            messages: The messages.
+            messages: The messages. Must be a list of message lists — this is a
+                required positional argument and must be present in any override.
             run_id: The ID of the current run.
             parent_run_id: The ID of the parent run.
             tags: The tags.
@@ -544,7 +584,7 @@ class AsyncCallbackHandler(BaseCallbackHandler):
             **kwargs: Additional keyword arguments.
         """
         # NotImplementedError is thrown intentionally
-        # Callback handler will fall back to on_llm_start if this is exception is thrown
+        # Callback handler will fall back to on_llm_start if this exception is thrown
         msg = f"{self.__class__.__name__} does not implement `on_chat_model_start`"
         raise NotImplementedError(msg)
 

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -253,11 +253,6 @@ def shielded(func: Func) -> Func:
     return cast("Func", wrapped)
 
 
-# Minimum positional args required to fall back from on_chat_model_start to
-# on_llm_start: args[0] = serialized, args[1] = messages.
-_MIN_ARGS_FOR_CHAT_MODEL_FALLBACK = 2
-
-
 def handle_event(
     handlers: list[BaseCallbackHandler],
     event_name: str,
@@ -289,10 +284,7 @@ def handle_event(
                     if asyncio.iscoroutine(event):
                         coros.append(event)
             except NotImplementedError as e:
-                if (
-                    event_name == "on_chat_model_start"
-                    and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK
-                ):
+                if event_name == "on_chat_model_start":
                     if message_strings is None:
                         message_strings = [get_buffer_string(m) for m in args[1]]
                     handle_event(
@@ -396,10 +388,7 @@ async def _ahandle_event_for_handler(
                     ),
                 )
     except NotImplementedError as e:
-        if (
-            event_name == "on_chat_model_start"
-            and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK
-        ):
+        if event_name == "on_chat_model_start":
             message_strings = [get_buffer_string(m) for m in args[1]]
             await _ahandle_event_for_handler(
                 handler,

--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -253,6 +253,11 @@ def shielded(func: Func) -> Func:
     return cast("Func", wrapped)
 
 
+# Minimum positional args required to fall back from on_chat_model_start to
+# on_llm_start: args[0] = serialized, args[1] = messages.
+_MIN_ARGS_FOR_CHAT_MODEL_FALLBACK = 2
+
+
 def handle_event(
     handlers: list[BaseCallbackHandler],
     event_name: str,
@@ -284,7 +289,10 @@ def handle_event(
                     if asyncio.iscoroutine(event):
                         coros.append(event)
             except NotImplementedError as e:
-                if event_name == "on_chat_model_start":
+                if (
+                    event_name == "on_chat_model_start"
+                    and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK
+                ):
                     if message_strings is None:
                         message_strings = [get_buffer_string(m) for m in args[1]]
                     handle_event(
@@ -388,7 +396,10 @@ async def _ahandle_event_for_handler(
                     ),
                 )
     except NotImplementedError as e:
-        if event_name == "on_chat_model_start":
+        if (
+            event_name == "on_chat_model_start"
+            and len(args) >= _MIN_ARGS_FOR_CHAT_MODEL_FALLBACK
+        ):
             message_strings = [get_buffer_string(m) for m in args[1]]
             await _ahandle_event_for_handler(
                 handler,

--- a/libs/core/tests/unit_tests/callbacks/test_handle_event.py
+++ b/libs/core/tests/unit_tests/callbacks/test_handle_event.py
@@ -1,7 +1,8 @@
 """Tests for handle_event and _ahandle_event_for_handler fallback behavior.
 
-Specifically covers the NotImplementedError fallback from on_chat_model_start
-to on_llm_start, ensuring no IndexError when args are insufficient.
+Covers the NotImplementedError fallback from on_chat_model_start to on_llm_start.
+Handlers must declare `serialized` and `messages` as explicit positional args
+(not *args) — see on_chat_model_start docstring for details.
 
 See: https://github.com/langchain-ai/langchain/issues/31576
 """
@@ -16,34 +17,47 @@ from langchain_core.callbacks.manager import (
     _ahandle_event_for_handler,
     handle_event,
 )
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import BaseMessage, HumanMessage
 
 
-class _NotImplementedChatHandler(BaseCallbackHandler):
-    """Handler that raises NotImplementedError for on_chat_model_start."""
+class _FallbackChatHandler(BaseCallbackHandler):
+    """Handler that correctly declares the required args but raises NotImplementedError.
 
-    def on_chat_model_start(self, *args: Any, **kwargs: Any) -> None:
+    This triggers the fallback to on_llm_start, as documented.
+    """
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        **kwargs: Any,
+    ) -> None:
         raise NotImplementedError
 
     def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
         pass
 
 
-class _NotImplementedChatHandlerAsync(BaseCallbackHandler):
-    """Async-compatible handler that raises NotImplementedError."""
+class _FallbackChatHandlerAsync(BaseCallbackHandler):
+    """Async-compatible handler that raises NotImplementedError for on_chat_model_start."""
 
     run_inline = True
 
-    def on_chat_model_start(self, *args: Any, **kwargs: Any) -> None:
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        **kwargs: Any,
+    ) -> None:
         raise NotImplementedError
 
     def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
         pass
 
 
-def test_handle_event_chat_model_start_fallback_with_args() -> None:
-    """on_chat_model_start falls back to on_llm_start when args are provided."""
-    handler = _NotImplementedChatHandler()
+def test_handle_event_chat_model_start_fallback_to_llm_start() -> None:
+    """on_chat_model_start raises NotImplementedError → falls back to on_llm_start."""
+    handler = _FallbackChatHandler()
     handler.on_llm_start = MagicMock()  # type: ignore[method-assign]
 
     serialized = {"name": "test"}
@@ -60,31 +74,7 @@ def test_handle_event_chat_model_start_fallback_with_args() -> None:
     handler.on_llm_start.assert_called_once()
 
 
-def test_handle_event_chat_model_start_no_args_no_crash() -> None:
-    """on_chat_model_start with no positional args should not raise IndexError."""
-    handler = _NotImplementedChatHandler()
-
-    # Before the fix, this would raise IndexError: tuple index out of range
-    handle_event(
-        [handler],
-        "on_chat_model_start",
-        "ignore_chat_model",
-    )
-
-
-def test_handle_event_chat_model_start_one_arg_no_crash() -> None:
-    """on_chat_model_start with only one positional arg should not raise IndexError."""
-    handler = _NotImplementedChatHandler()
-
-    handle_event(
-        [handler],
-        "on_chat_model_start",
-        "ignore_chat_model",
-        {"name": "test"},
-    )
-
-
-def test_handle_event_other_event_not_implemented() -> None:
+def test_handle_event_other_event_not_implemented_logs_warning() -> None:
     """Non-chat_model_start events that raise NotImplementedError log a warning."""
 
     class _Handler(BaseCallbackHandler):
@@ -104,9 +94,9 @@ def test_handle_event_other_event_not_implemented() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ahandle_event_chat_model_start_fallback_with_args() -> None:
-    """Async: on_chat_model_start falls back to on_llm_start with proper args."""
-    handler = _NotImplementedChatHandlerAsync()
+async def test_ahandle_event_chat_model_start_fallback_to_llm_start() -> None:
+    """Async: on_chat_model_start raises NotImplementedError → falls back to on_llm_start."""
+    handler = _FallbackChatHandlerAsync()
     handler.on_llm_start = MagicMock()  # type: ignore[method-assign]
 
     serialized = {"name": "test"}
@@ -124,33 +114,7 @@ async def test_ahandle_event_chat_model_start_fallback_with_args() -> None:
 
 
 @pytest.mark.asyncio
-async def test_ahandle_event_chat_model_start_no_args_no_crash() -> None:
-    """Async: on_chat_model_start with no args should not raise IndexError."""
-    handler = _NotImplementedChatHandlerAsync()
-
-    # Before the fix, this would raise IndexError: tuple index out of range
-    await _ahandle_event_for_handler(
-        handler,
-        "on_chat_model_start",
-        "ignore_chat_model",
-    )
-
-
-@pytest.mark.asyncio
-async def test_ahandle_event_chat_model_start_one_arg_no_crash() -> None:
-    """Async: on_chat_model_start with one arg should not raise IndexError."""
-    handler = _NotImplementedChatHandlerAsync()
-
-    await _ahandle_event_for_handler(
-        handler,
-        "on_chat_model_start",
-        "ignore_chat_model",
-        {"name": "test"},
-    )
-
-
-@pytest.mark.asyncio
-async def test_ahandle_event_other_event_not_implemented() -> None:
+async def test_ahandle_event_other_event_not_implemented_logs_warning() -> None:
     """Async: non-chat_model_start events log warning on NotImplementedError."""
 
     class _Handler(BaseCallbackHandler):

--- a/libs/core/tests/unit_tests/callbacks/test_handle_event.py
+++ b/libs/core/tests/unit_tests/callbacks/test_handle_event.py
@@ -39,7 +39,7 @@ class _FallbackChatHandler(BaseCallbackHandler):
 
 
 class _FallbackChatHandlerAsync(BaseCallbackHandler):
-    """Async-compatible handler that raises NotImplementedError for on_chat_model_start."""
+    """Async-compatible handler; raises NotImplementedError for on_chat_model_start."""
 
     run_inline = True
 
@@ -95,7 +95,7 @@ def test_handle_event_other_event_not_implemented_logs_warning() -> None:
 
 @pytest.mark.asyncio
 async def test_ahandle_event_chat_model_start_fallback_to_llm_start() -> None:
-    """Async: on_chat_model_start raises NotImplementedError → falls back to on_llm_start."""
+    """Async: on_chat_model_start NotImplementedError falls back to on_llm_start."""
     handler = _FallbackChatHandlerAsync()
     handler.on_llm_start = MagicMock()  # type: ignore[method-assign]
 

--- a/libs/core/tests/unit_tests/callbacks/test_handle_event.py
+++ b/libs/core/tests/unit_tests/callbacks/test_handle_event.py
@@ -1,0 +1,170 @@
+"""Tests for handle_event and _ahandle_event_for_handler fallback behavior.
+
+Specifically covers the NotImplementedError fallback from on_chat_model_start
+to on_llm_start, ensuring no IndexError when args are insufficient.
+
+See: https://github.com/langchain-ai/langchain/issues/31576
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.callbacks.manager import (
+    _ahandle_event_for_handler,
+    handle_event,
+)
+from langchain_core.messages import HumanMessage
+
+
+class _NotImplementedChatHandler(BaseCallbackHandler):
+    """Handler that raises NotImplementedError for on_chat_model_start."""
+
+    def on_chat_model_start(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError
+
+    def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class _NotImplementedChatHandlerAsync(BaseCallbackHandler):
+    """Async-compatible handler that raises NotImplementedError."""
+
+    run_inline = True
+
+    def on_chat_model_start(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError
+
+    def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+def test_handle_event_chat_model_start_fallback_with_args() -> None:
+    """on_chat_model_start falls back to on_llm_start when args are provided."""
+    handler = _NotImplementedChatHandler()
+    handler.on_llm_start = MagicMock()  # type: ignore[method-assign]
+
+    serialized = {"name": "test"}
+    messages = [[HumanMessage(content="hello")]]
+
+    handle_event(
+        [handler],
+        "on_chat_model_start",
+        "ignore_chat_model",
+        serialized,
+        messages,
+    )
+
+    handler.on_llm_start.assert_called_once()
+
+
+def test_handle_event_chat_model_start_no_args_no_crash() -> None:
+    """on_chat_model_start with no positional args should not raise IndexError."""
+    handler = _NotImplementedChatHandler()
+
+    # Before the fix, this would raise IndexError: tuple index out of range
+    handle_event(
+        [handler],
+        "on_chat_model_start",
+        "ignore_chat_model",
+    )
+
+
+def test_handle_event_chat_model_start_one_arg_no_crash() -> None:
+    """on_chat_model_start with only one positional arg should not raise IndexError."""
+    handler = _NotImplementedChatHandler()
+
+    handle_event(
+        [handler],
+        "on_chat_model_start",
+        "ignore_chat_model",
+        {"name": "test"},
+    )
+
+
+def test_handle_event_other_event_not_implemented() -> None:
+    """Non-chat_model_start events that raise NotImplementedError log a warning."""
+
+    class _Handler(BaseCallbackHandler):
+        def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError
+
+    handler = _Handler()
+
+    # Should not raise — logs a warning instead
+    handle_event(
+        [handler],
+        "on_llm_start",
+        "ignore_llm",
+        {"name": "test"},
+        ["prompt"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_ahandle_event_chat_model_start_fallback_with_args() -> None:
+    """Async: on_chat_model_start falls back to on_llm_start with proper args."""
+    handler = _NotImplementedChatHandlerAsync()
+    handler.on_llm_start = MagicMock()  # type: ignore[method-assign]
+
+    serialized = {"name": "test"}
+    messages = [[HumanMessage(content="hello")]]
+
+    await _ahandle_event_for_handler(
+        handler,
+        "on_chat_model_start",
+        "ignore_chat_model",
+        serialized,
+        messages,
+    )
+
+    handler.on_llm_start.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ahandle_event_chat_model_start_no_args_no_crash() -> None:
+    """Async: on_chat_model_start with no args should not raise IndexError."""
+    handler = _NotImplementedChatHandlerAsync()
+
+    # Before the fix, this would raise IndexError: tuple index out of range
+    await _ahandle_event_for_handler(
+        handler,
+        "on_chat_model_start",
+        "ignore_chat_model",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ahandle_event_chat_model_start_one_arg_no_crash() -> None:
+    """Async: on_chat_model_start with one arg should not raise IndexError."""
+    handler = _NotImplementedChatHandlerAsync()
+
+    await _ahandle_event_for_handler(
+        handler,
+        "on_chat_model_start",
+        "ignore_chat_model",
+        {"name": "test"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_ahandle_event_other_event_not_implemented() -> None:
+    """Async: non-chat_model_start events log warning on NotImplementedError."""
+
+    class _Handler(BaseCallbackHandler):
+        run_inline = True
+
+        def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError
+
+    handler = _Handler()
+
+    await _ahandle_event_for_handler(
+        handler,
+        "on_llm_start",
+        "ignore_llm",
+        {"name": "test"},
+        ["prompt"],
+    )


### PR DESCRIPTION
## Summary

Rework of #35323 based on maintainer feedback from @ccurme.

> "The `on_chat_model_start` has 2 required arguments, this should just be typed / documented better."

Instead of a runtime `len(args) >= 2` guard, this PR improves the documentation on `on_chat_model_start` to make the required signature contract explicit.

### What changed

- **Reverted** the runtime guard (`_MIN_ARGS_FOR_CHAT_MODEL_FALLBACK` constant and `len(args)` checks) from `handle_event()` and `_ahandle_event_for_handler()` in `manager.py`
- **Improved docstrings** on `on_chat_model_start` in both `CallbackManagerMixin` (sync) and `AsyncCallbackHandler` (async) in `base.py`, with an explicit `cd /Users/balajiseshadri/workspace/langchain && git push origin fix/core-handle-event-index-error --force-with-lease! note` block:
  - States that `serialized` and `messages` are **required positional arguments**
  - Warns that using `*args` in an override suppresses these names, causing an `IndexError` in the fallback path to `on_llm_start`
  - Provides a correct example signature
- **Updated tests** in `test_handle_event.py` — removed invalid-usage tests (no-args, one-arg) that only tested the reverted guard; kept tests for the valid fallback path (correct signature + `NotImplementedError`)

### Why

The 2 required positional args (`serialized`, `messages`) are always provided by the internal call sites in `manager.py`. The `IndexError` only occurs when user-written handlers wrongly use `*args` in their override, violating the signature contract. The right fix is to make this contract clear in the documentation.

Closes #31576