### PR TITLE
core: Add __str__ to BaseMessage for intuitive text content output

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -306,6 +306,29 @@ class BaseMessage(Serializable):
         prompt = ChatPromptTemplate(messages=[self])
         return prompt.__add__(other)
 
+    def __str__(self) -> str:
+        """Return the text content of the message.
+
+        This returns the same value as the ``text`` property, providing an
+        intuitive string representation that contains just the message text
+        rather than the full object representation with metadata.
+
+        Returns:
+            The text content of the message.
+
+        Example:
+            ```python
+            from langchain_core.messages import AIMessage
+
+            msg = AIMessage(content="The capital of France is Paris.")
+            print(str(msg))
+            # "The capital of France is Paris."
+            ```
+
+        .. versionadded:: 0.3.58
+        """
+        return str(self.text)
+
     def pretty_repr(
         self,
         html: bool = False,  # noqa: FBT001,FBT002

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -502,3 +502,22 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+
+def test_str_returns_text_content() -> None:
+    """Test that str() on an AIMessage returns just the text content."""
+    msg = AIMessage(content="The capital of France is Paris.")
+    assert str(msg) == "The capital of France is Paris."
+
+    # Test with empty content
+    msg_empty = AIMessage(content="")
+    assert str(msg_empty) == ""
+
+    # Test with multimodal content (list)
+    msg_list = AIMessage(
+        content=[
+            {"type": "text", "text": "Hello "},
+            {"type": "text", "text": "world"},
+        ]
+    )
+    assert str(msg_list) == "Hello world"


### PR DESCRIPTION
## Summary

Adds a `__str__` method to `BaseMessage` that returns the text content of the message (same as the `.text` property), instead of the default Pydantic model repr.

## Problem

Currently, `str(AIMessage(content="hello"))` returns the full Pydantic representation with all metadata fields (`response_metadata`, `usage_metadata`, `id`, etc.). This is confusing for users who expect `str(message)` or `print(message)` to output just the text content.

This was reported in langchain-ai/docs#2765 where a user following the RAG tutorial got unexpected JSON/metadata output when printing a message object, rather than the actual response text. While the tutorial code should use `.content`, having an intuitive `__str__` prevents this class of confusion.

## Changes

- **`libs/core/langchain_core/messages/base.py`**: Added `__str__` method to `BaseMessage` that returns `str(self.text)`
- **`libs/core/tests/unit_tests/messages/test_ai.py`**: Added tests for `str()` on AIMessage with string content, empty content, and multimodal list content

## Behavior Change

| Expression | Before | After |
|---|---|---|
| `str(AIMessage(content="hello"))` | `content='hello' additional_kwargs={} ...` | `hello` |
| `repr(AIMessage(content="hello"))` | *(unchanged)* | *(unchanged)* |
| `msg.content` | *(unchanged)* | *(unchanged)* |
| `msg.text` | *(unchanged)* | *(unchanged)* |

`repr()` is unchanged, preserving full debugging output. Only `str()` / `print()` behavior changes.

Related: langchain-ai/docs#2765