### PR TITLE
fix(core): add __str__ to BaseMessage for intuitive text content output

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -306,6 +306,29 @@ class BaseMessage(Serializable):
         prompt = ChatPromptTemplate(messages=[self])
         return prompt.__add__(other)
 
+    def __str__(self) -> str:
+        """Return the text content of the message.
+
+        This returns the same value as the ``text`` property, providing an
+        intuitive string representation that contains just the message text
+        rather than the full object representation with metadata.
+
+        Returns:
+            The text content of the message.
+
+        Example:
+            ```python
+            from langchain_core.messages import AIMessage
+
+            msg = AIMessage(content="The capital of France is Paris.")
+            print(str(msg))
+            # "The capital of France is Paris."
+            ```
+
+        .. versionadded:: 0.3.58
+        """
+        return str(self.text)
+
     def pretty_repr(
         self,
         html: bool = False,  # noqa: FBT001,FBT002

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -502,3 +502,22 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+
+def test_str_returns_text_content() -> None:
+    """Test that str() on an AIMessage returns just the text content."""
+    msg = AIMessage(content="The capital of France is Paris.")
+    assert str(msg) == "The capital of France is Paris."
+
+    # Test with empty content
+    msg_empty = AIMessage(content="")
+    assert str(msg_empty) == ""
+
+    # Test with multimodal content (list)
+    msg_list = AIMessage(
+        content=[
+            {"type": "text", "text": "Hello "},
+            {"type": "text", "text": "world"},
+        ]
+    )
+    assert str(msg_list) == "Hello world"

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1037,7 +1037,7 @@ def test_tool_message_repr() -> None:
 
 def test_tool_message_str() -> None:
     message = ToolMessage("foo", artifact={"bar": {"baz": 123}}, tool_call_id="1")
-    expected = "content='foo' tool_call_id='1' artifact={'bar': {'baz': 123}}"
+    expected = "foo"
     actual = str(message)
     assert expected == actual
 


### PR DESCRIPTION
## Description
Adds a `__str__` method to `BaseMessage` so that `print(msg)` and `str(msg)` return the text content of the message, rather than the full Pydantic representation.

**Before:**
```python
msg = AIMessage(content='Hello!')
print(msg)  # content='Hello!' additional_kwargs={} ...
```

**After:**
```python
msg = AIMessage(content='Hello!')
print(msg)  # Hello!
```

Fixes langchain-ai/docs#2765

## Changes
- Added `__str__` to `BaseMessage` that returns `str(self.text)`
- Updated `test_tool_message_str` test to expect text content only