### PR TITLE
fix(core): prevent _configure_hooks accumulation in get_usage_metadata_callback

### DIFF
--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -19,9 +19,9 @@ from langchain_core.tracers.context import register_configure_hook
 # Each call to get_usage_metadata_callback() previously created a new ContextVar and
 # registered a new hook, causing unbounded growth of _configure_hooks in long-running
 # applications.
-_usage_metadata_callback_var: ContextVar[
-    "UsageMetadataCallbackHandler | None"
-] = ContextVar("usage_metadata_callback", default=None)
+_usage_metadata_callback_var: ContextVar["UsageMetadataCallbackHandler | None"] = (
+    ContextVar("usage_metadata_callback", default=None)
+)
 register_configure_hook(_usage_metadata_callback_var, inheritable=True)
 
 

--- a/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
+++ b/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
@@ -1,9 +1,13 @@
+import warnings
 from typing import Any
+
+import pytest
 
 from langchain_core.callbacks import (
     UsageMetadataCallbackHandler,
     get_usage_metadata_callback,
 )
+from langchain_core.callbacks.usage import _usage_metadata_callback_var
 from langchain_core.language_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage
 from langchain_core.messages.ai import (
@@ -13,6 +17,7 @@ from langchain_core.messages.ai import (
     add_usage,
 )
 from langchain_core.outputs import ChatResult
+from langchain_core.tracers.context import _configure_hooks
 
 usage1 = UsageMetadata(
     input_tokens=1,
@@ -120,3 +125,58 @@ async def test_usage_callback_async() -> None:
     callback = UsageMetadataCallbackHandler()
     _ = await llm.abatch(["Message 1", "Message 2"], config={"callbacks": [callback]})
     assert callback.usage_metadata == {"test_model": total_1_2}
+
+
+def test_configure_hooks_no_accumulation() -> None:
+    """Regression test for https://github.com/langchain-ai/langchain/issues/32300.
+
+    Each call to get_usage_metadata_callback() must NOT append a new entry to
+    _configure_hooks. The hook is registered once at module load time via the
+    module-level _usage_metadata_callback_var.
+    """
+    hooks_before = len(_configure_hooks)
+
+    for _ in range(10):
+        with get_usage_metadata_callback():
+            pass
+
+    hooks_after = len(_configure_hooks)
+    assert hooks_after == hooks_before, (
+        f"_configure_hooks grew from {hooks_before} to {hooks_after} entries after "
+        "repeated calls to get_usage_metadata_callback(). Each call must not register "
+        "a new hook."
+    )
+
+    # Sanity-check: the module-level var is registered exactly once.
+    registered_vars = [var for var, *_ in _configure_hooks]
+    assert registered_vars.count(_usage_metadata_callback_var) == 1
+
+
+def test_name_parameter_deprecated() -> None:
+    """Passing a custom `name` must emit a DeprecationWarning."""
+    with (
+        pytest.warns(DeprecationWarning, match="`name` parameter"),
+        get_usage_metadata_callback(name="my_custom_name"),
+    ):
+        pass
+
+
+def test_name_parameter_default_no_warning() -> None:
+    """Calling with the default `name` must NOT emit any deprecation warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with get_usage_metadata_callback():
+            pass
+
+
+def test_nested_context_managers() -> None:
+    """Inner context manager must not clobber the outer one on exit."""
+    with get_usage_metadata_callback() as outer_cb:
+        with get_usage_metadata_callback() as inner_cb:
+            assert outer_cb is not inner_cb
+
+        # After the inner CM exits, the outer handler must still be active.
+        assert _usage_metadata_callback_var.get() is outer_cb
+
+    # After the outer CM exits, the var must be back to its previous value (None).
+    assert _usage_metadata_callback_var.get() is None

--- a/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
+++ b/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
@@ -148,8 +148,10 @@ def test_configure_hooks_no_accumulation() -> None:
     )
 
     # Sanity-check: the module-level var is registered exactly once.
-    registered_vars = [var for var, *_ in _configure_hooks]
-    assert registered_vars.count(_usage_metadata_callback_var) == 1
+    count = sum(
+        1 for var, *_ in _configure_hooks if var is _usage_metadata_callback_var
+    )
+    assert count == 1
 
 
 def test_name_parameter_deprecated() -> None:


### PR DESCRIPTION
## Summary

Fixes #32300.

- `get_usage_metadata_callback()` previously created a new `ContextVar` and called `register_configure_hook` on **every invocation**, causing `_configure_hooks` to grow unboundedly
- In long-running applications (e.g. servers, evaluation loops) this caused a memory leak and progressively slower callback configuration on every LLM call
- Fix: move the `ContextVar` and `register_configure_hook` call to **module level** — registered exactly once at import time
- The context manager now uses `ContextVar.reset(token)` instead of `set(None)`, which correctly restores the previous handler in nested `get_usage_metadata_callback()` calls
- The `name` parameter is deprecated (it only named the now-global `ContextVar`) with a `DeprecationWarning` when a non-default value is passed

## Areas requiring careful review

- The `_usage_metadata_callback_var` symbol is now public-ish (module-level with a `_` prefix); tests import it directly — maintainers may prefer a different approach to expose it for testing
- The `name` parameter deprecation: currently only warns when the value differs from the default (`"usage_metadata_callback"`); we could also warn on any usage of the parameter

## Test plan

- [x] `test_configure_hooks_no_accumulation` — asserts `_configure_hooks` does not grow after repeated calls
- [x] `test_name_parameter_deprecated` — asserts `DeprecationWarning` when custom `name` is passed
- [x] `test_name_parameter_default_no_warning` — asserts no warning on default usage
- [x] `test_nested_context_managers` — asserts inner CM exit restores outer handler (not `None`)
- [x] Existing `test_usage_callback` and `test_usage_callback_async` still pass

> **AI disclaimer:** This PR was developed with assistance from Claude Code (Anthropic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)