### PR TITLE
fix(infra): fix trailing comma regex in profile generation script

### DIFF
--- a/libs/model-profiles/langchain_model_profiles/cli.py
+++ b/libs/model-profiles/langchain_model_profiles/cli.py
@@ -317,7 +317,7 @@ def refresh(provider: str, data_dir: Path) -> None:  # noqa: C901, PLR0915
         .replace("null", "None")
     )
     # Add trailing commas for ruff format compliance
-    json_str = re.sub(r"([^\s,{\[])(\n\s*[\}\]])", r"\1,\2", json_str)
+    json_str = re.sub(r"([^\s,{\[])(?=\n\s*[\}\]])", r"\1,", json_str)
     module_content.append(f"{json_str}\n")
     _write_profiles_file(output_file, "".join(module_content))
 

--- a/libs/partners/deepseek/uv.lock
+++ b/libs/partners/deepseek/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.13"
+version = "1.2.14"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
The trailing comma regex in the profile generation script consumed the closing `}` as part of its match, preventing nested closing braces from getting their own trailing comma. This caused `ruff format` failures on every generated `_profiles.py` file.

Switches to a lookahead (`(?=...)`) so the closing bracket is asserted but not consumed, allowing each nesting level to independently receive its trailing comma.

Fixes #35332.