### PR TITLE
fix(langchain): isolate middleware model calls from parent streaming …

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -601,7 +601,7 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         try:
             response = self.model.invoke(
                 self.summary_prompt.format(messages=formatted_messages).rstrip(),
-                config={"metadata": {"lc_source": "summarization"}},
+                config=self._get_internal_model_config(lc_source="summarization"),
             )
             return response.text.strip()
         except Exception as e:
@@ -627,7 +627,7 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         try:
             response = await self.model.ainvoke(
                 self.summary_prompt.format(messages=formatted_messages).rstrip(),
-                config={"metadata": {"lc_source": "summarization"}},
+                config=self._get_internal_model_config(lc_source="summarization"),
             )
             return response.text.strip()
         except Exception as e:

--- a/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
@@ -302,7 +302,8 @@ class LLMToolSelectorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT,
             [
                 {"role": "system", "content": selection_request.system_message},
                 selection_request.last_user_message,
-            ]
+            ],
+            config=self._get_internal_model_config(lc_source="tool_selection"),
         )
 
         # Response should be a dict since we're passing a schema (not a Pydantic model class)
@@ -345,7 +346,8 @@ class LLMToolSelectorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT,
             [
                 {"role": "system", "content": selection_request.system_message},
                 selection_request.last_user_message,
-            ]
+            ],
+            config=self._get_internal_model_config(lc_source="tool_selection"),
         )
 
         # Response should be a dict since we're passing a schema (not a Pydantic model class)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_streaming_isolation.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_streaming_isolation.py
@@ -1,0 +1,234 @@
+"""Tests for middleware streaming callback isolation.
+
+When an agent is executed using streaming (astream), model calls made inside
+middleware hooks should NOT inherit the parent agent's streaming callbacks.
+This prevents tokens from middleware-internal model calls from leaking into
+the parent stream.
+
+See: https://github.com/langchain-ai/langchain/issues/34382
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.callbacks import (
+    CallbackManagerForLLMRun,
+)
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables.config import (
+    RunnableConfig,
+    ensure_config,
+    var_child_runnable_config,
+)
+from langgraph.runtime import Runtime
+from typing_extensions import override
+
+from langchain.agents.middleware.summarization import SummarizationMiddleware
+from langchain.agents.middleware.types import AgentMiddleware, AgentState
+
+
+class CallbackCapturingModel(BaseChatModel):
+    """A model that captures the config it receives."""
+
+    captured_configs: list[RunnableConfig | None] = []  # noqa: RUF012
+
+    @override
+    def invoke(
+        self,
+        input: Any,
+        config: RunnableConfig | None = None,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> AIMessage:
+        self.captured_configs.append(config)
+        return AIMessage(content="Test summary response")
+
+    @override
+    async def ainvoke(
+        self,
+        input: Any,
+        config: RunnableConfig | None = None,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> AIMessage:
+        self.captured_configs.append(config)
+        return AIMessage(content="Test summary response")
+
+    @override
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="Test summary"))])
+
+    @property
+    def _llm_type(self) -> str:
+        return "callback-capturing"
+
+
+class TestGetInternalModelConfig:
+    """Tests for AgentMiddleware._get_internal_model_config."""
+
+    def test_returns_empty_callbacks(self) -> None:
+        """Config should have callbacks=[] to prevent inheritance."""
+        config = AgentMiddleware._get_internal_model_config()
+        assert config["callbacks"] == []
+
+    def test_includes_metadata(self) -> None:
+        """Metadata kwargs should be included in the config."""
+        config = AgentMiddleware._get_internal_model_config(
+            lc_source="summarization", custom_key="value"
+        )
+        assert config["callbacks"] == []
+        assert config["metadata"] == {
+            "lc_source": "summarization",
+            "custom_key": "value",
+        }
+
+    def test_no_metadata_when_not_provided(self) -> None:
+        """Config should not include metadata key when no kwargs are passed."""
+        config = AgentMiddleware._get_internal_model_config()
+        assert "metadata" not in config
+
+    def test_overrides_inherited_streaming_callbacks(self) -> None:
+        """Config with callbacks=[] should override var_child_runnable_config callbacks.
+
+        When ensure_config merges configs, explicit callbacks=[] should take
+        precedence over inherited streaming callbacks from the parent context.
+        """
+        # Simulate parent context with streaming callbacks
+        fake_callback = MagicMock()
+        parent_config: RunnableConfig = {"callbacks": [fake_callback]}
+        token = var_child_runnable_config.set(parent_config)
+        try:
+            # Without isolation: ensure_config inherits the streaming callback
+            inherited = ensure_config(None)
+            assert inherited["callbacks"] == [fake_callback]
+
+            # With isolation: our config overrides the callbacks
+            internal_config = AgentMiddleware._get_internal_model_config(lc_source="test")
+            isolated = ensure_config(internal_config)
+            assert isolated["callbacks"] == []
+        finally:
+            var_child_runnable_config.reset(token)
+
+
+class TestSummarizationMiddlewareStreamingIsolation:
+    """Tests that SummarizationMiddleware isolates internal model calls."""
+
+    def test_create_summary_uses_isolated_config(self) -> None:
+        """_create_summary should pass config with callbacks=[] to model.invoke."""
+        model = CallbackCapturingModel()
+        middleware = SummarizationMiddleware(
+            model=model,
+            trigger=("tokens", 100),
+        )
+
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi there!"),
+        ]
+        middleware._create_summary(messages)
+
+        assert len(model.captured_configs) == 1
+        config = model.captured_configs[0]
+        assert config is not None
+        assert config["callbacks"] == []
+        assert config["metadata"] == {"lc_source": "summarization"}
+
+    @pytest.mark.asyncio
+    async def test_acreate_summary_uses_isolated_config(self) -> None:
+        """_acreate_summary should pass config with callbacks=[] to model.ainvoke."""
+        model = CallbackCapturingModel()
+        middleware = SummarizationMiddleware(
+            model=model,
+            trigger=("tokens", 100),
+        )
+
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi there!"),
+        ]
+        await middleware._acreate_summary(messages)
+
+        assert len(model.captured_configs) == 1
+        config = model.captured_configs[0]
+        assert config is not None
+        assert config["callbacks"] == []
+        assert config["metadata"] == {"lc_source": "summarization"}
+
+    def test_create_summary_does_not_inherit_parent_callbacks(self) -> None:
+        """Verify _create_summary does not inherit parent streaming callbacks.
+
+        When var_child_runnable_config has streaming callbacks,
+        _create_summary should NOT pass those to the model.
+        """
+        model = CallbackCapturingModel()
+        middleware = SummarizationMiddleware(
+            model=model,
+            trigger=("tokens", 100),
+        )
+
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi there!"),
+        ]
+
+        # Simulate parent context with streaming callbacks
+        fake_streaming_callback = MagicMock()
+        parent_config: RunnableConfig = {"callbacks": [fake_streaming_callback]}
+        token = var_child_runnable_config.set(parent_config)
+        try:
+            middleware._create_summary(messages)
+        finally:
+            var_child_runnable_config.reset(token)
+
+        assert len(model.captured_configs) == 1
+        config = model.captured_configs[0]
+        assert config is not None
+        # The config should have empty callbacks, NOT the parent's streaming callback
+        assert config["callbacks"] == []
+
+
+class TestCustomMiddlewareStreamingIsolation:
+    """Tests that custom middleware can use _get_internal_model_config."""
+
+    def test_custom_middleware_can_isolate_model_calls(self) -> None:
+        """Custom middleware subclass should be able to use _get_internal_model_config."""
+        model = CallbackCapturingModel()
+
+        class CustomMiddleware(AgentMiddleware):
+            def __init__(self) -> None:
+                self.model = model
+
+            def before_model(self, state: AgentState[Any], runtime: Runtime) -> None:
+                self.model.invoke(
+                    "internal prompt",
+                    config=self._get_internal_model_config(lc_source="custom_middleware"),
+                )
+
+        middleware = CustomMiddleware()
+
+        # Simulate parent context with streaming callbacks
+        fake_callback = MagicMock()
+        parent_config: RunnableConfig = {"callbacks": [fake_callback]}
+        token = var_child_runnable_config.set(parent_config)
+        try:
+            state = AgentState[Any](messages=[HumanMessage(content="Hello")])
+            middleware.before_model(state, Runtime())
+        finally:
+            var_child_runnable_config.reset(token)
+
+        assert len(model.captured_configs) == 1
+        config = model.captured_configs[0]
+        assert config is not None
+        assert config["callbacks"] == []
+        assert config["metadata"] == {"lc_source": "custom_middleware"}

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2028,7 +2028,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.75.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.78.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2404,7 +2404,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Add `_get_internal_model_config()` static method to `AgentMiddleware`
  base class that returns a `RunnableConfig` with `callbacks=[]` to
  prevent streaming callback inheritance from the parent agent context
- Update `SummarizationMiddleware` to use isolated config in both
  `_create_summary()` and `_acreate_summary()`
- Update `LLMToolSelectorMiddleware` to use isolated config in both
  `wrap_model_call()` and `awrap_model_call()` (previously passed no
  config at all)

Fixes #34382

## Why
When `astream()` runs, `var_child_runnable_config` is set with streaming
callbacks. `ensure_config()` additively merges this into any config that
doesn't explicitly override `callbacks`. This caused internal middleware
model calls to emit tokens into the parent stream — breaking stream
correctness and isolation.

The fix passes `callbacks=[]` which `ensure_config()` merges on top of
the inherited config, clearing the streaming callbacks. This is backward
compatible: non-streaming usage already has no callbacks to clear.

## Review notes
- `SummarizationMiddleware` previously passed `config={"metadata": {...}}`
  which preserved inherited callbacks. Now uses the isolated config.
- `LLMToolSelectorMiddleware` previously passed **no config at all**,
  fully inheriting parent callbacks. Now uses the isolated config.
- The `_get_internal_model_config()` method is intentionally private
  (`_`-prefixed) since it's an implementation detail, but available to
  custom middleware subclasses.