### PR TITLE
fix(anthropic): set max input tokens based on 1m context beta header

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -94,6 +94,8 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
 
 
 _FALLBACK_MAX_OUTPUT_TOKENS: Final[int] = 4096
+_1M_CONTEXT_BETA: Final[str] = "context-1m-2025-08-07"
+_1M_CONTEXT_MAX_INPUT_TOKENS: Final[int] = 1000000
 
 
 class AnthropicTool(TypedDict):
@@ -1024,7 +1026,14 @@ class ChatAnthropic(BaseChatModel):
         """Set model profile if not overridden."""
         if self.profile is None:
             self.profile = _get_default_model_profile(self.model)
+        if self.profile is not None and self._has_1m_context_beta():
+            self.profile["max_input_tokens"] = _1M_CONTEXT_MAX_INPUT_TOKENS
         return self
+
+    def _has_1m_context_beta(self) -> bool:
+        """Check if the 1M context beta header is enabled."""
+        betas = self.betas or self.model_kwargs.get("betas") or []
+        return _1M_CONTEXT_BETA in betas
 
     @cached_property
     def _client_params(self) -> dict[str, Any]:

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -94,8 +94,6 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
 
 
 _FALLBACK_MAX_OUTPUT_TOKENS: Final[int] = 4096
-_1M_CONTEXT_BETA: Final[str] = "context-1m-2025-08-07"
-_1M_CONTEXT_MAX_INPUT_TOKENS: Final[int] = 1000000
 
 
 class AnthropicTool(TypedDict):
@@ -1026,14 +1024,13 @@ class ChatAnthropic(BaseChatModel):
         """Set model profile if not overridden."""
         if self.profile is None:
             self.profile = _get_default_model_profile(self.model)
-        if self.profile is not None and self._has_1m_context_beta():
-            self.profile["max_input_tokens"] = _1M_CONTEXT_MAX_INPUT_TOKENS
+        if (
+            self.profile is not None
+            and self.betas
+            and "context-1m-2025-08-07" in self.betas
+        ):
+            self.profile["max_input_tokens"] = 1_000_000
         return self
-
-    def _has_1m_context_beta(self) -> bool:
-        """Check if the 1M context beta header is enabled."""
-        betas = self.betas or self.model_kwargs.get("betas") or []
-        return _1M_CONTEXT_BETA in betas
 
     @cached_property
     def _client_params(self) -> dict[str, Any]:

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2171,6 +2171,51 @@ def test_profile() -> None:
     assert model.profile == {"tool_calling": False}
 
 
+def test_profile_1m_context_beta() -> None:
+    model = ChatAnthropic(model="claude-sonnet-4-5")
+    assert model.profile
+    assert model.profile["max_input_tokens"] == 200000
+
+    model = ChatAnthropic(model="claude-sonnet-4-5", betas=["context-1m-2025-08-07"])
+    assert model.profile
+    assert model.profile["max_input_tokens"] == 1000000
+
+    model = ChatAnthropic(
+        model="claude-sonnet-4-5",
+        betas=["token-efficient-tools-2025-02-19", "context-1m-2025-08-07"],
+    )
+    assert model.profile
+    assert model.profile["max_input_tokens"] == 1000000
+
+    model = ChatAnthropic(
+        model="claude-sonnet-4-5",
+        model_kwargs={"betas": ["context-1m-2025-08-07"]},
+    )
+    assert model.profile
+    assert model.profile["max_input_tokens"] == 1000000
+
+    model = ChatAnthropic(
+        model="claude-sonnet-4-5",
+        betas=["context-1m-2025-08-07"],
+        profile={"tool_calling": False},
+    )
+    assert model.profile
+    assert model.profile["max_input_tokens"] == 1000000
+    assert not model.profile["tool_calling"]
+
+    model_no_profile = ChatAnthropic(
+        model="some-unknown-model", betas=["context-1m-2025-08-07"]
+    )
+    assert model_no_profile.profile == {"max_input_tokens": 1000000}
+
+    model_no_beta = ChatAnthropic(
+        model="claude-sonnet-4-5",
+        betas=["token-efficient-tools-2025-02-19"],
+    )
+    assert model_no_beta.profile
+    assert model_no_beta.profile["max_input_tokens"] == 200000
+
+
 async def test_model_profile_not_blocking() -> None:
     with blockbuster_ctx():
         model = ChatAnthropic(model="claude-sonnet-4-5")

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2182,38 +2182,10 @@ def test_profile_1m_context_beta() -> None:
 
     model = ChatAnthropic(
         model="claude-sonnet-4-5",
-        betas=["token-efficient-tools-2025-02-19", "context-1m-2025-08-07"],
-    )
-    assert model.profile
-    assert model.profile["max_input_tokens"] == 1000000
-
-    model = ChatAnthropic(
-        model="claude-sonnet-4-5",
-        model_kwargs={"betas": ["context-1m-2025-08-07"]},
-    )
-    assert model.profile
-    assert model.profile["max_input_tokens"] == 1000000
-
-    model = ChatAnthropic(
-        model="claude-sonnet-4-5",
-        betas=["context-1m-2025-08-07"],
-        profile={"tool_calling": False},
-    )
-    assert model.profile
-    assert model.profile["max_input_tokens"] == 1000000
-    assert not model.profile["tool_calling"]
-
-    model_no_profile = ChatAnthropic(
-        model="some-unknown-model", betas=["context-1m-2025-08-07"]
-    )
-    assert model_no_profile.profile == {"max_input_tokens": 1000000}
-
-    model_no_beta = ChatAnthropic(
-        model="claude-sonnet-4-5",
         betas=["token-efficient-tools-2025-02-19"],
     )
-    assert model_no_beta.profile
-    assert model_no_beta.profile["max_input_tokens"] == 200000
+    assert model.profile
+    assert model.profile["max_input_tokens"] == 200000
 
 
 async def test_model_profile_not_blocking() -> None:


### PR DESCRIPTION
Set `max_input_tokens` to 1m if the relevant beta header is passed.

Claude docs: https://platform.claude.com/docs/en/build-with-claude/context-windows#1-m-token-context-window