### PR TITLE
fix(core): remove str() cast in get_from_dict_or_env to preserve original types

### DIFF
--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -28,7 +28,7 @@ def get_from_dict_or_env(
     key: str | list[str],
     env_key: str,
     default: str | None = None,
-) -> str:
+) -> Any:
     """Get a value from a dictionary or an environment variable.
 
     Args:
@@ -42,15 +42,17 @@ def get_from_dict_or_env(
             or the environment.
 
     Returns:
-        The dict value or the environment variable value.
+        The dict value or the environment variable value. When the value comes
+        from the dictionary, it is returned as-is (preserving its original type).
+        When it comes from an environment variable or default, it will be a string.
     """
     if isinstance(key, (list, tuple)):
         for k in key:
             if value := data.get(k):
-                return str(value)
+                return value
 
     if isinstance(key, str) and key in data and data[key]:
-        return str(data[key])
+        return data[key]
 
     key_for_err = key[0] if isinstance(key, (list, tuple)) else key
 

--- a/libs/core/tests/unit_tests/utils/test_env.py
+++ b/libs/core/tests/unit_tests/utils/test_env.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 import pytest
 
 from langchain_core.utils.env import get_from_dict_or_env
@@ -67,3 +69,46 @@ def test_get_from_dict_or_env() -> None:
             )
             is None
         )
+
+
+def test_get_from_dict_or_env_preserves_non_string_types() -> None:
+    """Non-string dict values should be returned as-is without str() cast."""
+
+    class Status(Enum):
+        ACTIVE = "active"
+        INACTIVE = "inactive"
+
+    # Enum value with string key
+    result = get_from_dict_or_env(
+        {"status": Status.ACTIVE},
+        "status",
+        "__SOME_KEY_IN_ENV",
+    )
+    assert result is Status.ACTIVE
+
+    # Enum value with list key
+    result = get_from_dict_or_env(
+        {"status": Status.INACTIVE},
+        ["status"],
+        "__SOME_KEY_IN_ENV",
+    )
+    assert result is Status.INACTIVE
+
+    # Integer value
+    result = get_from_dict_or_env(
+        {"port": 8080},
+        "port",
+        "__SOME_KEY_IN_ENV",
+    )
+    assert result == 8080
+    assert isinstance(result, int)
+
+
+def test_get_from_dict_or_env_falls_back_to_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When key is not in dict, should fall back to environment variable."""
+    monkeypatch.setenv("__TEST_ENV_KEY", "from_env")
+    result = get_from_dict_or_env({}, "missing", "__TEST_ENV_KEY")
+    assert result == "from_env"
+    assert isinstance(result, str)


### PR DESCRIPTION
Removes the `str()` cast in `get_from_dict_or_env` that was silently coercing enum and integer values to strings. Updates return type annotation from `str` to `Any` to match the `dict[str, Any]` input.

Fixes #35285

Generated with the help of AI tools.