### PR TITLE
fix(core): handle non-dict elements in merge_lists index lookup

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -118,7 +118,8 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                         i
                         for i, e_left in enumerate(merged)
                         if (
-                            "index" in e_left
+                            isinstance(e_left, dict)
+                            and "index" in e_left
                             and e_left["index"] == e["index"]  # index matches
                             and (  # IDs not inconsistent
                                 e_left.get("id") is None

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -433,6 +433,41 @@ def test_generation_chunk_addition_type_error() -> None:
             [{"no_index": "b"}],
             [{"no_index": "a"}, {"no_index": "b"}],
         ),
+        # Mixed str and dict elements with matching index
+        # (Mistral inline citations scenario, issue #35259).
+        # Strings containing "index" as a substring previously triggered a
+        # TypeError because Python's `in` operator on a string checks for
+        # substring containment, then str["index"] fails.
+        (
+            [
+                "see index 1 for details",
+                {"type": "reference", "index": 0, "reference_ids": ["iKcb2CAQ7"]},
+                "other answer...",
+            ],
+            [{"type": "reference", "index": 0, "reference_ids": ["DGqzzmqc3"]}],
+            [
+                "see index 1 for details",
+                {
+                    "type": "reference",
+                    "index": 0,
+                    "reference_ids": ["iKcb2CAQ7", "DGqzzmqc3"],
+                },
+                "other answer...",
+            ],
+        ),
+        # Mixed str and dict where dict has no matching index
+        (
+            [
+                "reindex the data",
+                {"type": "reference", "index": 0, "reference_ids": ["abc"]},
+            ],
+            [{"type": "reference", "index": 1, "reference_ids": ["def"]}],
+            [
+                "reindex the data",
+                {"type": "reference", "index": 0, "reference_ids": ["abc"]},
+                {"type": "reference", "index": 1, "reference_ids": ["def"]},
+            ],
+        ),
     ],
 )
 def test_merge_lists(


### PR DESCRIPTION
Adds a type guard in `merge_lists` to skip non-dict elements when looking up the merge index, preventing `AttributeError` when streaming Mistral citation objects.

Fixes #35259

Generated with the help of AI tools.