### PR TITLE
fix(openai): reuse httpx clients in AzureChatOpenAI

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -17,6 +17,10 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 from langchain_openai.chat_models.base import BaseChatOpenAI, _get_default_model_profile
 
 logger = logging.getLogger(__name__)
@@ -683,11 +687,23 @@ class AzureChatOpenAI(BaseChatOpenAI):
             client_params["max_retries"] = self.max_retries
 
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(
+                    self.azure_endpoint or self.openai_api_base,
+                    self.request_timeout,
+                ),
+            }
             self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
             self.client = self.root_client.chat.completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.azure_endpoint or self.openai_api_base,
+                    self.request_timeout,
+                ),
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (


### PR DESCRIPTION
## Description

`AzureChatOpenAI` creates a new `httpx` client on each instantiation instead of reusing cached clients. This leads to resource leaks (file descriptors, socket connections) and unnecessary overhead when creating multiple instances.

The base `ChatOpenAI` class already uses `_get_default_httpx_client` and `_get_default_async_httpx_client` from `_client_utils` to cache and reuse httpx clients keyed by `(base_url, timeout)`. However, `AzureChatOpenAI` overrides `validate_environment` without using these cached clients.

## Changes

- Import `_get_default_httpx_client` and `_get_default_async_httpx_client` in `azure.py`
- Update sync and async client initialization to fall back to cached clients when no explicit `http_client`/`http_async_client` is provided
- Cache key uses `self.azure_endpoint or self.openai_api_base` and `self.request_timeout`
- Add `test_azure_client_caching` unit test verifying client reuse across instances

## Test plan

- [x] New `test_azure_client_caching` test verifies:
  - Same config → same httpx client (identity check)
  - Different endpoint → different client
  - `timeout=None` → reuses default client
  - Different timeout → different client
  - `httpx.Timeout` object → different client (unhashable)
- [x] All existing Azure unit tests pass (10/10)
- [x] Ruff format and lint checks pass

Fixes #32489