### PR TITLE
fix(langchain): make LLMToolSelectorMiddleware robust to malformed LL…

### DIFF
--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2028,7 +2028,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.75.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.78.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2404,7 +2404,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Make `_process_selection_response()` defensive: use `response.get("tools")`
  with `isinstance` validation instead of direct `response["tools"]` indexing.
  Missing or non-list values fall back to the original request with all tools.
- Change invalid tool name handling from raising `ValueError` to logging a
  warning and skipping the invalid names
- Refactor `wrap_model_call` / `awrap_model_call` to delegate to new
  `_select_tools` / `_aselect_tools` methods that wrap the entire selection
  model call in try/except, falling back on any failure
- Add `_log_warning()` helper to `AgentMiddleware` base class for consistent
  middleware-prefixed warning logs
- Add `logging` + warning on middleware chain failures in `factory.py` for
  observability

Fixes #34358
