### PR TITLE
fix(core): auto-exclude non-serializable tool args from JSON schema

### DIFF
--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -26,6 +26,7 @@ from pydantic import (  # type: ignore[deprecated]
     Field,
     PydanticDeprecationWarning,
     RootModel,
+    TypeAdapter,
     root_validator,
 )
 from pydantic import (
@@ -301,6 +302,28 @@ def _create_subset_model(
         descriptions=descriptions,
         fn_description=fn_description,
     )
+
+
+def _can_generate_json_schema(annotation: Any) -> bool:
+    """Check if a type annotation can produce a valid JSON schema.
+
+    Uses Pydantic's ``TypeAdapter`` to test schema generation. Returns ``False``
+    for custom Python classes and other types that Pydantic cannot serialize to
+    JSON schema (e.g. ``IsInstanceSchema`` types).
+
+    Args:
+        annotation: The type annotation to check.
+
+    Returns:
+        ``True`` if the annotation can be serialized to a JSON schema,
+        ``False`` otherwise.
+    """
+    try:
+        ta = TypeAdapter(annotation, config=ConfigDict(arbitrary_types_allowed=True))
+        ta.json_schema()
+    except Exception:
+        return False
+    return True
 
 
 @overload

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
#Summary
Auto-detect and exclude tool argument fields with non-JSON-serializable types (e.g. custom Python classes) from the tool schema sent to the LLM, preventing PydanticInvalidForJsonSchema errors
Add defense-in-depth error handling in _convert_pydantic_to_openai_function with actionable guidance when schema generation still fails
Emit a warning when fields are auto-excluded, suggesting users annotate them with InjectedToolArg explicitly

Fixes #34371 