### PR TITLE
fix(core): reject empty list as valid tool message content

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -110,6 +110,10 @@ class ToolMessage(BaseMessage, ToolOutputMixin):
                     "string."
                 )
                 raise ValueError(msg) from e
+        elif isinstance(content, list) and len(content) == 0:
+            # Empty lists are not valid message content for LLM providers.
+            # Coerce to empty string to avoid serialization errors.
+            values["content"] = ""
         elif isinstance(content, list):
             values["content"] = []
             for i, x in enumerate(content):

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1291,7 +1291,9 @@ def _is_message_content_type(obj: Any) -> bool:
         `True` if the object is valid message content, `False` otherwise.
     """
     return isinstance(obj, str) or (
-        isinstance(obj, list) and all(_is_message_content_block(e) for e in obj)
+        isinstance(obj, list)
+        and len(obj) > 0
+        and all(_is_message_content_block(e) for e in obj)
     )
 
 

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1043,6 +1043,13 @@ def test_tool_message_content() -> None:
     )
 
 
+def test_tool_message_empty_list_content_coerced() -> None:
+    """Empty list content is coerced to empty string to prevent provider errors."""
+    msg = ToolMessage([], tool_call_id="1")
+    assert msg.content == ""
+    assert isinstance(msg.content, str)
+
+
 def test_tool_message_tool_call_id() -> None:
     ToolMessage("foo", tool_call_id="1")
     ToolMessage("foo", tool_call_id=uuid.uuid4())

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2133,6 +2133,7 @@ def test__is_message_content_block(obj: Any, *, expected: bool) -> None:
         ("foo", True),
         (valid_tool_result_blocks, True),
         (invalid_tool_result_blocks, False),
+        ([], False),
     ],
 )
 def test__is_message_content_type(obj: Any, *, expected: bool) -> None:

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -230,6 +230,10 @@ def _format_message_content(
     role: str | None = None,
 ) -> Any:
     """Format message content."""
+    # An empty list is not valid message content for LLM providers.
+    # Coerce to empty string to prevent serialization errors.
+    if isinstance(content, list) and len(content) == 0:
+        return ""
     if content and isinstance(content, list):
         formatted_content = []
         for block in content:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -776,8 +776,9 @@ def test_format_message_content() -> None:
     content = None
     assert content == _format_message_content(content)
 
+    # Empty list is coerced to empty string to prevent provider serialization errors
     content = []
-    assert content == _format_message_content(content)
+    assert _format_message_content(content) == ""
 
     content = [
         {"type": "text", "text": "What is in this image?"},
@@ -873,6 +874,18 @@ def test_format_message_content() -> None:
     expected = [{"type": "file", "file": {"file_id": "file-abc123"}}]
     for content in contents:
         assert expected == _format_message_content([content])
+
+
+def test_tool_message_empty_list_content_serialized_as_string() -> None:
+    """ToolMessage with empty list content should serialize as empty string."""
+    from langchain_core.messages import ToolMessage
+
+    msg = ToolMessage(content=[], tool_call_id="call_123")
+    result = _convert_message_to_dict(msg)
+    assert result["role"] == "tool"
+    # Must be empty string, not [], to avoid provider serialization errors
+    assert result["content"] == ""
+    assert isinstance(result["content"], str)
 
 
 class GenerateUsername(BaseModel):

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -547,7 +547,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.7"
+version = "1.2.9"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },
@@ -557,7 +557,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
+    { name = "langchain-anthropic", marker = "extra == 'anthropic'", editable = "../anthropic" },
     { name = "langchain-aws", marker = "extra == 'aws'" },
     { name = "langchain-azure-ai", marker = "extra == 'azure-ai'" },
     { name = "langchain-community", marker = "extra == 'community'" },
@@ -610,7 +610,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.7"
+version = "1.2.9"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -757,7 +757,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.2"
+version = "1.1.4"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Fix `_is_message_content_type` to reject empty lists, since `all([]) == True`
  incorrectly treated `[]` as valid structured content
- Coerce empty list content to empty string in `ToolMessage.coerce_args` at
  construction time
- Add defensive empty list handling in OpenAI's `_format_message_content` at
  serialization time

Closes #33758

## Technical changes

**langchain-core** (`tools/base.py`):
- Add `len(obj) > 0` check to `_is_message_content_type` so empty lists are
  rejected before reaching provider serialization

**langchain-core** (`messages/tool.py`):
- Add early check in `ToolMessage.coerce_args` model validator to coerce `[]`
  to `""` at message construction time

**langchain-openai** (`chat_models/base.py`):
- Add defensive empty list check at the top of `_format_message_content` to
  return `""` instead of passing `[]` through to the API payload

## Tests added
- `_is_message_content_type([])` returns `False`
- `ToolMessage([], tool_call_id="1").content == ""`
- `_format_message_content([])` returns `""`
- `_convert_message_to_dict(ToolMessage(content=[], ...))` produces `content == ""`
- Existing valid cases (strings, non-empty content block lists) still pass