### PR TITLE
fix(core,langchain): strip reasoning content from agent message history

### DIFF
--- a/libs/core/langchain_core/messages/__init__.py
+++ b/libs/core/langchain_core/messages/__init__.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
         merge_message_runs,
         message_chunk_to_message,
         messages_from_dict,
+        strip_reasoning,
         trim_messages,
     )
 
@@ -126,6 +127,7 @@ __all__ = (
     "message_to_dict",
     "messages_from_dict",
     "messages_to_dict",
+    "strip_reasoning",
     "trim_messages",
 )
 
@@ -183,6 +185,7 @@ _dynamic_imports = {
     "merge_message_runs": "utils",
     "message_chunk_to_message": "utils",
     "messages_from_dict": "utils",
+    "strip_reasoning": "utils",
     "trim_messages": "utils",
 }
 

--- a/libs/core/tests/unit_tests/messages/test_imports.py
+++ b/libs/core/tests/unit_tests/messages/test_imports.py
@@ -51,6 +51,7 @@ EXPECTED_ALL = [
     "messages_to_dict",
     "filter_messages",
     "merge_message_runs",
+    "strip_reasoning",
     "trim_messages",
     "convert_to_openai_data_block",
     "convert_to_openai_image_block",

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -17,6 +17,7 @@ from typing import (
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, AnyMessage, SystemMessage, ToolMessage
+from langchain_core.messages.utils import strip_reasoning
 from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.constants import END, START
@@ -994,6 +995,11 @@ def create_agent(
             effective_response_format: The actual strategy used (may differ from initial
                 if auto-detected).
         """
+        # Strip reasoning content (e.g. thinking, reasoning blocks) from the
+        # AI message so that internal reasoning is not persisted in the message
+        # history and re-sent to the model on subsequent turns.
+        output = strip_reasoning(output)
+
         # Handle structured output with provider strategy
         if isinstance(effective_response_format, ProviderStrategy):
             if not output.tool_calls:

--- a/libs/langchain_v1/tests/unit_tests/agents/test_reasoning_stripping.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_reasoning_stripping.py
@@ -1,0 +1,120 @@
+"""Tests for reasoning content stripping in create_agent."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import CallbackManagerForLLMRun
+
+from langchain.agents import create_agent
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+class FakeReasoningModel(FakeToolCallingModel):
+    """Fake model that includes reasoning content in responses."""
+
+    reasoning_blocks: list[dict[str, Any]] | None = None
+    reasoning_additional_kwargs: dict[str, Any] | None = None
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        content: str | list[dict[str, Any]]
+        if self.reasoning_blocks:
+            content = [
+                *self.reasoning_blocks,
+                {"type": "text", "text": "The answer is 42."},
+            ]
+        else:
+            content = "The answer is 42."
+
+        message = AIMessage(
+            content=content,
+            id=str(self.index),
+            additional_kwargs=dict(self.reasoning_additional_kwargs or {}),
+        )
+        self.index += 1
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+def test_reasoning_blocks_stripped_from_agent_output() -> None:
+    """Reasoning content blocks should not appear in agent output messages."""
+    model = FakeReasoningModel(
+        reasoning_blocks=[
+            {"type": "reasoning", "reasoning": "Let me think step by step..."},
+        ],
+    )
+    agent = create_agent(model, [])
+    result = agent.invoke({"messages": [HumanMessage("What is the answer?")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) == 1
+
+    ai_msg = ai_messages[0]
+    # Reasoning blocks should be stripped, only text remains
+    assert ai_msg.content == [{"type": "text", "text": "The answer is 42."}]
+
+
+def test_thinking_blocks_stripped_from_agent_output() -> None:
+    """Thinking blocks (e.g. Anthropic) should not appear in agent output messages."""
+    model = FakeReasoningModel(
+        reasoning_blocks=[
+            {"type": "thinking", "thinking": "I need to consider..."},
+        ],
+    )
+    agent = create_agent(model, [])
+    result = agent.invoke({"messages": [HumanMessage("What is the answer?")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    ai_msg = ai_messages[0]
+    assert ai_msg.content == [{"type": "text", "text": "The answer is 42."}]
+
+
+def test_reasoning_additional_kwargs_stripped_from_agent_output() -> None:
+    """reasoning_content in additional_kwargs should be stripped."""
+    model = FakeReasoningModel(
+        reasoning_additional_kwargs={
+            "reasoning_content": "Deep reasoning here...",
+        },
+    )
+    agent = create_agent(model, [])
+    result = agent.invoke({"messages": [HumanMessage("What is the answer?")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    ai_msg = ai_messages[0]
+    assert ai_msg.content == "The answer is 42."
+    assert "reasoning_content" not in ai_msg.additional_kwargs
+
+
+def test_reasoning_key_stripped_from_additional_kwargs() -> None:
+    """Reasoning key (OpenAI Responses API) in additional_kwargs should be stripped."""
+    model = FakeReasoningModel(
+        reasoning_additional_kwargs={
+            "reasoning": {"id": "rs_abc", "summary": [{"text": "thinking..."}]},
+        },
+    )
+    agent = create_agent(model, [])
+    result = agent.invoke({"messages": [HumanMessage("What is the answer?")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    ai_msg = ai_messages[0]
+    assert "reasoning" not in ai_msg.additional_kwargs
+
+
+def test_no_reasoning_messages_unchanged() -> None:
+    """Messages without reasoning content should pass through unchanged."""
+    model = FakeReasoningModel()
+    agent = create_agent(model, [])
+    result = agent.invoke({"messages": [HumanMessage("What is the answer?")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    ai_msg = ai_messages[0]
+    assert ai_msg.content == "The answer is 42."

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2028,7 +2028,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.75.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.78.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2404,7 +2404,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Adds `strip_reasoning()` to `langchain-core` that removes reasoning/thinking
  blocks from AIMessage content and `additional_kwargs`
- Calls `strip_reasoning()` in `create_agent`'s `_handle_model_output()` so
  internal reasoning is not persisted in state and re-sent to the model
- Covers all reasoning formats: content blocks (`reasoning`, `thinking`,
  `reasoning_content`) and `additional_kwargs` keys (`reasoning_content`,
  `reasoning`)

## Test plan
- [x] 13 unit tests for `strip_reasoning` utility (block types, kwargs, edge cases)
- [x] 5 agent-level tests verifying reasoning is stripped during create_agent execution
- [x] `make lint` and `make test` pass for both `libs/core` and `libs/langchain_v1`

Closes #33834