### PR TITLE
fix(core): make schema constructors union-safe for pydantic serde

### DIFF
--- a/libs/core/langchain_core/agents.py
+++ b/libs/core/langchain_core/agents.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Any, Literal, overload
 
 from langchain_core.load.serializable import Serializable
 from langchain_core.messages import (
@@ -67,10 +67,28 @@ class AgentAction(Serializable):
 
     type: Literal["AgentAction"] = "AgentAction"
 
-    # Override init to support instantiation by position for backward compat.
+    @overload
     def __init__(
         self, tool: str, tool_input: str | dict[Any, Any], log: str, **kwargs: Any
-    ):
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        tool: str | None = None,
+        tool_input: str | dict[Any, Any] | None = None,
+        log: str | None = None,
+        **kwargs: Any,
+    ) -> None: ...
+
+    # Override init to support instantiation by position for backward compat.
+    def __init__(
+        self,
+        tool: str | None = None,
+        tool_input: str | dict[Any, Any] | None = None,
+        log: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Create an `AgentAction`.
 
         Args:
@@ -78,7 +96,23 @@ class AgentAction(Serializable):
             tool_input: The input to pass in to the `Tool`.
             log: Additional information to log about the action.
         """
-        super().__init__(tool=tool, tool_input=tool_input, log=log, **kwargs)
+        if tool is not None:
+            if "tool" in kwargs:
+                msg = "AgentAction() got multiple values for argument 'tool'"
+                raise TypeError(msg)
+            kwargs["tool"] = tool
+        if tool_input is not None:
+            if "tool_input" in kwargs:
+                msg = "AgentAction() got multiple values for argument 'tool_input'"
+                raise TypeError(msg)
+            kwargs["tool_input"] = tool_input
+        if log is not None:
+            if "log" in kwargs:
+                msg = "AgentAction() got multiple values for argument 'log'"
+                raise TypeError(msg)
+            kwargs["log"] = log
+
+        super().__init__(**kwargs)
 
     @classmethod
     def is_lc_serializable(cls) -> bool:
@@ -166,9 +200,38 @@ class AgentFinish(Serializable):
     """
     type: Literal["AgentFinish"] = "AgentFinish"
 
-    def __init__(self, return_values: dict[Any, Any], log: str, **kwargs: Any):
+    @overload
+    def __init__(
+        self, return_values: dict[Any, Any], log: str, **kwargs: Any
+    ) -> None: ...
+
+    @overload
+    def __init__(
+        self,
+        return_values: dict[Any, Any] | None = None,
+        log: str | None = None,
+        **kwargs: Any,
+    ) -> None: ...
+
+    def __init__(
+        self,
+        return_values: dict[Any, Any] | None = None,
+        log: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Override init to support instantiation by position for backward compat."""
-        super().__init__(return_values=return_values, log=log, **kwargs)
+        if return_values is not None:
+            if "return_values" in kwargs:
+                msg = "AgentFinish() got multiple values for argument 'return_values'"
+                raise TypeError(msg)
+            kwargs["return_values"] = return_values
+        if log is not None:
+            if "log" in kwargs:
+                msg = "AgentFinish() got multiple values for argument 'log'"
+                raise TypeError(msg)
+            kwargs["log"] = log
+
+        super().__init__(**kwargs)
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/langchain/tests/unit_tests/test_schema.py
+++ b/libs/langchain/tests/unit_tests/test_schema.py
@@ -21,7 +21,6 @@ from langchain_core.prompt_values import ChatPromptValueConcrete, StringPromptVa
 from pydantic import RootModel, ValidationError
 
 
-@pytest.mark.xfail(reason="TODO: FIX BEFORE 0.3 RELEASE")
 def test_serialization_of_wellknown_objects() -> None:
     """Test that pydantic is able to serialize and deserialize well known objects."""
     well_known_lc_object = RootModel[


### PR DESCRIPTION
## Summary
Fixes a pydantic union-deserialization failure where custom positional constructors raised `TypeError` before union validation could continue.

## Why
`Document`, `AgentAction`, and `AgentFinish` override `__init__` for positional backwards-compat. In pydantic v2, `TypeError` raised during validation is not converted into `ValidationError`, so unions can short-circuit on the first candidate.

This broke round-trip validation for well-known schema objects (`libs/langchain/tests/unit_tests/test_schema.py` was xfailed for this reason).

## Changes
- Updated `Document.__init__` to keep positional support while routing missing required fields through pydantic validation.
- Applied the same union-safe constructor pattern to `AgentAction` and `AgentFinish`.
- Added core regression tests for:
  - `Document | HumanMessage` union parsing
  - missing `Document.page_content` behavior (`ValidationError`)
  - `AgentFinish | AgentAction | HumanMessage` union parsing
- Removed the xfail from `test_serialization_of_wellknown_objects` now that behavior is fixed.

## Testing
- `uv run --group test pytest tests/unit_tests/test_pydantic_serde.py -q` (in `libs/core`)
- `uv run --group test pytest tests/unit_tests/test_schema.py -q` (in `libs/langchain`)
- `uv run --group lint ruff check langchain_core/agents.py langchain_core/documents/base.py tests/unit_tests/test_pydantic_serde.py` (in `libs/core`)
- `uv run --group lint ruff check tests/unit_tests/test_schema.py` (in `libs/langchain`)

## Review Focus
- Constructor behavior parity for direct instantiation (`Document(...)`, `AgentAction(...)`, `AgentFinish(...)`) while enabling union validation fallback semantics.

## AI Disclosure
This PR was created with substantial assistance from an AI coding agent; all code changes, tests, and final content were reviewed before submission.
