### PR TITLE
chore(infra): disable tests on prior published packages on core release

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -396,9 +396,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    if: false # temporarily skip
     strategy:
       matrix:
-        partner: [anthropic]
+        partner: [openai, anthropic]
       fail-fast: false # Continue testing other partners if one fails
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -541,7 +542,7 @@ jobs:
       - test-pypi-publish
       - pre-release-checks
       - test-dependents
-      - test-prior-published-packages-against-new-core
+      # - test-prior-published-packages-against-new-core
     # Run if all needed jobs succeeded or were skipped (test-dependents only runs for core/langchain_v1)
     if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -399,7 +399,7 @@ jobs:
     if: false # temporarily skip
     strategy:
       matrix:
-        partner: [openai, anthropic]
+        partner: [anthropic]
       fail-fast: false # Continue testing other partners if one fails
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
Claude haiku 3.5 reached EOL, so tests fail. Will revert after release.