### PR TITLE
fix(core): include tool_call_id in on_tool_start and on_tool_end events

### DIFF
--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -684,6 +684,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
                 "event": "on_tool_start",
                 "data": {
                     "input": inputs or {},
+                    "tool_call_id": kwargs.get("tool_call_id"),
                 },
                 "name": name_,
                 "tags": tags or [],
@@ -730,7 +731,10 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
     @override
     async def on_tool_end(self, output: Any, *, run_id: UUID, **kwargs: Any) -> None:
         """End a trace for a tool run."""
+        tool_call_id = kwargs.get("tool_call_id")
         run_info, inputs = self._get_tool_run_info_with_inputs(run_id)
+        if tool_call_id is None:
+            tool_call_id = run_info.get("tool_call_id")
 
         self._send(
             {
@@ -738,6 +742,7 @@ class _AstreamEventsCallbackHandler(AsyncCallbackHandler, _StreamingCallbackHand
                 "data": {
                     "output": output,
                     "input": inputs,
+                    "tool_call_id": tool_call_id,
                 },
                 "run_id": str(run_id),
                 "name": run_info["name"],


### PR DESCRIPTION
## Summary

- `on_tool_error` already included `tool_call_id` in its event data payload, but `on_tool_start` and `on_tool_end` were missing it.
- Without this field, callback handlers and `astream_events()` consumers cannot correlate a tool execution with the originating LLM tool call — breaking observability and tracing.

Fixes #34849.

## Root cause

In `langchain_core/tracers/event_stream.py`, `tool_call_id` is received in `on_tool_start` via `**kwargs` and stored in `run_info`. However, the `_send()` calls for `on_tool_start` and `on_tool_end` never included it in the event `data` dict. `on_tool_error` already did this correctly and serves as the reference pattern.

## Changes

- **`on_tool_start`**: add `"tool_call_id": kwargs.get("tool_call_id")` to the `_send` data
- **`on_tool_end`**: read `tool_call_id` from `run_info` (with `kwargs` fallback, identical to `on_tool_error`) and include it in the `_send` data

## Areas requiring careful review

- The `tool_call_id` field is `None` when the tool is invoked with a plain dict rather than a `ToolCall` dict — this is intentional and consistent with `on_tool_error`.
- No change to `on_tool_error` (already correct).

## Test plan

- [x] `test_tool_start_event_includes_tool_call_id` — asserts correct id is present
- [x] `test_tool_start_event_tool_call_id_is_none_when_not_provided` — asserts `None` for plain dict input
- [x] `test_tool_end_event_includes_tool_call_id` — asserts correct id is present
- [x] `test_tool_end_event_tool_call_id_is_none_when_not_provided` — asserts `None` for plain dict input
- [x] All 6 `tool_call_id` tests pass (including the 2 pre-existing `on_tool_error` tests)
- [x] `ruff check`, `ruff format`, `mypy` clean

---

> This PR was developed with the assistance of Claude Code (AI agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)