### PR TITLE
fix(core): resolve nested pydantic v2  in BaseTool.args and remove ti…

### DIFF
--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
Fixes #32224 — tool invocation fails to correctly recognize nested Pydantic v2 schemas.

Two root causes fixed:

BaseTool.args returned unresolved $ref entries for nested Pydantic v2 models.
model_json_schema() emits $defs + $ref for nested models. The args property was returning {"inner": {"$ref": "#/$defs/InnerModel"}} instead of the inlined schema. Tool execution frameworks that consume args to validate/parse arguments would fail to recognize the argument schema.

Fixed in libs/core/langchain_core/tools/base.py: when $defs or definitions is present in the schema, dereference_refs() is called before extracting .properties.

_rm_titles did not recurse into anyOf / oneOf / allOf list items.
After dereference_refs() inlines $refs, optional Pydantic v2 fields (e.g. Optional[NestedModel]) produce anyOf: [{model schema with title}, {type: null}]. The old _rm_titles only recursed into plain dicts, leaving "title" fields inside schema composition lists untouched.

Fixed in libs/core/langchain_core/utils/function_calling.py: _rm_titles now recurses into list values specifically for anyOf, oneOf, and allOf keys. Tuple-type items lists (e.g. Tuple[A, B]) are deliberately excluded to preserve existing behavior.