### PR TITLE
fix(core): prevent _configure_hooks accumulation in get_usage_metadat…

### DIFF
--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Problem
get_usage_metadata_callback registered a new configure hook on every context-manager entry by creating a fresh ContextVar and calling register_configure_hook each time. Because register_configure_hook had no deduplication, _configure_hooks grew unboundedly in long-running processes — a memory leak and a progressive performance regression (the _configure loop is called on every LLM invocation).

## Fix
Three-layer defence:

callbacks/usage.py — _usage_metadata_callback_var is now a module-level singleton registered once at import time. The context manager uses ContextVar.set/reset (with token) for correct nesting semantics, so nested get_usage_metadata_callback calls properly restore the outer handler when they exit.

tracers/context.py — register_configure_hook is now idempotent: repeated registration of the same ContextVar object is silently skipped. This is a general guard for any future caller.

callbacks/manager.py — _configure now tracks processed ContextVar ids in a local set so that even pre-existing duplicate entries in _configure_hooks are skipped in a single configure pass.

Backward compatibility
The name parameter of get_usage_metadata_callback is preserved (now a no-op, documented as deprecated).
No existing public API signatures change.
All 1652 existing unit tests continue to pass.

Fixes #32300 