### PR TITLE
feat(langchain): add TokenBudgetMiddleware for token/cost budget enfo…

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -19,6 +19,10 @@ from langchain.agents.middleware.shell_tool import (
 )
 from langchain.agents.middleware.summarization import SummarizationMiddleware
 from langchain.agents.middleware.todo import TodoListMiddleware
+from langchain.agents.middleware.token_budget import (
+    TokenBudgetExceededError,
+    TokenBudgetMiddleware,
+)
 from langchain.agents.middleware.tool_call_limit import ToolCallLimitMiddleware
 from langchain.agents.middleware.tool_emulator import LLMToolEmulator
 from langchain.agents.middleware.tool_retry import ToolRetryMiddleware
@@ -67,6 +71,8 @@ __all__ = [
     "ShellToolMiddleware",
     "SummarizationMiddleware",
     "TodoListMiddleware",
+    "TokenBudgetExceededError",
+    "TokenBudgetMiddleware",
     "ToolCallLimitMiddleware",
     "ToolCallRequest",
     "ToolRetryMiddleware",

--- a/libs/langchain_v1/langchain/agents/middleware/token_budget.py
+++ b/libs/langchain_v1/langchain/agents/middleware/token_budget.py
@@ -1,0 +1,649 @@
+"""Token budget middleware for agents."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, Literal
+
+from langchain_core.messages import AIMessage
+from langchain_core.messages.utils import count_tokens_approximately
+from langgraph.channels.untracked_value import UntrackedValue
+from typing_extensions import NotRequired, override
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    PrivateStateAttr,
+    ResponseT,
+    hook_config,
+)
+
+if TYPE_CHECKING:
+    from langgraph.runtime import Runtime
+
+ExitBehavior = Literal["continue", "error", "end"]
+"""How to handle execution when token budgets are exceeded.
+
+- ``'continue'``: Inject a warning AI message and let the agent continue (default)
+- ``'error'``: Raise a ``TokenBudgetExceededError`` exception
+- ``'end'``: Stop execution immediately with an AI message explaining the limit
+"""
+
+
+class TokenBudgetState(AgentState[ResponseT]):
+    """State schema for ``TokenBudgetMiddleware``.
+
+    Extends ``AgentState`` with token usage tracking fields.
+
+    Token usage is stored as a dictionary with keys ``'input_tokens'``,
+    ``'output_tokens'``, and ``'total_tokens'``.
+
+    Type Parameters:
+        ResponseT: The type of the structured response. Defaults to ``Any``.
+    """
+
+    thread_token_usage: NotRequired[Annotated[dict[str, int], PrivateStateAttr]]
+    run_token_usage: NotRequired[
+        Annotated[dict[str, int], UntrackedValue, PrivateStateAttr]
+    ]
+
+
+def _empty_usage() -> dict[str, int]:
+    """Return a zero-initialized token usage dictionary.
+
+    Returns:
+        Dictionary with ``'input_tokens'``, ``'output_tokens'``, and
+        ``'total_tokens'`` all set to ``0``.
+    """
+    return {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+def _add_usage(
+    current: dict[str, int], input_tokens: int, output_tokens: int
+) -> dict[str, int]:
+    """Add token counts to a usage dictionary and return a new copy.
+
+    Args:
+        current: The current token usage dictionary.
+        input_tokens: Number of input tokens to add.
+        output_tokens: Number of output tokens to add.
+
+    Returns:
+        A new dictionary with updated token counts.
+    """
+    return {
+        "input_tokens": current.get("input_tokens", 0) + input_tokens,
+        "output_tokens": current.get("output_tokens", 0) + output_tokens,
+        "total_tokens": (
+            current.get("total_tokens", 0) + input_tokens + output_tokens
+        ),
+    }
+
+
+def _calculate_cost(
+    usage: dict[str, int],
+    cost_per_input_token: float,
+    cost_per_output_token: float,
+) -> float:
+    """Calculate estimated cost from token usage.
+
+    Args:
+        usage: Token usage dictionary.
+        cost_per_input_token: Cost per input token in dollars.
+        cost_per_output_token: Cost per output token in dollars.
+
+    Returns:
+        Estimated cost in dollars.
+    """
+    return (
+        usage.get("input_tokens", 0) * cost_per_input_token
+        + usage.get("output_tokens", 0) * cost_per_output_token
+    )
+
+
+def _build_limit_message(
+    thread_usage: dict[str, int],
+    run_usage: dict[str, int],
+    thread_token_limit: int | None,
+    run_token_limit: int | None,
+    thread_cost_limit: float | None,
+    run_cost_limit: float | None,
+    cost_per_input_token: float | None,
+    cost_per_output_token: float | None,
+) -> str:
+    """Build a message describing which token or cost limits were exceeded.
+
+    Args:
+        thread_usage: Current thread token usage.
+        run_usage: Current run token usage.
+        thread_token_limit: Thread token limit (if set).
+        run_token_limit: Run token limit (if set).
+        thread_cost_limit: Thread cost limit (if set).
+        run_cost_limit: Run cost limit (if set).
+        cost_per_input_token: Cost per input token (if set).
+        cost_per_output_token: Cost per output token (if set).
+
+    Returns:
+        A formatted message describing which limits were exceeded.
+    """
+    exceeded = []
+
+    thread_total = thread_usage.get("total_tokens", 0)
+    run_total = run_usage.get("total_tokens", 0)
+
+    if thread_token_limit is not None and thread_total >= thread_token_limit:
+        exceeded.append(
+            f"thread token limit ({thread_total:,}/{thread_token_limit:,} tokens)"
+        )
+    if run_token_limit is not None and run_total >= run_token_limit:
+        exceeded.append(
+            f"run token limit ({run_total:,}/{run_token_limit:,} tokens)"
+        )
+
+    if cost_per_input_token is not None and cost_per_output_token is not None:
+        if thread_cost_limit is not None:
+            thread_cost = _calculate_cost(
+                thread_usage, cost_per_input_token, cost_per_output_token
+            )
+            if thread_cost >= thread_cost_limit:
+                exceeded.append(
+                    f"thread cost limit (${thread_cost:.4f}/${thread_cost_limit:.4f})"
+                )
+        if run_cost_limit is not None:
+            run_cost = _calculate_cost(
+                run_usage, cost_per_input_token, cost_per_output_token
+            )
+            if run_cost >= run_cost_limit:
+                exceeded.append(
+                    f"run cost limit (${run_cost:.4f}/${run_cost_limit:.4f})"
+                )
+
+    return f"Token budget exceeded: {', '.join(exceeded)}."
+
+
+class TokenBudgetExceededError(Exception):
+    """Exception raised when token or cost budget is exceeded.
+
+    This exception is raised when the configured exit behavior is ``'error'`` and
+    either the thread or run token/cost limit has been exceeded.
+    """
+
+    def __init__(
+        self,
+        thread_usage: dict[str, int],
+        run_usage: dict[str, int],
+        thread_token_limit: int | None,
+        run_token_limit: int | None,
+        thread_cost_limit: float | None = None,
+        run_cost_limit: float | None = None,
+        estimated_cost: float | None = None,
+    ) -> None:
+        """Initialize the exception with usage information.
+
+        Args:
+            thread_usage: Current thread token usage.
+            run_usage: Current run token usage.
+            thread_token_limit: Thread token limit (if set).
+            run_token_limit: Run token limit (if set).
+            thread_cost_limit: Thread cost limit (if set).
+            run_cost_limit: Run cost limit (if set).
+            estimated_cost: Estimated cost in dollars (if calculated).
+        """
+        self.thread_usage = thread_usage
+        self.run_usage = run_usage
+        self.thread_token_limit = thread_token_limit
+        self.run_token_limit = run_token_limit
+        self.thread_cost_limit = thread_cost_limit
+        self.run_cost_limit = run_cost_limit
+        self.estimated_cost = estimated_cost
+
+        msg = _build_limit_message(
+            thread_usage,
+            run_usage,
+            thread_token_limit,
+            run_token_limit,
+            thread_cost_limit,
+            run_cost_limit,
+            None,
+            None,
+        )
+        super().__init__(msg)
+
+
+class TokenBudgetMiddleware(
+    AgentMiddleware[TokenBudgetState[ResponseT], ContextT, ResponseT]
+):
+    """Track token usage and enforce budgets during agent execution.
+
+    This middleware monitors cumulative input and output tokens across model calls
+    and can terminate or restrict execution when configured budgets are exceeded.
+    It supports both thread-level (persistent across runs) and run-level
+    (per invocation) budget enforcement.
+
+    Token counts are extracted from ``AIMessage.usage_metadata`` when available,
+    falling back to approximate counting via ``count_tokens_approximately`` when
+    the model does not report usage metadata.
+
+    Optionally tracks estimated cost using configurable per-token pricing.
+
+    Examples:
+        !!! example "Basic token limit per run"
+
+            ```python
+            from langchain.agents import create_agent
+            from langchain.agents.middleware.token_budget import TokenBudgetMiddleware
+
+            budget = TokenBudgetMiddleware(run_token_limit=50_000)
+            agent = create_agent("openai:gpt-4o", middleware=[budget])
+            ```
+
+        !!! example "Thread-level limit (persists across invocations)"
+
+            ```python
+            budget = TokenBudgetMiddleware(
+                thread_token_limit=200_000,
+                run_token_limit=50_000,
+            )
+            agent = create_agent("openai:gpt-4o", middleware=[budget])
+            ```
+
+        !!! example "Cost-based limit"
+
+            ```python
+            budget = TokenBudgetMiddleware(
+                run_cost_limit=0.50,
+                cost_per_input_token=0.000003,
+                cost_per_output_token=0.000015,
+            )
+            agent = create_agent("openai:gpt-4o", middleware=[budget])
+            ```
+
+        !!! example "Raise exception on budget exceeded"
+
+            ```python
+            budget = TokenBudgetMiddleware(
+                run_token_limit=10_000,
+                exit_behavior="error",
+            )
+            agent = create_agent("openai:gpt-4o", middleware=[budget])
+
+            try:
+                result = await agent.invoke({"messages": [HumanMessage("Task")]})
+            except TokenBudgetExceededError as e:
+                print(f"Budget exceeded: {e}")
+            ```
+
+    """
+
+    state_schema = TokenBudgetState  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        *,
+        thread_token_limit: int | None = None,
+        run_token_limit: int | None = None,
+        thread_cost_limit: float | None = None,
+        run_cost_limit: float | None = None,
+        cost_per_input_token: float | None = None,
+        cost_per_output_token: float | None = None,
+        exit_behavior: ExitBehavior = "continue",
+    ) -> None:
+        """Initialize the token budget middleware.
+
+        Args:
+            thread_token_limit: Maximum total tokens allowed per thread.
+                ``None`` means no token limit at thread level.
+            run_token_limit: Maximum total tokens allowed per run.
+                ``None`` means no token limit at run level.
+            thread_cost_limit: Maximum estimated cost in dollars per thread.
+                ``None`` means no cost limit at thread level.
+                Requires ``cost_per_input_token`` and ``cost_per_output_token``.
+            run_cost_limit: Maximum estimated cost in dollars per run.
+                ``None`` means no cost limit at run level.
+                Requires ``cost_per_input_token`` and ``cost_per_output_token``.
+            cost_per_input_token: Cost per input token in dollars.
+                Required if using cost-based limits.
+            cost_per_output_token: Cost per output token in dollars.
+                Required if using cost-based limits.
+            exit_behavior: How to handle when budgets are exceeded.
+
+                - ``'continue'``: Inject a warning AI message, let execution continue.
+                    The model may decide to stop based on the warning.
+                - ``'error'``: Raise a ``TokenBudgetExceededError`` exception.
+                - ``'end'``: Stop execution immediately with an AI message
+                    explaining the budget limit.
+
+        Raises:
+            ValueError: If no limits are specified, if cost limits are set without
+                per-token pricing, if ``exit_behavior`` is invalid, or if
+                ``run_token_limit`` exceeds ``thread_token_limit``.
+        """
+        super().__init__()
+
+        has_token_limit = (
+            thread_token_limit is not None or run_token_limit is not None
+        )
+        has_cost_limit = (
+            thread_cost_limit is not None or run_cost_limit is not None
+        )
+
+        if not has_token_limit and not has_cost_limit:
+            msg = (
+                "At least one limit must be specified "
+                "(thread_token_limit, run_token_limit, thread_cost_limit, "
+                "or run_cost_limit)"
+            )
+            raise ValueError(msg)
+
+        if has_cost_limit and (
+            cost_per_input_token is None or cost_per_output_token is None
+        ):
+            msg = (
+                "cost_per_input_token and cost_per_output_token must both be "
+                "specified when using cost-based limits"
+            )
+            raise ValueError(msg)
+
+        valid_behaviors = ("continue", "error", "end")
+        if exit_behavior not in valid_behaviors:
+            msg = (
+                f"Invalid exit_behavior: {exit_behavior!r}. "
+                f"Must be one of {valid_behaviors}"
+            )
+            raise ValueError(msg)
+
+        if (
+            thread_token_limit is not None
+            and run_token_limit is not None
+            and run_token_limit > thread_token_limit
+        ):
+            msg = (
+                f"run_token_limit ({run_token_limit}) cannot exceed "
+                f"thread_token_limit ({thread_token_limit}). "
+                "The run limit should be less than or equal to the thread limit."
+            )
+            raise ValueError(msg)
+
+        self.thread_token_limit = thread_token_limit
+        self.run_token_limit = run_token_limit
+        self.thread_cost_limit = thread_cost_limit
+        self.run_cost_limit = run_cost_limit
+        self.cost_per_input_token = cost_per_input_token
+        self.cost_per_output_token = cost_per_output_token
+        self.exit_behavior = exit_behavior
+
+    def _is_budget_exceeded(
+        self, thread_usage: dict[str, int], run_usage: dict[str, int]
+    ) -> bool:
+        """Check if any configured budget would be exceeded.
+
+        Args:
+            thread_usage: Current thread token usage.
+            run_usage: Current run token usage.
+
+        Returns:
+            ``True`` if any budget limit is exceeded.
+        """
+        thread_total = thread_usage.get("total_tokens", 0)
+        run_total = run_usage.get("total_tokens", 0)
+
+        if (
+            self.thread_token_limit is not None
+            and thread_total >= self.thread_token_limit
+        ):
+            return True
+        if (
+            self.run_token_limit is not None
+            and run_total >= self.run_token_limit
+        ):
+            return True
+
+        if (
+            self.cost_per_input_token is not None
+            and self.cost_per_output_token is not None
+        ):
+            if self.thread_cost_limit is not None:
+                thread_cost = _calculate_cost(
+                    thread_usage,
+                    self.cost_per_input_token,
+                    self.cost_per_output_token,
+                )
+                if thread_cost >= self.thread_cost_limit:
+                    return True
+            if self.run_cost_limit is not None:
+                run_cost = _calculate_cost(
+                    run_usage,
+                    self.cost_per_input_token,
+                    self.cost_per_output_token,
+                )
+                if run_cost >= self.run_cost_limit:
+                    return True
+
+        return False
+
+    def _handle_exceeded(
+        self,
+        thread_usage: dict[str, int],
+        run_usage: dict[str, int],
+    ) -> dict[str, Any]:
+        """Handle budget exceeded based on configured exit behavior.
+
+        Args:
+            thread_usage: Current thread token usage.
+            run_usage: Current run token usage.
+
+        Returns:
+            State updates with appropriate messages and jump directives.
+
+        Raises:
+            TokenBudgetExceededError: If ``exit_behavior`` is ``'error'``.
+        """
+        limit_message = _build_limit_message(
+            thread_usage,
+            run_usage,
+            self.thread_token_limit,
+            self.run_token_limit,
+            self.thread_cost_limit,
+            self.run_cost_limit,
+            self.cost_per_input_token,
+            self.cost_per_output_token,
+        )
+
+        if self.exit_behavior == "error":
+            estimated_cost = None
+            if (
+                self.cost_per_input_token is not None
+                and self.cost_per_output_token is not None
+            ):
+                estimated_cost = _calculate_cost(
+                    thread_usage,
+                    self.cost_per_input_token,
+                    self.cost_per_output_token,
+                )
+            raise TokenBudgetExceededError(
+                thread_usage=thread_usage,
+                run_usage=run_usage,
+                thread_token_limit=self.thread_token_limit,
+                run_token_limit=self.run_token_limit,
+                thread_cost_limit=self.thread_cost_limit,
+                run_cost_limit=self.run_cost_limit,
+                estimated_cost=estimated_cost,
+            )
+
+        ai_message = AIMessage(content=limit_message)
+
+        if self.exit_behavior == "end":
+            return {
+                "jump_to": "end",
+                "messages": [ai_message],
+            }
+
+        # exit_behavior == "continue": inject warning but don't stop
+        return {
+            "messages": [ai_message],
+        }
+
+    def _extract_token_usage(
+        self, state: TokenBudgetState[ResponseT]
+    ) -> tuple[int, int] | None:
+        """Extract token usage from the last AI message in state.
+
+        First tries to read ``usage_metadata`` from the ``AIMessage``. Falls back
+        to ``count_tokens_approximately`` if ``usage_metadata`` is not available.
+
+        Args:
+            state: The current agent state.
+
+        Returns:
+            A tuple of ``(input_tokens, output_tokens)`` or ``None`` if no
+            AI message is found.
+        """
+        messages = state.get("messages", [])
+        if not messages:
+            return None
+
+        # Find the last AIMessage
+        last_ai_message = None
+        for message in reversed(messages):
+            if isinstance(message, AIMessage):
+                last_ai_message = message
+                break
+
+        if last_ai_message is None:
+            return None
+
+        # Try usage_metadata first (provider-reported, most accurate)
+        if last_ai_message.usage_metadata:
+            return (
+                last_ai_message.usage_metadata.get("input_tokens", 0),
+                last_ai_message.usage_metadata.get("output_tokens", 0),
+            )
+
+        # Fallback: approximate output tokens from message content
+        output_tokens = count_tokens_approximately([last_ai_message])
+
+        # Approximate input tokens from all non-AI messages preceding the last AI
+        input_messages = []
+        for message in messages:
+            if message is last_ai_message:
+                break
+            input_messages.append(message)
+        input_tokens = (
+            count_tokens_approximately(input_messages)
+            if input_messages
+            else 0
+        )
+
+        return (input_tokens, output_tokens)
+
+    @hook_config(can_jump_to=["end"])
+    @override
+    def before_model(
+        self,
+        state: TokenBudgetState[ResponseT],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Check token budgets before making a model call.
+
+        If the budget is already exceeded from previous calls, this will prevent
+        the next model call based on the configured ``exit_behavior``.
+
+        Args:
+            state: The current agent state containing token usage.
+            runtime: The langgraph runtime.
+
+        Returns:
+            If budgets are exceeded and ``exit_behavior`` is ``'end'`` or
+            ``'continue'``, returns state updates with messages. Otherwise
+            returns ``None``.
+
+        Raises:
+            TokenBudgetExceededError: If budgets are exceeded and ``exit_behavior``
+                is ``'error'``.
+        """
+        thread_usage = state.get("thread_token_usage", _empty_usage())
+        run_usage = state.get("run_token_usage", _empty_usage())
+
+        if self._is_budget_exceeded(thread_usage, run_usage):
+            result = self._handle_exceeded(thread_usage, run_usage)
+            result["thread_token_usage"] = thread_usage
+            result["run_token_usage"] = run_usage
+            return result
+
+        return None
+
+    @hook_config(can_jump_to=["end"])
+    async def abefore_model(
+        self,
+        state: TokenBudgetState[ResponseT],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Async check token budgets before making a model call.
+
+        Args:
+            state: The current agent state containing token usage.
+            runtime: The langgraph runtime.
+
+        Returns:
+            If budgets are exceeded and ``exit_behavior`` is ``'end'`` or
+            ``'continue'``, returns state updates with messages. Otherwise
+            returns ``None``.
+
+        Raises:
+            TokenBudgetExceededError: If budgets are exceeded and ``exit_behavior``
+                is ``'error'``.
+        """
+        return self.before_model(state, runtime)
+
+    @override
+    def after_model(
+        self,
+        state: TokenBudgetState[ResponseT],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Extract token usage after a model call and update cumulative counts.
+
+        Reads ``usage_metadata`` from the ``AIMessage`` in the state. Falls back
+        to ``count_tokens_approximately`` if ``usage_metadata`` is not available.
+
+        Args:
+            state: The current agent state.
+            runtime: The langgraph runtime.
+
+        Returns:
+            State updates with incremented token usage counts, or ``None`` if
+            no usage data could be extracted.
+        """
+        usage = self._extract_token_usage(state)
+        if usage is None:
+            return None
+
+        input_tokens, output_tokens = usage
+
+        thread_usage = state.get("thread_token_usage", _empty_usage())
+        run_usage = state.get("run_token_usage", _empty_usage())
+
+        new_thread_usage = _add_usage(thread_usage, input_tokens, output_tokens)
+        new_run_usage = _add_usage(run_usage, input_tokens, output_tokens)
+
+        return {
+            "thread_token_usage": new_thread_usage,
+            "run_token_usage": new_run_usage,
+        }
+
+    async def aafter_model(
+        self,
+        state: TokenBudgetState[ResponseT],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Async extract token usage after a model call and update counts.
+
+        Args:
+            state: The current agent state.
+            runtime: The langgraph runtime.
+
+        Returns:
+            State updates with incremented token usage counts, or ``None`` if
+            no usage data could be extracted.
+        """
+        return self.after_model(state, runtime)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_token_budget.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_token_budget.py
@@ -1,0 +1,660 @@
+"""Unit tests for TokenBudgetMiddleware."""
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+from langchain_core.messages.ai import UsageMetadata
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware.token_budget import (
+    TokenBudgetExceededError,
+    TokenBudgetMiddleware,
+    TokenBudgetState,
+    _add_usage,
+    _calculate_cost,
+    _empty_usage,
+)
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+# --- Initialization Validation ---
+
+
+def test_middleware_initialization_validation() -> None:
+    """Test that middleware initialization validates parameters correctly."""
+    # Test that at least one limit must be specified
+    with pytest.raises(ValueError, match="At least one limit must be specified"):
+        TokenBudgetMiddleware()
+
+    # Test valid initialization with token limits
+    middleware = TokenBudgetMiddleware(
+        thread_token_limit=100_000, run_token_limit=50_000
+    )
+    assert middleware.thread_token_limit == 100_000
+    assert middleware.run_token_limit == 50_000
+    assert middleware.exit_behavior == "continue"
+
+    # Test valid initialization with only run limit
+    middleware = TokenBudgetMiddleware(run_token_limit=50_000)
+    assert middleware.run_token_limit == 50_000
+    assert middleware.thread_token_limit is None
+
+    # Test valid initialization with only thread limit
+    middleware = TokenBudgetMiddleware(thread_token_limit=200_000)
+    assert middleware.thread_token_limit == 200_000
+    assert middleware.run_token_limit is None
+
+
+def test_cost_limits_require_pricing() -> None:
+    """Test that cost limits require per-token pricing to be specified."""
+    with pytest.raises(
+        ValueError,
+        match="cost_per_input_token and cost_per_output_token must both be specified",
+    ):
+        TokenBudgetMiddleware(run_cost_limit=0.50)
+
+    with pytest.raises(
+        ValueError,
+        match="cost_per_input_token and cost_per_output_token must both be specified",
+    ):
+        TokenBudgetMiddleware(
+            run_cost_limit=0.50, cost_per_input_token=0.000003
+        )
+
+    # Valid cost-based initialization
+    middleware = TokenBudgetMiddleware(
+        run_cost_limit=0.50,
+        cost_per_input_token=0.000003,
+        cost_per_output_token=0.000015,
+    )
+    assert middleware.run_cost_limit == 0.50
+    assert middleware.cost_per_input_token == 0.000003
+    assert middleware.cost_per_output_token == 0.000015
+
+
+def test_invalid_exit_behavior() -> None:
+    """Test that invalid exit behavior raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid exit_behavior"):
+        TokenBudgetMiddleware(
+            run_token_limit=10_000,
+            exit_behavior="invalid",  # type: ignore[arg-type]
+        )
+
+
+def test_run_limit_exceeds_thread_limit() -> None:
+    """Test that run_token_limit cannot exceed thread_token_limit."""
+    with pytest.raises(
+        ValueError, match=r"run_token_limit .* cannot exceed thread_token_limit"
+    ):
+        TokenBudgetMiddleware(thread_token_limit=10_000, run_token_limit=50_000)
+
+    # Equal limits should be valid
+    middleware = TokenBudgetMiddleware(
+        thread_token_limit=50_000, run_token_limit=50_000
+    )
+    assert middleware.thread_token_limit == 50_000
+    assert middleware.run_token_limit == 50_000
+
+    # Run limit less than thread limit should be valid
+    middleware = TokenBudgetMiddleware(
+        thread_token_limit=100_000, run_token_limit=50_000
+    )
+    assert middleware.thread_token_limit == 100_000
+    assert middleware.run_token_limit == 50_000
+
+
+def test_exit_behaviors() -> None:
+    """Test that all valid exit behaviors are accepted."""
+    for behavior in ["continue", "error", "end"]:
+        middleware = TokenBudgetMiddleware(
+            run_token_limit=10_000, exit_behavior=behavior  # type: ignore[arg-type]
+        )
+        assert middleware.exit_behavior == behavior
+
+
+# --- Helper function tests ---
+
+
+def test_empty_usage() -> None:
+    """Test that _empty_usage returns zero-initialized dict."""
+    usage = _empty_usage()
+    assert usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+
+def test_add_usage() -> None:
+    """Test that _add_usage correctly adds token counts."""
+    current = {"input_tokens": 100, "output_tokens": 50, "total_tokens": 150}
+    result = _add_usage(current, input_tokens=200, output_tokens=100)
+    assert result == {
+        "input_tokens": 300,
+        "output_tokens": 150,
+        "total_tokens": 450,
+    }
+
+    # Starting from empty
+    result = _add_usage(_empty_usage(), input_tokens=50, output_tokens=25)
+    assert result == {
+        "input_tokens": 50,
+        "output_tokens": 25,
+        "total_tokens": 75,
+    }
+
+
+def test_calculate_cost() -> None:
+    """Test cost calculation from token usage."""
+    usage = {"input_tokens": 1000, "output_tokens": 500, "total_tokens": 1500}
+    cost = _calculate_cost(
+        usage, cost_per_input_token=0.000003, cost_per_output_token=0.000015
+    )
+    expected = 1000 * 0.000003 + 500 * 0.000015
+    assert abs(cost - expected) < 1e-10
+
+
+# --- Token extraction tests ---
+
+
+def test_token_extraction_with_usage_metadata() -> None:
+    """Test that token usage is extracted from AIMessage.usage_metadata."""
+    middleware = TokenBudgetMiddleware(run_token_limit=50_000)
+    runtime = None
+
+    state = TokenBudgetState(
+        messages=[
+            HumanMessage("What is 2+2?"),
+            AIMessage(
+                content="The answer is 4.",
+                usage_metadata=UsageMetadata(
+                    input_tokens=10,
+                    output_tokens=5,
+                    total_tokens=15,
+                ),
+            ),
+        ],
+    )
+
+    result = middleware.after_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["run_token_usage"]["input_tokens"] == 10
+    assert result["run_token_usage"]["output_tokens"] == 5
+    assert result["run_token_usage"]["total_tokens"] == 15
+    assert result["thread_token_usage"]["input_tokens"] == 10
+    assert result["thread_token_usage"]["output_tokens"] == 5
+    assert result["thread_token_usage"]["total_tokens"] == 15
+
+
+def test_token_extraction_fallback_no_usage_metadata() -> None:
+    """Test fallback to approximate counting when usage_metadata is not available."""
+    middleware = TokenBudgetMiddleware(run_token_limit=50_000)
+    runtime = None
+
+    state = TokenBudgetState(
+        messages=[
+            HumanMessage("What is 2+2?"),
+            AIMessage(content="The answer is 4."),  # No usage_metadata
+        ],
+    )
+
+    result = middleware.after_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    # Should have non-zero counts from approximate counting
+    assert result["run_token_usage"]["total_tokens"] > 0
+    assert result["thread_token_usage"]["total_tokens"] > 0
+
+
+def test_no_ai_message_returns_none() -> None:
+    """Test that after_model returns None if no AIMessage is found."""
+    middleware = TokenBudgetMiddleware(run_token_limit=50_000)
+    runtime = None
+
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hello")],
+    )
+
+    result = middleware.after_model(state, runtime)  # type: ignore[arg-type]
+    assert result is None
+
+
+def test_empty_messages_returns_none() -> None:
+    """Test that after_model returns None if messages are empty."""
+    middleware = TokenBudgetMiddleware(run_token_limit=50_000)
+    runtime = None
+
+    state = TokenBudgetState(messages=[])
+
+    result = middleware.after_model(state, runtime)  # type: ignore[arg-type]
+    assert result is None
+
+
+# --- Budget enforcement tests ---
+
+
+def test_run_token_limit_not_exceeded() -> None:
+    """Test that before_model returns None when budget is not exceeded."""
+    middleware = TokenBudgetMiddleware(run_token_limit=50_000)
+    runtime = None
+
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+    )
+
+    result = middleware.before_model(state, runtime)  # type: ignore[arg-type]
+    assert result is None
+
+
+def test_run_token_limit_exceeded_end() -> None:
+    """Test that 'end' behavior jumps to end when run budget is exceeded."""
+    middleware = TokenBudgetMiddleware(run_token_limit=1000, exit_behavior="end")
+    runtime = None
+
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={
+            "input_tokens": 800,
+            "output_tokens": 300,
+            "total_tokens": 1100,
+        },
+    )
+
+    result = middleware.before_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], AIMessage)
+    assert "token budget exceeded" in result["messages"][0].content.lower()
+    assert "run token limit" in result["messages"][0].content.lower()
+
+
+def test_run_token_limit_exceeded_error() -> None:
+    """Test that 'error' behavior raises TokenBudgetExceededError."""
+    middleware = TokenBudgetMiddleware(run_token_limit=1000, exit_behavior="error")
+    runtime = None
+
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={
+            "input_tokens": 800,
+            "output_tokens": 300,
+            "total_tokens": 1100,
+        },
+    )
+
+    with pytest.raises(TokenBudgetExceededError) as exc_info:
+        middleware.before_model(state, runtime)  # type: ignore[arg-type]
+
+    error = exc_info.value
+    assert error.run_token_limit == 1000
+    assert error.run_usage["total_tokens"] == 1100
+
+
+def test_run_token_limit_exceeded_continue() -> None:
+    """Test that 'continue' behavior injects warning but doesn't jump to end."""
+    middleware = TokenBudgetMiddleware(run_token_limit=1000, exit_behavior="continue")
+    runtime = None
+
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={
+            "input_tokens": 800,
+            "output_tokens": 300,
+            "total_tokens": 1100,
+        },
+    )
+
+    result = middleware.before_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    # Should NOT have jump_to
+    assert "jump_to" not in result
+    # Should have warning message
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], AIMessage)
+    assert "budget exceeded" in result["messages"][0].content.lower()
+
+
+def test_thread_token_limit_exceeded() -> None:
+    """Test thread-level token limit enforcement."""
+    middleware = TokenBudgetMiddleware(
+        thread_token_limit=5000, exit_behavior="end"
+    )
+    runtime = None
+
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        thread_token_usage={
+            "input_tokens": 3000,
+            "output_tokens": 2500,
+            "total_tokens": 5500,
+        },
+        run_token_usage=_empty_usage(),
+    )
+
+    result = middleware.before_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert "thread token limit" in result["messages"][0].content.lower()
+
+
+def test_cost_limit_exceeded() -> None:
+    """Test cost-based limit enforcement."""
+    middleware = TokenBudgetMiddleware(
+        run_cost_limit=0.01,  # $0.01
+        cost_per_input_token=0.000003,  # $3/M
+        cost_per_output_token=0.000015,  # $15/M
+        exit_behavior="end",
+    )
+    runtime = None
+
+    # Usage: 2000 input * $0.000003 + 1000 output * $0.000015 = $0.006 + $0.015 = $0.021
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={
+            "input_tokens": 2000,
+            "output_tokens": 1000,
+            "total_tokens": 3000,
+        },
+    )
+
+    result = middleware.before_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert "cost limit" in result["messages"][0].content.lower()
+
+
+def test_cost_limit_not_exceeded() -> None:
+    """Test that cost limit is not triggered when within budget."""
+    middleware = TokenBudgetMiddleware(
+        run_cost_limit=1.00,  # $1.00
+        cost_per_input_token=0.000003,
+        cost_per_output_token=0.000015,
+    )
+    runtime = None
+
+    # Usage: 100 input * $0.000003 + 50 output * $0.000015 = $0.00105
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+        },
+    )
+
+    result = middleware.before_model(state, runtime)  # type: ignore[arg-type]
+    assert result is None  # Budget not exceeded, should continue
+
+
+def test_both_token_and_cost_limits() -> None:
+    """Test that both token and cost limits can be set simultaneously."""
+    middleware = TokenBudgetMiddleware(
+        run_token_limit=10_000,
+        run_cost_limit=0.50,
+        cost_per_input_token=0.000003,
+        cost_per_output_token=0.000015,
+        exit_behavior="end",
+    )
+    runtime = None
+
+    # Token limit exceeded, cost limit not
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={
+            "input_tokens": 8000,
+            "output_tokens": 3000,
+            "total_tokens": 11000,
+        },
+    )
+
+    result = middleware.before_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert "token limit" in result["messages"][0].content.lower()
+
+
+def test_limit_at_exact_boundary() -> None:
+    """Test that limit is triggered at exact boundary (>=)."""
+    middleware = TokenBudgetMiddleware(run_token_limit=1000, exit_behavior="end")
+    runtime = None
+
+    # At exactly the limit — should trigger
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={
+            "input_tokens": 600,
+            "output_tokens": 400,
+            "total_tokens": 1000,
+        },
+    )
+
+    result = middleware.before_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["jump_to"] == "end"
+
+
+def test_limit_just_below_boundary() -> None:
+    """Test that limit is NOT triggered just below boundary."""
+    middleware = TokenBudgetMiddleware(run_token_limit=1000, exit_behavior="end")
+    runtime = None
+
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={
+            "input_tokens": 599,
+            "output_tokens": 400,
+            "total_tokens": 999,
+        },
+    )
+
+    result = middleware.before_model(state, runtime)  # type: ignore[arg-type]
+    assert result is None  # Budget not exceeded
+
+
+# --- Cumulative tracking tests ---
+
+
+def test_cumulative_token_tracking() -> None:
+    """Test that token counts accumulate across multiple after_model calls."""
+    middleware = TokenBudgetMiddleware(run_token_limit=100_000)
+    runtime = None
+
+    # First model call
+    state1 = TokenBudgetState(
+        messages=[
+            HumanMessage("First question"),
+            AIMessage(
+                content="First answer",
+                usage_metadata=UsageMetadata(
+                    input_tokens=100, output_tokens=50, total_tokens=150
+                ),
+            ),
+        ],
+    )
+    result1 = middleware.after_model(state1, runtime)  # type: ignore[arg-type]
+    assert result1 is not None
+    assert result1["run_token_usage"]["total_tokens"] == 150
+    assert result1["thread_token_usage"]["total_tokens"] == 150
+
+    # Second model call, with existing usage
+    state2 = TokenBudgetState(
+        messages=[
+            HumanMessage("Second question"),
+            AIMessage(
+                content="Second answer",
+                usage_metadata=UsageMetadata(
+                    input_tokens=200, output_tokens=100, total_tokens=300
+                ),
+            ),
+        ],
+        thread_token_usage=result1["thread_token_usage"],
+        run_token_usage=result1["run_token_usage"],
+    )
+    result2 = middleware.after_model(state2, runtime)  # type: ignore[arg-type]
+    assert result2 is not None
+    assert result2["run_token_usage"]["total_tokens"] == 450
+    assert result2["thread_token_usage"]["total_tokens"] == 450
+    assert result2["run_token_usage"]["input_tokens"] == 300
+    assert result2["run_token_usage"]["output_tokens"] == 150
+
+
+# --- Exception error messages ---
+
+
+def test_exception_error_messages() -> None:
+    """Test that error exception messages include expected information."""
+    with pytest.raises(TokenBudgetExceededError) as exc_info:
+        raise TokenBudgetExceededError(
+            thread_usage={
+                "input_tokens": 50000,
+                "output_tokens": 60000,
+                "total_tokens": 110000,
+            },
+            run_usage={
+                "input_tokens": 30000,
+                "output_tokens": 25000,
+                "total_tokens": 55000,
+            },
+            thread_token_limit=100_000,
+            run_token_limit=50_000,
+        )
+    msg = str(exc_info.value)
+    assert "token budget exceeded" in msg.lower()
+    assert "thread" in msg.lower()
+    assert "run" in msg.lower()
+
+
+# --- Integration test ---
+
+
+def test_integration_with_create_agent() -> None:
+    """Test end-to-end integration with create_agent and FakeToolCallingModel."""
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results for {query}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="search", args={"query": "test1"}, id="1")],
+            [ToolCall(name="search", args={"query": "test2"}, id="2")],
+            [ToolCall(name="search", args={"query": "test3"}, id="3")],
+            [],
+        ]
+    )
+
+    # Set a very low token limit to trigger budget enforcement
+    # Note: FakeToolCallingModel doesn't set usage_metadata, so the middleware
+    # will use the fallback approximate counting
+    budget = TokenBudgetMiddleware(run_token_limit=50, exit_behavior="end")
+    agent = create_agent(
+        model=model,
+        tools=[search],
+        middleware=[budget],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Run all searches")]},
+        {"configurable": {"thread_id": "test_integration"}},
+    )
+
+    # Agent should eventually stop due to token budget
+    messages = result["messages"]
+    assert len(messages) > 0
+
+    ai_limit_messages = [
+        msg
+        for msg in messages
+        if isinstance(msg, AIMessage)
+        and isinstance(msg.content, str)
+        and "budget exceeded" in msg.content.lower()
+    ]
+
+    # With a very low token limit and approximate counting, budget should be hit
+    assert len(ai_limit_messages) > 0, (
+        "Should have at least one AI message about budget exceeded"
+    )
+
+
+def test_integration_no_limit_exceeded() -> None:
+    """Test integration where the budget is high enough to not be exceeded."""
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results for {query}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="search", args={"query": "test1"}, id="1")],
+            [],
+        ]
+    )
+
+    # Set a very high token limit
+    budget = TokenBudgetMiddleware(run_token_limit=1_000_000)
+    agent = create_agent(
+        model=model,
+        tools=[search],
+        middleware=[budget],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Search for test1")]},
+        {"configurable": {"thread_id": "test_no_exceed"}},
+    )
+
+    messages = result["messages"]
+
+    # Should have completed without budget-related messages
+    budget_messages = [
+        msg
+        for msg in messages
+        if isinstance(msg, AIMessage)
+        and isinstance(msg.content, str)
+        and "budget exceeded" in msg.content.lower()
+    ]
+    assert len(budget_messages) == 0, (
+        "Should not have any budget exceeded messages"
+    )
+
+    # Should have successful tool execution
+    tool_messages = [msg for msg in messages if isinstance(msg, ToolMessage)]
+    assert len(tool_messages) > 0, "Should have tool execution results"
+
+
+async def test_async_methods_delegate_to_sync() -> None:
+    """Test that async methods delegate to their sync counterparts."""
+    middleware = TokenBudgetMiddleware(run_token_limit=1000, exit_behavior="end")
+    runtime = None
+
+    # Test abefore_model delegates to before_model
+    state = TokenBudgetState(
+        messages=[HumanMessage("Hi")],
+        run_token_usage={
+            "input_tokens": 800,
+            "output_tokens": 300,
+            "total_tokens": 1100,
+        },
+    )
+
+    result = await middleware.abefore_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["jump_to"] == "end"
+
+    # Test aafter_model delegates to after_model
+    state2 = TokenBudgetState(
+        messages=[
+            HumanMessage("Question"),
+            AIMessage(
+                content="Answer",
+                usage_metadata=UsageMetadata(
+                    input_tokens=10, output_tokens=5, total_tokens=15
+                ),
+            ),
+        ],
+    )
+
+    result2 = await middleware.aafter_model(state2, runtime)  # type: ignore[arg-type]
+    assert result2 is not None
+    assert result2["run_token_usage"]["total_tokens"] == 15


### PR DESCRIPTION
Add a new production-grade middleware that tracks cumulative token usage across model calls and enforces configurable budgets at both run and thread scopes.

Problem
Production LangChain agents can generate unbounded LLM costs. Existing middleware (ModelCallLimitMiddleware) counts the number of model calls but doesn't track actual token consumption. A single model call can vary wildly from 100 to 10,000+ tokens, making call-count limits insufficient for real cost control.

Solution
TokenBudgetMiddleware provides:

Thread-level token limits — persistent across invocations via checkpointer
Run-level token limits — per invocation, auto-resets between runs
Cost-based limits — optional dollar-based budgets with configurable per-token pricing
Three exit behaviors: continue (inject warning), error (raise exception), end (stop execution)
Graceful degradation — uses AIMessage.usage_metadata when available, falls back to count_tokens_approximately
Full async support — abefore_model / aafter_model
Usage
python
from langchain.agents.middleware import TokenBudgetMiddleware
budget = TokenBudgetMiddleware(run_token_limit=50_000)
# Or cost-based
budget = TokenBudgetMiddleware(
    run_cost_limit=0.50,
    cost_per_input_token=0.000003,
    cost_per_output_token=0.000015,
)
agent = create_agent("openai:gpt-4o", middleware=[budget])
Testing
27 unit tests — all passing. Lint clean (ruff).

