### PR TITLE
fix(langchain): create ToolMessages for all tool calls in end behavior

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -19,7 +19,10 @@ from langchain.agents.middleware.shell_tool import (
 )
 from langchain.agents.middleware.summarization import SummarizationMiddleware
 from langchain.agents.middleware.todo import TodoListMiddleware
-from langchain.agents.middleware.tool_call_limit import ToolCallLimitMiddleware
+from langchain.agents.middleware.tool_call_limit import (
+    ToolCallLimitExceededError,
+    ToolCallLimitMiddleware,
+)
 from langchain.agents.middleware.tool_emulator import LLMToolEmulator
 from langchain.agents.middleware.tool_retry import ToolRetryMiddleware
 from langchain.agents.middleware.tool_selection import LLMToolSelectorMiddleware
@@ -67,6 +70,7 @@ __all__ = [
     "ShellToolMiddleware",
     "SummarizationMiddleware",
     "TodoListMiddleware",
+    "ToolCallLimitExceededError",
     "ToolCallLimitMiddleware",
     "ToolCallRequest",
     "ToolRetryMiddleware",

--- a/libs/langchain_v1/tests/unit_tests/agents/test_repair_orphaned_tool_calls.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_repair_orphaned_tool_calls.py
@@ -1,0 +1,106 @@
+"""Unit tests for _repair_orphaned_tool_calls in factory.py."""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+
+from langchain.agents.factory import _repair_orphaned_tool_calls
+
+
+def test_no_repair_needed() -> None:
+    """Test that messages without orphaned tool calls are returned unchanged."""
+    messages = [
+        HumanMessage("Hello"),
+        AIMessage(
+            content="",
+            tool_calls=[ToolCall(name="search", args={"q": "test"}, id="tc1")],
+        ),
+        ToolMessage(content="result", tool_call_id="tc1", name="search"),
+        AIMessage(content="Done"),
+    ]
+    result = _repair_orphaned_tool_calls(messages)
+    assert result is messages, "Should return original list when no repairs needed"
+
+
+def test_repair_single_orphaned_tool_call() -> None:
+    """Test that a single orphaned tool call gets a placeholder ToolMessage."""
+    messages = [
+        HumanMessage("Hello"),
+        AIMessage(
+            content="",
+            tool_calls=[ToolCall(name="search", args={"q": "test"}, id="tc1")],
+        ),
+        # No ToolMessage for tc1
+        AIMessage(content="Limit reached"),
+    ]
+    result = _repair_orphaned_tool_calls(messages)
+    assert len(result) == 4, "Should inject one placeholder ToolMessage"
+
+    injected = result[2]
+    assert isinstance(injected, ToolMessage)
+    assert injected.tool_call_id == "tc1"
+    assert injected.status == "error"
+    assert "search" in injected.content
+
+
+def test_repair_multiple_orphaned_tool_calls() -> None:
+    """Test that multiple orphaned tool calls all get placeholder ToolMessages."""
+    messages = [
+        HumanMessage("Hello"),
+        AIMessage(
+            content="",
+            tool_calls=[
+                ToolCall(name="search", args={"q": "q1"}, id="tc1"),
+                ToolCall(name="search", args={"q": "q2"}, id="tc2"),
+                ToolCall(name="calc", args={"x": "1"}, id="tc3"),
+            ],
+        ),
+        # No ToolMessages at all
+        AIMessage(content="Limit reached"),
+    ]
+    result = _repair_orphaned_tool_calls(messages)
+
+    tool_messages = [m for m in result if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 3, "All 3 orphaned tool calls need placeholders"
+
+    repaired_ids = {m.tool_call_id for m in tool_messages}
+    assert repaired_ids == {"tc1", "tc2", "tc3"}
+
+
+def test_repair_partial_orphaned_tool_calls() -> None:
+    """Test that only orphaned calls get repaired, not already-answered ones."""
+    messages = [
+        HumanMessage("Hello"),
+        AIMessage(
+            content="",
+            tool_calls=[
+                ToolCall(name="search", args={"q": "q1"}, id="tc1"),
+                ToolCall(name="search", args={"q": "q2"}, id="tc2"),
+            ],
+        ),
+        ToolMessage(content="result1", tool_call_id="tc1", name="search"),
+        # tc2 is orphaned
+        AIMessage(content="Limit reached"),
+    ]
+    result = _repair_orphaned_tool_calls(messages)
+
+    tool_messages = [m for m in result if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 2, "Should have original + 1 injected"
+
+    injected = [m for m in tool_messages if m.tool_call_id == "tc2"]
+    assert len(injected) == 1
+    assert injected[0].status == "error"
+
+
+def test_no_ai_messages_with_tool_calls() -> None:
+    """Test that messages without any tool calls need no repair."""
+    messages = [
+        HumanMessage("Hello"),
+        AIMessage(content="Hi there"),
+    ]
+    result = _repair_orphaned_tool_calls(messages)
+    assert result is messages
+
+
+def test_empty_messages() -> None:
+    """Test that empty message list is handled."""
+    result = _repair_orphaned_tool_calls([])
+    assert result == []

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2028,7 +2028,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.75.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.78.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2404,7 +2404,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Fixed `ToolCallLimitMiddleware` with `exit_behavior="end"` creating invalid
  state when the model emits parallel tool calls. Error `ToolMessage` objects
  are now created for ALL tool calls (allowed + blocked) since none execute
  when jumping to end.
- Added `_repair_orphaned_tool_calls()` defense-in-depth in `factory.py` to
  handle existing invalid states in checkpointers.
- Exported `ToolCallLimitExceededError` from middleware public API.

Closes #34159

## Test plan
- [x] Updated `test_parallel_tool_calls_with_limit_end_mode` to verify all
  tool calls get error ToolMessages
- [x] Added `test_end_behavior_all_tool_calls_have_responses` (4 parallel
  calls, all get error ToolMessages)
- [x] Added `test_end_behavior_state_valid_for_next_invocation` (second
  invocation succeeds after first hits limit)
- [x] Added 6 unit tests for `_repair_orphaned_tool_calls`
- [x] Full test suite passes (788 passed)
