### PR TITLE
fix(langchain): emit on_agent_finish callback in new agent system

### DIFF
--- a/libs/langchain_v1/langchain/agents/_callbacks.py
+++ b/libs/langchain_v1/langchain/agents/_callbacks.py
@@ -1,0 +1,93 @@
+"""Callback emission helpers for the LangGraph-based agent."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.agents import AgentFinish
+from langchain_core.callbacks.manager import (
+    ahandle_event,
+    handle_event,
+)
+from langchain_core.messages import AIMessage
+from langchain_core.runnables.config import (
+    get_async_callback_manager_for_config,
+    get_callback_manager_for_config,
+)
+
+if TYPE_CHECKING:
+    from langchain_core.runnables import RunnableConfig
+
+    from langchain.agents.middleware.types import AgentState
+
+
+def _build_agent_finish(state: AgentState[Any]) -> AgentFinish:
+    """Construct an `AgentFinish` from the current agent state.
+
+    Extracts the final AI message content from the state's messages list.
+    If no AI message is found, uses an empty string.
+
+    Args:
+        state: The current agent state.
+
+    Returns:
+        An `AgentFinish` with the final response content.
+    """
+    messages = state.get("messages", [])
+    output = ""
+    for msg in reversed(messages):
+        if isinstance(msg, AIMessage):
+            output = msg.content if isinstance(msg.content, str) else str(msg.content)
+            break
+
+    return AgentFinish(
+        return_values={"output": output},
+        log=output,
+    )
+
+
+def _emit_agent_finish(state: AgentState[Any], config: RunnableConfig) -> None:
+    """Emit `on_agent_finish` to all registered callback handlers (sync).
+
+    Args:
+        state: The current agent state.
+        config: The runnable config containing callback handlers.
+    """
+    callback_manager = get_callback_manager_for_config(config)
+    if not callback_manager.handlers:
+        return
+
+    finish = _build_agent_finish(state)
+    handle_event(
+        callback_manager.handlers,
+        "on_agent_finish",
+        "ignore_agent",
+        finish,
+        run_id=uuid.uuid4(),
+        parent_run_id=None,
+        tags=callback_manager.tags,
+    )
+
+
+async def _aemit_agent_finish(state: AgentState[Any], config: RunnableConfig) -> None:
+    """Emit `on_agent_finish` to all registered callback handlers (async).
+
+    Args:
+        state: The current agent state.
+        config: The runnable config containing callback handlers.
+    """
+    callback_manager = get_async_callback_manager_for_config(config)
+    if not callback_manager.handlers:
+        return
+
+    finish = _build_agent_finish(state)
+    await ahandle_event(
+        callback_manager.handlers,
+        "on_agent_finish",
+        "ignore_agent",
+        finish,
+        run_id=uuid.uuid4(),
+        parent_run_id=None,
+        tags=callback_manager.tags,
+    )

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
     from langchain.agents.structured_output import ResponseFormat
 
 __all__ = [
+    "AGENT_FINISH_NODE",
     "AgentMiddleware",
     "AgentState",
     "ContextT",
@@ -65,6 +66,13 @@ __all__ = [
     "hook_config",
     "wrap_tool_call",
 ]
+
+AGENT_FINISH_NODE: str = "__agent_finish__"
+"""Internal graph node name for the agent finish callback emission node.
+
+This node always runs as the last node before ``END`` and emits the
+``on_agent_finish`` callback event to all registered handlers.
+"""
 
 JumpTo = Literal["tools", "model", "end"]
 """Destination to jump to when a middleware node returns."""

--- a/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_return_direct_graph.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_return_direct_graph.ambr
@@ -10,12 +10,14 @@
   	__start__([<p>__start__</p>]):::first
   	model(model)
   	tools(tools)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> model;
-  	model -.-> __end__;
+  	model -.-> __agent_finish__;
   	model -.-> tools;
-  	tools -.-> __end__;
+  	tools -.-> __agent_finish__;
   	tools -.-> model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -33,12 +35,14 @@
   	__start__([<p>__start__</p>]):::first
   	model(model)
   	tools(tools)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> model;
-  	model -.-> __end__;
+  	model -.-> __agent_finish__;
   	model -.-> tools;
-  	tools -.-> __end__;
+  	tools -.-> __agent_finish__;
   	tools -.-> model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -56,11 +60,13 @@
   	__start__([<p>__start__</p>]):::first
   	model(model)
   	tools(tools)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> model;
-  	model -.-> __end__;
+  	model -.-> __agent_finish__;
   	model -.-> tools;
   	tools -.-> model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_decorators.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_decorators.ambr
@@ -10,11 +10,13 @@
   	__start__([<p>__start__</p>]):::first
   	model(model)
   	async_before_with_jump\2ebefore_model(async_before_with_jump.before_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> async_before_with_jump\2ebefore_model;
-  	async_before_with_jump\2ebefore_model -.-> __end__;
+  	async_before_with_jump\2ebefore_model -.-> __agent_finish__;
   	async_before_with_jump\2ebefore_model -.-> model;
-  	model --> __end__;
+  	model --> __agent_finish__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -32,11 +34,13 @@
   	__start__([<p>__start__</p>]):::first
   	model(model)
   	async_after_with_jump\2eafter_model(async_after_with_jump.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> model;
-  	async_after_with_jump\2eafter_model -.-> __end__;
+  	async_after_with_jump\2eafter_model -.-> __agent_finish__;
   	async_after_with_jump\2eafter_model -.-> model;
   	model --> async_after_with_jump\2eafter_model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -55,13 +59,15 @@
   	model(model)
   	async_before_early_exit\2ebefore_model(async_before_early_exit.before_model)
   	async_after_retry\2eafter_model(async_after_retry.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> async_before_early_exit\2ebefore_model;
-  	async_after_retry\2eafter_model -.-> __end__;
+  	async_after_retry\2eafter_model -.-> __agent_finish__;
   	async_after_retry\2eafter_model -.-> async_before_early_exit\2ebefore_model;
-  	async_before_early_exit\2ebefore_model -.-> __end__;
+  	async_before_early_exit\2ebefore_model -.-> __agent_finish__;
   	async_before_early_exit\2ebefore_model -.-> model;
   	model --> async_after_retry\2eafter_model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -80,13 +86,15 @@
   	model(model)
   	sync_before_with_jump\2ebefore_model(sync_before_with_jump.before_model)
   	async_after_with_jumps\2eafter_model(async_after_with_jumps.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> sync_before_with_jump\2ebefore_model;
-  	async_after_with_jumps\2eafter_model -.-> __end__;
+  	async_after_with_jumps\2eafter_model -.-> __agent_finish__;
   	async_after_with_jumps\2eafter_model -.-> sync_before_with_jump\2ebefore_model;
   	model --> async_after_with_jumps\2eafter_model;
-  	sync_before_with_jump\2ebefore_model -.-> __end__;
+  	sync_before_with_jump\2ebefore_model -.-> __agent_finish__;
   	sync_before_with_jump\2ebefore_model -.-> model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_diagram.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_diagram.ambr
@@ -9,9 +9,11 @@
   graph TD;
   	__start__([<p>__start__</p>]):::first
   	model(model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> model;
-  	model --> __end__;
+  	model --> __agent_finish__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -29,10 +31,12 @@
   	__start__([<p>__start__</p>]):::first
   	model(model)
   	NoopOne\2ebefore_model(NoopOne.before_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopOne\2ebefore_model --> model;
   	__start__ --> NoopOne\2ebefore_model;
-  	model --> __end__;
+  	model --> __agent_finish__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -51,11 +55,13 @@
   	model(model)
   	NoopTen\2ebefore_model(NoopTen.before_model)
   	NoopTen\2eafter_model(NoopTen.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
+  	NoopTen\2eafter_model --> __agent_finish__;
   	NoopTen\2ebefore_model --> model;
   	__start__ --> NoopTen\2ebefore_model;
   	model --> NoopTen\2eafter_model;
-  	NoopTen\2eafter_model --> __end__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -76,13 +82,15 @@
   	NoopTen\2eafter_model(NoopTen.after_model)
   	NoopEleven\2ebefore_model(NoopEleven.before_model)
   	NoopEleven\2eafter_model(NoopEleven.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopEleven\2eafter_model --> NoopTen\2eafter_model;
   	NoopEleven\2ebefore_model --> model;
+  	NoopTen\2eafter_model --> __agent_finish__;
   	NoopTen\2ebefore_model --> NoopEleven\2ebefore_model;
   	__start__ --> NoopTen\2ebefore_model;
   	model --> NoopEleven\2eafter_model;
-  	NoopTen\2eafter_model --> __end__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -101,11 +109,13 @@
   	model(model)
   	NoopOne\2ebefore_model(NoopOne.before_model)
   	NoopTwo\2ebefore_model(NoopTwo.before_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopOne\2ebefore_model --> NoopTwo\2ebefore_model;
   	NoopTwo\2ebefore_model --> model;
   	__start__ --> NoopOne\2ebefore_model;
-  	model --> __end__;
+  	model --> __agent_finish__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -125,12 +135,14 @@
   	NoopOne\2ebefore_model(NoopOne.before_model)
   	NoopTwo\2ebefore_model(NoopTwo.before_model)
   	NoopThree\2ebefore_model(NoopThree.before_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopOne\2ebefore_model --> NoopTwo\2ebefore_model;
   	NoopThree\2ebefore_model --> model;
   	NoopTwo\2ebefore_model --> NoopThree\2ebefore_model;
   	__start__ --> NoopOne\2ebefore_model;
-  	model --> __end__;
+  	model --> __agent_finish__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -148,10 +160,12 @@
   	__start__([<p>__start__</p>]):::first
   	model(model)
   	NoopFour\2eafter_model(NoopFour.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
+  	NoopFour\2eafter_model --> __agent_finish__;
   	__start__ --> model;
   	model --> NoopFour\2eafter_model;
-  	NoopFour\2eafter_model --> __end__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -170,11 +184,13 @@
   	model(model)
   	NoopFour\2eafter_model(NoopFour.after_model)
   	NoopFive\2eafter_model(NoopFive.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopFive\2eafter_model --> NoopFour\2eafter_model;
+  	NoopFour\2eafter_model --> __agent_finish__;
   	__start__ --> model;
   	model --> NoopFive\2eafter_model;
-  	NoopFour\2eafter_model --> __end__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -194,12 +210,14 @@
   	NoopFour\2eafter_model(NoopFour.after_model)
   	NoopFive\2eafter_model(NoopFive.after_model)
   	NoopSix\2eafter_model(NoopSix.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopFive\2eafter_model --> NoopFour\2eafter_model;
+  	NoopFour\2eafter_model --> __agent_finish__;
   	NoopSix\2eafter_model --> NoopFive\2eafter_model;
   	__start__ --> model;
   	model --> NoopSix\2eafter_model;
-  	NoopFour\2eafter_model --> __end__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -218,11 +236,13 @@
   	model(model)
   	NoopSeven\2ebefore_model(NoopSeven.before_model)
   	NoopSeven\2eafter_model(NoopSeven.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
+  	NoopSeven\2eafter_model --> __agent_finish__;
   	NoopSeven\2ebefore_model --> model;
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopSeven\2eafter_model;
-  	NoopSeven\2eafter_model --> __end__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -243,13 +263,15 @@
   	NoopSeven\2eafter_model(NoopSeven.after_model)
   	NoopEight\2ebefore_model(NoopEight.before_model)
   	NoopEight\2eafter_model(NoopEight.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
   	NoopEight\2ebefore_model --> model;
+  	NoopSeven\2eafter_model --> __agent_finish__;
   	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
-  	NoopSeven\2eafter_model --> __end__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -272,15 +294,17 @@
   	NoopEight\2eafter_model(NoopEight.after_model)
   	NoopNine\2ebefore_model(NoopNine.before_model)
   	NoopNine\2eafter_model(NoopNine.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
   	NoopEight\2ebefore_model --> NoopNine\2ebefore_model;
   	NoopNine\2eafter_model --> NoopEight\2eafter_model;
   	NoopNine\2ebefore_model --> model;
+  	NoopSeven\2eafter_model --> __agent_finish__;
   	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopNine\2eafter_model;
-  	NoopSeven\2eafter_model --> __end__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
@@ -13,7 +13,9 @@
   	NoopZero\2ebefore_agent(NoopZero.before_agent)
   	NoopOne\2eafter_agent(NoopOne.after_agent)
   	NoopTwo\2eafter_agent(NoopTwo.after_agent)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
+  	NoopOne\2eafter_agent --> __agent_finish__;
   	NoopTwo\2eafter_agent --> NoopOne\2eafter_agent;
   	NoopZero\2ebefore_agent -.-> NoopTwo\2eafter_agent;
   	NoopZero\2ebefore_agent -.-> model;
@@ -21,7 +23,7 @@
   	model -.-> NoopTwo\2eafter_agent;
   	model -.-> tools;
   	tools -.-> model;
-  	NoopOne\2eafter_agent --> __end__;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -43,17 +45,19 @@
   	NoopSeven\2eafter_model(NoopSeven.after_model)
   	NoopEight\2ebefore_model(NoopEight.before_model)
   	NoopEight\2eafter_model(NoopEight.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
+  	NoopEight\2ebefore_model -.-> __agent_finish__;
   	NoopEight\2ebefore_model -.-> model;
   	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
+  	NoopSeven\2eafter_model -.-> __agent_finish__;
   	NoopSeven\2eafter_model -.-> tools;
   	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -75,17 +79,19 @@
   	NoopSeven\2eafter_model(NoopSeven.after_model)
   	NoopEight\2ebefore_model(NoopEight.before_model)
   	NoopEight\2eafter_model(NoopEight.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
+  	NoopEight\2ebefore_model -.-> __agent_finish__;
   	NoopEight\2ebefore_model -.-> model;
   	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
+  	NoopSeven\2eafter_model -.-> __agent_finish__;
   	NoopSeven\2eafter_model -.-> tools;
   	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -107,17 +113,19 @@
   	NoopSeven\2eafter_model(NoopSeven.after_model)
   	NoopEight\2ebefore_model(NoopEight.before_model)
   	NoopEight\2eafter_model(NoopEight.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
+  	NoopEight\2ebefore_model -.-> __agent_finish__;
   	NoopEight\2ebefore_model -.-> model;
   	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
+  	NoopSeven\2eafter_model -.-> __agent_finish__;
   	NoopSeven\2eafter_model -.-> tools;
   	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -139,17 +147,19 @@
   	NoopSeven\2eafter_model(NoopSeven.after_model)
   	NoopEight\2ebefore_model(NoopEight.before_model)
   	NoopEight\2eafter_model(NoopEight.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
+  	NoopEight\2ebefore_model -.-> __agent_finish__;
   	NoopEight\2ebefore_model -.-> model;
   	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
+  	NoopSeven\2eafter_model -.-> __agent_finish__;
   	NoopSeven\2eafter_model -.-> tools;
   	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -171,17 +181,19 @@
   	NoopSeven\2eafter_model(NoopSeven.after_model)
   	NoopEight\2ebefore_model(NoopEight.before_model)
   	NoopEight\2eafter_model(NoopEight.after_model)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
+  	NoopEight\2ebefore_model -.-> __agent_finish__;
   	NoopEight\2ebefore_model -.-> model;
   	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
+  	NoopSeven\2eafter_model -.-> __agent_finish__;
   	NoopSeven\2eafter_model -.-> tools;
   	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -199,11 +211,13 @@
   	__start__([<p>__start__</p>]):::first
   	model(model)
   	tools(tools)
+  	__agent_finish__(<p>__agent_finish__</p>)
   	__end__([<p>__end__</p>]):::last
   	__start__ --> model;
-  	model -.-> __end__;
+  	model -.-> __agent_finish__;
   	model -.-> tools;
   	tools -.-> model;
+  	__agent_finish__ --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_finish_callback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_finish_callback.py
@@ -1,0 +1,283 @@
+"""Unit tests for on_agent_finish callback emission."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from uuid import UUID
+from langchain_core.agents import AgentFinish
+from langchain_core.callbacks.base import AsyncCallbackHandler, BaseCallbackHandler
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall
+from langchain_core.tools import tool
+from langgraph.typing import ContextT
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, hook_config
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+class TrackingHandler(BaseCallbackHandler):
+    """Sync callback handler that records on_agent_finish calls."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.finishes: list[AgentFinish] = []
+        self.run_ids: list[UUID] = []
+
+    def on_agent_finish(
+        self,
+        finish: AgentFinish,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.finishes.append(finish)
+        self.run_ids.append(run_id)
+
+
+class AsyncTrackingHandler(AsyncCallbackHandler):
+    """Async callback handler that records on_agent_finish calls."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.finishes: list[AgentFinish] = []
+        self.run_ids: list[UUID] = []
+
+    async def on_agent_finish(
+        self,
+        finish: AgentFinish,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.finishes.append(finish)
+        self.run_ids.append(run_id)
+
+
+class IgnoreAgentHandler(BaseCallbackHandler):
+    """Handler with ignore_agent=True. Should NOT receive on_agent_finish."""
+
+    ignore_agent = True
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.finishes: list[AgentFinish] = []
+
+    def on_agent_finish(
+        self,
+        finish: AgentFinish,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.finishes.append(finish)
+
+
+def test_on_agent_finish_called_on_normal_completion() -> None:
+    """Test on_agent_finish is called when agent completes without tools."""
+    handler = TrackingHandler()
+    model = FakeToolCallingModel(tool_calls=[[]])
+    agent = create_agent(model=model, tools=[])
+
+    agent.invoke(
+        {"messages": [HumanMessage("hello")]},
+        config={"callbacks": [handler]},
+    )
+
+    assert len(handler.finishes) == 1
+    assert isinstance(handler.finishes[0], AgentFinish)
+    assert "output" in handler.finishes[0].return_values
+
+
+def test_on_agent_finish_called_with_tools() -> None:
+    """Test on_agent_finish is called after agent uses tools and responds."""
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results: {query}"
+
+    handler = TrackingHandler()
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="search", args={"query": "test"}, id="tc1")],
+            [],  # No tools on second call = agent finishes
+        ]
+    )
+    agent = create_agent(model=model, tools=[search])
+
+    agent.invoke(
+        {"messages": [HumanMessage("search for test")]},
+        config={"callbacks": [handler]},
+    )
+
+    assert len(handler.finishes) == 1
+    assert isinstance(handler.finishes[0], AgentFinish)
+
+
+def test_on_agent_finish_called_on_jump_to_end() -> None:
+    """Test on_agent_finish is called when middleware uses jump_to='end'.
+
+    This is the core bug from issue #34165: when middleware returns
+    jump_to='end', on_agent_finish should still fire.
+    """
+
+    class JumpToEndMiddleware(AgentMiddleware[AgentState[Any], ContextT]):
+        @hook_config(can_jump_to=["end"])
+        def before_model(self, state: AgentState[Any], runtime: Any) -> dict[str, Any] | None:
+            return {
+                "jump_to": "end",
+                "messages": [AIMessage(content="Blocked by middleware")],
+            }
+
+    handler = TrackingHandler()
+    model = FakeToolCallingModel(tool_calls=[[]])
+    middleware = JumpToEndMiddleware()
+    agent = create_agent(model=model, tools=[], middleware=[middleware])
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("trigger")]},
+        config={"callbacks": [handler]},
+    )
+
+    # Verify the agent was stopped by middleware
+    messages = result["messages"]
+    ai_messages = [m for m in messages if isinstance(m, AIMessage)]
+    assert any("Blocked" in str(m.content) for m in ai_messages)
+
+    # Verify on_agent_finish was called
+    assert len(handler.finishes) == 1
+    assert isinstance(handler.finishes[0], AgentFinish)
+    assert handler.finishes[0].return_values["output"] == "Blocked by middleware"
+
+
+@pytest.mark.asyncio
+async def test_on_agent_finish_async() -> None:
+    """Test async handler's on_agent_finish is called."""
+    handler = AsyncTrackingHandler()
+    model = FakeToolCallingModel(tool_calls=[[]])
+    agent = create_agent(model=model, tools=[])
+
+    await agent.ainvoke(
+        {"messages": [HumanMessage("hello")]},
+        config={"callbacks": [handler]},
+    )
+
+    assert len(handler.finishes) == 1
+    assert isinstance(handler.finishes[0], AgentFinish)
+
+
+@pytest.mark.asyncio
+async def test_on_agent_finish_async_with_jump_to_end() -> None:
+    """Test async handler's on_agent_finish is called on jump_to='end'."""
+
+    class JumpToEndMiddleware(AgentMiddleware[AgentState[Any], ContextT]):
+        @hook_config(can_jump_to=["end"])
+        async def abefore_model(
+            self, state: AgentState[Any], runtime: Any
+        ) -> dict[str, Any] | None:
+            return {
+                "jump_to": "end",
+                "messages": [AIMessage(content="Blocked by middleware")],
+            }
+
+    handler = AsyncTrackingHandler()
+    model = FakeToolCallingModel(tool_calls=[[]])
+    middleware = JumpToEndMiddleware()
+    agent = create_agent(model=model, tools=[], middleware=[middleware])
+
+    await agent.ainvoke(
+        {"messages": [HumanMessage("trigger")]},
+        config={"callbacks": [handler]},
+    )
+
+    assert len(handler.finishes) == 1
+    assert handler.finishes[0].return_values["output"] == "Blocked by middleware"
+
+
+def test_on_agent_finish_called_with_after_agent_middleware() -> None:
+    """Test on_agent_finish fires after after_agent middleware completes."""
+    call_order: list[str] = []
+
+    class OrderTrackingMiddleware(AgentMiddleware[AgentState[Any], ContextT]):
+        def after_agent(self, state: AgentState[Any], runtime: Any) -> dict[str, Any] | None:
+            call_order.append("after_agent")
+            return None
+
+    class OrderTrackingHandler(BaseCallbackHandler):
+        def on_agent_finish(
+            self,
+            finish: AgentFinish,
+            *,
+            run_id: UUID,
+            parent_run_id: UUID | None = None,
+            **kwargs: Any,
+        ) -> None:
+            call_order.append("on_agent_finish")
+
+    handler = OrderTrackingHandler()
+    model = FakeToolCallingModel(tool_calls=[[]])
+    middleware = OrderTrackingMiddleware()
+    agent = create_agent(model=model, tools=[], middleware=[middleware])
+
+    agent.invoke(
+        {"messages": [HumanMessage("hello")]},
+        config={"callbacks": [handler]},
+    )
+
+    assert call_order == ["after_agent", "on_agent_finish"]
+
+
+def test_on_agent_finish_content_matches_last_ai_message() -> None:
+    """Test AgentFinish.return_values['output'] matches last AIMessage."""
+    handler = TrackingHandler()
+    model = FakeToolCallingModel(tool_calls=[[]])
+    agent = create_agent(model=model, tools=[])
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("hello")]},
+        config={"callbacks": [handler]},
+    )
+
+    # Find the last AIMessage
+    messages = result["messages"]
+    last_ai = None
+    for msg in reversed(messages):
+        if isinstance(msg, AIMessage):
+            last_ai = msg
+            break
+
+    assert last_ai is not None
+    assert handler.finishes[0].return_values["output"] == last_ai.content
+
+
+def test_ignore_agent_handler_not_called() -> None:
+    """Test handler with ignore_agent=True does not receive on_agent_finish."""
+    ignore_handler = IgnoreAgentHandler()
+    tracking_handler = TrackingHandler()
+    model = FakeToolCallingModel(tool_calls=[[]])
+    agent = create_agent(model=model, tools=[])
+
+    agent.invoke(
+        {"messages": [HumanMessage("hello")]},
+        config={"callbacks": [ignore_handler, tracking_handler]},
+    )
+
+    assert len(ignore_handler.finishes) == 0, "ignore_agent handler should not be called"
+    assert len(tracking_handler.finishes) == 1, "Normal handler should be called"
+
+
+def test_no_callbacks_no_error() -> None:
+    """Test agent works fine when no callbacks are registered."""
+    model = FakeToolCallingModel(tool_calls=[[]])
+    agent = create_agent(model=model, tools=[])
+
+    # Should not raise
+    result = agent.invoke({"messages": [HumanMessage("hello")]})
+    assert result is not None

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2028,7 +2028,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.75.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.78.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2404,7 +2404,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Added `on_agent_finish` callback emission to the new LangGraph-based agent
  system. Previously, `AsyncCallbackHandler.on_agent_finish()` was never called,
  regardless of exit path (normal completion or middleware `jump_to="end"`).
- Implemented via a new `__agent_finish__` graph node that always runs as the
  last node before `END`, ensuring all exit paths trigger the callback.
- Created `_callbacks.py` module with callback emission helpers to keep
  `factory.py` focused on graph construction.

Closes #34165

## Test plan
- [x] 9 new unit tests covering: normal completion, tool use, `jump_to="end"`,
  async handlers, `after_agent` ordering, content verification, `ignore_agent`,
  and no-callback scenarios
- [x] 22 snapshot tests updated for new graph node
- [x] Full test suite passes (789 passed)
- [x] Lint and mypy clean
