### PR TITLE
fix(core,langchain): strip reasoning content from agent message history

### DIFF
--- a/libs/core/langchain_core/messages/__init__.py
+++ b/libs/core/langchain_core/messages/__init__.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
         merge_message_runs,
         message_chunk_to_message,
         messages_from_dict,
+        strip_reasoning,
         trim_messages,
     )
 
@@ -126,6 +127,7 @@ __all__ = (
     "message_to_dict",
     "messages_from_dict",
     "messages_to_dict",
+    "strip_reasoning",
     "trim_messages",
 )
 
@@ -183,6 +185,7 @@ _dynamic_imports = {
     "merge_message_runs": "utils",
     "message_chunk_to_message": "utils",
     "messages_from_dict": "utils",
+    "strip_reasoning": "utils",
     "trim_messages": "utils",
 }
 

--- a/libs/core/tests/unit_tests/messages/test_imports.py
+++ b/libs/core/tests/unit_tests/messages/test_imports.py
@@ -52,6 +52,7 @@ EXPECTED_ALL = [
     "filter_messages",
     "merge_message_runs",
     "trim_messages",
+    "strip_reasoning",
     "convert_to_openai_data_block",
     "convert_to_openai_image_block",
     "convert_to_openai_messages",

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -16,7 +16,13 @@ from typing import (
 )
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, SystemMessage, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    SystemMessage,
+    ToolMessage,
+    strip_reasoning,
+)
 from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.constants import END, START
@@ -994,6 +1000,11 @@ def create_agent(
             effective_response_format: The actual strategy used (may differ from initial
                 if auto-detected).
         """
+        # Strip reasoning/thinking traces so they don't persist in message history.
+        # Many model APIs reject messages that contain reasoning content from
+        # previous turns.
+        output = strip_reasoning(output)
+
         # Handle structured output with provider strategy
         if isinstance(effective_response_format, ProviderStrategy):
             if not output.tool_calls:

--- a/libs/langchain_v1/tests/unit_tests/agents/test_reasoning_stripping.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_reasoning_stripping.py
@@ -1,0 +1,192 @@
+"""Test that reasoning content is stripped from agent message history."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolCall
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import tool
+
+from langchain.agents.factory import create_agent
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+class FakeReasoningModel(FakeToolCallingModel):
+    """Fake model that includes reasoning content in responses."""
+
+    reasoning_style: str = "content_blocks"
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        """Generate response with reasoning content."""
+        result = super()._generate(messages, stop, run_manager, **kwargs)
+        ai_msg = result.generations[0].message
+        assert isinstance(ai_msg, AIMessage)
+
+        if self.reasoning_style == "content_blocks":
+            # Add reasoning content blocks to the message content
+            text_content = ai_msg.content if isinstance(ai_msg.content, str) else ""
+            new_content: list[dict[str, Any]] = [
+                {"type": "reasoning", "reasoning": "Let me think step by step..."},
+                {"type": "text", "text": text_content},
+            ]
+            ai_msg = ai_msg.model_copy(update={"content": new_content})
+        elif self.reasoning_style == "thinking_blocks":
+            text_content = ai_msg.content if isinstance(ai_msg.content, str) else ""
+            new_content = [
+                {"type": "thinking", "thinking": "Internal monologue..."},
+                {"type": "text", "text": text_content},
+            ]
+            ai_msg = ai_msg.model_copy(update={"content": new_content})
+        elif self.reasoning_style == "additional_kwargs":
+            ai_msg = ai_msg.model_copy(
+                update={
+                    "additional_kwargs": {
+                        **ai_msg.additional_kwargs,
+                        "reasoning_content": "Step by step reasoning...",
+                    }
+                }
+            )
+        elif self.reasoning_style == "responses_api":
+            ai_msg = ai_msg.model_copy(
+                update={
+                    "additional_kwargs": {
+                        **ai_msg.additional_kwargs,
+                        "reasoning": {
+                            "id": "rs_123",
+                            "type": "reasoning",
+                            "summary": [{"text": "Thought process"}],
+                        },
+                    }
+                }
+            )
+
+        return ChatResult(generations=[ChatGeneration(message=ai_msg)])
+
+
+def test_reasoning_blocks_stripped_from_agent_output() -> None:
+    """Test that reasoning content blocks are stripped from output messages."""
+    model = FakeReasoningModel(
+        tool_calls=[[]],
+        reasoning_style="content_blocks",
+    )
+    agent = create_agent(model=model, tools=[])
+
+    result = agent.invoke({"messages": [HumanMessage("hello")]})
+    messages = result["messages"]
+
+    for msg in messages:
+        if isinstance(msg, AIMessage) and isinstance(msg.content, list):
+            for block in msg.content:
+                if isinstance(block, dict):
+                    assert block.get("type") != "reasoning", "Reasoning blocks should be stripped"
+
+
+def test_thinking_blocks_stripped_from_agent_output() -> None:
+    """Test that Anthropic-style thinking blocks are stripped."""
+    model = FakeReasoningModel(
+        tool_calls=[[]],
+        reasoning_style="thinking_blocks",
+    )
+    agent = create_agent(model=model, tools=[])
+
+    result = agent.invoke({"messages": [HumanMessage("hello")]})
+    messages = result["messages"]
+
+    for msg in messages:
+        if isinstance(msg, AIMessage) and isinstance(msg.content, list):
+            for block in msg.content:
+                if isinstance(block, dict):
+                    assert block.get("type") != "thinking", "Thinking blocks should be stripped"
+
+
+def test_additional_kwargs_reasoning_stripped() -> None:
+    """Test that reasoning_content in additional_kwargs is stripped."""
+    model = FakeReasoningModel(
+        tool_calls=[[]],
+        reasoning_style="additional_kwargs",
+    )
+    agent = create_agent(model=model, tools=[])
+
+    result = agent.invoke({"messages": [HumanMessage("hello")]})
+    messages = result["messages"]
+
+    for msg in messages:
+        if isinstance(msg, AIMessage):
+            assert "reasoning_content" not in msg.additional_kwargs, (
+                "reasoning_content should be stripped from additional_kwargs"
+            )
+
+
+def test_responses_api_reasoning_stripped() -> None:
+    """Test that OpenAI Responses API reasoning dict is stripped."""
+    model = FakeReasoningModel(
+        tool_calls=[[]],
+        reasoning_style="responses_api",
+    )
+    agent = create_agent(model=model, tools=[])
+
+    result = agent.invoke({"messages": [HumanMessage("hello")]})
+    messages = result["messages"]
+
+    for msg in messages:
+        if isinstance(msg, AIMessage):
+            assert "reasoning" not in msg.additional_kwargs, (
+                "reasoning dict should be stripped from additional_kwargs"
+            )
+
+
+def test_reasoning_stripped_with_tool_calls() -> None:
+    """Test that reasoning is stripped but tool calls are preserved."""
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results: {query}"
+
+    model = FakeReasoningModel(
+        tool_calls=[
+            [ToolCall(name="search", args={"query": "test"}, id="tc1")],
+            [],
+        ],
+        reasoning_style="content_blocks",
+    )
+    agent = create_agent(model=model, tools=[search])
+
+    result = agent.invoke({"messages": [HumanMessage("search for test")]})
+    messages = result["messages"]
+
+    # Verify tool was called (search results in messages)
+    tool_msgs = [m for m in messages if hasattr(m, "tool_call_id")]
+    assert len(tool_msgs) > 0, "Tool should have been called"
+
+    # Verify no reasoning in any AI message
+    for msg in messages:
+        if isinstance(msg, AIMessage) and isinstance(msg.content, list):
+            for block in msg.content:
+                if isinstance(block, dict):
+                    assert block.get("type") not in {"reasoning", "thinking"}
+
+
+def test_no_reasoning_passthrough() -> None:
+    """Test that messages without reasoning pass through unchanged."""
+    model = FakeToolCallingModel(tool_calls=[[]])
+    agent = create_agent(model=model, tools=[])
+
+    result = agent.invoke({"messages": [HumanMessage("hello")]})
+    messages = result["messages"]
+
+    # Should have at least the human message and an AI response
+    ai_messages = [m for m in messages if isinstance(m, AIMessage)]
+    assert len(ai_messages) >= 1
+    # Content should be a string (no list processing needed)
+    assert isinstance(ai_messages[-1].content, str)

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -2028,7 +2028,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.3.1"
+version = "1.3.2"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.75.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.78.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
@@ -2404,7 +2404,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Add `strip_reasoning()` utility in `langchain-core` that strips reasoning/thinking content from `AIMessage` objects (both content blocks and `additional_kwargs`)
- Call `strip_reasoning()` in `_handle_model_output()` in the agent factory so reasoning never persists in message history
- Supports all known reasoning formats: OpenAI reasoning blocks, Anthropic thinking blocks, Ollama/DeepSeek/XAI/Groq `reasoning_content` string, and OpenAI Responses API `reasoning` dict

## Test plan
- [x] 12 unit tests for `strip_reasoning()` in `langchain-core` covering all reasoning formats, edge cases, and preservation of non-reasoning data
- [x] 6 integration tests with agent factory using `FakeReasoningModel` that verifies reasoning is stripped from agent output across all formats
- [x] Full test suites pass for both `langchain-core` and `langchain`

Closes #34124
