### PR TITLE
feat(core): add streaming token classification metadata

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -476,6 +476,29 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         handlers = run_manager.handlers if run_manager else []
         return any(isinstance(h, _StreamingCallbackHandler) for h in handlers)
 
+    def _get_lc_token_callback_metadata(
+        self, chunk: ChatGenerationChunk
+    ) -> dict[str, Any]:
+        """Build metadata for filtering streamed tokens in callbacks."""
+        msg = chunk.message
+        if not isinstance(msg, AIMessageChunk):
+            return {
+                "lc_token_type": "other",
+                "lc_is_assistant_content": False,
+                "lc_is_tool_call": False,
+            }
+
+        has_tool_call = bool(getattr(msg, "tool_call_chunks", None))
+
+        lc_stream_type: Literal["content", "tool_call", "other"] = (
+            "tool_call" if has_tool_call else "content"
+        )
+        return {
+            "lc_token_type": lc_stream_type,
+            "lc_is_assistant_content": lc_stream_type == "content",
+            "lc_is_tool_call": has_tool_call,
+        }
+
     @override
     def stream(
         self,
@@ -555,7 +578,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                             if "index" not in block:
                                 block["index"] = index
                     run_manager.on_llm_new_token(
-                        cast("str", chunk.message.content), chunk=chunk
+                        cast("str", chunk.message.content),
+                        chunk=chunk,
+                        **self._get_lc_token_callback_metadata(chunk),
                     )
                     chunks.append(chunk)
                     yield cast("AIMessageChunk", chunk.message)
@@ -575,7 +600,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                         content=empty_content, chunk_position="last", id=run_id
                     )
                     run_manager.on_llm_new_token(
-                        "", chunk=ChatGenerationChunk(message=msg_chunk)
+                        "",
+                        chunk=ChatGenerationChunk(message=msg_chunk),
+                        **self._get_lc_token_callback_metadata(
+                            ChatGenerationChunk(message=msg_chunk)
+                        ),
                     )
                     yield msg_chunk
             except BaseException as e:
@@ -687,7 +716,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                         if "index" not in block:
                             block["index"] = index
                 await run_manager.on_llm_new_token(
-                    cast("str", chunk.message.content), chunk=chunk
+                    cast("str", chunk.message.content),
+                    chunk=chunk,
+                    **self._get_lc_token_callback_metadata(chunk),
                 )
                 chunks.append(chunk)
                 yield cast("AIMessageChunk", chunk.message)
@@ -706,7 +737,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                     content=empty_content, chunk_position="last", id=run_id
                 )
                 await run_manager.on_llm_new_token(
-                    "", chunk=ChatGenerationChunk(message=msg_chunk)
+                    "",
+                    chunk=ChatGenerationChunk(message=msg_chunk),
+                    **self._get_lc_token_callback_metadata(
+                        ChatGenerationChunk(message=msg_chunk)
+                    ),
                 )
                 yield msg_chunk
         except BaseException as e:
@@ -1208,7 +1243,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                     if chunk.message.id is None:
                         chunk.message.id = run_id
                     run_manager.on_llm_new_token(
-                        cast("str", chunk.message.content), chunk=chunk
+                        cast("str", chunk.message.content),
+                        chunk=chunk,
+                        **self._get_lc_token_callback_metadata(chunk),
                     )
                 chunks.append(chunk)
                 yielded = True
@@ -1228,7 +1265,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                     )
                 )
                 if run_manager:
-                    run_manager.on_llm_new_token("", chunk=chunk)
+                    run_manager.on_llm_new_token(
+                        "",
+                        chunk=chunk,
+                        **self._get_lc_token_callback_metadata(chunk),
+                    )
                 chunks.append(chunk)
             result = generate_from_stream(iter(chunks))
         elif inspect.signature(self._generate).parameters.get("run_manager"):
@@ -1334,7 +1375,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                     if chunk.message.id is None:
                         chunk.message.id = run_id
                     await run_manager.on_llm_new_token(
-                        cast("str", chunk.message.content), chunk=chunk
+                        cast("str", chunk.message.content),
+                        chunk=chunk,
+                        **self._get_lc_token_callback_metadata(chunk),
                     )
                 chunks.append(chunk)
                 yielded = True
@@ -1354,7 +1397,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                     )
                 )
                 if run_manager:
-                    await run_manager.on_llm_new_token("", chunk=chunk)
+                    await run_manager.on_llm_new_token(
+                        "",
+                        chunk=chunk,
+                        **self._get_lc_token_callback_metadata(chunk),
+                    )
                 chunks.append(chunk)
             result = generate_from_stream(iter(chunks))
         elif inspect.signature(self._agenerate).parameters.get("run_manager"):

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -9,6 +9,7 @@ import pytest
 from typing_extensions import override
 
 from langchain_core.callbacks import (
+    BaseCallbackHandler,
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models import (
@@ -29,6 +30,7 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
+from langchain_core.messages.tool import tool_call_chunk
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.outputs.llm_result import LLMResult
 from langchain_core.tracers import LogStreamCallbackHandler
@@ -264,6 +266,74 @@ async def test_astream_implementation_fallback_to_stream() -> None:
         _any_id_ai_message_chunk(content="b", chunk_position="last"),
     ]
     assert len({chunk.id for chunk in astream_chunks}) == 1
+
+
+def test_streaming_token_callback_includes_lc_token_metadata() -> None:
+    class _RecordingHandler(BaseCallbackHandler):
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, Any]]] = []
+
+        def on_llm_new_token(  # type: ignore[override]
+            self,
+            token: str,
+            *,
+            run_id: uuid.UUID,
+            chunk: ChatGenerationChunk | None = None,
+            **kwargs: Any,
+        ) -> None:
+            del run_id, chunk
+            self.calls.append((token, kwargs))
+
+    class _ToolCallStreamingModel(BaseChatModel):
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            return ChatResult(
+                generations=[ChatGeneration(message=AIMessage(content="unused"))]
+            )
+
+        @override
+        def _stream(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> Iterator[ChatGenerationChunk]:
+            yield ChatGenerationChunk(
+                message=AIMessageChunk(
+                    content="",
+                    tool_call_chunks=[
+                        tool_call_chunk(name="search", args="{}", id="call_1", index=0)
+                    ],
+                )
+            )
+            yield ChatGenerationChunk(message=AIMessageChunk(content="hi"))
+
+        @property
+        @override
+        def _llm_type(self) -> str:
+            return "tool-call-streaming"
+
+    handler = _RecordingHandler()
+    model = _ToolCallStreamingModel(callbacks=[handler])
+
+    _ = list(model.stream([HumanMessage(content="hello")]))
+
+    assert any(
+        kw.get("lc_token_type") == "tool_call" and kw.get("lc_is_tool_call") is True
+        for _token, kw in handler.calls
+    )
+    assert any(
+        kw.get("lc_token_type") == "content"
+        and kw.get("lc_is_assistant_content") is True
+        for _token, kw in handler.calls
+    )
 
 
 async def test_astream_implementation_uses_astream() -> None:

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -17,6 +17,7 @@ from typing import (
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, AnyMessage, SystemMessage, ToolMessage
+from langchain_core.runnables.config import ensure_config
 from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.constants import END, START
@@ -1235,7 +1236,15 @@ def create_agent(
         if request.system_message:
             messages = [request.system_message, *messages]
 
-        output = model_.invoke(messages)
+        model_call_config = ensure_config()
+        extra_tags = [
+            "lc:agent",
+            "lc:agent_node:model",
+            *([f"lc:agent_name:{name}"] if name else []),
+        ]
+        model_call_config["tags"] = [*model_call_config["tags"], *extra_tags]
+
+        output = model_.invoke(messages, config=model_call_config)
         if name:
             output.name = name
 
@@ -1283,7 +1292,15 @@ def create_agent(
         if request.system_message:
             messages = [request.system_message, *messages]
 
-        output = await model_.ainvoke(messages)
+        model_call_config = ensure_config()
+        extra_tags = [
+            "lc:agent",
+            "lc:agent_node:model",
+            *([f"lc:agent_name:{name}"] if name else []),
+        ]
+        model_call_config["tags"] = [*model_call_config["tags"], *extra_tags]
+
+        output = await model_.ainvoke(messages, config=model_call_config)
         if name:
             output.name = name
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_streaming_final_only_tokens.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_streaming_final_only_tokens.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+from langchain.agents import create_agent
+
+
+class _RecordingModel(BaseChatModel):
+    """Model that records the config passed from the agent."""
+
+    seen_config: dict[str, Any] | None = None
+
+    @property
+    def _llm_type(self) -> str:
+        return "recording-model"
+
+    def _generate(  # type: ignore[override]
+        self,
+        messages: list[Any],
+        stop: list[str] | None = None,
+        run_manager: Any = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="done"))])
+
+    async def ainvoke(  # type: ignore[override]
+        self,
+        model_input: Any,
+        config: dict[str, Any] | None = None,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> AIMessage:
+        del model_input, stop, kwargs
+        self.seen_config = config
+        return AIMessage(content="done")
+
+
+async def test_agent_model_calls_include_stable_tags() -> None:
+    model = _RecordingModel()
+    agent = create_agent(model=model, tools=[], name="my-agent")
+
+    _ = await agent.ainvoke({"messages": [{"role": "user", "content": "hi"}]})
+
+    assert model.seen_config is not None
+    tags = model.seen_config.get("tags") or []
+    assert "lc:agent_node:model" in tags
+    assert "lc:agent_name:my-agent" in tags

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2152,7 +2152,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.13"
+version = "1.2.15"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2335,7 +2335,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.9"
+version = "1.1.10"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },
@@ -2346,7 +2346,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", editable = "../core" },
-    { name = "openai", specifier = ">=1.109.1,<3.0.0" },
+    { name = "openai", specifier = ">=2.20.0,<3.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
 ]
 
@@ -2375,7 +2375,7 @@ test-integration = [
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
-    { name = "pillow", specifier = ">=10.3.0,<13.0.0" },
+    { name = "pillow", specifier = ">=12.1.1,<13.0.0" },
 ]
 typing = [
     { name = "langchain-core", editable = "../core" },
@@ -2443,7 +2443,7 @@ typing = [
 
 [[package]]
 name = "langchain-text-splitters"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "../text-splitters" }
 dependencies = [
     { name = "langchain-core" },
@@ -3371,7 +3371,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.8.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3383,9 +3383,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/0c/b9321e12f89e236f5e9a46346c30fb801818e22ba33b798a5aca84be895c/openai-2.8.0.tar.gz", hash = "sha256:4851908f6d6fcacbd47ba659c5ac084f7725b752b6bfa1e948b6fbfc111a6bad", size = 602412, upload-time = "2025-11-13T18:15:25.847Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/e1/0a6560bab7fb7b5a88d35a505b859c6d969cb2fa2681b568eb5d95019dec/openai-2.8.0-py3-none-any.whl", hash = "sha256:ba975e347f6add2fe13529ccb94d54a578280e960765e5224c34b08d7e029ddf", size = 1022692, upload-time = "2025-11-13T18:15:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
 ]
 
 [[package]]

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2152,7 +2152,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.15"
+version = "1.2.13"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2335,7 +2335,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.10"
+version = "1.1.9"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },
@@ -2346,7 +2346,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", editable = "../core" },
-    { name = "openai", specifier = ">=2.20.0,<3.0.0" },
+    { name = "openai", specifier = ">=1.109.1,<3.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
 ]
 
@@ -2375,7 +2375,7 @@ test-integration = [
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
-    { name = "pillow", specifier = ">=12.1.1,<13.0.0" },
+    { name = "pillow", specifier = ">=10.3.0,<13.0.0" },
 ]
 typing = [
     { name = "langchain-core", editable = "../core" },
@@ -2443,7 +2443,7 @@ typing = [
 
 [[package]]
 name = "langchain-text-splitters"
-version = "1.1.1"
+version = "1.1.0"
 source = { editable = "../text-splitters" }
 dependencies = [
     { name = "langchain-core" },
@@ -3371,7 +3371,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.21.0"
+version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3383,9 +3383,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/0c/b9321e12f89e236f5e9a46346c30fb801818e22ba33b798a5aca84be895c/openai-2.8.0.tar.gz", hash = "sha256:4851908f6d6fcacbd47ba659c5ac084f7725b752b6bfa1e948b6fbfc111a6bad", size = 602412, upload-time = "2025-11-13T18:15:25.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e1/0a6560bab7fb7b5a88d35a505b859c6d969cb2fa2681b568eb5d95019dec/openai-2.8.0-py3-none-any.whl", hash = "sha256:ba975e347f6add2fe13529ccb94d54a578280e960765e5224c34b08d7e029ddf", size = 1022692, upload-time = "2025-11-13T18:15:23.621Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

Adds minimal, stable metadata to on_llm_new_token callback kwargs so downstream consumers can filter streamed tokens:
- `lc_token_type: "content" | "tool_call" | "other"`
- `lc_is_assistant_content: bool`
- `lc_is_tool_call: bool`

Updates create_agent model invocations to include stable attribution tags in callback tags:
- `lc:agent`, `lc:agent_node:model`, and `lc:agent_name:<name>` (when provided)

Related to: #35276 

### Technical changes

- Metadata is derived strictly from the streamed ChatGenerationChunk / AIMessageChunk (checks tool_call_chunks).
- Agent tagging is additive and only affects model-node calls inside create_agent.

### Example usage

You can now filter on_llm_new_token events to stream only assistant content tokens (and ignore tool-call deltas) while running an agent with `astream(..., stream_mode="updates")`.

```
from typing import Any
from langchain_core.callbacks import AsyncCallbackHandler

class TokenQueueStreamingHandler(AsyncCallbackHandler):
    def __init__(self, queue):
        self.queue = queue

    async def on_llm_new_token(self, token: str, **kwargs: Any) -> None:
        if not token:
            return

        # Only stream assistant content tokens (ignore tool-call deltas)
        if kwargs.get("lc_is_assistant_content") is True:
            # Optional: only accept tokens emitted by the agent model node
            if "lc:agent_node:model" in (kwargs.get("tags") or []):
                await self.queue.put(token)
```

### Tests added

- `langchain-core`: unit test asserts the streaming callback receives the new metadata and differentiates tool-call vs content chunks.
- `langchain_v1`: unit test asserts create_agent passes the expected stable tags into the model call config.