### PR TITLE
fix(core): prevent empty list ToolMessage content breaking string-onl…

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -126,6 +126,9 @@ class ToolMessage(BaseMessage, ToolOutputMixin):
                         raise ValueError(msg) from e
                 else:
                     values["content"].append(x)
+            # Empty list is not valid content for many model APIs.
+            if not values["content"]:
+                values["content"] = ""
 
         tool_call_id = values["tool_call_id"]
         if isinstance(tool_call_id, (UUID, int, float)):

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1611,7 +1611,12 @@ def convert_to_openai_messages(
             oai_msg["id"] = message.id
 
         if not message.content:
-            content = "" if text_format == "string" else []
+            # ToolMessage empty content should always be "" since many model
+            # APIs reject empty arrays for tool message content fields.
+            if isinstance(message, ToolMessage):
+                content = ""
+            else:
+                content = "" if text_format == "string" else []
         elif isinstance(message.content, str):
             if text_format == "string":
                 content = message.content

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1291,7 +1291,9 @@ def _is_message_content_type(obj: Any) -> bool:
         `True` if the object is valid message content, `False` otherwise.
     """
     return isinstance(obj, str) or (
-        isinstance(obj, list) and all(_is_message_content_block(e) for e in obj)
+        isinstance(obj, list)
+        and len(obj) > 0
+        and all(_is_message_content_block(e) for e in obj)
     )
 
 

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1203,6 +1203,37 @@ def test_convert_to_openai_messages_tool_message() -> None:
     assert result[0]["tool_call_id"] == "123"
 
 
+def test_convert_to_openai_messages_tool_message_empty_list_string_format() -> None:
+    """ToolMessage with empty list content + text_format='string' should produce ''."""
+    tool_message = ToolMessage(content="", tool_call_id="123")
+    result = convert_to_openai_messages([tool_message], text_format="string")
+    assert len(result) == 1
+    assert result[0]["content"] == ""
+    assert result[0]["tool_call_id"] == "123"
+
+
+def test_convert_to_openai_messages_tool_message_empty_content_block_format() -> None:
+    """ToolMessage with empty content + text_format='block' should produce ''."""
+    tool_message = ToolMessage(content="", tool_call_id="123")
+    result = convert_to_openai_messages([tool_message], text_format="block")
+    assert len(result) == 1
+    # ToolMessage empty content is always "" even in block format, because
+    # many model APIs reject empty arrays for tool message content.
+    assert result[0]["content"] == ""
+    assert result[0]["tool_call_id"] == "123"
+
+
+def test_convert_to_openai_messages_tool_message_list_block_format() -> None:
+    """ToolMessage with list content + text_format='block' stays as list."""
+    tool_message = ToolMessage(
+        content=[{"type": "text", "text": "hello"}], tool_call_id="123"
+    )
+    result = convert_to_openai_messages([tool_message], text_format="block")
+    assert len(result) == 1
+    assert isinstance(result[0]["content"], list)
+    assert result[0]["content"] == [{"type": "text", "text": "hello"}]
+
+
 def test_convert_to_openai_messages_tool_use() -> None:
     messages = [
         AIMessage(

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1043,6 +1043,20 @@ def test_tool_message_content() -> None:
     )
 
 
+def test_tool_message_empty_list_content() -> None:
+    """Empty list content should be normalized to empty string."""
+    msg = ToolMessage([], tool_call_id="1")
+    assert msg.content == ""
+    assert isinstance(msg.content, str)
+
+
+def test_tool_message_nonempty_list_content_preserved() -> None:
+    """Non-empty list content with valid items should be preserved."""
+    msg = ToolMessage([{"type": "text", "text": "hello"}], tool_call_id="1")
+    assert msg.content == [{"type": "text", "text": "hello"}]
+    assert isinstance(msg.content, list)
+
+
 def test_tool_message_tool_call_id() -> None:
     ToolMessage("foo", tool_call_id="1")
     ToolMessage("foo", tool_call_id=uuid.uuid4())

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2133,10 +2133,41 @@ def test__is_message_content_block(obj: Any, *, expected: bool) -> None:
         ("foo", True),
         (valid_tool_result_blocks, True),
         (invalid_tool_result_blocks, False),
+        ([], False),  # Empty list should not be valid content
     ],
 )
 def test__is_message_content_type(obj: Any, *, expected: bool) -> None:
     assert _is_message_content_type(obj) is expected
+
+
+def test_tool_empty_list_return_stringified() -> None:
+    """Tool returning [] should produce ToolMessage(content='[]'), not content=[]."""
+
+    def return_empty_list(x: str) -> list:
+        return []
+
+    tool = Tool(name="empty_list", func=return_empty_list, description="test")
+    result = tool.invoke(
+        ToolCall(name="empty_list", args={"x": "hello"}, id="1", type="tool_call")
+    )
+    assert isinstance(result, ToolMessage)
+    assert result.content == "[]"
+    assert isinstance(result.content, str)
+
+
+def test_tool_empty_dict_return_stringified() -> None:
+    """Tool returning {} should produce ToolMessage(content='{}')."""
+
+    def return_empty_dict(x: str) -> dict:
+        return {}
+
+    tool = Tool(name="empty_dict", func=return_empty_dict, description="test")
+    result = tool.invoke(
+        ToolCall(name="empty_dict", args={"x": "hello"}, id="1", type="tool_call")
+    )
+    assert isinstance(result, ToolMessage)
+    assert result.content == "{}"
+    assert isinstance(result.content, str)
 
 
 @pytest.mark.parametrize("use_v1_namespace", [True, False])

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Fix `_is_message_content_type` to reject empty lists (`all([])` is `True` in Python)
- Add defense-in-depth in `ToolMessage.coerce_args` to normalize empty list content to `""`
- Ensure `convert_to_openai_messages` always produces `""` for empty ToolMessage content

Fixes #33965

## Test plan
- [x] `_is_message_content_type([])` now returns `False`
- [x] Tool returning `[]` produces `ToolMessage(content="[]")` not `content=[]`
- [x] `ToolMessage(content=[])` normalizes to `content=""`
- [x] `convert_to_openai_messages` with empty ToolMessage produces `""` in both formats
- [x] Non-empty list content preserved (no regression)
- [x] Full test suite passes (1654 tests)
