### PR TITLE
fix(core): resolve tool parameter name collision with RunnableConfig …

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -961,8 +961,10 @@ class ChildTool(BaseTool):
                 )
                 if signature(self._run).parameters.get("run_manager"):
                     tool_kwargs |= {"run_manager": run_manager}
-                if config_param := _get_runnable_config_param(self._run):
-                    tool_kwargs |= {config_param: config}
+                if (
+                    config_param := _get_runnable_config_param(self._run)
+                ) and config_param not in tool_kwargs:
+                    tool_kwargs[config_param] = config
                 response = context.run(self._run, *tool_args, **tool_kwargs)
             if self.response_format == "content_and_artifact":
                 msg = (
@@ -1089,7 +1091,9 @@ class ChildTool(BaseTool):
                 )
                 if signature(func_to_check).parameters.get("run_manager"):
                     tool_kwargs["run_manager"] = run_manager
-                if config_param := _get_runnable_config_param(func_to_check):
+                if (
+                    config_param := _get_runnable_config_param(func_to_check)
+                ) and config_param not in tool_kwargs:
                     tool_kwargs[config_param] = config
 
                 coro = self._arun(*tool_args, **tool_kwargs)

--- a/libs/core/langchain_core/tools/simple.py
+++ b/libs/core/langchain_core/tools/simple.py
@@ -16,7 +16,7 @@ from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,  # noqa: TC001
     CallbackManagerForToolRun,  # noqa: TC001
 )
-from langchain_core.runnables import RunnableConfig, run_in_executor
+from langchain_core.runnables import RunnableConfig, ensure_config, run_in_executor
 from langchain_core.tools.base import (
     ArgsSchema,
     BaseTool,
@@ -99,7 +99,6 @@ class Tool(BaseTool):
     def _run(
         self,
         *args: Any,
-        config: RunnableConfig,
         run_manager: CallbackManagerForToolRun | None = None,
         **kwargs: Any,
     ) -> Any:
@@ -107,13 +106,13 @@ class Tool(BaseTool):
 
         Args:
             *args: Positional arguments to pass to the tool
-            config: Configuration for the run
             run_manager: Optional callback manager to use for the run
             **kwargs: Keyword arguments to pass to the tool
 
         Returns:
             The result of the tool execution
         """
+        config = ensure_config()
         if self.func:
             if run_manager and signature(self.func).parameters.get("callbacks"):
                 kwargs["callbacks"] = run_manager.get_child()
@@ -126,7 +125,6 @@ class Tool(BaseTool):
     async def _arun(
         self,
         *args: Any,
-        config: RunnableConfig,
         run_manager: AsyncCallbackManagerForToolRun | None = None,
         **kwargs: Any,
     ) -> Any:
@@ -134,13 +132,13 @@ class Tool(BaseTool):
 
         Args:
             *args: Positional arguments to pass to the tool
-            config: Configuration for the run
             run_manager: Optional callback manager to use for the run
             **kwargs: Keyword arguments to pass to the tool
 
         Returns:
             The result of the tool execution
         """
+        config = ensure_config()
         if self.coroutine:
             if run_manager and signature(self.coroutine).parameters.get("callbacks"):
                 kwargs["callbacks"] = run_manager.get_child()
@@ -150,9 +148,7 @@ class Tool(BaseTool):
 
         # NOTE: this code is unreachable since _arun is only called if coroutine is not
         # None.
-        return await super()._arun(
-            *args, config=config, run_manager=run_manager, **kwargs
-        )
+        return await super()._arun(*args, run_manager=run_manager, **kwargs)
 
     # TODO: this is for backwards compatibility, remove in future
     def __init__(

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -21,7 +21,7 @@ from langchain_core.callbacks import (
     AsyncCallbackManagerForToolRun,  # noqa: TC001
     CallbackManagerForToolRun,  # noqa: TC001
 )
-from langchain_core.runnables import RunnableConfig, run_in_executor
+from langchain_core.runnables import RunnableConfig, ensure_config, run_in_executor
 from langchain_core.tools.base import (
     _EMPTY_SET,
     FILTERED_ARGS,
@@ -74,7 +74,6 @@ class StructuredTool(BaseTool):
     def _run(
         self,
         *args: Any,
-        config: RunnableConfig,
         run_manager: CallbackManagerForToolRun | None = None,
         **kwargs: Any,
     ) -> Any:
@@ -82,13 +81,13 @@ class StructuredTool(BaseTool):
 
         Args:
             *args: Positional arguments to pass to the tool
-            config: Configuration for the run
             run_manager: Optional callback manager to use for the run
             **kwargs: Keyword arguments to pass to the tool
 
         Returns:
             The result of the tool execution
         """
+        config = ensure_config()
         if self.func:
             if run_manager and signature(self.func).parameters.get("callbacks"):
                 kwargs["callbacks"] = run_manager.get_child()
@@ -101,7 +100,6 @@ class StructuredTool(BaseTool):
     async def _arun(
         self,
         *args: Any,
-        config: RunnableConfig,
         run_manager: AsyncCallbackManagerForToolRun | None = None,
         **kwargs: Any,
     ) -> Any:
@@ -109,13 +107,13 @@ class StructuredTool(BaseTool):
 
         Args:
             *args: Positional arguments to pass to the tool
-            config: Configuration for the run
             run_manager: Optional callback manager to use for the run
             **kwargs: Keyword arguments to pass to the tool
 
         Returns:
             The result of the tool execution
         """
+        config = ensure_config()
         if self.coroutine:
             if run_manager and signature(self.coroutine).parameters.get("callbacks"):
                 kwargs["callbacks"] = run_manager.get_child()
@@ -125,9 +123,7 @@ class StructuredTool(BaseTool):
 
         # If self.coroutine is None, then this will delegate to the default
         # implementation which is expected to delegate to _run on a separate thread.
-        return await super()._arun(
-            *args, config=config, run_manager=run_manager, **kwargs
-        )
+        return await super()._arun(*args, run_manager=run_manager, **kwargs)
 
     @classmethod
     def from_function(

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3631,3 +3631,103 @@ def test_tool_args_schema_falsy_defaults() -> None:
     # Invoke with only required argument - falsy defaults should be applied
     result = config_tool.invoke({"name": "test"})
     assert result == "name=test, enabled=False, count=0, prefix=''"
+
+
+# Tests for issue #34029: Tool parameter named "config" collides with RunnableConfig
+
+
+def test_tool_with_config_str_param() -> None:
+    """Tool with a parameter named 'config' (type str) should work correctly."""
+
+    @tool
+    def my_tool(config: str, name: str) -> str:
+        """A tool that takes a config string."""
+        return f"config={config}, name={name}"
+
+    result = my_tool.invoke({"config": "my_config", "name": "test"})
+    assert result == "config=my_config, name=test"
+
+
+def test_tool_with_config_str_param_via_tool_call() -> None:
+    """Tool with 'config' param invoked via ToolCall should work."""
+
+    @tool
+    def my_tool(config: str, name: str) -> str:
+        """A tool that takes a config string."""
+        return f"config={config}, name={name}"
+
+    tool_call: ToolCall = {
+        "name": "my_tool",
+        "args": {"config": "my_config", "name": "test"},
+        "id": "abc123",
+        "type": "tool_call",
+    }
+    result = my_tool.invoke(tool_call)
+    assert result == ToolMessage(
+        content="config=my_config, name=test",
+        name="my_tool",
+        tool_call_id="abc123",
+    )
+
+
+async def test_async_tool_with_config_str_param() -> None:
+    """Async tool with 'config' param should also work."""
+
+    @tool
+    async def my_tool(config: str, name: str) -> str:
+        """A tool that takes a config string."""
+        return f"config={config}, name={name}"
+
+    result = await my_tool.ainvoke({"config": "my_config", "name": "test"})
+    assert result == "config=my_config, name=test"
+
+
+def test_tool_with_config_runnable_config_still_works() -> None:
+    """Tool with config: RunnableConfig should still receive the RunnableConfig."""
+
+    @tool
+    def my_tool(bar: str, config: RunnableConfig) -> str:
+        """A tool that uses RunnableConfig."""
+        assert config["configurable"]["foo"] == "not-bar"
+        return bar
+
+    result = my_tool.invoke({"bar": "baz"}, {"configurable": {"foo": "not-bar"}})
+    assert result == "baz"
+
+
+async def test_async_tool_with_config_runnable_config_still_works() -> None:
+    """Async tool with config: RunnableConfig should still get it."""
+
+    @tool
+    async def my_tool(bar: str, config: RunnableConfig) -> str:
+        """A tool that uses RunnableConfig."""
+        assert config["configurable"]["foo"] == "not-bar"
+        return bar
+
+    result = await my_tool.ainvoke({"bar": "baz"}, {"configurable": {"foo": "not-bar"}})
+    assert result == "baz"
+
+
+def test_structured_tool_with_config_str_param() -> None:
+    """StructuredTool.from_function with 'config' str param should work."""
+
+    def my_func(config: str, name: str) -> str:
+        """A function that takes a config string."""
+        return f"config={config}, name={name}"
+
+    my_tool = StructuredTool.from_function(my_func)
+    result = my_tool.invoke({"config": "my_config", "name": "test"})
+    assert result == "config=my_config, name=test"
+
+
+def test_tool_with_config_str_param_schema() -> None:
+    """Tool with 'config: str' should include 'config' in the schema."""
+
+    @tool
+    def my_tool(config: str, name: str) -> str:
+        """A tool that takes a config string."""
+        return f"config={config}, name={name}"
+
+    schema = my_tool.get_input_schema().model_json_schema()
+    assert "config" in schema["properties"]
+    assert "name" in schema["properties"]

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1078,7 +1078,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.3"
+version = "1.1.4"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Fix tool calls failing with `TypeError: missing 1 required positional argument: 'config'`
  when a user's tool has a parameter named `config` (of non-`RunnableConfig` type)
- Remove `config: RunnableConfig` from `StructuredTool._run/_arun` and `Tool._run/_arun`
  signatures; retrieve config from context via `ensure_config()` instead
- Add collision guard in `BaseTool.run()/arun()` to protect custom subclasses

Fixes #34029

## Test plan
- [x] 7 new tests covering sync/async tools with `config: str` parameter
- [x] Regression tests for `config: RunnableConfig` still working
- [x] All 167 tool tests pass
- [x] All 1486 broader unit tests pass
- [x] `make format` and `make lint` pass
