### PR TITLE
fix(core): add ChatBedrockConverse to deserialization allowlist

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -316,6 +316,12 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "bedrock",
         "ChatBedrock",
     ),
+    ("langchain_aws", "chat_models", "ChatBedrockConverse"): (
+        "langchain_aws",
+        "chat_models",
+        "bedrock_converse",
+        "ChatBedrockConverse",
+    ),
     ("langchain_google_genai", "chat_models", "ChatGoogleGenerativeAI"): (
         "langchain_google_genai",
         "chat_models",

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 from langchain_core.documents import Document
 from langchain_core.load import InitValidator, Serializable, dumpd, dumps, load, loads
+from langchain_core.load.mapping import SERIALIZABLE_MAPPING
 from langchain_core.load.serializable import _is_field_useful
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration, Generation
@@ -891,3 +892,23 @@ class TestJinja2SecurityBlocking:
         # jinja2 should be blocked by default
         with pytest.raises(ValueError, match="Jinja2 templates are not allowed"):
             load(serialized_jinja2, allowed_objects=[PromptTemplate])
+
+
+def test_chat_bedrock_converse_in_serializable_mapping() -> None:
+    """ChatBedrockConverse must be in SERIALIZABLE_MAPPING.
+
+    Ensures langsmith pull_prompt(include_model=True) can deserialize it.
+    Regression test for https://github.com/langchain-ai/langchain/issues/34645.
+    """
+    key = ("langchain_aws", "chat_models", "ChatBedrockConverse")
+    assert key in SERIALIZABLE_MAPPING, (
+        "ChatBedrockConverse is missing from SERIALIZABLE_MAPPING. "
+        "Add it so langsmith pull_prompt(include_model=True) can deserialize it."
+    )
+    expected_value = (
+        "langchain_aws",
+        "chat_models",
+        "bedrock_converse",
+        "ChatBedrockConverse",
+    )
+    assert SERIALIZABLE_MAPPING[key] == expected_value


### PR DESCRIPTION
## Summary

Fixes #34645.

- `ChatBedrockConverse` was absent from `SERIALIZABLE_MAPPING` in `langchain_core/load/mapping.py`.
- Since `langchain-core>=1.2.5` (PR #34455 tightened the allowlist enforcement), calling `langsmith.pull_prompt(..., include_model=True)` with a `ChatBedrockConverse` model raises:
  ```
  ValueError: Trying to load an object that doesn't implement serialization:
  allowed_objects='core' only permits core langchain-core classes.
  ```
- `ChatBedrock` and `BedrockLLM` were already in the mapping — `ChatBedrockConverse` was simply missed.
- Fix: one entry added pointing `("langchain_aws", "chat_models", "ChatBedrockConverse")` → `langchain_aws.chat_models.bedrock_converse.ChatBedrockConverse` (confirmed via `ChatBedrockConverse.get_lc_namespace()` returning `["langchain_aws", "chat_models"]`).

## Areas requiring careful review

- The serialization key `("langchain_aws", "chat_models", "ChatBedrockConverse")` is derived from `get_lc_namespace()` + class name — confirmed against the source in `langchain-ai/langchain-aws`.
- No behaviour change for any other class.

## Test plan

- [x] `test_chat_bedrock_converse_in_serializable_mapping` — asserts the key is present and maps to the correct module path (no `langchain-aws` install required)
- [x] Full `tests/unit_tests/load/test_serializable.py` suite passes (45 tests)
- [x] `ruff check`, `ruff format`, `mypy` clean

> **AI disclaimer:** This PR was developed with assistance from Claude Code (Anthropic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)