### PR TITLE
fix(core): treat empty tool chunk ids as missing in merge

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -121,10 +121,9 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                             "index" in e_left
                             and e_left["index"] == e["index"]  # index matches
                             and (  # IDs not inconsistent
-                                (left_id := e_left.get("id")) is None
-                                or left_id == ""
-                                or (right_id := e.get("id")) is None
-                                or right_id in ("", left_id)
+                                e_left.get("id") in (None, "")
+                                or e.get("id") in (None, "")
+                                or e_left.get("id") == e.get("id")
                             )
                         )
                     ]

--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -124,8 +124,7 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                                 (left_id := e_left.get("id")) is None
                                 or left_id == ""
                                 or (right_id := e.get("id")) is None
-                                or right_id == ""
-                                or left_id == right_id
+                                or right_id in ("", left_id)
                             )
                         )
                     ]

--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -121,8 +121,8 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                             "index" in e_left
                             and e_left["index"] == e["index"]  # index matches
                             and (  # IDs not inconsistent
-                                e_left.get("id") is None
-                                or e.get("id") is None
+                                e_left.get("id") in {None, ""}
+                                or e.get("id") in {None, ""}
                                 or e_left["id"] == e["id"]
                             )
                         )

--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -121,9 +121,11 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                             "index" in e_left
                             and e_left["index"] == e["index"]  # index matches
                             and (  # IDs not inconsistent
-                                e_left.get("id") in {None, ""}
-                                or e.get("id") in {None, ""}
-                                or e_left["id"] == e["id"]
+                                (left_id := e_left.get("id")) is None
+                                or left_id == ""
+                                or (right_id := e.get("id")) is None
+                                or right_id == ""
+                                or left_id == right_id
                             )
                         )
                     ]

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -132,6 +132,34 @@ def test_message_chunks() -> None:
         + AIMessageChunk(
             content="",
             tool_call_chunks=[
+                create_tool_call_chunk(name=None, args='{"arg1": "val', id="", index=0)
+            ],
+        )
+        + AIMessageChunk(
+            content="",
+            tool_call_chunks=[
+                create_tool_call_chunk(name=None, args='ue"}', id="", index=0)
+            ],
+        )
+    ) == AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name="tool1", args='{"arg1": "value"}', id="1", index=0
+            )
+        ],
+    )
+
+    assert (
+        AIMessageChunk(
+            content="",
+            tool_call_chunks=[
+                create_tool_call_chunk(name="tool1", args="", id="1", index=0)
+            ],
+        )
+        + AIMessageChunk(
+            content="",
+            tool_call_chunks=[
                 create_tool_call_chunk(name="tool1", args="a", id=None, index=1)
             ],
         )


### PR DESCRIPTION
Fixes #35395

Tool call chunk aggregation treated `id=""` as a conflicting identifier, which prevented chunks with the same `index` from merging and could break streamed tool-argument reconstruction. This change treats empty ids as missing ids during list merge so chunks continue to merge correctly.

## How did you verify your code works?
- `uv run --project libs/core --group test pytest libs/core/tests/unit_tests/test_messages.py::test_message_chunks`
- `uv run --project libs/core --group test pytest libs/core/tests/unit_tests/test_messages.py`

## Breaking changes
- None

## Depends on
- None