### PR TITLE
docs: add direct LangSmith eval/observability quickstart links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ To improve your LLM application development, pair LangChain with:
 ## Additional resources
 
 - [API Reference](https://reference.langchain.com/python) – Detailed reference on navigating base packages and integrations for LangChain.
+- [LangSmith Evaluation Quickstart](https://docs.langchain.com/langsmith/evaluation-quickstart) – Add deterministic regression checks for agent behavior.
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) – Learn how to contribute to LangChain projects and find good first issues.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) – Our community guidelines and standards for participation.
 - [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -35,6 +35,7 @@ The LangChain ecosystem is built on top of `langchain-core`. Some of the benefit
 ## 📖 Documentation
 
 For full documentation, see the [API reference](https://reference.langchain.com/python/langchain_core/). For conceptual guides, tutorials, and examples on using LangChain, see the [LangChain Docs](https://docs.langchain.com/oss/python/langchain/overview). You can also chat with the docs using [Chat LangChain](https://chat.langchain.com).
+For production eval and tracing workflows, see [LangSmith Evaluation Quickstart](https://docs.langchain.com/langsmith/evaluation-quickstart) and [LangSmith Observability Quickstart](https://docs.langchain.com/langsmith/observability-quickstart).
 
 ## 📕 Releases & Versioning
 

--- a/libs/langchain_v1/README.md
+++ b/libs/langchain_v1/README.md
@@ -27,6 +27,7 @@ LangChain [agents](https://docs.langchain.com/oss/python/langchain/agents) are b
 ## 📖 Documentation
 
 For full documentation, see the [API reference](https://reference.langchain.com/python/langchain/langchain/). For conceptual guides, tutorials, and examples on using LangChain, see the [LangChain Docs](https://docs.langchain.com/oss/python/langchain/overview). You can also chat with the docs using [Chat LangChain](https://chat.langchain.com).
+For production eval and tracing workflows, see [LangSmith Evaluation Quickstart](https://docs.langchain.com/langsmith/evaluation-quickstart) and [LangSmith Observability Quickstart](https://docs.langchain.com/langsmith/observability-quickstart).
 
 ## 📕 Releases & Versioning
 


### PR DESCRIPTION
## Summary
Adds direct links to LangSmith Evaluation and Observability quickstarts in the top-level README, `libs/core/README.md`, and `libs/langchain_v1/README.md`.
This keeps eval and observability onboarding discoverable from the main documentation entry points.

## Scope
Docs-only change.

## Verification
- Verified the updated links and formatting in each modified README.
- Confirmed that no runtime code, imports, dependencies, or tests were changed.

## AI usage
This PR was drafted with assistance from an AI coding tool and reviewed by the author.
