### PR TITLE
fix(core): avoid str coercion in get_from_dict_or_env

### DIFF
--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, cast
 
 
 def env_var_is_set(env_var: str) -> bool:
@@ -47,10 +47,10 @@ def get_from_dict_or_env(
     if isinstance(key, (list, tuple)):
         for k in key:
             if value := data.get(k):
-                return str(value)
+                return cast("str", value)
 
     if isinstance(key, str) and key in data and data[key]:
-        return str(data[key])
+        return cast("str", data[key])
 
     key_for_err = key[0] if isinstance(key, (list, tuple)) else key
 

--- a/libs/core/tests/unit_tests/utils/test_env.py
+++ b/libs/core/tests/unit_tests/utils/test_env.py
@@ -3,7 +3,9 @@ import pytest
 from langchain_core.utils.env import get_from_dict_or_env
 
 
-class _MaskedValue:
+class _MaskedValue(str):
+    __slots__ = ()
+
     def __str__(self) -> str:
         return "masked"
 
@@ -75,15 +77,14 @@ def test_get_from_dict_or_env() -> None:
 
 
 def test_get_from_dict_or_env_does_not_coerce_with_str() -> None:
-    value = _MaskedValue()
-
-    assert (
-        get_from_dict_or_env(
-            {
-                "a": value,
-            },
-            "a",
-            "__SOME_KEY_IN_ENV",
-        )
-        is value
+    value = _MaskedValue("original")
+    result = get_from_dict_or_env(
+        {
+            "a": value,
+        },
+        "a",
+        "__SOME_KEY_IN_ENV",
     )
+
+    assert isinstance(result, _MaskedValue)
+    assert result == "original"

--- a/libs/core/tests/unit_tests/utils/test_env.py
+++ b/libs/core/tests/unit_tests/utils/test_env.py
@@ -3,6 +3,11 @@ import pytest
 from langchain_core.utils.env import get_from_dict_or_env
 
 
+class _MaskedValue:
+    def __str__(self) -> str:
+        return "masked"
+
+
 def test_get_from_dict_or_env() -> None:
     assert (
         get_from_dict_or_env(
@@ -67,3 +72,18 @@ def test_get_from_dict_or_env() -> None:
             )
             is None
         )
+
+
+def test_get_from_dict_or_env_does_not_coerce_with_str() -> None:
+    value = _MaskedValue()
+
+    assert (
+        get_from_dict_or_env(
+            {
+                "a": value,
+            },
+            "a",
+            "__SOME_KEY_IN_ENV",
+        )
+        is value
+    )


### PR DESCRIPTION
This PR fixes a regression where `get_from_dict_or_env` coerced dictionary values with `str(...)`, changing runtime behavior for non-string values. It restores non-coercive behavior and adds a unit test to prevent regressions.

Fixes #35285

Verification:
- uv run --group test pytest tests/unit_tests/utils/test_env.py -q  (from libs/core)
- uv run --group lint ruff check langchain_core/utils/env.py tests/unit_tests/utils/test_env.py  (from libs/core)

AI assistance disclaimer:
This contribution was prepared with assistance from an AI coding agent and reviewed by the author.