### PR TITLE
fix(openai): preserve temperature for gpt-5 when reasoning is unset

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -933,14 +933,18 @@ class BaseChatOpenAI(BaseChatModel):
         if model_lower.startswith("o1") and "temperature" not in values:
             values["temperature"] = 1
 
-        # For gpt-5 models, handle temperature restrictions. Temperature is supported
-        # by gpt-5-chat and gpt-5 models with reasoning_effort='none' or
-        # reasoning={'effort': 'none'}.
+        reasoning_effort = values.get("reasoning_effort")
+        reasoning = (values.get("reasoning") or {}).get("effort")
+
+        # Only restrict temperature if reasoning is explicitly enabled.
+        # Unset reasoning defaults to "none", so temperature is allowed.
+        reasoning_enabled = (
+            reasoning_effort is not None and reasoning_effort != "none"
+        ) or (reasoning is not None and reasoning != "none")
         if (
             model_lower.startswith("gpt-5")
             and ("chat" not in model_lower)
-            and values.get("reasoning_effort") != "none"
-            and (values.get("reasoning") or {}).get("effort") != "none"
+            and reasoning_enabled
         ):
             temperature = values.get("temperature")
             if temperature is not None and temperature != 1:
@@ -3946,15 +3950,18 @@ def _construct_responses_api_payload(
     if "reasoning_effort" in payload and "reasoning" not in payload:
         payload["reasoning"] = {"effort": payload.pop("reasoning_effort")}
 
-    # Remove temperature parameter for models that don't support it in responses API
-    # gpt-5-chat supports temperature, and gpt-5 models with reasoning.effort='none'
-    # also support temperature
+    # Remove temperature for gpt-5 (non-chat) models only when reasoning
+    # is explicitly enabled. Unset reasoning defaults to "none", so
+    # temperature should be preserved.
     model = payload.get("model") or ""
-    if (
-        model.startswith("gpt-5")
-        and ("chat" not in model)  # gpt-5-chat supports
-        and (payload.get("reasoning") or {}).get("effort") != "none"
-    ):
+    reasoning_effort = payload.get("reasoning_effort")
+    reasoning = (payload.get("reasoning") or {}).get("effort")
+
+    reasoning_enabled = (
+        reasoning_effort is not None and reasoning_effort != "none"
+    ) or (reasoning is not None and reasoning != "none")
+
+    if model.startswith("gpt-5") and ("chat" not in model) and reasoning_enabled:
         payload.pop("temperature", None)
 
     payload["input"] = _construct_responses_api_input(messages)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3130,7 +3130,9 @@ def test_gpt_5_temperature(use_responses_api: bool) -> None:
 
     messages = [HumanMessage(content="Hello")]
     payload = llm._get_request_payload(messages)
-    assert "temperature" not in payload  # not supported for gpt-5 family models
+    assert (
+        payload["temperature"] == 0.5
+    )  # Temperature is kept when reasoning is not set
 
     llm = ChatOpenAI(
         model="gpt-5-chat", temperature=0.5, use_responses_api=use_responses_api
@@ -3159,7 +3161,9 @@ def test_gpt_5_temperature_case_insensitive(
 
     messages = [HumanMessage(content="Hello")]
     payload = llm._get_request_payload(messages)
-    assert "temperature" not in payload
+    assert (
+        payload["temperature"] == 0.5
+    )  # Temperature is kept when reasoning is not set
 
     for chat_model in ["GPT-5-CHAT", "Gpt-5-Chat", "gpt-5-chat"]:
         llm = ChatOpenAI(
@@ -3174,8 +3178,16 @@ def test_gpt_5_temperature_case_insensitive(
 def test_gpt_5_1_temperature_with_reasoning_effort_none(
     use_responses_api: bool,
 ) -> None:
-    """Test that temperature is preserved when reasoning_effort is explicitly 'none'."""
-    # Test with reasoning_effort='none' explicitly set
+    """Test temperature behavior with reasoning parameters.
+
+    Temperature is kept when:
+    - reasoning is None (not set)
+    - reasoning is 'none'
+
+    Temperature is removed when:
+    - reasoning is set to other values ex: ('low', 'medium', 'high')
+    """
+    # Temperature is kept when reasoning_effort='none'
     llm = ChatOpenAI(
         model="gpt-5.1",
         temperature=0.5,
@@ -3186,7 +3198,7 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
     payload = llm._get_request_payload(messages)
     assert payload["temperature"] == 0.5
 
-    # Test with reasoning={'effort': 'none'}
+    # Temperature is kept when reasoning={'effort': 'none'}
     llm = ChatOpenAI(
         model="gpt-5.1",
         temperature=0.5,
@@ -3197,7 +3209,7 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
     payload = llm._get_request_payload(messages)
     assert payload["temperature"] == 0.5
 
-    # Test that temperature is restricted by default (no reasoning_effort)
+    # Temperature is kept when reasoning is not set
     llm = ChatOpenAI(
         model="gpt-5.1",
         temperature=0.5,
@@ -3205,9 +3217,9 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
     )
     messages = [HumanMessage(content="Hello")]
     payload = llm._get_request_payload(messages)
-    assert "temperature" not in payload
+    assert payload["temperature"] == 0.5
 
-    # Test that temperature is still restricted when reasoning_effort is something else
+    # Temperature is removed when reasoning_effort='low'
     llm = ChatOpenAI(
         model="gpt-5.1",
         temperature=0.5,
@@ -3218,7 +3230,7 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
     payload = llm._get_request_payload(messages)
     assert "temperature" not in payload
 
-    # Test with reasoning={'effort': 'low'}
+    # Temperature is removed when reasoning={'effort': 'low'}
     llm = ChatOpenAI(
         model="gpt-5.1",
         temperature=0.5,


### PR DESCRIPTION
## Summary

`gpt-5` (non-chat) models default to no reasoning when `reasoning_effort` is not provided, meaning temperature should be supported in this case.

Previously, temperature was stripped because `(reasoning != "none")` evaluated to `True` when reasoning was unset (`None != "none"`). This caused explicitly set temperature values to be silently dropped.

This updates the reasoning check in both `validate_temperature()` and `_construct_responses_api_payload()` to restrict temperature only when reasoning is explicitly enabled (i.e., not `None` and not `"none"`).

Fixes #35423

---

## Test Plan

* Updated `test_gpt_5_1_temperature_with_reasoning_effort_none` to reflect correct default behavior (temperature preserved when reasoning is unset)
* Verified temperature is preserved when:

  * `reasoning_effort="none"`
  * `reasoning={"effort": "none"}`
  * reasoning is not provided
* Verified temperature is removed when:

  * `reasoning_effort="low"`
  * `reasoning={"effort": "low"}`

All tests pass locally (`make format`, `make lint`, `make test`).