### PR TITLE
fix(core): cancel pending tasks in abatch_as_completed on early exit

### DIFF
--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -19,9 +19,9 @@ from langchain_core.tracers.context import register_configure_hook
 # Each call to get_usage_metadata_callback() previously created a new ContextVar and
 # registered a new hook, causing unbounded growth of _configure_hooks in long-running
 # applications.
-_usage_metadata_callback_var: ContextVar[
-    "UsageMetadataCallbackHandler | None"
-] = ContextVar("usage_metadata_callback", default=None)
+_usage_metadata_callback_var: ContextVar["UsageMetadataCallbackHandler | None"] = (
+    ContextVar("usage_metadata_callback", default=None)
+)
 register_configure_hook(_usage_metadata_callback_var, inheritable=True)
 
 

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1124,8 +1124,14 @@ class Runnable(ABC, Generic[Input, Output]):
             for i, (input_, config) in enumerate(zip(inputs, configs, strict=False))
         ]
 
-        for coro in asyncio.as_completed(coros):
-            yield await coro
+        tasks = [asyncio.ensure_future(coro) for coro in coros]
+        try:
+            for fut in asyncio.as_completed(tasks):
+                yield await fut
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
 
     def stream(
         self,

--- a/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
+++ b/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
@@ -1,9 +1,13 @@
+import warnings
 from typing import Any
+
+import pytest
 
 from langchain_core.callbacks import (
     UsageMetadataCallbackHandler,
     get_usage_metadata_callback,
 )
+from langchain_core.callbacks.usage import _usage_metadata_callback_var
 from langchain_core.language_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage
 from langchain_core.messages.ai import (
@@ -13,6 +17,7 @@ from langchain_core.messages.ai import (
     add_usage,
 )
 from langchain_core.outputs import ChatResult
+from langchain_core.tracers.context import _configure_hooks
 
 usage1 = UsageMetadata(
     input_tokens=1,
@@ -120,3 +125,58 @@ async def test_usage_callback_async() -> None:
     callback = UsageMetadataCallbackHandler()
     _ = await llm.abatch(["Message 1", "Message 2"], config={"callbacks": [callback]})
     assert callback.usage_metadata == {"test_model": total_1_2}
+
+
+def test_configure_hooks_no_accumulation() -> None:
+    """Regression test for https://github.com/langchain-ai/langchain/issues/32300.
+
+    Each call to get_usage_metadata_callback() must NOT append a new entry to
+    _configure_hooks. The hook is registered once at module load time via the
+    module-level _usage_metadata_callback_var.
+    """
+    hooks_before = len(_configure_hooks)
+
+    for _ in range(10):
+        with get_usage_metadata_callback():
+            pass
+
+    hooks_after = len(_configure_hooks)
+    assert hooks_after == hooks_before, (
+        f"_configure_hooks grew from {hooks_before} to {hooks_after} entries after "
+        "repeated calls to get_usage_metadata_callback(). Each call must not register "
+        "a new hook."
+    )
+
+    # Sanity-check: the module-level var is registered exactly once.
+    registered_vars = [var for var, *_ in _configure_hooks]
+    assert registered_vars.count(_usage_metadata_callback_var) == 1
+
+
+def test_name_parameter_deprecated() -> None:
+    """Passing a custom `name` must emit a DeprecationWarning."""
+    with (
+        pytest.warns(DeprecationWarning, match="`name` parameter"),
+        get_usage_metadata_callback(name="my_custom_name"),
+    ):
+        pass
+
+
+def test_name_parameter_default_no_warning() -> None:
+    """Calling with the default `name` must NOT emit any deprecation warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with get_usage_metadata_callback():
+            pass
+
+
+def test_nested_context_managers() -> None:
+    """Inner context manager must not clobber the outer one on exit."""
+    with get_usage_metadata_callback() as outer_cb:
+        with get_usage_metadata_callback() as inner_cb:
+            assert outer_cb is not inner_cb
+
+        # After the inner CM exits, the outer handler must still be active.
+        assert _usage_metadata_callback_var.get() is outer_cb
+
+    # After the outer CM exits, the var must be back to its previous value (None).
+    assert _usage_metadata_callback_var.get() is None

--- a/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
+++ b/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
@@ -148,8 +148,10 @@ def test_configure_hooks_no_accumulation() -> None:
     )
 
     # Sanity-check: the module-level var is registered exactly once.
-    registered_vars = [var for var, *_ in _configure_hooks]
-    assert registered_vars.count(_usage_metadata_callback_var) == 1
+    count = sum(
+        1 for var, *_ in _configure_hooks if var is _usage_metadata_callback_var
+    )
+    assert count == 1
 
 
 def test_name_parameter_deprecated() -> None:

--- a/libs/core/tests/unit_tests/runnables/test_concurrency.py
+++ b/libs/core/tests/unit_tests/runnables/test_concurrency.py
@@ -107,6 +107,77 @@ def test_batch_concurrency() -> None:
     assert max_running_tasks <= max_concurrency
 
 
+@pytest.mark.asyncio
+async def test_abatch_as_completed_cancels_pending_on_exception() -> None:
+    """Pending tasks are cancelled when the consumer raises an exception."""
+    # Use an Event so we wait (with a 1s timeout) for all 4 slow tasks to be
+    # cancelled, rather than relying on a fixed number of asyncio.sleep(0) calls.
+    cancel_event = asyncio.Event()
+    cancel_count = 0
+
+    async def tracked_function(x: Any) -> str:
+        nonlocal cancel_count
+        # input 0 completes immediately so the consumer body runs; others block.
+        if x == 0:
+            return "fast"
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancel_count += 1
+            if cancel_count == 4:
+                cancel_event.set()
+            raise
+        return f"Completed {x}"
+
+    runnable = RunnableLambda(tracked_function)
+
+    async def consume_and_raise() -> None:
+        msg = "early exit"
+        async for _idx, _result in runnable.abatch_as_completed([0, 1, 2, 3, 4]):
+            raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="early exit"):
+        await consume_and_raise()
+
+    # asyncio finalises async generators asynchronously (via GC hooks), so we
+    # wait for the event rather than relying on a fixed sleep.
+    await asyncio.wait_for(cancel_event.wait(), timeout=1.0)
+    assert cancel_count == 4
+
+
+@pytest.mark.asyncio
+async def test_abatch_as_completed_cancels_pending_on_break() -> None:
+    """Pending tasks are cancelled when the consumer breaks out of the loop."""
+    cancel_event = asyncio.Event()
+    cancel_count = 0
+
+    async def tracked_function(x: Any) -> str:
+        nonlocal cancel_count
+        # input 0 completes immediately so we have something to break on.
+        if x == 0:
+            return "fast"
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cancel_count += 1
+            if cancel_count == 4:
+                cancel_event.set()
+            raise
+        return f"Completed {x}"
+
+    runnable = RunnableLambda(tracked_function)
+
+    results = []
+    async for _idx, result in runnable.abatch_as_completed([0, 1, 2, 3, 4]):
+        results.append(result)
+        break  # stop after first result
+
+    # Wait for all 4 slow tasks to be cancelled.
+    await asyncio.wait_for(cancel_event.wait(), timeout=1.0)
+    assert results == ["fast"]
+    assert cancel_count == 4
+
+
 def test_batch_as_completed_concurrency() -> None:
     """Test that batch_as_completed respects max_concurrency."""
     running_tasks = 0


### PR DESCRIPTION
## Summary

- `abatch_as_completed` passed bare coroutines to `asyncio.as_completed`, losing cancellable `Task` references. When a consumer broke early or raised an exception, the remaining in-flight async tasks continued running silently in the background.
- Fix wraps each coroutine with `asyncio.ensure_future` (creating real `Task` objects) and adds a `try/finally` that calls `task.cancel()` for every pending task — mirroring the existing pattern in the synchronous `batch_as_completed`.

## Areas requiring careful review

- `asyncio.ensure_future` vs `asyncio.create_task`: both schedule a coroutine as a `Task`; `ensure_future` is used here because it accepts both coroutines and futures, which is consistent with the `gated_coro` wrapper already in this path.
- The `finally` guard `if not task.done()` avoids a no-op `cancel()` call on already-completed tasks, keeping semantics clean.
- Two new tests in `test_concurrency.py` verify cancellation on consumer exception and consumer `break`. They use `asyncio.Event` + `asyncio.wait_for` instead of a fixed `sleep(0)` count because asyncio finalises async generators asynchronously (via GC hooks), which requires multiple event-loop cycles.

Fixes #35419.

> AI-assisted contribution: implementation and tests were developed with Claude Code (claude-sonnet-4-6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)