### PR TITLE
fix: abatch_as_completed does not cancel pending tasks on exception or early exit

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1124,8 +1124,17 @@ class Runnable(ABC, Generic[Input, Output]):
             for i, (input_, config) in enumerate(zip(inputs, configs, strict=False))
         ]
 
-        for coro in asyncio.as_completed(coros):
-            yield await coro
+        tasks = {asyncio.create_task(coro) for coro in coros}
+
+        try:
+            for task in asyncio.as_completed(tasks):
+                yield await task
+        finally:
+            pending_tasks = {task for task in tasks if not task.done()}
+            for task in pending_tasks:
+                task.cancel()
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
 
     def stream(
         self,

--- a/libs/core/tests/unit_tests/runnables/test_concurrency.py
+++ b/libs/core/tests/unit_tests/runnables/test_concurrency.py
@@ -86,7 +86,8 @@ async def test_abatch_as_completed_cancels_pending_tasks_on_exception() -> None:
     async def tracked_function(x: str) -> str:
         if x == "bad":
             await asyncio.sleep(0.01)
-            raise RuntimeError("boom")
+            msg = "boom"
+            raise RuntimeError(msg)
 
         blocked_task_inputs.append(x)
         try:

--- a/libs/core/tests/unit_tests/runnables/test_concurrency.py
+++ b/libs/core/tests/unit_tests/runnables/test_concurrency.py
@@ -76,6 +76,62 @@ async def test_abatch_as_completed_concurrency() -> None:
     assert max_running_tasks <= max_concurrency
 
 
+@pytest.mark.asyncio
+async def test_abatch_as_completed_cancels_pending_tasks_on_exception() -> None:
+    """Test that pending tasks are cancelled when one task raises."""
+    blocked_task_inputs: list[str] = []
+    cancelled_task_inputs: list[str] = []
+    block = asyncio.Event()
+
+    async def tracked_function(x: str) -> str:
+        if x == "bad":
+            await asyncio.sleep(0.01)
+            raise RuntimeError("boom")
+
+        blocked_task_inputs.append(x)
+        try:
+            await block.wait()
+        except asyncio.CancelledError:
+            cancelled_task_inputs.append(x)
+            raise
+
+        return f"Completed {x}"
+
+    runnable = RunnableLambda(tracked_function)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async for _idx, _result in runnable.abatch_as_completed(["bad", "a", "b"]):
+            pass
+
+    await asyncio.sleep(0)
+    assert set(blocked_task_inputs) == {"a", "b"}
+    assert set(cancelled_task_inputs) == {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_abatch_as_completed_cancels_pending_tasks_on_early_exit() -> None:
+    """Test that pending tasks are cancelled when iteration exits early."""
+    completed_task_inputs: list[int] = []
+
+    async def tracked_function(x: int) -> int:
+        if x == 0:
+            await asyncio.sleep(0.01)
+            return x
+
+        await asyncio.sleep(0.2)
+        completed_task_inputs.append(x)
+        return x
+
+    runnable = RunnableLambda(tracked_function)
+
+    async for _idx, result in runnable.abatch_as_completed([0, 1, 2]):
+        assert result == 0
+        break
+
+    await asyncio.sleep(0.25)
+    assert completed_task_inputs == []
+
+
 def test_batch_concurrency() -> None:
     """Test that batch respects max_concurrency."""
     running_tasks = 0


### PR DESCRIPTION
## Summary

Cancel remaining async tasks in `abatch_as_completed` when iteration exits early or an exception is raised, matching the behavior of the synchronous variant and preventing unnecessary background work.

## Changes

- add cancellation/cleanup logic for pending tasks in async completion path
- ensure cancellation runs on error and early iterator exit
- add unit tests covering exception and early-exit cancellation behavior

## Testing

- ran targeted unit tests for runnable batch completion behavior

Fixes langchain-ai/langchain#35419