### PR TITLE
fix(openai): handle null choices in ChatOpenAI for vLLM compatibility

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1554,9 +1554,24 @@ class BaseChatOpenAI(BaseChatModel):
             raise KeyError(msg) from e
 
         if choices is None:
-            # Some OpenAI-compatible APIs (e.g., vLLM) may return null choices
-            # when the response format differs or an error occurs without
-            # populating the error field. Provide a more helpful error message.
+            # When using OpenAI-compatible APIs (e.g., vLLM), `model_dump()` can
+            # return None for `choices` even though the response object has valid
+            # choices accessible via direct attribute access. This happens because
+            # the OpenAI SDK's Pydantic model may not serialize non-standard fields
+            # correctly. Fall back to extracting choices directly from the object.
+            # See: https://github.com/langchain-ai/langchain/issues/32252
+            if isinstance(response, openai.BaseModel):
+                raw_choices = getattr(response, "choices", None)
+                if raw_choices is not None:
+                    choices = [
+                        choice.model_dump()
+                        if hasattr(choice, "model_dump")
+                        else choice
+                        for choice in raw_choices
+                    ]
+                    response_dict["choices"] = choices
+
+        if choices is None:
             msg = (
                 "Received response with null value for 'choices'. "
                 "This can happen when using OpenAI-compatible APIs (e.g., vLLM) "

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3431,3 +3431,77 @@ def test_context_overflow_error_backwards_compatibility() -> None:
     # Verify it's both types (multiple inheritance)
     assert isinstance(exc_info.value, openai.BadRequestError)
     assert isinstance(exc_info.value, ContextOverflowError)
+
+
+def test_create_chat_result_null_choices_in_model_dump_vllm() -> None:
+    """Test _create_chat_result handles null choices from model_dump() for vLLM.
+
+    When using OpenAI-compatible APIs like vLLM, model_dump() can return None
+    for choices even though the response object exposes valid choices via direct
+    attribute access. This is a serialization quirk in the OpenAI SDK's Pydantic
+    model when handling non-standard response shapes.
+
+    Regression test for: https://github.com/langchain-ai/langchain/issues/32252
+    """
+    # Simulate a vLLM choice with valid data accessible via model_dump()
+    mock_choice = MagicMock(spec=openai.BaseModel)
+    mock_choice.model_dump.return_value = {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": None,
+        "message": {
+            "content": "Hello! How can I help you?",
+            "role": "assistant",
+            "tool_calls": None,
+            "function_call": None,
+        },
+    }
+
+    # Simulate vLLM response: top-level model_dump() returns choices=None,
+    # but response.choices is populated and valid.
+    mock_response = MagicMock(spec=openai.BaseModel)
+    mock_response.model_dump.return_value = {
+        "choices": None,
+        "created": 1234567890,
+        "id": "chatcmpl-test",
+        "model": "meta-llama/Llama-3.1-8B-Instruct",
+        "object": "chat.completion",
+        "usage": {
+            "completion_tokens": 20,
+            "prompt_tokens": 10,
+            "total_tokens": 30,
+        },
+    }
+    mock_response.choices = [mock_choice]
+
+    llm = ChatOpenAI(model="meta-llama/Llama-3.1-8B-Instruct", api_key="test-key")  # type: ignore[arg-type]
+
+    # Should succeed by falling back to direct attribute access on response.choices
+    result = llm._create_chat_result(mock_response)
+
+    assert len(result.generations) == 1
+    assert result.generations[0].message.content == "Hello! How can I help you?"
+
+
+def test_create_chat_result_null_choices_still_raises_when_genuinely_absent() -> None:
+    """Test _create_chat_result still raises TypeError when choices are truly absent.
+
+    The fallback for vLLM must not swallow genuinely missing choices. When both
+    model_dump() and direct attribute access return null/empty choices, the
+    TypeError should still be raised.
+    """
+    mock_response = MagicMock(spec=openai.BaseModel)
+    mock_response.model_dump.return_value = {
+        "choices": None,
+        "created": 1234567890,
+        "id": "chatcmpl-test",
+        "model": "test-model",
+        "object": "chat.completion",
+    }
+    # choices attribute is also None (genuine absence)
+    mock_response.choices = None
+
+    llm = ChatOpenAI(model="test-model", api_key="test-key")  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="null value for 'choices'"):
+        llm._create_chat_result(mock_response)


### PR DESCRIPTION
## Description

Fixes #32252

When using `ChatOpenAI` against vLLM or other OpenAI-compatible inference servers, the OpenAI SDK's Pydantic `model_dump()` can return `None` for `choices` even though the response object has valid choices accessible via direct attribute access. This serialization quirk caused an unhelpful crash:

```
TypeError: Received response with null value for 'choices'.
```

This occurs because the OpenAI SDK's Pydantic model may not serialize non-standard fields correctly when handling non-OpenAI API responses, even though the response object itself is fully populated. Direct HTTP calls and the raw openai SDK work fine against the same endpoint.

## Root Cause

In `_create_chat_result`, `response.model_dump()` is called to convert the response to a dict. For certain OpenAI-compatible APIs (e.g., vLLM on RunPod), this serialization returns `{"choices": None, ...}` even when `response.choices` is a valid, populated list.

## Fix

Added a fallback in `_create_chat_result`: when `model_dump()` yields `None` for `choices` and the response is an `openai.BaseModel` instance, extract choices directly from `response.choices` using each choice's own `model_dump()`. This preserves all fields (content, role, tool_calls, finish_reason, logprobs, etc.) without manual reconstruction.

Genuine null-choices cases (where both `model_dump()` and direct attribute access are absent) still raise `TypeError` with a descriptive message.

## Changes

- `libs/partners/openai/langchain_openai/chat_models/base.py`: Added fallback in `_create_chat_result` to extract choices via direct attribute access when `model_dump()` returns `None`
- `libs/partners/openai/tests/unit_tests/chat_models/test_base.py`: Added two regression tests covering the vLLM scenario and the genuine-absence case

## Testing

- `test_create_chat_result_null_choices_in_model_dump_vllm`: simulates the vLLM scenario where `model_dump()` returns `choices=None` but `response.choices` is valid — verifies the fix works
- `test_create_chat_result_null_choices_still_raises_when_genuinely_absent`: verifies that `TypeError` is still raised when choices are truly absent through both code paths

## Related Issues

- Closes #32252