### PR TITLE
fix(core): preserve anthropic input_json_delta args in streaming (#34767)

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/anthropic.py
+++ b/libs/core/langchain_core/messages/block_translators/anthropic.py
@@ -299,10 +299,15 @@ def _convert_to_v1_from_anthropic(message: AIMessage) -> list[types.ContentBlock
             ):
                 if len(message.tool_call_chunks) == 1:
                     chunk = message.tool_call_chunks[0]
+                    chunk_args = chunk.get("args")
+                    # Some providers emit empty chunk args while carrying the
+                    # real incremental JSON in content.partial_json.
+                    if not chunk_args:
+                        chunk_args = block.get("partial_json", "")
                     tool_call_chunk = types.ToolCallChunk(
                         name=chunk.get("name"),
                         id=chunk.get("id"),
-                        args=chunk.get("args"),
+                        args=chunk_args,
                         type="tool_call_chunk",
                     )
                     index = chunk.get("index")

--- a/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
@@ -507,3 +507,51 @@ def test_convert_to_v1_from_anthropic_input() -> None:
     ]
 
     assert message.content_blocks == expected
+
+
+def test_convert_to_v1_from_anthropic_chunk_uses_partial_json_when_chunk_args_empty() -> None:
+    # Reproduces providers that emit empty tool_call_chunks args while
+    # carrying actual incremental args in input_json_delta.partial_json.
+    chunk = AIMessageChunk(
+        content=[
+            {
+                "type": "web_search_tool_result",
+                "tool_use_id": "toolu_123",
+                "content": [{"type": "web_search_result", "title": "t", "url": "u"}],
+                "index": 0,
+            },
+            {
+                "type": "input_json_delta",
+                "partial_json": '{"search_term":"ai"}',
+                "index": 1,
+            },
+        ],
+        tool_call_chunks=[
+            {
+                "name": None,
+                "args": "",
+                "id": "toolu_123",
+                "index": 1,
+                "type": "tool_call_chunk",
+            }
+        ],
+        response_metadata={"model_provider": "anthropic"},
+    )
+
+    assert chunk.content_blocks == [
+        {
+            "type": "server_tool_result",
+            "tool_call_id": "toolu_123",
+            "status": "success",
+            "extras": {"block_type": "web_search_tool_result"},
+            "output": [{"type": "web_search_result", "title": "t", "url": "u"}],
+            "index": 0,
+        },
+        {
+            "type": "tool_call_chunk",
+            "name": None,
+            "id": "toolu_123",
+            "args": '{"search_term":"ai"}',
+            "index": 1,
+        },
+    ]


### PR DESCRIPTION
## Problem Background
- Upstream issue: https://github.com/langchain-ai/langchain/issues/34767
- Symptom: `input_json_delta.partial_json` can carry valid JSON while `tool_call_chunks.args` is empty, yielding empty tool args during streaming translation.

## Reproduction Evidence
Before fix:
- Construct `AIMessageChunk` with `content=[{"type": "input_json_delta", "partial_json": "{\"search_term\":\"ai\"}"}]`
- And `tool_call_chunks=[{"args": "", "id": "toolu_1"}]`
- Observed `content_blocks` had `args: ""`.

## Fix Summary
- In Anthropic block translator, for `input_json_delta` chunk conversion:
  - preserve existing chunk args when present
  - otherwise fallback to `block.partial_json`
- Added regression unit test covering stream shape with a preceding `*_tool_result` block.

## Validation Results
- `python -m pytest -q tests/unit_tests/messages/block_translators/test_anthropic.py::test_convert_to_v1_from_anthropic_chunk_uses_partial_json_when_chunk_args_empty`
- `python -m pytest -q tests/unit_tests/messages/block_translators/test_anthropic.py`

## Risk Assessment
- Narrow scope: only `input_json_delta` handling in Anthropic translator.
- No behavior change when chunk args are already populated.

Closes #34767
