### PR TITLE
Add AgentAudit security badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="https://pypi.org/project/langchain/#history" target="_blank"><img src="https://img.shields.io/pypi/v/langchain?label=%20" alt="Version"></a>
   <a href="https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/langchain-ai/langchain" target="_blank"><img src="https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue&logo=visualstudiocode" alt="Open in Dev Containers"></a>
   <a href="https://codespaces.new/langchain-ai/langchain" target="_blank"><img src="https://github.com/codespaces/badge.svg" alt="Open in Github Codespace" title="Open in Github Codespace" width="150" height="20"></a>
+  <a href="https://agentaudit.dev/packages/langchain" target="_blank"><img src="https://agentaudit.dev/api/badge/langchain" alt="AgentAudit Security"></a>
   <a href="https://codspeed.io/langchain-ai/langchain" target="_blank"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed Badge"></a>
   <a href="https://x.com/langchain" target="_blank"><img src="https://img.shields.io/twitter/url/https/twitter.com/langchain.svg?style=social&label=Follow%20%40LangChain" alt="Twitter / X"></a>
 </div>


### PR DESCRIPTION
## Summary

Adds an [AgentAudit](https://agentaudit.dev) security badge to the README, showing the current trust score for the `langchain` package.

**Current Trust Score: 98/100** — No significant security findings detected across multiple independent AI-powered audits.

[![AgentAudit Security](https://agentaudit.dev/api/badge/langchain)](https://agentaudit.dev/packages/langchain)

## What is AgentAudit?

[AgentAudit](https://agentaudit.dev) is an open security registry for AI agent packages (MCP servers, skills, npm/pip packages). It provides:

- Multi-model security audits (Claude, GPT-4o, Gemini, etc.)
- Consensus-based trust scoring
- Standardized vulnerability IDs (ASF-IDs)

The badge auto-updates as new audits are submitted. Full audit details: https://agentaudit.dev/packages/langchain