### PR TITLE
fix(core): cancel pending tasks in `abatch_as_completed` on exception or early exit

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1124,8 +1124,16 @@ class Runnable(ABC, Generic[Input, Output]):
             for i, (input_, config) in enumerate(zip(inputs, configs, strict=False))
         ]
 
-        for coro in asyncio.as_completed(coros):
-            yield await coro
+        tasks = [asyncio.ensure_future(coro) for coro in coros]
+
+        try:
+            for task in asyncio.as_completed(tasks):
+                yield await task
+        finally:
+            for task in tasks:
+                task.cancel()
+            # Allow cancelled tasks to handle the CancelledError
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def stream(
         self,

--- a/libs/core/tests/unit_tests/runnables/test_concurrency.py
+++ b/libs/core/tests/unit_tests/runnables/test_concurrency.py
@@ -140,3 +140,65 @@ def test_batch_as_completed_concurrency() -> None:
 
     assert len(results) == num_tasks
     assert max_running_tasks <= max_concurrency
+
+
+@pytest.mark.asyncio
+async def test_abatch_as_completed_cancels_on_exception() -> None:
+    """Test that abatch_as_completed cancels pending tasks when one raises."""
+    completed_count = 0
+
+    async def slow_function(x: Any) -> str:
+        nonlocal completed_count
+        if x == 0:
+            msg = "task failed"
+            raise ValueError(msg)
+        # Remaining tasks sleep long enough to still be pending when the
+        # exception propagates and the generator is closed.
+        await asyncio.sleep(5)
+        completed_count += 1
+        return f"Completed {x}"
+
+    runnable = RunnableLambda(slow_function)
+
+    with pytest.raises(ValueError, match="task failed"):
+        async for _idx, _result in runnable.abatch_as_completed(
+            list(range(5)),
+        ):
+            pass
+
+    # Give the event loop a chance to process cancellations
+    await asyncio.sleep(0.1)
+
+    # No long-running tasks should have completed because they were cancelled
+    assert completed_count == 0
+
+
+@pytest.mark.asyncio
+async def test_abatch_as_completed_cancels_on_early_break() -> None:
+    """Test that abatch_as_completed cancels pending tasks on early break."""
+    completed_count = 0
+    started = asyncio.Event()
+
+    async def slow_function(x: Any) -> str:
+        nonlocal completed_count
+        if x == 0:
+            started.set()
+            return "first"
+        # Wait for the first task to finish so it can be yielded, then sleep
+        # long enough that these tasks are still running when the caller breaks.
+        await started.wait()
+        await asyncio.sleep(5)
+        completed_count += 1
+        return f"Completed {x}"
+
+    runnable = RunnableLambda(slow_function)
+
+    async for _idx, _result in runnable.abatch_as_completed(list(range(5))):
+        # Break after receiving the first result
+        break
+
+    # Give the event loop a chance to process cancellations
+    await asyncio.sleep(0.1)
+
+    # No long-running tasks should have completed because they were cancelled
+    assert completed_count == 0


### PR DESCRIPTION
## Summary

- **Bug:** `abatch_as_completed` did not cancel remaining asyncio tasks when the caller broke out of the `async for` loop early or when a task raised an exception (with default `return_exceptions=False`). This caused background tasks to keep running, wasting resources and API credits.
- **Fix:** Wrap the yield loop in a `try/finally` block that cancels all outstanding tasks when the async generator is closed, matching the existing behavior of the sync `batch_as_completed` method.
- **Tests:** Added two new tests verifying tasks are cancelled on exception and on early `break`.

Closes #35419

## Detailed changes

In `Runnable.abatch_as_completed` (`libs/core/langchain_core/runnables/base.py`):

1. Create explicit `asyncio.Task` objects from the coroutines (via `asyncio.ensure_future`) so we hold references to them.
2. Wrap the `for task in asyncio.as_completed(tasks): yield await task` loop in `try/finally`.
3. In the `finally` block, cancel all tasks and `await asyncio.gather(*tasks, return_exceptions=True)` to allow clean cancellation propagation.

This mirrors the sync version which already does:
```python
try:
    while futures:
        done, futures = wait(futures, return_when=FIRST_COMPLETED)
        while done:
            yield done.pop().result()
finally:
    for future in futures:
        future.cancel()
```

## Test plan

- [x] `test_abatch_as_completed_cancels_on_exception` -- verifies that when one task raises a `ValueError`, the remaining long-running tasks are cancelled and do not complete
- [x] `test_abatch_as_completed_cancels_on_early_break` -- verifies that when the caller `break`s after the first result, the remaining long-running tasks are cancelled and do not complete
- [x] All existing concurrency tests continue to pass

## Disclaimer

This contribution was developed with the assistance of an AI coding agent (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)