### PR TITLE
fix(core): lazy loading transformers, numpy, simsimd

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins  # noqa: TC003  # runtime-evaluated; subclass `dict()` shadows the builtin
+import importlib.util
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
@@ -39,12 +40,7 @@ from langchain_core.runnables import Runnable, RunnableSerializable
 if TYPE_CHECKING:
     from langchain_core.outputs import LLMResult
 
-try:
-    from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
-
-    _HAS_TRANSFORMERS = True
-except ImportError:
-    _HAS_TRANSFORMERS = False
+_HAS_TRANSFORMERS = importlib.util.find_spec("transformers") is not None
 
 
 class LangSmithParams(TypedDict, total=False):
@@ -94,6 +90,11 @@ def get_tokenizer() -> Any:
             "Please install it with `pip install transformers`."
         )
         raise ImportError(msg)
+
+    from transformers import (  # type: ignore[import-not-found]  # noqa: PLC0415
+        GPT2TokenizerFast,
+    )
+
     # create a GPT-2 tokenizer instance
     return GPT2TokenizerFast.from_pretrained("gpt2")
 

--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import uuid
 from pathlib import Path
@@ -23,12 +24,7 @@ if TYPE_CHECKING:
 
     from langchain_core.embeddings import Embeddings
 
-try:
-    import numpy as np
-
-    _HAS_NUMPY = True
-except ImportError:
-    _HAS_NUMPY = False
+_HAS_NUMPY = importlib.util.find_spec("numpy") is not None
 
 
 class InMemoryVectorStore(VectorStore):
@@ -438,6 +434,8 @@ class InMemoryVectorStore(VectorStore):
                 "pip install numpy"
             )
             raise ImportError(msg)
+
+        import numpy as np  # noqa: PLC0415
 
         mmr_chosen_indices = maximal_marginal_relevance(
             np.array(embedding, dtype=np.float32),

--- a/libs/core/langchain_core/vectorstores/utils.py
+++ b/libs/core/langchain_core/vectorstores/utils.py
@@ -8,25 +8,17 @@
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 import warnings
 from typing import TYPE_CHECKING
 
-try:
-    import numpy as np
+_HAS_NUMPY = importlib.util.find_spec("numpy") is not None
+_HAS_SIMSIMD = importlib.util.find_spec("simsimd") is not None
 
-    _HAS_NUMPY = True
-except ImportError:
-    _HAS_NUMPY = False
-
-try:
-    import simsimd as simd  # type: ignore[import-not-found]
-
-    _HAS_SIMSIMD = True
-except ImportError:
-    _HAS_SIMSIMD = False
 
 if TYPE_CHECKING:
+    import numpy as np
     import numpy.typing as npt
 
     Matrix = (
@@ -57,6 +49,8 @@ def _cosine_similarity(x: Matrix, y: Matrix) -> npt.NDArray[np.floating]:
             "Please install numpy with `pip install numpy`."
         )
         raise ImportError(msg)
+
+    import numpy as np  # noqa: PLC0415
 
     if len(x) == 0 or len(y) == 0:
         return np.array([[]])
@@ -104,6 +98,8 @@ def _cosine_similarity(x: Matrix, y: Matrix) -> npt.NDArray[np.floating]:
         similarity[np.isnan(similarity) | np.isinf(similarity)] = 0.0
         return similarity
 
+    import simsimd as simd  # type: ignore[import-not-found]  # noqa: PLC0415
+
     x = np.array(x, dtype=np.float32)
     y = np.array(y, dtype=np.float32)
     return 1 - np.array(simd.cdist(x, y, metric="cosine"))
@@ -135,6 +131,8 @@ def maximal_marginal_relevance(
             "Please install numpy with `pip install numpy`."
         )
         raise ImportError(msg)
+
+    import numpy as np  # noqa: PLC0415
 
     if min(k, len(embedding_list)) <= 0:
         return []


### PR DESCRIPTION
fix(core): lazy loading transformers, numpy, simsimd

## Summary
Optimized the initial import speed of langchain_core by converting top-level imports of transformers, numpy, and simsimd into lazy, local imports.

## Details
Confirmed with python -X importtime that these dependencies are no longer loaded on initial import, and verified functionality through make format/lint and est.

## Disclaimer
I used the Gemini CLI to help with the specific implementation details and to ensure compliance with linting and type checking and drafting this PR description.

**before**
without transformers / torch env.
```bash
$ time uv run python -c "from langchain_core.prompts import BasePromptTemplate"
real    0m0.600s
user    0m0.509s
sys     0m0.074s
```

with transformers / torch installed env.

```bash
$ uv pip install transformers
...
$ uv pip install numpy
...

$ time uv run python -c "from langchain_core.prompts import BasePromptTemplate"
real    0m9.664s
user    0m4.268s
sys     0m0.752s

$ time uv run python -c "from langchain_core.prompts import BasePromptTemplate" # one more time

real    0m4.030s
user    0m3.877s
sys     0m0.468s
```

**after PR applied**
```bash

$ time uv run python -c "from langchain_core.prompts import BasePromptTemplate"
real    0m0.797s
user    0m0.662s
sys     0m0.110s

$ uv pip show transformers
Name: transformers
Version: 4.55.0
Location: /home/future/repo/linkBrain-server/.venv/lib/python3.13/site-packages
Requires: filelock, huggingface-hub, numpy, packaging, pyyaml, regex, requests, safetensors, tokenizers, tqdm
Required-by: docling-ibm-models, optimum, sentence-transformers
```

See also #35469