### PR TITLE
perf(text-splitters): use deque for line consumption in markdown splitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import deque
 from typing import Any, TypedDict
 
 from langchain_core.documents import Document
@@ -389,10 +390,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
         self.current_chunk = Document(page_content="")
         self.current_header_stack.clear()
 
-        raw_lines = text.splitlines(keepends=True)
+        raw_lines = deque(text.splitlines(keepends=True))
 
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             header_match = self._match_header(raw_line)
             code_match = self._match_code(raw_line)
             horz_match = self._match_horz(raw_line)
@@ -439,10 +440,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
                 break
         self.current_header_stack.append((header_depth, header_text))
 
-    def _resolve_code_chunk(self, current_line: str, raw_lines: list[str]) -> str:
+    def _resolve_code_chunk(self, current_line: str, raw_lines: deque[str]) -> str:
         chunk = current_line
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk


### PR DESCRIPTION
## Problem

`ExperimentalMarkdownSyntaxTextSplitter.split_text()` and `_resolve_code_chunk()` use `list.pop(0)` to consume lines from the front of a list while parsing markdown.

`list.pop(0)` is **O(n)** because CPython must shift every remaining element left by one slot. On large markdown documents with thousands of lines, this accumulates to **O(n²)** total work.

## Solution

Convert `raw_lines` to a `collections.deque` at the start of `split_text()` and replace all `.pop(0)` calls with `.popleft()`, which is **O(1)** amortised.

`deque` supports the same boolean truthiness check and iteration used by both methods. The `_resolve_code_chunk` type annotation is updated to `deque[str]` to match.

## Testing

All 9 markdown-related tests in `tests/unit_tests/test_text_splitters.py` pass (2 consecutive clean runs).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>