### PR TITLE
perf(core): use deque for result reassembly in RunnableRetry batch

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -1,5 +1,6 @@
 """`Runnable` that retries a `Runnable` if it fails."""
 
+from collections import deque
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -280,11 +281,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                 result = cast("list[Output]", [e] * len(inputs))
 
         outputs: list[Output | Exception] = []
+        result_queue = deque(result)
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(result_queue.popleft())
         return outputs
 
     @override
@@ -355,11 +357,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                 result = cast("list[Output]", [e] * len(inputs))
 
         outputs: list[Output | Exception] = []
+        result_queue = deque(result)
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(result_queue.popleft())
         return outputs
 
     @override


### PR DESCRIPTION
## Problem

`RunnableRetry._batch()` and `_abatch()` use `list.pop(0)` to reassemble batch outputs by merging a `results_map` (already-succeeded inputs) with remaining results consumed front-to-back.

`list.pop(0)` is **O(n)** per call because CPython must shift every remaining element. For large batch sizes this accumulates to **O(n²)** total work in the reassembly loop.

## Solution

Convert the `result` list to a `collections.deque` just before the reassembly loop and replace `.pop(0)` with `.popleft()`, which is **O(1)** amortised.

The original `result` list is not used after reassembly, so the conversion is safe. The deque is consumed exactly once, front-to-back.

## Testing

All 4 retry-related tests pass:
- `test_retrying`
- `test_retry_batch_preserves_order`
- `test_async_retry_batch_preserves_order`
- `test_async_retrying`

(2 consecutive clean runs)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>