### PR TITLE
perf(core): use deque for pipeline batch output reassembly in RunnableSequence

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -3290,13 +3290,13 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
                         break
 
                 # Reassemble the outputs, inserting Exceptions for failed inputs
-                inputs_copy = inputs.copy()
+                inputs_copy = collections.deque(inputs)
                 inputs = []
                 for i in range(len(configs)):
                     if i in failed_inputs_map:
                         inputs.append(cast("Input", failed_inputs_map[i]))
                     else:
-                        inputs.append(inputs_copy.pop(0))
+                        inputs.append(inputs_copy.popleft())
             else:
                 for i, step in enumerate(self.steps):
                     inputs = step.batch(
@@ -3421,13 +3421,13 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
                         break
 
                 # Reassemble the outputs, inserting Exceptions for failed inputs
-                inputs_copy = inputs.copy()
+                inputs_copy = collections.deque(inputs)
                 inputs = []
                 for i in range(len(configs)):
                     if i in failed_inputs_map:
                         inputs.append(cast("Input", failed_inputs_map[i]))
                     else:
-                        inputs.append(inputs_copy.pop(0))
+                        inputs.append(inputs_copy.popleft())
             else:
                 for i, step in enumerate(self.steps):
                     inputs = await step.abatch(


### PR DESCRIPTION
## Problem

`RunnableSequence.batch()` and `abatch()` use `list.pop(0)` to reassemble outputs by merging a `failed_inputs_map` with remaining successful inputs consumed front-to-back.

`list.pop(0)` is **O(n)** per call because CPython must shift every remaining element. For large batch sizes this accumulates to **O(n²)** total work.

## Solution

Convert the copied inputs list to a `collections.deque` and replace `.pop(0)` with `.popleft()`, which is **O(1)** amortised. The `collections` module is already imported in this file.

## Testing

All 6 batch-related tests pass:
- `test_retry_batch_preserves_order`
- `test_async_retry_batch_preserves_order`
- `test_seq_batch_return_exceptions`
- `test_seq_abatch_return_exceptions`
- `test_runnable_branch_batch`
- `test_runnable_branch_abatch`

(2 consecutive clean runs)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>