### PR TITLE
fix(core): RunnableRetry.batch corrupted outputs on partial retry success

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -279,12 +279,15 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
+        # Filter out successful results already recorded in results_map;
+        # only exceptions should remain for indices that never succeeded.
+        exceptions = [r for r in result if isinstance(r, BaseException)]
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(exceptions.pop(0))
         return outputs
 
     @override
@@ -354,12 +357,15 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
+        # Filter out successful results already recorded in results_map;
+        # only exceptions should remain for indices that never succeeded.
+        exceptions = [r for r in result if isinstance(r, BaseException)]
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(exceptions.pop(0))
         return outputs
 
     @override

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3980,8 +3980,10 @@ async def test_async_retry_batch_preserves_order() -> None:
 
 
 def test_retry_batch_mixed_success_and_permanent_failure() -> None:
-    """Regression test: batch outputs should not be corrupted when some items
-    succeed on retry while others still fail after all attempts.
+    """Regression test: batch outputs must not be corrupted on partial retry.
+
+    When some items succeed on retry while others still fail after all attempts,
+    batch outputs should not be corrupted.
 
     Previously, the output assembly used ``result.pop(0)`` on the raw last-batch
     result which still contained successful outputs alongside exceptions,

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3979,6 +3979,80 @@ async def test_async_retry_batch_preserves_order() -> None:
     assert results == [0, 1, 2]
 
 
+def test_retry_batch_mixed_success_and_permanent_failure() -> None:
+    """Regression test: batch outputs should not be corrupted when some items
+    succeed on retry while others still fail after all attempts.
+
+    Previously, the output assembly used ``result.pop(0)`` on the raw last-batch
+    result which still contained successful outputs alongside exceptions,
+    causing a successful result to be returned in place of a permanently-failed
+    item.
+
+    See https://github.com/langchain-ai/langchain/issues/35475
+    """
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                raise ValueError
+            return "retry-result"
+        raise ValueError
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = runnable.batch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
+async def test_async_retry_batch_mixed_success_and_permanent_failure() -> None:
+    """Async variant of mixed success / permanent failure regression test.
+
+    See https://github.com/langchain-ai/langchain/issues/35475
+    """
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                raise ValueError
+            return "retry-result"
+        raise ValueError
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = await runnable.abatch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
 async def test_async_retrying(mocker: MockerFixture) -> None:
     def _lambda(x: int) -> int:
         if x == 1:


### PR DESCRIPTION
## Summary

Fixes #35475

`RunnableRetry.batch()` and `abatch()` return corrupted outputs when some items succeed on retry while others still fail after all attempts. A successful result appears in the output position of a permanently-failed item.

## Root Cause

After retries exhaust, the output assembly loop (lines 282-288) uses `result.pop(0)` on the raw last-batch result list. But `result` still contains **both** successful outputs (already stored in `results_map`) **and** exceptions. Popping from the front returns a successful result instead of the expected exception.

**Example:** With inputs `["ok", "retry_then_ok", "always_fail"]`:
1. After final retry: `result = ["retry-result", ValueError()]`
2. `"retry-result"` is already in `results_map[1]`
3. For failed index 2: `result.pop(0)` → `"retry-result"` ❌ (should be `ValueError`)

## Fix

Filter the last-batch result to only contain exceptions before assembling the output list, since successful results are already captured in `results_map`:

```python
exceptions = [r for r in result if isinstance(r, BaseException)]
```

Applied to both `_batch()` and `_abatch()`.

## Tests

Added 2 regression tests (`test_retry_batch_mixed_success_and_permanent_failure` + async variant) that reproduce the exact issue scenario. All 6 retry-related tests pass.

```
6 passed in 0.75s
```