### PR TITLE
fix(core): prevent RunnableRetry.batch from returning corrupted outputs on partial failure

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -279,6 +279,10 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
+        # Filter out successful results already captured in results_map so that
+        # only the exceptions remain for items that never succeeded.
+        result = [r for r in result if isinstance(r, Exception)]
+
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
@@ -353,6 +357,10 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         except RetryError as e:
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
+
+        # Filter out successful results already captured in results_map so that
+        # only the exceptions remain for items that never succeeded.
+        result = [r for r in result if isinstance(r, Exception)]
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3980,8 +3980,10 @@ async def test_async_retry_batch_preserves_order() -> None:
 
 
 def test_retry_batch_no_corrupted_outputs_on_partial_failure() -> None:
-    """Regression test: batch with retry must not replace a permanently-failed
-    item's exception with a successful result from a different item.
+    """Regression test: batch with retry must not corrupt outputs.
+
+    Batch with retry must not replace a permanently-failed item's exception
+    with a successful result from a different item.
 
     When some items succeed on a retry while others still fail, the output list
     should contain the successful result at its original position and an
@@ -3998,7 +4000,8 @@ def test_retry_batch_no_corrupted_outputs_on_partial_failure() -> None:
         if name == "retry_then_ok":
             if not failed_once:
                 failed_once = True
-                raise ValueError("transient")
+                _msg = "transient"
+                raise ValueError(_msg)
             return "retry-result"
         msg = "permanent"
         raise ValueError(msg)
@@ -4030,7 +4033,8 @@ async def test_async_retry_batch_no_corrupted_outputs_on_partial_failure() -> No
         if name == "retry_then_ok":
             if not failed_once:
                 failed_once = True
-                raise ValueError("transient")
+                _msg = "transient"
+                raise ValueError(_msg)
             return "retry-result"
         msg = "permanent"
         raise ValueError(msg)

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3979,6 +3979,78 @@ async def test_async_retry_batch_preserves_order() -> None:
     assert results == [0, 1, 2]
 
 
+def test_retry_batch_no_corrupted_outputs_on_partial_failure() -> None:
+    """Regression test: batch with retry must not replace a permanently-failed
+    item's exception with a successful result from a different item.
+
+    When some items succeed on a retry while others still fail, the output list
+    should contain the successful result at its original position and an
+    exception at the permanently-failed position.
+
+    See https://github.com/langchain-ai/langchain/issues/35475
+    """
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                raise ValueError("transient")
+            return "retry-result"
+        msg = "permanent"
+        raise ValueError(msg)
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = runnable.batch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
+async def test_async_retry_batch_no_corrupted_outputs_on_partial_failure() -> None:
+    """Async variant of the corrupted output regression test."""
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                raise ValueError("transient")
+            return "retry-result"
+        msg = "permanent"
+        raise ValueError(msg)
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = await runnable.abatch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
 async def test_async_retrying(mocker: MockerFixture) -> None:
     def _lambda(x: int) -> int:
         if x == 1:


### PR DESCRIPTION
## Summary

Fixes #35475

When using `RunnableLambda(...).with_retry(...).batch(..., return_exceptions=True)`, if some items succeed on retry while others permanently fail, the failed items' positions in the output list can contain a successful result from a different item instead of the expected exception.

## Root Cause

In both `_batch()` and `_abatch()`, after the retry loop completes:

1. `result` holds the raw outputs from the **last** retry attempt (both successes and exceptions)
2. Successful outputs from that attempt are added to `results_map`, but are **not removed** from `result`
3. The output-assembly loop uses `result.pop(0)` for items not in `results_map`
4. This pops a successful result (from a different item) instead of the exception for the permanently-failed item

**Example** with `stop_after_attempt=2` and inputs `['ok', 'retry_then_ok', 'always_fail']`:
- After attempt 2: `result = ['retry-result', ValueError()]`, `results_map = {0: 'ok-result', 1: 'retry-result'}`
- For index 2 (not in `results_map`): `result.pop(0)` returns `'retry-result'` instead of `ValueError()`

## Fix

Filter `result` to keep only exceptions before the output-assembly loop:
```python
result = [r for r in result if isinstance(r, Exception)]
```

This ensures each permanently-failed item gets its actual exception. Applied to both sync `_batch` and async `_abatch`.

## Tests

Added:
- `test_retry_batch_no_corrupted_outputs_on_partial_failure` (sync)
- `test_async_retry_batch_no_corrupted_outputs_on_partial_failure` (async)

Both verify that the third item (always fails) is an exception while the first two items have their correct results. All 6 retry tests pass.