### PR TITLE
fix(core): cancel pending tasks in abatch_as_completed on exception or early exit

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1124,8 +1124,15 @@ class Runnable(ABC, Generic[Input, Output]):
             for i, (input_, config) in enumerate(zip(inputs, configs, strict=False))
         ]
 
-        for coro in asyncio.as_completed(coros):
-            yield await coro
+        tasks = [asyncio.ensure_future(coro) for coro in coros]
+        try:
+            for future in asyncio.as_completed(tasks):
+                yield await future
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def stream(
         self,

--- a/libs/core/tests/unit_tests/runnables/test_concurrency.py
+++ b/libs/core/tests/unit_tests/runnables/test_concurrency.py
@@ -140,3 +140,56 @@ def test_batch_as_completed_concurrency() -> None:
 
     assert len(results) == num_tasks
     assert max_running_tasks <= max_concurrency
+
+
+@pytest.mark.asyncio
+async def test_abatch_as_completed_cancels_on_exception() -> None:
+    """Test that abatch_as_completed cancels pending tasks when one raises."""
+    completed_tasks: list[str] = []
+
+    async def llm_call(prompt: str) -> str:
+        if prompt == "bad":
+            await asyncio.sleep(0.05)
+            raise RuntimeError("rate limit")
+        await asyncio.sleep(0.3)
+        completed_tasks.append(prompt)
+        return f"ok:{prompt}"
+
+    runnable = RunnableLambda(llm_call)
+    with pytest.raises(RuntimeError, match="rate limit"):
+        async for _, _out in runnable.abatch_as_completed(
+            ["bad", "a", "b"],
+            config=RunnableConfig(max_concurrency=3),
+        ):
+            pass
+
+    await asyncio.sleep(0.5)
+    assert completed_tasks == [], (
+        f"Expected no tasks to complete after exception, but got: {completed_tasks}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_abatch_as_completed_cancels_on_break() -> None:
+    """Test that abatch_as_completed cancels remaining tasks on early exit."""
+    completed_tasks: list[str] = []
+
+    async def llm_call(prompt: str) -> str:
+        if prompt == "fast":
+            await asyncio.sleep(0.05)
+            return "done"
+        await asyncio.sleep(0.3)
+        completed_tasks.append(prompt)
+        return f"ok:{prompt}"
+
+    runnable = RunnableLambda(llm_call)
+    async for _idx, _out in runnable.abatch_as_completed(
+        ["fast", "slow1", "slow2"],
+        config=RunnableConfig(max_concurrency=3),
+    ):
+        break
+
+    await asyncio.sleep(0.5)
+    assert completed_tasks == [], (
+        f"Expected no tasks to complete after break, but got: {completed_tasks}"
+    )

--- a/libs/core/tests/unit_tests/runnables/test_concurrency.py
+++ b/libs/core/tests/unit_tests/runnables/test_concurrency.py
@@ -147,10 +147,12 @@ async def test_abatch_as_completed_cancels_on_exception() -> None:
     """Test that abatch_as_completed cancels pending tasks when one raises."""
     completed_tasks: list[str] = []
 
+    _msg = "rate limit"
+
     async def llm_call(prompt: str) -> str:
         if prompt == "bad":
             await asyncio.sleep(0.05)
-            raise RuntimeError("rate limit")
+            raise RuntimeError(_msg)
         await asyncio.sleep(0.3)
         completed_tasks.append(prompt)
         return f"ok:{prompt}"


### PR DESCRIPTION
## Problem

`abatch_as_completed` does not cancel pending tasks when the consumer stops iterating (via exception or `break`). This means remaining `ainvoke` calls continue running in the background and can still complete API calls, incurring extra cost even though their results will never be consumed.

The sync `batch_as_completed` already handles this correctly with a `try/finally` block that cancels remaining futures.

### Reproduction (from #35419)

```python
async def llm_call(prompt: str) -> str:
    if prompt == "bad":
        raise RuntimeError("429 rate limit")
    await asyncio.sleep(0.25)
    print(f"CHARGED: {prompt}")  # still runs after exception
    return f"ok:{prompt}"

r = RunnableLambda(llm_call)
async for _, out in r.abatch_as_completed(["bad", "a", "b"]):
    print(out)
# Expected: only the RuntimeError, no CHARGED output
# Actual: RuntimeError + CHARGED: a + CHARGED: b
```

## Root Cause

`abatch_as_completed` passed coroutines directly to `asyncio.as_completed()`, which wraps them in tasks internally. Since the caller never held references to those tasks, there was no way to cancel them when iteration stopped.

## Fix

1. Create explicit `asyncio.Task` objects via `asyncio.ensure_future()` so we hold references
2. Wrap the yield loop in `try/finally` that cancels any unfinished tasks (mirroring the sync version)
3. `await asyncio.gather(*tasks, return_exceptions=True)` to suppress `CancelledError`

## Tests

Added two regression tests:
- `test_abatch_as_completed_cancels_on_exception`: verifies no tasks complete after one raises
- `test_abatch_as_completed_cancels_on_break`: verifies no tasks complete after consumer breaks

All 6 concurrency tests pass.

Fixes #35419