### PR TITLE
fix(openai): strip stream param in _generate/_agenerate to fix disable_streaming crash

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1441,7 +1441,7 @@ class BaseChatOpenAI(BaseChatModel):
         raw_response = None
         try:
             if "response_format" in payload:
-                payload.pop("stream")
+                payload.pop("stream", None)
                 raw_response = (
                     self.root_client.chat.completions.with_raw_response.parse(**payload)
                 )
@@ -1696,7 +1696,7 @@ class BaseChatOpenAI(BaseChatModel):
         raw_response = None
         try:
             if "response_format" in payload:
-                payload.pop("stream")
+                payload.pop("stream", None)
                 raw_response = await self.root_async_client.chat.completions.with_raw_response.parse(  # noqa: E501
                     **payload
                 )

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1436,6 +1436,7 @@ class BaseChatOpenAI(BaseChatModel):
     ) -> ChatResult:
         self._ensure_sync_client_available()
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        payload.pop("stream", None)
         generation_info = None
         raw_response = None
         try:
@@ -1690,6 +1691,7 @@ class BaseChatOpenAI(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        payload.pop("stream", None)
         generation_info = None
         raw_response = None
         try:


### PR DESCRIPTION
## Problem

When `disable_streaming="tool_calling"` triggers, `BaseChatModel._agenerate_with_cache` calls `_agenerate()` instead of `_astream()`. But `_get_request_payload()` includes `stream=True` from `_default_params`, so the OpenAI client returns an `AsyncStream` object instead of a `ChatCompletion`. The subsequent `response.model_dump()` then crashes:

```
AttributeError: 'AsyncStream' object has no attribute 'model_dump'
```

This makes `disable_streaming="tool_calling"` completely unusable with `ChatOpenAI` when `streaming=True`.

## Root Cause

`BaseChatOpenAI._default_params` hardcodes `"stream": self.streaming`. When `self.streaming=True`, this ends up in the payload for `_generate()/_agenerate()` — which are the non-streaming code paths. The `response_format` branch already handled this by popping `stream`, but the regular completion path did not.

## Fix

Pop `stream` from the payload at the start of both `_generate()` and `_agenerate()` since these are non-streaming code paths that should never send `stream=True` to the API.

## Tests

All 181 existing unit tests pass (2 consecutive clean runs).

Fixes #35436