### PR TITLE
fix(core): guard merge_lists against non-dict elements when matching by index

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -118,7 +118,8 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                         i
                         for i, e_left in enumerate(merged)
                         if (
-                            "index" in e_left
+                            isinstance(e_left, dict)
+                            and "index" in e_left
                             and e_left["index"] == e["index"]  # index matches
                             and (  # IDs not inconsistent
                                 e_left.get("id") in (None, "")

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -459,6 +459,22 @@ def test_merge_lists_all_none() -> None:
     assert result is None
 
 
+def test_merge_lists_mixed_strings_and_dicts() -> None:
+    """Test merge_lists with mixed string and dict elements (Mistral citations)."""
+    merged = [
+        "start answer...",
+        {"type": "reference", "index": 0, "reference_ids": ["iKcb2CAQ7"]},
+        "other answer...",
+    ]
+    other = [{"type": "reference", "index": 0, "reference_ids": ["DGqzzmqc3"]}]
+    result = merge_lists(merged, other)
+    assert result is not None
+    assert result[0] == "start answer..."
+    assert result[2] == "other answer..."
+    assert isinstance(result[1], dict)
+    assert result[1]["index"] == 0
+
+
 @pytest.mark.parametrize(
     ("left", "right", "expected"),
     [

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -469,10 +469,15 @@ def test_merge_lists_mixed_strings_and_dicts() -> None:
     other = [{"type": "reference", "index": 0, "reference_ids": ["DGqzzmqc3"]}]
     result = merge_lists(merged, other)
     assert result is not None
+    assert len(result) == 3
     assert result[0] == "start answer..."
     assert result[2] == "other answer..."
     assert isinstance(result[1], dict)
     assert result[1]["index"] == 0
+    assert result[1]["type"] == "reference"
+    reference_ids = result[1].get("reference_ids")
+    assert isinstance(reference_ids, list)
+    assert set(reference_ids) == {"iKcb2CAQ7", "DGqzzmqc3"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

`merge_lists` crashes with `TypeError: string indices must be integers, not 'str'` when the merged list contains a mix of strings and dicts with `"index"` keys.

This happens with Mistral streaming responses that include inline citations — the content array alternates between text strings and reference dicts:

```python
merged = [
    "start answer...",
    {"type": "reference", "index": 0, "reference_ids": ["iKcb2CAQ7"]},
    "other answer..."
]
other = [{"type": "reference", "index": 0, "reference_ids": ["DGqzzmqc3"]}]

merge_lists(merged, other)  # TypeError!
```

## Root Cause

The index-matching list comprehension iterates over all elements in `merged` and checks `"index" in e_left`. For string elements, Python's `in` operator checks for substring containment (which works), but then `e_left["index"]` tries to index a string with a string key, which raises `TypeError`.

## Fix

Add `isinstance(e_left, dict)` guard before accessing dict-specific attributes.

## Tests

Added regression test with mixed strings and dicts (the exact pattern from the Mistral streaming scenario). 81 tests pass.

Fixes #35259