### PR TITLE
fix(openai): fix if/elif chain and unhandled tool name in `_consolidate_calls`

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/_compat.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_compat.py
@@ -313,7 +313,7 @@ def _consolidate_calls(items: Iterable[dict[str, Any]]) -> Iterator[dict[str, An
                     pass
                 collapsed["type"] = "web_search_call"
 
-            if current.get("name") == "file_search":
+            elif current.get("name") == "file_search":
                 collapsed = {"id": current["id"]}
                 if "args" in current and "queries" in current["args"]:
                     collapsed["queries"] = current["args"]["queries"]
@@ -394,7 +394,10 @@ def _consolidate_calls(items: Iterable[dict[str, Any]]) -> Iterator[dict[str, An
                     if k not in ("server_label", "error"):
                         collapsed[k] = v
             else:
-                pass
+                # unrecognized server tool - emit both items unchanged
+                yield current
+                yield nxt
+                continue
 
             yield collapsed
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -69,6 +69,7 @@ from typing_extensions import Self, TypedDict
 from langchain_openai import ChatOpenAI
 from langchain_openai.chat_models._compat import (
     _FUNCTION_CALL_IDS_MAP_KEY,
+    _consolidate_calls,
     _convert_from_v1_to_chat_completions,
     _convert_from_v1_to_responses,
     _convert_to_v03_ai_message,
@@ -4771,3 +4772,48 @@ def test_langsmith_gateway_provider_base_url_uses_provider_key(
     assert llm.openai_api_base == "https://api.openai.com/v1"
     assert isinstance(llm.openai_api_key, SecretStr)
     assert llm.openai_api_key.get_secret_value() == "provider-key"
+
+
+def test_consolidate_calls_unknown_tool_name() -> None:
+    """Unrecognized server tool names should pass through without error."""
+    items: list[dict[str, Any]] = [
+        {
+            "type": "server_tool_call",
+            "name": "some_future_tool",
+            "id": "call_abc",
+            "args": {"query": "test"},
+        },
+        {
+            "type": "server_tool_result",
+            "tool_call_id": "call_abc",
+            "status": "success",
+            "output": "result",
+        },
+    ]
+    result = list(_consolidate_calls(items))
+    # both items should be emitted unchanged
+    assert len(result) == 2
+    assert result[0]["type"] == "server_tool_call"
+    assert result[1]["type"] == "server_tool_result"
+
+
+def test_consolidate_calls_web_search() -> None:
+    """web_search call+result pair should be collapsed into web_search_call."""
+    items: list[dict[str, Any]] = [
+        {
+            "type": "server_tool_call",
+            "name": "web_search",
+            "id": "ws_123",
+            "args": {"query": "langchain"},
+        },
+        {
+            "type": "server_tool_result",
+            "tool_call_id": "ws_123",
+            "status": "success",
+        },
+    ]
+    result = list(_consolidate_calls(items))
+    assert len(result) == 1
+    assert result[0]["type"] == "web_search_call"
+    assert result[0]["id"] == "ws_123"
+    assert result[0]["status"] == "completed"


### PR DESCRIPTION
## problem

`_consolidate_calls` in `_compat.py` has two issues:

1. the `file_search` branch uses a bare `if` instead of `elif`, breaking the mutually exclusive chain that starts with `web_search`. functionally this doesn't cause wrong results today since a tool name can only match one branch, but it means the `file_search` condition is evaluated even after `web_search` already matched — and more importantly, the downstream `elif`/`else` chain is attached to `file_search` rather than the full dispatch.

2. when a `server_tool_call` has a name that doesn't match any known tool (`web_search`, `file_search`, `code_interpreter`, `remote_mcp`, `mcp_list_tools`), the `else` branch does `pass` but the code still falls through to `yield collapsed` — where `collapsed` was never assigned, causing an `UnboundLocalError`. this can happen if openai adds new server tool types in the future.

## fix

- change `file_search`'s `if` to `elif` so the entire dispatch is a single `if/elif/else` chain
- in the `else` branch, emit both the call and result items unchanged instead of silently dropping them

## tests

added two tests:
- `test_consolidate_calls_unknown_tool_name`: verifies that unrecognized tool names pass through both items without error
- `test_consolidate_calls_web_search`: verifies that web_search pairs are still collapsed correctly

Fixes #35694