### PR TITLE
fix(huggingface): use PydanticOutputParser for Pydantic models in with_structured_output

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,7 +47,7 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
     make_invalid_tool_call,
@@ -1190,7 +1190,11 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[type-var, arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()  # type: ignore[arg-type]
+            )
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1199,7 +1203,11 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[type-var, arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()  # type: ignore[arg-type]
+            )
         else:
             msg = (
                 f"Unrecognized method argument. Expected one of 'function_calling' or "

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -9,8 +9,10 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.outputs import ChatResult
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
@@ -337,6 +339,104 @@ def test_profile() -> None:
         llm=empty_llm,
     )
     assert model.profile
+
+
+class MyModel(BaseModel):
+    """A test Pydantic model for structured output tests."""
+
+    name: str
+    age: int
+
+
+def _get_output_parser(chain: Any) -> Any:
+    """Extract the last step (output parser) from a RunnableSequence chain."""
+    # with_structured_output returns llm | output_parser when include_raw=False
+    # The chain is a RunnableSequence whose .last attribute is the parser.
+    return chain.last
+
+
+def test_with_structured_output_json_schema_pydantic(
+    chat_hugging_face: Any,
+) -> None:
+    """Test that json_schema method uses PydanticOutputParser for Pydantic models."""
+    chain = chat_hugging_face.with_structured_output(
+        MyModel, method="json_schema"
+    )
+    parser = _get_output_parser(chain)
+    assert isinstance(parser, PydanticOutputParser)
+
+
+def test_with_structured_output_json_schema_dict(
+    chat_hugging_face: Any,
+) -> None:
+    """Test that json_schema method uses JsonOutputParser for dict schemas."""
+    dict_schema = {
+        "title": "MySchema",
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+    }
+    chain = chat_hugging_face.with_structured_output(
+        dict_schema, method="json_schema"
+    )
+    parser = _get_output_parser(chain)
+    assert isinstance(parser, JsonOutputParser)
+
+
+def test_with_structured_output_json_mode_pydantic(
+    chat_hugging_face: Any,
+) -> None:
+    """Test that json_mode method uses PydanticOutputParser for Pydantic models."""
+    chain = chat_hugging_face.with_structured_output(
+        MyModel, method="json_mode"
+    )
+    parser = _get_output_parser(chain)
+    assert isinstance(parser, PydanticOutputParser)
+
+
+def test_with_structured_output_json_mode_dict(
+    chat_hugging_face: Any,
+) -> None:
+    """Test that json_mode method uses JsonOutputParser for dict schemas."""
+    dict_schema = {
+        "title": "MySchema",
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+        },
+    }
+    chain = chat_hugging_face.with_structured_output(
+        dict_schema, method="json_mode"
+    )
+    parser = _get_output_parser(chain)
+    assert isinstance(parser, JsonOutputParser)
+
+
+def test_with_structured_output_json_mode_no_schema(
+    chat_hugging_face: Any,
+) -> None:
+    """Test that json_mode with no schema uses JsonOutputParser."""
+    chain = chat_hugging_face.with_structured_output(
+        schema=None, method="json_mode"
+    )
+    parser = _get_output_parser(chain)
+    assert isinstance(parser, JsonOutputParser)
+
+
+def test_with_structured_output_include_raw_pydantic(
+    chat_hugging_face: Any,
+) -> None:
+    """Test that include_raw=True with Pydantic still uses PydanticOutputParser."""
+    chain = chat_hugging_face.with_structured_output(
+        MyModel, method="json_schema", include_raw=True
+    )
+    # When include_raw=True, the chain is RunnableMap | RunnableAssign(with fallback).
+    # The parser is embedded inside the RunnableAssign's mapper.
+    # We verify the chain was constructed without error (the parser type is internal).
+    assert chain is not None
 
 
 def test_init_chat_model_huggingface() -> None:


### PR DESCRIPTION
## Summary
- When a Pydantic `BaseModel` subclass is passed as the `schema` to `ChatHuggingFace.with_structured_output()`, use `PydanticOutputParser` instead of `JsonOutputParser` so that the output is returned as a validated Pydantic model instance rather than a plain dict.
- Dict/JSON schemas continue to use `JsonOutputParser` (backward compatible).
- Applies to both `json_schema` and `json_mode` methods; `function_calling` is unaffected.

## Motivation
Fixes #32197. Previously, `with_structured_output()` always used `JsonOutputParser()` regardless of schema type, which meant:
1. Pydantic model schemas returned plain dicts instead of validated model instances
2. When `include_raw=True`, parsing retries wasted tokens re-parsing to dicts

This aligns `ChatHuggingFace` with the behavior of other partner integrations (OpenAI, Groq, Fireworks) that already use `PydanticOutputParser` for Pydantic schemas.

## Changes
- **`libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py`**: Added `PydanticOutputParser` import; in the `json_schema` and `json_mode` branches of `with_structured_output`, detect Pydantic schemas via the existing `is_pydantic_schema` flag and use the appropriate parser.
- **`libs/partners/huggingface/tests/unit_tests/test_chat_models.py`**: Added 6 unit tests covering Pydantic vs dict schemas for both methods, no-schema json_mode, and include_raw with Pydantic.

## Test plan
- [x] All 6 new unit tests pass (`test_with_structured_output_json_schema_pydantic`, `test_with_structured_output_json_schema_dict`, `test_with_structured_output_json_mode_pydantic`, `test_with_structured_output_json_mode_dict`, `test_with_structured_output_json_mode_no_schema`, `test_with_structured_output_include_raw_pydantic`)
- [x] All 32 existing unit tests in `test_chat_models.py` continue to pass
- [x] Ruff linting passes on both changed files

> This contribution was made with assistance from an AI agent (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)