### PR TITLE
fix(core): fix RunnableRetry.batch position corruption with return_exceptions

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -279,13 +279,19 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
-        outputs: list[Output | Exception] = []
-        for idx in range(len(inputs)):
-            if idx in results_map:
-                outputs.append(results_map[idx])
-            else:
-                outputs.append(result.pop(0))
-        return outputs
+        # Map remaining (failed) results back to their original indices.
+        # After retries, `result` corresponds 1-to-1 with `remaining_indices`
+        # (the indices still pending in the last retry attempt).  Using
+        # `result.pop(0)` is wrong because `result` contains *all* outputs
+        # from the last attempt—including items that succeeded on retry and
+        # were already placed into `results_map`.  Popping sequentially for
+        # positions not in `results_map` skips those successes and pulls the
+        # wrong element for each position.
+        for offset, orig_idx in enumerate(remaining_indices):
+            if orig_idx not in results_map:
+                results_map[orig_idx] = result[offset]
+
+        return [results_map[i] for i in range(len(inputs))]
 
     @override
     def batch(
@@ -354,13 +360,13 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
-        outputs: list[Output | Exception] = []
-        for idx in range(len(inputs)):
-            if idx in results_map:
-                outputs.append(results_map[idx])
-            else:
-                outputs.append(result.pop(0))
-        return outputs
+        # Map remaining (failed) results back to their original indices.
+        # See the sync _batch_with_config for a detailed explanation.
+        for offset, orig_idx in enumerate(remaining_indices):
+            if orig_idx not in results_map:
+                results_map[orig_idx] = result[offset]
+
+        return [results_map[i] for i in range(len(inputs))]
 
     @override
     async def abatch(

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3979,6 +3979,76 @@ async def test_async_retry_batch_preserves_order() -> None:
     assert results == [0, 1, 2]
 
 
+def test_retry_batch_return_exceptions_position_integrity() -> None:
+    """Regression test for issue #35475.
+
+    When batch() is called with return_exceptions=True and one item succeeds on
+    retry while another permanently fails, the exception must remain at its
+    original position.  The old code used ``result.pop(0)`` during output
+    reconstruction which pulled the wrong element because ``result`` contained
+    the full last-attempt output (both successes and exceptions), not just the
+    exceptions for permanently-failed items.
+    """
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                raise ValueError("transient")
+            return "retry-result"
+        raise ValueError("permanent")
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = runnable.batch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
+async def test_async_retry_batch_return_exceptions_position_integrity() -> None:
+    """Async variant of issue #35475 regression test."""
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                raise ValueError("transient")
+            return "retry-result"
+        raise ValueError("permanent")
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = await runnable.abatch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
 async def test_async_retrying(mocker: MockerFixture) -> None:
     def _lambda(x: int) -> int:
         if x == 1:

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3998,9 +3998,11 @@ def test_retry_batch_return_exceptions_position_integrity() -> None:
         if name == "retry_then_ok":
             if not failed_once:
                 failed_once = True
-                raise ValueError("transient")
+                msg = "transient"
+                raise ValueError(msg)
             return "retry-result"
-        raise ValueError("permanent")
+        msg = "permanent"
+        raise ValueError(msg)
 
     runnable = RunnableLambda(process_item).with_retry(
         stop_after_attempt=2,
@@ -4029,9 +4031,11 @@ async def test_async_retry_batch_return_exceptions_position_integrity() -> None:
         if name == "retry_then_ok":
             if not failed_once:
                 failed_once = True
-                raise ValueError("transient")
+                msg = "transient"
+                raise ValueError(msg)
             return "retry-result"
-        raise ValueError("permanent")
+        msg = "permanent"
+        raise ValueError(msg)
 
     runnable = RunnableLambda(process_item).with_retry(
         stop_after_attempt=2,


### PR DESCRIPTION
## Summary

Fixes #35475

When `batch()` is called with `return_exceptions=True` and some items succeed on retry while others permanently fail, the output positions get corrupted. A retry-successful item can overwrite the exception position of a permanently-failed item.

## Root Cause

The reconstruction loop at lines 282-287 used `result.pop(0)` to fill positions not in `results_map`, but `result` contained the **full** last-attempt output — including items that succeeded on retry and were already placed into `results_map`. Popping sequentially skipped those successes and pulled the wrong element for each remaining position.

### Example

Given inputs `["ok", "retry_then_ok", "always_fail"]` with `stop_after_attempt=2`:

1. **Attempt 1**: `ok` succeeds → `results_map[0]`; `retry_then_ok` and `always_fail` fail
2. **Attempt 2**: `retry_then_ok` succeeds → `results_map[1]`; `always_fail` still fails
3. **Reconstruction**: Position 2 is not in `results_map`, so `result.pop(0)` is called — but `result = ["retry-result", ValueError]`. The pop returns `"retry-result"` instead of the `ValueError`, corrupting position 2.

## Fix

Map the last-attempt results back to their original indices using `remaining_indices`, which correctly tracks the 1-to-1 correspondence between result offsets and original input positions. Both sync and async paths are fixed.

## Tests

Added `test_retry_batch_return_exceptions_position_integrity` and its async variant, reproducing the exact scenario from the issue.