### PR TITLE
fix(openai): ensure stream=False in payload when disable_streaming is active

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1436,6 +1436,10 @@ class BaseChatOpenAI(BaseChatModel):
     ) -> ChatResult:
         self._ensure_sync_client_available()
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        # _generate is the non-streaming path; ensure stream is False so that
+        # the API returns a complete response even when self.streaming is True
+        # (e.g. when disable_streaming routes here instead of _stream).
+        payload["stream"] = False
         generation_info = None
         raw_response = None
         try:
@@ -1690,6 +1694,10 @@ class BaseChatOpenAI(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        # _agenerate is the non-streaming path; ensure stream is False so that
+        # the API returns a complete response even when self.streaming is True
+        # (e.g. when disable_streaming routes here instead of _astream).
+        payload["stream"] = False
         generation_info = None
         raw_response = None
         try:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -103,6 +103,49 @@ def test_streaming_attribute_should_stream(async_api: bool) -> None:
     assert llm._should_stream(async_api=async_api)
 
 
+def test_disable_streaming_payload_stream_false(
+    mock_client: MagicMock,
+) -> None:
+    """When disable_streaming routes through _generate, the API payload must
+    have stream=False even if self.streaming is True.  Regression test for
+    https://github.com/langchain-ai/langchain/issues/35436
+    """
+    llm = ChatOpenAI(
+        model="gpt-4",
+        api_key="test",
+        streaming=True,
+        disable_streaming="tool_calling",
+    )
+    tools = [{"type": "function", "function": {"name": "noop", "parameters": {}}}]
+    with patch.object(llm, "client", mock_client):
+        llm.invoke("hi", tools=tools)
+    call_kwargs = mock_client.with_raw_response.create.call_args[1]
+    assert call_kwargs["stream"] is False, (
+        "Expected stream=False in payload when disable_streaming is active"
+    )
+
+
+async def test_disable_streaming_payload_stream_false_async(
+    mock_async_client: AsyncMock,
+) -> None:
+    """Async variant: payload must have stream=False when disable_streaming
+    routes through _agenerate.
+    """
+    llm = ChatOpenAI(
+        model="gpt-4",
+        api_key="test",
+        streaming=True,
+        disable_streaming="tool_calling",
+    )
+    tools = [{"type": "function", "function": {"name": "noop", "parameters": {}}}]
+    with patch.object(llm, "async_client", mock_async_client):
+        await llm.ainvoke("hi", tools=tools)
+    call_kwargs = mock_async_client.with_raw_response.create.call_args[1]
+    assert call_kwargs["stream"] is False, (
+        "Expected stream=False in payload when disable_streaming is active"
+    )
+
+
 def test_openai_client_caching() -> None:
     """Test that the OpenAI client is cached."""
     llm1 = ChatOpenAI(model="gpt-4.1-mini")

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -112,7 +112,7 @@ def test_disable_streaming_payload_stream_false(
     """
     llm = ChatOpenAI(
         model="gpt-4",
-        api_key="test",
+        api_key=SecretStr("test"),
         streaming=True,
         disable_streaming="tool_calling",
     )
@@ -133,7 +133,7 @@ async def test_disable_streaming_payload_stream_false_async(
     """
     llm = ChatOpenAI(
         model="gpt-4",
-        api_key="test",
+        api_key=SecretStr("test"),
         streaming=True,
         disable_streaming="tool_calling",
     )


### PR DESCRIPTION
## Summary

Fixes #35436

When `disable_streaming='tool_calling'` (or `True`) routes execution through `_generate`/`_agenerate` instead of `_stream`/`_astream`, the request payload still contained `stream=True` because `_default_params` unconditionally includes `"stream": self.streaming`.

This caused the OpenAI client to return an `AsyncStream` object instead of a `ChatCompletion`, leading to a crash in `_create_chat_result` when calling `response.model_dump()`.

## Root Cause

`_default_params` (line 1113) hardcodes `"stream": self.streaming`. When `self.streaming=True` and `disable_streaming` routes through `_generate`/`_agenerate` (the non-streaming code path), the payload still has `stream: True`, causing the API to return a stream iterator.

## Fix

Explicitly set `payload['stream'] = False` at the top of both `_generate` and `_agenerate`. These methods are the non-streaming code path by definition — they should never send `stream: True` to the API.

## Tests

Added `test_disable_streaming_payload_stream_false` and its async variant. Both verify that when `streaming=True` + `disable_streaming='tool_calling'` + tools are bound, the actual API payload has `stream=False`.