### PR TITLE
fix(openai): enable bind_tools after with_structured_output

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3843,46 +3843,44 @@ class _RunnableWithStructuredOutput(RunnableSerializable[LanguageModelInput, Any
     @property
     def first(self) -> Runnable:
         """Get the first runnable in the chain."""
-        return self.chain.first
+        return getattr(self.chain, "first", self.chain)
 
     @property
     def steps(self) -> list[Runnable]:
         """Get all steps in the chain."""
-        if hasattr(self.chain, "steps"):
-            return self.chain.steps
-        return [self.chain]
+        return getattr(self.chain, "steps", [self.chain])
 
     def invoke(
         self,
-        input_: LanguageModelInput,
+        input: LanguageModelInput,  # noqa: A002
         config: RunnableConfig | None = None,
         **kwargs: Any,
     ) -> Any:
-        return self.chain.invoke(input_, config, **kwargs)
+        return self.chain.invoke(input, config, **kwargs)
 
     async def ainvoke(
         self,
-        input_: LanguageModelInput,
+        input: LanguageModelInput,  # noqa: A002
         config: RunnableConfig | None = None,
         **kwargs: Any,
     ) -> Any:
-        return await self.chain.ainvoke(input_, config, **kwargs)
+        return await self.chain.ainvoke(input, config, **kwargs)
 
     def stream(
         self,
-        input_: LanguageModelInput,
+        input: LanguageModelInput,  # noqa: A002
         config: RunnableConfig | None = None,
         **kwargs: Any,
     ) -> Iterator[Any]:
-        yield from self.chain.stream(input_, config, **kwargs)
+        yield from self.chain.stream(input, config, **kwargs)
 
     async def astream(
         self,
-        input_: LanguageModelInput,
+        input: LanguageModelInput,  # noqa: A002
         config: RunnableConfig | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[Any]:
-        async for chunk in self.chain.astream(input_, config, **kwargs):
+        async for chunk in self.chain.astream(input, config, **kwargs):
             yield chunk
 
     def batch(

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3840,6 +3840,18 @@ class _RunnableWithStructuredOutput(RunnableSerializable[LanguageModelInput, Any
     def OutputType(self) -> type:
         return self.chain.OutputType
 
+    @property
+    def first(self) -> Runnable:
+        """Get the first runnable in the chain."""
+        return self.chain.first
+
+    @property
+    def steps(self) -> list[Runnable]:
+        """Get all steps in the chain."""
+        if hasattr(self.chain, "steps"):
+            return self.chain.steps
+        return [self.chain]
+
     def invoke(
         self,
         input_: LanguageModelInput,
@@ -3904,6 +3916,7 @@ class _RunnableWithStructuredOutput(RunnableSerializable[LanguageModelInput, Any
             tools=list(tools),
             **merged_kwargs,
         )
+
 
 def _create_usage_metadata(
     oai_token_usage: dict, service_tier: str | None = None

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -41,6 +41,7 @@ from typing import (
     TypeAlias,
     TypeVar,
     cast,
+    override,
 )
 from urllib.parse import urlparse
 
@@ -100,9 +101,11 @@ from langchain_core.output_parsers.openai_tools import (
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables import (
     Runnable,
+    RunnableConfig,
     RunnableLambda,
     RunnableMap,
     RunnablePassthrough,
+    RunnableSerializable,
 )
 from langchain_core.runnables.config import run_in_executor
 from langchain_core.tools import BaseTool
@@ -2279,8 +2282,19 @@ class BaseChatOpenAI(BaseChatModel):
             parser_with_fallback = parser_assign.with_fallbacks(
                 [parser_none], exception_key="parsing_error"
             )
-            return RunnableMap(raw=llm) | parser_with_fallback
-        return llm | output_parser
+            chain = RunnableMap(raw=llm) | parser_with_fallback
+        else:
+            chain = llm | output_parser
+
+        return _RunnableWithStructuredOutput(
+            chain=chain,
+            llm=self,
+            target_schema=schema,
+            method=method,
+            include_raw=include_raw,
+            strict=strict,
+            kwargs=kwargs,
+        )
 
     def _filter_disabled_params(self, **kwargs: Any) -> dict[str, Any]:
         if not self.disabled_params:
@@ -3803,6 +3817,94 @@ class OpenAIRefusalError(Exception):
     See [more on refusals](https://platform.openai.com/docs/guides/structured-outputs/refusals).
     """
 
+
+class _RunnableWithStructuredOutput(RunnableSerializable[LanguageModelInput, Any]):
+    """Wrapper for structured output chains that preserves bind_tools capability."""
+
+    chain: Runnable
+    llm: Any
+    target_schema: Any
+    method: str
+    include_raw: bool
+    strict: Any
+    kwargs: dict
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @override
+    @property
+    def InputType(self) -> type[LanguageModelInput]:
+        return self.chain.InputType
+
+    @override
+    @property
+    def OutputType(self) -> type:
+        return self.chain.OutputType
+
+    def invoke(
+        self,
+        input_: LanguageModelInput,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        return self.chain.invoke(input_, config, **kwargs)
+
+    async def ainvoke(
+        self,
+        input_: LanguageModelInput,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        return await self.chain.ainvoke(input_, config, **kwargs)
+
+    def stream(
+        self,
+        input_: LanguageModelInput,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> Iterator[Any]:
+        yield from self.chain.stream(input_, config, **kwargs)
+
+    async def astream(
+        self,
+        input_: LanguageModelInput,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[Any]:
+        async for chunk in self.chain.astream(input_, config, **kwargs):
+            yield chunk
+
+    def batch(
+        self,
+        inputs: list[LanguageModelInput],
+        config: RunnableConfig | list[RunnableConfig] | None = None,
+        **kwargs: Any,
+    ) -> list[Any]:
+        return self.chain.batch(inputs, config, **kwargs)
+
+    async def abatch(
+        self,
+        inputs: list[LanguageModelInput],
+        config: RunnableConfig | list[RunnableConfig] | None = None,
+        **kwargs: Any,
+    ) -> list[Any]:
+        return await self.chain.abatch(inputs, config, **kwargs)
+
+    def bind_tools(
+        self,
+        tools: Sequence[Any],
+        **kwargs: Any,
+    ) -> _RunnableWithStructuredOutput:
+        """Bind tools to the structured output chain."""
+        merged_kwargs = {**self.kwargs, **kwargs}
+        return self.llm.with_structured_output(
+            self.target_schema,
+            method=self.method,
+            include_raw=True,
+            strict=self.strict if self.strict is not None else True,
+            tools=list(tools),
+            **merged_kwargs,
+        )
 
 def _create_usage_metadata(
     oai_token_usage: dict, service_tier: str | None = None

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -41,7 +41,6 @@ from typing import (
     TypeAlias,
     TypeVar,
     cast,
-    override,
 )
 from urllib.parse import urlparse
 
@@ -129,7 +128,7 @@ from pydantic import (
     model_validator,
 )
 from pydantic.v1 import BaseModel as BaseModelV1
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from langchain_openai.chat_models._client_utils import (
     _get_default_async_httpx_client,

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -737,7 +737,10 @@ def test_image_token_counting_jpeg() -> None:
 
 def test_image_token_counting_png() -> None:
     model = ChatOpenAI(model="gpt-4o", temperature=0)
-    image_url = "https://raw.githubusercontent.com/langchain-ai/docs/4d11d08b6b0e210bd456943f7a22febbd168b543/src/images/agentic-rag-output.png"
+    image_url = (
+        "https://raw.githubusercontent.com/langchain-ai/docs/"
+        "4d11d08b6b0e210bd456943f7a22febbd168b543/src/images/agentic-rag-output.png"
+    )
     message = HumanMessage(
         content=[
             {"type": "text", "text": "how many dice are in this image"},

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -982,6 +982,7 @@ def test_with_structured_output_bind_tools_sets_include_raw() -> None:
     with_tools = structured_llm.bind_tools([dummy_tool])  # type: ignore[attr-defined]
     assert with_tools.include_raw is True
 
+
 def test_get_num_tokens_from_messages() -> None:
     llm = ChatOpenAI(model="gpt-4o")
     messages = [

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -940,39 +940,25 @@ def test_with_structured_output(
 
 def test_with_structured_output_bind_tools_available() -> None:
     """Test that bind_tools is available after with_structured_output."""
-    from pydantic import BaseModel, Field
 
-    class ResponseSchema(BaseModel):
-        answer: str = Field(description="The answer")
+    class ResponseModel(BaseModel):
+        answer: str
 
-    def dummy_tool(x: int) -> int:
-        """A dummy tool."""
-        return x * 2
-
-    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0, api_key="fake-key")
-    structured_llm = llm.with_structured_output(ResponseSchema)
-
-    # bind_tools should be callable
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key=SecretStr("fake-key"))
+    structured_llm = llm.with_structured_output(ResponseModel)
     assert hasattr(structured_llm, "bind_tools")
     assert callable(structured_llm.bind_tools)
 
-    # calling bind_tools should return a new chain
-    llm_with_tools = structured_llm.bind_tools([dummy_tool])
-    assert llm_with_tools is not None
-    assert hasattr(llm_with_tools, "invoke")
-
 
 def test_with_structured_output_preserves_runnable_interface() -> None:
-    """Test that structured output wrapper preserves Runnable interface."""
-    from pydantic import BaseModel
+    """Test that the wrapper preserves the Runnable interface."""
 
-    class SimpleSchema(BaseModel):
-        value: str
+    class ResponseModel(BaseModel):
+        answer: str
 
-    llm = ChatOpenAI(model="gpt-4o-mini", api_key="fake-key")
-    structured_llm = llm.with_structured_output(SimpleSchema)
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key=SecretStr("fake-key"))
+    structured_llm = llm.with_structured_output(ResponseModel)
 
-    # should have standard Runnable methods
     assert hasattr(structured_llm, "invoke")
     assert hasattr(structured_llm, "ainvoke")
     assert hasattr(structured_llm, "stream")
@@ -982,23 +968,19 @@ def test_with_structured_output_preserves_runnable_interface() -> None:
 
 
 def test_with_structured_output_bind_tools_sets_include_raw() -> None:
-    """Test that bind_tools on structured output sets include_raw=True."""
-    from pydantic import BaseModel
+    """Test that calling bind_tools sets include_raw=True."""
 
-    class Schema(BaseModel):
-        result: str
+    class ResponseModel(BaseModel):
+        answer: str
 
-    def tool_func(x: str) -> str:
-        """Tool function."""
+    def dummy_tool(x: str) -> str:
+        """A dummy tool."""
         return x
 
-    llm = ChatOpenAI(model="gpt-4o-mini", api_key="fake-key")
-    structured_llm = llm.with_structured_output(Schema, include_raw=False)
-
-    # binding tools should force include_raw=True
-    with_tools = structured_llm.bind_tools([tool_func])
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key=SecretStr("fake-key"))
+    structured_llm = llm.with_structured_output(ResponseModel)
+    with_tools = structured_llm.bind_tools([dummy_tool])  # type: ignore[attr-defined]
     assert with_tools.include_raw is True
-
 
 def test_get_num_tokens_from_messages() -> None:
     llm = ChatOpenAI(model="gpt-4o")

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -938,6 +938,68 @@ def test_with_structured_output(
     )
 
 
+def test_with_structured_output_bind_tools_available() -> None:
+    """Test that bind_tools is available after with_structured_output."""
+    from pydantic import BaseModel, Field
+
+    class ResponseSchema(BaseModel):
+        answer: str = Field(description="The answer")
+
+    def dummy_tool(x: int) -> int:
+        """A dummy tool."""
+        return x * 2
+
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0, api_key="fake-key")
+    structured_llm = llm.with_structured_output(ResponseSchema)
+
+    # bind_tools should be callable
+    assert hasattr(structured_llm, "bind_tools")
+    assert callable(structured_llm.bind_tools)
+
+    # calling bind_tools should return a new chain
+    llm_with_tools = structured_llm.bind_tools([dummy_tool])
+    assert llm_with_tools is not None
+    assert hasattr(llm_with_tools, "invoke")
+
+
+def test_with_structured_output_preserves_runnable_interface() -> None:
+    """Test that structured output wrapper preserves Runnable interface."""
+    from pydantic import BaseModel
+
+    class SimpleSchema(BaseModel):
+        value: str
+
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key="fake-key")
+    structured_llm = llm.with_structured_output(SimpleSchema)
+
+    # should have standard Runnable methods
+    assert hasattr(structured_llm, "invoke")
+    assert hasattr(structured_llm, "ainvoke")
+    assert hasattr(structured_llm, "stream")
+    assert hasattr(structured_llm, "astream")
+    assert hasattr(structured_llm, "batch")
+    assert hasattr(structured_llm, "abatch")
+
+
+def test_with_structured_output_bind_tools_sets_include_raw() -> None:
+    """Test that bind_tools on structured output sets include_raw=True."""
+    from pydantic import BaseModel
+
+    class Schema(BaseModel):
+        result: str
+
+    def tool_func(x: str) -> str:
+        """Tool function."""
+        return x
+
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key="fake-key")
+    structured_llm = llm.with_structured_output(Schema, include_raw=False)
+
+    # binding tools should force include_raw=True
+    with_tools = structured_llm.bind_tools([tool_func])
+    assert with_tools.include_raw is True
+
+
 def test_get_num_tokens_from_messages() -> None:
     llm = ChatOpenAI(model="gpt-4o")
     messages = [


### PR DESCRIPTION
Wraps the chain returned by "with_structured_output" so users can call "bind_tools" on it. Before this fix, calling "structured_llm.bind_tools([...])" threw "RunnableSequence" object has no attribute "bind_tools".

Fixes #28848

I added "RunnableWithStructuredOutput" wrapper class that delegates to the underlying chain but exposes "bind_tools". When "bind_tools" is called, it rebuilds the chain with "include_raw=True" which is required for tool usage.

I tested it by adding 3 unit tests for the new functionality and ran "make format" and "make lint" which both passed. Also, ran existing "with_structured_output" tests to make sure nothing broke