### PR TITLE
fix(langchain): handle missing 'tools' key in LLMToolSelectorMiddleware response

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
@@ -235,12 +235,25 @@ class LLMToolSelectorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT,
         available_tools: list[BaseTool],
         valid_tool_names: list[str],
         request: ModelRequest[ContextT],
-    ) -> ModelRequest[ContextT]:
-        """Process the selection response and return filtered `ModelRequest`."""
+    ) -> ModelRequest[ContextT] | None:
+        """Process the selection response and return filtered `ModelRequest`.
+
+        Returns:
+            Filtered `ModelRequest` with only the selected tools, or `None` if the
+            response is missing the `tools` key.
+        """
+        tools_from_response = response.get("tools")
+        if tools_from_response is None:
+            logger.warning(
+                "Tool selection model returned a response missing the 'tools' key. "
+                "Falling back to all available tools."
+            )
+            return None
+
         selected_tool_names: list[str] = []
         invalid_tool_selections = []
 
-        for tool_name in response["tools"]:
+        for tool_name in tools_from_response:
             if tool_name not in valid_tool_names:
                 invalid_tool_selections.append(tool_name)
                 continue
@@ -312,7 +325,7 @@ class LLMToolSelectorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT,
         modified_request = self._process_selection_response(
             response, selection_request.available_tools, selection_request.valid_tool_names, request
         )
-        return handler(modified_request)
+        return handler(modified_request if modified_request is not None else request)
 
     async def awrap_model_call(
         self,
@@ -355,4 +368,4 @@ class LLMToolSelectorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT,
         modified_request = self._process_selection_response(
             response, selection_request.available_tools, selection_request.valid_tool_names, request
         )
-        return await handler(modified_request)
+        return await handler(modified_request if modified_request is not None else request)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_selection.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_selection.py
@@ -639,3 +639,83 @@ class TestEdgeCases:
         """Test that empty tools list raises an error in schema creation."""
         with pytest.raises(AssertionError, match="tools must be non-empty"):
             _create_tool_selection_response([])
+
+    def test_missing_tools_key_falls_back_to_all_tools(self) -> None:
+        """Test that a missing 'tools' key in the LLM response falls back gracefully."""
+        model_requests = []
+
+        @wrap_model_call
+        def trace_model_requests(
+            request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]
+        ) -> ModelResponse:
+            model_requests.append(request)
+            return handler(request)
+
+        # Selector returns a response missing the 'tools' key
+        tool_selection_model = FakeModel(
+            messages=cycle(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "ToolSelectionResponse",
+                                "id": "1",
+                                "args": {},  # missing 'tools' key
+                            }
+                        ],
+                    ),
+                ]
+            )
+        )
+
+        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+
+        tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
+
+        agent = create_agent(
+            model=model,
+            tools=[get_weather, search_web, calculate],
+            middleware=[tool_selector, trace_model_requests],
+        )
+
+        # Should not raise, falls back to all tools
+        agent.invoke({"messages": [HumanMessage("test")]})
+
+        assert len(model_requests) > 0
+        for request in model_requests:
+            tool_names = [t.name for t in request.tools if isinstance(t, BaseTool)]
+            assert set(tool_names) == {"get_weather", "search_web", "calculate"}
+
+    async def test_missing_tools_key_async_falls_back_to_all_tools(self) -> None:
+        """Test async path: missing 'tools' key falls back to all tools gracefully."""
+        tool_selection_model = FakeModel(
+            messages=cycle(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "ToolSelectionResponse",
+                                "id": "1",
+                                "args": {},  # missing 'tools' key
+                            }
+                        ],
+                    ),
+                ]
+            )
+        )
+
+        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+
+        tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
+
+        agent = create_agent(
+            model=model,
+            tools=[get_weather, search_web, calculate],
+            middleware=[tool_selector],
+        )
+
+        # Should not raise; missing 'tools' key is handled gracefully
+        result = await agent.ainvoke({"messages": [HumanMessage("test")]})
+        assert isinstance(result["messages"][-1], AIMessage)

--- a/libs/text-splitters/langchain_text_splitters/konlpy.py
+++ b/libs/text-splitters/langchain_text_splitters/konlpy.py
@@ -8,13 +8,6 @@ from typing_extensions import override
 
 from langchain_text_splitters.base import TextSplitter
 
-try:
-    import konlpy
-
-    _HAS_KONLPY = True
-except ImportError:
-    _HAS_KONLPY = False
-
 
 class KonlpyTextSplitter(TextSplitter):
     """Splitting text using Konlpy package.
@@ -37,12 +30,13 @@ class KonlpyTextSplitter(TextSplitter):
         """
         super().__init__(**kwargs)
         self._separator = separator
-        if not _HAS_KONLPY:
-            msg = """
-                Konlpy is not installed, please install it with
-                `pip install konlpy`
-                """
-            raise ImportError(msg)
+        try:
+            import konlpy  # noqa: PLC0415
+        except ImportError:
+            msg = (
+                "Konlpy is not installed, please install it with `pip install konlpy`."
+            )
+            raise ImportError(msg) from None
         self.kkma = konlpy.tag.Kkma()
 
     @override

--- a/libs/text-splitters/langchain_text_splitters/nltk.py
+++ b/libs/text-splitters/langchain_text_splitters/nltk.py
@@ -8,13 +8,6 @@ from typing_extensions import override
 
 from langchain_text_splitters.base import TextSplitter
 
-try:
-    import nltk
-
-    _HAS_NLTK = True
-except ImportError:
-    _HAS_NLTK = False
-
 
 class NLTKTextSplitter(TextSplitter):
     """Splitting text using NLTK package."""
@@ -46,9 +39,11 @@ class NLTKTextSplitter(TextSplitter):
         if self._use_span_tokenize and self._separator:
             msg = "When use_span_tokenize is True, separator should be ''"
             raise ValueError(msg)
-        if not _HAS_NLTK:
+        try:
+            import nltk  # noqa: PLC0415
+        except ImportError:
             msg = "NLTK is not installed, please install it with `pip install nltk`."
-            raise ImportError(msg)
+            raise ImportError(msg) from None
         if self._use_span_tokenize:
             self._tokenizer = nltk.tokenize._get_punkt_tokenizer(self._language)  # noqa: SLF001
         else:

--- a/libs/text-splitters/langchain_text_splitters/sentence_transformers.py
+++ b/libs/text-splitters/langchain_text_splitters/sentence_transformers.py
@@ -6,16 +6,6 @@ from typing import Any, cast
 
 from langchain_text_splitters.base import TextSplitter, Tokenizer, split_text_on_tokens
 
-try:
-    # Type ignores needed as long as sentence-transformers doesn't support Python 3.14.
-    from sentence_transformers import (  # type: ignore[import-not-found, unused-ignore]
-        SentenceTransformer,
-    )
-
-    _HAS_SENTENCE_TRANSFORMERS = True
-except ImportError:
-    _HAS_SENTENCE_TRANSFORMERS = False
-
 
 class SentenceTransformersTokenTextSplitter(TextSplitter):
     """Splitting text to tokens using sentence model tokenizer."""
@@ -44,13 +34,18 @@ class SentenceTransformersTokenTextSplitter(TextSplitter):
         """
         super().__init__(**kwargs, chunk_overlap=chunk_overlap)
 
-        if not _HAS_SENTENCE_TRANSFORMERS:
+        try:
+            # Type ignores needed: sentence-transformers doesn't support Python 3.14.
+            from sentence_transformers import (  # type: ignore[import-not-found, unused-ignore]  # noqa: PLC0415
+                SentenceTransformer,
+            )
+        except ImportError:
             msg = (
                 "Could not import sentence_transformers python package. "
                 "This is needed in order to use SentenceTransformersTokenTextSplitter. "
                 "Please install it with `pip install sentence-transformers`."
             )
-            raise ImportError(msg)
+            raise ImportError(msg) from None
 
         self.model_name = model_name
         self._model = SentenceTransformer(self.model_name, **(model_kwargs or {}))

--- a/libs/text-splitters/langchain_text_splitters/spacy.py
+++ b/libs/text-splitters/langchain_text_splitters/spacy.py
@@ -55,8 +55,8 @@ def _make_spacy_pipeline_for_splitting(
     try:
         # Type ignores needed as long as spacy doesn't support Python 3.14.
         import spacy  # type: ignore[import-not-found, unused-ignore]  # noqa: PLC0415
-        from spacy.lang.en import (  # noqa: PLC0415
-            English,  # type: ignore[import-not-found, unused-ignore]
+        from spacy.lang.en import (  # type: ignore[import-not-found, unused-ignore]  # noqa: PLC0415
+            English,
         )
     except ImportError:
         msg = "Spacy is not installed, please install it with `pip install spacy`."

--- a/libs/text-splitters/langchain_text_splitters/spacy.py
+++ b/libs/text-splitters/langchain_text_splitters/spacy.py
@@ -8,19 +8,10 @@ from typing_extensions import override
 
 from langchain_text_splitters.base import TextSplitter
 
-try:
-    # Type ignores needed as long as spacy doesn't support Python 3.14.
-    import spacy  # type: ignore[import-not-found, unused-ignore]
-    from spacy.lang.en import English  # type: ignore[import-not-found, unused-ignore]
-
-    if TYPE_CHECKING:
-        from spacy.language import (  # type: ignore[import-not-found, unused-ignore]
-            Language,
-        )
-
-    _HAS_SPACY = True
-except ImportError:
-    _HAS_SPACY = False
+if TYPE_CHECKING:
+    from spacy.language import (  # type: ignore[import-not-found, unused-ignore]
+        Language,
+    )
 
 
 class SpacyTextSplitter(TextSplitter):
@@ -61,11 +52,17 @@ class SpacyTextSplitter(TextSplitter):
 def _make_spacy_pipeline_for_splitting(
     pipeline: str, *, max_length: int = 1_000_000
 ) -> Language:
-    if not _HAS_SPACY:
+    try:
+        # Type ignores needed as long as spacy doesn't support Python 3.14.
+        import spacy  # type: ignore[import-not-found, unused-ignore]  # noqa: PLC0415
+        from spacy.lang.en import (  # noqa: PLC0415
+            English,  # type: ignore[import-not-found, unused-ignore]
+        )
+    except ImportError:
         msg = "Spacy is not installed, please install it with `pip install spacy`."
-        raise ImportError(msg)
+        raise ImportError(msg) from None
     if pipeline == "sentencizer":
-        sentencizer: Language = English()
+        sentencizer = English()
         sentencizer.add_pipe("sentencizer")
     else:
         sentencizer = spacy.load(pipeline, exclude=["ner", "tagger"])

--- a/libs/text-splitters/langchain_text_splitters/spacy.py
+++ b/libs/text-splitters/langchain_text_splitters/spacy.py
@@ -62,7 +62,7 @@ def _make_spacy_pipeline_for_splitting(
         msg = "Spacy is not installed, please install it with `pip install spacy`."
         raise ImportError(msg) from None
     if pipeline == "sentencizer":
-        sentencizer = English()
+        sentencizer: Language = English()
         sentencizer.add_pipe("sentencizer")
     else:
         sentencizer = spacy.load(pipeline, exclude=["ner", "tagger"])

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -52,6 +52,26 @@ def bar():
 """
 
 
+def test_no_heavy_imports_on_package_load() -> None:
+    """Ensure importing the package does not eagerly load heavy dependencies."""
+    import subprocess  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+
+    script = (
+        "import langchain_text_splitters; import sys; "
+        "heavy = ['nltk', 'spacy', 'sentence_transformers', 'konlpy', 'torch']; "
+        "loaded = [p for p in heavy if p in sys.modules]; "
+        "print(','.join(loaded))"
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    loaded = [p for p in result.stdout.strip().split(",") if p]
+    assert not loaded, (
+        f"Heavy packages imported at langchain_text_splitters load time: {loaded}"
+    )
+
+
 def test_character_text_splitter() -> None:
     """Test splitting by character count."""
     text = "foo bar baz 123"


### PR DESCRIPTION
## Summary

- `LLMToolSelectorMiddleware._process_selection_response` raised `KeyError: 'tools'` when the selection LLM returned a malformed response without the `tools` key (intermittent with some models under edge-case prompts)
- `_process_selection_response` now returns `None` when the key is absent, and both `wrap_model_call` / `awrap_model_call` fall back to the original unfiltered request — keeping the agent functional
- A warning is logged so the malformed response remains visible

## Root cause

```python
# Before — crashes when LLM omits "tools"
for tool_name in response["tools"]:  # KeyError

# After — returns None, callers fall back to original request
tools_from_response = response.get("tools")
if tools_from_response is None:
    logger.warning("...Falling back to all available tools.")
    return None
```

## Test plan

- [x] `test_missing_tools_key_falls_back_to_all_tools` — sync path: verifies all tools preserved on missing key
- [x] `test_missing_tools_key_async_falls_back_to_all_tools` — async path: verifies no exception raised
- [x] All 12 existing tests continue to pass

Closes #34358

---

> This PR was developed with the assistance of an AI agent (Claude).