### PR TITLE
fix(core): add bind_tools to RunnableSequence for post-structured-out…

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -3127,6 +3127,72 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
             name=self.name,
         )
 
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],
+        **kwargs: Any,
+    ) -> RunnableSequence:
+        """Bind tools to the LLM step of this sequence, if applicable.
+
+        This enables the pattern::
+
+            structured_llm = llm.with_structured_output(MySchema)
+            agent = structured_llm.bind_tools([tool1, tool2])
+
+        The tools are bound to the first element of the sequence (or its
+        underlying chat model if that element is a `RunnableBinding`). An
+        `AttributeError` is raised when no `BaseChatModel` can be found.
+
+        Args:
+            tools: A list of tools to bind. Accepts the same types as
+                `BaseChatModel.bind_tools`.
+            **kwargs: Additional keyword arguments forwarded to
+                `BaseChatModel.bind_tools` (e.g. `tool_choice`, `strict`).
+
+        Returns:
+            A new `RunnableSequence` with the tools bound to the first step.
+
+        Raises:
+            AttributeError: If the first step in this sequence is not a
+                `BaseChatModel` (or a `RunnableBinding` wrapping one), and
+                therefore does not support tool binding.
+        """
+        from langchain_core.language_models import BaseChatModel  # noqa: PLC0415
+
+        first = self.first
+
+        if isinstance(first, BaseChatModel):
+            bound_first = first.bind_tools(tools, **kwargs)
+        elif isinstance(first, RunnableBindingBase) and isinstance(
+            first.bound, BaseChatModel
+        ):
+            # `with_structured_output` typically wraps the LLM in a
+            # RunnableBinding (e.g. to attach `response_format` or existing
+            # tools).  Call bind_tools on the underlying model to get the
+            # properly formatted tool kwargs, then merge them with the
+            # existing binding so that previously set kwargs are preserved.
+            new_binding = first.bound.bind_tools(tools, **kwargs)
+            if isinstance(new_binding, RunnableBindingBase):
+                merged_kwargs = {**first.kwargs, **new_binding.kwargs}
+                bound_first = first.model_copy(update={"kwargs": merged_kwargs})
+            else:
+                bound_first = first.model_copy(update={"bound": new_binding})
+        else:
+            first_type = type(self.first).__name__
+            msg = (
+                f"'bind_tools' is not supported on this RunnableSequence because "
+                f"its first step ({first_type!r}) is not a BaseChatModel. "
+                f"Tool binding requires the sequence to start with a chat model."
+            )
+            raise AttributeError(msg)  # noqa: TRY004
+
+        return RunnableSequence(
+            first=bound_first,
+            middle=self.middle,
+            last=self.last,
+            name=self.name,
+        )
+
     @override
     def invoke(
         self, input: Input, config: RunnableConfig | None = None, **kwargs: Any

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -27,12 +27,14 @@ from typing_extensions import TypedDict, override
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.callbacks.manager import (
     AsyncCallbackManagerForRetrieverRun,
+    CallbackManagerForLLMRun,
     CallbackManagerForRetrieverRun,
     atrace_as_chain_group,
     trace_as_chain_group,
 )
 from langchain_core.documents import Document
 from langchain_core.language_models import (
+    BaseChatModel,
     FakeListChatModel,
     FakeListLLM,
     FakeStreamingListLLM,
@@ -40,13 +42,19 @@ from langchain_core.language_models import (
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.load import dumpd, dumps
 from langchain_core.load.load import loads
-from langchain_core.messages import AIMessageChunk, HumanMessage, SystemMessage
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    HumanMessage,
+    SystemMessage,
+)
 from langchain_core.messages.base import BaseMessage
 from langchain_core.output_parsers import (
     BaseOutputParser,
     CommaSeparatedListOutputParser,
     StrOutputParser,
 )
+from langchain_core.outputs import ChatResult
 from langchain_core.outputs.chat_generation import ChatGeneration
 from langchain_core.outputs.llm_result import LLMResult
 from langchain_core.prompt_values import ChatPromptValue, StringPromptValue
@@ -5767,3 +5775,68 @@ def test_runnable_typed_dict_schema() -> None:
         repr(parallel.input_schema.model_validate({"foo": "Y", "bar": "Z"}))
         == "RunnableParallel<foo,other>Input(root={'foo': 'Y', 'bar': 'Z'})"
     )
+
+
+class _FakeChatModelWithBindTools(BaseChatModel):
+    """Minimal fake chat model that tracks bound tools, for testing."""
+
+    bound_tools: list = Field(default_factory=list)
+
+    @property
+    @override
+    def _llm_type(self) -> str:
+        return "fake-with-bind-tools"
+
+    @override
+    def _generate(
+        self,
+        _messages: list[BaseMessage],
+        _stop: list[str] | None = None,
+        _run_manager: CallbackManagerForLLMRun | None = None,
+        **_kwargs: Any,
+    ) -> ChatResult:
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="ok"))])
+
+    def bind_tools(  # type: ignore[override]
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable | BaseTool],
+        **_kwargs: Any,
+    ) -> "_FakeChatModelWithBindTools":
+        return self.model_copy(update={"bound_tools": list(tools)})
+
+
+def test_runnable_sequence_bind_tools_after_with_structured_output() -> None:
+    """bind_tools on a RunnableSequence starting with a BaseChatModel."""
+
+    class OutputSchema(BaseModel):
+        answer: str
+
+    @tool
+    def search(_query: str) -> str:
+        """Search the web."""
+        return "results"
+
+    llm = _FakeChatModelWithBindTools()
+    parser = RunnableLambda(lambda x: OutputSchema(answer=str(x)))
+    sequence = RunnableSequence(first=llm, last=parser)
+
+    bound_sequence = sequence.bind_tools([search])
+    assert isinstance(bound_sequence, RunnableSequence)
+    assert isinstance(bound_sequence.first, _FakeChatModelWithBindTools)
+    assert search in bound_sequence.first.bound_tools
+
+
+def test_runnable_sequence_bind_tools_raises_when_first_not_chat_model() -> None:
+    """bind_tools should raise when first step is not a BaseChatModel."""
+
+    @tool
+    def dummy_tool(_x: str) -> str:
+        """A dummy tool."""
+        return _x
+
+    step_a = RunnableLambda(lambda x: x)
+    step_b = RunnableLambda(lambda x: x)
+    sequence = RunnableSequence(first=step_a, last=step_b)
+
+    with pytest.raises(AttributeError, match=r"bind_tools.*not supported"):
+        sequence.bind_tools([dummy_tool])

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3431,3 +3431,28 @@ def test_context_overflow_error_backwards_compatibility() -> None:
     # Verify it's both types (multiple inheritance)
     assert isinstance(exc_info.value, openai.BadRequestError)
     assert isinstance(exc_info.value, ContextOverflowError)
+
+
+def test_bind_tools_after_with_structured_output() -> None:
+    """bind_tools should work on the RunnableSequence from with_structured_output."""
+    from langchain_core.runnables import RunnableSequence
+    from langchain_core.tools import tool
+    from pydantic import BaseModel, SecretStr
+
+    class ResponseModel(BaseModel):
+        answer: str
+
+    @tool
+    def get_weather(location: str) -> str:
+        """Get the weather at a location."""
+        return f"Sunny in {location}"
+
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key=SecretStr("test-api-key"))
+    structured_llm = llm.with_structured_output(ResponseModel)
+
+    agent = structured_llm.bind_tools([get_weather])
+
+    assert isinstance(agent, RunnableSequence)
+    bound_kwargs = agent.first.kwargs
+    assert "tools" in bound_kwargs
+    assert any(t["function"]["name"] == "get_weather" for t in bound_kwargs["tools"])


### PR DESCRIPTION
…put chaining

Fixes #28848. `with_structured_output` returns a `RunnableSequence` that previously had no `bind_tools` method, making it impossible to add tools to a structured-output chain without reconstructing the pipeline manually.

Add `RunnableSequence.bind_tools` that:
- delegates to `self.first.bind_tools(tools, **kwargs)` when the first step is a `BaseChatModel` directly
- handles the common `with_structured_output` case where the LLM is already wrapped in a `RunnableBinding` (e.g. carrying `response_format`, `tool_choice`, or existing tools) by calling `bind_tools` on the underlying model and merging the resulting kwargs with the existing binding so previously set parameters are preserved
- raises a descriptive `AttributeError` for sequences whose first step is neither a `BaseChatModel` nor a `RunnableBinding` wrapping one

Also adds unit tests in `langchain-core` and an integration-style unit test in `langchain-openai` that covers the real `with_structured_output` → `bind_tools` flow without network calls.

Disclaimer: Claude.ai was used to assist with this PR

## Social handles
LinkedIn: https://linkedin.com/in/navin-senguttuvan
