### PR TITLE
test(langchain): use neutral column names in PandasDataFrameOutputParser test fixture

### DIFF
--- a/libs/langchain/tests/unit_tests/output_parsers/test_pandas_dataframe_parser.py
+++ b/libs/langchain/tests/unit_tests/output_parsers/test_pandas_dataframe_parser.py
@@ -12,9 +12,9 @@ from langchain_classic.output_parsers.pandas_dataframe import (
 
 df = pd.DataFrame(
     {
-        "chicken": [1, 2, 3, 4],
+        "apples": [1, 2, 3, 4],
         "veggies": [5, 4, 3, 2],
-        "steak": [9, 8, 7, 6],
+        "grains": [9, 8, 7, 6],
     },
 )
 
@@ -35,17 +35,17 @@ def test_pandas_output_parser_col_oob() -> None:
 
 # Test Column with array [x]
 def test_pandas_output_parser_col_first_elem() -> None:
-    expected_output = {"chicken": 1}
-    actual_output = parser.parse("column:chicken[0]")
+    expected_output = {"apples": 1}
+    actual_output = parser.parse("column:apples[0]")
     assert actual_output == expected_output
 
 
 # Test Column with array [x,y,z]
 def test_pandas_output_parser_col_multi_elem() -> None:
-    expected_output = {"chicken": pd.Series([1, 2], name="chicken", dtype="int64")}
-    actual_output = parser.parse("column:chicken[0, 1]")
+    expected_output = {"apples": pd.Series([1, 2], name="apples", dtype="int64")}
+    actual_output = parser.parse("column:apples[0, 1]")
     for key in actual_output:
-        assert expected_output["chicken"].equals(actual_output[key])
+        assert expected_output["apples"].equals(actual_output[key])
 
 
 # Test Row with invalid row entry
@@ -56,7 +56,7 @@ def test_pandas_output_parser_row_no_array() -> None:
 
 # Test Row with valid row entry
 def test_pandas_output_parser_row_first() -> None:
-    expected_output = {"1": pd.Series({"chicken": 2, "veggies": 4, "steak": 8})}
+    expected_output = {"1": pd.Series({"apples": 2, "veggies": 4, "grains": 8})}
     actual_output = parser.parse("row:1")
     assert actual_output["1"].equals(expected_output["1"])
 
@@ -70,7 +70,7 @@ def test_pandas_output_parser_row_no_column() -> None:
 # Test Row with valid col entry
 def test_pandas_output_parser_row_col_1() -> None:
     expected_output = {"1": 2}
-    actual_output = parser.parse("row:1[chicken]")
+    actual_output = parser.parse("row:1[apples]")
     assert actual_output == expected_output
 
 
@@ -87,14 +87,14 @@ def test_pandas_output_parser_special_ops() -> None:
     ]
 
     expected_output = [
-        parser.parse("mean:chicken[1..3]"),
-        parser.parse("median:chicken[1..3]"),
-        parser.parse("min:chicken[1..3]"),
-        parser.parse("max:chicken[1..3]"),
-        parser.parse("var:chicken[1..3]"),
-        parser.parse("std:chicken[1..3]"),
-        parser.parse("count:chicken[1..3]"),
-        parser.parse("quantile:chicken[1..3]"),
+        parser.parse("mean:apples[1..3]"),
+        parser.parse("median:apples[1..3]"),
+        parser.parse("min:apples[1..3]"),
+        parser.parse("max:apples[1..3]"),
+        parser.parse("var:apples[1..3]"),
+        parser.parse("std:apples[1..3]"),
+        parser.parse("count:apples[1..3]"),
+        parser.parse("quantile:apples[1..3]"),
     ]
 
     assert actual_output == expected_output
@@ -102,7 +102,7 @@ def test_pandas_output_parser_special_ops() -> None:
 
 def test_pandas_output_parser_invalid_special_op() -> None:
     with pytest.raises(OutputParserException):
-        parser.parse("riemann_sum:chicken")
+        parser.parse("riemann_sum:apples")
 
 
 def test_pandas_output_parser_output_type() -> None:


### PR DESCRIPTION
The `PandasDataFrameOutputParser` test fixture creates a DataFrame with columns `chicken`, `veggies`, and `steak`. These food-category names suggest the data has semantic meaning, when the fixture is really just scaffolding for testing parser syntax. Renaming to `apples`, `veggies`, and `grains` makes it clearer the columns are arbitrary — `veggies` is kept unchanged since it already reads as a generic category name.

All 11 unit tests pass after the rename.

*(Identified with AI assistance; reviewed and verified manually.)*