### PR TITLE
fix(core): make trim_messages respect tool-call group integrity

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1932,7 +1932,7 @@ def _get_message_group_boundaries(
     invalid message sequence for providers that validate ordering (e.g. Anthropic).
 
     The returned list contains every index *i* such that ``messages[:i]`` is a
-    structurally valid prefix – i.e. every ``AIMessage`` with tool calls is
+    structurally valid prefix - i.e. every ``AIMessage`` with tool calls is
     followed by all of its ``ToolMessage`` replies.
 
     Index ``0`` (empty prefix) and ``len(messages)`` (full list) are always

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1415,7 +1415,20 @@ def trim_messages(
         actual_token_counter = token_counter  # type: ignore[assignment]
 
     if hasattr(actual_token_counter, "get_num_tokens_from_messages"):
-        list_token_counter = actual_token_counter.get_num_tokens_from_messages
+        _base_method = actual_token_counter.get_num_tokens_from_messages
+        # Forward bound tools (e.g., from bind_tools()) to the token counter
+        # if the counter method accepts a ``tools`` parameter.
+        _extra: dict[str, Any] = {}
+        if hasattr(actual_token_counter, "kwargs"):
+            _bound_tools = actual_token_counter.kwargs.get("tools")
+            if _bound_tools is not None:
+                sig = inspect.signature(_base_method)
+                if "tools" in sig.parameters:
+                    _extra["tools"] = _bound_tools
+        if _extra:
+            list_token_counter = partial(_base_method, **_extra)
+        else:
+            list_token_counter = _base_method
     elif callable(actual_token_counter):
         if (
             next(
@@ -1909,6 +1922,37 @@ def convert_to_openai_messages(
     return oai_messages
 
 
+def _get_message_group_boundaries(
+    messages: Sequence[BaseMessage],
+) -> list[int]:
+    """Return valid split-point indices that never break tool-call groups.
+
+    A tool-call group is an ``AIMessage`` with ``tool_calls`` followed by one or
+    more ``ToolMessage`` instances.  Splitting inside such a group produces an
+    invalid message sequence for providers that validate ordering (e.g. Anthropic).
+
+    The returned list contains every index *i* such that ``messages[:i]`` is a
+    structurally valid prefix – i.e. every ``AIMessage`` with tool calls is
+    followed by all of its ``ToolMessage`` replies.
+
+    Index ``0`` (empty prefix) and ``len(messages)`` (full list) are always
+    included.
+    """
+    boundaries: list[int] = [0]
+    i = 0
+    n = len(messages)
+    while i < n:
+        if isinstance(messages[i], AIMessage) and messages[i].tool_calls:
+            # Consume the AIMessage and all following ToolMessages as one group.
+            i += 1
+            while i < n and isinstance(messages[i], ToolMessage):
+                i += 1
+        else:
+            i += 1
+        boundaries.append(i)
+    return boundaries
+
+
 def _first_max_tokens(
     messages: Sequence[BaseMessage],
     *,
@@ -1933,21 +1977,23 @@ def _first_max_tokens(
                     break
         return messages
 
-    # Use binary search to find the maximum number of messages within token limit
-    left, right = 0, len(messages)
-    max_iterations = len(messages).bit_length()
+    # Build group boundaries so the binary search never splits a tool-call
+    # exchange (AIMessage with tool_calls + following ToolMessages).
+    boundaries = _get_message_group_boundaries(messages)
+
+    # Binary search on group boundaries to find maximum valid prefix.
+    left, right = 0, len(boundaries) - 1
+    max_iterations = len(boundaries).bit_length()
     for _ in range(max_iterations):
         if left >= right:
             break
         mid = (left + right + 1) // 2
-        if token_counter(messages[:mid]) <= max_tokens:
+        if token_counter(messages[: boundaries[mid]]) <= max_tokens:
             left = mid
-            idx = mid
         else:
             right = mid - 1
 
-    # idx now contains the maximum number of complete messages we can include
-    idx = left
+    idx = boundaries[left]
 
     if partial_strategy and idx < len(messages):
         included_partial = False
@@ -2054,26 +2100,119 @@ def _last_max_tokens(
         system_message = messages[0]
         messages = messages[1:]
 
-    # Reverse messages to use _first_max_tokens with reversed logic
-    reversed_messages = messages[::-1]
-
     # Calculate remaining tokens after accounting for system message if present
     remaining_tokens = max_tokens
     if system_message:
         system_tokens = token_counter([system_message])
         remaining_tokens = max(0, max_tokens - system_tokens)
 
-    reversed_result = _first_max_tokens(
-        reversed_messages,
-        max_tokens=remaining_tokens,
-        token_counter=token_counter,
-        text_splitter=text_splitter,
-        partial_strategy="last" if allow_partial else None,
-        end_on=start_on,
-    )
+    # Build group boundaries so we never split tool-call exchanges.
+    # boundaries[i] are valid split-points where messages[boundary:] is
+    # a structurally correct suffix.
+    boundaries = _get_message_group_boundaries(messages)
 
-    # Re-reverse the messages and add back the system message if needed
-    result = reversed_result[::-1]
+    if not messages or remaining_tokens <= 0:
+        result = []
+    else:
+        # Binary search on group boundaries to find the earliest start
+        # such that messages[start:] fits within remaining_tokens.
+        # boundaries is sorted ascending; we want the smallest boundary
+        # whose suffix fits.
+        lo, hi = 0, len(boundaries) - 1
+        # Start assuming we can include nothing (idx = len(messages))
+        best = len(boundaries) - 1
+        max_iterations = len(boundaries).bit_length()
+        for _ in range(max_iterations):
+            if lo > hi:
+                break
+            mid = (lo + hi) // 2
+            if token_counter(messages[boundaries[mid] :]) <= remaining_tokens:
+                best = mid
+                hi = mid - 1  # try starting even earlier
+            else:
+                lo = mid + 1  # need to start later
+        start_idx = boundaries[best]
+        result = messages[start_idx:]
+
+        # Handle allow_partial: try to include a partial first message
+        if allow_partial and start_idx > 0:
+            candidate_idx = start_idx - 1
+            # Only attempt partial on the message just before start_idx,
+            # but never try to partially include a ToolMessage (that would
+            # break the tool-call group invariant).
+            if not isinstance(messages[candidate_idx], ToolMessage):
+                partial_msg = messages[candidate_idx].model_copy(deep=True)
+                # Try including partial content blocks
+                included_partial = False
+                if isinstance(partial_msg.content, list) and len(
+                    partial_msg.content
+                ) > 1:
+                    original_blocks = list(partial_msg.content)
+                    # Keep last N blocks (since we want the tail of the
+                    # conversation).
+                    for keep in range(len(original_blocks) - 1, 0, -1):
+                        partial_msg.content = original_blocks[-keep:]
+                        if (
+                            token_counter([partial_msg, *result])
+                            <= remaining_tokens
+                        ):
+                            result = [partial_msg, *result]
+                            included_partial = True
+                            break
+                if not included_partial:
+                    text = None
+                    if isinstance(partial_msg.content, str):
+                        text = partial_msg.content
+                    elif isinstance(partial_msg.content, list):
+                        for block in partial_msg.content:
+                            if isinstance(block, str):
+                                text = block
+                                break
+                            if (
+                                isinstance(block, dict)
+                                and block.get("type") == "text"
+                            ):
+                                text = block.get("text")
+                                break
+                    if text:
+                        split_texts = text_splitter(text)
+                        # Keep last N splits
+                        lo2, hi2 = 0, len(split_texts)
+                        max_iter2 = len(split_texts).bit_length()
+                        for _ in range(max_iter2):
+                            if lo2 >= hi2:
+                                break
+                            mid2 = (lo2 + hi2 + 1) // 2
+                            partial_msg.content = "".join(split_texts[-mid2:])
+                            if (
+                                token_counter([partial_msg, *result])
+                                <= remaining_tokens
+                            ):
+                                lo2 = mid2
+                            else:
+                                hi2 = mid2 - 1
+                        if lo2 > 0:
+                            partial_msg.content = "".join(split_texts[-lo2:])
+                            result = [partial_msg, *result]
+
+        # Apply start_on filter (skip leading messages that don't match)
+        if start_on:
+            while result and not _is_message_type(result[0], start_on):
+                # Don't orphan ToolMessages: if removing the first message
+                # would leave a ToolMessage at the front, skip the whole
+                # tool-call group.
+                if (
+                    len(result) > 1
+                    and isinstance(result[0], AIMessage)
+                    and result[0].tool_calls
+                ):
+                    # Remove the AIMessage and all its ToolMessages
+                    result.pop(0)
+                    while result and isinstance(result[0], ToolMessage):
+                        result.pop(0)
+                else:
+                    result.pop(0)
+
     if system_message:
         result = [system_message, *result]
 

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1939,7 +1939,8 @@ def _get_message_group_boundaries(
     i = 0
     n = len(messages)
     while i < n:
-        if isinstance(messages[i], AIMessage) and messages[i].tool_calls:
+        msg = messages[i]
+        if isinstance(msg, AIMessage) and msg.tool_calls:
             # Consume the AIMessage and all following ToolMessages as one group.
             i += 1
             while i < n and isinstance(messages[i], ToolMessage):

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1425,10 +1425,7 @@ def trim_messages(
                 sig = inspect.signature(_base_method)
                 if "tools" in sig.parameters:
                     _extra["tools"] = _bound_tools
-        if _extra:
-            list_token_counter = partial(_base_method, **_extra)
-        else:
-            list_token_counter = _base_method
+        list_token_counter = partial(_base_method, **_extra) if _extra else _base_method
     elif callable(actual_token_counter):
         if (
             next(

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2146,18 +2146,16 @@ def _last_max_tokens(
                 partial_msg = messages[candidate_idx].model_copy(deep=True)
                 # Try including partial content blocks
                 included_partial = False
-                if isinstance(partial_msg.content, list) and len(
-                    partial_msg.content
-                ) > 1:
+                if (
+                    isinstance(partial_msg.content, list)
+                    and len(partial_msg.content) > 1
+                ):
                     original_blocks = list(partial_msg.content)
                     # Keep last N blocks (since we want the tail of the
                     # conversation).
                     for keep in range(len(original_blocks) - 1, 0, -1):
                         partial_msg.content = original_blocks[-keep:]
-                        if (
-                            token_counter([partial_msg, *result])
-                            <= remaining_tokens
-                        ):
+                        if token_counter([partial_msg, *result]) <= remaining_tokens:
                             result = [partial_msg, *result]
                             included_partial = True
                             break
@@ -2170,10 +2168,7 @@ def _last_max_tokens(
                             if isinstance(block, str):
                                 text = block
                                 break
-                            if (
-                                isinstance(block, dict)
-                                and block.get("type") == "text"
-                            ):
+                            if isinstance(block, dict) and block.get("type") == "text":
                                 text = block.get("text")
                                 break
                     if text:

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1996,9 +1996,14 @@ def _first_max_tokens(
     idx = boundaries[left]
 
     if partial_strategy and idx < len(messages):
+        # Never partially include an AIMessage with tool_calls — doing so would
+        # produce an orphaned tool-call without its ToolMessage(s).
+        _skip_partial = isinstance(messages[idx], AIMessage) and bool(
+            getattr(messages[idx], "tool_calls", None)
+        )
         included_partial = False
         copied = False
-        if isinstance(messages[idx].content, list):
+        if not _skip_partial and isinstance(messages[idx].content, list):
             excluded = messages[idx].model_copy(deep=True)
             copied = True
             num_block = len(excluded.content)
@@ -2013,7 +2018,7 @@ def _first_max_tokens(
                     break
             if included_partial and partial_strategy == "last":
                 excluded.content = list(reversed(excluded.content))
-        if not included_partial:
+        if not _skip_partial and not included_partial:
             if not copied:
                 excluded = messages[idx].model_copy(deep=True)
                 copied = True

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -3021,6 +3021,27 @@ def test_trim_messages_tool_group_never_split_first() -> None:
             assert isinstance(result[idx + 1], ToolMessage)
 
 
+def test_trim_messages_tool_group_never_split_first_allow_partial() -> None:
+    """strategy='first', allow_partial=True: still must not orphan tool_calls."""
+    result = trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=35,
+        token_counter=dummy_token_counter,
+        strategy="first",
+        allow_partial=True,
+    )
+    # First 3 non-tool messages fit (~30 tokens), but the tool-call group
+    # does not fit entirely.  Result must not contain an orphaned AIMessage.
+    assert len(result) == 3
+    assert isinstance(result[0], HumanMessage)
+    assert isinstance(result[2], HumanMessage)
+    for msg in result:
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            idx = result.index(msg)
+            assert idx + 1 < len(result)
+            assert isinstance(result[idx + 1], ToolMessage)
+
+
 def test_trim_messages_tool_group_never_split_last() -> None:
     """strategy='last': must not orphan a ToolMessage without its AIMessage."""
     # With max_tokens=15 (1.5 messages worth), only the last message (ToolMessage)

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2958,3 +2958,280 @@ def test_count_tokens_approximately_with_tools() -> None:
     # Test with empty tools list should equal base count
     count_empty_tools = count_tokens_approximately(messages, tools=[])
     assert count_empty_tools == base_count
+
+
+# ---------- Tests for tool-call group-aware trim_messages (issue #29637) ----------
+
+# Shared fixture: a conversation that includes a tool-call exchange.
+_TOOL_CALL_MESSAGES = [
+    HumanMessage("hi"),
+    AIMessage("hello"),
+    HumanMessage("what's the weather in florida?"),
+    AIMessage(
+        [
+            {"type": "text", "text": "let's check the weather in florida"},
+            {
+                "type": "tool_use",
+                "id": "abc123",
+                "name": "get_weather",
+                "input": {"location": "florida"},
+            },
+        ],
+        tool_calls=[
+            {
+                "name": "get_weather",
+                "args": {"location": "florida"},
+                "id": "abc123",
+                "type": "tool_call",
+            },
+        ],
+    ),
+    ToolMessage(
+        "It's sunny.",
+        name="get_weather",
+        tool_call_id="abc123",
+    ),
+]
+
+
+def test_trim_messages_tool_group_never_split_first() -> None:
+    """strategy='first': must not include AIMessage(tool_calls) without ToolMessage."""
+    # 10 tokens per message → 3 messages = 30 tokens.
+    # The 4th message is an AIMessage with tool_calls. Including it alone (40 tokens)
+    # would leave the ToolMessage out and create an invalid sequence. The trimmer
+    # must stop at 3 messages.
+    result = trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=35,
+        token_counter=dummy_token_counter,
+        strategy="first",
+    )
+    # Should include first 3 messages (30 tokens) but NOT the AIMessage(tool_calls)
+    # alone because the ToolMessage wouldn't fit.
+    assert len(result) == 3
+    assert isinstance(result[0], HumanMessage)
+    assert isinstance(result[2], HumanMessage)
+    # No orphaned tool-call messages
+    for msg in result:
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            # If an AIMessage with tool_calls is present, the following messages
+            # must include the ToolMessage(s).
+            idx = result.index(msg)
+            assert idx + 1 < len(result)
+            assert isinstance(result[idx + 1], ToolMessage)
+
+
+def test_trim_messages_tool_group_never_split_last() -> None:
+    """strategy='last': must not orphan a ToolMessage without its AIMessage."""
+    # With max_tokens=15 (1.5 messages worth), only the last message (ToolMessage)
+    # fits. But a ToolMessage without its AIMessage is invalid. The trimmer should
+    # either include nothing or skip to an earlier valid group.
+    result = trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=15,
+        token_counter=dummy_token_counter,
+        strategy="last",
+    )
+    # Result must not start with an orphaned ToolMessage
+    if result:
+        assert not isinstance(result[0], ToolMessage)
+
+
+def test_trim_messages_tool_group_included_together_last() -> None:
+    """strategy='last': tool-call group (AIMessage + ToolMessage) is atomic."""
+    # AIMessage(tool_calls, list content 2 blocks) = 14 tokens, ToolMessage = 10.
+    # Group total = 24. With max_tokens=25, the group fits from the end.
+    result = trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=25,
+        token_counter=dummy_token_counter,
+        strategy="last",
+    )
+    # Should include the tool call group = 24 tokens
+    assert len(result) == 2
+    assert isinstance(result[0], AIMessage)
+    assert result[0].tool_calls
+    assert isinstance(result[1], ToolMessage)
+
+
+def test_trim_messages_tool_group_included_together_first() -> None:
+    """strategy='first': tool-call group fits entirely within budget."""
+    # dummy_token_counter: str content = 10, list content with 2 blocks = 14
+    # Total: 10 + 10 + 10 + 14 + 10 = 54 tokens.
+    # With max_tokens=55, all 5 messages fit.
+    result = trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=55,
+        token_counter=dummy_token_counter,
+        strategy="first",
+    )
+    assert len(result) == 5
+    # The AIMessage(tool_calls) at index 3 must be followed by ToolMessage at 4
+    assert isinstance(result[3], AIMessage)
+    assert result[3].tool_calls
+    assert isinstance(result[4], ToolMessage)
+
+
+def test_trim_messages_no_reversed_messages_sent_to_counter() -> None:
+    """strategy='last': token counter must never receive reversed messages.
+
+    Providers like Anthropic validate message ordering and reject reversed
+    sequences (ToolMessage before AIMessage). Verify that the token counter
+    always receives messages in their natural (forward) order.
+    """
+    call_log: list[list[BaseMessage]] = []
+
+    def tracking_counter(messages: list[BaseMessage]) -> int:
+        call_log.append(list(messages))
+        return len(messages) * 10
+
+    trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=30,
+        token_counter=tracking_counter,
+        strategy="last",
+    )
+
+    for call_msgs in call_log:
+        for i, msg in enumerate(call_msgs):
+            if isinstance(msg, ToolMessage):
+                # A ToolMessage must be preceded by an AIMessage with tool_calls
+                assert i > 0, "ToolMessage at index 0 — reversed sequence detected"
+                prev = call_msgs[i - 1]
+                assert isinstance(prev, AIMessage) and prev.tool_calls, (
+                    f"ToolMessage at index {i} not preceded by AIMessage(tool_calls)"
+                )
+
+
+def test_trim_messages_tool_group_with_include_system() -> None:
+    """strategy='last' with include_system preserves system + tool groups."""
+    messages = [
+        SystemMessage("You are a helpful assistant."),
+        *_TOOL_CALL_MESSAGES,
+    ]
+    result = trim_messages(
+        messages,
+        max_tokens=35,
+        token_counter=dummy_token_counter,
+        strategy="last",
+        include_system=True,
+    )
+    # System message (10 tokens) + remaining budget = 25 tokens → fits the
+    # tool-call group (AIMessage 14 + ToolMessage 10 = 24 tokens).
+    assert isinstance(result[0], SystemMessage)
+    # The rest should form a valid sequence
+    non_system = result[1:]
+    for i, msg in enumerate(non_system):
+        if isinstance(msg, ToolMessage):
+            assert i > 0
+            assert isinstance(non_system[i - 1], AIMessage)
+
+
+def test_trim_messages_tool_group_start_on_human() -> None:
+    """strategy='last' + start_on='human': skip tool group if it starts sequence."""
+    # If the only messages that fit are the tool-call group, but start_on='human'
+    # requires starting with a HumanMessage, the group should be skipped.
+    result = trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=25,
+        token_counter=dummy_token_counter,
+        strategy="last",
+        start_on="human",
+    )
+    # Result should either be empty or start with a HumanMessage
+    if result:
+        assert isinstance(result[0], HumanMessage)
+
+
+def test_trim_messages_multiple_tool_groups() -> None:
+    """Multiple tool-call groups should each be treated atomically."""
+    messages = [
+        HumanMessage("query 1"),
+        AIMessage(
+            "calling tool A",
+            tool_calls=[
+                {"name": "A", "args": {}, "id": "a1", "type": "tool_call"},
+            ],
+        ),
+        ToolMessage("result A", tool_call_id="a1"),
+        HumanMessage("query 2"),
+        AIMessage(
+            "calling tool B",
+            tool_calls=[
+                {"name": "B", "args": {}, "id": "b1", "type": "tool_call"},
+            ],
+        ),
+        ToolMessage("result B", tool_call_id="b1"),
+    ]
+    # 6 messages × 10 tokens = 60. Budget = 35 → fits 3 messages.
+    # From the end: group [AIMessage+ToolMessage] = 20, + HumanMessage = 30 → fits.
+    result = trim_messages(
+        messages,
+        max_tokens=35,
+        token_counter=dummy_token_counter,
+        strategy="last",
+    )
+    # Should include the second tool group + the preceding HumanMessage
+    assert len(result) == 3
+    assert isinstance(result[0], HumanMessage)
+    assert result[0].content == "query 2"
+    assert isinstance(result[1], AIMessage) and result[1].tool_calls
+    assert isinstance(result[2], ToolMessage)
+
+
+def test_trim_messages_tool_group_boundary_exact_fit() -> None:
+    """Tool-call group that exactly fills the token budget is included."""
+    # AIMessage(tool_calls, list 2 blocks) = 14 + ToolMessage = 10 → 24 tokens
+    result = trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=24,
+        token_counter=dummy_token_counter,
+        strategy="last",
+    )
+    assert len(result) == 2
+    assert isinstance(result[0], AIMessage) and result[0].tool_calls
+    assert isinstance(result[1], ToolMessage)
+
+
+def test_get_message_group_boundaries() -> None:
+    """Directly test the _get_message_group_boundaries helper."""
+    from langchain_core.messages.utils import _get_message_group_boundaries
+
+    boundaries = _get_message_group_boundaries(_TOOL_CALL_MESSAGES)
+    # 5 messages: [H, AI, H, AI(tc)+TM] → groups at indices [0,1,2,3-4]
+    # boundaries = [0, 1, 2, 3, 5]
+    assert boundaries == [0, 1, 2, 3, 5]
+
+    # Empty
+    assert _get_message_group_boundaries([]) == [0]
+
+    # No tool calls
+    simple = [HumanMessage("a"), AIMessage("b"), HumanMessage("c")]
+    assert _get_message_group_boundaries(simple) == [0, 1, 2, 3]
+
+
+def test_trim_messages_tool_forward_bound_tools() -> None:
+    """Bound tools from bind_tools() are forwarded to get_num_tokens_from_messages."""
+    received_kwargs: dict[str, Any] = {}
+
+    class _MockLLM:
+        """Mock LLM that records kwargs passed to get_num_tokens_from_messages."""
+
+        # Simulates RunnableBinding.kwargs from bind_tools()
+        kwargs: dict[str, Any] = {"tools": ["tool_a", "tool_b"]}
+
+        def get_num_tokens_from_messages(
+            self,
+            messages: list[BaseMessage],
+            tools: list[str] | None = None,
+        ) -> int:
+            received_kwargs["tools"] = tools
+            return len(messages) * 10
+
+    mock_llm = _MockLLM()
+    trim_messages(
+        [HumanMessage("hi")],
+        max_tokens=100,
+        token_counter=mock_llm,  # type: ignore[arg-type]
+    )
+    assert received_kwargs.get("tools") == ["tool_a", "tool_b"]

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -3274,3 +3274,35 @@ def test_trim_messages_tool_group_first_allow_partial() -> None:
     assert isinstance(result[0], HumanMessage)
     assert isinstance(result[1], AIMessage) and not result[1].tool_calls
     assert isinstance(result[2], HumanMessage)
+
+
+def test_trim_messages_tool_group_partial_boundary_first_allow_partial() -> None:
+    """strategy='first', allow_partial=True with budget that fits AI_tc but not TM.
+
+    This is the critical edge case where the token boundary falls *inside* the
+    tool-call group: the AIMessage(tool_calls) alone fits (30+14=44 ≤ 45) but the
+    full group (44+10=54) exceeds the budget. The trimmer must not produce an
+    orphaned AIMessage(tool_calls) without its ToolMessage.
+    """
+    # _TOOL_CALL_MESSAGES: [H(10), AI(10), H(10), AI_tc(14), TM(10)]
+    # max_tokens=45 → first 3 msgs = 30, AI_tc alone = 44 fits, but full group = 54.
+    result = trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=45,
+        token_counter=dummy_token_counter,
+        strategy="first",
+        allow_partial=True,
+    )
+    # The tool-call group partially crosses the boundary — AI_tc fits but TM
+    # does not. The entire group must be excluded to avoid an invalid sequence.
+    assert len(result) == 3
+    assert isinstance(result[0], HumanMessage)
+    assert isinstance(result[1], AIMessage)
+    assert not result[1].tool_calls
+    assert isinstance(result[2], HumanMessage)
+    # Verify no orphaned AIMessage(tool_calls) exists in the output
+    for msg in result:
+        if isinstance(msg, AIMessage):
+            assert not msg.tool_calls, (
+                "AIMessage with tool_calls must not appear without its ToolMessage"
+            )

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -3257,7 +3257,7 @@ def test_trim_messages_tool_forward_bound_tools() -> None:
     trim_messages(
         [HumanMessage("hi")],
         max_tokens=100,
-        token_counter=mock_llm,  # type: ignore[arg-type]
+        token_counter=mock_llm,  # type: ignore[call-overload]
     )
     assert received_kwargs.get("tools") == ["tool_a", "tool_b"]
 

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -3,7 +3,7 @@ import json
 import math
 import re
 from collections.abc import Callable, Sequence
-from typing import Any, TypedDict
+from typing import Any, ClassVar, TypedDict
 
 import pytest
 from typing_extensions import NotRequired, override
@@ -21,6 +21,7 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.utils import (
     MessageLikeRepresentation,
+    _get_message_group_boundaries,
     convert_to_messages,
     convert_to_openai_messages,
     count_tokens_approximately,
@@ -3119,7 +3120,10 @@ def test_trim_messages_no_reversed_messages_sent_to_counter() -> None:
                 # A ToolMessage must be preceded by an AIMessage with tool_calls
                 assert i > 0, "ToolMessage at index 0 — reversed sequence detected"
                 prev = call_msgs[i - 1]
-                assert isinstance(prev, AIMessage) and prev.tool_calls, (
+                assert isinstance(prev, AIMessage), (
+                    f"ToolMessage at index {i} not preceded by AIMessage"
+                )
+                assert prev.tool_calls, (
                     f"ToolMessage at index {i} not preceded by AIMessage(tool_calls)"
                 )
 
@@ -3184,7 +3188,7 @@ def test_trim_messages_multiple_tool_groups() -> None:
         ),
         ToolMessage("result B", tool_call_id="b1"),
     ]
-    # 6 messages × 10 tokens = 60. Budget = 35 → fits 3 messages.
+    # 6 messages x 10 tokens = 60. Budget = 35 -> fits 3 messages.
     # From the end: group [AIMessage+ToolMessage] = 20, + HumanMessage = 30 → fits.
     result = trim_messages(
         messages,
@@ -3196,7 +3200,8 @@ def test_trim_messages_multiple_tool_groups() -> None:
     assert len(result) == 3
     assert isinstance(result[0], HumanMessage)
     assert result[0].content == "query 2"
-    assert isinstance(result[1], AIMessage) and result[1].tool_calls
+    assert isinstance(result[1], AIMessage)
+    assert result[1].tool_calls
     assert isinstance(result[2], ToolMessage)
 
 
@@ -3210,14 +3215,13 @@ def test_trim_messages_tool_group_boundary_exact_fit() -> None:
         strategy="last",
     )
     assert len(result) == 2
-    assert isinstance(result[0], AIMessage) and result[0].tool_calls
+    assert isinstance(result[0], AIMessage)
+    assert result[0].tool_calls
     assert isinstance(result[1], ToolMessage)
 
 
 def test_get_message_group_boundaries() -> None:
     """Directly test the _get_message_group_boundaries helper."""
-    from langchain_core.messages.utils import _get_message_group_boundaries
-
     boundaries = _get_message_group_boundaries(_TOOL_CALL_MESSAGES)
     # 5 messages: [H, AI, H, AI(tc)+TM] → groups at indices [0,1,2,3-4]
     # boundaries = [0, 1, 2, 3, 5]
@@ -3239,7 +3243,7 @@ def test_trim_messages_tool_forward_bound_tools() -> None:
         """Mock LLM that records kwargs passed to get_num_tokens_from_messages."""
 
         # Simulates RunnableBinding.kwargs from bind_tools()
-        kwargs: dict[str, Any] = {"tools": ["tool_a", "tool_b"]}
+        kwargs: ClassVar[dict[str, Any]] = {"tools": ["tool_a", "tool_b"]}
 
         def get_num_tokens_from_messages(
             self,
@@ -3259,7 +3263,7 @@ def test_trim_messages_tool_forward_bound_tools() -> None:
 
 
 def test_trim_messages_tool_group_first_allow_partial() -> None:
-    """strategy='first' + allow_partial: tool group that doesn't fit is excluded whole."""
+    """strategy='first' + allow_partial: tool group doesn't fit is excluded."""
     # _TOOL_CALL_MESSAGES: [H(10), AI(10), H(10), AI_tc(14), TM(10)]
     # max_tokens=35 → H(10)+AI(10)+H(10)=30 fits, adding AI_tc(14)=44 exceeds.
     # With allow_partial, the AI_tc+TM group is dropped entirely (not split).
@@ -3272,7 +3276,8 @@ def test_trim_messages_tool_group_first_allow_partial() -> None:
     )
     assert len(result) == 3
     assert isinstance(result[0], HumanMessage)
-    assert isinstance(result[1], AIMessage) and not result[1].tool_calls
+    assert isinstance(result[1], AIMessage)
+    assert not result[1].tool_calls
     assert isinstance(result[2], HumanMessage)
 
 

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -3256,3 +3256,21 @@ def test_trim_messages_tool_forward_bound_tools() -> None:
         token_counter=mock_llm,  # type: ignore[arg-type]
     )
     assert received_kwargs.get("tools") == ["tool_a", "tool_b"]
+
+
+def test_trim_messages_tool_group_first_allow_partial() -> None:
+    """strategy='first' + allow_partial: tool group that doesn't fit is excluded whole."""
+    # _TOOL_CALL_MESSAGES: [H(10), AI(10), H(10), AI_tc(14), TM(10)]
+    # max_tokens=35 → H(10)+AI(10)+H(10)=30 fits, adding AI_tc(14)=44 exceeds.
+    # With allow_partial, the AI_tc+TM group is dropped entirely (not split).
+    result = trim_messages(
+        _TOOL_CALL_MESSAGES,
+        max_tokens=35,
+        token_counter=dummy_token_counter,
+        strategy="first",
+        allow_partial=True,
+    )
+    assert len(result) == 3
+    assert isinstance(result[0], HumanMessage)
+    assert isinstance(result[1], AIMessage) and not result[1].tool_calls
+    assert isinstance(result[2], HumanMessage)


### PR DESCRIPTION
## Description

`trim_messages` now treats `AIMessage(tool_calls)` + following `ToolMessage(s)` as atomic groups that cannot be split during trimming. This fixes three classes of `BadRequestError` when using providers that validate message ordering (e.g. Anthropic's token counting API).

Fixes #29637

## Changes

### 1. Group-aware binary search (`_first_max_tokens`)
Binary search now operates on **group boundaries** instead of individual message indices. A group is either a single non-tool message or an `AIMessage(tool_calls)` + all following `ToolMessages`. This ensures that `messages[:mid]` never splits a tool-call exchange.

### 2. Rewritten `_last_max_tokens` (no more message reversal)
The old implementation reversed messages and delegated to `_first_max_tokens`. Reversed sequences like `[ToolMessage, AIMessage(tool_calls), ...]` are invalid for Anthropic's `count_tokens` API. The new implementation performs a **forward binary search** on group boundaries from the end, preserving natural message ordering in all calls to the token counter.

### 3. Forward bound tools to token counter
When `token_counter` is a bound LLM (via `bind_tools()`), the bound `tools` are automatically extracted from `kwargs` and forwarded to `get_num_tokens_from_messages()` — fixing the _"tool_use blocks must define tools"_ error (Example 2 from the issue).

### New helper: `_get_message_group_boundaries()`
Returns valid split-point indices where `messages[:i]` is always a structurally valid prefix — no orphaned `ToolMessages`, no `AIMessage(tool_calls)` without their replies.

## Tests
11 new tests covering:
- Tool groups never split with strategy `first` / `last`
- Token counter never receives reversed messages
- Tool groups with `include_system`, `start_on`, `end_on`
- Multiple tool groups
- Exact token boundary fit
- Bound tools forwarded to counter
- Direct `_get_message_group_boundaries()` unit test

All 165 tests pass (154 existing + 11 new).