### PR TITLE
fix(openai): handle null choices from model_dump() for vLLM compatibility

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1553,6 +1553,23 @@ class BaseChatOpenAI(BaseChatModel):
             msg = f"Response missing 'choices' key: {response_dict.keys()}"
             raise KeyError(msg) from e
 
+        if choices is None and not isinstance(response, dict):
+            # Some OpenAI-compatible APIs (e.g., vLLM) return responses where
+            # model_dump() serializes choices as null, even though the response
+            # object has valid choices accessible via direct attribute access.
+            # Fall back to extracting choices from the response object.
+            raw_choices = getattr(response, "choices", None)
+            if raw_choices is not None:
+                choices = [
+                    c.model_dump() if hasattr(c, "model_dump") else c
+                    for c in raw_choices
+                ]
+                response_dict["choices"] = choices
+                logger.debug(
+                    "choices was null in model_dump() but present on response "
+                    "object; using direct attribute access as fallback."
+                )
+
         if choices is None:
             # Some OpenAI-compatible APIs (e.g., vLLM) may return null choices
             # when the response format differs or an error occurs without

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3431,3 +3431,79 @@ def test_context_overflow_error_backwards_compatibility() -> None:
     # Verify it's both types (multiple inheritance)
     assert isinstance(exc_info.value, openai.BadRequestError)
     assert isinstance(exc_info.value, ContextOverflowError)
+
+
+def test_create_chat_result_null_choices_fallback_to_response_object() -> None:
+    """Test _create_chat_result falls back to direct attribute access when
+    model_dump() returns null for choices.
+
+    Some OpenAI-compatible APIs (e.g., vLLM) return response objects where
+    model_dump() serializes choices as null, even though the response object
+    itself has valid choices via direct attribute access. The fix should
+    recover gracefully instead of raising TypeError.
+
+    Regression test for: https://github.com/langchain-ai/langchain/issues/32252
+    """
+
+    # Create a mock choice that behaves like an openai Choice object
+    mock_choice = MagicMock()
+    mock_choice.model_dump.return_value = {
+        "finish_reason": "stop",
+        "index": 0,
+        "logprobs": None,
+        "message": {
+            "content": "Hello! How can I help you?",
+            "role": "assistant",
+            "tool_calls": None,
+        },
+    }
+
+    # Create a response that simulates the vLLM bug: model_dump() returns
+    # choices as None, but the object's .choices attribute has valid data.
+    mock_response = MagicMock(spec=openai.BaseModel)
+    mock_response.model_dump.return_value = {
+        "choices": None,
+        "created": 1234567890,
+        "id": "chatcmpl-test-vllm",
+        "model": "test-vllm-model",
+        "object": "chat.completion",
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        },
+    }
+    mock_response.choices = [mock_choice]
+
+    llm = ChatOpenAI(model="test-model", api_key="test-key")  # type: ignore[arg-type]
+    result = llm._create_chat_result(mock_response)
+
+    assert len(result.generations) == 1
+    assert result.generations[0].message.content == "Hello! How can I help you?"
+    assert result.llm_output is not None
+    assert result.llm_output["token_usage"] == {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+    }
+
+
+def test_create_chat_result_null_choices_still_raises_when_truly_null() -> None:
+    """Test that TypeError is still raised when choices is genuinely null
+    (i.e., not recoverable from the response object either)."""
+
+    mock_response = MagicMock(spec=openai.BaseModel)
+    mock_response.model_dump.return_value = {
+        "choices": None,
+        "created": 1234567890,
+        "id": "chatcmpl-test",
+        "model": "test-model",
+        "object": "chat.completion",
+    }
+    # choices is also None on the response object itself
+    mock_response.choices = None
+
+    llm = ChatOpenAI(model="test-model", api_key="test-key")  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="null value for 'choices'"):
+        llm._create_chat_result(mock_response)


### PR DESCRIPTION
## Description

Fixes #32252

When using OpenAI-compatible APIs like vLLM, model_dump() can serialize choices as null even though the response object has valid choices accessible via direct attribute access (e.g., response.choices). This causes _create_chat_result to raise a TypeError, even though the data is present and usable.

This PR adds a fallback in _create_chat_result that, when choices is None in the serialized dict and the response is not already a plain dict, attempts to extract choices directly from the response object's .choices attribute. If valid choices are found, they are serialized individually via model_dump() and used in place of the null value. If the fallback also yields None, the existing improved error message (from #35236) is still raised.

## Changes

- libs/partners/openai/langchain_openai/chat_models/base.py: Added fallback logic between the choices extraction and the null-check error, recovering choices from response.choices when model_dump() returns null.
- libs/partners/openai/tests/unit_tests/chat_models/test_base.py: Added two regression tests:
  - test_create_chat_result_null_choices_fallback_to_response_object: verifies the fallback recovers valid choices and produces correct ChatResult.
  - test_create_chat_result_null_choices_still_raises_when_truly_null: verifies the TypeError is still raised when choices is genuinely null on both the serialized dict and the response object.

## Why this approach

- PR #35236 (merged) improved the error message but did not fix the underlying issue -- users of vLLM still get an error instead of a successful response.
- PR #34791 (open, stale since Jan 17 with no reviews) takes a similar fallback approach. This PR improves on it with: a not isinstance(response, dict) guard to avoid unnecessary work on dict responses, debug logging when the fallback is triggered, and a second test covering the case where the error should still be raised.
- The fix is minimal and backward-compatible: it only activates when choices would otherwise be null, and only for non-dict response objects.

## Disclaimer

This contribution was developed with assistance from an AI agent (Claude).