### PR TITLE
fix(core): render nested subgraph boxes for 3+ levels in draw_mermaid

### DIFF
--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -121,6 +121,15 @@ def draw_mermaid(
         else:
             regular_nodes[key] = node
 
+    # Compute all subgraph prefixes, including intermediate ancestors.
+    # e.g., for subgraph_nodes key "a:b:c", also register "a" and "a:b"
+    # so that add_empty_subgraph can discover every nesting level.
+    all_subgraph_prefixes: set[str] = set()
+    for prefix in subgraph_nodes:
+        parts = prefix.split(":")
+        for i in range(1, len(parts) + 1):
+            all_subgraph_prefixes.add(":".join(parts[:i]))
+
     # Node formatting templates
     default_class_label = "default"
     format_dict = {default_class_label: "{0}({1})"}
@@ -220,8 +229,47 @@ def draw_mermaid(
                 continue
             add_subgraph(edges_, nested_prefix)
 
+        # Also add nested empty subgraphs (with nodes but no internal edges)
+        if with_styles:
+            for nested_prefix in sorted(all_subgraph_prefixes):
+                if not nested_prefix.startswith(prefix + ":"):
+                    continue
+                rest = nested_prefix[len(prefix) + 1 :]
+                if ":" in rest:
+                    continue
+                nested_name = rest
+                if nested_name not in seen_subgraphs:
+                    add_empty_subgraph(nested_prefix)
+
         if prefix and not self_loop:
             mermaid_graph += "\tend\n"
+
+    def add_empty_subgraph(prefix: str) -> None:
+        """Add a subgraph that has no internal edges, recursing into children."""
+        nonlocal mermaid_graph
+        subgraph_name = prefix.rsplit(":", maxsplit=1)[-1]
+        if subgraph_name in seen_subgraphs:
+            return
+        seen_subgraphs.add(subgraph_name)
+        mermaid_graph += f"\tsubgraph {subgraph_name}\n"
+        # Render nodes at this level (if any)
+        if prefix in subgraph_nodes:
+            for key, node in subgraph_nodes[prefix].items():
+                mermaid_graph += render_node(key, node)
+        # Recursively add direct-child subgraphs
+        for child_prefix in sorted(all_subgraph_prefixes):
+            if not child_prefix.startswith(prefix + ":"):
+                continue
+            rest = child_prefix[len(prefix) + 1 :]
+            if ":" in rest:
+                continue
+            child_name = rest
+            if child_name not in seen_subgraphs:
+                if child_prefix in edge_groups:
+                    add_subgraph(edge_groups[child_prefix], child_prefix)
+                else:
+                    add_empty_subgraph(child_prefix)
+        mermaid_graph += "\tend\n"
 
     # Start with the top-level edges (no common prefix)
     add_subgraph(edge_groups.get("", []), "")
@@ -233,18 +281,17 @@ def draw_mermaid(
         add_subgraph(edges_, prefix)
         seen_subgraphs.add(prefix)
 
-    # Add empty subgraphs (subgraphs with no internal edges)
+    # Add empty subgraphs (subgraphs with no internal edges).
+    # Use add_empty_subgraph which recurses into nested children,
+    # so multi-level prefixes (e.g. "parent:child") are handled correctly.
     if with_styles:
-        for prefix, subgraph_node in subgraph_nodes.items():
-            if ":" not in prefix and prefix not in seen_subgraphs:
-                mermaid_graph += f"\tsubgraph {prefix}\n"
-
-                # Add nodes that belong to this subgraph
-                for key, node in subgraph_node.items():
-                    mermaid_graph += render_node(key, node)
-
-                mermaid_graph += "\tend\n"
-                seen_subgraphs.add(prefix)
+        unseen_roots: set[str] = set()
+        for prefix in all_subgraph_prefixes:
+            root = prefix.split(":")[0]
+            if root not in seen_subgraphs:
+                unseen_roots.add(root)
+        for root in sorted(unseen_roots):
+            add_empty_subgraph(root)
 
     # Add custom styles for nodes
     if with_styles:

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -30,6 +30,29 @@
   
   '''
 # ---
+# name: test_empty_nested_subgraph_mermaid[mermaid]
+  '''
+  ---
+  config:
+    flowchart:
+      curve: linear
+  ---
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> parent\3achild\3agrandchild;
+  	parent\3achild\3agrandchild --> __end__;
+  	subgraph parent
+  	subgraph child
+  	parent\3achild\3agrandchild(grandchild)
+  	end
+  	end
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
 # name: test_graph_mermaid_duplicate_nodes[mermaid]
   '''
   graph TD;

--- a/libs/core/tests/unit_tests/runnables/test_graph.py
+++ b/libs/core/tests/unit_tests/runnables/test_graph.py
@@ -455,6 +455,50 @@ def test_triple_nested_subgraph_mermaid(snapshot: SnapshotAssertion) -> None:
     assert graph.draw_mermaid() == snapshot(name="mermaid")
 
 
+def test_empty_nested_subgraph_mermaid(snapshot: SnapshotAssertion) -> None:
+    """Test that 3-level nesting works when subgraphs have no internal edges.
+
+    Reproduces https://github.com/langchain-ai/langchain/issues/35492:
+    When every nested subgraph wraps a single node, there are no internal
+    edges at any prefix level, so all subgraph rendering goes through the
+    "empty subgraphs" path. Previously this path only handled 1-level
+    prefixes and silently dropped deeper nesting.
+    """
+    empty_data = BaseModel
+    nodes = {
+        "__start__": Node(
+            id="__start__", name="__start__", data=empty_data, metadata=None
+        ),
+        "parent:child:grandchild": Node(
+            id="parent:child:grandchild",
+            name="grandchild",
+            data=empty_data,
+            metadata=None,
+        ),
+        "__end__": Node(id="__end__", name="__end__", data=empty_data, metadata=None),
+    }
+    edges = [
+        Edge(
+            source="__start__",
+            target="parent:child:grandchild",
+            data=None,
+            conditional=False,
+        ),
+        Edge(
+            source="parent:child:grandchild",
+            target="__end__",
+            data=None,
+            conditional=False,
+        ),
+    ]
+    graph = Graph(nodes, edges)
+    output = graph.draw_mermaid()
+    assert output == snapshot(name="mermaid")
+    # Verify that proper subgraph nesting was generated (not flat IDs)
+    assert "subgraph parent" in output
+    assert "subgraph child" in output
+
+
 def test_single_node_subgraph_mermaid(snapshot: SnapshotAssertion) -> None:
     empty_data = BaseModel
     nodes = {


### PR DESCRIPTION
## Summary

- Fixes `draw_mermaid()` with `xray=True` failing to render nested subgraph boxes for 3+ levels of nesting
- The "empty subgraphs" code path skipped multi-level prefixes (`if ":" not in prefix`), causing deeply nested nodes to appear as flat elements with escaped colons instead of properly nested subgraph containers
- Additionally, `add_subgraph()` only discovered nested subgraphs via `edge_groups`, missing empty subgraphs entirely

## Changes

- **Precompute `all_subgraph_prefixes`** — expands `subgraph_nodes` keys into all ancestor prefixes so the recursive functions can discover intermediate nesting levels
- **Add `add_empty_subgraph()`** — recursive function that opens a subgraph block, renders its nodes, recurses into child subgraphs (both edge-based and empty), and closes
- **Extend `add_subgraph()`** — after the existing edge-groups recursion, also discover nested empty subgraphs from `all_subgraph_prefixes`
- **Replace flat empty-subgraph loop** — the old `if ":" not in prefix` loop is replaced with a root-level scan that calls `add_empty_subgraph()` recursively

## Test plan

- [x] Added `test_empty_nested_subgraph_mermaid` — reproduces the exact bug (3-level nesting with no internal edges)
- [x] All 15 existing mermaid tests pass unchanged (snapshots verified)
- [x] New snapshot shows correct nested `subgraph parent` → `subgraph child` → `grandchild` output

Closes #35492

🤖 Generated with [Claude Code](https://claude.com/claude-code)