### PR TITLE
ci: fix codspeed segfault

### DIFF
--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -187,11 +187,15 @@ jobs:
       - name: "📦 Install UV Package Manager"
         uses: astral-sh/setup-uv@v7
         with:
-          python-version: "3.13"
+          # Pinned to 3.13.11 to work around CodSpeed walltime segfault on 3.13.12+
+          # See: https://github.com/CodSpeedHQ/pytest-codspeed/issues/106
+          python-version: "3.13.11"
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          # Pinned to 3.13.11 to work around CodSpeed walltime segfault on 3.13.12+
+          # See: https://github.com/CodSpeedHQ/pytest-codspeed/issues/106
+          python-version: "3.13.11"
 
       - name: "📦 Install Test Dependencies"
         run: uv sync --group test


### PR DESCRIPTION
Pin Python to 3.13.11 in the CodSpeed benchmark job. CPython 3.13.12 introduced a segfault in CodSpeed's walltime callgraph post-processing ([CodSpeedHQ/pytest-codspeed#106](https://github.com/CodSpeedHQ/pytest-codspeed/issues/106)), causing all `libs/core` benchmark runs to fail with `exit status: 139` since Feb 26 despite all 13 benchmarks passing.