### PR TITLE
fix(openai): extract reasoning_content from DeepSeek streaming responses

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -412,6 +412,9 @@ def _convert_delta_to_message_chunk(
         if "name" in function_call and function_call["name"] is None:
             function_call["name"] = ""
         additional_kwargs["function_call"] = function_call
+    # Extract reasoning_content (DeepSeek specific)
+    if _dict.get("reasoning_content"):
+        additional_kwargs["reasoning_content"] = _dict["reasoning_content"]
     tool_call_chunks = []
     if raw_tool_calls := _dict.get("tool_calls"):
         try:


### PR DESCRIPTION
## Summary

Extract `reasoning_content` from delta in `_convert_delta_to_message_chunk` to make DeepSeek's thinking process available in `additional_kwargs`.

## Changes

- Added extraction of `reasoning_content` from delta in `libs/partners/openai/langchain_openai/chat_models/base.py`

## Testing

Verified the fix works with DeepSeek `deepseek-reasoner` model.

## Related Issue

Fixes #35516