### PR TITLE
fix(openai): let user-provided User-Agent override the Azure default

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -674,8 +674,8 @@ class AzureChatOpenAI(BaseChatOpenAI):
             "base_url": self.openai_api_base,
             "timeout": self.request_timeout,
             "default_headers": {
-                **(self.default_headers or {}),
                 "User-Agent": "langchain-partner-python-azure-openai",
+                **(self.default_headers or {}),
             },
             "default_query": self.default_query,
         }

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -200,8 +200,8 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):  # type: ignore[override]
             "timeout": self.request_timeout,
             "max_retries": self.max_retries,
             "default_headers": {
-                **(self.default_headers or {}),
                 "User-Agent": "langchain-partner-python-azure-openai",
+                **(self.default_headers or {}),
             },
             "default_query": self.default_query,
         }

--- a/libs/partners/openai/langchain_openai/llms/azure.py
+++ b/libs/partners/openai/langchain_openai/llms/azure.py
@@ -169,8 +169,8 @@ class AzureOpenAI(BaseOpenAI):
             "timeout": self.request_timeout,
             "max_retries": self.max_retries,
             "default_headers": {
-                **(self.default_headers or {}),
                 "User-Agent": "langchain-partner-python-azure-openai",
+                **(self.default_headers or {}),
             },
             "default_query": self.default_query,
         }


### PR DESCRIPTION
## Summary
- Swapped dict unpacking order so the hardcoded `User-Agent` acts as a **fallback** instead of an **override**
- Applied to all three Azure classes: `AzureChatOpenAI`, `AzureOpenAI`, and `AzureOpenAIEmbeddings`

## Problem
The `default_headers` dict construction placed the hardcoded `User-Agent` **after** the user's headers:

```python
"default_headers": {
    **(self.default_headers or {}),
    "User-Agent": "langchain-partner-python-azure-openai",  # always wins
},
```

This means any `User-Agent` set by the user via `default_headers` is silently overwritten, which caused 403 errors for users whose custom Azure endpoints require a specific User-Agent.

## Fix
Swap the order so the hardcoded value comes first and user headers come second:

```python
"default_headers": {
    "User-Agent": "langchain-partner-python-azure-openai",  # fallback
    **(self.default_headers or {}),  # user can override
},
```

In Python dict unpacking, later keys override earlier ones, so user-provided headers now take precedence.

## Test plan
- [ ] `AzureChatOpenAI(default_headers={"User-Agent": "custom"})` — verify `custom` is used
- [ ] `AzureChatOpenAI()` — verify default `langchain-partner-python-azure-openai` is still used

**Note:** This PR was generated with AI assistance (Claude Code).

Fixes #35521

🤖 Generated with [Claude Code](https://claude.com/claude-code)