### PR TITLE
fix(huggingface): switch integration test provider to together

### DIFF
--- a/libs/partners/huggingface/tests/integration_tests/test_standard.py
+++ b/libs/partners/huggingface/tests/integration_tests/test_standard.py
@@ -20,7 +20,7 @@ class TestHuggingFaceEndpoint(ChatModelIntegrationTests):
         llm = HuggingFaceEndpoint(  # type: ignore[call-arg]
             repo_id="meta-llama/Llama-3.3-70B-Instruct",
             task="conversational",
-            provider="sambanova",
+            provider="together",
             temperature=0,
         )
         return {"llm": llm}


### PR DESCRIPTION
Switch the `TestHuggingFaceEndpoint` serverless inference provider from `sambanova` to `together` for `Llama-3.3-70B-Instruct`. Sambanova doesn't support `tool_choice: "any"` (needed by `test_structured_few_shot_examples` and `test_unicode_tool_call_integration`) and doesn't return `usage_metadata` in streaming responses.