### PR TITLE
fix(anthropic): populate input_tokens in streaming usage metadata

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1996,16 +1996,23 @@ def _make_message_chunk_from_anthropic_event(
     # Reference: Anthropic SDK streaming implementation
     # https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/streaming/_messages.py  # noqa: E501
     if event.type == "message_start" and stream_usage:
-        # Capture model name, but don't include usage_metadata yet
-        # as it will be properly reported in message_delta with complete info
+        # Capture model name and input usage metadata from message_start.
+        # Input tokens are only reported in message_start, not message_delta.
         if hasattr(event.message, "model"):
             response_metadata: dict[str, Any] = {"model_name": event.message.model}
         else:
             response_metadata = {}
 
+        usage_metadata = (
+            _create_usage_metadata(event.message.usage)
+            if hasattr(event.message, "usage") and event.message.usage is not None
+            else None
+        )
+
         message_chunk = AIMessageChunk(
             content="" if coerce_content_to_string else [],
             response_metadata=response_metadata,
+            usage_metadata=usage_metadata,
         )
 
     elif (

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1703,12 +1703,10 @@ def test_streaming_cache_token_reporting() -> None:
     message_start_event.type = "message_start"
     message_start_event.message = mock_message
 
-    # Create a mock message_delta event with complete usage info
+    # Create a mock message_delta event.
+    # In the real Anthropic API, message_delta only contains output_tokens.
     mock_delta_usage = MessageDeltaUsage(
         output_tokens=50,
-        input_tokens=100,
-        cache_read_input_tokens=25,
-        cache_creation_input_tokens=10,
     )
 
     mock_delta = MagicMock()
@@ -1736,24 +1734,28 @@ def test_streaming_cache_token_reporting() -> None:
         block_start_event=None,
     )
 
-    # Verify message_delta has complete usage_metadata including cache tokens
+    # Verify message_start has usage_metadata with input tokens and cache details.
+    # Input tokens are only reported in message_start, not message_delta.
     assert start_chunk is not None, "message_start should produce a chunk"
-    assert getattr(start_chunk, "usage_metadata", None) is None, (
-        "message_start should not have usage_metadata"
+    assert start_chunk.usage_metadata is not None, (
+        "message_start should have usage_metadata with input tokens"
     )
+    assert "input_token_details" in start_chunk.usage_metadata
+    input_details = start_chunk.usage_metadata["input_token_details"]
+    assert input_details.get("cache_read") == 25
+    assert input_details.get("cache_creation") == 10
+
+    # Verify input totals: 100 base + 25 cache_read + 10 cache_creation = 135
+    assert start_chunk.usage_metadata["input_tokens"] == 135
+    assert start_chunk.usage_metadata["output_tokens"] == 0
+    assert start_chunk.usage_metadata["total_tokens"] == 135
+
+    # Verify message_delta has usage_metadata with output tokens
     assert delta_chunk is not None, "message_delta should produce a chunk"
     assert delta_chunk.usage_metadata is not None, (
         "message_delta should have usage_metadata"
     )
-    assert "input_token_details" in delta_chunk.usage_metadata
-    input_details = delta_chunk.usage_metadata["input_token_details"]
-    assert input_details.get("cache_read") == 25
-    assert input_details.get("cache_creation") == 10
-
-    # Verify totals are correct: 100 base + 25 cache_read + 10 cache_creation = 135
-    assert delta_chunk.usage_metadata["input_tokens"] == 135
     assert delta_chunk.usage_metadata["output_tokens"] == 50
-    assert delta_chunk.usage_metadata["total_tokens"] == 185
 
 
 def test_strict_tool_use() -> None:


### PR DESCRIPTION
Fixes langchain-ai/langchain-aws#916

In ChatAnthropic streaming, `input_tokens` was always 0 because the value from Anthropic's `message_start` event was not being passed through to usage metadata. This PR correctly maps it.