### PR TITLE
feat(fireworks,groq,openrouter): add standard model property

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -328,6 +328,11 @@ class ChatFireworks(BaseChatModel):
     model_name: str = Field(alias="model")
     """Model name to use."""
 
+    @property
+    def model(self) -> str:
+        """Same as model_name."""
+        return self.model_name
+
     temperature: float | None = None
     """What sampling temperature to use."""
 

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 from langchain_core.messages import AIMessage
 
+from langchain_fireworks import ChatFireworks
 from langchain_fireworks.chat_models import _convert_dict_to_message
+
+
+def test_fireworks_model_param() -> None:
+    llm = ChatFireworks(model="foo", api_key="fake-key")  # type: ignore[arg-type]
+    assert llm.model_name == "foo"
+    assert llm.model == "foo"
+    llm = ChatFireworks(model_name="foo", api_key="fake-key")  # type: ignore[call-arg, arg-type]
+    assert llm.model_name == "foo"
+    assert llm.model == "foo"
 
 
 def test_convert_dict_to_message_with_reasoning_content() -> None:

--- a/libs/partners/fireworks/uv.lock
+++ b/libs/partners/fireworks/uv.lock
@@ -685,7 +685,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.13"
+version = "1.2.17"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/groq/langchain_groq/chat_models.py
+++ b/libs/partners/groq/langchain_groq/chat_models.py
@@ -351,6 +351,11 @@ class ChatGroq(BaseChatModel):
     model_name: str = Field(alias="model")
     """Model name to use."""
 
+    @property
+    def model(self) -> str:
+        """Same as model_name."""
+        return self.model_name
+
     temperature: float = 0.7
     """What sampling temperature to use."""
 

--- a/libs/partners/groq/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/groq/tests/unit_tests/test_chat_models.py
@@ -32,8 +32,10 @@ if "GROQ_API_KEY" not in os.environ:
 def test_groq_model_param() -> None:
     llm = ChatGroq(model="foo")  # type: ignore[call-arg]
     assert llm.model_name == "foo"
+    assert llm.model == "foo"
     llm = ChatGroq(model_name="foo")  # type: ignore[call-arg]
     assert llm.model_name == "foo"
+    assert llm.model == "foo"
 
 
 def test_function_message_dict_to_function_message() -> None:

--- a/libs/partners/groq/uv.lock
+++ b/libs/partners/groq/uv.lock
@@ -314,7 +314,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.13"
+version = "1.2.17"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -188,6 +188,11 @@ class ChatOpenRouter(BaseChatModel):
     model_name: str = Field(alias="model")
     """The name of the model, e.g. `'anthropic/claude-sonnet-4-5'`."""
 
+    @property
+    def model(self) -> str:
+        """Same as model_name."""
+        return self.model_name
+
     temperature: float | None = None
     """Sampling temperature."""
 

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -202,6 +202,7 @@ class TestChatOpenRouterInstantiation:
         """Test basic model instantiation with required params."""
         model = _make_model()
         assert model.model_name == MODEL_NAME
+        assert model.model == MODEL_NAME
         assert model.openrouter_api_base is None
 
     def test_api_key_from_field(self) -> None:

--- a/libs/partners/openrouter/uv.lock
+++ b/libs/partners/openrouter/uv.lock
@@ -318,7 +318,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.15"
+version = "1.2.17"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Add a `model` property to `ChatFireworks`, `ChatGroq`, and `ChatOpenRouter` that returns `model_name`. These partners use Pydantic's `Field(alias="model")` on `model_name`, which means `instance.model` doesn't work as a read accessor after construction — it raises an `AttributeError` or returns the field descriptor. `ChatOpenAI` already has this property; this brings the remaining in-repo partners to parity.