### PR TITLE
fix(core): fix inflated usage_metadata when aggregating streaming chunks

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -672,11 +672,12 @@ def add_ai_message_chunks(
     else:
         tool_call_chunks = []
 
-    # Token usage
+    # Token usage — use max (not sum) to handle providers that report
+    # cumulative usage per chunk, not just in the final chunk (#30429).
     if left.usage_metadata or any(o.usage_metadata is not None for o in others):
         usage_metadata: UsageMetadata | None = left.usage_metadata
         for other in others:
-            usage_metadata = add_usage(usage_metadata, other.usage_metadata)
+            usage_metadata = merge_usage(usage_metadata, other.usage_metadata)
     else:
         usage_metadata = None
 
@@ -835,6 +836,70 @@ def subtract_usage(
                 cast("dict", left),
                 cast("dict", right),
                 (lambda le, ri: max(le - ri, 0)),
+            ),
+        )
+    )
+
+
+def merge_usage(
+    left: UsageMetadata | None, right: UsageMetadata | None
+) -> UsageMetadata:
+    """Merge two ``UsageMetadata`` objects, taking the max of each field.
+
+    Unlike :func:`add_usage` which sums values, this takes the element-wise
+    maximum.  This is appropriate for aggregating streaming chunks because
+    some providers (e.g. vLLM, Ollama) report **cumulative** usage in every
+    chunk rather than only in the final one.  Using ``max`` produces correct
+    totals regardless of whether the provider sends usage once (OpenAI) or
+    cumulatively (vLLM).
+
+    Example:
+        .. code-block:: python
+
+            from langchain_core.messages.ai import merge_usage
+
+            left = UsageMetadata(
+                input_tokens=35,
+                output_tokens=1,
+                total_tokens=36,
+            )
+            right = UsageMetadata(
+                input_tokens=35,
+                output_tokens=11,
+                total_tokens=46,
+            )
+
+            merge_usage(left, right)
+
+        results in
+
+        .. code-block:: python
+
+            UsageMetadata(
+                input_tokens=35,
+                output_tokens=11,
+                total_tokens=46,
+            )
+
+    Args:
+        left: The first ``UsageMetadata`` object.
+        right: The second ``UsageMetadata`` object.
+
+    Returns:
+        A ``UsageMetadata`` whose fields are the element-wise maxima.
+    """
+    if not (left or right):
+        return UsageMetadata(input_tokens=0, output_tokens=0, total_tokens=0)
+    if not (left and right):
+        return cast("UsageMetadata", left or right)
+
+    return UsageMetadata(
+        **cast(
+            "UsageMetadata",
+            _dict_int_op(
+                cast("dict", left),
+                cast("dict", right),
+                max,
             ),
         )
     )

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -9,6 +9,7 @@ from langchain_core.messages.ai import (
     UsageMetadata,
     add_ai_message_chunks,
     add_usage,
+    merge_usage,
     subtract_usage,
 )
 from langchain_core.messages.tool import invalid_tool_call as create_invalid_tool_call
@@ -168,7 +169,53 @@ def test_subtract_usage_with_negative_result() -> None:
     assert result == UsageMetadata(input_tokens=0, output_tokens=0, total_tokens=0)
 
 
+def test_merge_usage_both_none() -> None:
+    result = merge_usage(None, None)
+    assert result == UsageMetadata(input_tokens=0, output_tokens=0, total_tokens=0)
+
+
+def test_merge_usage_one_none() -> None:
+    usage = UsageMetadata(input_tokens=10, output_tokens=20, total_tokens=30)
+    result = merge_usage(usage, None)
+    assert result == usage
+
+
+def test_merge_usage_takes_max() -> None:
+    usage1 = UsageMetadata(input_tokens=35, output_tokens=1, total_tokens=36)
+    usage2 = UsageMetadata(input_tokens=35, output_tokens=11, total_tokens=46)
+    result = merge_usage(usage1, usage2)
+    assert result == UsageMetadata(input_tokens=35, output_tokens=11, total_tokens=46)
+
+
+def test_merge_usage_with_details() -> None:
+    usage1 = UsageMetadata(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        input_token_details=InputTokenDetails(audio=2, cache_read=3),
+        output_token_details=OutputTokenDetails(reasoning=4),
+    )
+    usage2 = UsageMetadata(
+        input_tokens=10,
+        output_tokens=8,
+        total_tokens=18,
+        input_token_details=InputTokenDetails(audio=2, cache_read=3),
+        output_token_details=OutputTokenDetails(reasoning=7),
+    )
+    result = merge_usage(usage1, usage2)
+    assert result["input_tokens"] == 10
+    assert result["output_tokens"] == 8
+    assert result["total_tokens"] == 18
+    assert result["input_token_details"]["audio"] == 2
+    assert result["input_token_details"]["cache_read"] == 3
+    assert result["output_token_details"]["reasoning"] == 7
+
+
 def test_add_ai_message_chunks_usage() -> None:
+    """Chunk aggregation uses max to handle cumulative usage providers.
+
+    Providers like vLLM report cumulative usage per chunk.  See #30429.
+    """
     chunks = [
         AIMessageChunk(content="", usage_metadata=None),
         AIMessageChunk(
@@ -192,12 +239,75 @@ def test_add_ai_message_chunks_usage() -> None:
     assert combined == AIMessageChunk(
         content="",
         usage_metadata=UsageMetadata(
-            input_tokens=4,
-            output_tokens=6,
-            total_tokens=10,
+            input_tokens=2,
+            output_tokens=3,
+            total_tokens=5,
             input_token_details=InputTokenDetails(audio=1, cache_read=1),
             output_token_details=OutputTokenDetails(audio=1, reasoning=2),
         ),
+    )
+
+
+def test_add_ai_message_chunks_usage_openai_pattern() -> None:
+    """OpenAI sends usage only in the final chunk; all others have None."""
+    chunks = [
+        AIMessageChunk(content="Hello", usage_metadata=None),
+        AIMessageChunk(content=" world", usage_metadata=None),
+        AIMessageChunk(
+            content="",
+            usage_metadata=UsageMetadata(
+                input_tokens=32, output_tokens=11, total_tokens=43
+            ),
+        ),
+    ]
+    combined = add_ai_message_chunks(*chunks)
+    assert combined.usage_metadata == UsageMetadata(
+        input_tokens=32, output_tokens=11, total_tokens=43
+    )
+
+
+def test_add_ai_message_chunks_usage_vllm_pattern() -> None:
+    """VLLM sends cumulative usage in every chunk.
+
+    Aggregation must not inflate counts by summing repeated
+    input_tokens values (#30429).
+    """
+    chunks = [
+        AIMessageChunk(
+            content="",
+            usage_metadata=UsageMetadata(
+                input_tokens=35, output_tokens=0, total_tokens=35
+            ),
+        ),
+        AIMessageChunk(
+            content="TEST",
+            usage_metadata=UsageMetadata(
+                input_tokens=35, output_tokens=1, total_tokens=36
+            ),
+        ),
+        AIMessageChunk(
+            content=" TEST",
+            usage_metadata=UsageMetadata(
+                input_tokens=35, output_tokens=1, total_tokens=36
+            ),
+        ),
+        AIMessageChunk(
+            content=" TEST",
+            usage_metadata=UsageMetadata(
+                input_tokens=35, output_tokens=1, total_tokens=36
+            ),
+        ),
+        # Final summary chunk with cumulative totals
+        AIMessageChunk(
+            content="",
+            usage_metadata=UsageMetadata(
+                input_tokens=35, output_tokens=11, total_tokens=46
+            ),
+        ),
+    ]
+    combined = add_ai_message_chunks(*chunks)
+    assert combined.usage_metadata == UsageMetadata(
+        input_tokens=35, output_tokens=11, total_tokens=46
     )
 
 

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -201,7 +201,7 @@ def test_message_chunks() -> None:
     )
     assert left + right == AIMessageChunk(
         content="",
-        usage_metadata={"input_tokens": 5, "output_tokens": 7, "total_tokens": 12},
+        usage_metadata={"input_tokens": 4, "output_tokens": 5, "total_tokens": 9},
     )
     assert AIMessageChunk(content="") + left == left
     assert right + AIMessageChunk(content="") == right


### PR DESCRIPTION
## Description

Fixes incorrect (inflated) `usage_metadata` token counts when aggregating streaming chunks from providers that report cumulative usage in every chunk (e.g. vLLM, Ollama), rather than only in the final chunk (OpenAI).

**Root cause**: `add_ai_message_chunks()` used `add_usage()` (which sums all fields) to aggregate usage across chunks. When a provider sends cumulative `input_tokens=35` in every chunk, summing produces `35 * chunk_count` instead of `35`.

**Fix**: Introduce `merge_usage()` which takes the element-wise `max` instead of `sum`, and use it in `add_ai_message_chunks()`. This produces correct totals for both patterns:
- **OpenAI**: sends usage only in final chunk → `max` of one non-None value = correct ✓
- **vLLM/Ollama**: sends cumulative usage per chunk → `max` of monotonically increasing values = final (correct) value ✓

The existing `add_usage()` function is preserved unchanged for backward compatibility.

## Issue

Closes #30429

## Changes

- Add `merge_usage()` function to `langchain_core.messages.ai` — same structure as `add_usage`/`subtract_usage` but uses `max` operator
- Change `add_ai_message_chunks()` to use `merge_usage()` instead of `add_usage()` for streaming chunk aggregation
- Update existing test to reflect `max` behavior
- Add tests for OpenAI pattern (usage in final chunk only) and vLLM pattern (cumulative usage per chunk)
- Add unit tests for `merge_usage()` itself

## Dependencies

None.