### PR TITLE
fix: accept both camelCase and snake_case in multimodal image format

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/langchain_v0.py
+++ b/libs/core/langchain_core/messages/block_translators/langchain_v0.py
@@ -65,6 +65,13 @@ def _convert_legacy_v0_content_block_to_v1(
         """
         return {k: v for k, v in block_dict.items() if k not in known_keys}
 
+    # Normalize camelCase to snake_case for cross-SDK compatibility
+    # JS LangGraph SDK uses camelCase (mimeType), Python expects snake_case (mime_type)
+    if "mimeType" in block and "mime_type" not in block:
+        block = {**block, "mime_type": block["mimeType"]}
+    if "sourceType" in block and "source_type" not in block:
+        block = {**block, "source_type": block["sourceType"]}
+
     # Check if this is actually a v0 format block
     block_type = block.get("type")
     if block_type not in {"image", "audio", "file"} or "source_type" not in block:

--- a/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
@@ -111,3 +111,60 @@ def test_convert_with_extras_on_v0_block() -> None:
     }
 
     assert _convert_legacy_v0_content_block_to_v1(block) == expected_output
+
+
+def test_convert_camelCase_to_snake_case() -> None:
+    """Test that camelCase keys from JS SDK are normalized to snake_case.
+
+    Issue: LangGraph JS SDK generates camelCase (mimeType, sourceType),
+    but Python expects snake_case (mime_type, source_type).
+    """
+    # Test mimeType -> mime_type conversion
+    block_image = {
+        "type": "image",
+        "sourceType": "base64",  # camelCase
+        "data": "<base64 data>",
+        "mimeType": "image/png",  # camelCase
+    }
+    result_image = _convert_legacy_v0_content_block_to_v1(block_image)
+    assert result_image["type"] == "image"
+    assert result_image["base64"] == "<base64 data>"
+    assert result_image["mime_type"] == "image/png"
+
+    # Test audio with camelCase
+    block_audio = {
+        "type": "audio",
+        "sourceType": "url",  # camelCase
+        "url": "https://example.com/audio.mp3",
+        "mimeType": "audio/mpeg",  # camelCase
+    }
+    result_audio = _convert_legacy_v0_content_block_to_v1(block_audio)
+    assert result_audio["type"] == "audio"
+    assert result_audio["url"] == "https://example.com/audio.mp3"
+    assert result_audio["mime_type"] == "audio/mpeg"
+
+    # Test file with camelCase
+    block_file = {
+        "type": "file",
+        "sourceType": "base64",  # camelCase
+        "data": "<base64 data>",
+        "mimeType": "application/pdf",  # camelCase
+    }
+    result_file = _convert_legacy_v0_content_block_to_v1(block_file)
+    assert result_file["type"] == "file"
+    assert result_file["base64"] == "<base64 data>"
+    assert result_file["mime_type"] == "application/pdf"
+
+
+def test_convert_snake_case_unchanged() -> None:
+    """Test that existing snake_case blocks still work correctly."""
+    block = {
+        "type": "image",
+        "source_type": "base64",
+        "data": "<base64 data>",
+        "mime_type": "image/png",
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    assert result["type"] == "image"
+    assert result["base64"] == "<base64 data>"
+    assert result["mime_type"] == "image/png"


### PR DESCRIPTION
## Summary

Fixes inconsistent multimodal image format between JS and Python SDKs. LangGraph JS SDK generates camelCase keys (`mimeType`, `sourceType`), but Python expected snake_case (`mime_type`, `source_type`), causing 400 BadRequestError when using Agent Chat UI (JS) → Python agent.

## Changes

- Normalize `mimeType` → `mime_type` in `_convert_legacy_v0_content_block_to_v1`
- Normalize `sourceType` → `source_type` for consistency
- Add comprehensive tests for camelCase to snake_case conversion
- Support both formats for backward compatibility

## Testing

Added unit tests covering:
- Image blocks with camelCase keys
- Audio blocks with camelCase keys
- File blocks with camelCase keys
- Existing snake_case blocks (unchanged behavior)

Fixes #35548