### PR TITLE
fix(anthropic): downgrade tool_choice when thinking is enabled

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1567,6 +1567,22 @@ class ChatAnthropic(BaseChatModel):
                 msg,
             )
 
+        # Anthropic rejects forced tool use when thinking is enabled.
+        # Downgrade to "auto" so the model can still choose voluntarily.
+        if (
+            self.thinking is not None
+            and self.thinking.get("type") == "enabled"
+            and "tool_choice" in kwargs
+            and kwargs["tool_choice"].get("type") in ("any", "tool")
+        ):
+            warnings.warn(
+                "tool_choice is forced but thinking is enabled. "
+                "Downgrading tool_choice to 'auto' because Anthropic "
+                "does not support forced tool use with thinking.",
+                stacklevel=2,
+            )
+            kwargs["tool_choice"] = {"type": "auto"}
+
         if parallel_tool_calls is not None:
             disable_parallel_tool_use = not parallel_tool_calls
             if "tool_choice" in kwargs:

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1396,6 +1396,62 @@ def test_anthropic_bind_tools_tool_choice() -> None:
     }
 
 
+def test_bind_tools_tool_choice_downgraded_when_thinking_enabled() -> None:
+    """Anthropic rejects forced tool use with thinking enabled.
+    bind_tools should downgrade tool_choice to 'auto' and warn."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+        thinking={"type": "enabled", "budget_tokens": 5000},
+    )
+    import warnings
+
+    # "any" should be downgraded to "auto" with warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        bound = chat_model.bind_tools([GetWeather], tool_choice="any")
+        assert cast("RunnableBinding", bound).kwargs["tool_choice"] == {"type": "auto"}
+        assert len(w) == 1
+        assert "Downgrading tool_choice" in str(w[0].message)
+
+    # Named tool choice should also be downgraded with warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        bound = chat_model.bind_tools([GetWeather], tool_choice="GetWeather")
+        assert cast("RunnableBinding", bound).kwargs["tool_choice"] == {"type": "auto"}
+        assert len(w) == 1
+
+    # "auto" should stay "auto" — no warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        bound = chat_model.bind_tools([GetWeather], tool_choice="auto")
+        assert cast("RunnableBinding", bound).kwargs["tool_choice"] == {"type": "auto"}
+        assert len(w) == 0
+
+    # No tool_choice should remain unset — no warning
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        bound = chat_model.bind_tools([GetWeather])
+        assert "tool_choice" not in cast("RunnableBinding", bound).kwargs
+        assert len(w) == 0
+
+
+def test_bind_tools_tool_choice_not_downgraded_without_thinking() -> None:
+    """Without thinking enabled, tool_choice should be passed through as-is."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    bound = chat_model.bind_tools([GetWeather], tool_choice="any")
+    assert cast("RunnableBinding", bound).kwargs["tool_choice"] == {"type": "any"}
+
+    bound = chat_model.bind_tools([GetWeather], tool_choice="GetWeather")
+    assert cast("RunnableBinding", bound).kwargs["tool_choice"] == {
+        "type": "tool",
+        "name": "GetWeather",
+    }
+
+
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""
     # Test with betas parameter at initialization


### PR DESCRIPTION
## Summary
- `create_agent(model, response_format=Schema)` with a thinking-enabled Anthropic model crashes with `400: "Thinking may not be enabled when tool_choice forces tool use"` because the factory sets `tool_choice="any"` for structured output
- `ChatAnthropic.bind_tools` now detects when thinking is enabled and `tool_choice` forces tool use (`"any"` or a specific tool name), and downgrades to `"auto"` with a warning
- This matches the approach already used by `ChatAnthropic.with_structured_output` (via `_get_llm_for_structured_output_when_thinking_is_enabled`)

## Files changed
- `libs/partners/anthropic/langchain_anthropic/chat_models.py` — 8 lines in `bind_tools()` to detect and downgrade forced tool_choice when thinking is enabled
- `libs/partners/anthropic/tests/unit_tests/test_chat_models.py` — 2 test functions covering downgrade behavior + warning emission, and pass-through without thinking

## Test plan
- [x] `test_bind_tools_tool_choice_downgraded_when_thinking_enabled` — verifies `"any"` and named tool choice are downgraded to `"auto"` with warning; `"auto"` and `None` are unchanged without warning
- [x] `test_bind_tools_tool_choice_not_downgraded_without_thinking` — verifies `"any"` and named tool choice pass through unchanged when thinking is not enabled
- [x] Existing `test_anthropic_bind_tools_tool_choice` still passes
- [x] Full anthropic unit test suite: 77 passed, 0 failed

Closes #35539

🤖 Generated with [Claude Code](https://claude.com/claude-code)