### PR TITLE
fix: RunnableRetry.batch/abatch can return corrupted outputs when s...

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -279,12 +279,16 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
+        # Create final outputs by mapping failed results to their original indices
         outputs: list[Output | Exception] = []
+        failed_indices = [i for i in range(len(inputs)) if i not in results_map]
+        failed_results_map = dict(zip(failed_indices, result, strict=True))
+
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(failed_results_map[idx])
         return outputs
 
     @override
@@ -354,12 +358,16 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
+        # Create final outputs by mapping failed results to their original indices
         outputs: list[Output | Exception] = []
+        failed_indices = [i for i in range(len(inputs)) if i not in results_map]
+        failed_results_map = dict(zip(failed_indices, result, strict=True))
+
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(failed_results_map[idx])
         return outputs
 
     @override

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3979,6 +3979,85 @@ async def test_async_retry_batch_preserves_order() -> None:
     assert results == [0, 1, 2]
 
 
+def test_retry_batch_return_exceptions_with_partial_success() -> None:
+    """Regression test for batch with retry and return_exceptions.
+
+    Should maintain correct mapping when some items succeed on retry and others
+    still fail. Previous implementation could corrupt outputs by incorrectly using
+    result.pop(0) to assign failed results to wrong indices.
+    """
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                msg = "retry_then_ok failed once"
+                raise ValueError(msg)
+            return "retry-result"
+        msg = "always_fail failed"
+        raise ValueError(msg)
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = runnable.batch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    # Expected: [success, success, exception]
+    assert len(result) == 3
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+    assert "always_fail failed" in str(result[2])
+
+
+async def test_async_retry_batch_return_exceptions_with_partial_success() -> None:
+    """Async version of the regression test for batch retry and return_exceptions."""
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                msg = "retry_then_ok failed once"
+                raise ValueError(msg)
+            return "retry-result"
+        msg = "always_fail failed"
+        raise ValueError(msg)
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = await runnable.abatch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    # Expected: [success, success, exception]
+    assert len(result) == 3
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+    assert "always_fail failed" in str(result[2])
+
+
 async def test_async_retrying(mocker: MockerFixture) -> None:
     def _lambda(x: int) -> int:
         if x == 1:


### PR DESCRIPTION
## Summary

Fixes #35475

## Changes

Auto-generated contribution addressing: RunnableRetry.batch/abatch can return corrupted outputs when some items succeed on retry and others still fail

## Testing

- Ran the project's test suite
- Verified the fix addresses the issue

---
*Contributed via automated open-source bot*
