### PR TITLE
fix(core): preserve default_factory when creating subset models

### DIFF
--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -242,7 +242,11 @@ def _create_subset_model_v2(
     for field_name in field_names:
         field = model.model_fields[field_name]
         description = descriptions_.get(field_name, field.description)
-        field_info = FieldInfoV2(description=description, default=field.default)
+        field_info = FieldInfoV2(
+            description=description,
+            default=field.default,
+            default_factory=field.default_factory,
+        )
         if field.metadata:
             field_info.metadata = field.metadata
         fields[field_name] = (field.annotation, field_info)

--- a/libs/core/tests/unit_tests/utils/test_pydantic.py
+++ b/libs/core/tests/unit_tests/utils/test_pydantic.py
@@ -133,6 +133,28 @@ def test_with_field_metadata() -> None:
     }
 
 
+def test_with_default_factory() -> None:
+    """Fields with default_factory should not be required."""
+
+    class Foo(BaseModel):
+        required_field: str = Field(description="Required")
+        optional_with_default: str = Field(default="hi", description="Has default")
+        optional_with_factory: list[int] = Field(
+            default_factory=list, description="Has default_factory"
+        )
+
+    subset_model = _create_subset_model_v2(
+        "Foo", Foo, ["required_field", "optional_with_default", "optional_with_factory"]
+    )
+    schema = subset_model.model_json_schema()
+    assert schema["required"] == ["required_field"]
+
+    # Verify defaults actually work at runtime
+    instance = subset_model(required_field="hello")
+    assert instance.optional_with_default == "hi"
+    assert instance.optional_with_factory == []
+
+
 def test_fields_pydantic_v2_proper() -> None:
     class Foo(BaseModel):
         x: int

--- a/libs/core/tests/unit_tests/utils/test_pydantic.py
+++ b/libs/core/tests/unit_tests/utils/test_pydantic.py
@@ -151,8 +151,8 @@ def test_with_default_factory() -> None:
 
     # Verify defaults actually work at runtime
     instance = subset_model(required_field="hello")
-    assert instance.optional_with_default == "hi"
-    assert instance.optional_with_factory == []
+    assert instance.optional_with_default == "hi"  # type: ignore[attr-defined]
+    assert instance.optional_with_factory == []  # type: ignore[attr-defined]
 
 
 def test_fields_pydantic_v2_proper() -> None:


### PR DESCRIPTION
## Summary
- `_create_subset_model_v2` only copied `field.default` when rebuilding `FieldInfo`, ignoring `field.default_factory`
- This caused fields with `default_factory` (e.g. `Field(default_factory=list)`) to be incorrectly marked as `"required"` in generated tool schemas
- Fix: pass `default_factory=field.default_factory` alongside `default=field.default` in the `FieldInfoV2` constructor

## Files changed
- `libs/core/langchain_core/utils/pydantic.py` — add `default_factory` parameter to `FieldInfoV2()` call in `_create_subset_model_v2`
- `libs/core/tests/unit_tests/utils/test_pydantic.py` — add `test_with_default_factory` covering schema correctness and runtime instantiation

## Test plan
- [x] `test_with_default_factory` — verifies only truly required fields appear in `"required"`, and that `default`/`default_factory` values work at runtime
- [x] Full `test_pydantic.py` suite: 10 passed
- [x] Full `test_tools.py` suite: 161 passed

Closes #35547

🤖 Generated with [Claude Code](https://claude.com/claude-code)