### PR TITLE
feat(langchain): add ToolTimeoutMiddleware to prevent infinite tool hangs

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -23,6 +23,7 @@ from langchain.agents.middleware.tool_call_limit import ToolCallLimitMiddleware
 from langchain.agents.middleware.tool_emulator import LLMToolEmulator
 from langchain.agents.middleware.tool_retry import ToolRetryMiddleware
 from langchain.agents.middleware.tool_selection import LLMToolSelectorMiddleware
+from langchain.agents.middleware.tool_timeout import ToolTimeoutMiddleware
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
@@ -70,6 +71,7 @@ __all__ = [
     "ToolCallLimitMiddleware",
     "ToolCallRequest",
     "ToolRetryMiddleware",
+    "ToolTimeoutMiddleware",
     "after_agent",
     "after_model",
     "before_agent",

--- a/libs/langchain_v1/langchain/agents/middleware/tool_timeout.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_timeout.py
@@ -1,0 +1,117 @@
+"""Tool timeout middleware for agents."""
+
+import asyncio
+import concurrent.futures
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+from typing_extensions import override
+
+from langchain.agents.middleware.types import AgentMiddleware, ToolCallRequest
+
+
+class ToolTimeoutMiddleware(AgentMiddleware[Any, Any, Any]):
+    """Enforce execution timeouts on tools.
+
+    This middleware wraps tool execution in a strict timeout. If the tool fails to
+    complete within the specified duration, the execution is interrupted (or abandoned)
+    and a ``ToolMessage`` with ``status="error"`` is returned natively to the LLM.
+
+    This prevents agents from permanently freezing when interacting with unresponsive
+    external APIs or hung processes.
+
+    Examples:
+        !!! example "Basic usage"
+
+            ```python
+            from langchain.agents import create_agent
+            from langchain.agents.middleware.tool_timeout import ToolTimeoutMiddleware
+
+            # Tools will be forcefully timed out after 5.0 seconds
+            timeout_middleware = ToolTimeoutMiddleware(timeout=5.0)
+            agent = create_agent("openai:gpt-4o", middleware=[timeout_middleware])
+            ```
+    """
+
+    def __init__(self, timeout: float) -> None:
+        """Initialize the timeout middleware.
+
+        Args:
+            timeout: Maximum allowed execution time in seconds.
+
+        Raises:
+            ValueError: If timeout is perfectly zero or negative.
+        """
+        super().__init__()
+        if timeout <= 0:
+            msg = f"Timeout must be safely greater than 0, got {timeout}."
+            raise ValueError(msg)
+        self.timeout = timeout
+
+    def _generate_timeout_error(self, request: ToolCallRequest) -> ToolMessage:
+        """Generate a generic ToolMessage informing the LLM of the timeout.
+
+        Args:
+            request: The current tool call request.
+
+        Returns:
+            A ToolMessage containing the timeout payload and error status.
+        """
+        tool_call_id = request.tool_call.get("id", "")
+        name = request.tool_call.get("name", "unknown_tool")
+
+        return ToolMessage(
+            content=f"Error: Tool '{name}' execution timed out after {self.timeout} seconds.",
+            name=name,
+            tool_call_id=tool_call_id,
+            status="error",
+        )
+
+    @override
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Wrap synchronous tool execution with a timeout.
+
+        Uses a ThreadPoolExecutor to bound the execution. If the tool hangs, the
+        thread is abandoned and an error message is immediately returned.
+
+        Args:
+            request: Tool call request object.
+            handler: Synchronous tool handler.
+
+        Returns:
+            The tool's result, or an error ``ToolMessage`` if a timeout occurred.
+        """
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(handler, request)
+            try:
+                return future.result(timeout=self.timeout)
+            except concurrent.futures.TimeoutError:
+                return self._generate_timeout_error(request)
+
+    @override
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Wrap asynchronous tool execution with a timeout.
+
+        Uses ``asyncio.wait_for`` to strictly bound the execution.
+
+        Args:
+            request: Tool call request object.
+            handler: Asynchronous tool handler.
+
+        Returns:
+            The tool's result, or an error ``ToolMessage`` if a timeout occurred.
+        """
+        try:
+            return await asyncio.wait_for(handler(request), timeout=self.timeout)
+        except asyncio.TimeoutError:
+            return self._generate_timeout_error(request)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_timeout.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_timeout.py
@@ -1,0 +1,129 @@
+import asyncio
+import time
+from typing import cast
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from langchain.agents.middleware.tool_timeout import ToolTimeoutMiddleware
+from langchain.agents.middleware.types import ToolCallRequest
+
+
+class DummyRuntime:
+    """Dummy runtime for testing."""
+
+
+class DummyState:
+    """Dummy state for testing."""
+
+
+@pytest.fixture
+def dummy_request() -> ToolCallRequest:
+    """Return a valid ToolCallRequest mock."""
+    return ToolCallRequest(
+        tool_call={"name": "test_tool", "args": {"input": "test"}, "id": "call_123"},
+        tool=None,  # type: ignore[arg-type]
+        state={},  # type: ignore[arg-type]
+        runtime=DummyRuntime(),  # type: ignore[arg-type]
+    )
+
+
+def test_initialization() -> None:
+    """Test standard initialization and ValueError cases."""
+    middleware = ToolTimeoutMiddleware(timeout=2.0)
+    assert middleware.timeout == 2.0
+
+    with pytest.raises(ValueError, match="safely greater than 0"):
+        ToolTimeoutMiddleware(timeout=0.0)
+
+    with pytest.raises(ValueError, match="safely greater than 0"):
+        ToolTimeoutMiddleware(timeout=-1.5)
+
+
+def test_sync_wrap_tool_call_success(dummy_request: ToolCallRequest) -> None:
+    """Test successful synchronous execution within the timeout."""
+    middleware = ToolTimeoutMiddleware(timeout=1.0)
+
+    def fast_handler(req: ToolCallRequest) -> ToolMessage:
+        return ToolMessage(
+            content="Success", name=req.tool_call["name"], tool_call_id=req.tool_call["id"]
+        )
+
+    result = middleware.wrap_tool_call(dummy_request, fast_handler)
+    assert isinstance(result, ToolMessage)
+    assert result.content == "Success"
+    assert result.status != "error"
+
+
+def test_sync_wrap_tool_call_timeout(dummy_request: ToolCallRequest) -> None:
+    """Test synchronous execution that times out."""
+    middleware = ToolTimeoutMiddleware(timeout=0.1)
+
+    def slow_handler(req: ToolCallRequest) -> ToolMessage:
+        time.sleep(0.5)
+        return ToolMessage(
+            content="Too Late", name=req.tool_call["name"], tool_call_id=req.tool_call["id"]
+        )
+
+    result = middleware.wrap_tool_call(dummy_request, slow_handler)
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "timed out after 0.1 seconds" in cast("str", result.content)
+    assert result.name == "test_tool"
+    assert result.tool_call_id == "call_123"
+
+
+@pytest.mark.asyncio
+async def test_async_wrap_tool_call_success(dummy_request: ToolCallRequest) -> None:
+    """Test successful asynchronous execution within the timeout."""
+    middleware = ToolTimeoutMiddleware(timeout=1.0)
+
+    async def async_fast_handler(req: ToolCallRequest) -> ToolMessage:
+        await asyncio.sleep(0.01)
+        return ToolMessage(
+            content="Async Success", name=req.tool_call["name"], tool_call_id=req.tool_call["id"]
+        )
+
+    result = await middleware.awrap_tool_call(dummy_request, async_fast_handler)
+    assert isinstance(result, ToolMessage)
+    assert result.content == "Async Success"
+    assert result.status != "error"
+
+
+@pytest.mark.asyncio
+async def test_async_wrap_tool_call_timeout(dummy_request: ToolCallRequest) -> None:
+    """Test asynchronous execution that times out."""
+    middleware = ToolTimeoutMiddleware(timeout=0.1)
+
+    async def async_slow_handler(req: ToolCallRequest) -> ToolMessage:
+        await asyncio.sleep(0.5)
+        return ToolMessage(
+            content="Too Late Async", name=req.tool_call["name"], tool_call_id=req.tool_call["id"]
+        )
+
+    result = await middleware.awrap_tool_call(dummy_request, async_slow_handler)
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "timed out after 0.1 seconds" in cast("str", result.content)
+    assert result.name == "test_tool"
+    assert result.tool_call_id == "call_123"
+
+
+def test_generate_timeout_error_handles_missing_keys() -> None:
+    """Test _generate_timeout_error safely handles malformed tool_call dicts."""
+    middleware = ToolTimeoutMiddleware(timeout=1.0)
+
+    # Missing optional keys like id/name
+    bad_request = ToolCallRequest(
+        tool_call={},
+        tool=None,  # type: ignore[arg-type]
+        state={},  # type: ignore[arg-type]
+        runtime=DummyRuntime(),  # type: ignore[arg-type]
+    )
+
+    msg = middleware._generate_timeout_error(bad_request)
+    assert isinstance(msg, ToolMessage)
+    assert msg.status == "error"
+    assert msg.name == "unknown_tool"
+    assert msg.tool_call_id == ""
+    assert "unknown_tool" in cast("str", msg.content)


### PR DESCRIPTION
## Description

As LangChain agents become increasingly autonomous and reliant on remote tools, a single unresponsive API call can permanently freeze the orchestration layer. 

This PR introduces `ToolTimeoutMiddleware` for LangGraph-backed agents. Instead of allowing execution to hang, the middleware bounds the execution (`asyncio.wait_for` in async contexts, and standard bounded threads in sync contexts). If a tool exceeds the threshold, the middleware intercepts it and returns a `ToolMessage` with `status="error"`, allowing the LLM to gracefully recover instead of the entire system crashing.

### Testing
- [x] Full unit test suite written inside `tests/unit_tests/agents/middleware/implementations/test_tool_timeout.py`
- [x] Verified `wrap_tool_call` and `awrap_tool_call` integration.
- [x] `make format` and `make lint` passing successfully.
