### PR TITLE
fix(openrouter): include role in sdk `model_construct` for min dep compat

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -969,8 +969,7 @@ def _wrap_messages_for_sdk(
             # Unknown role — pass dict through and hope for the best.
             wrapped.append(msg)
             continue
-        fields = {k: v for k, v in msg.items() if k != "role"}
-        wrapped.append(model_cls.model_construct(**fields))
+        wrapped.append(model_cls.model_construct(**msg))
     return wrapped
 
 


### PR DESCRIPTION
Fix `_wrap_messages_for_sdk` stripping `role` before `model_construct` — on `openrouter==0.6.0` (minimum dep), the SDK models don't auto-populate a default `role`, so `model_dump()` omitted it entirely, causing `KeyError: 'role'` in pre-release checks.