### PR TITLE
fix(core): support camelCase mimeType in v0 content blocks

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/langchain_v0.py
+++ b/libs/core/langchain_core/messages/block_translators/langchain_v0.py
@@ -5,6 +5,21 @@ from typing import Any, cast
 from langchain_core.messages import content as types
 
 
+def _get_mime_type(block: dict) -> str | None:
+    """Get MIME type from block, handling both snake_case and camelCase keys.
+
+    LangGraph JS SDK uses camelCase (mimeType) while Python uses snake_case (mime_type).
+    This function checks for both keys to ensure compatibility.
+
+    Args:
+        block: The content block dictionary.
+
+    Returns:
+        The MIME type if found, None otherwise.
+    """
+    return block.get("mime_type") or block.get("mimeType")
+
+
 def _convert_v0_multimodal_input_to_v1(
     content: list[types.ContentBlock],
 ) -> list[types.ContentBlock]:
@@ -75,20 +90,21 @@ def _convert_legacy_v0_content_block_to_v1(
         source_type = block.get("source_type")
         if source_type == "url":
             # image-url
-            known_keys = {"mime_type", "type", "source_type", "url"}
+            known_keys = {"mime_type", "mimeType", "type", "source_type", "url"}
             extras = _extract_v0_extras(block, known_keys)
+            mime_type = _get_mime_type(block)
             if "id" in block:
                 return types.create_image_block(
                     url=block["url"],
-                    mime_type=block.get("mime_type"),
+                    mime_type=mime_type,
                     id=block["id"],
                     **extras,
                 )
 
             # Don't construct with an ID if not present in original block
             v1_image_url = types.ImageContentBlock(type="image", url=block["url"])
-            if block.get("mime_type"):
-                v1_image_url["mime_type"] = block["mime_type"]
+            if mime_type:
+                v1_image_url["mime_type"] = mime_type
 
             v1_image_url["extras"] = {}
             for key, value in extras.items():
@@ -100,12 +116,13 @@ def _convert_legacy_v0_content_block_to_v1(
             return v1_image_url
         if source_type == "base64":
             # image-base64
-            known_keys = {"mime_type", "type", "source_type", "data"}
+            known_keys = {"mime_type", "mimeType", "type", "source_type", "data"}
             extras = _extract_v0_extras(block, known_keys)
+            mime_type = _get_mime_type(block)
             if "id" in block:
                 return types.create_image_block(
                     base64=block["data"],
-                    mime_type=block.get("mime_type"),
+                    mime_type=mime_type,
                     id=block["id"],
                     **extras,
                 )
@@ -113,8 +130,8 @@ def _convert_legacy_v0_content_block_to_v1(
             v1_image_base64 = types.ImageContentBlock(
                 type="image", base64=block["data"]
             )
-            if block.get("mime_type"):
-                v1_image_base64["mime_type"] = block["mime_type"]
+            if mime_type:
+                v1_image_base64["mime_type"] = mime_type
 
             v1_image_base64["extras"] = {}
             for key, value in extras.items():
@@ -143,12 +160,13 @@ def _convert_legacy_v0_content_block_to_v1(
         source_type = block.get("source_type")
         if source_type == "url":
             # audio-url
-            known_keys = {"mime_type", "type", "source_type", "url"}
+            known_keys = {"mime_type", "mimeType", "type", "source_type", "url"}
             extras = _extract_v0_extras(block, known_keys)
+            mime_type = _get_mime_type(block)
             if "id" in block:
                 return types.create_audio_block(
                     url=block["url"],
-                    mime_type=block.get("mime_type"),
+                    mime_type=mime_type,
                     id=block["id"],
                     **extras,
                 )
@@ -157,8 +175,8 @@ def _convert_legacy_v0_content_block_to_v1(
             v1_audio_url: types.AudioContentBlock = types.AudioContentBlock(
                 type="audio", url=block["url"]
             )
-            if block.get("mime_type"):
-                v1_audio_url["mime_type"] = block["mime_type"]
+            if mime_type:
+                v1_audio_url["mime_type"] = mime_type
 
             v1_audio_url["extras"] = {}
             for key, value in extras.items():
@@ -170,12 +188,13 @@ def _convert_legacy_v0_content_block_to_v1(
             return v1_audio_url
         if source_type == "base64":
             # audio-base64
-            known_keys = {"mime_type", "type", "source_type", "data"}
+            known_keys = {"mime_type", "mimeType", "type", "source_type", "data"}
             extras = _extract_v0_extras(block, known_keys)
+            mime_type = _get_mime_type(block)
             if "id" in block:
                 return types.create_audio_block(
                     base64=block["data"],
-                    mime_type=block.get("mime_type"),
+                    mime_type=mime_type,
                     id=block["id"],
                     **extras,
                 )
@@ -183,8 +202,8 @@ def _convert_legacy_v0_content_block_to_v1(
             v1_audio_base64: types.AudioContentBlock = types.AudioContentBlock(
                 type="audio", base64=block["data"]
             )
-            if block.get("mime_type"):
-                v1_audio_base64["mime_type"] = block["mime_type"]
+            if mime_type:
+                v1_audio_base64["mime_type"] = mime_type
 
             v1_audio_base64["extras"] = {}
             for key, value in extras.items():
@@ -214,12 +233,13 @@ def _convert_legacy_v0_content_block_to_v1(
         source_type = block.get("source_type")
         if source_type == "url":
             # file-url
-            known_keys = {"mime_type", "type", "source_type", "url"}
+            known_keys = {"mime_type", "mimeType", "type", "source_type", "url"}
             extras = _extract_v0_extras(block, known_keys)
+            mime_type = _get_mime_type(block)
             if "id" in block:
                 return types.create_file_block(
                     url=block["url"],
-                    mime_type=block.get("mime_type"),
+                    mime_type=mime_type,
                     id=block["id"],
                     **extras,
                 )
@@ -227,8 +247,8 @@ def _convert_legacy_v0_content_block_to_v1(
             v1_file_url: types.FileContentBlock = types.FileContentBlock(
                 type="file", url=block["url"]
             )
-            if block.get("mime_type"):
-                v1_file_url["mime_type"] = block["mime_type"]
+            if mime_type:
+                v1_file_url["mime_type"] = mime_type
 
             v1_file_url["extras"] = {}
             for key, value in extras.items():
@@ -240,12 +260,13 @@ def _convert_legacy_v0_content_block_to_v1(
             return v1_file_url
         if source_type == "base64":
             # file-base64
-            known_keys = {"mime_type", "type", "source_type", "data"}
+            known_keys = {"mime_type", "mimeType", "type", "source_type", "data"}
             extras = _extract_v0_extras(block, known_keys)
+            mime_type = _get_mime_type(block)
             if "id" in block:
                 return types.create_file_block(
                     base64=block["data"],
-                    mime_type=block.get("mime_type"),
+                    mime_type=mime_type,
                     id=block["id"],
                     **extras,
                 )
@@ -253,8 +274,8 @@ def _convert_legacy_v0_content_block_to_v1(
             v1_file_base64: types.FileContentBlock = types.FileContentBlock(
                 type="file", base64=block["data"]
             )
-            if block.get("mime_type"):
-                v1_file_base64["mime_type"] = block["mime_type"]
+            if mime_type:
+                v1_file_base64["mime_type"] = mime_type
 
             v1_file_base64["extras"] = {}
             for key, value in extras.items():
@@ -271,8 +292,9 @@ def _convert_legacy_v0_content_block_to_v1(
             return types.create_file_block(file_id=block["id"], **extras)
         if source_type == "text":
             # file-text
-            known_keys = {"mime_type", "type", "source_type", "url"}
+            known_keys = {"mime_type", "mimeType", "type", "source_type", "url"}
             extras = _extract_v0_extras(block, known_keys)
+            mime_type = _get_mime_type(block)
             if "id" in block:
                 return types.create_plaintext_block(
                     # In v0, URL points to the text file content
@@ -285,8 +307,8 @@ def _convert_legacy_v0_content_block_to_v1(
             v1_file_text: types.PlainTextContentBlock = types.PlainTextContentBlock(
                 type="text-plain", text=block["url"], mime_type="text/plain"
             )
-            if block.get("mime_type"):
-                v1_file_text["mime_type"] = block["mime_type"]
+            if mime_type:
+                v1_file_text["mime_type"] = mime_type
 
             v1_file_text["extras"] = {}
             for key, value in extras.items():

--- a/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
@@ -2,10 +2,238 @@ from langchain_core.messages import HumanMessage
 from langchain_core.messages import content as types
 from langchain_core.messages.block_translators.langchain_v0 import (
     _convert_legacy_v0_content_block_to_v1,
+    _get_mime_type,
 )
 from tests.unit_tests.language_models.chat_models.test_base import (
     _content_blocks_equal_ignore_id,
 )
+
+
+def test_get_mime_type_snake_case() -> None:
+    """Test that _get_mime_type handles snake_case mime_type."""
+    block = {"mime_type": "image/png"}
+    assert _get_mime_type(block) == "image/png"
+
+
+def test_get_mime_type_camel_case() -> None:
+    """Test that _get_mime_type handles camelCase mimeType (from JS SDK)."""
+    block = {"mimeType": "image/png"}
+    assert _get_mime_type(block) == "image/png"
+
+
+def test_get_mime_type_both_keys_snake_priority() -> None:
+    """Test that _get_mime_type prefers snake_case when both are present."""
+    block = {"mime_type": "image/png", "mimeType": "image/jpeg"}
+    # snake_case should take priority
+    assert _get_mime_type(block) == "image/png"
+
+
+def test_get_mime_type_none_values() -> None:
+    """Test that _get_mime_type handles None values correctly."""
+    block = {"mime_type": None, "mimeType": "image/png"}
+    # None is falsy, so should fall back to camelCase
+    assert _get_mime_type(block) == "image/png"
+
+
+def test_get_mime_type_empty_string() -> None:
+    """Test that _get_mime_type handles empty strings correctly."""
+    block = {"mime_type": "", "mimeType": "image/png"}
+    # Empty string is falsy, so should fall back to camelCase
+    assert _get_mime_type(block) == "image/png"
+
+
+def test_get_mime_type_missing() -> None:
+    """Test that _get_mime_type returns None when key is missing."""
+    block = {"url": "https://example.com/image.png"}
+    assert _get_mime_type(block) is None
+
+
+def test_convert_image_url_with_camel_case_mime_type() -> None:
+    """Test converting image block with camelCase mimeType (from JS SDK)."""
+    block = {
+        "type": "image",
+        "source_type": "url",
+        "url": "https://example.com/image.png",
+        "mimeType": "image/png",  # camelCase from JS SDK
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    assert result["type"] == "image"
+    assert result["url"] == "https://example.com/image.png"
+    assert result["mime_type"] == "image/png"
+    # mimeType should NOT be in extras
+    assert "extras" not in result or "mimeType" not in result.get("extras", {})
+
+
+def test_convert_image_base64_with_camel_case_mime_type() -> None:
+    """Test converting base64 image block with camelCase mimeType."""
+    block = {
+        "type": "image",
+        "source_type": "base64",
+        "data": "iVBORw0KGgo=",
+        "mimeType": "image/png",
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    assert result["type"] == "image"
+    assert result["base64"] == "iVBORw0KGgo="
+    assert result["mime_type"] == "image/png"
+
+
+def test_convert_audio_url_with_camel_case_mime_type() -> None:
+    """Test converting audio URL block with camelCase mimeType."""
+    block = {
+        "type": "audio",
+        "source_type": "url",
+        "url": "https://example.com/audio.mp3",
+        "mimeType": "audio/mpeg",
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    assert result["type"] == "audio"
+    assert result["url"] == "https://example.com/audio.mp3"
+    assert result["mime_type"] == "audio/mpeg"
+
+
+def test_convert_audio_base64_with_camel_case_mime_type() -> None:
+    """Test converting base64 audio block with camelCase mimeType."""
+    block = {
+        "type": "audio",
+        "source_type": "base64",
+        "data": "//uQxAAAA",
+        "mimeType": "audio/wav",
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    assert result["type"] == "audio"
+    assert result["base64"] == "//uQxAAAA"
+    assert result["mime_type"] == "audio/wav"
+
+
+def test_convert_file_url_with_camel_case_mime_type() -> None:
+    """Test converting file URL block with camelCase mimeType."""
+    block = {
+        "type": "file",
+        "source_type": "url",
+        "url": "https://example.com/document.pdf",
+        "mimeType": "application/pdf",
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    assert result["type"] == "file"
+    assert result["url"] == "https://example.com/document.pdf"
+    assert result["mime_type"] == "application/pdf"
+
+
+def test_convert_file_base64_with_camel_case_mime_type() -> None:
+    """Test converting base64 file block with camelCase mimeType."""
+    block = {
+        "type": "file",
+        "source_type": "base64",
+        "data": "JVBERi0xLjQ=",
+        "mimeType": "application/pdf",
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    assert result["type"] == "file"
+    assert result["base64"] == "JVBERi0xLjQ="
+    assert result["mime_type"] == "application/pdf"
+
+
+def test_convert_file_text_with_camel_case_mime_type() -> None:
+    """Test converting text file block with camelCase mimeType."""
+    block = {
+        "type": "file",
+        "source_type": "text",
+        "url": "This is the text content",
+        "mimeType": "text/markdown",
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    assert result["type"] == "text-plain"
+    assert result["text"] == "This is the text content"
+    assert result["mime_type"] == "text/markdown"
+
+
+def test_camel_case_mime_type_not_in_extras() -> None:
+    """Test that camelCase mimeType is not included in extras after conversion."""
+    block = {
+        "type": "image",
+        "source_type": "url",
+        "url": "https://example.com/image.png",
+        "mimeType": "image/png",
+        "alt_text": "An image",  # This should go to extras
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    # alt_text should be in extras
+    assert result.get("extras", {}).get("alt_text") == "An image"
+    # mimeType should NOT be in extras (it's consumed as mime_type)
+    assert "mimeType" not in result.get("extras", {})
+
+
+def test_convert_message_with_js_sdk_format() -> None:
+    """Test full message conversion with JS SDK format (camelCase)."""
+    message = HumanMessage(
+        content=[
+            {"type": "text", "text": "Hello from JS SDK"},
+            {
+                "type": "image",
+                "source_type": "base64",
+                "data": "<base64 data>",
+                "mimeType": "image/jpeg",  # camelCase from JS
+            },
+            {
+                "type": "audio",
+                "source_type": "base64",
+                "data": "<audio data>",
+                "mimeType": "audio/mp3",  # camelCase from JS
+            },
+            {
+                "type": "file",
+                "source_type": "base64",
+                "data": "<pdf data>",
+                "mimeType": "application/pdf",  # camelCase from JS
+            },
+        ]
+    )
+
+    expected: list[types.ContentBlock] = [
+        {"type": "text", "text": "Hello from JS SDK"},
+        {
+            "type": "image",
+            "base64": "<base64 data>",
+            "mime_type": "image/jpeg",
+        },
+        {
+            "type": "audio",
+            "base64": "<audio data>",
+            "mime_type": "audio/mp3",
+        },
+        {
+            "type": "file",
+            "base64": "<pdf data>",
+            "mime_type": "application/pdf",
+        },
+    ]
+
+    assert _content_blocks_equal_ignore_id(message.content_blocks, expected)
+
+
+def test_backward_compatibility_snake_case() -> None:
+    """Test that existing snake_case format still works after the fix."""
+    message = HumanMessage(
+        content=[
+            {
+                "type": "image",
+                "source_type": "base64",
+                "data": "<base64 data>",
+                "mime_type": "image/png",  # snake_case (Python format)
+            },
+        ]
+    )
+
+    expected: list[types.ContentBlock] = [
+        {
+            "type": "image",
+            "base64": "<base64 data>",
+            "mime_type": "image/png",
+        },
+    ]
+
+    assert _content_blocks_equal_ignore_id(message.content_blocks, expected)
 
 
 def test_convert_to_v1_from_openai_input() -> None:


### PR DESCRIPTION
## Summary
- add a small helper that reads MIME types from both `mime_type` and `mimeType`
- use it across v0 image/audio/file translation paths
- treat `mimeType` as a known key so it is not leaked into `extras`

## Why
LangGraph JS payloads use `mimeType` while Python-side payloads use `mime_type`. The current translator only reads `mime_type`, so converted blocks can lose MIME metadata when content originates from JS clients.

## Testing
- added unit coverage for `_get_mime_type`
- added translation tests for image/audio/file paths using camelCase payloads
- verified snake_case backward compatibility coverage
