### PR TITLE
fix(langchain): avoid hardcoding tool_choice='any' in create_agent when thinking is enabled

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -513,6 +513,30 @@ def _supports_provider_strategy(
     )
 
 
+def _has_thinking_enabled(model: BaseChatModel) -> bool:
+    """Check if a model has thinking/reasoning actively enabled.
+
+    Some providers (e.g. Anthropic) do not allow ``tool_choice="any"`` when
+    thinking/extended-reasoning mode is turned on.  This helper inspects
+    common provider attributes so that callers can fall back to
+    ``tool_choice="auto"`` instead of forcing tool use.
+
+    Args:
+        model: A ``BaseChatModel`` instance.
+
+    Returns:
+        ``True`` if the model has thinking/reasoning enabled, ``False`` otherwise.
+    """
+    # Anthropic: thinking={"type": "enabled"} or {"type": "adaptive"}
+    thinking = getattr(model, "thinking", None)
+    if isinstance(thinking, dict) and thinking.get("type") in ("enabled", "adaptive"):
+        return True
+    # OpenAI / DeepSeek: reasoning_effort is set (e.g. "high", "medium", "low")
+    if getattr(model, "reasoning_effort", None) is not None:
+        return True
+    return False
+
+
 def _handle_structured_output_error(
     exception: Exception,
     response_format: ResponseFormat[Any],
@@ -1203,8 +1227,19 @@ def create_agent(
                     )
                     raise ValueError(msg)
 
-            # Force tool use if we have structured output tools
-            tool_choice = "any" if structured_output_tools else request.tool_choice
+            # Force tool use if we have structured output tools, but fall
+            # back to "auto" when the model has thinking/reasoning enabled
+            # because some providers (e.g. Anthropic) reject tool_choice="any"
+            # when thinking mode is active.
+            if structured_output_tools:
+                if isinstance(request.model, BaseChatModel) and _has_thinking_enabled(
+                    request.model
+                ):
+                    tool_choice = "auto"
+                else:
+                    tool_choice = "any"
+            else:
+                tool_choice = request.tool_choice
             return (
                 request.model.bind_tools(
                     final_tools, tool_choice=tool_choice, **request.model_settings

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -527,14 +527,10 @@ def _has_thinking_enabled(model: BaseChatModel) -> bool:
     Returns:
         ``True`` if the model has thinking/reasoning enabled, ``False`` otherwise.
     """
-    # Anthropic: thinking={"type": "enabled"} or {"type": "adaptive"}
     thinking = getattr(model, "thinking", None)
     if isinstance(thinking, dict) and thinking.get("type") in ("enabled", "adaptive"):
         return True
-    # OpenAI / DeepSeek: reasoning_effort is set (e.g. "high", "medium", "low")
-    if getattr(model, "reasoning_effort", None) is not None:
-        return True
-    return False
+    return getattr(model, "reasoning_effort", None) is not None
 
 
 def _handle_structured_output_error(
@@ -1231,6 +1227,7 @@ def create_agent(
             # back to "auto" when the model has thinking/reasoning enabled
             # because some providers (e.g. Anthropic) reject tool_choice="any"
             # when thinking mode is active.
+            tool_choice: str | None
             if structured_output_tools:
                 if isinstance(request.model, BaseChatModel) and _has_thinking_enabled(
                     request.model

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -939,3 +939,141 @@ class TestSupportsProviderStrategy:
         """Latest aliases stay blocked until they point to Gemini 3."""
         model = self._make_structured_model(alias)
         assert not _supports_provider_strategy(model, tools=[get_weather])
+
+
+class FakeThinkingModel(FakeToolCallingModel):
+    """Fake model with a thinking attribute (like ChatAnthropic)."""
+
+    thinking: dict[str, Any] | None = None
+
+
+class FakeReasoningModel(FakeToolCallingModel):
+    """Fake model with a reasoning_effort attribute (like ChatOpenAI)."""
+
+    reasoning_effort: str | None = None
+
+
+class TestHasThinkingEnabled:
+    """Unit tests for `_has_thinking_enabled`."""
+
+    def test_anthropic_thinking_enabled(self) -> None:
+        """Model with thinking={"type": "enabled"} should be detected."""
+        from langchain.agents.factory import _has_thinking_enabled
+
+        model = FakeThinkingModel(thinking={"type": "enabled", "budget_tokens": 5000})
+        assert _has_thinking_enabled(model) is True
+
+    def test_anthropic_thinking_adaptive(self) -> None:
+        """Model with thinking={"type": "adaptive"} should be detected."""
+        from langchain.agents.factory import _has_thinking_enabled
+
+        model = FakeThinkingModel(thinking={"type": "adaptive"})
+        assert _has_thinking_enabled(model) is True
+
+    def test_anthropic_thinking_disabled(self) -> None:
+        """Model with thinking={"type": "disabled"} should not be detected."""
+        from langchain.agents.factory import _has_thinking_enabled
+
+        model = FakeThinkingModel(thinking={"type": "disabled"})
+        assert _has_thinking_enabled(model) is False
+
+    def test_anthropic_thinking_none(self) -> None:
+        """Model with thinking=None should not be detected."""
+        from langchain.agents.factory import _has_thinking_enabled
+
+        model = FakeThinkingModel(thinking=None)
+        assert _has_thinking_enabled(model) is False
+
+    def test_no_thinking_attribute(self) -> None:
+        """Model without thinking attribute should not be detected."""
+        from langchain.agents.factory import _has_thinking_enabled
+
+        model = FakeToolCallingModel()
+        assert _has_thinking_enabled(model) is False
+
+    def test_reasoning_effort_set(self) -> None:
+        """Model with reasoning_effort set should be detected."""
+        from langchain.agents.factory import _has_thinking_enabled
+
+        model = FakeReasoningModel(reasoning_effort="high")
+        assert _has_thinking_enabled(model) is True
+
+    def test_reasoning_effort_none(self) -> None:
+        """Model with reasoning_effort=None should not be detected."""
+        from langchain.agents.factory import _has_thinking_enabled
+
+        model = FakeReasoningModel(reasoning_effort=None)
+        assert _has_thinking_enabled(model) is False
+
+
+class TestToolChoiceWithThinking:
+    """Verify that tool_choice falls back to 'auto' when thinking is enabled.
+
+    Regression tests for https://github.com/langchain-ai/langchain/issues/35539
+    """
+
+    def test_tool_choice_auto_when_thinking_enabled(self) -> None:
+        """When model has thinking enabled, tool_choice should be 'auto' not 'any'."""
+        tool_calls = [
+            [
+                {
+                    "name": "WeatherBaseModel",
+                    "id": "1",
+                    "args": WEATHER_DATA,
+                }
+            ],
+        ]
+
+        model = FakeThinkingModel(
+            tool_calls=tool_calls,
+            thinking={"type": "enabled", "budget_tokens": 5000},
+        )
+
+        # Patch bind_tools to capture tool_choice argument
+        original_bind_tools = FakeThinkingModel.bind_tools
+        captured_kwargs: dict[str, Any] = {}
+
+        def patched_bind_tools(self_inner, tools, *, tool_choice=None, **kwargs):
+            captured_kwargs["tool_choice"] = tool_choice
+            return original_bind_tools(self_inner, tools, tool_choice=tool_choice, **kwargs)
+
+        with patch.object(FakeThinkingModel, "bind_tools", patched_bind_tools):
+            with patch(
+                "langchain.agents.factory._supports_provider_strategy",
+                return_value=False,
+            ):
+                agent = create_agent(model, [], response_format=WeatherBaseModel)
+                agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        assert captured_kwargs["tool_choice"] == "auto"
+
+    def test_tool_choice_any_when_no_thinking(self) -> None:
+        """When model has no thinking, tool_choice should remain 'any'."""
+        tool_calls = [
+            [
+                {
+                    "name": "WeatherBaseModel",
+                    "id": "1",
+                    "args": WEATHER_DATA,
+                }
+            ],
+        ]
+
+        model = FakeToolCallingModel(tool_calls=tool_calls)
+
+        original_bind_tools = FakeToolCallingModel.bind_tools
+        captured_kwargs: dict[str, Any] = {}
+
+        def patched_bind_tools(self_inner, tools, *, tool_choice=None, **kwargs):
+            captured_kwargs["tool_choice"] = tool_choice
+            return original_bind_tools(self_inner, tools, tool_choice=tool_choice, **kwargs)
+
+        with patch.object(FakeToolCallingModel, "bind_tools", patched_bind_tools):
+            with patch(
+                "langchain.agents.factory._supports_provider_strategy",
+                return_value=False,
+            ):
+                agent = create_agent(model, [], response_format=WeatherBaseModel)
+                agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        assert captured_kwargs["tool_choice"] == "any"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import TypedDict
 
 from langchain.agents import create_agent
-from langchain.agents.factory import _supports_provider_strategy
+from langchain.agents.factory import _has_thinking_enabled, _supports_provider_strategy
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     ModelCallResult,
@@ -958,50 +958,36 @@ class TestHasThinkingEnabled:
 
     def test_anthropic_thinking_enabled(self) -> None:
         """Model with thinking={"type": "enabled"} should be detected."""
-        from langchain.agents.factory import _has_thinking_enabled
-
         model = FakeThinkingModel(thinking={"type": "enabled", "budget_tokens": 5000})
         assert _has_thinking_enabled(model) is True
 
     def test_anthropic_thinking_adaptive(self) -> None:
         """Model with thinking={"type": "adaptive"} should be detected."""
-        from langchain.agents.factory import _has_thinking_enabled
-
         model = FakeThinkingModel(thinking={"type": "adaptive"})
         assert _has_thinking_enabled(model) is True
 
     def test_anthropic_thinking_disabled(self) -> None:
         """Model with thinking={"type": "disabled"} should not be detected."""
-        from langchain.agents.factory import _has_thinking_enabled
-
         model = FakeThinkingModel(thinking={"type": "disabled"})
         assert _has_thinking_enabled(model) is False
 
     def test_anthropic_thinking_none(self) -> None:
         """Model with thinking=None should not be detected."""
-        from langchain.agents.factory import _has_thinking_enabled
-
         model = FakeThinkingModel(thinking=None)
         assert _has_thinking_enabled(model) is False
 
     def test_no_thinking_attribute(self) -> None:
         """Model without thinking attribute should not be detected."""
-        from langchain.agents.factory import _has_thinking_enabled
-
         model = FakeToolCallingModel()
         assert _has_thinking_enabled(model) is False
 
     def test_reasoning_effort_set(self) -> None:
         """Model with reasoning_effort set should be detected."""
-        from langchain.agents.factory import _has_thinking_enabled
-
         model = FakeReasoningModel(reasoning_effort="high")
         assert _has_thinking_enabled(model) is True
 
     def test_reasoning_effort_none(self) -> None:
         """Model with reasoning_effort=None should not be detected."""
-        from langchain.agents.factory import _has_thinking_enabled
-
         model = FakeReasoningModel(reasoning_effort=None)
         assert _has_thinking_enabled(model) is False
 
@@ -1037,13 +1023,15 @@ class TestToolChoiceWithThinking:
             captured_kwargs["tool_choice"] = tool_choice
             return original_bind_tools(self_inner, tools, tool_choice=tool_choice, **kwargs)
 
-        with patch.object(FakeThinkingModel, "bind_tools", patched_bind_tools):
-            with patch(
+        with (
+            patch.object(FakeThinkingModel, "bind_tools", patched_bind_tools),
+            patch(
                 "langchain.agents.factory._supports_provider_strategy",
                 return_value=False,
-            ):
-                agent = create_agent(model, [], response_format=WeatherBaseModel)
-                agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+            ),
+        ):
+            agent = create_agent(model, [], response_format=WeatherBaseModel)
+            agent.invoke({"messages": [HumanMessage("What's the weather?")]})
 
         assert captured_kwargs["tool_choice"] == "auto"
 
@@ -1068,12 +1056,14 @@ class TestToolChoiceWithThinking:
             captured_kwargs["tool_choice"] = tool_choice
             return original_bind_tools(self_inner, tools, tool_choice=tool_choice, **kwargs)
 
-        with patch.object(FakeToolCallingModel, "bind_tools", patched_bind_tools):
-            with patch(
+        with (
+            patch.object(FakeToolCallingModel, "bind_tools", patched_bind_tools),
+            patch(
                 "langchain.agents.factory._supports_provider_strategy",
                 return_value=False,
-            ):
-                agent = create_agent(model, [], response_format=WeatherBaseModel)
-                agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+            ),
+        ):
+            agent = create_agent(model, [], response_format=WeatherBaseModel)
+            agent.invoke({"messages": [HumanMessage("What's the weather?")]})
 
         assert captured_kwargs["tool_choice"] == "any"


### PR DESCRIPTION
## Summary

- `create_agent` with `response_format` hardcodes `tool_choice="any"` when using `ToolStrategy`, which causes Anthropic's API to reject requests with `400: "Thinking may not be enabled when tool_choice forces tool use"`
- Adds a `_has_thinking_enabled()` helper that detects when a model has thinking/reasoning actively enabled (Anthropic `thinking` param, OpenAI/DeepSeek `reasoning_effort` param)
- When thinking is enabled, falls back to `tool_choice="auto"` instead of `"any"` — the model can still voluntarily call the structured output tool, but the API constraint is respected
- Default behavior (`tool_choice="any"`) is preserved for all models without thinking enabled

Fixes #35539

## Test plan

- [x] Added 7 unit tests for `_has_thinking_enabled()` helper covering: Anthropic thinking enabled/adaptive/disabled/None, no thinking attribute, OpenAI reasoning_effort set/None
- [x] Added 2 integration tests for `TestToolChoiceWithThinking` verifying: `tool_choice="auto"` when thinking is enabled, `tool_choice="any"` preserved when thinking is not enabled
- [x] All 38 tests in `test_response_format.py` pass (29 existing + 9 new)
- [x] Full agents test suite (725 tests) passes with zero regressions


🤖 Generated with [Claude Code](https://claude.com/claude-code)