### PR TITLE
fix(langchain-openai): include explicit null status in responses function call items

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4245,6 +4245,9 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                     "type": "function_call_output",
                     "output": tool_output,
                     "call_id": msg["tool_call_id"],
+                    # Keep explicit null for compatibility with servers expecting the
+                    # field to be present on responses API function output items.
+                    "status": None,
                 }
                 input_.append(function_call_output)
         elif msg["role"] == "assistant":
@@ -4303,7 +4306,15 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                             "mcp_list_tools",
                             "mcp_approval_request",
                         ):
-                            input_.append(_pop_index_and_sub_index(block))
+                            converted_block = _pop_index_and_sub_index(block)
+                            if (
+                                block_type == "function_call"
+                                and "status" not in converted_block
+                            ):
+                                # Preserve explicit null status for maximum responses
+                                # API compatibility with function call flows.
+                                converted_block["status"] = None
+                            input_.append(converted_block)
                         elif block_type == "image_generation_call":
                             # A previous image generation call can be referenced by ID
                             input_.append(
@@ -4341,6 +4352,9 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                             "name": tool_call["function"]["name"],
                             "arguments": tool_call["function"]["arguments"],
                             "call_id": tool_call["id"],
+                            # Preserve explicit null status for compatibility with
+                            # providers that reject items missing this field.
+                            "status": None,
                         }
                         input_.append(function_call)
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2270,6 +2270,7 @@ def test__construct_responses_api_input_ai_message_with_tool_calls() -> None:
     assert result[0]["arguments"] == '{"location": "San Francisco"}'
     assert result[0]["call_id"] == "call_123"
     assert result[0]["id"] == "fc_456"
+    assert result[0]["status"] is None
 
     # Message with only tool calls attribute provided
     ai_message = AIMessage(content="", tool_calls=tool_calls)
@@ -2282,6 +2283,7 @@ def test__construct_responses_api_input_ai_message_with_tool_calls() -> None:
     assert result[0]["arguments"] == '{"location": "San Francisco"}'
     assert result[0]["call_id"] == "call_123"
     assert "id" not in result[0]
+    assert result[0]["status"] is None
 
 
 def test__construct_responses_api_input_ai_message_with_tool_calls_and_content() -> (
@@ -2330,6 +2332,7 @@ def test__construct_responses_api_input_ai_message_with_tool_calls_and_content()
     assert result[1]["arguments"] == '{"location": "San Francisco"}'
     assert result[1]["call_id"] == "call_123"
     assert result[1]["id"] == "fc_456"
+    assert result[1]["status"] is None
 
     # String content
     ai_message = AIMessage(
@@ -2354,6 +2357,7 @@ def test__construct_responses_api_input_ai_message_with_tool_calls_and_content()
     assert result[1]["arguments"] == '{"location": "San Francisco"}'
     assert result[1]["call_id"] == "call_123"
     assert "id" not in result[1]
+    assert result[1]["status"] is None
 
 
 def test__construct_responses_api_input_tool_message_conversion() -> None:
@@ -2371,6 +2375,7 @@ def test__construct_responses_api_input_tool_message_conversion() -> None:
     assert result[0]["type"] == "function_call_output"
     assert result[0]["output"] == '{"temperature": 72, "conditions": "sunny"}'
     assert result[0]["call_id"] == "call_123"
+    assert result[0]["status"] is None
 
 
 def test__construct_responses_api_input_multiple_message_types() -> None:
@@ -2437,11 +2442,13 @@ def test__construct_responses_api_input_multiple_message_types() -> None:
     assert result[4]["name"] == "get_weather"
     assert result[4]["arguments"] == '{"location": "San Francisco"}'
     assert result[4]["call_id"] == "call_123"
+    assert result[4]["status"] is None
 
     # Check function call output
     assert result[5]["type"] == "function_call_output"
     assert result[5]["output"] == '{"temperature": 72, "conditions": "sunny"}'
     assert result[5]["call_id"] == "call_123"
+    assert result[5]["status"] is None
 
     assert result[6]["role"] == "assistant"
     assert result[6]["content"] == [


### PR DESCRIPTION
## Changes

- Add `"status": None` to generated `function_call_output` items.
- Ensure assistant content blocks of type `function_call` include `status` when absent.
- Add `"status": None` to synthesized `function_call` items built from `tool_calls`.
- Add unit assertions that validate this behavior.

## Why

Some providers/servers reject function call items when `status` is omitted. Sending explicit null keeps compatibility while preserving existing semantics.

the PR was exploratory and closed intentionally pending stronger validation.