### PR TITLE
fix(core): use compact json for tool_use/tool_result in count_tokens_approximately

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2183,6 +2183,14 @@ def _convert_to_openai_tool_calls(tool_calls: list[ToolCall]) -> list[dict]:
     ]
 
 
+def _compact_json_len(value: Any) -> int:
+    """Return compact JSON length for counting, falling back to `repr`."""
+    try:
+        return len(json.dumps(value, ensure_ascii=False, separators=(",", ":")))
+    except (TypeError, ValueError):
+        return len(repr(value))
+
+
 def count_tokens_approximately(
     messages: Iterable[MessageLikeRepresentation],
     *,
@@ -2276,6 +2284,10 @@ def count_tokens_approximately(
                     elif block_type == "text":
                         text = block.get("text", "")
                         message_chars += len(text)
+                    # Normalize Anthropic tool blocks to compact JSON instead of
+                    # Python `repr`, which inflates token estimates.
+                    elif block_type in {"tool_use", "tool_result"}:
+                        message_chars += _compact_json_len(block)
                     # Conservative estimate for unknown block types
                     else:
                         message_chars += len(repr(block))

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2896,7 +2896,71 @@ def test_count_tokens_approximately_ai_tool_calls_skipped_for_list_content() -> 
     )
     count_list = count_tokens_approximately([ai_with_list_content])
 
-    assert count_text - 1 <= count_list <= count_text + 1
+    # Anthropic-style content should include the tool block once.
+    list_text_only = count_tokens_approximately(
+        [AIMessage(content=[{"type": "text", "text": "do something"}])]
+    )
+    assert count_list > list_text_only
+
+    # And it should be cheaper than the string-content path that serializes
+    # `tool_calls` metadata with Python repr formatting.
+    assert count_list < count_text
+
+
+def test_count_tokens_approximately_tool_use_block_uses_compact_json() -> None:
+    """Test that tool_use block counting avoids inflated Python repr formatting."""
+    tool_use_block = {
+        "type": "tool_use",
+        "id": "toolu_01AbCdEf",
+        "name": "search_memories",
+        "input": {
+            "query": "recent events",
+            "filters": {
+                "source": ["crm", "email", "calendar"],
+                "include_archived": False,
+                "limit": 25,
+            },
+            "window": {"start": "2025-01-01", "end": "2025-12-31"},
+        },
+    }
+    message = AIMessage(content=[tool_use_block])
+
+    compact_chars = len(
+        json.dumps(tool_use_block, ensure_ascii=False, separators=(",", ":"))
+    )
+    expected = math.ceil((compact_chars + len("assistant")) / 4) + 3
+
+    assert count_tokens_approximately([message]) == expected
+
+
+def test_count_tokens_approximately_tool_result_block_uses_compact_json() -> None:
+    """Test that tool_result block counting avoids inflated Python repr formatting."""
+    tool_result_block = {
+        "type": "tool_result",
+        "tool_use_id": "toolu_01AbCdEf",
+        "is_error": False,
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    "Recent events:\n- planning meeting\n- budget review\n"
+                    "- release prep"
+                ),
+            },
+            {
+                "type": "text",
+                "text": "Follow-up: send minutes to leadership and product.",
+            },
+        ],
+    }
+    message = HumanMessage(content=[tool_result_block])
+
+    compact_chars = len(
+        json.dumps(tool_result_block, ensure_ascii=False, separators=(",", ":"))
+    )
+    expected = math.ceil((compact_chars + len("user")) / 4) + 3
+
+    assert count_tokens_approximately([message]) == expected
 
 
 def test_count_tokens_approximately_respects_count_name_flag() -> None:


### PR DESCRIPTION
- Added explicit handling for tool_use and tool_result list-content blocks.
- Switched these blocks from repr(block) length counting to compact JSON length counting (json.dumps(..., separators=(",", ":"))), with a safe fallback to repr.
- Added regression tests for both tool_use and tool_result counting.
- Updated the existing list-content/tool-call test to assert the correct invariant after this normalization.

Fixes: #35558