### PR TITLE
fix(core): handle tool_use/tool_result blocks in count_tokens_approximately

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2276,6 +2276,18 @@ def count_tokens_approximately(
                     elif block_type == "text":
                         text = block.get("text", "")
                         message_chars += len(text)
+                    # Count tool_use blocks using compact JSON
+                    elif block_type == "tool_use":
+                        # Use json.dumps for accurate size estimation
+                        # instead of repr() which inflates the count
+                        message_chars += len(
+                            json.dumps(block, separators=(",", ":"))
+                        )
+                    # Count tool_result blocks using compact JSON
+                    elif block_type == "tool_result":
+                        message_chars += len(
+                            json.dumps(block, separators=(",", ":"))
+                        )
                     # Conservative estimate for unknown block types
                     else:
                         message_chars += len(repr(block))

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2896,7 +2896,55 @@ def test_count_tokens_approximately_ai_tool_calls_skipped_for_list_content() -> 
     )
     count_list = count_tokens_approximately([ai_with_list_content])
 
-    assert count_text - 1 <= count_list <= count_text + 1
+    # Allow a small tolerance because the Anthropic-style tool_use block
+    # (JSON-serialized) and the tool_calls repr have slightly different sizes.
+    assert count_text - 5 <= count_list <= count_text + 5
+
+
+def test_count_tokens_approximately_tool_use_block() -> None:
+    """Test that tool_use blocks use json.dumps instead of repr for counting."""
+    import json
+
+    tool_use_block = {
+        "type": "tool_use",
+        "id": "toolu_01AbCdEf",
+        "name": "search_memories",
+        "input": {"query": "recent events"},
+    }
+    msg = AIMessage(content=[tool_use_block])
+    count = count_tokens_approximately([msg])
+
+    # The count should be based on compact JSON, not repr.
+    # Compact JSON is shorter than repr (no spaces around separators,
+    # double quotes instead of single quotes).
+    json_len = len(json.dumps(tool_use_block, separators=(",", ":")))
+    repr_len = len(repr(tool_use_block))
+    assert json_len < repr_len  # json.dumps is more compact
+
+    # Verify token count is reasonable (role + json content + overhead)
+    # role "assistant" = 9 chars → ~3 tokens, + extra_tokens_per_message = 3
+    expected_min = json_len / 4 + 3 + 3  # json tokens + role + overhead
+    assert count >= expected_min - 2  # allow small rounding
+
+
+def test_count_tokens_approximately_tool_result_block() -> None:
+    """Test that tool_result blocks use json.dumps instead of repr for counting."""
+    import json
+
+    tool_result_block = {
+        "type": "tool_result",
+        "tool_use_id": "toolu_01AbCdEf",
+        "content": "Found 3 recent events.",
+    }
+    msg = HumanMessage(content=[tool_result_block])
+    count = count_tokens_approximately([msg])
+
+    json_len = len(json.dumps(tool_result_block, separators=(",", ":")))
+    repr_len = len(repr(tool_result_block))
+    assert json_len < repr_len
+
+    expected_min = json_len / 4 + 1 + 3  # json tokens + role("user") + overhead
+    assert count >= expected_min - 2
 
 
 def test_count_tokens_approximately_respects_count_name_flag() -> None:


### PR DESCRIPTION
Use `json.dumps(separators=(",",":"))` instead of `repr()` for `tool_use` and `tool_result` content blocks in `count_tokens_approximately()`.

`repr()` produces Python-style output (single quotes, `True`/`False`) that inflates the character count by ~2.4x for nested tool inputs compared to the actual JSON representation used by providers.

Fixes #35558

**Changes:**
- `libs/core/langchain_core/messages/utils.py`: Added explicit handlers for `tool_use` and `tool_result` block types using compact `json.dumps`
- `libs/core/tests/unit_tests/messages/test_utils.py`: Added 2 new tests for tool_use/tool_result blocks, widened tolerance in existing test

**Verification:**
- `make test` passes (156/156 tests in `test_utils.py`)
- `ruff check` passes