### PR TITLE
fix(openai): catch LengthFinishReasonError in structured output calls

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1431,6 +1431,8 @@ class BaseChatOpenAI(BaseChatModel):
                         )
                     is_first_chunk = False
                     yield generation_chunk
+        except openai.LengthFinishReasonError as e:
+            response = e.completion
         except openai.BadRequestError as e:
             _handle_openai_bad_request(e)
         except openai.APIError as e:
@@ -1486,6 +1488,8 @@ class BaseChatOpenAI(BaseChatModel):
             else:
                 raw_response = self.client.with_raw_response.create(**payload)
                 response = raw_response.parse()
+        except openai.LengthFinishReasonError as e:
+            response = e.completion
         except openai.BadRequestError as e:
             _handle_openai_bad_request(e)
         except openai.APIError as e:
@@ -1692,6 +1696,8 @@ class BaseChatOpenAI(BaseChatModel):
                         )
                     is_first_chunk = False
                     yield generation_chunk
+        except openai.LengthFinishReasonError as e:
+            response = e.completion
         except openai.BadRequestError as e:
             _handle_openai_bad_request(e)
         except openai.APIError as e:
@@ -1752,6 +1758,8 @@ class BaseChatOpenAI(BaseChatModel):
                     **payload
                 )
                 response = raw_response.parse()
+        except openai.LengthFinishReasonError as e:
+            response = e.completion
         except openai.BadRequestError as e:
             _handle_openai_bad_request(e)
         except openai.APIError as e:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3599,3 +3599,80 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def _make_length_completion() -> openai.types.chat.ChatCompletion:
+    """Create a ChatCompletion with finish_reason='length' for testing."""
+    from openai.types.chat import ChatCompletion, ChatCompletionMessage
+    from openai.types.chat.chat_completion import Choice
+    from openai.types.completion_usage import CompletionUsage
+
+    return ChatCompletion(
+        id="chatcmpl-length-test",
+        object="chat.completion",
+        created=1689989000,
+        model="gpt-4o",
+        choices=[
+            Choice(
+                index=0,
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content="partial response that was truncated",
+                ),
+                finish_reason="length",
+            )
+        ],
+        usage=CompletionUsage(
+            prompt_tokens=100,
+            completion_tokens=16384,
+            total_tokens=16484,
+        ),
+    )
+
+
+def test_length_finish_reason_does_not_raise() -> None:
+    """LengthFinishReasonError should be caught so invoke returns a result."""
+    completion = _make_length_completion()
+    llm = ChatOpenAI(model="gpt-4o")
+
+    mock_raw_response = MagicMock()
+    mock_raw_response.parse.side_effect = openai.LengthFinishReasonError(
+        completion=completion
+    )
+
+    with patch.object(
+        llm.root_client.chat.completions, "with_raw_response"
+    ) as mock_client:
+        mock_client.parse.return_value = mock_raw_response
+        result = llm.invoke(
+            [HumanMessage(content="test")],
+            response_format={"type": "json_object"},
+        )
+
+    assert result.content == "partial response that was truncated"
+    assert result.response_metadata["finish_reason"] == "length"
+
+
+async def test_length_finish_reason_does_not_raise_async() -> None:
+    """LengthFinishReasonError should be caught so ainvoke returns a result."""
+    completion = _make_length_completion()
+    llm = ChatOpenAI(model="gpt-4o")
+
+    mock_raw_response = MagicMock()
+    mock_raw_response.parse.side_effect = openai.LengthFinishReasonError(
+        completion=completion
+    )
+
+    mock_parse = AsyncMock(return_value=mock_raw_response)
+
+    with patch.object(
+        llm.root_async_client.chat.completions, "with_raw_response"
+    ) as mock_client:
+        mock_client.parse = mock_parse
+        result = await llm.ainvoke(
+            [HumanMessage(content="test")],
+            response_format={"type": "json_object"},
+        )
+
+    assert result.content == "partial response that was truncated"
+    assert result.response_metadata["finish_reason"] == "length"


### PR DESCRIPTION
## Description

Fixes #30924

When using `response_format` with structured outputs (e.g., `with_structured_output`, `JsonOutputParser` with structured output), the OpenAI SDK's `completions.parse()` API raises `openai.LengthFinishReasonError` if the model's output is truncated due to reaching the token limit (`finish_reason="length"`).

`LengthFinishReasonError` inherits from `OpenAIError` (not `APIError`), so it was **not** caught by the existing `except openai.APIError` handler and propagated as an unhandled exception. This caused intermittent failures in `abatch` calls with `AzureChatOpenAI` (and `ChatOpenAI`) when any individual request in the batch hit the token limit.

### Root cause

In `BaseChatOpenAI._generate()` and `._agenerate()`:
```python
raw_response = client.chat.completions.with_raw_response.parse(**payload)
response = raw_response.parse()  # <-- raises LengthFinishReasonError
```

The OpenAI SDK's `parse()` post-processor checks `finish_reason` and raises `LengthFinishReasonError` when it is `"length"`. The exception contains the full `ChatCompletion` object, which has valid (though truncated) content.

### Fix

Catch `openai.LengthFinishReasonError` in all four code paths (`_generate`, `_agenerate`, `_stream`, `_astream`) **before** the `openai.APIError` handler, extract the completion from the exception, and return it normally. The `finish_reason="length"` is preserved in `response_metadata` so downstream code can detect truncation.

### Changes

- `libs/partners/openai/langchain_openai/chat_models/base.py`: Added `except openai.LengthFinishReasonError` handlers in `_generate`, `_agenerate`, `_stream`, and `_astream`.
- `libs/partners/openai/tests/unit_tests/chat_models/test_base.py`: Added sync and async tests verifying the error is caught and a result with `finish_reason="length"` is returned.

### Disclaimer

This contribution was developed with the assistance of an AI coding agent.