### PR TITLE
fix(openai): ensure _generate/_agenerate send stream=False to the API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1446,6 +1446,7 @@ class BaseChatOpenAI(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         self._ensure_sync_client_available()
+        kwargs["stream"] = False
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
         generation_info = None
         raw_response = None
@@ -1706,6 +1707,7 @@ class BaseChatOpenAI(BaseChatModel):
         run_manager: AsyncCallbackManagerForLLMRun | None = None,
         **kwargs: Any,
     ) -> ChatResult:
+        kwargs["stream"] = False
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
         generation_info = None
         raw_response = None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3507,7 +3507,7 @@ def _chat_completion_response() -> MagicMock:
 
 
 @pytest.mark.parametrize(
-    "streaming,disable_streaming",
+    ("streaming", "disable_streaming"),
     [
         (True, None),
         (True, "tool_calling"),
@@ -3546,7 +3546,7 @@ def test_generate_always_sets_stream_false(
 
 
 @pytest.mark.parametrize(
-    "streaming,disable_streaming",
+    ("streaming", "disable_streaming"),
     [
         (True, None),
         (True, "tool_calling"),

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3590,9 +3590,7 @@ def test_generate_stream_false_with_tools() -> None:
     When disable_streaming='tool_calling' and tools are bound, _should_stream
     returns False and routes to _generate. The payload must have stream=False.
     """
-    llm = ChatOpenAI(
-        model="gpt-4o", streaming=True, disable_streaming="tool_calling"
-    )
+    llm = ChatOpenAI(model="gpt-4o", streaming=True, disable_streaming="tool_calling")
     tools = [{"type": "function", "function": {"name": "get_weather"}}]
 
     with patch.object(llm.client, "with_raw_response") as mock_client:
@@ -3609,9 +3607,7 @@ def test_generate_stream_false_with_tools() -> None:
 
 async def test_agenerate_stream_false_with_tools() -> None:
     """_agenerate sends stream=False even with tools kwarg (async #35436 scenario)."""
-    llm = ChatOpenAI(
-        model="gpt-4o", streaming=True, disable_streaming="tool_calling"
-    )
+    llm = ChatOpenAI(model="gpt-4o", streaming=True, disable_streaming="tool_calling")
     tools = [{"type": "function", "function": {"name": "get_weather"}}]
 
     with patch.object(llm.async_client, "with_raw_response") as mock_client:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3474,3 +3474,153 @@ def test_context_overflow_error_backwards_compatibility() -> None:
     # Verify it's both types (multiple inheritance)
     assert isinstance(exc_info.value, openai.BadRequestError)
     assert isinstance(exc_info.value, ContextOverflowError)
+
+
+# --- Tests for _generate / _agenerate stream=False in payload ---
+# Regression tests for https://github.com/langchain-ai/langchain/issues/35436
+# When _generate/_agenerate are called (e.g. via disable_streaming="tool_calling"),
+# the payload must contain stream=False to prevent the OpenAI client from returning
+# a Stream/AsyncStream instead of a ChatCompletion.
+
+
+def _chat_completion_response() -> MagicMock:
+    """Create a mock ChatCompletion response for testing."""
+    mock = MagicMock()
+    mock.model_dump.return_value = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        },
+    }
+    return mock
+
+
+@pytest.mark.parametrize(
+    "streaming,disable_streaming",
+    [
+        (True, None),
+        (True, "tool_calling"),
+        (True, True),
+        (False, None),
+        (False, "tool_calling"),
+        (False, True),
+    ],
+    ids=[
+        "streaming=True,disable_streaming=None",
+        "streaming=True,disable_streaming=tool_calling",
+        "streaming=True,disable_streaming=True",
+        "streaming=False,disable_streaming=None",
+        "streaming=False,disable_streaming=tool_calling",
+        "streaming=False,disable_streaming=True",
+    ],
+)
+def test_generate_always_sets_stream_false(
+    streaming: bool, disable_streaming: bool | str | None
+) -> None:
+    """_generate must always send stream=False to the OpenAI API."""
+    kwargs: dict = {"model": "gpt-4o", "streaming": streaming}
+    if disable_streaming is not None:
+        kwargs["disable_streaming"] = disable_streaming
+    llm = ChatOpenAI(**kwargs)
+
+    with patch.object(llm.client, "with_raw_response") as mock_client:
+        mock_raw = MagicMock()
+        mock_raw.parse.return_value = _chat_completion_response()
+        mock_raw.headers = {}
+        mock_client.create.return_value = mock_raw
+        llm._generate([HumanMessage(content="test")])
+
+        call_kwargs = mock_client.create.call_args.kwargs
+        assert call_kwargs["stream"] is False
+
+
+@pytest.mark.parametrize(
+    "streaming,disable_streaming",
+    [
+        (True, None),
+        (True, "tool_calling"),
+        (True, True),
+        (False, None),
+        (False, "tool_calling"),
+        (False, True),
+    ],
+    ids=[
+        "streaming=True,disable_streaming=None",
+        "streaming=True,disable_streaming=tool_calling",
+        "streaming=True,disable_streaming=True",
+        "streaming=False,disable_streaming=None",
+        "streaming=False,disable_streaming=tool_calling",
+        "streaming=False,disable_streaming=True",
+    ],
+)
+async def test_agenerate_always_sets_stream_false(
+    streaming: bool, disable_streaming: bool | str | None
+) -> None:
+    """_agenerate must always send stream=False to the OpenAI API."""
+    kwargs: dict = {"model": "gpt-4o", "streaming": streaming}
+    if disable_streaming is not None:
+        kwargs["disable_streaming"] = disable_streaming
+    llm = ChatOpenAI(**kwargs)
+
+    with patch.object(llm.async_client, "with_raw_response") as mock_client:
+        mock_raw = MagicMock()
+        mock_raw.parse.return_value = _chat_completion_response()
+        mock_raw.headers = {}
+        mock_client.create = AsyncMock(return_value=mock_raw)
+        await llm._agenerate([HumanMessage(content="test")])
+
+        call_kwargs = mock_client.create.call_args.kwargs
+        assert call_kwargs["stream"] is False
+
+
+def test_generate_stream_false_with_tools() -> None:
+    """_generate sends stream=False even with tools kwarg (issue #35436 scenario).
+
+    When disable_streaming='tool_calling' and tools are bound, _should_stream
+    returns False and routes to _generate. The payload must have stream=False.
+    """
+    llm = ChatOpenAI(
+        model="gpt-4o", streaming=True, disable_streaming="tool_calling"
+    )
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+
+    with patch.object(llm.client, "with_raw_response") as mock_client:
+        mock_raw = MagicMock()
+        mock_raw.parse.return_value = _chat_completion_response()
+        mock_raw.headers = {}
+        mock_client.create.return_value = mock_raw
+        llm._generate([HumanMessage(content="test")], tools=tools)
+
+        call_kwargs = mock_client.create.call_args.kwargs
+        assert call_kwargs["stream"] is False
+        assert "tools" in call_kwargs
+
+
+async def test_agenerate_stream_false_with_tools() -> None:
+    """_agenerate sends stream=False even with tools kwarg (async #35436 scenario)."""
+    llm = ChatOpenAI(
+        model="gpt-4o", streaming=True, disable_streaming="tool_calling"
+    )
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+
+    with patch.object(llm.async_client, "with_raw_response") as mock_client:
+        mock_raw = MagicMock()
+        mock_raw.parse.return_value = _chat_completion_response()
+        mock_raw.headers = {}
+        mock_client.create = AsyncMock(return_value=mock_raw)
+        await llm._agenerate([HumanMessage(content="test")], tools=tools)
+
+        call_kwargs = mock_client.create.call_args.kwargs
+        assert call_kwargs["stream"] is False
+        assert "tools" in call_kwargs


### PR DESCRIPTION
## Summary
- When `streaming=True` and `disable_streaming="tool_calling"`, `_should_stream` correctly routes to `_generate`/`_agenerate` (non-streaming path)
- But `_default_params` hardcodes `"stream": self.streaming`, so the payload still contained `stream=True`
- The OpenAI client returned a `Stream`/`AsyncStream` instead of a `ChatCompletion`, crashing `_create_chat_result` with `AttributeError: 'AsyncStream' object has no attribute 'model_dump'`
- Fix: explicitly set `kwargs["stream"] = False` at the top of `_generate` and `_agenerate`, mirroring `_astream` which already sets `kwargs["stream"] = True`

## Files changed
- `libs/partners/openai/langchain_openai/chat_models/base.py` — 2 lines: set `kwargs["stream"] = False` in `_generate` and `_agenerate`
- `libs/partners/openai/tests/unit_tests/chat_models/test_base.py` — 14 test cases covering all combinations of `streaming` × `disable_streaming`, plus explicit tool-calling scenarios

## Test plan
- [x] `test_generate_always_sets_stream_false` — 6 parametrized cases (`streaming=True/False` × `disable_streaming=None/tool_calling/True`)
- [x] `test_agenerate_always_sets_stream_false` — 6 parametrized cases (async counterpart)
- [x] `test_generate_stream_false_with_tools` — exact issue #35436 scenario: `streaming=True` + `disable_streaming="tool_calling"` + tools in kwargs
- [x] `test_agenerate_stream_false_with_tools` — async counterpart
- [x] Full existing unit test suite: 196 passed, 0 failed

Closes #35436

🤖 Generated with [Claude Code](https://claude.com/claude-code)