### PR TITLE
feat(openai): add websocket streaming support for responses API

### DIFF
--- a/libs/langchain/tests/unit_tests/chat_models/test_base.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_base.py
@@ -169,6 +169,7 @@ def test_configurable() -> None:
             "stream_usage": True,
             "use_previous_response_id": False,
             "use_responses_api": None,
+            "use_websocket": None,
         },
         "kwargs": {
             "tools": [

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -214,6 +214,7 @@ def test_configurable() -> None:
             "stream_usage": True,
             "use_previous_response_id": False,
             "use_responses_api": None,
+            "use_websocket": None,
         },
         "kwargs": {
             "tools": [

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1298,9 +1298,7 @@ class BaseChatOpenAI(BaseChatModel):
 
                 data = json.loads(raw)
                 if data.get("type") == "error":
-                    error_msg = (data.get("error") or {}).get(
-                        "message", str(raw)
-                    )
+                    error_msg = (data.get("error") or {}).get("message", str(raw))
                     msg = f"WebSocket error from OpenAI: {error_msg}"
                     raise ValueError(msg)
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -41,6 +41,7 @@ from typing import (
     TypeAlias,
     TypeVar,
     cast,
+    get_args,
 )
 from urllib.parse import urlparse
 
@@ -895,6 +896,13 @@ class BaseChatOpenAI(BaseChatModel):
     !!! version-added "Added in `langchain-openai` 0.3.9"
     """
 
+    use_websocket: bool | None = None
+    """Whether to use WebSocket for streaming responses.
+
+    WebSocket streaming is opt-in only. If `use_websocket` is `None` or `False`,
+    HTTP streaming is used instead.
+    """
+
     output_version: str | None = Field(
         default_factory=from_env("LC_OUTPUT_VERSION", default=None)
     )
@@ -1223,6 +1231,121 @@ class BaseChatOpenAI(BaseChatModel):
             )
             raise ValueError(msg)
 
+    def _stream_responses_websocket(
+        self,
+        payload: dict,
+        run_manager: CallbackManagerForLLMRun | None = None,
+    ) -> Iterator[ChatGenerationChunk]:
+        """Stream responses using a WebSocket connection to /v1/responses."""
+        try:
+            from websocket import create_connection
+        except ImportError as e:
+            msg = (
+                "Could not import websocket-client python package. "
+                "Please install it with `pip install langchain-openai[websocket]` "
+                "or `pip install websocket-client`."
+            )
+            raise ImportError(msg) from e
+
+        if self.openai_api_key is None:
+            msg = (
+                "API key is required for WebSocket streaming. "
+                "Set `api_key` or `OPENAI_API_KEY`."
+            )
+            raise ValueError(msg)
+
+        sync_api_key_value, _ = _resolve_sync_and_async_api_keys(self.openai_api_key)
+        if sync_api_key_value is None:
+            msg = (
+                "WebSocket streaming requires a sync API key. An async callable was "
+                "provided. Use a string or sync callable instead."
+            )
+            raise ValueError(msg)
+        api_key = (
+            sync_api_key_value() if callable(sync_api_key_value) else sync_api_key_value
+        )
+
+        # Derive WebSocket URL from the client's configured base_url
+        base = str(self.root_client.base_url).rstrip("/")
+        ws_base = base.replace("https://", "wss://").replace("http://", "ws://")
+        ws_url = f"{ws_base}/responses"
+
+        ws = create_connection(
+            ws_url,
+            header=[f"Authorization: Bearer {api_key}"],
+        )
+
+        try:
+            # Strip HTTP-only fields that are invalid over WebSocket
+            ws_payload = {
+                k: v for k, v in payload.items() if k not in ("stream", "background")
+            }
+            ws.send(json.dumps({"type": "response.create", **ws_payload}))
+
+            original_schema_obj = payload.get("response_format")
+            current_index = -1
+            current_output_index = -1
+            current_sub_index = -1
+            has_reasoning = False
+            from openai.types.responses import ResponseStreamEvent
+
+            event_types = get_args(get_args(ResponseStreamEvent)[0])
+
+            while True:
+                raw = ws.recv()
+                if not raw:
+                    break
+
+                data = json.loads(raw)
+                if data.get("type") == "error":
+                    error_msg = (data.get("error") or {}).get(
+                        "message", str(raw)
+                    )
+                    msg = f"WebSocket error from OpenAI: {error_msg}"
+                    raise ValueError(msg)
+
+                # Convert raw dict to typed event model
+                for event_cls in event_types:
+                    try:
+                        chunk = event_cls.model_validate(data)
+                        break
+                    except Exception:  # noqa: S112
+                        continue
+                else:
+                    continue
+
+                (
+                    current_index,
+                    current_output_index,
+                    current_sub_index,
+                    generation_chunk,
+                ) = _convert_responses_chunk_to_generation_chunk(
+                    chunk,
+                    current_index,
+                    current_output_index,
+                    current_sub_index,
+                    schema=original_schema_obj,
+                    has_reasoning=has_reasoning,
+                    output_version=self.output_version,
+                )
+                if generation_chunk:
+                    if run_manager:
+                        run_manager.on_llm_new_token(
+                            generation_chunk.text, chunk=generation_chunk
+                        )
+                    if "reasoning" in generation_chunk.message.additional_kwargs:
+                        has_reasoning = True
+                    yield generation_chunk
+
+                if chunk.type in ("response.completed", "response.incomplete"):
+                    break
+        except openai.BadRequestError as e:
+            _handle_openai_bad_request(e)
+        except openai.APIError as e:
+            _handle_openai_api_error(e)
+        finally:
+            ws.close()
+
     def _stream_responses(
         self,
         messages: list[BaseMessage],
@@ -1234,7 +1357,12 @@ class BaseChatOpenAI(BaseChatModel):
         kwargs["stream"] = True
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
         try:
-            if self.include_response_headers:
+            if self.use_websocket:
+                yield from self._stream_responses_websocket(
+                    payload, run_manager=run_manager
+                )
+                return
+            elif self.include_response_headers:
                 raw_context_manager = (
                     self.root_client.with_raw_response.responses.create(**payload)
                 )

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
     "tiktoken>=0.7.0,<1.0.0",
 ]
 
+[project.optional-dependencies]
+websocket = ["websocket-client>=1.9.0"]
+
 [project.urls]
 Homepage = "https://docs.langchain.com/oss/python/integrations/providers/openai"
 Documentation = "https://reference.langchain.com/python/integrations/langchain_openai/"
@@ -53,6 +56,7 @@ test = [
     "vcrpy>=8.0.0,<9.0.0",
     "numpy>=1.26.4; python_version<'3.13'",
     "numpy>=2.1.0; python_version>='3.13'",
+    "websocket-client>=1.9.0",
     "langchain",
     "langchain-core",
     "langchain-tests",

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
@@ -800,14 +800,16 @@ def test_responses_stream_defaults_to_http() -> None:
     llm = ChatOpenAI(model="o4-mini", use_responses_api=True)
     mock_client = MagicMock()
     mock_client.responses.create = MagicMock(
-        side_effect=lambda *a, **kw: MockSyncContextManager(responses_stream)
+        side_effect=lambda *_args, **_kwargs: MockSyncContextManager(responses_stream)
     )
 
     mock_ws = MagicMock()
 
-    with patch.object(llm, "root_client", mock_client):
-        with patch.object(llm, "_stream_responses_websocket", mock_ws):
-            _ = list(llm.stream("test"))
+    with (
+        patch.object(llm, "root_client", mock_client),
+        patch.object(llm, "_stream_responses_websocket", mock_ws),
+    ):
+        _ = list(llm.stream("test"))
 
     mock_ws.assert_not_called()
     mock_client.responses.create.assert_called()
@@ -827,9 +829,11 @@ def test_responses_stream_uses_websocket_when_enabled() -> None:
         ]
     )
 
-    with patch.object(llm, "root_client", mock_client):
-        with patch.object(llm, "_stream_responses_websocket", mock_ws):
-            chunks = list(llm.stream("test"))
+    with (
+        patch.object(llm, "root_client", mock_client),
+        patch.object(llm, "_stream_responses_websocket", mock_ws),
+    ):
+        chunks = list(llm.stream("test"))
 
     mock_ws.assert_called_once()
     mock_client.responses.create.assert_not_called()
@@ -851,12 +855,14 @@ def test_responses_stream_websocket_custom_base_url() -> None:
     mock_connection = MagicMock()
     mock_connection.recv.side_effect = ws_messages
 
-    with patch.object(llm, "root_client", mock_client):
-        with patch(
+    with (
+        patch.object(llm, "root_client", mock_client),
+        patch(
             "websocket.create_connection",
             return_value=mock_connection,
-        ) as mock_create_conn:
-            chunks = list(llm.stream("test"))
+        ) as mock_create_conn,
+    ):
+        chunks = list(llm.stream("test"))
 
     assert len(chunks) > 0
     mock_create_conn.assert_called_once()
@@ -878,13 +884,15 @@ def test_responses_stream_websocket_error_event() -> None:
     mock_connection = MagicMock()
     mock_connection.recv.side_effect = [json.dumps(error_event)]
 
-    with patch.object(llm, "root_client", mock_client):
-        with patch(
+    with (
+        patch.object(llm, "root_client", mock_client),
+        patch(
             "websocket.create_connection",
             return_value=mock_connection,
-        ):
-            with pytest.raises(ValueError, match="Test error"):
-                _ = list(llm.stream("test"))
+        ),
+        pytest.raises(ValueError, match="Test error"),
+    ):
+        _ = list(llm.stream("test"))
 
 
 def test_responses_stream_websocket_missing_api_key() -> None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_core.messages import AIMessageChunk, BaseMessageChunk
+from langchain_core.outputs import ChatGenerationChunk
 from openai.types.responses import (
     ResponseCompletedEvent,
     ResponseContentPartAddedEvent,
@@ -791,3 +793,110 @@ def test_responses_stream_with_image_generation_multiple_calls() -> None:
     with patch.object(llm, "root_client", mock_client):
         chunks = list(llm_with_tools.stream("test again"))
         assert len(chunks) > 0
+
+
+def test_responses_stream_defaults_to_http() -> None:
+    """Test that HTTP is used by default instead of WebSocket."""
+    llm = ChatOpenAI(model="o4-mini", use_responses_api=True)
+    mock_client = MagicMock()
+    mock_client.responses.create = MagicMock(
+        side_effect=lambda *a, **kw: MockSyncContextManager(responses_stream)
+    )
+
+    mock_ws = MagicMock()
+
+    with patch.object(llm, "root_client", mock_client):
+        with patch.object(llm, "_stream_responses_websocket", mock_ws):
+            _ = list(llm.stream("test"))
+
+    mock_ws.assert_not_called()
+    mock_client.responses.create.assert_called()
+
+
+def test_responses_stream_uses_websocket_when_enabled() -> None:
+    """Test that WebSocket is used when explicitly enabled."""
+    llm = ChatOpenAI(
+        model="o4-mini",
+        use_responses_api=True,
+        use_websocket=True,
+    )
+    mock_client = MagicMock()
+    mock_ws = MagicMock(
+        return_value=[
+            ChatGenerationChunk(message=AIMessageChunk(content="hi")),
+        ]
+    )
+
+    with patch.object(llm, "root_client", mock_client):
+        with patch.object(llm, "_stream_responses_websocket", mock_ws):
+            chunks = list(llm.stream("test"))
+
+    mock_ws.assert_called_once()
+    mock_client.responses.create.assert_not_called()
+    assert chunks[0].content == "hi"
+
+
+def test_responses_stream_websocket_custom_base_url() -> None:
+    """Test that WebSocket URL is derived from custom base_url."""
+    llm = ChatOpenAI(
+        model="o4-mini",
+        use_responses_api=True,
+        use_websocket=True,
+    )
+    mock_client = MagicMock()
+    mock_client.base_url = "https://custom.api.com/v1/"
+
+    # Feed real stream events as JSON, then signal connection closed
+    ws_messages = [e.model_dump_json() for e in responses_stream] + [None]
+    mock_connection = MagicMock()
+    mock_connection.recv.side_effect = ws_messages
+
+    with patch.object(llm, "root_client", mock_client):
+        with patch(
+            "websocket.create_connection",
+            return_value=mock_connection,
+        ) as mock_create_conn:
+            chunks = list(llm.stream("test"))
+
+    assert len(chunks) > 0
+    mock_create_conn.assert_called_once()
+    ws_url = mock_create_conn.call_args[0][0]
+    assert ws_url == "wss://custom.api.com/v1/responses"
+
+
+def test_responses_stream_websocket_error_event() -> None:
+    """Test that error events raise ValueError."""
+    llm = ChatOpenAI(
+        model="o4-mini",
+        use_responses_api=True,
+        use_websocket=True,
+    )
+    mock_client = MagicMock()
+    mock_client.base_url = "https://api.openai.com/v1/"
+
+    error_event = {"type": "error", "error": {"message": "Test error"}}
+    mock_connection = MagicMock()
+    mock_connection.recv.side_effect = [json.dumps(error_event)]
+
+    with patch.object(llm, "root_client", mock_client):
+        with patch(
+            "websocket.create_connection",
+            return_value=mock_connection,
+        ):
+            with pytest.raises(ValueError, match="Test error"):
+                _ = list(llm.stream("test"))
+
+
+def test_responses_stream_websocket_missing_api_key() -> None:
+    """Test that ValueError is raised if API key is missing."""
+    llm = ChatOpenAI(
+        model="o4-mini",
+        use_responses_api=True,
+        use_websocket=True,
+    )
+    mock_client = MagicMock()
+
+    with patch.object(llm, "root_client", mock_client):
+        llm.openai_api_key = None
+        with pytest.raises(ValueError, match="API key is required"):
+            _ = list(llm.stream("test"))

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -610,7 +610,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.16"
+version = "1.2.17"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -678,6 +678,11 @@ dependencies = [
     { name = "tiktoken" },
 ]
 
+[package.optional-dependencies]
+websocket = [
+    { name = "websocket-client" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "langchain-core" },
@@ -702,6 +707,7 @@ test = [
     { name = "pytest-xdist" },
     { name = "syrupy" },
     { name = "vcrpy" },
+    { name = "websocket-client" },
 ]
 test-integration = [
     { name = "httpx" },
@@ -720,7 +726,9 @@ requires-dist = [
     { name = "langchain-core", editable = "../../core" },
     { name = "openai", specifier = ">=2.20.0,<3.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
+    { name = "websocket-client", marker = "extra == 'websocket'", specifier = ">=1.9.0" },
 ]
+provides-extras = ["websocket"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "langchain-core", editable = "../../core" }]
@@ -742,6 +750,7 @@ test = [
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
     { name = "syrupy", specifier = ">=4.0.2,<5.0.0" },
     { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
+    { name = "websocket-client", specifier = ">=1.9.0" },
 ]
 test-integration = [
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
@@ -2237,6 +2246,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description**:
Adds WebSocket streaming capability to the OpenAI Responses API integration. Enables lower-latency streaming by connecting via WebSocket instead of HTTP when use_websocket=True is specified. Fixes #35415 

**Verification**:
All 8 unit tests passing (5 WebSocket-specific, 3 HTTP baseline regression tests). Tested with both default HTTP and WebSocket modes.