### PR TITLE
fix(openai): update responses API model detection for pro and codex models

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -532,10 +532,17 @@ def _handle_openai_api_error(e: openai.APIError) -> None:
     raise
 
 
+_RESPONSES_API_ONLY_PREFIXES = (
+    "gpt-5-pro",
+    "gpt-5.2-pro",
+    "gpt-5.4-pro",
+)
+
+
 def _model_prefers_responses_api(model_name: str | None) -> bool:
     if not model_name:
         return False
-    return "gpt-5.2-pro" in model_name or "codex" in model_name
+    return model_name.startswith(_RESPONSES_API_ONLY_PREFIXES) or "codex" in model_name
 
 
 _BM = TypeVar("_BM", bound=BaseModel)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3231,13 +3231,28 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
 
 
 def test_model_prefers_responses_api() -> None:
+    # Pro models (with and without date snapshots): Responses API only
+    assert _model_prefers_responses_api("gpt-5-pro")
+    assert _model_prefers_responses_api("gpt-5-pro-2025-10-06")
     assert _model_prefers_responses_api("gpt-5.2-pro")
+    assert _model_prefers_responses_api("gpt-5.2-pro-2025-12-11")
+    assert _model_prefers_responses_api("gpt-5.4-pro")
+    assert _model_prefers_responses_api("gpt-5.4-pro-2026-03-05")
+    # Codex models: Responses API only
+    assert _model_prefers_responses_api("gpt-5.3-codex")
     assert _model_prefers_responses_api("gpt-5.2-codex")
     assert _model_prefers_responses_api("gpt-5.1-codex")
     assert _model_prefers_responses_api("gpt-5.1-codex-max")
+    assert _model_prefers_responses_api("gpt-5.1-codex-mini")
     assert _model_prefers_responses_api("gpt-5-codex")
-    assert not _model_prefers_responses_api("gpt-5.1")
+    assert _model_prefers_responses_api("codex-mini-latest")
+    # These should not match
     assert not _model_prefers_responses_api("gpt-5")
+    assert not _model_prefers_responses_api("gpt-5.1")
+    assert not _model_prefers_responses_api("gpt-5.4")
+    assert not _model_prefers_responses_api("o3-pro")
+    assert not _model_prefers_responses_api("gpt-4.1")
+    assert not _model_prefers_responses_api(None)
 
 
 def test_openai_structured_output_refusal_handling_responses_api() -> None:


### PR DESCRIPTION
## Summary

- Updates `_model_prefers_responses_api` to match the three pro model
  families (`gpt-5-pro`, `gpt-5.2-pro`, `gpt-5.4-pro`) and all codex
  models, which are Responses API only per OpenAI's documentation.
- Uses prefix matching so dated snapshots (e.g. `gpt-5.4-pro-2026-03-05`)
  are also covered.
  
  - According to OpenAI all gpt-5 pro families support Response Only API: 
        - https://developers.openai.com/api/docs/models/gpt-5-pro
        - https://developers.openai.com/api/docs/models/gpt-5.2-pro
        - https://developers.openai.com/api/docs/models/gpt-5.4-pro   
     
  Related: #35584