### PR TITLE
fix: Add gpt-5.4+ models to Responses API detection (fixes #35584)

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -535,7 +535,11 @@ def _handle_openai_api_error(e: openai.APIError) -> None:
 def _model_prefers_responses_api(model_name: str | None) -> bool:
     if not model_name:
         return False
-    return "gpt-5.2-pro" in model_name or "codex" in model_name
+    return (
+        "gpt-5.4" in model_name
+        or "gpt-5.2-pro" in model_name
+        or "codex" in model_name
+    )
 
 
 _BM = TypeVar("_BM", bound=BaseModel)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -536,9 +536,7 @@ def _model_prefers_responses_api(model_name: str | None) -> bool:
     if not model_name:
         return False
     return (
-        "gpt-5.4" in model_name
-        or "gpt-5.2-pro" in model_name
-        or "codex" in model_name
+        "gpt-5.4" in model_name or "gpt-5.2-pro" in model_name or "codex" in model_name
     )
 
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3274,13 +3274,20 @@ def test_gpt_5_1_temperature_with_reasoning_effort_none(
 
 
 def test_model_prefers_responses_api() -> None:
+    # GPT-5.4 models (Responses API)
+    assert _model_prefers_responses_api("gpt-5.4")
+    assert _model_prefers_responses_api("gpt-5.4-2026-03-05")
+    # GPT-5.2 Pro models
     assert _model_prefers_responses_api("gpt-5.2-pro")
     assert _model_prefers_responses_api("gpt-5.2-codex")
     assert _model_prefers_responses_api("gpt-5.1-codex")
     assert _model_prefers_responses_api("gpt-5.1-codex-max")
     assert _model_prefers_responses_api("gpt-5-codex")
+    # Models that should NOT use Responses API
     assert not _model_prefers_responses_api("gpt-5.1")
     assert not _model_prefers_responses_api("gpt-5")
+    assert not _model_prefers_responses_api("gpt-4")
+    assert not _model_prefers_responses_api(None)
 
 
 def test_openai_structured_output_refusal_handling_responses_api() -> None:


### PR DESCRIPTION
## Problem
`_model_prefers_responses_api()` does not recognize `gpt-5.4+` models (e.g., `gpt-5.4-2026-03-05`), causing them to be routed through Chat Completions instead of Responses API. This results in OpenAI rejecting requests with:

```
Unknown parameter: 'tool_choice.function'
```

## Solution
Add `gpt-5.4` to the Responses API model detection pattern.

## Changes
- `libs/partners/openai/langchain_openai/chat_models/base.py`: Add `"gpt-5.4" in model_name` check
- `libs/partners/openai/tests/unit_tests/chat_models/test_base.py`: Add test coverage for gpt-5.4 models

## Testing
- Added test cases for `gpt-5.4` and `gpt-5.4-2026-03-05`
- Added negative test cases for non-Responses API models
- All existing tests pass

Fixes #35584