### PR TITLE
fix(langchain): suppress mypy errors in langchain_classic for deprecated openai APIs

### DIFF
--- a/libs/langchain/langchain_classic/agents/openai_assistant/base.py
+++ b/libs/langchain/langchain_classic/agents/openai_assistant/base.py
@@ -21,7 +21,7 @@ from typing_extensions import Self, override
 
 if TYPE_CHECKING:
     import openai
-    from openai.types.beta.threads import ThreadMessage
+    from openai.types.beta.threads import ThreadMessage  # type: ignore[attr-defined]
     from openai.types.beta.threads.required_action_function_tool_call import (
         RequiredActionFunctionToolCall,
     )
@@ -276,10 +276,10 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
             OpenAIAssistantRunnable configured to run using the created assistant.
         """
         client = client or _get_openai_client()
-        assistant = client.beta.assistants.create(
+        assistant = client.beta.assistants.create(  # type: ignore[deprecated]
             name=name,
             instructions=instructions,
-            tools=[_get_assistants_tool(tool) for tool in tools],
+            tools=[_get_assistants_tool(tool) for tool in tools],  # type: ignore[misc]
             model=model,
         )
         return cls(assistant_id=assistant.id, client=client, **kwargs)
@@ -409,10 +409,10 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
         """
         async_client = async_client or _get_openai_async_client()
         openai_tools = [_get_assistants_tool(tool) for tool in tools]
-        assistant = await async_client.beta.assistants.create(
+        assistant = await async_client.beta.assistants.create(  # type: ignore[deprecated]
             name=name,
             instructions=instructions,
-            tools=openai_tools,
+            tools=openai_tools,  # type: ignore[arg-type]
             model=model,
         )
         return cls(assistant_id=assistant.id, async_client=async_client, **kwargs)
@@ -617,7 +617,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
                     if version_gte_1_14
                     else isinstance(
                         content,
-                        openai.types.beta.threads.MessageContentText,
+                        openai.types.beta.threads.MessageContentText,  # type: ignore[attr-defined]
                     )
                 )
                 for content in answer
@@ -771,7 +771,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
                     if version_gte_1_14
                     else isinstance(
                         content,
-                        openai.types.beta.threads.MessageContentText,
+                        openai.types.beta.threads.MessageContentText,  # type: ignore[attr-defined]
                     )
                 )
                 for content in answer

--- a/libs/langchain/langchain_classic/chains/moderation.py
+++ b/libs/langchain/langchain_classic/chains/moderation.py
@@ -69,7 +69,7 @@ class OpenAIModerationChain(Chain):
             except ValueError:
                 values["openai_pre_1_0"] = True
             if values["openai_pre_1_0"]:
-                values["client"] = openai.Moderation
+                values["client"] = openai.Moderation  # type: ignore[attr-defined]
             else:
                 values["client"] = openai.OpenAI(api_key=openai_api_key)
                 values["async_client"] = openai.AsyncOpenAI(api_key=openai_api_key)

--- a/libs/langchain/langchain_classic/evaluation/embedding_distance/base.py
+++ b/libs/langchain/langchain_classic/evaluation/embedding_distance/base.py
@@ -60,7 +60,7 @@ def _embedding_factory() -> Embeddings:
         from langchain_openai import OpenAIEmbeddings
     except ImportError:
         try:
-            from langchain_community.embeddings.openai import (
+            from langchain_community.embeddings.openai import (  # type: ignore[no-redef]
                 OpenAIEmbeddings,
             )
         except ImportError as e:
@@ -121,7 +121,7 @@ class _EmbeddingDistanceChainMixin(Chain):
             pass
 
         try:
-            from langchain_community.embeddings.openai import (
+            from langchain_community.embeddings.openai import (  # type: ignore[no-redef]
                 OpenAIEmbeddings,
             )
 

--- a/libs/langchain/langchain_classic/evaluation/loading.py
+++ b/libs/langchain/langchain_classic/evaluation/loading.py
@@ -152,7 +152,7 @@ def load_evaluator(
                 from langchain_openai import ChatOpenAI
             except ImportError:
                 try:
-                    from langchain_community.chat_models.openai import (
+                    from langchain_community.chat_models.openai import (  # type: ignore[no-redef]
                         ChatOpenAI,
                     )
                 except ImportError as e:

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2589,7 +2589,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.16"
+version = "1.2.17"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
The `langchain_classic` package has compatibility code paths for older OpenAI SDK versions (pre-1.0) that reference removed/deprecated attributes like `ThreadMessage`, `MessageContentText`, and `openai.Moderation`. It also uses try/except fallback imports between `langchain-openai` and `langchain-community` that trigger `no-redef` errors. Since this is legacy code that intentionally supports multiple SDK versions, the correct fix is `type: ignore` annotations rather than code changes.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).