### PR TITLE
release(langchain): bump langchain-classic to 1.0.2

### DIFF
--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.0.1"
+version = "1.0.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.2.5,<2.0.0",

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.0.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.2.5,<2.0.0",
+    "langchain-core>=1.2.17,<2.0.0",
     "langchain-text-splitters>=1.1.0,<2.0.0",
     "langsmith>=0.1.17,<1.0.0",
     "pydantic>=2.7.4,<3.0.0",

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2379,7 +2379,7 @@ wheels = [
 
 [[package]]
 name = "langchain-classic"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
@@ -2589,7 +2589,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.16"
+version = "1.2.17"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Patch bump langchain-classic from 1.0.1 to 1.0.2.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).