### PR TITLE
fix(langchain): handle NotRequired fields in InjectedState without KeyError

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -21,7 +21,9 @@ from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.constants import END, START
 from langgraph.graph.state import StateGraph
-from langgraph.prebuilt.tool_node import ToolCallWithContext, ToolNode
+from langgraph.prebuilt.tool_node import ToolCallWithContext
+
+from langchain.tools.tool_node import ToolNode
 from langgraph.types import Command, Send
 from typing_extensions import NotRequired, Required, TypedDict
 
@@ -892,11 +894,15 @@ def create_agent(
 
     # Create ToolNode if we have client-side tools OR if middleware defines wrap_tool_call
     # (which may handle dynamically registered tools)
+    # Pass state_schema to ToolNode so it can detect NotRequired fields
+    # and safely handle InjectedState annotations that reference them.
+    _tool_node_schema = state_schema if state_schema is not None else AgentState
     tool_node = (
         ToolNode(
             tools=available_tools,
             wrap_tool_call=wrap_tool_call_wrapper,
             awrap_tool_call=awrap_tool_call_wrapper,
+            state_schema=_tool_node_schema,
         )
         if available_tools or wrap_tool_call_wrapper or awrap_tool_call_wrapper
         else None

--- a/libs/langchain_v1/langchain/tools/__init__.py
+++ b/libs/langchain_v1/langchain/tools/__init__.py
@@ -8,7 +8,12 @@ from langchain_core.tools import (
     tool,
 )
 
-from langchain.tools.tool_node import InjectedState, InjectedStore, ToolRuntime
+from langchain.tools.tool_node import (
+    InjectedState,
+    InjectedStore,
+    ToolNode,
+    ToolRuntime,
+)
 
 __all__ = [
     "BaseTool",
@@ -17,6 +22,7 @@ __all__ = [
     "InjectedToolArg",
     "InjectedToolCallId",
     "ToolException",
+    "ToolNode",
     "ToolRuntime",
     "tool",
 ]

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -1,14 +1,32 @@
-"""Utils file included for backwards compat imports."""
+"""Tool node with enhanced state injection support.
 
+This module provides a ``ToolNode`` subclass that adds safe handling for
+``NotRequired`` (and ``Optional``) fields when using ``InjectedState``.
+The upstream ``langgraph`` ``ToolNode`` raises a ``KeyError`` (or
+``AttributeError``) when an ``InjectedState("<field>")`` annotation
+references a state field declared as ``NotRequired`` and that field is
+absent from the current state.  The subclass defined here overrides
+``_inject_tool_args`` to use ``.get()`` with sensible defaults so that
+missing ``NotRequired`` fields resolve to ``None`` instead of raising.
+"""
+
+from __future__ import annotations
+
+from copy import copy
+from typing import Any, get_args, get_origin, get_type_hints
+
+from langchain_core.tools import BaseTool
 from langgraph.prebuilt import InjectedState, InjectedStore, ToolRuntime
 from langgraph.prebuilt.tool_node import (
     ToolCallRequest,
     ToolCallWithContext,
     ToolCallWrapper,
+    ToolNode as _ToolNode,
+    _get_all_injected_args,
 )
-from langgraph.prebuilt.tool_node import (
-    ToolNode as _ToolNode,  # noqa: F401
-)
+from typing_extensions import Annotated, NotRequired, Required
+
+from langchain_core.messages import ToolCall
 
 __all__ = [
     "InjectedState",
@@ -16,5 +34,287 @@ __all__ = [
     "ToolCallRequest",
     "ToolCallWithContext",
     "ToolCallWrapper",
+    "ToolNode",
     "ToolRuntime",
 ]
+
+
+def _is_not_required(annotation: Any) -> bool:
+    """Return ``True`` if *annotation* wraps ``NotRequired[...]``.
+
+    Handles raw ``NotRequired[T]`` as well as
+    ``NotRequired[Annotated[T, ...]]`` forms that ``typing_extensions``
+    emits.
+
+    Args:
+        annotation: A type annotation to inspect.
+
+    Returns:
+        ``True`` when *annotation* is ``NotRequired[...]``.
+    """
+    origin = get_origin(annotation)
+    if origin is NotRequired:
+        return True
+    return False
+
+
+def _is_not_required_string(annotation: Any) -> bool:
+    """Return ``True`` if *annotation* is a stringified ``NotRequired[...]``.
+
+    When ``from __future__ import annotations`` is active, all
+    annotations are stored as strings (or ``ForwardRef`` objects).
+    This helper detects that case by inspecting the string
+    representation.
+
+    Args:
+        annotation: A type annotation to inspect (may be a string or
+            ``ForwardRef``).
+
+    Returns:
+        ``True`` when the annotation textually wraps ``NotRequired``.
+    """
+    text: str | None = None
+    if isinstance(annotation, str):
+        text = annotation
+    else:
+        # typing.ForwardRef stores the original string in __arg__
+        arg = getattr(annotation, "__arg__", None)
+        if isinstance(arg, str):
+            text = arg
+    if text is not None:
+        return text.startswith("NotRequired[")
+    return False
+
+
+def _get_not_required_fields(state_schema: type | None) -> set[str]:
+    """Collect the names of all ``NotRequired`` fields in a TypedDict schema.
+
+    The function inspects the ``__annotations__`` (and
+    ``__required_keys__`` / ``__optional_keys__`` when available) of the
+    given TypedDict class to determine which fields are *not* required.
+
+    For ``total=True`` TypedDicts (the default), a field is not-required
+    only when explicitly wrapped in ``NotRequired[...]``.  For
+    ``total=False`` TypedDicts, every field that is *not* wrapped in
+    ``Required[...]`` is considered not-required.
+
+    Args:
+        state_schema: A ``TypedDict`` subclass used as the graph state
+            schema, or ``None``.
+
+    Returns:
+        A set of field names that are not-required.  Returns an empty set
+        when *state_schema* is ``None`` or is not a TypedDict.
+    """
+    if state_schema is None:
+        return set()
+
+    # typing_extensions TypedDicts expose __optional_keys__.  However,
+    # when ``from __future__ import annotations`` is active the
+    # TypedDict metaclass cannot resolve ``NotRequired[...]`` wrappers
+    # and ``__optional_keys__`` may be an empty frozenset even though
+    # some fields *are* optional.  We therefore treat a non-empty
+    # ``__optional_keys__`` as authoritative but fall through to
+    # annotation inspection otherwise.
+    optional_keys: frozenset[str] | None = getattr(
+        state_schema, "__optional_keys__", None
+    )
+    if optional_keys:
+        return set(optional_keys)
+
+    # Fallback: resolve annotations via get_type_hints (handles forward
+    # references from ``from __future__ import annotations``) and
+    # inspect them for NotRequired wrappers.
+    try:
+        annotations = get_type_hints(state_schema, include_extras=True)
+    except Exception:
+        # get_type_hints can fail on complex schemas with unresolvable
+        # forward references.  Fall back to raw __annotations__.
+        annotations = getattr(state_schema, "__annotations__", {})
+
+    not_required: set[str] = set()
+    total: bool = getattr(state_schema, "__total__", True)
+    for field_name, field_type in annotations.items():
+        if _is_not_required(field_type):
+            not_required.add(field_name)
+        elif _is_not_required_string(field_type):
+            # Handle stringified annotations from
+            # ``from __future__ import annotations``
+            not_required.add(field_name)
+        elif not total and get_origin(field_type) is not Required:
+            # In a total=False TypedDict, fields not marked Required are
+            # optional.
+            not_required.add(field_name)
+    return not_required
+
+
+class ToolNode(_ToolNode):
+    """``ToolNode`` with safe handling for ``NotRequired`` state fields.
+
+    When a tool parameter is annotated with ``InjectedState("<field>")``,
+    the upstream ``_ToolNode._inject_tool_args`` accesses the state via
+    direct subscript (``state[field]``), which raises ``KeyError`` if the
+    field is absent.  This subclass overrides the injection logic so that
+    fields declared as ``NotRequired`` in the state schema are accessed
+    via ``.get(field)`` instead, returning ``None`` when the field has not
+    been populated.
+
+    The ``state_schema`` is an *optional* parameter.  When not supplied
+    the ``ToolNode`` still works but falls back to ``.get()`` for **all**
+    field-level ``InjectedState`` accesses on ``dict`` states, which is a
+    safe superset of the original behaviour (``state.get(k)`` returns the
+    same value as ``state[k]`` when the key exists).
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        state_schema: type | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the ``ToolNode``.
+
+        Args:
+            *args: Positional arguments forwarded to the parent
+                ``ToolNode.__init__``.
+            state_schema: An optional ``TypedDict`` class used as the
+                graph state schema.  When provided the node can
+                distinguish ``NotRequired`` fields from required ones and
+                only relax access for the former.
+            **kwargs: Keyword arguments forwarded to the parent
+                ``ToolNode.__init__``.
+        """
+        super().__init__(*args, **kwargs)
+        self._state_schema = state_schema
+        self._not_required_fields: set[str] = _get_not_required_fields(
+            state_schema
+        )
+
+    def _inject_tool_args(
+        self,
+        tool_call: ToolCall,
+        tool_runtime: ToolRuntime,
+        tool: BaseTool | None = None,
+    ) -> ToolCall:
+        """Inject graph state, store, and runtime into tool call arguments.
+
+        This override adds safe handling for ``NotRequired`` state fields.
+        When a state field referenced by ``InjectedState("<field>")`` is
+        declared as ``NotRequired`` in the state schema (or when no schema
+        is known), the field is accessed via ``.get()`` so that missing
+        keys resolve to ``None`` instead of raising ``KeyError``.
+
+        Args:
+            tool_call: The tool call dictionary to augment.
+            tool_runtime: The ``ToolRuntime`` with state, config, store,
+                context, and stream_writer.
+            tool: Optional tool instance for dynamically registered tools.
+
+        Returns:
+            A new ``ToolCall`` dict with injected arguments.
+
+        Raises:
+            ValueError: If store injection is required but no store is
+                provided, or if state injection requirements cannot be
+                satisfied.
+        """
+        injected = self._injected_args.get(tool_call["name"])
+        if not injected and tool is not None:
+            injected = _get_all_injected_args(tool)
+        if not injected:
+            return tool_call
+
+        tool_call_copy: ToolCall = copy(tool_call)
+        injected_args: dict[str, Any] = {}
+
+        # --- Inject state (with NotRequired awareness) ---
+        if injected.state:
+            state = tool_runtime.state
+            # Handle list state by converting to dict
+            if isinstance(state, list):
+                required_fields = list(injected.state.values())
+                if (
+                    len(required_fields) == 1
+                    and required_fields[0] == self._messages_key
+                ) or required_fields[0] is None:
+                    state = {self._messages_key: state}
+                else:
+                    err_msg = (
+                        f"Invalid input to ToolNode. Tool {tool_call['name']} "
+                        f"requires graph state dict as input."
+                    )
+                    if any(
+                        state_field
+                        for state_field in injected.state.values()
+                    ):
+                        required_fields_str = ", ".join(
+                            f for f in required_fields if f
+                        )
+                        err_msg += (
+                            f" State should contain fields "
+                            f"{required_fields_str}."
+                        )
+                    raise ValueError(err_msg)
+
+            # Extract state values with NotRequired safety
+            if isinstance(state, dict):
+                for tool_arg, state_field in injected.state.items():
+                    if state_field is None:
+                        # Entire state requested
+                        injected_args[tool_arg] = state
+                    elif self._is_field_not_required(state_field):
+                        # Field is NotRequired or schema is unknown:
+                        # use .get() so missing keys yield None
+                        injected_args[tool_arg] = state.get(state_field)
+                    else:
+                        # Field is required: preserve original behaviour
+                        injected_args[tool_arg] = state[state_field]
+            else:
+                for tool_arg, state_field in injected.state.items():
+                    if state_field is None:
+                        injected_args[tool_arg] = state
+                    elif self._is_field_not_required(state_field):
+                        injected_args[tool_arg] = getattr(
+                            state, state_field, None
+                        )
+                    else:
+                        injected_args[tool_arg] = getattr(
+                            state, state_field
+                        )
+
+        # --- Inject store ---
+        if injected.store:
+            if tool_runtime.store is None:
+                msg = (
+                    "Cannot inject store into tools with InjectedStore "
+                    "annotations - please compile your graph with a store."
+                )
+                raise ValueError(msg)
+            injected_args[injected.store] = tool_runtime.store
+
+        # --- Inject runtime ---
+        if injected.runtime:
+            injected_args[injected.runtime] = tool_runtime
+
+        tool_call_copy["args"] = {**tool_call_copy["args"], **injected_args}
+        return tool_call_copy
+
+    def _is_field_not_required(self, field_name: str) -> bool:
+        """Check whether *field_name* is a ``NotRequired`` state field.
+
+        When no ``state_schema`` was provided (i.e. we have no schema
+        information), we conservatively treat **all** fields as
+        potentially not-required and use safe ``.get()`` access.  This
+        avoids ``KeyError`` at the cost of returning ``None`` for truly
+        missing required fields (which would have raised anyway).
+
+        Args:
+            field_name: The state field name to check.
+
+        Returns:
+            ``True`` if the field should be accessed via ``.get()``.
+        """
+        if self._state_schema is None:
+            # No schema known: be safe and use .get() for all fields
+            return True
+        return field_name in self._not_required_fields

--- a/libs/langchain_v1/tests/unit_tests/agents/test_injected_state_not_required.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_injected_state_not_required.py
@@ -1,0 +1,315 @@
+"""Tests for InjectedState with NotRequired state fields.
+
+Verifies that tools annotated with ``InjectedState("<field>")`` do not
+raise ``KeyError`` when the referenced field is declared as
+``NotRequired`` in the state schema and has not been populated.
+
+See: https://github.com/langchain-ai/langchain/issues/35585
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
+from typing_extensions import NotRequired
+
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentState
+from langchain.tools import InjectedState
+from langchain.tools.tool_node import (
+    ToolNode,
+    _get_not_required_fields,
+    _is_not_required,
+)
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class _TotalTrueState(AgentState[Any]):
+    """State where ``total=True`` (default) with a NotRequired field."""
+
+    city: NotRequired[str]
+    country: str
+
+
+class _TotalFalseState(AgentState[Any], total=False):
+    """State where ``total=False`` -- all fields are optional by default."""
+
+    city: str
+    country: str
+
+
+def test_is_not_required_positive() -> None:
+    """``_is_not_required`` returns True for NotRequired annotations."""
+    assert _is_not_required(NotRequired[str]) is True
+    assert _is_not_required(NotRequired[int]) is True
+
+
+def test_is_not_required_negative() -> None:
+    """``_is_not_required`` returns False for plain types."""
+    assert _is_not_required(str) is False
+    assert _is_not_required(int) is False
+    assert _is_not_required(list[str]) is False
+
+
+def test_get_not_required_fields_total_true() -> None:
+    """Detect NotRequired fields in a total=True TypedDict."""
+    fields = _get_not_required_fields(_TotalTrueState)
+    assert "city" in fields
+    # 'country' is required
+    assert "country" not in fields
+
+
+def test_get_not_required_fields_total_false() -> None:
+    """In a total=False TypedDict all non-Required fields are optional."""
+    fields = _get_not_required_fields(_TotalFalseState)
+    assert "city" in fields
+    assert "country" in fields
+
+
+def test_get_not_required_fields_none_schema() -> None:
+    """Passing None returns an empty set."""
+    assert _get_not_required_fields(None) == set()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for ToolNode._is_field_not_required
+# ---------------------------------------------------------------------------
+
+
+def test_tool_node_is_field_not_required_with_schema() -> None:
+    """ToolNode correctly identifies not-required fields from schema."""
+
+    @tool
+    def dummy_tool(x: int) -> str:
+        """Dummy."""
+        return str(x)
+
+    node = ToolNode([dummy_tool], state_schema=_TotalTrueState)
+    assert node._is_field_not_required("city") is True
+    assert node._is_field_not_required("country") is False
+
+
+def test_tool_node_is_field_not_required_without_schema() -> None:
+    """Without schema all fields are treated as potentially not-required."""
+
+    @tool
+    def dummy_tool(x: int) -> str:
+        """Dummy."""
+        return str(x)
+
+    node = ToolNode([dummy_tool])
+    # No schema -> conservative: all fields use .get()
+    assert node._is_field_not_required("anything") is True
+
+
+# ---------------------------------------------------------------------------
+# Integration tests with create_agent
+# ---------------------------------------------------------------------------
+
+
+def test_injected_state_not_required_field_absent() -> None:
+    """InjectedState referencing a NotRequired field that is absent.
+
+    This is the exact scenario reported in issue #35585.  Previously this
+    raised ``KeyError: 'city'``.
+    """
+
+    class CustomState(AgentState[Any]):
+        city: NotRequired[str]
+
+    injected_values: dict[str, Any] = {}
+
+    @tool
+    def get_weather(city: Annotated[str, InjectedState("city")]) -> str:
+        """Get weather for a given city."""
+        injected_values["city"] = city
+        if city is None:
+            return "No city provided"
+        return f"Sunny in {city}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {}, "id": "call_1", "name": "get_weather"}],
+                [],
+            ]
+        ),
+        tools=[get_weather],
+        system_prompt="You are a helpful assistant.",
+        state_schema=CustomState,
+    )
+
+    # Invoke WITHOUT providing the 'city' field -- previously crashed
+    result = agent.invoke({"messages": [HumanMessage("What is the weather?")]})
+
+    # The tool should have received None for the absent NotRequired field
+    assert injected_values["city"] is None
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert "No city provided" in tool_messages[0].content
+
+
+def test_injected_state_not_required_field_present() -> None:
+    """InjectedState referencing a NotRequired field that IS present.
+
+    When the field is populated it should be injected normally.
+    """
+
+    class CustomState(AgentState[Any]):
+        city: NotRequired[str]
+
+    injected_values: dict[str, Any] = {}
+
+    @tool
+    def get_weather(city: Annotated[str, InjectedState("city")]) -> str:
+        """Get weather for a given city."""
+        injected_values["city"] = city
+        return f"Sunny in {city}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {}, "id": "call_1", "name": "get_weather"}],
+                [],
+            ]
+        ),
+        tools=[get_weather],
+        system_prompt="You are a helpful assistant.",
+        state_schema=CustomState,
+    )
+
+    result = agent.invoke({
+        "messages": [HumanMessage("Weather?")],
+        "city": "Paris",
+    })
+
+    assert injected_values["city"] == "Paris"
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert "Sunny in Paris" in tool_messages[0].content
+
+
+def test_injected_state_required_field_still_raises() -> None:
+    """InjectedState referencing a required field should still KeyError.
+
+    We only relax access for NotRequired fields; required fields that are
+    missing should still surface an error so developers catch schema
+    violations early.
+    """
+
+    class CustomState(AgentState[Any]):
+        city: str  # required
+
+    @tool
+    def get_weather(city: Annotated[str, InjectedState("city")]) -> str:
+        """Get weather for a given city."""
+        return f"Sunny in {city}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {}, "id": "call_1", "name": "get_weather"}],
+                [],
+            ]
+        ),
+        tools=[get_weather],
+        system_prompt="You are a helpful assistant.",
+        state_schema=CustomState,
+    )
+
+    import pytest
+
+    with pytest.raises(KeyError):
+        agent.invoke({"messages": [HumanMessage("Weather?")]})
+
+
+def test_injected_state_full_state_still_works() -> None:
+    """InjectedState() (no field) should inject the full state dict."""
+
+    class CustomState(AgentState[Any]):
+        city: NotRequired[str]
+
+    injected_values: dict[str, Any] = {}
+
+    @tool
+    def inspect_state(state: Annotated[dict, InjectedState()]) -> str:
+        """Inspect full state."""
+        injected_values["state"] = state
+        return f"Keys: {sorted(state.keys())}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {}, "id": "call_1", "name": "inspect_state"}],
+                [],
+            ]
+        ),
+        tools=[inspect_state],
+        system_prompt="You are a helpful assistant.",
+        state_schema=CustomState,
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Inspect")]})
+
+    assert "messages" in injected_values["state"]
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+
+
+def test_injected_state_multiple_not_required_fields() -> None:
+    """Multiple NotRequired fields, some absent and some present."""
+
+    class CustomState(AgentState[Any]):
+        city: NotRequired[str]
+        temperature_unit: NotRequired[str]
+        country: str
+
+    injected_values: dict[str, Any] = {}
+
+    @tool
+    def weather_report(
+        city: Annotated[str, InjectedState("city")],
+        unit: Annotated[str, InjectedState("temperature_unit")],
+        country: Annotated[str, InjectedState("country")],
+    ) -> str:
+        """Get weather report."""
+        injected_values["city"] = city
+        injected_values["unit"] = unit
+        injected_values["country"] = country
+        city_str = city or "unknown"
+        unit_str = unit or "celsius"
+        return f"Weather in {city_str}, {country}: 20 {unit_str}"
+
+    agent = create_agent(
+        model=FakeToolCallingModel(
+            tool_calls=[
+                [{"args": {}, "id": "call_1", "name": "weather_report"}],
+                [],
+            ]
+        ),
+        tools=[weather_report],
+        system_prompt="You are a helpful assistant.",
+        state_schema=CustomState,
+    )
+
+    result = agent.invoke({
+        "messages": [HumanMessage("Report")],
+        "country": "France",
+        # city and temperature_unit intentionally omitted
+    })
+
+    assert injected_values["city"] is None
+    assert injected_values["unit"] is None
+    assert injected_values["country"] == "France"
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert "France" in tool_messages[0].content

--- a/libs/langchain_v1/tests/unit_tests/tools/test_imports.py
+++ b/libs/langchain_v1/tests/unit_tests/tools/test_imports.py
@@ -7,6 +7,7 @@ EXPECTED_ALL = {
     "InjectedToolArg",
     "InjectedToolCallId",
     "ToolException",
+    "ToolNode",
     "ToolRuntime",
     "tool",
 }


### PR DESCRIPTION
Fixes #35585 - InjectedState with NotRequired state field raises KeyError when field is absent.

> This contribution was developed with AI assistance.

## Problem

When a tool parameter annotated with `InjectedState('<field>')` references a `NotRequired` state field, the upstream ToolNode crashes with `KeyError` if that field hasn't been populated.

## Solution

**New ToolNode subclass** (308 lines) in `langchain.tools.tool_node` that overrides `_inject_tool_args` with NotRequired-aware state access:

- `_get_not_required_fields()` detects NotRequired fields via `__optional_keys__`, `get_type_hints()`, and stringified annotation inspection
- Uses `.get()` for NotRequired fields (returns None) vs direct subscript for required fields
- Handles `total=True` and `total=False` TypedDicts
- `create_agent()` factory passes `state_schema` to the custom ToolNode

**9 unit/integration tests** (316 lines) covering absent fields, present fields, required fields still raising, full state injection, and mixed field scenarios.

## Review areas

1. ToolNode subclass re-implements `_inject_tool_args` - upstream langgraph changes could diverge
2. Conservative fallback: no schema = all fields use `.get()` 
3. Stringified annotation detection for `from __future__ import annotations`