### PR TITLE
release(langchain): 0.3.28

### DIFF
--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "async-timeout>=4.0.0,<5.0.0; python_version < \"3.11\"",
 ]
 name = "langchain"
-version = "0.3.27"
+version = "0.3.28"
 description = "Building applications with LLMs through composability"
 readme = "README.md"
 

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2163,7 +2163,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "0.3.27"
+version = "0.3.28"
 source = { editable = "." }
 dependencies = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Patch release for langchain 0.3.28.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).