### PR TITLE
fix(langchain): bump minimum langchain-core to 0.3.73

### DIFF
--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -7,7 +7,7 @@ authors = []
 license = { text = "MIT" }
 requires-python = ">=3.9.0,<4.0.0"
 dependencies = [
-    "langchain-core>=0.3.72,<1.0.0",
+    "langchain-core>=0.3.73,<1.0.0",
     "langchain-text-splitters>=0.3.9,<1.0.0",
     "langsmith>=0.1.17,<1.0.0",
     "pydantic>=2.7.4,<3.0.0",


### PR DESCRIPTION
The within-batch deduplication fix (langchain-core 0.3.73, #32273) changed `num_skipped` counting in the indexing API. Tests in `libs/langchain` were updated to expect the new behavior, but the minimum version was left at 0.3.72, causing [pre-release checks to fail](https://github.com/langchain-ai/langchain/actions/runs/22783515938/job/66097466123).

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).