### PR TITLE
fix(core): prevent inflated token counts when merging streaming usage_metadata

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -635,36 +635,6 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
         return super().__add__(other)
 
 
-def _is_cumulative_usage(usages: list[UsageMetadata]) -> bool:
-    """Detect if usage_metadata values represent cumulative streaming counts.
-
-    Streaming providers (e.g. OpenAI with ``stream_usage=True``) send running
-    totals in each chunk: ``input_tokens`` stays constant (same prompt) and
-    ``total_tokens`` is monotonically non-decreasing.  In contrast, independent
-    invocations produce varying ``input_tokens`` that should be summed.
-
-    Args:
-        usages: Non-null usage_metadata values from the chunks being merged.
-
-    Returns:
-        ``True`` if the pattern matches cumulative streaming counts.
-    """
-    if len(usages) < 2:  # noqa: PLR2004
-        return False
-    first_input = usages[0].get("input_tokens", -1)
-    prev_total = usages[0].get("total_tokens", 0)
-    for u in usages[1:]:
-        # Different input_tokens → independent invocations, not cumulative.
-        if u.get("input_tokens", -1) != first_input:
-            return False
-        cur_total = u.get("total_tokens", 0)
-        # Totals going down → not a running total.
-        if cur_total < prev_total:
-            return False
-        prev_total = cur_total
-    return True
-
-
 def add_ai_message_chunks(
     left: AIMessageChunk, *others: AIMessageChunk
 ) -> AIMessageChunk:
@@ -707,19 +677,21 @@ def add_ai_message_chunks(
     # counts (e.g. OpenAI with stream_usage=True sends running totals in
     # every chunk) vs. independent invocations that should be summed.
     # See: https://github.com/langchain-ai/langchain/issues/31351
-    usages = [c.usage_metadata for c in (left, *others) if c.usage_metadata is not None]
+    usages = [m.usage_metadata for m in (left, *others) if m.usage_metadata is not None]
+
     if not usages:
         usage_metadata = None
-    elif len(usages) == 1:
-        usage_metadata = usages[0]
-    elif _is_cumulative_usage(usages):
-        # Streaming: provider already sent cumulative totals → last is final
-        usage_metadata = usages[-1]
     else:
-        # Independent invocations → sum
-        usage_metadata = usages[0]
-        for u in usages[1:]:
-            usage_metadata = add_usage(usage_metadata, u)
+        inputs = [u.get("input_tokens", 0) for u in usages]
+        totals = [u.get("total_tokens", 0) for u in usages]
+
+        # Detect cumulative pattern: constant input_tokens and monotonic increasing totals
+        if len(set(inputs)) == 1 and totals == sorted(totals) and len(set(totals)) > 1:
+            usage_metadata = usages[-1].copy()
+        else:
+            usage_metadata = usages[0].copy()
+            for u in usages[1:]:
+                usage_metadata = add_usage(usage_metadata, u)
 
     # Ranks are defined by the order of preference. Higher is better:
     # 2. Provider-assigned IDs (non lc_* and non lc_run-*)

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -635,6 +635,36 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
         return super().__add__(other)
 
 
+def _is_cumulative_usage(usages: list[UsageMetadata]) -> bool:
+    """Detect if usage_metadata values represent cumulative streaming counts.
+
+    Streaming providers (e.g. OpenAI with ``stream_usage=True``) send running
+    totals in each chunk: ``input_tokens`` stays constant (same prompt) and
+    ``total_tokens`` is monotonically non-decreasing.  In contrast, independent
+    invocations produce varying ``input_tokens`` that should be summed.
+
+    Args:
+        usages: Non-null usage_metadata values from the chunks being merged.
+
+    Returns:
+        ``True`` if the pattern matches cumulative streaming counts.
+    """
+    if len(usages) < 2:  # noqa: PLR2004
+        return False
+    first_input = usages[0].get("input_tokens", -1)
+    prev_total = usages[0].get("total_tokens", 0)
+    for u in usages[1:]:
+        # Different input_tokens → independent invocations, not cumulative.
+        if u.get("input_tokens", -1) != first_input:
+            return False
+        cur_total = u.get("total_tokens", 0)
+        # Totals going down → not a running total.
+        if cur_total < prev_total:
+            return False
+        prev_total = cur_total
+    return True
+
+
 def add_ai_message_chunks(
     left: AIMessageChunk, *others: AIMessageChunk
 ) -> AIMessageChunk:
@@ -673,15 +703,23 @@ def add_ai_message_chunks(
         tool_call_chunks = []
 
     # Token usage
-    # Take the last non-null usage_metadata rather than summing, because
-    # streaming providers (e.g. OpenAI with stream_usage=True) send
-    # cumulative token counts in each chunk. Summing them would inflate
-    # the totals. See: https://github.com/langchain-ai/langchain/issues/31351
-    usage_metadata: UsageMetadata | None = None
-    for candidate in reversed((left, *others)):
-        if candidate.usage_metadata is not None:
-            usage_metadata = candidate.usage_metadata
-            break
+    # Detect whether usage_metadata values represent cumulative streaming
+    # counts (e.g. OpenAI with stream_usage=True sends running totals in
+    # every chunk) vs. independent invocations that should be summed.
+    # See: https://github.com/langchain-ai/langchain/issues/31351
+    usages = [c.usage_metadata for c in (left, *others) if c.usage_metadata is not None]
+    if not usages:
+        usage_metadata = None
+    elif len(usages) == 1:
+        usage_metadata = usages[0]
+    elif _is_cumulative_usage(usages):
+        # Streaming: provider already sent cumulative totals → last is final
+        usage_metadata = usages[-1]
+    else:
+        # Independent invocations → sum
+        usage_metadata = usages[0]
+        for u in usages[1:]:
+            usage_metadata = add_usage(usage_metadata, u)
 
     # Ranks are defined by the order of preference. Higher is better:
     # 2. Provider-assigned IDs (non lc_* and non lc_run-*)

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -685,7 +685,8 @@ def add_ai_message_chunks(
         inputs = [u.get("input_tokens", 0) for u in usages]
         totals = [u.get("total_tokens", 0) for u in usages]
 
-        # Detect cumulative pattern: constant input_tokens and monotonic increasing totals
+        # Detect cumulative pattern:
+        # constant input_tokens and monotonic increasing totals
         if len(set(inputs)) == 1 and totals == sorted(totals) and len(set(totals)) > 1:
             usage_metadata = usages[-1].copy()
         else:

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -673,12 +673,15 @@ def add_ai_message_chunks(
         tool_call_chunks = []
 
     # Token usage
-    if left.usage_metadata or any(o.usage_metadata is not None for o in others):
-        usage_metadata: UsageMetadata | None = left.usage_metadata
-        for other in others:
-            usage_metadata = add_usage(usage_metadata, other.usage_metadata)
-    else:
-        usage_metadata = None
+    # Take the last non-null usage_metadata rather than summing, because
+    # streaming providers (e.g. OpenAI with stream_usage=True) send
+    # cumulative token counts in each chunk. Summing them would inflate
+    # the totals. See: https://github.com/langchain-ai/langchain/issues/31351
+    usage_metadata: UsageMetadata | None = None
+    for candidate in reversed((left, *others)):
+        if candidate.usage_metadata is not None:
+            usage_metadata = candidate.usage_metadata
+            break
 
     # Ranks are defined by the order of preference. Higher is better:
     # 2. Provider-assigned IDs (non lc_* and non lc_run-*)

--- a/libs/core/tests/unit_tests/messages/test_usage_metadata_streaming.py
+++ b/libs/core/tests/unit_tests/messages/test_usage_metadata_streaming.py
@@ -1,0 +1,59 @@
+"""Regression test for https://github.com/langchain-ai/langchain/issues/31351."""
+
+from langchain_core.messages import AIMessageChunk
+from langchain_core.messages.ai import add_ai_message_chunks
+
+
+def test_usage_metadata_streaming_not_summed() -> None:
+    """Merged usage_metadata should equal the last chunk, not the sum."""
+    chunk1 = AIMessageChunk(
+        content="Hello",
+        usage_metadata={"input_tokens": 10, "output_tokens": 1, "total_tokens": 11},
+    )
+
+    chunk2 = AIMessageChunk(
+        content=" world",
+        usage_metadata={"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
+    )
+
+    chunk3 = AIMessageChunk(
+        content="!",
+        usage_metadata={"input_tokens": 10, "output_tokens": 3, "total_tokens": 13},
+    )
+
+    merged = add_ai_message_chunks(chunk1, chunk2, chunk3)
+
+    assert merged.usage_metadata is not None
+    assert merged.usage_metadata["input_tokens"] == 10
+    assert merged.usage_metadata["output_tokens"] == 3
+    assert merged.usage_metadata["total_tokens"] == 13
+
+
+def test_usage_metadata_none_chunks() -> None:
+    """If no chunks carry usage_metadata, the merged result should be None."""
+    chunk1 = AIMessageChunk(content="Hello")
+    chunk2 = AIMessageChunk(content=" world")
+
+    merged = add_ai_message_chunks(chunk1, chunk2)
+
+    assert merged.usage_metadata is None
+
+
+def test_usage_metadata_partial_chunks() -> None:
+    """If only some chunks carry usage_metadata, use the last non-null one."""
+    chunk1 = AIMessageChunk(content="Hello")
+
+    chunk2 = AIMessageChunk(
+        content=" world",
+        usage_metadata={"input_tokens": 5, "output_tokens": 10, "total_tokens": 15},
+    )
+
+    chunk3 = AIMessageChunk(content="!")
+
+    merged = add_ai_message_chunks(chunk1, chunk2, chunk3)
+
+    # Last non-null is chunk2
+    assert merged.usage_metadata is not None
+    assert merged.usage_metadata["input_tokens"] == 5
+    assert merged.usage_metadata["output_tokens"] == 10
+    assert merged.usage_metadata["total_tokens"] == 15

--- a/libs/core/tests/unit_tests/messages/test_usage_metadata_streaming.py
+++ b/libs/core/tests/unit_tests/messages/test_usage_metadata_streaming.py
@@ -4,18 +4,35 @@ from langchain_core.messages import AIMessageChunk
 from langchain_core.messages.ai import add_ai_message_chunks
 
 
+def test_usage_metadata_summed_for_independent_merges() -> None:
+    """Independent chunks with different input_tokens should be summed."""
+    left = AIMessageChunk(
+        content="",
+        usage_metadata={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+    )
+    right = AIMessageChunk(
+        content="",
+        usage_metadata={"input_tokens": 4, "output_tokens": 5, "total_tokens": 9},
+    )
+
+    merged = add_ai_message_chunks(left, right)
+
+    assert merged.usage_metadata is not None
+    assert merged.usage_metadata["input_tokens"] == 5
+    assert merged.usage_metadata["output_tokens"] == 7
+    assert merged.usage_metadata["total_tokens"] == 12
+
+
 def test_usage_metadata_streaming_not_summed() -> None:
-    """Merged usage_metadata should equal the last chunk, not the sum."""
+    """Cumulative streaming chunks (same input, increasing total) use last."""
     chunk1 = AIMessageChunk(
         content="Hello",
         usage_metadata={"input_tokens": 10, "output_tokens": 1, "total_tokens": 11},
     )
-
     chunk2 = AIMessageChunk(
         content=" world",
         usage_metadata={"input_tokens": 10, "output_tokens": 2, "total_tokens": 12},
     )
-
     chunk3 = AIMessageChunk(
         content="!",
         usage_metadata={"input_tokens": 10, "output_tokens": 3, "total_tokens": 13},
@@ -40,20 +57,34 @@ def test_usage_metadata_none_chunks() -> None:
 
 
 def test_usage_metadata_partial_chunks() -> None:
-    """If only some chunks carry usage_metadata, use the last non-null one."""
+    """Only some chunks have usage_metadata — use the single non-null one."""
     chunk1 = AIMessageChunk(content="Hello")
-
     chunk2 = AIMessageChunk(
         content=" world",
         usage_metadata={"input_tokens": 5, "output_tokens": 10, "total_tokens": 15},
     )
-
     chunk3 = AIMessageChunk(content="!")
 
     merged = add_ai_message_chunks(chunk1, chunk2, chunk3)
 
-    # Last non-null is chunk2
     assert merged.usage_metadata is not None
     assert merged.usage_metadata["input_tokens"] == 5
     assert merged.usage_metadata["output_tokens"] == 10
     assert merged.usage_metadata["total_tokens"] == 15
+
+
+def test_usage_metadata_last_chunk_only() -> None:
+    """Common pattern: only the final streaming chunk carries usage."""
+    chunk1 = AIMessageChunk(content="Hello")
+    chunk2 = AIMessageChunk(content=" world")
+    chunk3 = AIMessageChunk(
+        content="",
+        usage_metadata={"input_tokens": 10, "output_tokens": 20, "total_tokens": 30},
+    )
+
+    merged = add_ai_message_chunks(chunk1, chunk2, chunk3)
+
+    assert merged.usage_metadata is not None
+    assert merged.usage_metadata["input_tokens"] == 10
+    assert merged.usage_metadata["output_tokens"] == 20
+    assert merged.usage_metadata["total_tokens"] == 30

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -610,7 +610,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.16"
+version = "1.2.17"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -802,7 +802,7 @@ typing = [
 
 [[package]]
 name = "langgraph"
-version = "1.0.8"
+version = "1.0.10rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -812,9 +812,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/49/e9551965d8a44dd9afdc55cbcdc5a9bd18bee6918cc2395b225d40adb77c/langgraph-1.0.8.tar.gz", hash = "sha256:2630fc578846995114fd659f8b14df9eff5a4e78c49413f67718725e88ceb544", size = 498708, upload-time = "2026-02-06T12:31:13.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/33/34c8ab47938ac2ac6df1d2696e28b6000e98c2a783b89655fe2261b7f93b/langgraph-1.0.10rc1.tar.gz", hash = "sha256:4042dc1f33297ccbd593bddc5a4e77dc7e0f37c7ac19d48551c53a22287bacaa", size = 511667, upload-time = "2026-02-26T20:13:38.38Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/b0d7fc1007821a08dfc03ce232f39f209aa4aa46414ea3d125b24e35093a/langgraph-1.0.8-py3-none-any.whl", hash = "sha256:da737177c024caad7e5262642bece4f54edf4cba2c905a1d1338963f41cf0904", size = 158144, upload-time = "2026-02-06T12:31:12.489Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/b6e7fd50c70116369874d681e3aa14bf32adbdde6c05014e5260c081452f/langgraph-1.0.10rc1-py3-none-any.whl", hash = "sha256:10750c035cc48b6809a4657ad0c9fd63fb6ee47dd2f1f2a57adb940381d096e5", size = 160950, upload-time = "2026-02-26T20:13:37.223Z" },
 ]
 
 [[package]]
@@ -832,15 +832,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.7"
+version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/59/711aecd1a50999456850dc328f3cad72b4372d8218838d8d5326f80cb76f/langgraph_prebuilt-1.0.7.tar.gz", hash = "sha256:38e097e06de810de4d0e028ffc0e432bb56d1fb417620fb1dfdc76c5e03e4bf9", size = 163692, upload-time = "2026-01-22T16:45:22.801Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/06/dd61a5c2dce009d1b03b1d56f2a85b3127659fdddf5b3be5d8f1d60820fb/langgraph_prebuilt-1.0.8.tar.gz", hash = "sha256:0cd3cf5473ced8a6cd687cc5294e08d3de57529d8dd14fdc6ae4899549efcf69", size = 164442, upload-time = "2026-02-19T18:14:39.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/49/5e37abb3f38a17a3487634abc2a5da87c208cc1d14577eb8d7184b25c886/langgraph_prebuilt-1.0.7-py3-none-any.whl", hash = "sha256:e14923516504405bb5edc3977085bc9622c35476b50c1808544490e13871fe7c", size = 35324, upload-time = "2026-01-22T16:45:21.784Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/41/ec966424ad3f2ed3996d24079d3342c8cd6c0bd0653c12b2a917a685ec6c/langgraph_prebuilt-1.0.8-py3-none-any.whl", hash = "sha256:d16a731e591ba4470f3e313a319c7eee7dbc40895bcf15c821f985a3522a7ce0", size = 35648, upload-time = "2026-02-19T18:14:37.611Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fix incorrect token counting when streaming with `stream_usage=True`.

Root cause:
Streaming providers (e.g. OpenAI) return cumulative token usage in each chunk.
`add_ai_message_chunks()` previously summed usage_metadata across chunks,
which inflated token counts.

Example:
chunk1: input_tokens=10
chunk2: input_tokens=10
chunk3: input_tokens=10

Previous result:
30 input tokens

Correct result:
10 input tokens (last cumulative value)

Fix:
Use the last non-null `usage_metadata` when merging message chunks.

Adds a regression test ensuring streaming token usage is not summed.

Fixes #31351