### PR TITLE
fix(openai): preserve status field in function_call blocks for GPT-OSS compatibility

### DIFF
--- a/libs/partners/deepseek/uv.lock
+++ b/libs/partners/deepseek/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.14"
+version = "1.2.16"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4330,6 +4330,7 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                             "name": tool_call["function"]["name"],
                             "arguments": tool_call["function"]["arguments"],
                             "call_id": tool_call["id"],
+                            "status": None,
                         }
                         input_.append(function_call)
 
@@ -4449,7 +4450,12 @@ def _construct_lc_result_from_responses_api(
                         {"type": "refusal", "refusal": content.refusal, "id": output.id}
                     )
         elif output.type == "function_call":
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            # Use exclude_none=False to preserve "status" field (even when
+            # None).  Some OpenAI-compatible servers (e.g. vLLM serving
+            # GPT-OSS models) require "status" to be present in the
+            # function_call block when it is sent back as conversation
+            # history; omitting it causes "No call message found" errors.
+            content_blocks.append(output.model_dump(exclude_none=False, mode="json"))
             try:
                 args = json.loads(output.arguments, strict=False)
                 error = None
@@ -4689,6 +4695,7 @@ def _convert_responses_chunk_to_generation_chunk(
                 "arguments": chunk.item.arguments,
                 "call_id": chunk.item.call_id,
                 "id": chunk.item.id,
+                "status": getattr(chunk.item, "status", None),
                 "index": current_index,
             }
         )

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1723,6 +1723,7 @@ def test__construct_lc_result_from_responses_api_function_call_preserves_status(
     assert isinstance(msg.content, list)
     assert len(msg.content) == 1
     block = msg.content[0]
+    assert isinstance(block, dict)
     assert "status" in block, "status field must be present in function_call block"
     assert block["status"] is None
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1684,8 +1684,74 @@ def test__construct_lc_result_from_responses_api_function_call_valid_json() -> N
             "name": "get_weather",
             "arguments": '{"location": "New York", "unit": "celsius"}',
             "call_id": "call_123",
+            "status": None,
         }
     ]
+
+
+def test__construct_lc_result_from_responses_api_function_call_preserves_status() -> (
+    None
+):
+    """Test that function_call status field is preserved (even when None).
+
+    Some OpenAI-compatible servers (e.g. vLLM serving GPT-OSS models) require
+    the "status" field to be present in function_call blocks when they are sent
+    back as conversation history. Omitting it causes "No call message found"
+    errors.  See https://github.com/langchain-ai/langchain/issues/32885
+    """
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseFunctionToolCall(
+                type="function_call",
+                id="func_123",
+                call_id="call_123",
+                name="get_weather",
+                arguments='{"location": "New York"}',
+                # status defaults to None
+            )
+        ],
+    )
+    result = _construct_lc_result_from_responses_api(response)
+    msg = cast(AIMessage, result.generations[0].message)
+    assert isinstance(msg.content, list) and len(msg.content) == 1
+    block = msg.content[0]
+    assert "status" in block, "status field must be present in function_call block"
+    assert block["status"] is None
+
+    # Verify a round-trip through _construct_responses_api_input preserves status
+    rebuilt = _construct_responses_api_input([msg])
+    assert any(
+        item.get("type") == "function_call" and "status" in item for item in rebuilt
+    ), "status field must survive round-trip through _construct_responses_api_input"
+
+
+def test__construct_responses_api_input_fallback_function_call_includes_status() -> (
+    None
+):
+    """Test that function_call blocks created from tool_calls include status."""
+    tool_calls = [
+        {
+            "id": "call_123",
+            "name": "get_weather",
+            "args": {"location": "San Francisco"},
+            "type": "tool_call",
+        }
+    ]
+    # When content is empty, function_call is reconstructed from tool_calls
+    ai_message = AIMessage(content="", tool_calls=tool_calls)
+    result = _construct_responses_api_input([ai_message])
+    fc_items = [item for item in result if item.get("type") == "function_call"]
+    assert len(fc_items) == 1
+    assert "status" in fc_items[0], (
+        "status field must be present in reconstructed function_call"
+    )
 
 
 def test__construct_lc_result_from_responses_api_function_call_invalid_json() -> None:
@@ -1809,6 +1875,7 @@ def test__construct_lc_result_from_responses_api_complex_response() -> None:
             "call_id": "call_123",
             "name": "get_weather",
             "arguments": '{"location": "New York"}',
+            "status": None,
         },
     ]
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1720,7 +1720,8 @@ def test__construct_lc_result_from_responses_api_function_call_preserves_status(
     )
     result = _construct_lc_result_from_responses_api(response)
     msg = cast(AIMessage, result.generations[0].message)
-    assert isinstance(msg.content, list) and len(msg.content) == 1
+    assert isinstance(msg.content, list)
+    assert len(msg.content) == 1
     block = msg.content[0]
     assert "status" in block, "status field must be present in function_call block"
     assert block["status"] is None


### PR DESCRIPTION
## Description

Fixes #32885

When using OpenAI-compatible servers (e.g. vLLM serving GPT-OSS models) with the Responses API, the server requires the `status` field to be present in `function_call` blocks — even when its value is `null`. Previously, `model_dump(exclude_none=True)` stripped this field, causing:

```
BadRequestError: No call message found for call_<id>
```

### Root Cause

The `_construct_lc_result_from_responses_api` function serializes `function_call` output items using `output.model_dump(exclude_none=True)`, which strips `"status": null`. When these blocks are later sent back to the API as conversation history (via `_construct_responses_api_input`), the missing `status` field causes vLLM/GPT-OSS servers to reject the request.

As [identified by @pamelafox](https://github.com/langchain-ai/langchain/issues/32885#issuecomment-3433606530):
> The issue is due to missing `"status":null`

### Changes

Three code paths are fixed to ensure `status` is always present:

1. **Non-streaming** (`_construct_lc_result_from_responses_api`): Changed `model_dump(exclude_none=True)` → `model_dump(exclude_none=False)` for `function_call` type outputs
2. **Streaming** (`_convert_responses_chunk_to_generation_chunk`): Added `"status": getattr(chunk.item, "status", None)` to the manually constructed `function_call` dict
3. **Fallback reconstruction** (`_construct_responses_api_input`): Added `"status": None` when rebuilding `function_call` from `tool_calls`

### Tests

- Updated existing test assertions to include the `"status"` field
- Added `test__construct_lc_result_from_responses_api_function_call_preserves_status`: verifies `status` is preserved (including round-trip through `_construct_responses_api_input`)
- Added `test__construct_responses_api_input_fallback_function_call_includes_status`: verifies the fallback path includes `status`
- All 21 construct-related unit tests pass

### Compatibility

This change is fully backwards-compatible with OpenAI's own API (which accepts `null` status values). It also fixes compatibility with:
- vLLM serving GPT-OSS models
- Any OpenAI-compatible server that validates the `status` field presence

### Related

- Previous fix attempt: #33450 (closed, took a broader approach changing `exclude_none` globally)
- This PR takes a targeted approach, only modifying `function_call`-specific code paths