### PR TITLE
fix(deepseek): preserve reasoning_content in multi-turn tool calling

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -267,20 +267,39 @@ class ChatDeepSeek(BaseChatOpenAI):
         **kwargs: Any,
     ) -> dict:
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
-        for message in payload["messages"]:
+
+        # Resolve original messages so we can extract reasoning_content from
+        # additional_kwargs.  The parent's payload builder does not propagate
+        # this DeepSeek-specific field.
+        messages = self._convert_input(input_).to_messages()
+
+        for i, message in enumerate(payload["messages"]):
             if message["role"] == "tool" and isinstance(message["content"], list):
                 message["content"] = json.dumps(message["content"])
-            elif message["role"] == "assistant" and isinstance(
-                message["content"], list
-            ):
-                # DeepSeek API expects assistant content to be a string, not a list.
-                # Extract text blocks and join them, or use empty string if none exist.
-                text_parts = [
-                    block.get("text", "")
-                    for block in message["content"]
-                    if isinstance(block, dict) and block.get("type") == "text"
-                ]
-                message["content"] = "".join(text_parts) if text_parts else ""
+            elif message["role"] == "assistant":
+                if isinstance(message["content"], list):
+                    # DeepSeek API expects assistant content to be a string,
+                    # not a list. Extract text blocks and join them, or use
+                    # empty string if none exist.
+                    text_parts = [
+                        block.get("text", "")
+                        for block in message["content"]
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    message["content"] = "".join(text_parts) if text_parts else ""
+
+                # DeepSeek reasoning models require every assistant message to
+                # carry a reasoning_content field (even when empty).  The value
+                # is stored in AIMessage.additional_kwargs by
+                # _create_chat_result(); re-inject it into the API payload.
+                if (
+                    "reasoning_content" not in message
+                    and i < len(messages)
+                    and isinstance(messages[i], AIMessage)
+                ):
+                    message["reasoning_content"] = messages[i].additional_kwargs.get(
+                        "reasoning_content", ""
+                    )
 
         # Azure-hosted DeepSeek does not support the dict/object form of
         # tool_choice (e.g. {"type": "function", "function": {"name": "..."}}).

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal
 from unittest.mock import MagicMock
 
-from langchain_core.messages import AIMessageChunk, ToolMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
 from openai import BaseModel
 from openai.types.chat import ChatCompletionMessage
@@ -243,6 +243,55 @@ class TestChatDeepSeekCustomUnit:
         tool_message = ToolMessage(content="test string", tool_call_id="test_id")
         payload = chat_model._get_request_payload([tool_message])
         assert payload["messages"][0]["content"] == "test string"
+
+    def test_get_request_payload_reasoning_content(self) -> None:
+        """Test that reasoning_content is preserved in assistant messages.
+
+        The DeepSeek reasoner API requires every assistant message to carry
+        a reasoning_content field (even when empty).  This verifies the
+        round-trip: _create_chat_result stores it in additional_kwargs, and
+        _get_request_payload re-injects it into the API payload.
+        """
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+
+        # Multi-turn conversation with reasoning_content in the assistant msg
+        messages = [
+            HumanMessage(content="What is 1 + 2?"),
+            AIMessage(
+                content="",
+                additional_kwargs={
+                    "reasoning_content": "Let me think... 1 + 2 = 3."
+                },
+                tool_calls=[
+                    {
+                        "id": "call_123",
+                        "name": "calculator",
+                        "args": {"a": 1, "b": 2},
+                    }
+                ],
+            ),
+            ToolMessage(content="3", tool_call_id="call_123"),
+        ]
+
+        payload = chat_model._get_request_payload(messages)
+        assistant_msg = payload["messages"][1]
+        assert assistant_msg["role"] == "assistant"
+        assert assistant_msg["reasoning_content"] == "Let me think... 1 + 2 = 3."
+
+    def test_get_request_payload_reasoning_content_empty(self) -> None:
+        """Test that a missing reasoning_content defaults to empty string."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+
+        messages = [
+            HumanMessage(content="Hi"),
+            AIMessage(content="Hello!"),
+        ]
+
+        payload = chat_model._get_request_payload(messages)
+        assistant_msg = payload["messages"][1]
+        assert assistant_msg["role"] == "assistant"
+        # When no reasoning_content was stored, default to empty string
+        assert assistant_msg["reasoning_content"] == ""
 
 
 class SampleTool(PydanticBaseModel):


### PR DESCRIPTION
## Description

Fixes #34166

When using `deepseek-reasoner` with tool calling, the DeepSeek API requires every assistant message to carry a `reasoning_content` field — even when its value is empty. Currently, `_create_chat_result()` correctly stores it in `AIMessage.additional_kwargs["reasoning_content"]`, but `_get_request_payload()` does not re-inject it when building the API payload for subsequent turns.

### Root Cause

The parent `BaseChatOpenAI._convert_message_to_dict()` does not know about the DeepSeek-specific `reasoning_content` field, so it is silently dropped. On the second API call (after tool execution), the assistant message is missing `reasoning_content`, causing:

```
BadRequestError: 400 - Missing `reasoning_content` field in the assistant message at message index 1
```

### Changes

Modified `ChatDeepSeek._get_request_payload()` to:

1. Resolve the original input messages via `self._convert_input(input_).to_messages()`
2. For each assistant message in the payload, check if the corresponding original `AIMessage` has `reasoning_content` in `additional_kwargs`
3. Re-inject it into the payload dict (defaulting to empty string if absent)

### Tests

- Added `test_get_request_payload_reasoning_content`: verifies round-trip preservation of `reasoning_content` through a multi-turn tool-calling conversation
- Added `test_get_request_payload_reasoning_content_empty`: verifies that assistant messages without `reasoning_content` get an empty string default
- All 27 unit tests pass

### Reproduction

```python
from langchain_deepseek import ChatDeepSeek
from langchain_core.messages import HumanMessage, ToolMessage
from langchain_core.tools import tool

@tool
def calculator(a: float, b: float) -> float:
    """Add two numbers."""
    return a + b

llm = ChatDeepSeek(model="deepseek-reasoner")
llm_with_tools = llm.bind_tools([calculator])

messages = [HumanMessage(content="What is 1 + 2?")]
response = llm_with_tools.invoke(messages)

messages.append(response)
messages.append(ToolMessage(content="3", tool_call_id=response.tool_calls[0]["id"]))

# Before fix: BadRequestError 400 — missing reasoning_content
# After fix: works correctly
response2 = llm_with_tools.invoke(messages)
```