### PR TITLE
fix(core): prevent output corruption in RunnableRetry.batch with return_exceptions

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -235,6 +235,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         not_set: list[Output] = []
         result = not_set
+        last_remaining_indices: list[int] = list(range(len(inputs)))
         try:
             for attempt in self._sync_retrying():
                 with attempt:
@@ -245,6 +246,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     ]
                     if not remaining_indices:
                         break
+                    last_remaining_indices = remaining_indices
                     pending_inputs = [inputs[i] for i in remaining_indices]
                     pending_configs = [config[i] for i in remaining_indices]
                     pending_run_managers = [run_manager[i] for i in remaining_indices]
@@ -279,12 +281,21 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
+        # Map remaining results back to their original indices so that
+        # successfully-retried items (already in results_map) don't
+        # corrupt the output positions of still-failed items.
+        remaining_results: dict[int, Output | Exception] = {}
+        if result is not not_set:
+            for offset, orig_idx in enumerate(last_remaining_indices):
+                if orig_idx not in results_map:
+                    remaining_results[orig_idx] = result[offset]
+
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
-            else:
-                outputs.append(result.pop(0))
+            elif idx in remaining_results:
+                outputs.append(remaining_results[idx])
         return outputs
 
     @override
@@ -311,6 +322,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         not_set: list[Output] = []
         result = not_set
+        last_remaining_indices: list[int] = list(range(len(inputs)))
         try:
             async for attempt in self._async_retrying():
                 with attempt:
@@ -321,6 +333,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     ]
                     if not remaining_indices:
                         break
+                    last_remaining_indices = remaining_indices
                     pending_inputs = [inputs[i] for i in remaining_indices]
                     pending_configs = [config[i] for i in remaining_indices]
                     pending_run_managers = [run_manager[i] for i in remaining_indices]
@@ -354,12 +367,21 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
+        # Map remaining results back to their original indices so that
+        # successfully-retried items (already in results_map) don't
+        # corrupt the output positions of still-failed items.
+        remaining_results: dict[int, Output | Exception] = {}
+        if result is not not_set:
+            for offset, orig_idx in enumerate(last_remaining_indices):
+                if orig_idx not in results_map:
+                    remaining_results[orig_idx] = result[offset]
+
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
-            else:
-                outputs.append(result.pop(0))
+            elif idx in remaining_results:
+                outputs.append(remaining_results[idx])
         return outputs
 
     @override

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3980,8 +3980,10 @@ async def test_async_retry_batch_preserves_order() -> None:
 
 
 def test_retry_batch_return_exceptions_no_corruption() -> None:
-    """Regression test: items that succeed on retry must not overwrite
-    positions of items that still fail when ``return_exceptions=True``.
+    """Regression test for retry batch output corruption.
+
+    Items that succeed on retry must not overwrite positions of items
+    that still fail when ``return_exceptions=True``.
 
     Previously, ``_batch`` used ``result.pop(0)`` to fill non-succeeded
     positions but ``result`` still contained the successful retries,
@@ -3998,9 +4000,11 @@ def test_retry_batch_return_exceptions_no_corruption() -> None:
         if name == "retry_then_ok":
             if not failed_once:
                 failed_once = True
-                raise ValueError("retry me")
+                msg = "retry me"
+                raise ValueError(msg)
             return "retry-result"
-        raise ValueError("always fail")
+        msg = "always fail"
+        raise ValueError(msg)
 
     runnable = RunnableLambda(process_item).with_retry(
         stop_after_attempt=2,
@@ -4029,9 +4033,11 @@ async def test_async_retry_batch_return_exceptions_no_corruption() -> None:
         if name == "retry_then_ok":
             if not failed_once:
                 failed_once = True
-                raise ValueError("retry me")
+                msg = "retry me"
+                raise ValueError(msg)
             return "retry-result"
-        raise ValueError("always fail")
+        msg = "always fail"
+        raise ValueError(msg)
 
     runnable = RunnableLambda(process_item).with_retry(
         stop_after_attempt=2,

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3979,6 +3979,76 @@ async def test_async_retry_batch_preserves_order() -> None:
     assert results == [0, 1, 2]
 
 
+def test_retry_batch_return_exceptions_no_corruption() -> None:
+    """Regression test: items that succeed on retry must not overwrite
+    positions of items that still fail when ``return_exceptions=True``.
+
+    Previously, ``_batch`` used ``result.pop(0)`` to fill non-succeeded
+    positions but ``result`` still contained the successful retries,
+    causing the wrong value to be placed at the failing position.
+
+    See: https://github.com/langchain-ai/langchain/issues/35475
+    """
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                raise ValueError("retry me")
+            return "retry-result"
+        raise ValueError("always fail")
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = runnable.batch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
+async def test_async_retry_batch_return_exceptions_no_corruption() -> None:
+    """Async variant of return_exceptions corruption regression test."""
+    failed_once = False
+
+    def process_item(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                raise ValueError("retry me")
+            return "retry-result"
+        raise ValueError("always fail")
+
+    runnable = RunnableLambda(process_item).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = await runnable.abatch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
 async def test_async_retrying(mocker: MockerFixture) -> None:
     def _lambda(x: int) -> int:
         if x == 1:


### PR DESCRIPTION
## Bug

`RunnableRetry.batch()` (and `.abatch()`) can return corrupted outputs when some items succeed on retry while others still fail and `return_exceptions=True` is set.

**Reported in:** #35475

### Root cause

After retries, the final assembly loop used `result.pop(0)` to fill positions of items not in `results_map`. However, `result` still contained the successfully-retried values alongside the exceptions. The pop consumed the wrong elements, replacing exceptions with stale success values.

**Walkthrough** (from the issue reproducer):

1. **Attempt 1**: batch `["ok", "retry_then_ok", "always_fail"]` → `["ok-result", ValueError, ValueError]`. `"ok-result"` saved to `results_map[0]`.
2. **Attempt 2**: batch `["retry_then_ok", "always_fail"]` → `result = ["retry-result", ValueError]`. `"retry-result"` saved to `results_map[1]`.
3. **Assembly**: for idx=2 (not in `results_map`): `result.pop(0)` → **pops `"retry-result"`** instead of the `ValueError`.

### Fix

Replace the `result.pop(0)` assembly with an index-mapped lookup. After the retry loop, `last_remaining_indices` records which original positions the last batch call corresponded to, allowing direct lookup of each position's result without the ordering bug.

### Tests

- Added `test_retry_batch_return_exceptions_no_corruption` (sync)
- Added `test_async_retry_batch_return_exceptions_no_corruption` (async)
- All 6 retry tests pass with no regressions