### PR TITLE
Fix TypeError in merge_lists when handling mixed type lists

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -118,7 +118,8 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                         i
                         for i, e_left in enumerate(merged)
                         if (
-                            "index" in e_left
+                            isinstance(e_left, dict)
+                            and "index" in e_left
                             and e_left["index"] == e["index"]  # index matches
                             and (  # IDs not inconsistent
                                 e_left.get("id") in (None, "")


### PR DESCRIPTION
Fixes #35259. Add isinstance check before accessing dict keys to prevent TypeError when merged list contains mixed types (strings and dicts).