### PR TITLE
fix(core): cancel pending tasks in abatch_as_completed on exit

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1124,8 +1124,15 @@ class Runnable(ABC, Generic[Input, Output]):
             for i, (input_, config) in enumerate(zip(inputs, configs, strict=False))
         ]
 
-        for coro in asyncio.as_completed(coros):
-            yield await coro
+        tasks = [asyncio.ensure_future(coro) for coro in coros]
+        try:
+            for fut in asyncio.as_completed(tasks):
+                yield await fut
+        finally:
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def stream(
         self,

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -5767,3 +5767,35 @@ def test_runnable_typed_dict_schema() -> None:
         repr(parallel.input_schema.model_validate({"foo": "Y", "bar": "Z"}))
         == "RunnableParallel<foo,other>Input(root={'foo': 'Y', 'bar': 'Z'})"
     )
+
+
+async def test_abatch_as_completed_cancels_pending_on_exception() -> None:
+    """Regression test: abatch_as_completed must cancel pending tasks on error.
+
+    Previously, when one task raised and the consumer stopped iterating,
+    remaining tasks continued to run in the background, wasting resources.
+
+    See: https://github.com/langchain-ai/langchain/issues/35419
+    """
+    started: list[int] = []
+    finished: list[int] = []
+
+    async def slow_invoke(x: int) -> int:
+        started.append(x)
+        if x == 0:
+            msg = "fail fast"
+            raise ValueError(msg)
+        await asyncio.sleep(5)
+        finished.append(x)
+        return x
+
+    runnable = RunnableLambda(slow_invoke)
+
+    with pytest.raises(ValueError, match="fail fast"):
+        async for _idx, _result in runnable.abatch_as_completed([0, 1, 2]):
+            pass
+
+    await asyncio.sleep(0.1)
+
+    assert 0 in started
+    assert finished == [], "Pending tasks should have been cancelled"


### PR DESCRIPTION
## Bug

`abatch_as_completed` does not cancel pending tasks when the consumer stops iterating (due to an exception, `break`, or early exit). Remaining asyncio tasks continue running in the background, wasting resources and API calls.

**Reported in:** #35419

### Root cause

The coroutines passed to `asyncio.as_completed` are wrapped in internal tasks by the event loop, but no reference to these tasks is kept. When the async generator exits (via exception or `break`), there is no cleanup logic to cancel the remaining tasks.

### Fix

- Wrap coroutines as explicit `asyncio.Task` objects via `asyncio.ensure_future`
- Add a `try/finally` block around the yield loop
- In the `finally` block, cancel all unfinished tasks and `await asyncio.gather(*tasks, return_exceptions=True)` to ensure cancellation propagates

### Testing

- Added `test_abatch_as_completed_cancels_pending_on_exception`: creates 3 tasks where task 0 raises immediately, tasks 1-2 sleep for 5s. Verifies that after the exception, the sleeping tasks were cancelled (never reached their `finished.append` line).
- All existing `abatch_as_completed` tests pass.

Fixes #35419