### PR TITLE
fix(core): prevent RuntimeError in to_json under thread concurrency

### DIFF
--- a/libs/core/langchain_core/load/serializable.py
+++ b/libs/core/langchain_core/load/serializable.py
@@ -222,7 +222,13 @@ class Serializable(BaseModel, ABC):
         secrets = {}
         # Get latest values for kwargs if there is an attribute with same name
         lc_kwargs = {}
-        for k, v in self:
+        # Take a snapshot of __dict__ to avoid RuntimeError from concurrent
+        # mutation (e.g., cached_property writes from another thread).
+        # This replicates Pydantic's __iter__ behavior without holding a
+        # live reference to the dict's items view.
+        for k, v in list(self.__dict__.items()):
+            if k.startswith("_"):
+                continue
             if not _is_field_useful(self, k, v):
                 continue
             # Do nothing if the field is excluded

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -891,3 +891,50 @@ class TestJinja2SecurityBlocking:
         # jinja2 should be blocked by default
         with pytest.raises(ValueError, match="Jinja2 templates are not allowed"):
             load(serialized_jinja2, allowed_objects=[PromptTemplate])
+
+
+def test_to_json_thread_safety() -> None:
+    """Test that to_json does not crash under concurrent __dict__ mutation.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/34887.
+    """
+    import threading
+    from concurrent.futures import ThreadPoolExecutor
+
+    prompt = ChatPromptTemplate.from_messages(
+        [("system", "You are helpful."), ("human", "{q}")]
+    )
+
+    stop = threading.Event()
+    errors: list[BaseException] = []
+    iters = 500
+
+    def serialize_worker() -> None:
+        try:
+            for _ in range(iters):
+                if stop.is_set():
+                    return
+                dumpd(prompt)
+        except BaseException as e:
+            errors.append(e)
+            stop.set()
+
+    def mutate_worker() -> None:
+        try:
+            for _ in range(iters):
+                if stop.is_set():
+                    return
+                # Force cached_property re-computation to trigger __dict__ writes
+                prompt.__dict__.pop("_serialized", None)
+                prompt.invoke({"q": "hi"})
+        except BaseException as e:
+            errors.append(e)
+            stop.set()
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        futures = [pool.submit(serialize_worker) for _ in range(2)]
+        futures += [pool.submit(mutate_worker) for _ in range(2)]
+        for f in futures:
+            f.result()
+
+    assert not errors, f"Thread-safety error: {errors[0]}"

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -1,4 +1,6 @@
 import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import pytest
@@ -898,9 +900,6 @@ def test_to_json_thread_safety() -> None:
 
     Regression test for https://github.com/langchain-ai/langchain/issues/34887.
     """
-    import threading
-    from concurrent.futures import ThreadPoolExecutor
-
     prompt = ChatPromptTemplate.from_messages(
         [("system", "You are helpful."), ("human", "{q}")]
     )


### PR DESCRIPTION
## Bug

`Serializable.to_json()` crashes with `RuntimeError: dictionary keys changed during iteration` when called concurrently with `invoke()` or other operations that trigger `cached_property` writes to `__dict__`.

**Reported in:** #34887

### Root cause

`to_json()` iterates `self` (line 225), which delegates to Pydantic's `__iter__` — yielding from `self.__dict__.items()`. This holds a **live view** on the dict. When another thread writes to `__dict__` (e.g., `cached_property` re-computation during `invoke()`), Python raises:

```
RuntimeError: dictionary keys changed during iteration
```

This occurs naturally under thread concurrency in `.batch()`, `.map()`, and LangGraph execution — no `__dict__.pop()` hack is needed in production.

### Fix

Replace `for k, v in self:` with `for k, v in list(self.__dict__.items()):` — this takes a snapshot of the dict before iterating, so concurrent writes to `__dict__` no longer cause a `RuntimeError`. Private keys (`k.startswith('_')`) are filtered to replicate Pydantic's `__iter__` behavior.

### Testing

- Added `test_to_json_thread_safety` — 4 threads (2 serializers + 2 mutators) running 500 iterations each. Previously crashed within a few iterations; now passes consistently.
- All 44 serializable tests pass
- mypy clean, ruff clean

Fixes #34887