### PR TITLE
fix(core): prevent premature tool_call parsing on empty SSE args

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -540,6 +540,12 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
 
         for chunk in self.tool_call_chunks:
             try:
+                if chunk["args"] is not None and not chunk["args"]:
+                    # Empty string args = arguments not yet received during
+                    # streaming.  Do NOT treat as valid empty-dict tool call.
+                    # The final accumulated chunk will carry the full args
+                    # string after merge_lists concatenation.
+                    continue
                 args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}
                 if isinstance(args_, dict):
                     tool_calls.append(

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -495,9 +495,7 @@ def test_sse_fragmented_tool_calls_no_premature_parse() -> None:
     chunk1 = AIMessageChunk(
         content="",
         tool_call_chunks=[
-            create_tool_call_chunk(
-                name="my_tool", args="", index=0, id="call_34db"
-            )
+            create_tool_call_chunk(name="my_tool", args="", index=0, id="call_34db")
         ],
     )
     assert chunk1.tool_calls == [], (
@@ -539,9 +537,7 @@ def test_no_arg_tool_call_still_works() -> None:
     chunk = AIMessageChunk(
         content="",
         tool_call_chunks=[
-            create_tool_call_chunk(
-                name="ping", args="{}", index=0, id="call_ping"
-            )
+            create_tool_call_chunk(name="ping", args="{}", index=0, id="call_ping")
         ],
     )
     assert len(chunk.tool_calls) == 1

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -482,6 +482,74 @@ def test_content_blocks() -> None:
     ]
 
 
+def test_sse_fragmented_tool_calls_no_premature_parse() -> None:
+    """Regression test for #35514.
+
+    OpenRouter/DeepSeek split tool_call arguments across multiple SSE chunks.
+    The first chunk carries name + id but empty args ("").  Previously this was
+    parsed as a valid tool call with ``args={}``, causing premature execution.
+    After the fix, empty-args chunks do NOT produce ``tool_calls`` entries;
+    only the final accumulated message carries the correctly parsed args.
+    """
+    # Chunk 1: name + id + empty args (first SSE fragment)
+    chunk1 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name="my_tool", args="", index=0, id="call_34db"
+            )
+        ],
+    )
+    assert chunk1.tool_calls == [], (
+        "Empty args should NOT produce a premature tool_call"
+    )
+
+    # Chunk 2-4: args fragments
+    chunk2 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(name=None, args="{", index=0, id=None)
+        ],
+    )
+    chunk3 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name=None, args='"url": "http://example.com"', index=0, id=None
+            )
+        ],
+    )
+    chunk4 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(name=None, args="}", index=0, id=None)
+        ],
+    )
+
+    # Accumulated message must have the full, correctly parsed args
+    accumulated = chunk1 + chunk2 + chunk3 + chunk4
+    assert len(accumulated.tool_calls) == 1
+    assert accumulated.tool_calls[0]["name"] == "my_tool"
+    assert accumulated.tool_calls[0]["args"] == {"url": "http://example.com"}
+    assert accumulated.tool_calls[0]["id"] == "call_34db"
+
+
+def test_no_arg_tool_call_still_works() -> None:
+    """Ensure a tool with no required params (args='{}') is still valid."""
+    chunk = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name="ping", args="{}", index=0, id="call_ping"
+            )
+        ],
+    )
+    assert len(chunk.tool_calls) == 1
+    assert chunk.tool_calls[0]["name"] == "ping"
+    assert chunk.tool_calls[0]["args"] == {}
+    assert chunk.tool_calls[0]["id"] == "call_ping"
+
+
 def test_content_blocks_reasoning_extraction() -> None:
     """Test best-effort reasoning extraction from `additional_kwargs`."""
     message = AIMessage(

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -188,7 +188,7 @@ def test_message_chunks() -> None:
             create_tool_call_chunk(name="tool1", args="", id="1", index=0)
         ],
     )
-    assert ai_msg_chunk.tool_calls == [create_tool_call(name="tool1", args={}, id="1")]
+    assert ai_msg_chunk.tool_calls == []  # empty-string args = not yet received (#35514)
 
     # Test token usage
     left = AIMessageChunk(

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -188,7 +188,8 @@ def test_message_chunks() -> None:
             create_tool_call_chunk(name="tool1", args="", id="1", index=0)
         ],
     )
-    assert ai_msg_chunk.tool_calls == []  # empty-string args = not yet received (#35514)
+    # empty-string args = not yet received (#35514)
+    assert ai_msg_chunk.tool_calls == []
 
     # Test token usage
     left = AIMessageChunk(


### PR DESCRIPTION
## Description

Fixes #35514

When streaming tool calls via SSE, some LLM providers (OpenRouter, DeepSeek) split `tool_call` arguments across multiple chunks. The first chunk carries `name` + `id` but empty args (`""`). Previously, the empty string fell through to `else {}` in `init_tool_calls`, producing a valid `tool_calls` entry with `args={}`. Downstream code (ToolNode, user streaming handlers) treated this as a complete tool call and executed the tool prematurely with empty arguments.

### Root Cause

In `AIMessageChunk.init_tool_calls()` (line 543):
```python
args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}
```

`chunk["args"]` is `""` (empty string) → falsy → `args_ = {}` → creates a valid `tool_call` with empty args.

### Fix

Skip `tool_call_chunks` whose `args` is explicitly the empty string `""`:
- **`args=""`** (empty string): streaming not started yet → **skip** (no premature tool_call)
- **`args=None`**: no args info (backward compat) → treat as `{}` (unchanged)
- **`args="{}"`** (explicit empty dict): valid no-arg tool call → parse normally (unchanged)

The final accumulated chunk (after `merge_lists` concatenation across all SSE fragments) carries the full args string and parses correctly.

### Verification

```python
# Before fix: chunk1.tool_calls = [{name: "my_tool", args: {}}]  ← WRONG
# After fix:  chunk1.tool_calls = []                              ← CORRECT

# Accumulated (chunk1 + chunk2 + chunk3 + chunk4):
# tool_calls = [{name: "my_tool", args: {"url": "http://example.com"}}]  ← CORRECT (unchanged)
```

### Tests

- Updated existing test expectation for empty-string args behavior
- Added regression test `test_sse_fragmented_tool_calls_no_premature_parse` — verifies individual chunks don't produce premature tool_calls but accumulated result is correct
- Added `test_no_arg_tool_call_still_works` — verifies tools with `args="{}"` still work
- All 1703 core unit tests pass
- All 308 OpenAI partner unit tests pass

### Issue link

Fixes #35514