### PR TITLE
fix(core): stringify empty list from tool return instead of passing as content blocks

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1292,7 +1292,9 @@ def _is_message_content_type(obj: Any) -> bool:
         `True` if the object is valid message content, `False` otherwise.
     """
     return isinstance(obj, str) or (
-        isinstance(obj, list) and all(_is_message_content_block(e) for e in obj)
+        isinstance(obj, list)
+        and bool(obj)
+        and all(_is_message_content_block(e) for e in obj)
     )
 
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2134,6 +2134,7 @@ def test__is_message_content_block(obj: Any, *, expected: bool) -> None:
         ("foo", True),
         (valid_tool_result_blocks, True),
         (invalid_tool_result_blocks, False),
+        ([], False),
     ],
 )
 def test__is_message_content_type(obj: Any, *, expected: bool) -> None:
@@ -2718,7 +2719,33 @@ def test_empty_string_tool_call_id() -> None:
     )
 
 
-def test_tool_decorator_description() -> None:
+def test_tool_returning_empty_list_is_stringified() -> None:
+    """Empty list from tool should be JSON-stringified, not passed as content blocks.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/30578
+    """
+
+    class ListTool(BaseTool):
+        name: str = "list_tool"
+        description: str = "Returns a list"
+
+        def _run(self, n: int) -> list:
+            return [{"item": str(i)} for i in range(n)]
+
+    list_tool = ListTool()
+
+    result_one = list_tool.invoke(
+        {"type": "tool_call", "args": {"n": 1}, "id": "1", "name": "list_tool"}
+    )
+    assert isinstance(result_one, ToolMessage)
+    assert result_one.content == '[{"item": "0"}]'
+
+    result_zero = list_tool.invoke(
+        {"type": "tool_call", "args": {"n": 0}, "id": "2", "name": "list_tool"}
+    )
+    assert isinstance(result_zero, ToolMessage)
+    assert result_zero.content == "[]"
+
     # test basic tool
     @tool
     def foo(x: int) -> str:


### PR DESCRIPTION
## Problem

`BaseTool` subclasses that return an empty `list` from `_run`/`_arun` get inconsistent behavior compared to non-empty lists:

```python
class MyTool(BaseTool):
    name = "my_tool"
    description = "Returns a list"

    def _run(self, n: int) -> list:
        return [{"item": str(i)} for i in range(n)]

tool = MyTool()

# Non-empty list → correctly JSON-stringified
tool.run({"n": 1}, tool_call_id="1").content  # '[{"item": "0"}]'

# Empty list → passed as raw [] (0 content blocks, not an empty list value)
tool.run({"n": 0}, tool_call_id="2").content  # []  ← BUG
```

This causes downstream failures because `[]` is interpreted as zero content blocks rather than an empty list result.

## Root Cause

`_is_message_content_type()` uses `all()` to check if every item in a list is a valid content block. For empty lists, `all([])` returns `True` (vacuous truth), so the empty list passes the content-type check and is used directly instead of being stringified.

## Fix

Add `bool(obj)` check to short-circuit on empty lists:

```python
def _is_message_content_type(obj: Any) -> bool:
    return isinstance(obj, str) or (
        isinstance(obj, list)
        and bool(obj)  # ← empty lists are not content blocks
        and all(_is_message_content_block(e) for e in obj)
    )
```

## Tests

- Extended parametrized `test__is_message_content_type` with empty list case
- Added regression test `test_tool_returning_empty_list_is_stringified` that verifies both `n=1` (non-empty → JSON string) and `n=0` (empty → `"[]"`) return consistent string content

Fixes #30578