### PR TITLE
fix(core): output parser bugs in xml.py and pydantic.py

### DIFF
--- a/libs/core/langchain_core/output_parsers/pydantic.py
+++ b/libs/core/langchain_core/output_parsers/pydantic.py
@@ -72,7 +72,7 @@ class PydanticOutputParser(JsonOutputParser, Generic[TBaseModel]):
             The parsed Pydantic object.
         """
         try:
-            json_object = super().parse_result(result)
+            json_object = super().parse_result(result, partial=partial)
             return self._parse_obj(json_object)
         except OutputParserException:
             if partial:

--- a/libs/core/langchain_core/output_parsers/xml.py
+++ b/libs/core/langchain_core/output_parsers/xml.py
@@ -63,7 +63,7 @@ class _StreamingParser:
             if not _HAS_DEFUSEDXML:
                 msg = (
                     "defusedxml is not installed. "
-                    "Please install it to use the defusedxml parser."
+                    "Please install it to use the defusedxml parser. "
                     "You can install it with `pip install defusedxml` "
                 )
                 raise ImportError(msg)
@@ -224,8 +224,8 @@ class XMLOutputParser(BaseTransformOutputParser):
             if not _HAS_DEFUSEDXML:
                 msg = (
                     "defusedxml is not installed. "
-                    "Please install it to use the defusedxml parser."
-                    "You can install it with `pip install defusedxml`"
+                    "Please install it to use the defusedxml parser. "
+                    "You can install it with `pip install defusedxml`. "
                     "See https://github.com/tiran/defusedxml for more details"
                 )
                 raise ImportError(msg)

--- a/libs/core/langchain_core/output_parsers/xml.py
+++ b/libs/core/langchain_core/output_parsers/xml.py
@@ -64,7 +64,8 @@ class _StreamingParser:
                 msg = (
                     "defusedxml is not installed. "
                     "Please install it to use the defusedxml parser. "
-                    "You can install it with `pip install defusedxml` "
+                    "You can install it with `pip install defusedxml`. "
+                    "See https://github.com/tiran/defusedxml for more details"
                 )
                 raise ImportError(msg)
             parser_ = XMLParser(target=TreeBuilder())
@@ -214,8 +215,8 @@ class XMLOutputParser(BaseTransformOutputParser):
 
         Raises:
             OutputParserException: If the XML is not well-formed.
-            ImportError: If defus`edxml is not installed and the `defusedxml` parser is
-                requested.
+            ImportError: If `defusedxml` is not installed and the `defusedxml` parser
+                is requested.
         """
         # Try to find XML string within triple backticks
         # Imports are temporarily placed here to avoid issue with caching on CI


### PR DESCRIPTION
- **Fix missing spaces in error messages in `xml.py`**: Adjacent string literals in two `ImportError` messages were missing spaces between them, resulting in concatenated words like "parser.You" and "defusedxml`See".
- **Fix `partial` parameter not forwarded in `PydanticOutputParser.parse_result`**: The `partial` parameter was accepted but not passed to `super().parse_result()`, so partial parsing mode had no effect.