### PR TITLE
fix: detect gpt-5.4+ models as Responses API models

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -535,11 +535,13 @@ def _handle_openai_api_error(e: openai.APIError) -> None:
 def _model_prefers_responses_api(model_name: str | None) -> bool:
     if not model_name:
         return False
+    # fmt: off
     return (
         "gpt-5.2-pro" in model_name
         or "gpt-5.4" in model_name
         or "codex" in model_name
     )
+    # fmt: on
 
 
 _BM = TypeVar("_BM", bound=BaseModel)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -535,7 +535,7 @@ def _handle_openai_api_error(e: openai.APIError) -> None:
 def _model_prefers_responses_api(model_name: str | None) -> bool:
     if not model_name:
         return False
-    return "gpt-5.2-pro" in model_name or "codex" in model_name
+    return "gpt-5.2-pro" in model_name or "gpt-5.4" in model_name or "codex" in model_name
 
 
 _BM = TypeVar("_BM", bound=BaseModel)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -535,7 +535,11 @@ def _handle_openai_api_error(e: openai.APIError) -> None:
 def _model_prefers_responses_api(model_name: str | None) -> bool:
     if not model_name:
         return False
-    return "gpt-5.2-pro" in model_name or "gpt-5.4" in model_name or "codex" in model_name
+    return (
+        "gpt-5.2-pro" in model_name
+        or "gpt-5.4" in model_name
+        or "codex" in model_name
+    )
 
 
 _BM = TypeVar("_BM", bound=BaseModel)


### PR DESCRIPTION
Fixes #35584

Adds gpt-5.4 to _model_prefers_responses_api detection to ensure these models use the Responses API instead of Chat Completions.

This fixes the tool_choice.function error when using gpt-5.4+ models.

/attempt #35584