### PR TITLE
fix: path traversal false positive on filenames containing ..

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -238,8 +238,10 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
         if not path.startswith("/"):
             path = "/" + path
 
-        # Check for path traversal
-        if ".." in path or "~" in path:
+        # Check for path traversal -- reject ".." or "~" as discrete path
+        # segments but allow them inside filenames (e.g. "[...nextauth].ts").
+        segments = Path(path).parts
+        if ".." in segments or "~" in segments:
             msg = "Path traversal not allowed"
             raise ValueError(msg)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -296,6 +296,55 @@ class TestPathTraversalSecurity:
         assert result == "No matches found"
         assert "secret" not in result
 
+    def test_path_with_dots_in_filename_not_blocked(self, tmp_path: Path) -> None:
+        """Test that filenames containing '..' (like [...nextauth].ts) are not blocked."""
+        # Create a Next.js-style catch-all route file
+        pages_dir = tmp_path / "pages" / "api" / "auth"
+        pages_dir.mkdir(parents=True)
+        nextauth_file = pages_dir / "[...nextauth].ts"
+        nextauth_file.write_text("export default handler\n", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(
+            pattern="*.ts", path="/pages/api/auth"
+        )
+
+        assert "[...nextauth].ts" in result
+
+    def test_path_with_dots_in_directory_name_not_blocked(self, tmp_path: Path) -> None:
+        """Test that directory names containing '..' are allowed when not a traversal."""
+        dotdir = tmp_path / "my..folder"
+        dotdir.mkdir()
+        (dotdir / "file.txt").write_text("content", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.txt", path="/my..folder")
+
+        assert "/my..folder/file.txt" in result
+
+    def test_grep_path_with_dots_in_filename(self, tmp_path: Path) -> None:
+        """Test that grep works on paths with '..' in filenames."""
+        pages_dir = tmp_path / "pages"
+        pages_dir.mkdir()
+        nextauth_file = pages_dir / "[...nextauth].ts"
+        nextauth_file.write_text("export default handler\n", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(
+            root_path=str(tmp_path), use_ripgrep=False
+        )
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+        result = middleware.grep_search.func(pattern="handler", path="/pages")
+
+        assert "[...nextauth].ts" in result
+
 
 class TestExpandIncludePatterns:
     """Tests for _expand_include_patterns helper function."""


### PR DESCRIPTION
## Description

Fixes #34961

`FilesystemFileSearchMiddleware._validate_and_resolve_path()` checks for path traversal using `".." in path`, which is a **substring** match. This incorrectly rejects any path where `..` appears anywhere in the string — including legitimate filenames like Next.js catch-all routes (`[...nextauth].ts`).

## Fix

Replace the substring check with a `Path(path).parts` membership check so that `..` is only rejected when it appears as a **discrete path segment** (i.e., actual directory traversal like `/../` or `/foo/../bar`), not when it appears inside a filename.

Before:
```python
if ".." in path or "~" in path:
```

After:
```python
segments = Path(path).parts
if ".." in segments or "~" in segments:
```

The same fix is applied to the `~` check for consistency.

Security is maintained by three layers of defense:
1. **Segment check** (this fix) — rejects `..` and `~` as path segments
2. **`Path.resolve()`** — canonicalizes the path, collapsing any `..` segments
3. **`relative_to()` containment check** — ensures the resolved path is within the root directory

## Tests

Added 3 tests to `TestPathTraversalSecurity`:
- `test_path_with_dots_in_filename_not_blocked` — `[...nextauth].ts` glob works
- `test_path_with_dots_in_directory_name_not_blocked` — `my..folder` directory works
- `test_grep_path_with_dots_in_filename` — grep on `[...nextauth].ts` works

All existing path traversal security tests continue to pass since `/../`, `~/`, etc. contain `..`/`~` as discrete path segments.