### PR TITLE
fix(core): add ChatBedrockConverse to SERIALIZABLE_MAPPING

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -316,6 +316,12 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "bedrock",
         "ChatBedrock",
     ),
+    ("langchain_aws", "chat_models", "ChatBedrockConverse"): (
+        "langchain_aws",
+        "chat_models",
+        "bedrock_converse",
+        "ChatBedrockConverse",
+    ),
     ("langchain_google_genai", "chat_models", "ChatGoogleGenerativeAI"): (
         "langchain_google_genai",
         "chat_models",


### PR DESCRIPTION
## Summary

Fixes #34645.

`ChatBedrockConverse` is missing from `SERIALIZABLE_MAPPING` in `langchain_core/load/mapping.py`. This causes `langsmith.pull_prompt(..., include_model=True)` to fail with a `ValueError` when the prompt includes a `ChatBedrockConverse` model, since `langchain-core>=1.2.5` tightened the deserialization allowlist (PR #34455).

`ChatBedrock` and `BedrockLLM` were already in the mapping — `ChatBedrockConverse` was simply missed.

## Fix

One entry added to `SERIALIZABLE_MAPPING`:

```python
("langchain_aws", "chat_models", "ChatBedrockConverse"): (
    "langchain_aws",
    "chat_models",
    "bedrock_converse",
    "ChatBedrockConverse",
),
```

The serialization key `("langchain_aws", "chat_models", "ChatBedrockConverse")` matches `ChatBedrockConverse.get_lc_namespace()` + class name, confirmed against the [source in langchain-aws](https://github.com/langchain-ai/langchain-aws/blob/main/libs/aws/langchain_aws/chat_models/bedrock_converse.py).

> **AI disclaimer:** This PR was authored by Claude Opus 4.6 (an AI). See https://maxcalkin.com for context.