### PR TITLE
fix: use compact JSON for tool_use blocks in count_tokens_approximately

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2276,9 +2276,13 @@ def count_tokens_approximately(
                     elif block_type == "text":
                         text = block.get("text", "")
                         message_chars += len(text)
-                    # Conservative estimate for unknown block types
+                    # Use compact JSON for structured blocks (tool_use,
+                    # tool_result, etc.) to avoid repr() inflation that
+                    # causes ~2.4x overcounting of tool call tokens.
                     else:
-                        message_chars += len(repr(block))
+                        message_chars += len(
+                            json.dumps(block, separators=(",", ":"))
+                        )
                 else:
                     # Fallback for unexpected block types
                     message_chars += len(repr(block))


### PR DESCRIPTION
## Summary

Fixes #35558

`count_tokens_approximately()` uses `repr()` as a fallback for unknown content block types. For `tool_use` and `tool_result` blocks (Anthropic format), `repr()` produces Python dict representation with single quotes and verbose formatting, causing ~2.4x overcounting compared to actual token usage.

This change switches the fallback to `json.dumps()` with compact separators, which produces output much closer to what LLM APIs actually tokenize.

## Impact

In production, the `repr()` overcounting compounded with tiktoken approximation to cause **4.6x overcounting** for conversations with tool calls, leading to premature context summarization at only ~40% of actual token budget utilization.

## Test plan

- [ ] Verify `count_tokens_approximately` produces more accurate counts for messages with `tool_use` blocks
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)