### PR TITLE
fix(langchain): normalize custom detector output to prevent KeyError in hash/mask strategies

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_redaction.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_redaction.py
@@ -373,7 +373,25 @@ def resolve_detector(pii_type: str, detector: Detector | str | None) -> Detector
             ]
 
         return regex_detector
-    return detector
+
+    # Wrap the custom callable to normalize its output.
+    # Custom detectors may return dicts with "text" instead of "value"
+    # and may omit "type".  Map them to proper PIIMatch objects so that
+    # downstream strategies (hash, mask) can access match["value"].
+    raw_detector = detector
+
+    def _normalizing_detector(content: str) -> list[PIIMatch]:
+        return [
+            PIIMatch(
+                type=m.get("type", pii_type),
+                value=m.get("value", m.get("text", "")),
+                start=m["start"],
+                end=m["end"],
+            )
+            for m in raw_detector(content)
+        ]
+
+    return _normalizing_detector
 
 
 @dataclass(frozen=True)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -557,6 +557,59 @@ class TestCustomDetector:
         assert result is not None
         assert "[REDACTED_CONFIDENTIAL]" in result["messages"][0].content
 
+    def test_custom_callable_detector_with_text_key_hash(self) -> None:
+        """Custom detectors returning 'text' instead of 'value' must work with hash strategy.
+
+        Regression test for https://github.com/langchain-ai/langchain/issues/35647:
+        Custom detectors documented to return {"text", "start", "end"} caused
+        KeyError: 'value' when used with hash or mask strategies.
+        """
+        import re
+
+        def detect_phone(content: str) -> list[dict]:  # type: ignore[type-arg]
+            return [
+                {"text": m.group(), "start": m.start(), "end": m.end()}
+                for m in re.finditer(r"\+91[\s.-]?\d{10}", content)
+            ]
+
+        middleware = PIIMiddleware(
+            "indian_phone",
+            detector=detect_phone,
+            strategy="hash",
+            apply_to_input=True,
+        )
+
+        state = AgentState[Any](messages=[HumanMessage("Call +91 9876543210")])
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        assert "<indian_phone_hash:" in result["messages"][0].content
+        assert "+91 9876543210" not in result["messages"][0].content
+
+    def test_custom_callable_detector_with_text_key_mask(self) -> None:
+        """Custom detectors returning 'text' instead of 'value' must work with mask strategy."""
+        import re
+
+        def detect_phone(content: str) -> list[dict]:  # type: ignore[type-arg]
+            return [
+                {"text": m.group(), "start": m.start(), "end": m.end()}
+                for m in re.finditer(r"\+91[\s.-]?\d{10}", content)
+            ]
+
+        middleware = PIIMiddleware(
+            "indian_phone",
+            detector=detect_phone,
+            strategy="mask",
+            apply_to_input=True,
+        )
+
+        state = AgentState[Any](messages=[HumanMessage("Call +91 9876543210")])
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        assert "****" in result["messages"][0].content
+        assert "+91 9876543210" not in result["messages"][0].content
+
     def test_unknown_builtin_type_raises_error(self) -> None:
         with pytest.raises(ValueError, match="Unknown PII type"):
             PIIMiddleware("unknown_type", strategy="redact")

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -1,5 +1,6 @@
 """Tests for PII detection middleware."""
 
+import re
 from typing import Any
 
 import pytest
@@ -564,7 +565,6 @@ class TestCustomDetector:
         Custom detectors documented to return {"text", "start", "end"} caused
         KeyError: 'value' when used with hash or mask strategies.
         """
-        import re
 
         def detect_phone(content: str) -> list[dict]:  # type: ignore[type-arg]
             return [
@@ -588,7 +588,6 @@ class TestCustomDetector:
 
     def test_custom_callable_detector_with_text_key_mask(self) -> None:
         """Custom detectors returning 'text' instead of 'value' must work with mask strategy."""
-        import re
 
         def detect_phone(content: str) -> list[dict]:  # type: ignore[type-arg]
             return [


### PR DESCRIPTION
## Summary

Fixes #35647 — `PIIMiddleware` raises `KeyError: 'value'` when using a custom callable detector with `hash` or `mask` strategies.

## Root Cause

Custom callable detectors may return dicts with `"text"` instead of `"value"` (as shown in the [documentation examples](https://python.langchain.com/docs/concepts/middleware/#pii-detection)):

```python
def detector(content: str) -> list[dict]:
    return [{"text": "matched", "start": 0, "end": 7}]
```

Built-in and regex detectors produce proper `PIIMatch` objects with `type`, `value`, `start`, `end`. But custom callables are returned as-is from `resolve_detector()`. When `_apply_hash_strategy` or `_apply_mask_strategy` access `match["value"]`, they fail with `KeyError`.

The `redact` and `block` strategies only use `match["type"]`, `match["start"]`, and `match["end"]` — which is why they work.

## Fix

In `resolve_detector()`, wrap custom callable detectors in a normalizing function that:
- Maps `"text"` → `"value"` if `"value"` is missing
- Adds the `pii_type` as `"type"` if missing
- Produces proper `PIIMatch` objects for all downstream strategies

This is consistent with how regex string detectors are already wrapped (lines 362-375).

## Tests

All 53 tests pass (51 existing + 2 new):
- `test_custom_callable_detector_with_text_key_hash` — verifies hash strategy works with `text`-only dicts
- `test_custom_callable_detector_with_text_key_mask` — verifies mask strategy works with `text`-only dicts

## Changes

| File | Change |
|------|--------|
| `libs/langchain_v1/langchain/agents/middleware/_redaction.py` | Wrap custom callable in normalizing detector |
| `libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py` | 2 new regression tests |
