### PR TITLE
fix: handle custom PII detectors returning 'text' instead of 'value'

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_redaction.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_redaction.py
@@ -336,6 +336,21 @@ def apply_strategy(
     raise ValueError(msg)
 
 
+def _normalize_match(match: dict, pii_type: str) -> PIIMatch:  # type: ignore[type-arg]
+    """Normalize a detector match dict into a PIIMatch.
+
+    Custom detectors may return dicts with ``text`` instead of ``value``
+    and may omit ``type``.  This helper ensures all required keys are
+    present so downstream strategy functions don't raise ``KeyError``.
+    """
+    return PIIMatch(
+        type=match.get("type", pii_type),
+        value=match.get("value") or match.get("text", ""),
+        start=match["start"],
+        end=match["end"],
+    )
+
+
 def resolve_detector(pii_type: str, detector: Detector | str | None) -> Detector:
     """Return a callable detector for the given configuration.
 
@@ -373,7 +388,17 @@ def resolve_detector(pii_type: str, detector: Detector | str | None) -> Detector
             ]
 
         return regex_detector
-    return detector
+
+    # Wrap custom callable detectors so their output is normalized.
+    # This allows detectors that return dicts with "text" instead of
+    # "value" (or that omit "type") to work without raising KeyError.
+    raw_detector = detector
+
+    def normalizing_detector(content: str) -> list[PIIMatch]:
+        raw_matches = raw_detector(content)
+        return [_normalize_match(m, pii_type) for m in raw_matches]
+
+    return normalizing_detector
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

Fixes #35647

Custom PII detectors may return match dicts with `text` instead of `value` (following common regex match conventions) and may omit the `type` key. This causes `KeyError: 'value'` when `hash` and `mask` strategies try to access `match['value']`.

## Changes

Added a `_normalize_match()` helper in `_redaction.py` that:
- Accepts `text` as an alias for `value`
- Auto-populates `type` from the configured `pii_type` if missing
- Wraps custom callable detectors with normalization on output

Built-in detectors already return properly-typed `PIIMatch` dicts, so this only affects custom detectors.

## Reproduction

```python
def detect_phone(content: str) -> list[dict]:
    matches = []
    for match in re.finditer(r'\+91[\s.-]?[6-9]\d{9}', content):
        matches.append({
            "text": match.group(0),  # "text" not "value"
            "start": match.start(),
            "end": match.end(),
        })
    return matches

# Before fix: KeyError: 'value'
# After fix: works correctly
PIIMiddleware("phone", detector=detect_phone, strategy="hash")
```

## Test plan

- [ ] Verify custom detectors with `text` key work with all strategies
- [ ] Verify built-in detectors still work unchanged
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)