### PR TITLE
core: fix merge_lists crash when merged list contains non-dict elements

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -118,7 +118,8 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                         i
                         for i, e_left in enumerate(merged)
                         if (
-                            "index" in e_left
+                            isinstance(e_left, dict)
+                            and "index" in e_left
                             and e_left["index"] == e["index"]  # index matches
                             and (  # IDs not inconsistent
                                 e_left.get("id") in (None, "")


### PR DESCRIPTION
## Description

Fixes a bug in `merge_lists()` where iterating over `merged` to find elements with a matching `"index"` key assumes all elements are dicts. However, `merged` can contain non-dict elements (strings, ints, etc.):

- Using `"index" in e_left` on a **string** checks for substring membership (unexpected behavior)
- Using `"index" in e_left` on an **int** raises `TypeError: argument of type 'int' is not iterable`

This adds an `isinstance(e_left, dict)` guard before the `"index" in e_left` check to prevent both cases.

Related: #35259

## Issue

Prevents `TypeError` and unexpected substring matching when non-dict items exist in merged lists during tool call chunk aggregation.

## Dependencies

None.