### PR TITLE
core: fix trim_messages token_counter detection for lambdas and postponed annotations

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1076,6 +1076,57 @@ def merge_message_runs(
     return merged
 
 
+def _is_per_message_counter(fn: Callable) -> bool:
+    """Detect whether *fn* is a per-message ``(BaseMessage) -> int`` counter.
+
+    The previous heuristic used ``annotation is BaseMessage`` (identity check),
+    which fails for lambdas, un-annotated functions, string annotations,
+    subclass annotations, and postponed annotations
+    (``from __future__ import annotations``).
+
+    This implementation resolves annotations via :func:`typing.get_type_hints`
+    and falls back to inspecting the raw annotation when that is not possible
+    (e.g. for lambdas).  If the first parameter's resolved type is
+    ``BaseMessage`` or a subclass thereof the function is treated as a
+    per-message counter.
+    """
+    try:
+        params = list(inspect.signature(fn).parameters.values())
+    except (ValueError, TypeError):
+        return False
+    if not params:
+        return False
+    first = params[0]
+
+    # Try to resolve annotations (handles string annotations and
+    # ``from __future__ import annotations``).
+    try:
+        from typing import get_type_hints  # noqa: PLC0415
+
+        hints = get_type_hints(fn)
+        if hints:
+            first_type = next(iter(hints.values()))
+            return isinstance(first_type, type) and issubclass(
+                first_type, BaseMessage
+            )
+    except Exception:
+        pass
+
+    # Fall back to raw annotation for cases where get_type_hints fails
+    # (e.g. lambdas, some built-ins).
+    ann = first.annotation
+    if ann is inspect.Parameter.empty:
+        # No annotation at all — probe by calling with a dummy message.
+        # A per-message counter will return an int; a list counter will
+        # typically raise (e.g. ``len`` receives a BaseMessage).
+        try:
+            probe = fn(HumanMessage(content="x"))
+            return isinstance(probe, (int, float))
+        except Exception:
+            return False
+    return isinstance(ann, type) and issubclass(ann, BaseMessage)
+
+
 # TODO: Update so validation errors (for token_counter, for example) are raised on
 # init not at runtime.
 @_runnable_support
@@ -1417,12 +1468,7 @@ def trim_messages(
     if hasattr(actual_token_counter, "get_num_tokens_from_messages"):
         list_token_counter = actual_token_counter.get_num_tokens_from_messages
     elif callable(actual_token_counter):
-        if (
-            next(
-                iter(inspect.signature(actual_token_counter).parameters.values())
-            ).annotation
-            is BaseMessage
-        ):
+        if _is_per_message_counter(actual_token_counter):
 
             def list_token_counter(messages: Sequence[BaseMessage]) -> int:
                 return sum(actual_token_counter(msg) for msg in messages)  # type: ignore[arg-type, misc]


### PR DESCRIPTION
## Description

Fixes a bug where `trim_messages` misclassifies per-message `token_counter` callables as per-list counters, causing `AttributeError: 'list' object has no attribute 'content'` at runtime.

### Root cause

The detection logic used `annotation is BaseMessage` (identity check) to determine if `token_counter` accepts a single `BaseMessage` or a list. This fails for:

- **Lambdas** — no annotation available
- **Unannotated functions** — annotation is `inspect.Parameter.empty`
- **String annotations** — annotation is a string like `"BaseMessage"`, not the class
- **Subclass annotations** — e.g. `msg: HumanMessage` — `HumanMessage is not BaseMessage`
- **Postponed annotations** — `from __future__ import annotations` turns all annotations into strings

### Fix

Added a `_is_per_message_counter()` helper that:
1. Uses `typing.get_type_hints()` to resolve string and postponed annotations
2. Uses `issubclass()` instead of identity to handle subclass annotations
3. Falls back to probing with a dummy message for lambdas and unannotated callables

### Before

```python
# All of these fail with AttributeError
trim_messages(messages, max_tokens=5, token_counter=lambda msg: len(msg.content.split()))
trim_messages(messages, max_tokens=5, token_counter=counter_no_annotation)
trim_messages(messages, max_tokens=5, token_counter=counter_with_subclass_annotation)
```

### After

All forms work correctly, including `len` as a list counter.

## Issue

Fixes #35629

## Tests

Verified with the reproduction script from the issue — all five cases now pass. List counters (`len`, annotated list functions) continue to work correctly.