### PR TITLE
fix(core): fix double backticks in deprecation docstring for alternative_import

### DIFF
--- a/libs/core/langchain_core/_api/deprecation.py
+++ b/libs/core/langchain_core/_api/deprecation.py
@@ -399,7 +399,7 @@ def deprecated(
         components = [
             _message,
             f"Use {_alternative} instead." if _alternative else "",
-            f"Use `{_alternative_import}` instead." if _alternative_import else "",
+            f"Use {_alternative_import} instead." if _alternative_import else "",
             _addendum,
         ]
         details = " ".join([component.strip() for component in components if component])


### PR DESCRIPTION
## Description

Fixes a rendering bug in the `@deprecated` decorator where `alternative_import` paths get wrapped in double backticks in the deprecation docstring.

### Root cause

In `deprecation.py`, line 397 wraps `_alternative_import` in backticks:
```python
_alternative_import = f"`{_alternative_import}`"
```

Then line 402 wraps it again when building the docstring component:
```python
f"Use `{_alternative_import}` instead."
```

This produces `Use ``langchain.foo.Bar`` instead.` (double backticks) in the docstring, which renders incorrectly in documentation and IDEs.

### Fix

Remove the redundant backticks from line 402 since the value is already backtick-wrapped.

### Before
```
Use ``langchain_foo.bar.NewClass`` instead.
```

### After
```
Use `langchain_foo.bar.NewClass` instead.
```