### PR TITLE
core: preserve default_factory in tool call schema so fields are not incorrectly required

### DIFF
--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -242,7 +242,12 @@ def _create_subset_model_v2(
     for field_name in field_names:
         field = model.model_fields[field_name]
         description = descriptions_.get(field_name, field.description)
-        field_info = FieldInfoV2(description=description, default=field.default)
+        field_kwargs: dict[str, Any] = {"description": description}
+        if field.default_factory is not None:
+            field_kwargs["default_factory"] = field.default_factory
+        else:
+            field_kwargs["default"] = field.default
+        field_info = FieldInfoV2(**field_kwargs)
         if field.metadata:
             field_info.metadata = field.metadata
         fields[field_name] = (field.annotation, field_info)


### PR DESCRIPTION
## Description

Fixes a bug where tool schema fields defined with `default_factory` (e.g. `Field(default_factory=list)`) are incorrectly marked as `required` in the generated OpenAI function/tool schema.

### Root cause

In `_create_subset_model_v2` (`libs/core/langchain_core/utils/pydantic.py`), the subset model's `FieldInfo` is created with only `default=field.default`:

```python
field_info = FieldInfoV2(description=description, default=field.default)
```

When a field uses `default_factory`, `field.default` is `PydanticUndefined`, so the new field has no default value and appears as required in the schema.

### Fix

Check for `default_factory` first and pass it through to the new `FieldInfo`. Only fall back to `default` when no factory is set.

### Before
```json
{
  "required": ["names"],  // names has default_factory=list, should NOT be required
  ...
}
```

### After
```json
{
  "required": ["required_arg"],  // only truly required fields
  ...
}
```

## Issue

Fixes #35547

## Tests

Verified with reproduction script from the issue.