### PR TITLE
core: fix RunnableWithFallbacks.stream missing config propagation

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -496,6 +496,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     stream = context.run(
                         runnable.stream,
                         input,
+                        child_config,
                         **kwargs,
                     )
                     chunk: Output = context.run(next, stream)


### PR DESCRIPTION
## Description

`RunnableWithFallbacks.stream()` was not passing the `child_config` to `runnable.stream()`, causing callbacks and tracing to silently not work during synchronous streaming with fallbacks.

The `invoke()`, `ainvoke()`, and `astream()` methods all correctly propagate the child config, but `stream()` was missing it:

**Before (broken):**
```python
stream = context.run(
    runnable.stream,
    input,
    **kwargs,
)
```

**After (fixed):**
```python
stream = context.run(
    runnable.stream,
    input,
    child_config,
    **kwargs,
)
```

This is a one-line fix to match the behavior of `astream()` which correctly passes `child_config` at line 562.

## Issue

No issue filed, found by code review comparing `stream()` vs `astream()` implementations.

## Dependencies

None.