### PR TITLE
core: fix _parse_google_docstring mishandling continuation lines with colons

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -781,8 +781,24 @@ def _parse_google_docstring(
     arg_descriptions = {}
     if args_block:
         arg = None
+        # Detect the base indentation level from the first argument line
+        # to distinguish argument definitions from continuation lines.
+        arg_indent: int | None = None
         for line in args_block.split("\n")[1:]:
-            if ":" in line:
+            if not line.strip():
+                continue
+            current_indent = len(line) - len(line.lstrip())
+            if arg_indent is None and ":" in line:
+                # First argument line establishes the base indentation
+                arg_indent = current_indent
+            is_continuation = (
+                arg is not None
+                and arg_indent is not None
+                and current_indent > arg_indent
+            )
+            if is_continuation:
+                arg_descriptions[arg] += " " + line.strip()
+            elif ":" in line:
                 arg, desc = line.split(":", maxsplit=1)
                 arg = arg.strip()
                 arg_name, _, annotations_ = arg.partition(" ")


### PR DESCRIPTION
## Description

`_parse_google_docstring` incorrectly parses multi-line argument descriptions when a continuation line contains a colon. The continuation line is treated as a new argument definition instead of being appended to the current argument's description.

### Example

```python
def search(query: str, top_k: int = 5) -> str:
    """Search the knowledge base.

    Args:
        query: The search query to use
            for finding things: important ones
        top_k: Number of results to return
    """
```

**Before (broken):** The parser creates 3 args: `query`, `for finding things`, `top_k`
**After (fixed):** The parser correctly creates 2 args: `query` (with full description including "for finding things: important ones"), `top_k`

### Root Cause

The parser used `if ":" in line` to detect new argument lines without considering indentation. In Google-style docstrings, continuation lines have deeper indentation than argument definition lines.

### Fix

Detect the base indentation level from the first argument line and treat any line with deeper indentation as a continuation line, regardless of whether it contains a colon.

## Issue

Related to #34292

## Dependencies

None.