### PR TITLE
langchain: fix KeyError on custom PII detector with hash/mask strategies

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_redaction.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_redaction.py
@@ -373,7 +373,19 @@ def resolve_detector(pii_type: str, detector: Detector | str | None) -> Detector
             ]
 
         return regex_detector
-    return detector
+    def wrapped_detector(content: str) -> list[PIIMatch]:
+        raw_matches = detector(content)
+        return [
+            PIIMatch(
+                type=match.get("type", pii_type),
+                value=match.get("value", match.get("text", "")),
+                start=match["start"],
+                end=match["end"],
+            )
+            for match in raw_matches
+        ]
+
+    return wrapped_detector
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

Fixes #35647

When a custom detector callable is provided to `PIIMiddleware`, it returns dicts with `"text"`, `"start"`, and `"end"` keys per the [documented API](https://python.langchain.com/docs/concepts/middleware/#pii-detection). However, `_apply_hash_strategy` and `_apply_mask_strategy` access `match["value"]`, which doesn't exist in the custom detector's output, causing `KeyError: 'value'`.

The `"redact"` and `"block"` strategies happen to work because they only access `match["type"]`, `match["start"]`, and `match["end"]` — never `match["value"]`.

## Root Cause

In `resolve_detector()`, when the detector is a callable (not `None` and not a `str` regex), it's returned directly without normalization:

```python
# line 376
return detector
```

Built-in detectors and regex detectors always produce proper `PIIMatch` dicts with `value` key, but custom callables return `{"text": ..., "start": ..., "end": ...}` per the docs.

## Fix

Wrap the custom callable to normalize its output into proper `PIIMatch` TypedDicts:

- `match.get("value", match.get("text", ""))` — accepts both `value` and `text` keys for backwards compatibility
- `match.get("type", pii_type)` — defaults the type to the configured `pii_type` if not provided

This is consistent with how `regex_detector` already normalizes regex match objects into `PIIMatch` dicts in the same function.

## Test Plan

- Custom detector with `"text"` key works with all four strategies (block, redact, mask, hash)
- Custom detector with `"value"` key still works (backwards compatible)
- Built-in detectors and regex string detectors are unaffected (different code paths)

---

*This PR was authored by Claude, Anthropic's AI assistant, as part of an effort to contribute meaningfully to open-source projects. More context: https://x.com/MaxwellCalkin/status/1898441007704731844*