### PR TITLE
core: fix trim_messages token_counter detection for lambdas, subclasses, and string annotations

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1076,6 +1076,72 @@ def merge_message_runs(
     return merged
 
 
+def _is_per_message_token_counter(fn: Callable) -> bool:
+    """Detect whether a callable token counter operates on individual messages.
+
+    Returns ``True`` if *fn* is a **per-message** counter (takes a single
+    :class:`BaseMessage`), ``False`` if it is a **per-list** counter (takes a
+    list of messages).
+
+    The previous implementation used an identity check
+    (``annotation is BaseMessage``) which failed for lambdas, un-annotated
+    functions, string annotations, ``BaseMessage`` sub-class annotations, and
+    postponed annotations (``from __future__ import annotations``).
+
+    The new implementation handles these cases with a three-tier strategy:
+
+    1. **Class annotation** – ``issubclass`` instead of ``is``.
+    2. **String annotation** – match against known message class names.
+    3. **No annotation** – probe by calling the function with a single dummy
+       message and catching ``TypeError`` / ``AttributeError``.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (ValueError, TypeError):
+        return False
+
+    params = list(sig.parameters.values())
+    if not params:
+        return False
+
+    annotation = params[0].annotation
+
+    # 1. Class annotation: use issubclass to handle BaseMessage sub-classes.
+    if isinstance(annotation, type) and issubclass(annotation, BaseMessage):
+        return True
+
+    # 2. String annotation: covers `from __future__ import annotations` and
+    #    explicit `"BaseMessage"` / `"HumanMessage"` etc.
+    if isinstance(annotation, str):
+        _message_class_names = {
+            cls.__name__
+            for cls in (
+                BaseMessage,
+                HumanMessage,
+                AIMessage,
+                SystemMessage,
+                ChatMessage,
+                FunctionMessage,
+                ToolMessage,
+            )
+        }
+        return annotation in _message_class_names
+
+    # 3. No annotation (lambdas, un-annotated functions): probe by calling with
+    #    a single dummy message.  Built-in list-level callables like ``len``
+    #    will raise ``TypeError`` here because ``BaseMessage`` has no
+    #    ``__len__``; list-iterating counters will raise ``TypeError`` because
+    #    ``BaseMessage`` is not iterable.
+    if annotation is inspect.Parameter.empty:
+        try:
+            fn(HumanMessage(content="a"))
+            return True
+        except (TypeError, AttributeError):
+            return False
+
+    return False
+
+
 # TODO: Update so validation errors (for token_counter, for example) are raised on
 # init not at runtime.
 @_runnable_support
@@ -1417,12 +1483,7 @@ def trim_messages(
     if hasattr(actual_token_counter, "get_num_tokens_from_messages"):
         list_token_counter = actual_token_counter.get_num_tokens_from_messages
     elif callable(actual_token_counter):
-        if (
-            next(
-                iter(inspect.signature(actual_token_counter).parameters.values())
-            ).annotation
-            is BaseMessage
-        ):
+        if _is_per_message_token_counter(actual_token_counter):
 
             def list_token_counter(messages: Sequence[BaseMessage]) -> int:
                 return sum(actual_token_counter(msg) for msg in messages)  # type: ignore[arg-type, misc]

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2958,3 +2958,81 @@ def test_count_tokens_approximately_with_tools() -> None:
     # Test with empty tools list should equal base count
     count_empty_tools = count_tokens_approximately(messages, tools=[])
     assert count_empty_tools == base_count
+
+
+# --- Tests for per-message token_counter detection (issue #35629) ---
+
+_PER_MSG_TRIM_INPUT = [
+    HumanMessage("What is 2 + 2?"),
+    AIMessage("It is 4."),
+    HumanMessage("What about 3 + 3?"),
+]
+
+
+def test_trim_messages_lambda_token_counter() -> None:
+    """Lambda per-message counters have no annotation and should be detected."""
+    result = trim_messages(
+        _PER_MSG_TRIM_INPUT,
+        max_tokens=5,
+        token_counter=lambda msg: len(msg.content.split()),
+        strategy="last",
+    )
+    # "What about 3 + 3?" = 5 tokens, fits exactly
+    assert result == [HumanMessage("What about 3 + 3?")]
+
+
+def test_trim_messages_unannotated_token_counter() -> None:
+    """Un-annotated per-message counters should be detected via probing."""
+
+    def counter_no_annotation(msg):  # noqa: ANN001
+        return len(msg.content.split())
+
+    result = trim_messages(
+        _PER_MSG_TRIM_INPUT,
+        max_tokens=5,
+        token_counter=counter_no_annotation,
+        strategy="last",
+    )
+    assert result == [HumanMessage("What about 3 + 3?")]
+
+
+def test_trim_messages_string_annotation_token_counter() -> None:
+    """String-annotated per-message counters should be detected."""
+
+    def counter_string(msg: "BaseMessage") -> int:  # noqa: UP037
+        return len(msg.content.split())
+
+    result = trim_messages(
+        _PER_MSG_TRIM_INPUT,
+        max_tokens=5,
+        token_counter=counter_string,
+        strategy="last",
+    )
+    assert result == [HumanMessage("What about 3 + 3?")]
+
+
+def test_trim_messages_subclass_annotation_token_counter() -> None:
+    """Counters annotated with a BaseMessage subclass should be detected."""
+
+    def counter_subclass(msg: HumanMessage) -> int:
+        return len(msg.content.split())
+
+    result = trim_messages(
+        _PER_MSG_TRIM_INPUT,
+        max_tokens=5,
+        token_counter=counter_subclass,
+        strategy="last",
+    )
+    assert result == [HumanMessage("What about 3 + 3?")]
+
+
+def test_trim_messages_list_counter_len_still_works() -> None:
+    """Built-in ``len`` (per-list counter) must not be misclassified."""
+    result = trim_messages(
+        _PER_MSG_TRIM_INPUT,
+        max_tokens=2,
+        token_counter=len,
+        strategy="last",
+    )
+    # len counts messages, not tokens — last 2 messages
+    assert result == [AIMessage("It is 4."), HumanMessage("What about 3 + 3?")]


### PR DESCRIPTION
## Description

Fixes #35629

`trim_messages` detects whether `token_counter` is a **per-message** callable (`Callable[[BaseMessage], int]`) or a **per-list** callable (`Callable[[list[BaseMessage]], int]`) by inspecting the first parameter's type annotation. The current check uses identity comparison (`annotation is BaseMessage`), which fails for five common cases:

| Case | Annotation value | `is BaseMessage` |
|---|---|---|
| Lambda | `inspect.Parameter.empty` | `False` |
| Un-annotated function | `inspect.Parameter.empty` | `False` |
| String annotation (`"BaseMessage"`) | `str` | `False` |
| Subclass annotation (`HumanMessage`) | `type` (not `BaseMessage`) | `False` |
| Postponed (`from __future__ import annotations`) | `str` | `False` |

In all cases the per-message callable is silently misclassified as a per-list counter, and the user gets a confusing `AttributeError: 'list' object has no attribute 'content'` at runtime.

## Fix

Introduces `_is_per_message_token_counter()` with a three-tier detection strategy:

1. **Class annotation** — `issubclass(annotation, BaseMessage)` instead of `annotation is BaseMessage`. Handles subclass annotations like `HumanMessage`.
2. **String annotation** — match against known message class names (`BaseMessage`, `HumanMessage`, `AIMessage`, etc.). Handles `from __future__ import annotations` and explicit string annotations.
3. **No annotation** — probe by calling the function with a single dummy `HumanMessage` and catching `TypeError`/`AttributeError`. Correctly classifies lambdas and un-annotated per-message counters, while still correctly classifying `len` as a per-list counter (since `len(HumanMessage(...))` raises `TypeError`).

## Tests

Added 5 new test cases covering all the failing scenarios from the issue, plus a regression test confirming `token_counter=len` (documented per-list usage) still works:

- `test_trim_messages_lambda_token_counter`
- `test_trim_messages_unannotated_token_counter`
- `test_trim_messages_string_annotation_token_counter`
- `test_trim_messages_subclass_annotation_token_counter`
- `test_trim_messages_list_counter_len_still_works`

## Reproducer (from issue)

```python
from __future__ import annotations
from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
from langchain_core.messages.utils import trim_messages

messages = [
    HumanMessage("What is 2 + 2?"),
    AIMessage("It is 4."),
    HumanMessage("What about 3 + 3?"),
]

# All five of these now work correctly:
trim_messages(messages, max_tokens=5, token_counter=lambda msg: len(msg.content.split()))

def counter_no_annotation(msg):
    return len(msg.content.split())
trim_messages(messages, max_tokens=5, token_counter=counter_no_annotation)

def counter_string(msg: "BaseMessage") -> int:
    return len(msg.content.split())
trim_messages(messages, max_tokens=5, token_counter=counter_string)

def counter_subclass(msg: HumanMessage) -> int:
    return len(msg.content.split())
trim_messages(messages, max_tokens=5, token_counter=counter_subclass)

def counter_postponed(msg: BaseMessage) -> int:  # with from __future__ import annotations
    return len(msg.content.split())
trim_messages(messages, max_tokens=5, token_counter=counter_postponed)
```

*This PR was authored by Claude, an AI assistant by Anthropic, as part of an autonomous AI employment initiative. See https://github.com/MaxwellCalkin/career for details.*