### PR TITLE
anthropic: include input_tokens in message_start for streaming

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2016,16 +2016,21 @@ def _make_message_chunk_from_anthropic_event(
     # Reference: Anthropic SDK streaming implementation
     # https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/streaming/_messages.py  # noqa: E501
     if event.type == "message_start" and stream_usage:
-        # Capture model name, but don't include usage_metadata yet
-        # as it will be properly reported in message_delta with complete info
         if hasattr(event.message, "model"):
             response_metadata: dict[str, Any] = {"model_name": event.message.model}
         else:
             response_metadata = {}
 
+        # Include input_tokens from message_start, as message_delta
+        # only contains output_tokens.
+        usage_metadata = None
+        if hasattr(event.message, "usage") and event.message.usage is not None:
+            usage_metadata = _create_usage_metadata(event.message.usage)
+
         message_chunk = AIMessageChunk(
             content="" if coerce_content_to_string else [],
             response_metadata=response_metadata,
+            **({"usage_metadata": usage_metadata} if usage_metadata else {}),
         )
 
     elif (

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1739,9 +1739,11 @@ def test_streaming_cache_token_reporting() -> None:
 
     # Verify message_delta has complete usage_metadata including cache tokens
     assert start_chunk is not None, "message_start should produce a chunk"
-    assert getattr(start_chunk, "usage_metadata", None) is None, (
-        "message_start should not have usage_metadata"
+    assert getattr(start_chunk, "usage_metadata", None) is not None, (
+        "message_start should have usage_metadata"
     )
+    assert start_chunk.usage_metadata["input_tokens"] == 135
+    assert start_chunk.usage_metadata["output_tokens"] == 0
     assert delta_chunk is not None, "message_delta should produce a chunk"
     assert delta_chunk.usage_metadata is not None, (
         "message_delta should have usage_metadata"


### PR DESCRIPTION
This PR fixes an issue where `input_tokens` were reported as 0 in streaming scenarios for `ChatAnthropic`. 

The Anthropic SDK provides usage information (including input tokens) in the `message_start` event. Previously, LangChain was skipping this information and waiting for the `message_delta` event, which only contains delta usage (usually just output tokens).

Changes:
- Extracted usage metadata from `message_start` events in `_make_message_chunk_from_anthropic_event`.
- Updated unit tests to verify that `usage_metadata` is present in the first chunk of a stream.

Fixes langchain-ai/langchain-aws#916