### PR TITLE
chore: update dependencies and add numpy support

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/__init__.py
+++ b/libs/text-splitters/langchain_text_splitters/__init__.py
@@ -36,6 +36,7 @@ from langchain_text_splitters.markdown import (
 )
 from langchain_text_splitters.nltk import NLTKTextSplitter
 from langchain_text_splitters.python import PythonCodeTextSplitter
+from langchain_text_splitters.semantic import SemanticChunker
 from langchain_text_splitters.sentence_transformers import (
     SentenceTransformersTokenTextSplitter,
 )
@@ -60,6 +61,7 @@ __all__ = [
     "PythonCodeTextSplitter",
     "RecursiveCharacterTextSplitter",
     "RecursiveJsonSplitter",
+    "SemanticChunker",
     "SentenceTransformersTokenTextSplitter",
     "SpacyTextSplitter",
     "TextSplitter",

--- a/libs/text-splitters/langchain_text_splitters/semantic.py
+++ b/libs/text-splitters/langchain_text_splitters/semantic.py
@@ -1,0 +1,653 @@
+"""Semantic text splitter based on embedding similarity.
+
+Splits text at natural thematic boundaries by measuring cosine distance between
+consecutive sentence embeddings, rather than splitting at fixed character counts.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import re
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
+
+from langchain_core.documents import BaseDocumentTransformer, Document
+from typing_extensions import override
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from langchain_core.embeddings import Embeddings
+
+try:
+    import numpy as np
+
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
+
+
+logger = logging.getLogger(__name__)
+
+BreakpointThresholdType = Literal[
+    "percentile",
+    "standard_deviation",
+    "interquartile",
+    "gradient",
+]
+
+_BREAKPOINT_DEFAULTS: dict[BreakpointThresholdType, float] = {
+    "percentile": 95,
+    "standard_deviation": 3,
+    "interquartile": 1.5,
+    "gradient": 95,
+}
+
+
+class _SentenceGroup(NamedTuple):
+    """Internal representation of a sentence with its positional context."""
+
+    sentence: str
+    sentence_index: int
+    combined_sentence: str
+
+
+class _SentenceSpan(NamedTuple):
+    """Internal representation of a sentence span in the original text."""
+
+    sentence: str
+    sentence_index: int
+    start_index: int
+    end_index: int
+
+
+class _ChunkRange(NamedTuple):
+    """Internal start/end offsets for a chunk in the original text."""
+
+    start_index: int
+    end_index: int
+
+
+def _combine_sentences(
+    sentences: list[str], *, buffer_size: int = 1
+) -> list[_SentenceGroup]:
+    """Build context windows around each sentence by including neighbors.
+
+    Each sentence is combined with its surrounding sentences (determined by
+    ``buffer_size``) to produce a richer text for embedding. This helps the
+    embedding model capture cross-sentence semantic relationships.
+
+    Args:
+        sentences: Individual sentences extracted from the source text.
+        buffer_size: Number of neighboring sentences on each side to include
+            in the combined representation.
+
+    Returns:
+        A list of ``_SentenceGroup`` named tuples, each containing the original
+        sentence, its index, and the combined context string.
+    """
+    groups: list[_SentenceGroup] = []
+    for i, sentence in enumerate(sentences):
+        start = max(0, i - buffer_size)
+        end = min(len(sentences), i + buffer_size + 1)
+        combined = " ".join(sentences[start:end])
+        groups.append(
+            _SentenceGroup(
+                sentence=sentence, sentence_index=i, combined_sentence=combined
+            )
+        )
+    return groups
+
+
+def _cosine_distances_between_consecutive(
+    embeddings: list[list[float]],
+) -> list[float]:
+    """Compute cosine distances between each pair of consecutive embeddings.
+
+    Uses the formula: ``distance = 1 - cosine_similarity``, where cosine
+    similarity is computed via the dot product of L2-normalized vectors.
+
+    Args:
+        embeddings: A list of embedding vectors, one per sentence group.
+
+    Returns:
+        A list of ``len(embeddings) - 1`` cosine distances. The ``i``-th
+        element is the distance between ``embeddings[i]`` and
+        ``embeddings[i + 1]``.
+    """
+    embedding_array = np.array(embeddings, dtype=np.float64)
+
+    # L2-normalize each row; handle zero-norm rows gracefully.
+    norms = np.linalg.norm(embedding_array, axis=1, keepdims=True)
+    norms = np.where(norms == 0, 1.0, norms)
+    normalized = embedding_array / norms
+
+    # Cosine similarity between consecutive pairs via row-wise dot product.
+    similarities = np.sum(normalized[:-1] * normalized[1:], axis=1)
+
+    # Clip to [-1, 1] to guard against floating-point drift.
+    similarities = np.clip(similarities, -1.0, 1.0)
+
+    distances: list[float] = (1.0 - similarities).tolist()
+    return distances
+
+
+def _merge_small_chunks(chunks: list[str], *, min_chunk_size: int) -> list[str]:
+    """Merge chunks that are shorter than ``min_chunk_size`` into neighbors.
+
+    Small chunks are folded into the *previous* chunk when possible, or into
+    the *next* chunk when the small chunk is the first in the list. This
+    preserves all content rather than dropping undersized chunks.
+
+    Args:
+        chunks: The initial list of text chunks to consolidate.
+        min_chunk_size: Minimum character length for a chunk to stand alone.
+
+    Returns:
+        A new list of chunks where no chunk is shorter than ``min_chunk_size``
+        (unless the entire input text is shorter).
+    """
+    if not chunks:
+        return []
+
+    merged: list[str] = [chunks[0]]
+    for chunk in chunks[1:]:
+        if len(merged[-1]) < min_chunk_size:
+            # Previous chunk is too small — absorb the current one into it.
+            merged[-1] = merged[-1] + " " + chunk
+        else:
+            merged.append(chunk)
+
+    # Final pass: if the last chunk is still too small, merge it backward.
+    if len(merged) > 1 and len(merged[-1]) < min_chunk_size:
+        last = merged.pop()
+        merged[-1] = merged[-1] + " " + last
+
+    return merged
+
+
+class SemanticChunker(BaseDocumentTransformer):
+    """Split text into semantically coherent chunks using embedding similarity.
+
+    Unlike character- or token-based splitters, ``SemanticChunker`` identifies
+    natural thematic boundaries by:
+
+    1. Splitting the text into sentences.
+    2. Building context windows around each sentence (controlled by
+       ``buffer_size``).
+    3. Embedding the context windows using the provided ``Embeddings`` model.
+    4. Computing cosine distances between consecutive embeddings.
+    5. Placing chunk boundaries where the distance exceeds a threshold.
+
+    Four threshold strategies are available (``breakpoint_threshold_type``):
+
+    * ``"percentile"`` — split where the distance exceeds the *N*-th
+      percentile of all distances.
+    * ``"standard_deviation"`` — split where the distance exceeds
+      ``mean + N * std``.
+    * ``"interquartile"`` — split where the distance exceeds
+      ``mean + N * IQR``.
+    * ``"gradient"`` — split where the *rate of change* of distances
+      exceeds the *N*-th percentile.
+
+    Alternatively, set ``number_of_chunks`` to let the chunker automatically
+    find the threshold that produces the desired number of chunks.
+
+    !!! warning
+
+        This class requires ``numpy`` to be installed. Install it with
+        ``pip install numpy``.
+
+    Example:
+        ```python
+        from langchain_openai import OpenAIEmbeddings
+        from langchain_text_splitters import SemanticChunker
+
+        chunker = SemanticChunker(
+            OpenAIEmbeddings(),
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=90,
+        )
+        chunks = chunker.split_text("Your long document text here...")
+        ```
+
+    Args:
+        embeddings: The embedding model used to compute sentence vectors.
+        buffer_size: Number of neighboring sentences on each side to include
+            when building the context window for embedding.
+        add_start_index: If ``True``, each ``Document`` produced by
+            ``create_documents`` will include a ``start_index`` key in its
+            metadata indicating the character offset in the original text.
+        breakpoint_threshold_type: Strategy for determining chunk boundaries.
+        breakpoint_threshold_amount: Numeric parameter for the chosen
+            threshold strategy. When ``None``, a sensible default is used
+            (95 for percentile, 3 for standard_deviation, 1.5 for
+            interquartile, 95 for gradient).
+        number_of_chunks: If set, the chunker finds the threshold that
+            produces this many chunks. If ``breakpoint_threshold_amount``
+            is also provided, ``number_of_chunks`` takes precedence for
+            backward compatibility with the experimental implementation.
+        sentence_split_regex: Regular expression used to split the input
+            text into sentences.
+        min_chunk_size: Minimum character length for a chunk. Chunks shorter
+            than this are merged into a neighbor rather than discarded.
+    """
+
+    def __init__(
+        self,
+        embeddings: Embeddings,
+        buffer_size: int = 1,
+        add_start_index: bool = False,  # noqa: FBT001, FBT002
+        breakpoint_threshold_type: BreakpointThresholdType = "percentile",
+        breakpoint_threshold_amount: float | None = None,
+        number_of_chunks: int | None = None,
+        sentence_split_regex: str = r"(?<=[.?!])\s+",
+        min_chunk_size: int | None = None,
+    ) -> None:
+        """Initialize the ``SemanticChunker``.
+
+        Raises:
+            ImportError: If numpy is not installed.
+            ValueError: If ``breakpoint_threshold_type`` is unknown.
+            ValueError: If ``buffer_size`` is negative.
+            ValueError: If ``number_of_chunks`` is less than 1.
+            ValueError: If ``min_chunk_size`` is less than 1.
+        """
+        if not _HAS_NUMPY:
+            msg = "SemanticChunker requires numpy. Install it with `pip install numpy`."
+            raise ImportError(msg)
+
+        if breakpoint_threshold_type not in _BREAKPOINT_DEFAULTS:
+            msg = (
+                "Got unexpected `breakpoint_threshold_type`: "
+                f"{breakpoint_threshold_type}"
+            )
+            raise ValueError(msg)
+
+        if buffer_size < 0:
+            msg = f"`buffer_size` must be >= 0, got {buffer_size}"
+            raise ValueError(msg)
+
+        if number_of_chunks is not None and number_of_chunks < 1:
+            msg = f"`number_of_chunks` must be >= 1, got {number_of_chunks}"
+            raise ValueError(msg)
+
+        if min_chunk_size is not None and min_chunk_size < 1:
+            msg = f"`min_chunk_size` must be >= 1, got {min_chunk_size}"
+            raise ValueError(msg)
+
+        if number_of_chunks is not None and breakpoint_threshold_amount is not None:
+            logger.warning(
+                "Both `number_of_chunks` and `breakpoint_threshold_amount` were "
+                "provided. `number_of_chunks` takes precedence."
+            )
+
+        self.embeddings = embeddings
+        self.buffer_size = buffer_size
+        self.breakpoint_threshold_type = breakpoint_threshold_type
+        self.breakpoint_threshold_amount = (
+            breakpoint_threshold_amount
+            if breakpoint_threshold_amount is not None
+            else _BREAKPOINT_DEFAULTS[breakpoint_threshold_type]
+        )
+        self.number_of_chunks = number_of_chunks
+        self.sentence_split_regex = sentence_split_regex
+        self.min_chunk_size = min_chunk_size
+
+        # Backward-compatible aliases used by existing code/tests.
+        self._embeddings = self.embeddings
+        self._buffer_size = self.buffer_size
+        self._add_start_index = add_start_index
+        self._breakpoint_threshold_type = self.breakpoint_threshold_type
+        self._breakpoint_threshold_amount = self.breakpoint_threshold_amount
+        self._number_of_chunks = self.number_of_chunks
+        self._sentence_split_regex = self.sentence_split_regex
+        self._min_chunk_size = self.min_chunk_size
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def split_text(self, text: str) -> list[str]:
+        """Split a single text into semantically coherent chunks.
+
+        Args:
+            text: The text to split.
+
+        Returns:
+            A list of text chunks ordered by their position in the original
+            text.
+        """
+        chunk_ranges = self._split_text_to_ranges(text)
+        return [text[r.start_index : r.end_index] for r in chunk_ranges]
+
+    def create_documents(
+        self,
+        texts: list[str],
+        metadatas: list[dict[str, Any]] | None = None,
+    ) -> list[Document]:
+        """Split texts and wrap the resulting chunks as ``Document`` objects.
+
+        Args:
+            texts: A list of texts to split.
+            metadatas: Optional per-text metadata dicts that are copied into
+                every ``Document`` produced from the corresponding text.
+
+        Returns:
+            A flat list of ``Document`` objects across all input texts.
+        """
+        metadatas_ = metadatas or [{}] * len(texts)
+        documents: list[Document] = []
+        for i, text in enumerate(texts):
+            chunk_ranges = self._split_text_to_ranges(text)
+            for chunk_range in chunk_ranges:
+                metadata = copy.deepcopy(metadatas_[i])
+                if self._add_start_index:
+                    metadata["start_index"] = chunk_range.start_index
+                chunk_text = text[chunk_range.start_index : chunk_range.end_index]
+                documents.append(Document(page_content=chunk_text, metadata=metadata))
+        return documents
+
+    def split_documents(self, documents: Iterable[Document]) -> list[Document]:
+        """Split ``Document`` objects and return new ``Document`` objects.
+
+        Args:
+            documents: The documents to split.
+
+        Returns:
+            A list of split ``Document`` objects.
+        """
+        texts, metadatas = [], []
+        for doc in documents:
+            texts.append(doc.page_content)
+            metadatas.append(doc.metadata)
+        return self.create_documents(texts, metadatas=metadatas)
+
+    @override
+    def transform_documents(
+        self, documents: Sequence[Document], **kwargs: Any
+    ) -> Sequence[Document]:
+        """Transform documents by splitting them into semantic chunks.
+
+        Args:
+            documents: The sequence of documents to split.
+
+        Returns:
+            A sequence of split documents.
+        """
+        return self.split_documents(list(documents))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _split_text_to_ranges(self, text: str) -> list[_ChunkRange]:
+        """Split text into chunk ranges over the original text string.
+
+        Args:
+            text: The text to split.
+
+        Returns:
+            A list of ``_ChunkRange`` values that map each chunk back to
+            character offsets in ``text``.
+        """
+        sentence_spans = self._split_into_sentences_with_spans(text)
+
+        if not sentence_spans:
+            return []
+
+        if len(sentence_spans) == 1:
+            sentence = sentence_spans[0]
+            return [
+                _ChunkRange(
+                    start_index=sentence.start_index,
+                    end_index=sentence.end_index,
+                )
+            ]
+
+        # Preserve experimental behavior for 2-sentence gradient mode.
+        if self.breakpoint_threshold_type == "gradient" and len(sentence_spans) == 2:  # noqa: PLR2004
+            return [
+                _ChunkRange(
+                    start_index=sentence.start_index,
+                    end_index=sentence.end_index,
+                )
+                for sentence in sentence_spans
+            ]
+
+        sentences = [sentence.sentence for sentence in sentence_spans]
+        groups = _combine_sentences(sentences, buffer_size=self.buffer_size)
+        combined_texts = [group.combined_sentence for group in groups]
+        embeddings = self.embeddings.embed_documents(combined_texts)
+        distances = _cosine_distances_between_consecutive(embeddings)
+
+        breakpoint_indices = self._compute_breakpoint_indices(distances)
+        chunk_ranges = self._assemble_chunk_ranges(sentence_spans, breakpoint_indices)
+        if self.min_chunk_size is not None:
+            chunk_ranges = self._merge_small_chunk_ranges(
+                chunk_ranges,
+                text=text,
+                min_chunk_size=self.min_chunk_size,
+            )
+        return chunk_ranges
+
+    def _split_into_sentences_with_spans(self, text: str) -> list[_SentenceSpan]:
+        """Split text into sentence spans using the configured regex.
+
+        Args:
+            text: The raw text to split.
+
+        Returns:
+            Sentence spans with exact start/end offsets into the original text.
+        """
+        spans: list[_SentenceSpan] = []
+        start_index = 0
+        sentence_index = 0
+
+        for match in re.finditer(self.sentence_split_regex, text):
+            end_index = match.start()
+            sentence = text[start_index:end_index]
+            if sentence.strip():
+                spans.append(
+                    _SentenceSpan(
+                        sentence=sentence,
+                        sentence_index=sentence_index,
+                        start_index=start_index,
+                        end_index=end_index,
+                    )
+                )
+                sentence_index += 1
+            start_index = match.end()
+
+        final_sentence = text[start_index:]
+        if final_sentence.strip():
+            spans.append(
+                _SentenceSpan(
+                    sentence=final_sentence,
+                    sentence_index=sentence_index,
+                    start_index=start_index,
+                    end_index=len(text),
+                )
+            )
+
+        return spans
+
+    def _split_into_sentences(self, text: str) -> list[str]:
+        """Split text into individual sentences using the configured regex.
+
+        Args:
+            text: The text to split into sentences.
+
+        Returns:
+            A list of sentence strings. Empty/whitespace-only results are
+            filtered out.
+        """
+        return [s.sentence for s in self._split_into_sentences_with_spans(text)]
+
+    def _compute_breakpoint_indices(self, distances: list[float]) -> list[int]:
+        """Determine which inter-sentence positions should become chunk boundaries.
+
+        Args:
+            distances: Cosine distances between consecutive sentence pairs.
+
+        Returns:
+            A sorted list of sentence indices *after* which a chunk boundary
+            should be inserted.
+        """
+        if self.number_of_chunks is not None:
+            threshold = self._threshold_for_target_chunks(distances)
+        else:
+            threshold = self._calculate_threshold(distances)
+
+        return [i for i, d in enumerate(distances) if d > threshold]
+
+    def _calculate_threshold(self, distances: list[float]) -> float:
+        """Compute the breakpoint threshold using the configured strategy.
+
+        Args:
+            distances: Cosine distances between consecutive sentence pairs.
+
+        Returns:
+            The threshold value above which a distance is considered a
+            chunk boundary.
+
+        Raises:
+            ValueError: If the configured threshold type is unknown.
+        """
+        amount = self.breakpoint_threshold_amount
+        threshold_type = str(self.breakpoint_threshold_type)
+        dist_array = np.array(distances)
+
+        if threshold_type == "percentile":
+            return float(np.percentile(dist_array, amount))
+
+        if threshold_type == "standard_deviation":
+            return float(np.mean(dist_array) + amount * np.std(dist_array))
+
+        if threshold_type == "interquartile":
+            q1 = float(np.percentile(dist_array, 25))
+            q3 = float(np.percentile(dist_array, 75))
+            iqr = q3 - q1
+            return float(np.mean(dist_array) + amount * iqr)
+
+        if threshold_type == "gradient":
+            gradient = np.gradient(dist_array)
+            return float(np.percentile(gradient, amount))
+
+        msg = f"Got unexpected `breakpoint_threshold_type`: {threshold_type}"
+        raise ValueError(msg)
+
+    def _threshold_for_target_chunks(self, distances: list[float]) -> float:
+        """Find the threshold that produces ``number_of_chunks`` chunks.
+
+        Uses binary search over percentile values to converge on a threshold
+        that yields the desired number of breakpoints (= chunks - 1).
+
+        Args:
+            distances: Cosine distances between consecutive sentence pairs.
+
+        Returns:
+            The threshold value that produces the closest match to the
+            target number of chunks.
+        """
+        if self.number_of_chunks is None:
+            msg = "This should never be called if `number_of_chunks` is None."
+            raise ValueError(msg)
+
+        target_breakpoints = self.number_of_chunks - 1
+        dist_array = np.array(distances)
+
+        # Edge case: more chunks requested than sentences allow.
+        if target_breakpoints >= len(distances):
+            return float(np.min(dist_array)) - 1e-10
+
+        # Edge case: single chunk requested.
+        if target_breakpoints <= 0:
+            return float(np.max(dist_array)) + 1e-10
+
+        # Binary search over percentile values [0, 100].
+        low, high = 0.0, 100.0
+        for _ in range(64):
+            mid = (low + high) / 2.0
+            threshold = float(np.percentile(dist_array, mid))
+            num_breakpoints = int(np.sum(dist_array > threshold))
+            if num_breakpoints < target_breakpoints:
+                high = mid
+            elif num_breakpoints > target_breakpoints:
+                low = mid
+            else:
+                break
+
+        return float(np.percentile(dist_array, mid))
+
+    @staticmethod
+    def _assemble_chunk_ranges(
+        sentence_spans: list[_SentenceSpan], breakpoint_indices: list[int]
+    ) -> list[_ChunkRange]:
+        """Build chunk ranges according to breakpoint positions.
+
+        Args:
+            sentence_spans: Sentence spans from the source text.
+            breakpoint_indices: Positions *after* which a chunk boundary
+                should be placed.
+
+        Returns:
+            A list of chunk ranges mapping directly onto the original text.
+        """
+        chunk_ranges: list[_ChunkRange] = []
+        start = 0
+        for bp in sorted(breakpoint_indices):
+            chunk_ranges.append(
+                _ChunkRange(
+                    start_index=sentence_spans[start].start_index,
+                    end_index=sentence_spans[bp].end_index,
+                )
+            )
+            start = bp + 1
+
+        # Remaining sentences form the final chunk.
+        if start < len(sentence_spans):
+            chunk_ranges.append(
+                _ChunkRange(
+                    start_index=sentence_spans[start].start_index,
+                    end_index=sentence_spans[-1].end_index,
+                )
+            )
+
+        return chunk_ranges
+
+    @staticmethod
+    def _merge_small_chunk_ranges(
+        chunk_ranges: list[_ChunkRange],
+        *,
+        text: str,
+        min_chunk_size: int,
+    ) -> list[_ChunkRange]:
+        """Merge undersized chunk ranges into neighboring chunk ranges."""
+        if not chunk_ranges:
+            return []
+
+        merged: list[_ChunkRange] = [chunk_ranges[0]]
+        for chunk_range in chunk_ranges[1:]:
+            previous = merged[-1]
+            previous_text = text[previous.start_index : previous.end_index]
+            if len(previous_text) < min_chunk_size:
+                merged[-1] = _ChunkRange(
+                    start_index=previous.start_index,
+                    end_index=chunk_range.end_index,
+                )
+            else:
+                merged.append(chunk_range)
+
+        if len(merged) > 1:
+            last = merged[-1]
+            last_text = text[last.start_index : last.end_index]
+            if len(last_text) < min_chunk_size:
+                last = merged.pop()
+                previous = merged[-1]
+                merged[-1] = _ChunkRange(
+                    start_index=previous.start_index,
+                    end_index=last.end_index,
+                )
+
+        return merged

--- a/libs/text-splitters/pyproject.toml
+++ b/libs/text-splitters/pyproject.toml
@@ -62,9 +62,11 @@ test = [
     "pytest-asyncio>=0.21.1,<2.0.0",
     "pytest-socket>=0.7.0,<1.0.0",
     "pytest-xdist<4.0.0,>=3.6.1",
+    "numpy>=1.24.0,<3.0.0",
     "langchain-core",
 ]
 test_integration = [
+    "numpy>=1.24.0,<3.0.0",
     "spacy>=3.8.7,<4.0.0; python_version < \"3.14\"",
     "thinc>=8.3.6,<10.0.0",
     "nltk>=3.9.1,<4.0.0",
@@ -87,7 +89,7 @@ enable_error_code = "deprecated"
 warn_unreachable = true
 
 [[tool.mypy.overrides]]
-module = ["konlpy", "nltk",]
+module = ["konlpy", "nltk", "numpy",]
 ignore_missing_imports = true
 
 [tool.ruff.format]

--- a/libs/text-splitters/tests/integration_tests/test_semantic_chunker.py
+++ b/libs/text-splitters/tests/integration_tests/test_semantic_chunker.py
@@ -1,0 +1,316 @@
+"""Integration tests for SemanticChunker.
+
+These tests require ``numpy`` and use ``DeterministicFakeEmbedding`` from
+``langchain-core`` to run without external API keys while still exercising the
+full pipeline end-to-end with real numpy operations.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+from langchain_core.documents import Document
+from langchain_core.embeddings import DeterministicFakeEmbedding, Embeddings
+
+from langchain_text_splitters.semantic import SemanticChunker
+
+
+@pytest.mark.requires("numpy")
+class TestSemanticChunkerIntegration:
+    """End-to-end tests with deterministic (but realistic) embeddings."""
+
+    def test_basic_split(self) -> None:
+        embeddings = DeterministicFakeEmbedding(size=128)
+        chunker = SemanticChunker(
+            embeddings,
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=50,
+        )
+        text = (
+            "Machine learning is a subset of artificial intelligence. "
+            "It allows systems to learn from data. "
+            "Deep learning uses neural networks with many layers. "
+            "The weather today is sunny with clear skies. "
+            "Tomorrow it might rain in the afternoon. "
+            "Pack an umbrella just in case."
+        )
+        chunks = chunker.split_text(text)
+        assert len(chunks) >= 1
+        # All content preserved.
+        joined = " ".join(chunks)
+        assert "Machine learning" in joined
+        assert "umbrella" in joined
+
+    def test_long_document(self) -> None:
+        embeddings = DeterministicFakeEmbedding(size=64)
+        chunker = SemanticChunker(
+            embeddings,
+            breakpoint_threshold_type="standard_deviation",
+        )
+        # Generate a longer document with distinct topics.
+        paragraphs = [
+            "Python is a programming language. It supports multiple paradigms. "
+            "Python is widely used in data science.",
+            "The ocean is vast and deep. Marine life is incredibly diverse. "
+            "Coral reefs are under threat from climate change.",
+            "Music has been part of human culture for millennia. "
+            "Instruments range from simple drums to complex synthesizers. "
+            "Genres evolve and blend over time.",
+        ]
+        text = " ".join(paragraphs)
+        chunks = chunker.split_text(text)
+        assert len(chunks) >= 1
+        assert all(len(c) > 0 for c in chunks)
+
+    def test_create_documents_round_trip(self) -> None:
+        embeddings = DeterministicFakeEmbedding(size=64)
+        chunker = SemanticChunker(embeddings, add_start_index=True)
+        text = "Alpha sentence. Beta sentence. Gamma sentence."
+        docs = chunker.create_documents([text], metadatas=[{"source": "test"}])
+        assert all(isinstance(d, Document) for d in docs)
+        assert all(d.metadata["source"] == "test" for d in docs)
+        for doc in docs:
+            idx = doc.metadata["start_index"]
+            assert text[idx:].startswith(doc.page_content)
+
+    def test_number_of_chunks_mode(self) -> None:
+        embeddings = DeterministicFakeEmbedding(size=64)
+        chunker = SemanticChunker(embeddings, number_of_chunks=2)
+        text = (
+            "Stars are massive balls of gas. "
+            "They produce energy through nuclear fusion. "
+            "Our sun is a medium-sized star. "
+            "Computers process information using binary logic. "
+            "Modern CPUs contain billions of transistors. "
+            "Software controls how hardware operates."
+        )
+        chunks = chunker.split_text(text)
+        assert len(chunks) == 2
+
+
+class _IndexedRandomEmbedding(Embeddings):
+    """Deterministic embeddings keyed by sentence index for stress testing."""
+
+    def __init__(self, *, size: int = 64) -> None:
+        self._size = size
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        vectors: list[list[float]] = []
+        for i in range(len(texts)):
+            rng = random.Random(i)
+            vectors.append([rng.uniform(-1.0, 1.0) for _ in range(self._size)])
+        return vectors
+
+    def embed_query(self, text: str) -> list[float]:  # noqa: ARG002
+        return [0.0] * self._size
+
+
+def _assert_exact_offsets(text: str, docs: list[Document]) -> None:
+    previous_end = -1
+    for doc in docs:
+        start_index = doc.metadata["start_index"]
+        assert isinstance(start_index, int)
+        assert 0 <= start_index < len(text)
+        assert start_index >= previous_end
+        end_index = start_index + len(doc.page_content)
+        assert text[start_index:end_index] == doc.page_content
+        previous_end = end_index
+
+
+def _build_large_html_document(*, sections: int = 240) -> str:
+    parts: list[str] = []
+    for i in range(sections):
+        section_id = f"section-{i:03d}"
+        parts.extend(
+            [
+                f"<section id='{section_id}'>\n",
+                f"<h2>{section_id}</h2>\n",
+                (
+                    f"<p>{section_id} summarizes retrieval quality metrics. "
+                    "Analysts compared answer grounding across corpora. "
+                    "The baseline model missed cross-paragraph evidence.</p>\n"
+                ),
+                (
+                    f"<p>The remediation plan for {section_id} emphasizes semantic "
+                    "boundaries. This change reduced context fragmentation in long "
+                    "pages. Follow-up audits confirmed stable precision.</p>\n"
+                ),
+                "</section>\n\n",
+            ]
+        )
+    return "".join(parts)
+
+
+def _build_chat_transcript(*, turns: int = 700) -> str:
+    lines: list[str] = []
+    for i in range(turns):
+        speaker = "user" if i % 2 == 0 else "assistant"
+        lines.append(
+            f"turn-{i:04d} [{speaker}]: I observed incident bucket {i % 23}. "
+            f"We should update remediation checklist shard {i % 31} before "
+            "deployment.\n"
+        )
+    return "".join(lines)
+
+
+@pytest.mark.requires("numpy")
+class TestSemanticChunkerStress:
+    def test_stress_large_html_document_offsets_and_markers(self) -> None:
+        text = _build_large_html_document(sections=240)
+        chunker = SemanticChunker(
+            DeterministicFakeEmbedding(size=128),
+            add_start_index=True,
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=75,
+            min_chunk_size=600,
+        )
+        docs = chunker.create_documents([text], metadatas=[{"source": "html-stress"}])
+        assert len(docs) > 50
+        assert all(doc.metadata["source"] == "html-stress" for doc in docs)
+        _assert_exact_offsets(text, docs)
+
+        joined = "".join(doc.page_content for doc in docs)
+        for marker in ("section-000", "section-120", "section-239"):
+            assert marker in joined
+
+    def test_stress_long_chat_transcript_with_target_chunks(self) -> None:
+        text = _build_chat_transcript(turns=700)
+        chunker_a = SemanticChunker(
+            _IndexedRandomEmbedding(size=96),
+            add_start_index=True,
+            number_of_chunks=40,
+            breakpoint_threshold_amount=99,
+            min_chunk_size=300,
+        )
+        chunker_b = SemanticChunker(
+            _IndexedRandomEmbedding(size=96),
+            add_start_index=True,
+            number_of_chunks=40,
+            breakpoint_threshold_amount=5,
+            min_chunk_size=300,
+        )
+
+        docs_a = chunker_a.create_documents([text], metadatas=[{"source": "chat"}])
+        docs_b = chunker_b.create_documents([text], metadatas=[{"source": "chat"}])
+        assert len(docs_a) == len(docs_b)
+        assert 10 <= len(docs_a) <= 40
+        _assert_exact_offsets(text, docs_a)
+        _assert_exact_offsets(text, docs_b)
+
+        joined = "".join(doc.page_content for doc in docs_a)
+        for marker in ("turn-0000", "turn-0350", "turn-0699"):
+            assert marker in joined
+
+    def test_stress_batch_many_documents_metadata_and_offsets(self) -> None:
+        texts: list[str] = []
+        metadatas: list[dict[str, object]] = []
+        for doc_id in range(180):
+            segments = [
+                (
+                    f"doc-{doc_id:03d} segment-{segment:02d} discusses retrieval "
+                    "precision changes after semantic splitting."
+                )
+                for segment in range(12)
+            ]
+            texts.append(".\n".join(segments) + ".")
+            metadatas.append({"doc_id": doc_id, "nested": {"source": "stress"}})
+
+        chunker = SemanticChunker(
+            DeterministicFakeEmbedding(size=72),
+            add_start_index=True,
+            breakpoint_threshold_type="interquartile",
+            breakpoint_threshold_amount=1.2,
+            min_chunk_size=180,
+        )
+        docs = chunker.create_documents(texts, metadatas=metadatas)
+        assert len(docs) >= len(texts)
+
+        source_text_by_id = dict(enumerate(texts))
+        for doc in docs:
+            doc_id = doc.metadata["doc_id"]
+            source_text = source_text_by_id[doc_id]
+            start_index = doc.metadata["start_index"]
+            end_index = start_index + len(doc.page_content)
+            assert source_text[start_index:end_index] == doc.page_content
+            assert doc.metadata["nested"]["source"] == "stress"
+
+        sample_doc_id = docs[0].metadata["doc_id"]
+        sample_docs = [doc for doc in docs if doc.metadata["doc_id"] == sample_doc_id]
+        assert len(sample_docs) >= 1
+        sample_docs[0].metadata["nested"]["mutated"] = True
+        for other in sample_docs[1:]:
+            assert "mutated" not in other.metadata["nested"]
+
+    def test_realistic_html_like_text_preserves_exact_offsets(self) -> None:
+        embeddings = DeterministicFakeEmbedding(size=96)
+        chunker = SemanticChunker(
+            embeddings,
+            add_start_index=True,
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=60,
+        )
+        text = (
+            "<h1>Clinical Trial Summary</h1>\n"
+            "<p>Participants received treatment A for six weeks.</p>\n\n"
+            "<p>Primary endpoint was reduction in symptom severity by week eight.</p>\n"
+            "<p>Adverse events were mild and self-limited in most cases.</p>\n\n"
+            "<h2>Methods</h2>\n"
+            "<p>Randomization was stratified by age and baseline biomarkers.</p>\n"
+            "<p>Missing values were imputed using multiple imputation.</p>\n"
+        )
+        docs = chunker.create_documents([text], metadatas=[{"source": "html"}])
+        assert len(docs) >= 1
+        for doc in docs:
+            idx = doc.metadata["start_index"]
+            assert idx >= 0
+            assert doc.metadata["source"] == "html"
+            assert text[idx : idx + len(doc.page_content)] == doc.page_content
+
+    def test_realistic_scientific_text_min_chunk_size_preserves_content(self) -> None:
+        embeddings = DeterministicFakeEmbedding(size=128)
+        chunker = SemanticChunker(
+            embeddings,
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=20,
+            min_chunk_size=180,
+        )
+        text = (
+            "Background. Retrieval-augmented generation systems depend on chunk "
+            "quality. "
+            "Simple fixed-size chunking can separate related findings. "
+            "Methods. We compare recursive and semantic chunking over biomedical "
+            "abstracts. "
+            "The semantic method computes sentence embeddings and identifies topic "
+            "shifts. "
+            "Results. Semantic chunks improved retrieval precision and reduced "
+            "hallucination rates. "
+            "Conclusion. Structure-aware segmentation helps preserve context integrity."
+        )
+        chunks = chunker.split_text(text)
+        assert len(chunks) >= 1
+        joined = "".join(chunks)
+        assert (
+            "Retrieval-augmented generation systems depend on chunk quality."
+            in joined
+        )
+        assert (
+            "Structure-aware segmentation helps preserve context integrity."
+            in joined
+        )
+        if len(chunks) > 1:
+            assert all(len(chunk) >= 180 for chunk in chunks[:-1])
+
+    def test_number_of_chunks_takes_precedence_over_breakpoint_amount(self) -> None:
+        embeddings = DeterministicFakeEmbedding(size=64)
+        chunker = SemanticChunker(
+            embeddings,
+            number_of_chunks=2,
+            breakpoint_threshold_amount=99,
+        )
+        text = (
+            "Sentence one. Sentence two. Sentence three. Sentence four. "
+            "Sentence five. Sentence six."
+        )
+        chunks = chunker.split_text(text)
+        assert len(chunks) == 2

--- a/libs/text-splitters/tests/integration_tests/test_semantic_chunker.py
+++ b/libs/text-splitters/tests/integration_tests/test_semantic_chunker.py
@@ -291,12 +291,10 @@ class TestSemanticChunkerStress:
         assert len(chunks) >= 1
         joined = "".join(chunks)
         assert (
-            "Retrieval-augmented generation systems depend on chunk quality."
-            in joined
+            "Retrieval-augmented generation systems depend on chunk quality." in joined
         )
         assert (
-            "Structure-aware segmentation helps preserve context integrity."
-            in joined
+            "Structure-aware segmentation helps preserve context integrity." in joined
         )
         if len(chunks) > 1:
             assert all(len(chunk) >= 180 for chunk in chunks[:-1])

--- a/libs/text-splitters/tests/unit_tests/test_semantic_chunker.py
+++ b/libs/text-splitters/tests/unit_tests/test_semantic_chunker.py
@@ -1,0 +1,513 @@
+"""Unit tests for SemanticChunker."""
+
+from __future__ import annotations
+
+import math
+from unittest.mock import patch
+
+import pytest
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+
+from langchain_text_splitters.semantic import (
+    SemanticChunker,
+    _combine_sentences,
+    _cosine_distances_between_consecutive,
+    _merge_small_chunks,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+class _IdentityEmbeddings(Embeddings):
+    """Embeddings that assign a unique unit vector per sentence position.
+
+    Sentence *i* is mapped to a one-hot-like vector with a 1.0 at dimension *i*.
+    This gives maximum cosine distance (1.0) between all non-identical sentences
+    and 0.0 distance for identical ones — useful for controlled breakpoint tests.
+    """
+
+    def __init__(self, *, dims: int = 64) -> None:
+        self._dims = dims
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        result: list[list[float]] = []
+        for i in range(len(texts)):
+            vec = [0.0] * self._dims
+            vec[i % self._dims] = 1.0
+            result.append(vec)
+        return result
+
+    def embed_query(self, text: str) -> list[float]:  # noqa: ARG002
+        return [0.0] * self._dims
+
+
+class _ClusterEmbeddings(Embeddings):
+    """Embeddings that cluster sentences into groups via a mapping.
+
+    Sentences in the same cluster share the same embedding vector, so cosine
+    distance within a cluster is 0 and between clusters is 1. This lets us
+    deterministically control where breakpoints should appear.
+
+    ``cluster_map`` maps sentence index -> cluster id. Cluster ids are used
+    as the non-zero dimension index in the embedding vector.
+    """
+
+    def __init__(self, cluster_map: list[int], *, dims: int = 64) -> None:
+        self._cluster_map = cluster_map
+        self._dims = dims
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        result: list[list[float]] = []
+        for i in range(len(texts)):
+            vec = [0.0] * self._dims
+            cluster = self._cluster_map[i] if i < len(self._cluster_map) else 0
+            vec[cluster % self._dims] = 1.0
+            result.append(vec)
+        return result
+
+    def embed_query(self, text: str) -> list[float]:  # noqa: ARG002
+        return [0.0] * self._dims
+
+
+# ---------------------------------------------------------------------------
+# Tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestCombineSentences:
+    def test_buffer_zero(self) -> None:
+        groups = _combine_sentences(["A", "B", "C"], buffer_size=0)
+        assert [g.combined_sentence for g in groups] == ["A", "B", "C"]
+
+    def test_buffer_one(self) -> None:
+        groups = _combine_sentences(["A", "B", "C"], buffer_size=1)
+        assert groups[0].combined_sentence == "A B"
+        assert groups[1].combined_sentence == "A B C"
+        assert groups[2].combined_sentence == "B C"
+
+    def test_buffer_larger_than_list(self) -> None:
+        groups = _combine_sentences(["A", "B"], buffer_size=5)
+        assert groups[0].combined_sentence == "A B"
+        assert groups[1].combined_sentence == "A B"
+
+    def test_preserves_original_sentence(self) -> None:
+        groups = _combine_sentences(["Hello world", "Goodbye"], buffer_size=1)
+        assert groups[0].sentence == "Hello world"
+        assert groups[1].sentence == "Goodbye"
+
+    def test_index_tracking(self) -> None:
+        groups = _combine_sentences(["A", "B", "C"], buffer_size=0)
+        assert [g.sentence_index for g in groups] == [0, 1, 2]
+
+    def test_empty_list(self) -> None:
+        assert _combine_sentences([], buffer_size=1) == []
+
+    def test_single_sentence(self) -> None:
+        groups = _combine_sentences(["Only one"], buffer_size=1)
+        assert len(groups) == 1
+        assert groups[0].combined_sentence == "Only one"
+
+
+@pytest.mark.requires("numpy")
+class TestCosineDistances:
+    def test_identical_embeddings(self) -> None:
+        embeddings = [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]
+        distances = _cosine_distances_between_consecutive(embeddings)
+        assert len(distances) == 2
+        assert all(math.isclose(d, 0.0, abs_tol=1e-9) for d in distances)
+
+    def test_orthogonal_embeddings(self) -> None:
+        embeddings = [[1.0, 0.0], [0.0, 1.0], [1.0, 0.0]]
+        distances = _cosine_distances_between_consecutive(embeddings)
+        assert len(distances) == 2
+        assert math.isclose(distances[0], 1.0, abs_tol=1e-9)
+        assert math.isclose(distances[1], 1.0, abs_tol=1e-9)
+
+    def test_opposite_embeddings(self) -> None:
+        embeddings = [[1.0, 0.0], [-1.0, 0.0]]
+        distances = _cosine_distances_between_consecutive(embeddings)
+        assert math.isclose(distances[0], 2.0, abs_tol=1e-9)
+
+    def test_zero_vector_handled(self) -> None:
+        embeddings = [[0.0, 0.0], [1.0, 0.0]]
+        distances = _cosine_distances_between_consecutive(embeddings)
+        assert len(distances) == 1
+        # Zero vector after normalization gives 0 similarity.
+        assert 0.0 <= distances[0] <= 2.0
+
+
+@pytest.mark.requires("numpy")
+class TestMergeSmallChunks:
+    def test_no_merge_needed(self) -> None:
+        chunks = ["Hello world", "Goodbye world"]
+        result = _merge_small_chunks(chunks, min_chunk_size=5)
+        assert result == chunks
+
+    def test_merge_into_previous(self) -> None:
+        chunks = ["Hello world", "Hi", "Goodbye world"]
+        result = _merge_small_chunks(chunks, min_chunk_size=5)
+        assert result == ["Hello world", "Hi Goodbye world"]
+
+    def test_merge_first_chunk_forward(self) -> None:
+        chunks = ["Hi", "Hello world", "Goodbye world"]
+        result = _merge_small_chunks(chunks, min_chunk_size=5)
+        assert result == ["Hi Hello world", "Goodbye world"]
+
+    def test_merge_last_chunk_backward(self) -> None:
+        chunks = ["Hello world", "Goodbye world", "Hi"]
+        result = _merge_small_chunks(chunks, min_chunk_size=5)
+        assert result == ["Hello world", "Goodbye world Hi"]
+
+    def test_empty_input(self) -> None:
+        assert _merge_small_chunks([], min_chunk_size=5) == []
+
+    def test_single_small_chunk(self) -> None:
+        result = _merge_small_chunks(["Hi"], min_chunk_size=100)
+        assert result == ["Hi"]
+
+    def test_all_small_chunks_collapse(self) -> None:
+        chunks = ["A", "B", "C"]
+        result = _merge_small_chunks(chunks, min_chunk_size=10)
+        assert len(result) == 1
+        assert result == ["A B C"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for SemanticChunker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires("numpy")
+class TestSemanticChunkerInit:
+    def test_default_init(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings())
+        assert chunker.breakpoint_threshold_type == "percentile"
+        assert chunker.breakpoint_threshold_amount == 95
+        assert chunker.buffer_size == 1
+        assert chunker.number_of_chunks is None
+        assert chunker.min_chunk_size is None
+        # Backward-compatible private aliases.
+        assert chunker._breakpoint_threshold_type == "percentile"
+        assert chunker._breakpoint_threshold_amount == 95
+
+    def test_mutual_exclusion_preserves_experimental_precedence(self) -> None:
+        chunker = SemanticChunker(
+            _IdentityEmbeddings(),
+            number_of_chunks=3,
+            breakpoint_threshold_amount=90,
+        )
+        assert chunker.number_of_chunks == 3
+        assert chunker.breakpoint_threshold_amount == 90
+
+    def test_positional_args_supported_for_backward_compatibility(self) -> None:
+        add_start_index = True
+        chunker = SemanticChunker(
+            _IdentityEmbeddings(),
+            2,
+            add_start_index,
+            "percentile",
+            90,
+            None,
+            r"(?<=[.?!])\s+",
+            20,
+        )
+        assert chunker.buffer_size == 2
+        assert chunker._add_start_index is True
+        assert chunker.min_chunk_size == 20
+
+    def test_invalid_breakpoint_threshold_type(self) -> None:
+        with pytest.raises(ValueError, match="unexpected `breakpoint_threshold_type`"):
+            SemanticChunker(
+                _IdentityEmbeddings(),
+                breakpoint_threshold_type="bad",  # type: ignore[arg-type]
+            )
+
+    def test_invalid_buffer_size(self) -> None:
+        with pytest.raises(ValueError, match="buffer_size"):
+            SemanticChunker(_IdentityEmbeddings(), buffer_size=-1)
+
+    def test_invalid_number_of_chunks(self) -> None:
+        with pytest.raises(ValueError, match="number_of_chunks"):
+            SemanticChunker(_IdentityEmbeddings(), number_of_chunks=0)
+
+    def test_invalid_min_chunk_size(self) -> None:
+        with pytest.raises(ValueError, match="min_chunk_size"):
+            SemanticChunker(_IdentityEmbeddings(), min_chunk_size=0)
+
+    def test_numpy_not_installed(self) -> None:
+        with (
+            patch("langchain_text_splitters.semantic._HAS_NUMPY", new=False),
+            pytest.raises(ImportError, match="numpy"),
+        ):
+            SemanticChunker(_IdentityEmbeddings())
+
+
+@pytest.mark.requires("numpy")
+class TestSemanticChunkerSplitText:
+    def test_empty_text(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings())
+        assert chunker.split_text("") == []
+
+    def test_whitespace_only(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings())
+        assert chunker.split_text("   \n\t  ") == []
+
+    def test_single_sentence(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings())
+        result = chunker.split_text("Hello world.")
+        assert result == ["Hello world."]
+
+    def test_two_sentences_returns_single_chunk(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings())
+        text = "First sentence. Second sentence."
+        result = chunker.split_text(text)
+        assert result == [text]
+
+    def test_two_sentences_gradient_matches_experimental_behavior(self) -> None:
+        chunker = SemanticChunker(
+            _IdentityEmbeddings(),
+            breakpoint_threshold_type="gradient",
+        )
+        text = "First sentence. Second sentence."
+        result = chunker.split_text(text)
+        assert result == ["First sentence.", "Second sentence."]
+
+    def test_clear_topic_boundary(self) -> None:
+        """Verify that a clear topic change produces a chunk boundary.
+
+        Sentences in the same cluster embed identically (distance=0), while
+        sentences in different clusters are orthogonal (distance=1). With
+        percentile=50, the boundary between clusters should be detected.
+        """
+        # Cluster 0: sentences 0,1,2  |  Cluster 1: sentences 3,4,5
+        cluster_map = [0, 0, 0, 1, 1, 1]
+        embeddings = _ClusterEmbeddings(cluster_map)
+        chunker = SemanticChunker(
+            embeddings,
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=50,
+        )
+        text = "A cat sat. A cat played. A cat slept. Dogs run. Dogs bark. Dogs play."
+        result = chunker.split_text(text)
+        assert len(result) == 2
+        assert "cat" in result[0]
+        assert "Dogs" in result[1]
+
+    def test_all_identical_produces_single_chunk(self) -> None:
+        """When all embeddings are identical, no breakpoints are found."""
+
+        class _ConstantEmbeddings(Embeddings):
+            def embed_documents(self, texts: list[str]) -> list[list[float]]:
+                return [[1.0, 0.0, 0.0]] * len(texts)
+
+            def embed_query(self, text: str) -> list[float]:  # noqa: ARG002
+                return [1.0, 0.0, 0.0]
+
+        chunker = SemanticChunker(
+            _ConstantEmbeddings(),
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=50,
+        )
+        text = "First point. Second point. Third point. Fourth point."
+        result = chunker.split_text(text)
+        assert len(result) == 1
+
+    def test_custom_regex(self) -> None:
+        chunker = SemanticChunker(
+            _IdentityEmbeddings(),
+            sentence_split_regex=r"\n",
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=0,
+        )
+        text = "Line one\nLine two\nLine three"
+        result = chunker.split_text(text)
+        assert len(result) >= 1
+        # All content preserved.
+        full = " ".join(result)
+        assert "Line one" in full
+        assert "Line two" in full
+        assert "Line three" in full
+
+
+@pytest.mark.requires("numpy")
+class TestSemanticChunkerThresholdTypes:
+    """Verify each threshold type runs without error and produces chunks."""
+
+    _text = "The sky is blue. Water is wet. Fire is hot. Ice is cold. Rocks are hard."
+
+    @pytest.mark.parametrize(
+        "threshold_type",
+        ["percentile", "standard_deviation", "interquartile", "gradient"],
+    )
+    def test_threshold_type_runs(self, threshold_type: str) -> None:
+        chunker = SemanticChunker(
+            _IdentityEmbeddings(),
+            breakpoint_threshold_type=threshold_type,  # type: ignore[arg-type]
+        )
+        result = chunker.split_text(self._text)
+        assert len(result) >= 1
+        # All original content should be preserved across chunks.
+        joined = " ".join(result)
+        for sentence_fragment in ["sky", "Water", "Fire", "Ice", "Rocks"]:
+            assert sentence_fragment in joined
+
+    def test_invalid_threshold_type_raises_even_with_amount(self) -> None:
+        with pytest.raises(ValueError, match="unexpected `breakpoint_threshold_type`"):
+            SemanticChunker(
+                _IdentityEmbeddings(),
+                breakpoint_threshold_type="bad",  # type: ignore[arg-type]
+                breakpoint_threshold_amount=90,
+            )
+
+
+@pytest.mark.requires("numpy")
+class TestSemanticChunkerNumberOfChunks:
+    def test_exact_number(self) -> None:
+        cluster_map = [0, 0, 1, 1, 2, 2]
+        embeddings = _ClusterEmbeddings(cluster_map)
+        chunker = SemanticChunker(embeddings, number_of_chunks=3)
+        text = "A one. A two. B one. B two. C one. C two."
+        result = chunker.split_text(text)
+        assert len(result) == 3
+
+    def test_more_chunks_than_sentences(self) -> None:
+        """Requesting more chunks than sentences returns each sentence."""
+        cluster_map = [0, 1, 2]
+        embeddings = _ClusterEmbeddings(cluster_map)
+        chunker = SemanticChunker(embeddings, number_of_chunks=10)
+        text = "First. Second. Third."
+        result = chunker.split_text(text)
+        assert len(result) == 3
+
+    def test_single_chunk(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings(), number_of_chunks=1)
+        text = "One. Two. Three. Four."
+        result = chunker.split_text(text)
+        assert len(result) == 1
+
+
+@pytest.mark.requires("numpy")
+class TestSemanticChunkerMinChunkSize:
+    def test_small_chunks_merged(self) -> None:
+        cluster_map = [0, 1, 2, 3, 4]
+        embeddings = _ClusterEmbeddings(cluster_map)
+        chunker = SemanticChunker(
+            embeddings,
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=0,
+            min_chunk_size=50,
+        )
+        text = "A. B. C. D. E."
+        result = chunker.split_text(text)
+        # All chunks should meet min_chunk_size or be the sole chunk.
+        for chunk in result:
+            if len(result) > 1:
+                assert len(chunk) >= 50 or chunk == result[-1]
+
+    def test_content_preserved(self) -> None:
+        cluster_map = [0, 1, 2]
+        embeddings = _ClusterEmbeddings(cluster_map)
+        chunker = SemanticChunker(
+            embeddings,
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=0,
+            min_chunk_size=100,
+        )
+        text = "Short. Also short. Yet another."
+        result = chunker.split_text(text)
+        joined = " ".join(result)
+        assert "Short" in joined
+        assert "Also short" in joined
+        assert "Yet another" in joined
+
+
+@pytest.mark.requires("numpy")
+class TestSemanticChunkerDocuments:
+    def test_create_documents(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings())
+        text = "Hello world."
+        docs = chunker.create_documents([text])
+        assert len(docs) >= 1
+        assert all(isinstance(d, Document) for d in docs)
+        assert docs[0].page_content == "Hello world."
+
+    def test_create_documents_with_metadata(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings())
+        docs = chunker.create_documents(
+            ["One sentence."], metadatas=[{"source": "test"}]
+        )
+        assert docs[0].metadata["source"] == "test"
+
+    def test_metadata_isolation(self) -> None:
+        """Metadata dicts should be deep-copied so mutations don't propagate."""
+        chunker = SemanticChunker(
+            _IdentityEmbeddings(),
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=0,
+        )
+        meta = {"source": "test"}
+        text = "First. Second. Third."
+        docs = chunker.create_documents([text], metadatas=[meta])
+        if len(docs) > 1:
+            docs[0].metadata["extra"] = "mutated"
+            assert "extra" not in docs[1].metadata
+
+    def test_add_start_index(self) -> None:
+        chunker = SemanticChunker(
+            _ClusterEmbeddings([0, 0, 1, 1]),
+            add_start_index=True,
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=50,
+        )
+        text = "Cat sat. Cat played. Dog ran. Dog barked."
+        docs = chunker.create_documents([text])
+        for doc in docs:
+            assert "start_index" in doc.metadata
+            idx = doc.metadata["start_index"]
+            assert text[idx:].startswith(doc.page_content)
+
+    def test_add_start_index_with_newlines_preserves_exact_offsets(self) -> None:
+        chunker = SemanticChunker(
+            _ClusterEmbeddings([0, 0, 1]),
+            add_start_index=True,
+            breakpoint_threshold_type="percentile",
+            breakpoint_threshold_amount=0,
+        )
+        text = "Alpha sentence.\n\nBeta sentence.\nGamma sentence."
+        docs = chunker.create_documents([text])
+        assert len(docs) >= 1
+        for doc in docs:
+            idx = doc.metadata["start_index"]
+            assert idx >= 0
+            assert text[idx : idx + len(doc.page_content)] == doc.page_content
+
+    def test_split_documents(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings())
+        input_docs = [
+            Document(page_content="Hello world.", metadata={"source": "a"}),
+        ]
+        result = chunker.split_documents(input_docs)
+        assert len(result) >= 1
+        assert result[0].metadata["source"] == "a"
+
+    def test_transform_documents(self) -> None:
+        chunker = SemanticChunker(_IdentityEmbeddings())
+        input_docs = [Document(page_content="Hello world.")]
+        result = chunker.transform_documents(input_docs)
+        assert len(result) >= 1
+
+
+@pytest.mark.requires("numpy")
+class TestSemanticChunkerBufferSize:
+    def test_buffer_zero_vs_one(self) -> None:
+        """Different buffer sizes should not lose content."""
+        text = "A. B. C. D. E."
+        for bs in (0, 1, 2):
+            chunker = SemanticChunker(_IdentityEmbeddings(), buffer_size=bs)
+            result = chunker.split_text(text)
+            joined = " ".join(result)
+            for fragment in ["A", "B", "C", "D", "E"]:
+                assert fragment in joined

--- a/libs/text-splitters/uv.lock
+++ b/libs/text-splitters/uv.lock
@@ -1262,6 +1262,8 @@ lint = [
 test = [
     { name = "freezegun" },
     { name = "langchain-core" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -1272,6 +1274,8 @@ test = [
 test-integration = [
     { name = "en-core-web-sm" },
     { name = "nltk" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.16.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sentence-transformers" },
     { name = "spacy", marker = "python_full_version < '3.14'" },
@@ -1302,6 +1306,7 @@ lint = [
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-core", editable = "../core" },
+    { name = "numpy", specifier = ">=1.24.0,<3.0.0" },
     { name = "pytest", specifier = ">=8.0.0,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.21.1,<2.0.0" },
     { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
@@ -1312,6 +1317,7 @@ test = [
 test-integration = [
     { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "nltk", specifier = ">=3.9.1,<4.0.0" },
+    { name = "numpy", specifier = ">=1.24.0,<3.0.0" },
     { name = "scipy", marker = "python_full_version == '3.12.*'", specifier = ">=1.7.0,<2.0.0" },
     { name = "scipy", marker = "python_full_version >= '3.13'", specifier = ">=1.14.1,<2.0.0" },
     { name = "sentence-transformers", specifier = ">=3.0.1,<6.0.0" },


### PR DESCRIPTION
## Summary
This PR migrates `SemanticChunker` into `langchain-text-splitters` and aligns behavior for production use, including backward compatible initialization, deterministic threshold validation, and exact source span chunk assembly for reliable `start_index` metadata.

It also adds realistic stress and integration coverage for large HTML like documents, long multi-turn transcripts, and high volume batch splitting workloads.

Fixes #35553

## Scope of Changes
  - Exported `SemanticChunker` in `langchain_text_splitters.__init__`
  - Added `langchain_text_splitters/semantic.py`
  - Restored compatibility for legacy positional constructor usage
  - Enforced explicit validation for invalid `breakpoint_threshold_type`
  - Preserved precedence behavior when both `number_of_chunks` and `breakpoint_threshold_amount` are provided
  - Reworked chunk assembly to use exact character spans from the original input
  - Added unit and integration coverage for:
    - threshold behavior and edge cases
    - exact `start_index` correctness
    - minchunk merge behavior
    - stress scenarios at scale

## Breaking Changes
  None intended.

## Dependency / Lockfile Notes
  - Added `numpy` to `test` group in `libs/text-splitters/pyproject.toml`
  - Updated `libs/text-splitters/uv.lock` accordingly

## Validation
  Executed in `libs/text-splitters`:
  - `make format`
  - `make lint`
  - `make test` (`174 passed, 10 skipped`)

Additional verification:
  - `pytest tests/unit_tests/test_semantic_chunker.py -q` (`52 passed`)
  - `pytest tests/integration_tests/test_semantic_chunker.py -q` (`10 passed`)
  - `pytest tests/integration_tests -q` (`29 passed`, 2 existing spaCy warnings)

## Social Handles
  Twitter: @SusmoySaswat
