### PR TITLE
Allow get_from_dict_or_env to return Any and avoid str casting

### DIFF
--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -27,8 +27,8 @@ def get_from_dict_or_env(
     data: dict[str, Any],
     key: str | list[str],
     env_key: str,
-    default: str | None = None,
-) -> str:
+    default: Any = None,
+) -> Any:
     """Get a value from a dictionary or an environment variable.
 
     Args:
@@ -46,18 +46,18 @@ def get_from_dict_or_env(
     """
     if isinstance(key, (list, tuple)):
         for k in key:
-            if value := data.get(k):
-                return str(value)
+            if k in data and data[k] is not None:
+                return data[k]
 
-    if isinstance(key, str) and key in data and data[key]:
-        return str(data[key])
+    if isinstance(key, str) and key in data and data[key] is not None:
+        return data[key]
 
     key_for_err = key[0] if isinstance(key, (list, tuple)) else key
 
     return get_from_env(key_for_err, env_key, default=default)
 
 
-def get_from_env(key: str, env_key: str, default: str | None = None) -> str:
+def get_from_env(key: str, env_key: str, default: Any = None) -> Any:
     """Get a value from a dictionary or an environment variable.
 
     Args:


### PR DESCRIPTION
### Description
`get_from_dict_or_env` currently casts its output to `str`. This is problematic when the input dictionary contains non-string types (e.g., Enums) that are expected to be preserved.

This PR:
1. Changes the return type of `get_from_dict_or_env` and `get_from_env` to `Any`.
2. Removes the explicit `str()` casting of values retrieved from the dictionary.
3. Updates the `default` parameter type to `Any`.

This allows users to pass and retrieve non-string objects through these utility functions while still defaulting to string behavior for environment variables.

Fixes #35285

### Checklist
- [x] Clear, descriptive title
- [x] Detailed description with problem/solution
- [x] Reference to issue being fixed
- [x] No unrelated changes
- [x] Follows repo contribution guidelines
