### PR TITLE
Skip empty non-assistant messages in ChatAnthropic to avoid API 400

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -683,6 +683,12 @@ def _format_messages(
             # anthropic.BadRequestError: Error code: 400: all messages must have
             # non-empty content except for the optional final assistant message
             continue
+
+        if not content and role != "assistant":
+            # anthropic.BadRequestError: Error code: 400: all messages must have
+            # non-empty content except for the optional final assistant message
+            continue
+
         formatted_messages.append({"role": role, "content": content})
     return system, formatted_messages
 


### PR DESCRIPTION
### Description
`ChatAnthropic` currently fails with a `BadRequestError` (400) from the Anthropic API when a `HumanMessage` (or any non-assistant message) has empty content. Anthropic enforces that "all messages must have non-empty content except for the optional final assistant message".

This PR fixes this by skipping messages with empty content in the `_format_messages` utility, similar to how empty intermediate assistant messages are already handled. This prevents the API from rejecting the entire request when a message is empty (e.g. from an empty tool output or accidental empty input).

Fixes #35081

### Checklist
- [x] Clear, descriptive title
- [x] Detailed description with problem/solution
- [x] Reference to issue being fixed
- [x] No unrelated changes
- [x] Follows repo contribution guidelines
