### PR TITLE
fix(core): merge tool_call_chunks with index=None by matching on id

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -262,8 +262,8 @@ class ToolCallChunk(TypedDict):
     """A chunk of a tool call (yielded when streaming).
 
     When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-    string attributes are concatenated. Chunks are only merged if their values of
-    `index` are equal and not `None`.
+    string attributes are concatenated. Chunks are merged if their values of `index`
+    are equal and not `None`, or if `index` is `None` but their `id` values match.
 
     Example:
     ```python

--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -162,6 +162,30 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                         merged[to_merge[0]] = merge_dicts(merged[to_merge[0]], new_e)
                     else:
                         merged.append(e)
+                elif (
+                    isinstance(e, dict)
+                    and e.get("index") is None
+                    and e.get("id") not in (None, "")
+                ):
+                    # No valid index but has an id — merge with an existing element
+                    # that shares the same id. This handles providers that send
+                    # index=null but use id to identify tool call chunks.
+                    id_matches = [
+                        i
+                        for i, e_left in enumerate(merged)
+                        if isinstance(e_left, dict) and e_left.get("id") == e.get("id")
+                    ]
+                    if id_matches:
+                        new_e = (
+                            {k: v for k, v in e.items() if k != "type"}
+                            if "type" in e
+                            else e
+                        )
+                        merged[id_matches[0]] = merge_dicts(
+                            merged[id_matches[0]], new_e
+                        )
+                    else:
+                        merged.append(e)
                 else:
                     merged.append(e)
     return merged

--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -173,7 +173,15 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                     id_matches = [
                         i
                         for i, e_left in enumerate(merged)
-                        if isinstance(e_left, dict) and e_left.get("id") == e.get("id")
+                        if (
+                            isinstance(e_left, dict)
+                            and e_left.get("id") == e.get("id")
+                            and (
+                                e_left.get("name") in (None, "")
+                                or e.get("name") in (None, "")
+                                or e_left.get("name") == e.get("name")
+                            )
+                        )
                     ]
                     if id_matches:
                         new_e = (

--- a/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
+++ b/libs/core/tests/unit_tests/prompts/__snapshots__/test_chat.ambr
@@ -1019,8 +1019,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python
@@ -2434,8 +2434,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -1443,8 +1443,8 @@
                 A chunk of a tool call (yielded when streaming).
                 
                 When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-                string attributes are concatenated. Chunks are only merged if their values of
-                `index` are equal and not `None`.
+                string attributes are concatenated. Chunks are merged if their values of `index`
+                are equal and not `None`, or if `index` is `None` but their `id` values match.
                 
                 Example:
                 ```python

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
@@ -2962,8 +2962,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python
@@ -4439,8 +4439,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python
@@ -5928,8 +5928,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python
@@ -7273,8 +7273,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python
@@ -8792,8 +8792,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python
@@ -10182,8 +10182,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python
@@ -11620,8 +11620,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python
@@ -13059,8 +13059,8 @@
           A chunk of a tool call (yielded when streaming).
           
           When merging `ToolCallChunk` objects (e.g., via `AIMessageChunk.__add__`), all
-          string attributes are concatenated. Chunks are only merged if their values of
-          `index` are equal and not `None`.
+          string attributes are concatenated. Chunks are merged if their values of `index`
+          are equal and not `None`, or if `index` is `None` but their `id` values match.
           
           Example:
           ```python

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -12,6 +12,8 @@ from pydantic.v1 import BaseModel as PydanticV1BaseModel
 from pydantic.v1 import Field as PydanticV1Field
 
 from langchain_core import utils
+from langchain_core.messages import AIMessageChunk
+from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.outputs import GenerationChunk
 from langchain_core.utils import (
     check_package_version,
@@ -433,6 +435,40 @@ def test_generation_chunk_addition_type_error() -> None:
             [{"no_index": "b"}],
             [{"no_index": "a"}, {"no_index": "b"}],
         ),
+        # index=None with same id: should merge (provider sends null index, uses id)
+        (
+            [{"index": None, "id": "call_abc", "name": "get_weather", "args": ""}],
+            [{"index": None, "id": "call_abc", "name": None, "args": '{"city": "NY"}'}],
+            [
+                {
+                    "index": None,
+                    "id": "call_abc",
+                    "name": "get_weather",
+                    "args": '{"city": "NY"}',
+                }
+            ],
+        ),
+        # index=None with different ids: should stay separate
+        (
+            [{"index": None, "id": "call_001", "name": "tool_a", "args": ""}],
+            [{"index": None, "id": "call_002", "name": "tool_b", "args": ""}],
+            [
+                {"index": None, "id": "call_001", "name": "tool_a", "args": ""},
+                {"index": None, "id": "call_002", "name": "tool_b", "args": ""},
+            ],
+        ),
+        # index=None with no id: falls back to append (original behavior)
+        (
+            [{"index": None, "name": "tool_a"}],
+            [{"index": None, "name": "tool_a"}],
+            [{"index": None, "name": "tool_a"}, {"index": None, "name": "tool_a"}],
+        ),
+        # integer index still works normally (not affected by change)
+        (
+            [{"index": 0, "name": "tool_a", "args": ""}],
+            [{"index": 0, "name": None, "args": "val"}],
+            [{"index": 0, "name": "tool_a", "args": "val"}],
+        ),
     ],
 )
 def test_merge_lists(
@@ -457,6 +493,50 @@ def test_merge_lists_all_none() -> None:
     """Test `merge_lists` with all `None` arguments."""
     result = merge_lists(None, None, None)
     assert result is None
+
+
+def test_merge_lists_tool_call_chunks_null_index() -> None:
+    """Test that tool call chunks with index=None are merged by id."""
+    chunk1 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            ToolCallChunk(name="get_weather", args="", id="call_abc123", index=None)
+        ],
+    )
+    chunk2 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            ToolCallChunk(
+                name="", args='{"city": "Boston"}', id="call_abc123", index=None
+            )
+        ],
+    )
+    accumulated = chunk1 + chunk2
+    assert len(accumulated.tool_call_chunks) == 1
+    tc = accumulated.tool_call_chunks[0]
+    assert tc["name"] == "get_weather"
+    assert tc["args"] == '{"city": "Boston"}'
+    assert tc["id"] == "call_abc123"
+
+
+def test_merge_lists_tool_call_chunks_null_index_different_ids() -> None:
+    """Test that tool call chunks with index=None and different ids stay separate."""
+    chunk1 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            ToolCallChunk(name="tool_a", args="", id="call_001", index=None)
+        ],
+    )
+    chunk2 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            ToolCallChunk(name="tool_b", args="", id="call_002", index=None)
+        ],
+    )
+    accumulated = chunk1 + chunk2
+    assert len(accumulated.tool_call_chunks) == 2
+    assert accumulated.tool_call_chunks[0]["id"] == "call_001"
+    assert accumulated.tool_call_chunks[1]["id"] == "call_002"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`merge_lists` only merges dict elements when `index` is an integer — when `index=None`, elements always get appended, producing multiple partial chunks instead of one merged tool call. This breaks streaming with any OpenAI-compatible server that sends `index=null` (e.g., vLLM, LM Studio, Ollama, and others).

The fix adds an `id`-based fallback: when a dict element has `index=None` but carries a non-empty `id`, it gets merged into the first existing element with the same `id` rather than appended as a new entry. When no matching `id` is found, it falls through to the existing append behavior — so the change is strictly additive.

I also updated the `ToolCallChunk` docstring (which currently says index=None means "no merging") and added six unit tests covering the new path.

**Note:** most of the diff line count comes from snapshot file updates (`.ambr`) triggered by the docstring change on `ToolCallChunk`. The actual logic change is ~24 lines in `_merge.py`.

Previous PR #34671 attempted the same fix but was abandoned by its author.

Fixes #34654

---

_Used AI tooling for research and understanding of the codebase._