### PR TITLE
fix(core): prevent output corruption in RunnableRetry.batch when partial retries succeed

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -283,6 +283,9 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         # Map last retry results back to original indices so that
         # successfully-retried values don't overwrite unrelated positions.
+        # If the final retry attempt succeeded for every remaining input, those
+        # indices are already in results_map, so last_result_map is never
+        # consulted for them.
         last_result_map = dict(zip(last_remaining_indices, result, strict=True))
 
         outputs: list[Output | Exception] = []
@@ -364,6 +367,9 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         # Map last retry results back to original indices so that
         # successfully-retried values don't overwrite unrelated positions.
+        # If the final retry attempt succeeded for every remaining input, those
+        # indices are already in results_map, so last_result_map is never
+        # consulted for them.
         last_result_map = dict(zip(last_remaining_indices, result, strict=True))
 
         outputs: list[Output | Exception] = []

--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -283,9 +283,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         # Map last retry results back to original indices so that
         # successfully-retried values don't overwrite unrelated positions.
-        # If the final retry attempt succeeded for every remaining input, those
-        # indices are already in results_map, so last_result_map is never
-        # consulted for them.
+        # Note: if all items succeed on the very first attempt, remaining_indices
+        # becomes empty on the second iteration → break before updating
+        # last_remaining_indices.  In that case last_remaining_indices ==
+        # range(len(inputs)) and result == the full first-attempt output, so the
+        # zip still pairs correctly.  However, every idx will already be in
+        # results_map, so last_result_map is never actually consulted.
         last_result_map = dict(zip(last_remaining_indices, result, strict=True))
 
         outputs: list[Output | Exception] = []
@@ -367,9 +370,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         # Map last retry results back to original indices so that
         # successfully-retried values don't overwrite unrelated positions.
-        # If the final retry attempt succeeded for every remaining input, those
-        # indices are already in results_map, so last_result_map is never
-        # consulted for them.
+        # Note: if all items succeed on the very first attempt, remaining_indices
+        # becomes empty on the second iteration → break before updating
+        # last_remaining_indices.  In that case last_remaining_indices ==
+        # range(len(inputs)) and result == the full first-attempt output, so the
+        # zip still pairs correctly.  However, every idx will already be in
+        # results_map, so last_result_map is never actually consulted.
         last_result_map = dict(zip(last_remaining_indices, result, strict=True))
 
         outputs: list[Output | Exception] = []

--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -289,7 +289,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         # range(len(inputs)) and result == the full first-attempt output, so the
         # zip still pairs correctly.  However, every idx will already be in
         # results_map, so last_result_map is never actually consulted.
-        last_result_map = dict(zip(last_remaining_indices, result))
+        last_result_map = dict(zip(last_remaining_indices, result, strict=False))
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
@@ -376,7 +376,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         # range(len(inputs)) and result == the full first-attempt output, so the
         # zip still pairs correctly.  However, every idx will already be in
         # results_map, so last_result_map is never actually consulted.
-        last_result_map = dict(zip(last_remaining_indices, result))
+        last_result_map = dict(zip(last_remaining_indices, result, strict=False))
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):

--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -289,7 +289,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         # range(len(inputs)) and result == the full first-attempt output, so the
         # zip still pairs correctly.  However, every idx will already be in
         # results_map, so last_result_map is never actually consulted.
-        last_result_map = dict(zip(last_remaining_indices, result, strict=True))
+        last_result_map = dict(zip(last_remaining_indices, result))
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
@@ -376,7 +376,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         # range(len(inputs)) and result == the full first-attempt output, so the
         # zip still pairs correctly.  However, every idx will already be in
         # results_map, so last_result_map is never actually consulted.
-        last_result_map = dict(zip(last_remaining_indices, result, strict=True))
+        last_result_map = dict(zip(last_remaining_indices, result))
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):

--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -235,6 +235,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         not_set: list[Output] = []
         result = not_set
+        last_remaining_indices: list[int] = list(range(len(inputs)))
         try:
             for attempt in self._sync_retrying():
                 with attempt:
@@ -245,6 +246,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     ]
                     if not remaining_indices:
                         break
+                    last_remaining_indices = remaining_indices
                     pending_inputs = [inputs[i] for i in remaining_indices]
                     pending_configs = [config[i] for i in remaining_indices]
                     pending_run_managers = [run_manager[i] for i in remaining_indices]
@@ -279,12 +281,16 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
+        # Map last retry results back to original indices so that
+        # successfully-retried values don't overwrite unrelated positions.
+        last_result_map = dict(zip(last_remaining_indices, result))
+
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(last_result_map[idx])
         return outputs
 
     @override
@@ -311,6 +317,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         not_set: list[Output] = []
         result = not_set
+        last_remaining_indices: list[int] = list(range(len(inputs)))
         try:
             async for attempt in self._async_retrying():
                 with attempt:
@@ -321,6 +328,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     ]
                     if not remaining_indices:
                         break
+                    last_remaining_indices = remaining_indices
                     pending_inputs = [inputs[i] for i in remaining_indices]
                     pending_configs = [config[i] for i in remaining_indices]
                     pending_run_managers = [run_manager[i] for i in remaining_indices]
@@ -354,12 +362,16 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
 
+        # Map last retry results back to original indices so that
+        # successfully-retried values don't overwrite unrelated positions.
+        last_result_map = dict(zip(last_remaining_indices, result))
+
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(last_result_map[idx])
         return outputs
 
     @override

--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -283,7 +283,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         # Map last retry results back to original indices so that
         # successfully-retried values don't overwrite unrelated positions.
-        last_result_map = dict(zip(last_remaining_indices, result))
+        last_result_map = dict(zip(last_remaining_indices, result, strict=True))
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
@@ -364,7 +364,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         # Map last retry results back to original indices so that
         # successfully-retried values don't overwrite unrelated positions.
-        last_result_map = dict(zip(last_remaining_indices, result))
+        last_result_map = dict(zip(last_remaining_indices, result, strict=True))
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3979,6 +3979,77 @@ async def test_async_retry_batch_preserves_order() -> None:
     assert results == [0, 1, 2]
 
 
+def test_retry_batch_no_corruption_on_partial_retry() -> None:
+    """Regression: items that still fail after retries must stay as exceptions.
+
+    When one item succeeds on retry while another permanently fails, the stale
+    index mapping caused the permanent failure to be replaced by the retried
+    success value (GH-35475).
+    """
+    failed_once = False
+
+    def process(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                msg = "transient"
+                raise ValueError(msg)
+            return "retry-result"
+        msg = "permanent"
+        raise ValueError(msg)
+
+    runnable = RunnableLambda(process).with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError,),
+    )
+
+    result = runnable.batch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
+async def test_async_retry_batch_no_corruption_on_partial_retry() -> None:
+    """Async variant of the partial-retry corruption regression test."""
+    failed_once = False
+
+    def process(name: str) -> str:
+        nonlocal failed_once
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if not failed_once:
+                failed_once = True
+                msg = "transient"
+                raise ValueError(msg)
+            return "retry-result"
+        msg = "permanent"
+        raise ValueError(msg)
+
+    runnable = RunnableLambda(process).with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError,),
+    )
+
+    result = await runnable.abatch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+
+
 async def test_async_retrying(mocker: MockerFixture) -> None:
     def _lambda(x: int) -> int:
         if x == 1:


### PR DESCRIPTION
## Bug

`RunnableRetry.batch()` / `abatch()` with `return_exceptions=True` can return **corrupted outputs** when some items succeed on retry while others still fail. A permanently-failing item can be silently replaced by a successfully-retried value from a different position.

## Root Cause

After retries exhaust, the final assembly loop uses `result.pop(0)` to fill positions not yet in `results_map`. But `result` still contains **all** items from the last retry batch — including successfully-retried values already saved to `results_map`. The `pop(0)` consumes them in order, picking up the wrong element for positions that should be exceptions.

**Example** (from the issue):
- Inputs: `["ok", "retry_then_ok", "always_fail"]`
- After attempt 2, `result = ["retry-result", ValueError]`
- `results_map = {0: "ok-result", 1: "retry-result"}`
- For index 2 (not in map): `result.pop(0)` returns `"retry-result"` instead of the `ValueError`

## Fix

Replace the `pop(0)`-based assembly with an **index-mapped lookup**:
- Track `last_remaining_indices` across retry iterations
- After the loop, build `last_result_map = dict(zip(last_remaining_indices, result))`
- Look up each original index in either `results_map` (succeeded) or `last_result_map` (still-failing)

Applied identically to both `_batch` and `_abatch`.

## Tests

Added sync and async regression tests that reproduce the exact scenario from the issue: one item succeeds immediately, one succeeds on retry, one always fails. Before this fix, `result[2]` was `"retry-result"` instead of an exception.

Fixes #35475