### PR TITLE
fix(openai): force stream=False in _generate/_agenerate when disable_streaming is active

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1455,6 +1455,10 @@ class BaseChatOpenAI(BaseChatModel):
     ) -> ChatResult:
         self._ensure_sync_client_available()
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        # _generate is the non-streaming path. Force stream=False so that
+        # the API returns a plain response even when self.streaming is True
+        # (e.g. when disable_streaming="tool_calling" redirects here).
+        payload["stream"] = False
         generation_info = None
         raw_response = None
         try:
@@ -1715,6 +1719,10 @@ class BaseChatOpenAI(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        # _agenerate is the non-streaming path. Force stream=False so that
+        # the API returns a plain response even when self.streaming is True
+        # (e.g. when disable_streaming="tool_calling" redirects here).
+        payload["stream"] = False
         generation_info = None
         raw_response = None
         try:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3599,3 +3599,142 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test_disable_streaming_tool_calling_forces_stream_false_sync() -> None:
+    """When disable_streaming='tool_calling' redirects to _generate,
+    the payload sent to the API must have stream=False even if
+    self.streaming is True.  Regression test for #35436."""
+    mock_completion = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1689989000,
+        "model": "gpt-4",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Tokyo"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+
+    llm = ChatOpenAI(
+        model="gpt-4",
+        api_key=SecretStr("fake-key"),
+        streaming=True,
+        disable_streaming="tool_calling",
+    )
+
+    mock_raw_resp = MagicMock()
+    mock_raw_resp.headers = {"content-type": "application/json"}
+    mock_raw_resp.parse.return_value = mock_completion
+
+    mock_client = MagicMock()
+    mock_client.with_raw_response.create.return_value = mock_raw_resp
+
+    with patch.object(llm, "client", mock_client):
+        result = llm.invoke(
+            "What is the weather in Tokyo?",
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        )
+
+    call_kwargs = mock_client.with_raw_response.create.call_args
+    payload = call_kwargs.kwargs if call_kwargs.kwargs else call_kwargs.args[0]
+    assert payload["stream"] is False, (
+        "stream must be False in the API payload when _generate is called"
+    )
+    assert result.tool_calls[0]["name"] == "get_weather"
+
+
+async def test_disable_streaming_tool_calling_forces_stream_false_async() -> None:
+    """Async variant: payload must have stream=False. Regression test for #35436."""
+    mock_completion = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "created": 1689989000,
+        "model": "gpt-4",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city":"Tokyo"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    }
+
+    llm = ChatOpenAI(
+        model="gpt-4",
+        api_key=SecretStr("fake-key"),
+        streaming=True,
+        disable_streaming="tool_calling",
+    )
+
+    mock_raw_resp = MagicMock()
+    mock_raw_resp.parse.return_value = mock_completion
+
+    mock_async_client = AsyncMock()
+    mock_async_client.with_raw_response.create.return_value = mock_raw_resp
+
+    with patch.object(llm, "async_client", mock_async_client):
+        result = await llm.ainvoke(
+            "What is the weather in Tokyo?",
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        )
+
+    call_kwargs = mock_async_client.with_raw_response.create.call_args
+    payload = call_kwargs.kwargs if call_kwargs.kwargs else call_kwargs.args[0]
+    assert payload["stream"] is False, (
+        "stream must be False in the API payload when _agenerate is called"
+    )
+    assert result.tool_calls[0]["name"] == "get_weather"


### PR DESCRIPTION
## Bug

When `disable_streaming="tool_calling"` is set and `streaming=True`, calling `_generate`/`_agenerate` (the non-streaming path) still sends `stream=True` to the OpenAI API because `_default_params` hardcodes `"stream": self.streaming`. The API returns an `AsyncStream`/`Stream` instead of a `ChatCompletion`, crashing with:

```
AttributeError: 'AsyncStream' object has no attribute 'model_dump'
```

## Fix

Explicitly set `payload["stream"] = False` at the top of both `_generate` and `_agenerate`. These methods are always the non-streaming code path — when `_should_stream` returns `False` (e.g. due to `disable_streaming`), execution is routed here, so the API payload must never request streaming.

## Tests

Added sync and async unit tests that verify the payload sent to the OpenAI client has `stream=False` when `disable_streaming="tool_calling"` is active with `streaming=True`.

Closes #35436