### PR TITLE
fix(openai): detect gpt-5.4+ as Responses API models

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -536,7 +536,7 @@ def _handle_openai_api_error(e: openai.APIError) -> None:
 _RESPONSES_API_ONLY_PREFIXES = (
     "gpt-5-pro",
     "gpt-5.2-pro",
-    "gpt-5.4-pro",
+    "gpt-5.4",
 )
 
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3281,6 +3281,9 @@ def test_model_prefers_responses_api() -> None:
     assert _model_prefers_responses_api("gpt-5.2-pro-2025-12-11")
     assert _model_prefers_responses_api("gpt-5.4-pro")
     assert _model_prefers_responses_api("gpt-5.4-pro-2026-03-05")
+    # gpt-5.4+ base models (with and without date snapshots): Responses API only
+    assert _model_prefers_responses_api("gpt-5.4")
+    assert _model_prefers_responses_api("gpt-5.4-2026-03-05")
     # Codex models: Responses API only
     assert _model_prefers_responses_api("gpt-5.3-codex")
     assert _model_prefers_responses_api("gpt-5.2-codex")
@@ -3292,7 +3295,6 @@ def test_model_prefers_responses_api() -> None:
     # These should not match
     assert not _model_prefers_responses_api("gpt-5")
     assert not _model_prefers_responses_api("gpt-5.1")
-    assert not _model_prefers_responses_api("gpt-5.4")
     assert not _model_prefers_responses_api("o3-pro")
     assert not _model_prefers_responses_api("gpt-4.1")
     assert not _model_prefers_responses_api(None)


### PR DESCRIPTION
## Problem

`_model_prefers_responses_api()` matched `gpt-5.4-pro` but not bare `gpt-5.4` variants (e.g. `gpt-5.4-2026-03-05`). This caused `langchain-openai` to route them through Chat Completions (`/v1/chat/completions`) instead of the Responses API, which fails with:

```
openai.BadRequestError: Unknown parameter: 'tool_choice.function'
```

Closes #35584

## Fix

Broadened the `_RESPONSES_API_ONLY_PREFIXES` entry from `"gpt-5.4-pro"` to `"gpt-5.4"` so all gpt-5.4 variants (base, pro, date snapshots) are correctly routed to the Responses API.

**Before:** `("gpt-5-pro", "gpt-5.2-pro", "gpt-5.4-pro")`
**After:** `("gpt-5-pro", "gpt-5.2-pro", "gpt-5.4")`

Since `"gpt-5.4"` is a prefix of `"gpt-5.4-pro"`, the pro variant continues to match.

## Tests

Updated `test_model_prefers_responses_api` to verify:
- `gpt-5.4` → detected ✅
- `gpt-5.4-2026-03-05` → detected ✅
- `gpt-5.4-pro` → still detected ✅
- Existing models (`gpt-5-pro`, `gpt-5.2-pro`, codex) → unchanged ✅
- Non-Responses API models (`gpt-5`, `gpt-5.1`, `gpt-4.1`) → not affected ✅