### PR TITLE
openai: add explicit `type: "message"` to Responses API input items

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4386,10 +4386,13 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                         pass
                 msg["content"] = new_blocks
                 if msg["content"]:
+                    msg["type"] = "message"
                     input_.append(msg)
             else:
+                msg["type"] = "message"
                 input_.append(msg)
         else:
+            msg["type"] = "message"
             input_.append(msg)
 
     return input_


### PR DESCRIPTION
## Description

`_construct_responses_api_input()` builds `EasyInputMessageParam`-style dicts for `user`, `system`, and `developer` messages **without** the `"type"` field. OpenAI's native endpoint silently infers `"message"`, but other OpenAI-compatible endpoints (e.g. Azure AI Foundry) enforce the schema strictly and return a **400 Bad Request**.

## Error

```
BadRequestError: Error code: 400 - {'error': {'message': "Invalid value: ''. Supported values are: 
'apply_patch_call', ..., 'message', ..., and 'web_search_call'.",
'type': 'invalid_request_error', 'param': 'input[1]', 'code': 'invalid_value'}}
```

## Fix

Sets `msg["type"] = "message"` explicitly on every `user`/`system`/`developer` input item (and the else fallthrough) before appending to the `input_` list.

This is:
- **Spec-conforming** — `EasyInputMessageParam` already defines `type: Literal["message"]`
- **Backward-compatible** — a no-op for OpenAI's endpoint which already infers it
- **Required** for Azure AI Foundry and potentially other strict OpenAI-compatible services

Fixes #35689