### PR TITLE
feat(langchain): auto-complete ToolMessage in Command returns from tools

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -655,6 +655,130 @@ def _chain_async_tool_call_wrappers(
     return result
 
 
+def _auto_complete_tool_command(
+    result: Any,
+    tool_call_id: str,
+    tool_name: str,
+) -> Any:
+    """Auto-create a ToolMessage in a Command when one is missing.
+
+    When a tool returns a ``Command`` with a dict update (e.g.
+    ``Command(update={"jump_to": "end"})``), langgraph's ``ToolNode`` requires a
+    matching ``ToolMessage``.  This helper fills it in automatically so that tool
+    authors don't need to construct one by hand.
+
+    The following cases are handled:
+
+    * **No messages key** – a ``ToolMessage`` with empty content is inserted.
+    * **String items in messages list** – each string is converted to a
+      ``ToolMessage`` with the string as its content.
+
+    Non-``Command`` results and ``Command`` objects that already contain a valid
+    ``ToolMessage`` are returned unchanged.
+
+    Args:
+        result: The raw return value from a tool execution.
+        tool_call_id: The id of the tool call that triggered this execution.
+        tool_name: The name of the tool.
+
+    Returns:
+        The (possibly modified) result with a proper ``ToolMessage`` present.
+    """
+    if not isinstance(result, Command):
+        return result
+
+    update = result.update
+    if not isinstance(update, dict):
+        return result
+
+    messages = update.get("messages")
+
+    # Case 1: No messages key at all – create a ToolMessage with empty content
+    if messages is None:
+        update["messages"] = [ToolMessage(content="", tool_call_id=tool_call_id, name=tool_name)]
+        return result
+
+    # Case 2: Messages list exists – check if it already has a matching ToolMessage
+    has_tool_message = False
+    for i, msg in enumerate(messages):
+        if isinstance(msg, ToolMessage) and msg.tool_call_id == tool_call_id:
+            has_tool_message = True
+            break
+        # Convert plain strings to ToolMessage
+        if isinstance(msg, str):
+            messages[i] = ToolMessage(content=msg, tool_call_id=tool_call_id, name=tool_name)
+            has_tool_message = True
+
+    # If still no matching ToolMessage, prepend one
+    if not has_tool_message:
+        messages.insert(
+            0,
+            ToolMessage(content="", tool_call_id=tool_call_id, name=tool_name),
+        )
+
+    return result
+
+
+def _wrap_tool_for_auto_command(tool: BaseTool) -> BaseTool:
+    """Wrap a tool so that Command returns are auto-completed with ToolMessage.
+
+    This patches the tool's ``invoke`` and ``ainvoke`` methods so that when a
+    tool returns a ``Command`` without a matching ``ToolMessage``, one is
+    automatically created using the ``tool_call_id`` from the invocation
+    context.  This allows tool authors to write::
+
+        @tool
+        def my_tool(data: str) -> Command[dict[str, Any]]:
+            return Command(update={"jump_to": "end"})
+
+    instead of manually constructing a ``ToolMessage``.
+
+    Args:
+        tool: The tool to wrap.
+
+    Returns:
+        The same tool instance with patched ``invoke``/``ainvoke`` methods.
+    """
+    original_invoke = tool.invoke
+    original_ainvoke = tool.ainvoke
+
+    def _extract_tool_call_id(
+        tool_input: Any,
+    ) -> tuple[str | None, str | None]:
+        """Extract tool_call_id and tool name from a ToolCall input."""
+        if isinstance(tool_input, dict) and "id" in tool_input and "name" in tool_input:
+            return tool_input["id"], tool_input["name"]
+        return None, None
+
+    def patched_invoke(
+        tool_input: Any,
+        config: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        result = original_invoke(tool_input, config, **kwargs)
+        tool_call_id, tool_name = _extract_tool_call_id(tool_input)
+        if tool_call_id is not None and tool_name is not None:
+            return _auto_complete_tool_command(result, tool_call_id, tool_name)
+        return result
+
+    async def patched_ainvoke(
+        tool_input: Any,
+        config: Any = None,
+        **kwargs: Any,
+    ) -> Any:
+        result = await original_ainvoke(tool_input, config, **kwargs)
+        tool_call_id, tool_name = _extract_tool_call_id(tool_input)
+        if tool_call_id is not None and tool_name is not None:
+            return _auto_complete_tool_command(result, tool_call_id, tool_name)
+        return result
+
+    # Use object.__setattr__ to bypass Pydantic's __setattr__ which rejects
+    # setting attributes not declared as model fields.
+    object.__setattr__(tool, "invoke", patched_invoke)
+    object.__setattr__(tool, "ainvoke", patched_ainvoke)
+    return tool
+
+
 def create_agent(
     model: str | BaseChatModel,
     tools: Sequence[BaseTool | Callable[..., Any] | dict[str, Any]] | None = None,
@@ -901,6 +1025,14 @@ def create_agent(
         if available_tools or wrap_tool_call_wrapper or awrap_tool_call_wrapper
         else None
     )
+
+    # Wrap all tools so that Command returns are auto-completed with ToolMessage.
+    # This allows tools to return e.g. Command(update={"jump_to": "end"}) without
+    # manually constructing a ToolMessage. Must happen after ToolNode creation since
+    # ToolNode converts callables to BaseTool instances.
+    if tool_node is not None:
+        for tool_instance in tool_node.tools_by_name.values():
+            _wrap_tool_for_auto_command(tool_instance)
 
     # Default tools for ModelRequest initialization
     # Use converted BaseTool instances from ToolNode (not raw callables)
@@ -1439,14 +1571,10 @@ def create_agent(
     graph.add_edge(START, entry_node)
     # add conditional edges only if tools exist
     if tool_node is not None:
-        # Only include exit_node in destinations if any tool has return_direct=True
-        # or if there are structured output tools
-        tools_to_model_destinations = [loop_entry_node]
-        if (
-            any(tool.return_direct for tool in tool_node.tools_by_name.values())
-            or structured_output_tools
-        ):
-            tools_to_model_destinations.append(exit_node)
+        # Always include exit_node in destinations so tools can dynamically end
+        # the loop via Command(update={"jump_to": "end"}), in addition to
+        # return_direct and structured output tools.
+        tools_to_model_destinations = [loop_entry_node, exit_node]
 
         graph.add_conditional_edges(
             "tools",
@@ -1761,7 +1889,17 @@ def _make_tools_to_model_edge(
         if any(t.name in structured_output_tools for t in tool_messages):
             return end_destination
 
-        # 4. Default: Continue the loop
+        # 4. If there's an explicit jump_to in the state, use it.
+        #    This allows tools to dynamically end (or redirect) the agent loop
+        #    by returning Command(update={"jump_to": "end"}).
+        if jump_to := state.get("jump_to"):
+            return _resolve_jump(
+                jump_to,
+                model_destination=model_destination,
+                end_destination=end_destination,
+            )
+
+        # 5. Default: Continue the loop
         #    Tool execution completed successfully, route back to the model
         #    so it can process the tool results and decide the next action.
         return model_destination

--- a/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_return_direct_graph.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_return_direct_graph.ambr
@@ -60,6 +60,7 @@
   	__start__ --> model;
   	model -.-> __end__;
   	model -.-> tools;
+  	tools -.-> __end__;
   	tools -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
@@ -20,6 +20,7 @@
   	__start__ --> NoopZero\2ebefore_agent;
   	model -.-> NoopTwo\2eafter_agent;
   	model -.-> tools;
+  	tools -.-> NoopTwo\2eafter_agent;
   	tools -.-> model;
   	NoopOne\2eafter_agent --> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
@@ -54,6 +55,7 @@
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	tools -.-> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -207,6 +209,7 @@
   	__start__ --> model;
   	model -.-> __end__;
   	model -.-> tools;
+  	tools -.-> __end__;
   	tools -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
@@ -86,10 +86,11 @@
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	tools -.-> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
-  
+
   '''
 # ---
 # name: test_create_agent_jump[postgres_pipe]
@@ -118,10 +119,11 @@
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	tools -.-> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
-  
+
   '''
 # ---
 # name: test_create_agent_jump[postgres_pool]
@@ -150,10 +152,11 @@
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	tools -.-> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
-  
+
   '''
 # ---
 # name: test_create_agent_jump[sqlite]
@@ -182,10 +185,11 @@
   	__start__ --> NoopSeven\2ebefore_model;
   	model --> NoopEight\2eafter_model;
   	tools -.-> NoopSeven\2ebefore_model;
+  	tools -.-> __end__;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
-  
+
   '''
 # ---
 # name: test_simple_agent_graph

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
@@ -90,7 +90,7 @@
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
-
+  
   '''
 # ---
 # name: test_create_agent_jump[postgres_pipe]
@@ -123,7 +123,7 @@
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
-
+  
   '''
 # ---
 # name: test_create_agent_jump[postgres_pool]
@@ -156,7 +156,7 @@
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
-
+  
   '''
 # ---
 # name: test_create_agent_jump[sqlite]
@@ -189,7 +189,7 @@
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
-
+  
   '''
 # ---
 # name: test_simple_agent_graph

--- a/libs/langchain_v1/tests/unit_tests/agents/test_tool_auto_command.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_tool_auto_command.py
@@ -1,0 +1,210 @@
+"""Tests for auto-completing ToolMessage in Command returns from tools.
+
+Verifies that tools can return Command(update={"jump_to": "end"}) without
+manually constructing ToolMessage objects. The agent should auto-create
+the ToolMessage using the tool_call_id from the request context.
+
+See: https://github.com/langchain-ai/langchain/issues/34884
+"""
+
+from typing import Any
+
+from langchain_core.messages import HumanMessage, ToolCall, ToolMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.types import Command
+
+from langchain.agents.factory import create_agent
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+def test_tool_command_jump_to_end_without_tool_message() -> None:
+    """Tool returns Command with jump_to='end' but no ToolMessage.
+
+    The agent should auto-create the ToolMessage and stop the loop.
+    """
+    model_call_count = [0]
+
+    class CountingModel(FakeToolCallingModel):
+        def _generate(self, *args: Any, **kwargs: Any) -> Any:
+            model_call_count[0] += 1
+            return super()._generate(*args, **kwargs)
+
+    @tool
+    def validate_and_finish(data: str) -> Command[dict[str, Any]]:
+        """Validate data and finish if valid."""
+        if data == "valid":
+            return Command(update={"jump_to": "end"})
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content="validation failed, please retry",
+                        tool_call_id="1",
+                        name="validate_and_finish",
+                    )
+                ],
+            }
+        )
+
+    model = CountingModel(
+        tool_calls=[
+            [ToolCall(name="validate_and_finish", args={"data": "valid"}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[validate_and_finish],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("validate this")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    # Model should only be called once (tool ends the loop)
+    assert model_call_count[0] == 1
+    tool_msgs = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 1
+
+
+def test_tool_command_jump_to_end_with_string_content() -> None:
+    """Tool returns Command with jump_to='end' and a string message content.
+
+    The string should be auto-wrapped into a ToolMessage.
+    """
+    model_call_count = [0]
+
+    class CountingModel(FakeToolCallingModel):
+        def _generate(self, *args: Any, **kwargs: Any) -> Any:
+            model_call_count[0] += 1
+            return super()._generate(*args, **kwargs)
+
+    @tool
+    def complete_task(task_id: str) -> Command[dict[str, Any]]:
+        """Complete a task and end the loop with a message."""
+        return Command(
+            update={
+                "messages": [f"Task {task_id} completed successfully."],
+                "jump_to": "end",
+            }
+        )
+
+    model = CountingModel(
+        tool_calls=[
+            [ToolCall(name="complete_task", args={"task_id": "123"}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[complete_task],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("complete task 123")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    assert model_call_count[0] == 1
+    tool_msgs = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 1
+    assert "completed successfully" in tool_msgs[0].content
+
+
+def test_tool_command_conditional_jump() -> None:
+    """Tool dynamically decides to end or continue without manual ToolMessage.
+
+    When valid: returns Command with jump_to='end' and no ToolMessage.
+    When invalid: returns plain string (continues loop normally).
+    """
+    model_call_count = [0]
+
+    class CountingModel(FakeToolCallingModel):
+        def _generate(self, *args: Any, **kwargs: Any) -> Any:
+            model_call_count[0] += 1
+            return super()._generate(*args, **kwargs)
+
+    call_count = [0]
+
+    @tool
+    def smart_validator(value: str) -> Any:
+        """Validate and decide flow based on result."""
+        call_count[0] += 1
+        if value.isdigit() and int(value) > 0:
+            # Dynamically end the loop
+            return Command(update={"jump_to": "end"})
+        # Continue normally — return a plain string
+        return f"invalid: {value}, need positive number"
+
+    model = CountingModel(
+        tool_calls=[
+            [ToolCall(name="smart_validator", args={"value": "abc"}, id="1")],
+            [ToolCall(name="smart_validator", args={"value": "42"}, id="2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[smart_validator],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("validate")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    # First call: invalid → continues to model. Second call: valid → ends loop.
+    assert call_count[0] == 2
+    assert model_call_count[0] == 2  # called twice (initial + after first tool fail)
+    tool_msgs = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 2
+    assert "invalid" in tool_msgs[0].content
+
+
+def test_tool_command_without_jump_to_unaffected() -> None:
+    """Command without jump_to still requires explicit ToolMessage (unchanged behavior)."""
+
+    @tool
+    def normal_command_tool(data: str) -> Command[dict[str, Any]]:
+        """Return a Command with explicit ToolMessage, no jump_to."""
+        return Command(
+            update={
+                "messages": [
+                    ToolMessage(
+                        content=f"processed: {data}",
+                        tool_call_id="1",
+                        name="normal_command_tool",
+                    )
+                ],
+            }
+        )
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="normal_command_tool", args={"data": "test"}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[normal_command_tool],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("process this")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    tool_msgs = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_msgs) == 1
+    assert "processed: test" in tool_msgs[0].content


### PR DESCRIPTION
## Summary

- Tools returning `Command(update={"jump_to": "end"})` no longer need to manually construct a `ToolMessage` — the agent factory auto-creates one using the `tool_call_id` from invocation context
- Wraps tool `invoke`/`ainvoke` methods after `ToolNode` creation so auto-completion runs before langgraph's validation
- Strings in `Command.update["messages"]` are also auto-converted to proper `ToolMessage` objects
- Re-added `jump_to` check in `_make_tools_to_model_edge` and always include `exit_node` in tools-to-model edge destinations

Closes #34884

## Motivation

The existing `jump_to` mechanism requires verbose `ToolMessage` construction:

```python
# Before (verbose — tool must know tool_call_id)
@tool
def validate(data: str) -> Command[dict[str, Any]]:
    return Command(update={
        "messages": [ToolMessage(content="done", tool_call_id="1", name="validate")],
        "jump_to": "end",
    })
```

Now tools can simply write:

```python
# After (concise)
@tool
def validate(data: str) -> Command[dict[str, Any]]:
    if verify(data):
        return Command(update={"jump_to": "end"})
    return "verify failed"
```

## Test plan

- [x] `test_tool_command_jump_to_end_without_tool_message` — Command with `jump_to` but no ToolMessage auto-creates one
- [x] `test_tool_command_jump_to_end_with_string_content` — String in messages list auto-converts to ToolMessage
- [x] `test_tool_command_conditional_jump` — Tool dynamically decides to end or continue
- [x] `test_tool_command_without_jump_to_unaffected` — Existing Command with explicit ToolMessage unchanged
- [x] Full agent test suite (732 passed, 0 failures)
- [x] Lint + mypy + format all pass

## Areas requiring careful review

- `_wrap_tool_for_auto_command` uses `object.__setattr__` to bypass Pydantic's field validation when patching `invoke`/`ainvoke` on tool instances
- The auto-complete logic in `_auto_complete_tool_command` handles three cases: no messages key, string items in messages, and missing ToolMessage — edge cases worth scrutinizing
- Always including `exit_node` in `tools_to_model_destinations` is a minor graph structure change (adds a `tools -.-> __end__` edge even when no `return_direct` tools exist)