### PR TITLE
ci: use app token for external PR label to trigger downstream workflows

### DIFF
--- a/.github/workflows/tag-external-contributions.yml
+++ b/.github/workflows/tag-external-contributions.yml
@@ -119,7 +119,10 @@ jobs:
         if: steps.check-membership.outputs.is-external == 'true' && github.event_name == 'pull_request_target'
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Use App token so the "labeled" event propagates to downstream
+          # workflows (e.g. require_issue_link.yml). Events created by the
+          # default GITHUB_TOKEN do not trigger additional workflow runs.
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
             const pull_number = context.payload.pull_request.number;


### PR DESCRIPTION
The `tag-external-contributions.yml` workflow was using `GITHUB_TOKEN` to add the `external` label to PRs, which silently prevented the `labeled` event from propagating to `require_issue_link.yml`. GitHub Actions suppresses events created by `GITHUB_TOKEN` to avoid infinite loops — but in this case, the downstream workflow depends on that event to enforce the issue-link requirement on external PRs.

## Changes
- Switch `github-token` from `secrets.GITHUB_TOKEN` to the existing App token (`steps.app-token.outputs.token`) in the "Add external label to pull request" step of `tag-external-contributions.yml`, so the `labeled` event fires and triggers `require_issue_link.yml`
