### PR TITLE
fix(langchain-openai): fix _consolidate_calls if/elif chain and UnboundLocalError on unknown tool names

### DIFF
--- a/docs/docs/integrations/chat/gigachat.ipynb
+++ b/docs/docs/integrations/chat/gigachat.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "raw",
+   "source": [
+    "---\n",
+    "sidebar_label: GigaChat\n",
+    "---"
+   ],
+   "id": "b4154fbe"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# GigaChat\n",
+    "\n",
+    "This notebook goes over how to use Langchain with [GigaChat](https://giga.chat/) chat model.\n",
+    "\n",
+    "## Overview\n",
+    "### Integration details\n",
+    "\n",
+    "| Class    | Package                | Local | Serializable | JS support |                                         Package downloads                                          |                                         Package latest                                          |\n",
+    "|:---------|:-----------------------| :---: | :---: |:----------:|:--------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|\n",
+    "| GigaChat | [langchain-gigachat](https://github.com/ai-forever/langchain-gigachat) | ❌ | beta | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-gigachat?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-gigachat?style=flat-square&label=%20) |\n",
+    "\n",
+    "### Model features\n",
+    "| [Tool calling](../../how_to/tool_calling.ipynb) | [Structured output](../../how_to/structured_output.ipynb) | JSON mode | [Image input](../../how_to/multimodal_inputs.ipynb) | Audio input | Video input | [Token-level streaming](../../how_to/chat_streaming.ipynb) | Native async | [Token usage](../../how_to/chat_token_usage_tracking.ipynb) | [Logprobs](../../how_to/logprobs.ipynb) |\n",
+    "| :---: | :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |\n",
+    "| ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "To access GigaChat models you'll need to [create a GigaChat account](https://developers.sber.ru/docs/ru/gigachat/quickstart/main), get an API key, and install the `langchain-gigachat` integration package."
+   ],
+   "id": "af63c9db-e4bd-4d3b-a4d7-7927f5541734"
+  },
+  {
+   "cell_type": "code",
+   "id": "f3a8f9cb-ff03-4fb8-8185-ff19f2b8fc89",
+   "metadata": {},
+   "source": "%pip install --upgrade --quiet  langchain-gigachat",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### Initialization\n",
+    "\n",
+    "To initialize chat model:"
+   ],
+   "id": "7242c121c9e2f2fe"
+  },
+  {
+   "cell_type": "code",
+   "id": "eba2d63b-f871-4f61-b55f-f6092bdc297a",
+   "metadata": {},
+   "source": [
+    "from langchain_gigachat.chat_models import GigaChat\n",
+    "\n",
+    "giga = GigaChat(credentials=\"YOUR_AUTHORIZATION_KEY\", model='GigaChat-2-Max', verify_ssl_certs=False)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "To initialize embeddings:",
+   "id": "5a532bcab6f30906"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "from langchain_gigachat.embeddings import GigaChatEmbeddings\n",
+    "\n",
+    "embedding = GigaChatEmbeddings(\n",
+    "    credentials=\"YOUR_AUTHORIZATION_KEY\",\n",
+    "    verify_ssl_certs=False\n",
+    ")"
+   ],
+   "id": "c1488db53c9739bc",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "You can check a list of available models [here](https://developers.sber.ru/docs/ru/gigachat/models).",
+   "id": "96155ba830362bc6"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### Usage\n",
+    "\n",
+    "Use the GigaChat object to generate responses:"
+   ],
+   "id": "3d631f52046a0fb5"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "print(giga.invoke(\"Hello, world!\"))",
+   "id": "2f1ce423f77fc411",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/docs/integrations/chat/gigachat.ipynb
+++ b/docs/docs/integrations/chat/gigachat.ipynb
@@ -1,18 +1,19 @@
 {
  "cells": [
   {
-   "metadata": {},
    "cell_type": "raw",
+   "id": "b4154fbe",
+   "metadata": {},
    "source": [
     "---\n",
     "sidebar_label: GigaChat\n",
     "---"
-   ],
-   "id": "b4154fbe"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "af63c9db-e4bd-4d3b-a4d7-7927f5541734",
+   "metadata": {},
    "source": [
     "# GigaChat\n",
     "\n",
@@ -33,83 +34,87 @@
     "## Setup\n",
     "\n",
     "To access GigaChat models you'll need to [create a GigaChat account](https://developers.sber.ru/docs/ru/gigachat/quickstart/main), get an API key, and install the `langchain-gigachat` integration package."
-   ],
-   "id": "af63c9db-e4bd-4d3b-a4d7-7927f5541734"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "f3a8f9cb-ff03-4fb8-8185-ff19f2b8fc89",
    "metadata": {},
-   "source": "%pip install --upgrade --quiet  langchain-gigachat",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "%pip install --upgrade --quiet  langchain-gigachat"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "7242c121c9e2f2fe",
+   "metadata": {},
    "source": [
     "### Initialization\n",
     "\n",
     "To initialize chat model:"
-   ],
-   "id": "7242c121c9e2f2fe"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "eba2d63b-f871-4f61-b55f-f6092bdc297a",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from langchain_gigachat.chat_models import GigaChat\n",
     "\n",
-    "giga = GigaChat(credentials=\"YOUR_AUTHORIZATION_KEY\", model='GigaChat-2-Max', verify_ssl_certs=False)"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "giga = GigaChat(\n",
+    "    credentials=\"YOUR_AUTHORIZATION_KEY\", model=\"GigaChat-2-Max\", verify_ssl_certs=False\n",
+    ")"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "To initialize embeddings:",
-   "id": "5a532bcab6f30906"
+   "id": "5a532bcab6f30906",
+   "metadata": {},
+   "source": "To initialize embeddings:"
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "c1488db53c9739bc",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from langchain_gigachat.embeddings import GigaChatEmbeddings\n",
     "\n",
     "embedding = GigaChatEmbeddings(\n",
-    "    credentials=\"YOUR_AUTHORIZATION_KEY\",\n",
-    "    verify_ssl_certs=False\n",
+    "    credentials=\"YOUR_AUTHORIZATION_KEY\", verify_ssl_certs=False\n",
     ")"
-   ],
-   "id": "c1488db53c9739bc",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "You can check a list of available models [here](https://developers.sber.ru/docs/ru/gigachat/models).",
-   "id": "96155ba830362bc6"
+   "id": "96155ba830362bc6",
+   "metadata": {},
+   "source": "You can check a list of available models [here](https://developers.sber.ru/docs/ru/gigachat/models)."
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "3d631f52046a0fb5",
+   "metadata": {},
    "source": [
     "### Usage\n",
     "\n",
     "Use the GigaChat object to generate responses:"
-   ],
-   "id": "3d631f52046a0fb5"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "print(giga.invoke(\"Hello, world!\"))",
+   "execution_count": null,
    "id": "2f1ce423f77fc411",
+   "metadata": {},
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "print(giga.invoke(\"Hello, world!\"))"
+   ]
   }
  ],
  "metadata": {

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -494,7 +494,7 @@ _SUPPORTED_PROVIDERS = {
     "ibm",
     "xai",
     "perplexity",
-    "gigachat"
+    "gigachat",
 }
 
 

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -120,6 +120,7 @@ def init_chat_model(
             - 'nvidia'              -> langchain-nvidia-ai-endpoints
             - 'xai'                 -> langchain-xai
             - 'perplexity'          -> langchain-perplexity
+            - 'gigachat'            -> langchain-gigachat
 
             Will attempt to infer model_provider from model if not specified. The
             following providers will be inferred based on these model prefixes:
@@ -134,6 +135,7 @@ def init_chat_model(
             - 'deepseek...'                     -> 'deepseek'
             - 'grok...'                         -> 'xai'
             - 'sonar...'                        -> 'perplexity'
+            - 'GigaChat...'                     -> 'gigachat'
         configurable_fields: Which model parameters are
             configurable:
 
@@ -459,6 +461,11 @@ def _init_chat_model_helper(
         from langchain_perplexity import ChatPerplexity
 
         return ChatPerplexity(model=model, **kwargs)
+    if model_provider == "gigachat":
+        _check_pkg("langchain_gigachat")
+        from langchain_gigachat import GigaChat
+
+        return GigaChat(model=model, **kwargs)
     supported = ", ".join(_SUPPORTED_PROVIDERS)
     msg = (
         f"Unsupported {model_provider=}.\n\nSupported model providers are: {supported}"
@@ -487,6 +494,7 @@ _SUPPORTED_PROVIDERS = {
     "ibm",
     "xai",
     "perplexity",
+    "gigachat"
 }
 
 
@@ -511,6 +519,8 @@ def _attempt_infer_model_provider(model_name: str) -> Optional[str]:
         return "xai"
     if model_name.startswith("sonar"):
         return "perplexity"
+    if model_name.startswith("GigaChat"):
+        return "gigachat"
     return None
 
 

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -39,6 +39,7 @@ aws = ["langchain-aws"]
 deepseek = ["langchain-deepseek"]
 xai = ["langchain-xai"]
 perplexity = ["langchain-perplexity"]
+gigachat = ["langchain-gigachat"]
 
 [project.urls]
 "Source Code" = "https://github.com/langchain-ai/langchain/tree/master/libs/langchain"

--- a/libs/partners/openai/langchain_openai/chat_models/_compat.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_compat.py
@@ -1,79 +1,89 @@
-"""
-This module converts between AIMessage output formats for the Responses API.
+"""Converts between AIMessage output formats, governed by `output_version`.
 
-ChatOpenAI v0.3 stores reasoning and tool outputs in AIMessage.additional_kwargs:
+`output_version` is an attribute on ChatOpenAI.
 
-.. code-block:: python
+Supported values are `None`, `'v0'`, and `'responses/v1'`.
 
-    AIMessage(
-        content=[
-            {"type": "text", "text": "Hello, world!", "annotations": [{"type": "foo"}]}
-        ],
-        additional_kwargs={
-            "reasoning": {
-                "type": "reasoning",
-                "id": "rs_123",
-                "summary": [{"type": "summary_text", "text": "Reasoning summary"}],
-            },
-            "tool_outputs": [
-                {
-                    "type": "web_search_call",
-                    "id": "websearch_123",
-                    "status": "completed",
-                }
-            ],
-            "refusal": "I cannot assist with that.",
+`'v0'` corresponds to the format as of `ChatOpenAI` v0.3. For the Responses API, it
+stores reasoning and tool outputs in `AIMessage.additional_kwargs`:
+
+```python
+AIMessage(
+    content=[
+        {"type": "text", "text": "Hello, world!", "annotations": [{"type": "foo"}]}
+    ],
+    additional_kwargs={
+        "reasoning": {
+            "type": "reasoning",
+            "id": "rs_123",
+            "summary": [{"type": "summary_text", "text": "Reasoning summary"}],
         },
-        response_metadata={"id": "resp_123"},
-        id="msg_123",
-    )
-
-To retain information about response item sequencing (and to accommodate multiple
-reasoning items), ChatOpenAI now stores these items in the content sequence:
-
-.. code-block:: python
-
-    AIMessage(
-        content=[
+        "tool_outputs": [
             {
-                "type": "reasoning",
-                "summary": [{"type": "summary_text", "text": "Reasoning summary"}],
-                "id": "rs_123",
-            },
-            {
-                "type": "text",
-                "text": "Hello, world!",
-                "annotations": [{"type": "foo"}],
-                "id": "msg_123",
-            },
-            {"type": "refusal", "refusal": "I cannot assist with that."},
-            {"type": "web_search_call", "id": "websearch_123", "status": "completed"},
+                "type": "web_search_call",
+                "id": "websearch_123",
+                "status": "completed",
+            }
         ],
-        response_metadata={"id": "resp_123"},
-        id="resp_123",
-    )
+        "refusal": "I cannot assist with that.",
+    },
+    response_metadata={"id": "resp_123"},
+    id="msg_123",
+)
+```
+
+`'responses/v1'` is only applicable to the Responses API. It retains information
+about response item sequencing and accommodates multiple reasoning items by
+representing these items in the content sequence:
+
+```python
+AIMessage(
+    content=[
+        {
+            "type": "reasoning",
+            "summary": [{"type": "summary_text", "text": "Reasoning summary"}],
+            "id": "rs_123",
+        },
+        {
+            "type": "text",
+            "text": "Hello, world!",
+            "annotations": [{"type": "foo"}],
+            "id": "msg_123",
+        },
+        {"type": "refusal", "refusal": "I cannot assist with that."},
+        {"type": "web_search_call", "id": "websearch_123", "status": "completed"},
+    ],
+    response_metadata={"id": "resp_123"},
+    id="resp_123",
+)
+```
 
 There are other, small improvements as well-- e.g., we store message IDs on text
 content blocks, rather than on the AIMessage.id, which now stores the response ID.
 
 For backwards compatibility, this module provides functions to convert between the
-old and new formats. The functions are used internally by ChatOpenAI.
-"""  # noqa: E501
+formats. The functions are used internally by ChatOpenAI.
+"""
+
+from __future__ import annotations
 
 import json
-from typing import Union
+from collections.abc import Iterable, Iterator
+from typing import Any, cast
 
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, is_data_content_block
+from langchain_core.messages import content as types
 
 _FUNCTION_CALL_IDS_MAP_KEY = "__openai_function_call_ids__"
 
 
+# v0.3 / Responses
 def _convert_to_v03_ai_message(
     message: AIMessage, has_reasoning: bool = False
 ) -> AIMessage:
-    """Mutate an AIMessage to the old-style v0.3 format."""
+    """Mutate an `AIMessage` to the old-style v0.3 format."""
     if isinstance(message.content, list):
-        new_content: list[Union[dict, str]] = []
+        new_content: list[dict | str] = []
         for block in message.content:
             if isinstance(block, dict):
                 if block.get("type") == "reasoning":
@@ -93,6 +103,8 @@ def _convert_to_v03_ai_message(
                     "mcp_list_tools",
                     "mcp_approval_request",
                     "image_generation_call",
+                    "tool_search_call",
+                    "tool_search_output",
                 ):
                     # Store built-in tool calls in additional_kwargs
                     if "tool_outputs" not in message.additional_kwargs:
@@ -140,115 +152,351 @@ def _convert_to_v03_ai_message(
     return message
 
 
-def _convert_from_v03_ai_message(message: AIMessage) -> AIMessage:
-    """Convert an old-style v0.3 AIMessage into the new content-block format."""
-    # Only update ChatOpenAI v0.3 AIMessages
-    # TODO: structure provenance into AIMessage
-    is_chatopenai_v03 = (
-        isinstance(message.content, list)
-        and all(isinstance(b, dict) for b in message.content)
-    ) and (
-        any(
-            item in message.additional_kwargs
-            for item in [
-                "reasoning",
-                "tool_outputs",
-                "refusal",
-                _FUNCTION_CALL_IDS_MAP_KEY,
+# v1 / Chat Completions
+def _convert_from_v1_to_chat_completions(message: AIMessage) -> AIMessage:
+    """Convert a v1 message to the Chat Completions format."""
+    if isinstance(message.content, list):
+        new_content: list = []
+        for block in message.content:
+            if isinstance(block, dict):
+                block_type = block.get("type")
+                if block_type == "text":
+                    # Strip annotations
+                    new_content.append({"type": "text", "text": block["text"]})
+                elif block_type in ("reasoning", "tool_call"):
+                    pass
+                else:
+                    new_content.append(block)
+            else:
+                new_content.append(block)
+        return message.model_copy(update={"content": new_content})
+
+    return message
+
+
+# v1 / Responses
+def _convert_annotation_from_v1(annotation: types.Annotation) -> dict[str, Any]:
+    """Convert a v1 `Annotation` to the v0.3 format (for Responses API)."""
+    if annotation["type"] == "citation":
+        new_ann: dict[str, Any] = {}
+        for field in ("end_index", "start_index"):
+            if field in annotation:
+                new_ann[field] = annotation[field]
+
+        if "url" in annotation:
+            # URL citation
+            if "title" in annotation:
+                new_ann["title"] = annotation["title"]
+            new_ann["type"] = "url_citation"
+            new_ann["url"] = annotation["url"]
+
+            if extra_fields := annotation.get("extras"):
+                new_ann.update(dict(extra_fields.items()))
+        else:
+            # Document citation
+            new_ann["type"] = "file_citation"
+
+            if extra_fields := annotation.get("extras"):
+                new_ann.update(dict(extra_fields.items()))
+
+            if "title" in annotation:
+                new_ann["filename"] = annotation["title"]
+
+        return new_ann
+
+    if annotation["type"] == "non_standard_annotation":
+        return annotation["value"]
+
+    return dict(annotation)
+
+
+def _implode_reasoning_blocks(blocks: list[dict[str, Any]]) -> Iterable[dict[str, Any]]:
+    i = 0
+    n = len(blocks)
+
+    while i < n:
+        block = blocks[i]
+
+        # Skip non-reasoning blocks or blocks already in Responses format
+        if block.get("type") != "reasoning" or "summary" in block:
+            yield dict(block)
+            i += 1
+            continue
+        elif "reasoning" not in block and "summary" not in block:
+            # {"type": "reasoning", "id": "rs_..."}
+            oai_format = {**block, "summary": []}
+            if "extras" in oai_format:
+                oai_format.update(oai_format.pop("extras"))
+            oai_format["type"] = oai_format.pop("type", "reasoning")
+            if "encrypted_content" in oai_format:
+                oai_format["encrypted_content"] = oai_format.pop("encrypted_content")
+            yield oai_format
+            i += 1
+            continue
+        else:
+            pass
+
+        summary: list[dict[str, str]] = [
+            {"type": "summary_text", "text": block.get("reasoning", "")}
+        ]
+        # 'common' is every field except the exploded 'reasoning'
+        common = {k: v for k, v in block.items() if k != "reasoning"}
+        if "extras" in common:
+            common.update(common.pop("extras"))
+
+        i += 1
+        while i < n:
+            next_ = blocks[i]
+            if next_.get("type") == "reasoning" and "reasoning" in next_:
+                summary.append(
+                    {"type": "summary_text", "text": next_.get("reasoning", "")}
+                )
+                i += 1
+            else:
+                break
+
+        merged = dict(common)
+        merged["summary"] = summary
+        merged["type"] = merged.pop("type", "reasoning")
+        yield merged
+
+
+def _consolidate_calls(items: Iterable[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+    """Generator that walks through *items* and, whenever it meets the pair.
+
+        {"type": "server_tool_call", "name": "web_search", "id": X, ...}
+        {"type": "server_tool_result", "id": X}
+
+    merges them into
+
+        {"id": X,
+         "output": ...,
+         "status": ...,
+         "type": "web_search_call"}
+
+    keeping every other element untouched.
+    """
+    items = iter(items)  # make sure we have a true iterator
+    for current in items:
+        # Only a call can start a pair worth collapsing
+        if current.get("type") != "server_tool_call":
+            yield current
+            continue
+
+        try:
+            nxt = next(items)  # look-ahead one element
+        except StopIteration:  # no “result” - just yield the call back
+            yield current
+            break
+
+        # If this really is the matching “result” - collapse
+        if nxt.get("type") == "server_tool_result" and nxt.get(
+            "tool_call_id"
+        ) == current.get("id"):
+            if current.get("name") == "web_search":
+                collapsed = {"id": current["id"]}
+                if "args" in current:
+                    # N.B. as of 2025-09-17 OpenAI raises BadRequestError if sources
+                    # are passed back in
+                    collapsed["action"] = current["args"]
+
+                if status := nxt.get("status"):
+                    if status == "success":
+                        collapsed["status"] = "completed"
+                    elif status == "error":
+                        collapsed["status"] = "failed"
+                elif nxt.get("extras", {}).get("status"):
+                    collapsed["status"] = nxt["extras"]["status"]
+                else:
+                    pass
+                collapsed["type"] = "web_search_call"
+
+            elif current.get("name") == "file_search":
+                collapsed = {"id": current["id"]}
+                if "args" in current and "queries" in current["args"]:
+                    collapsed["queries"] = current["args"]["queries"]
+
+                if "output" in nxt:
+                    collapsed["results"] = nxt["output"]
+                if status := nxt.get("status"):
+                    if status == "success":
+                        collapsed["status"] = "completed"
+                    elif status == "error":
+                        collapsed["status"] = "failed"
+                elif nxt.get("extras", {}).get("status"):
+                    collapsed["status"] = nxt["extras"]["status"]
+                else:
+                    pass
+                collapsed["type"] = "file_search_call"
+
+            elif current.get("name") == "code_interpreter":
+                collapsed = {"id": current["id"]}
+                if "args" in current and "code" in current["args"]:
+                    collapsed["code"] = current["args"]["code"]
+                for key in ("container_id",):
+                    if key in current:
+                        collapsed[key] = current[key]
+                    elif key in current.get("extras", {}):
+                        collapsed[key] = current["extras"][key]
+                    else:
+                        pass
+
+                if "output" in nxt:
+                    collapsed["outputs"] = nxt["output"]
+                if status := nxt.get("status"):
+                    if status == "success":
+                        collapsed["status"] = "completed"
+                    elif status == "error":
+                        collapsed["status"] = "failed"
+                elif nxt.get("extras", {}).get("status"):
+                    collapsed["status"] = nxt["extras"]["status"]
+                collapsed["type"] = "code_interpreter_call"
+
+            elif current.get("name") == "remote_mcp":
+                collapsed = {"id": current["id"]}
+                if "args" in current:
+                    collapsed["arguments"] = json.dumps(
+                        current["args"], separators=(",", ":")
+                    )
+                elif "arguments" in current.get("extras", {}):
+                    collapsed["arguments"] = current["extras"]["arguments"]
+                else:
+                    pass
+
+                if tool_name := current.get("extras", {}).get("tool_name"):
+                    collapsed["name"] = tool_name
+                if server_label := current.get("extras", {}).get("server_label"):
+                    collapsed["server_label"] = server_label
+                collapsed["type"] = "mcp_call"
+
+                if approval_id := current.get("extras", {}).get("approval_request_id"):
+                    collapsed["approval_request_id"] = approval_id
+                if error := nxt.get("extras", {}).get("error"):
+                    collapsed["error"] = error
+                if "output" in nxt:
+                    collapsed["output"] = nxt["output"]
+                for k, v in current.get("extras", {}).items():
+                    if k not in ("server_label", "arguments", "tool_name", "error"):
+                        collapsed[k] = v
+
+            elif current.get("name") == "mcp_list_tools":
+                collapsed = {"id": current["id"]}
+                if server_label := current.get("extras", {}).get("server_label"):
+                    collapsed["server_label"] = server_label
+                if "output" in nxt:
+                    collapsed["tools"] = nxt["output"]
+                collapsed["type"] = "mcp_list_tools"
+                if error := nxt.get("extras", {}).get("error"):
+                    collapsed["error"] = error
+                for k, v in current.get("extras", {}).items():
+                    if k not in ("server_label", "error"):
+                        collapsed[k] = v
+            else:
+                # Unknown server_tool_call name — emit both items unchanged and
+                # skip yielding `collapsed` (which was never assigned) to avoid
+                # an UnboundLocalError.
+                yield current
+                yield nxt
+                continue
+
+            yield collapsed
+
+        else:
+            # Not a matching pair - emit both, in original order
+            yield current
+            yield nxt
+
+
+def _convert_from_v1_to_responses(
+    content: list[types.ContentBlock], tool_calls: list[types.ToolCall]
+) -> list[dict[str, Any]]:
+    new_content: list = []
+    for block in content:
+        if block["type"] == "text" and "annotations" in block:
+            # Need a copy because we're changing the annotations list
+            new_block = dict(block)
+            new_block["annotations"] = [
+                _convert_annotation_from_v1(a) for a in block["annotations"]
             ]
-        )
-        or (
-            isinstance(message.id, str)
-            and message.id.startswith("msg_")
-            and (response_id := message.response_metadata.get("id"))
-            and isinstance(response_id, str)
-            and response_id.startswith("resp_")
-        )
-    )
-    if not is_chatopenai_v03:
-        return message
+            new_content.append(new_block)
+        elif block["type"] == "tool_call":
+            new_block = {"type": "function_call", "call_id": block["id"]}
+            if "extras" in block and "item_id" in block["extras"]:
+                new_block["id"] = block["extras"]["item_id"]
+            if "name" in block:
+                new_block["name"] = block["name"]
+            if "extras" in block and "arguments" in block["extras"]:
+                new_block["arguments"] = block["extras"]["arguments"]
+            if any(key not in new_block for key in ("name", "arguments")):
+                matching_tool_calls = [
+                    call for call in tool_calls if call["id"] == block["id"]
+                ]
+                if matching_tool_calls:
+                    tool_call = matching_tool_calls[0]
+                    if "name" not in new_block:
+                        new_block["name"] = tool_call["name"]
+                    if "arguments" not in new_block:
+                        new_block["arguments"] = json.dumps(
+                            tool_call["args"], separators=(",", ":")
+                        )
+            if "extras" in block:
+                for extra_key in ("status", "namespace"):
+                    if extra_key in block["extras"]:
+                        new_block[extra_key] = block["extras"][extra_key]
+            new_content.append(new_block)
 
-    content_order = [
-        "reasoning",
-        "code_interpreter_call",
-        "mcp_call",
-        "image_generation_call",
-        "text",
-        "refusal",
-        "function_call",
-        "computer_call",
-        "mcp_list_tools",
-        "mcp_approval_request",
-        # N. B. "web_search_call" and "file_search_call" were not passed back in
-        # in v0.3
-    ]
+        elif block["type"] == "server_tool_call" and block.get("name") == "tool_search":
+            extras = block.get("extras", {})
+            new_block = {"id": block["id"]}
+            status = extras.get("status")
+            if status:
+                new_block["status"] = status
+            new_block["type"] = "tool_search_call"
+            if "args" in block:
+                new_block["arguments"] = block["args"]
+            execution = extras.get("execution")
+            if execution:
+                new_block["execution"] = execution
+            new_content.append(new_block)
 
-    # Build a bucket for every known block type
-    buckets: dict[str, list] = {key: [] for key in content_order}
-    unknown_blocks = []
-
-    # Reasoning
-    if reasoning := message.additional_kwargs.get("reasoning"):
-        buckets["reasoning"].append(reasoning)
-
-    # Refusal
-    if refusal := message.additional_kwargs.get("refusal"):
-        buckets["refusal"].append({"type": "refusal", "refusal": refusal})
-
-    # Text
-    for block in message.content:
-        if isinstance(block, dict) and block.get("type") == "text":
-            block_copy = block.copy()
-            if isinstance(message.id, str) and message.id.startswith("msg_"):
-                block_copy["id"] = message.id
-            buckets["text"].append(block_copy)
-        else:
-            unknown_blocks.append(block)
-
-    # Function calls
-    function_call_ids = message.additional_kwargs.get(_FUNCTION_CALL_IDS_MAP_KEY)
-    for tool_call in message.tool_calls:
-        function_call = {
-            "type": "function_call",
-            "name": tool_call["name"],
-            "arguments": json.dumps(tool_call["args"]),
-            "call_id": tool_call["id"],
-        }
-        if function_call_ids is not None and (
-            _id := function_call_ids.get(tool_call["id"])
+        elif (
+            block["type"] == "server_tool_result"
+            and block.get("extras", {}).get("name") == "tool_search"
         ):
-            function_call["id"] = _id
-        buckets["function_call"].append(function_call)
+            extras = block.get("extras", {})
+            new_block = {"id": block.get("tool_call_id", "")}
+            status = block.get("status")
+            if status == "success":
+                new_block["status"] = "completed"
+            elif status == "error":
+                new_block["status"] = "failed"
+            elif status:
+                new_block["status"] = status
+            new_block["type"] = "tool_search_output"
+            new_block["execution"] = "server"
+            output: dict = block.get("output", {})
+            if isinstance(output, dict) and "tools" in output:
+                new_block["tools"] = output["tools"]
+            new_content.append(new_block)
 
-    # Tool outputs
-    tool_outputs = message.additional_kwargs.get("tool_outputs", [])
-    for block in tool_outputs:
-        if isinstance(block, dict) and (key := block.get("type")) and key in buckets:
-            buckets[key].append(block)
+        elif (
+            is_data_content_block(cast(dict, block))
+            and block["type"] == "image"
+            and "base64" in block
+            and isinstance(block.get("id"), str)
+            and block["id"].startswith("ig_")
+        ):
+            new_block = {"type": "image_generation_call", "result": block["base64"]}
+            for extra_key in ("id", "status"):
+                if extra_key in block:
+                    new_block[extra_key] = block[extra_key]  # type: ignore[literal-required]
+                elif extra_key in block.get("extras", {}):
+                    new_block[extra_key] = block["extras"][extra_key]
+            new_content.append(new_block)
+        elif block["type"] == "non_standard" and "value" in block:
+            new_content.append(block["value"])
         else:
-            unknown_blocks.append(block)
+            new_content.append(block)
 
-    # Re-assemble the content list in the canonical order
-    new_content = []
-    for key in content_order:
-        new_content.extend(buckets[key])
-    new_content.extend(unknown_blocks)
-
-    new_additional_kwargs = dict(message.additional_kwargs)
-    new_additional_kwargs.pop("reasoning", None)
-    new_additional_kwargs.pop("refusal", None)
-    new_additional_kwargs.pop("tool_outputs", None)
-
-    if "id" in message.response_metadata:
-        new_id = message.response_metadata["id"]
-    else:
-        new_id = message.id
-
-    return message.model_copy(
-        update={
-            "content": new_content,
-            "additional_kwargs": new_additional_kwargs,
-            "id": new_id,
-        },
-        deep=False,
-    )
+    new_content = list(_implode_reasoning_blocks(new_content))
+    return list(_consolidate_calls(new_content))


### PR DESCRIPTION
## Summary

Two bugs in `_consolidate_calls()` in `libs/partners/openai/langchain_openai/chat_models/_compat.py`:

### Bug 1: Broken `if`/`elif` dispatch chain

The `file_search` branch used a bare `if` (line 314) instead of `elif`, making it an independent condition evaluated **even after** the `web_search` branch already matched:

```python
# BEFORE (buggy)
if current.get("name") == "web_search":
    collapsed = ...
    collapsed["type"] = "web_search_call"

if current.get("name") == "file_search":   # ← bare 'if', not 'elif'!
    ...
elif current.get("name") == "code_interpreter":  # ← attaches to file_search, not web_search!
    ...
```

When a `web_search` call is processed, `file_search` condition is False (correct), but `code_interpreter`, `remote_mcp`, and `mcp_list_tools` branches are then **unreachable** from the `web_search` path because their `elif` is chained to `file_search`.

**Fix:** change the bare `if` for `file_search` to `elif`.

### Bug 2: `UnboundLocalError` on unknown tool names

When `server_tool_call.name` doesn't match any known tool (`web_search`, `file_search`, `code_interpreter`, `remote_mcp`, `mcp_list_tools`), the `else: pass` branch never assigns `collapsed`, but `yield collapsed` on the next line raises `UnboundLocalError: local variable 'collapsed' referenced before assignment`.

**Fix:** in the `else` branch, yield `current` and `nxt` unchanged and `continue` to skip the `yield collapsed` line.

```python
# AFTER (fixed)
else:
    # Unknown server_tool_call — emit both items unchanged
    yield current
    yield nxt
    continue

yield collapsed
```

Closes #35694