### PR TITLE
docs(huggingface): add [full] install guidance and sentence-transformers>=5.2.0 migration note

### DIFF
--- a/libs/partners/huggingface/README.md
+++ b/libs/partners/huggingface/README.md
@@ -13,6 +13,22 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 pip install langchain-huggingface
 ```
 
+> **Note:** The base install does not include `sentence-transformers` or `transformers`.
+> If you plan to use `HuggingFaceEmbeddings` or `HuggingFacePipeline` for **local inference**,
+> install the `[full]` extra which includes `sentence-transformers>=5.2.0` and `transformers>=5.0.0`:
+>
+> ```bash
+> pip install langchain-huggingface[full]
+> ```
+>
+> **Migrating from `langchain-community`?** Note that `langchain-community` accepted
+> `sentence-transformers>=2.2.0`, but `langchain-huggingface[full]` requires `>=5.2.0`.
+> If your project pins an older version, upgrade it:
+>
+> ```bash
+> pip install "sentence-transformers>=5.2.0"
+> ```
+
 ## 🤔 What is this?
 
 This package contains the LangChain integrations for Hugging Face related classes.


### PR DESCRIPTION
## Summary

Closes #35712

Adds a clear install note to `libs/partners/huggingface/README.md` explaining:

1. The base `pip install langchain-huggingface` does **not** include `sentence-transformers` or `transformers` (they are optional deps under `[full]`)
2. Users who need `HuggingFaceEmbeddings` must install `langchain-huggingface[full]`
3. **Migration trap**: users coming from `langchain-community` often have `sentence-transformers>=2.2.0` pinned — but `langchain-huggingface[full]` requires `>=5.2.0`, causing silent ImportError

## Changes

Single file: `libs/partners/huggingface/README.md`

Added a `> Note:` block immediately after the install command explaining:
- `pip install langchain-huggingface[full]` for local inference use cases
- The sentence-transformers version gap when migrating from `langchain-community`

## Why

The current README only shows the base install. First-time users and migration users hit `ImportError: Could not import sentence_transformers` with no guidance. This is a pure doc fix — no code changes.

## Checklist

- [x] Doc-only change
- [x] Covers both fresh installs and community → huggingface migrations
- [x] No breaking changes
