### PR TITLE
fix(core): use index-based result mapping in RunnableRetry batch methods

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -4,7 +4,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     TypeVar,
-    cast,
 )
 
 from tenacity import (
@@ -232,14 +231,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         **kwargs: Any,
     ) -> list[Output | Exception]:
         results_map: dict[int, Output] = {}
+        exceptions_map: dict[int, Exception] = {}
 
-        not_set: list[Output] = []
-        result = not_set
+        retry_error: RetryError | None = None
         try:
             for attempt in self._sync_retrying():
                 with attempt:
-                    # Retry for inputs that have not yet succeeded
-                    # Determine which original indices remain.
                     remaining_indices = [
                         i for i in range(len(inputs)) if i not in results_map
                     ]
@@ -248,7 +245,6 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     pending_inputs = [inputs[i] for i in remaining_indices]
                     pending_configs = [config[i] for i in remaining_indices]
                     pending_run_managers = [run_manager[i] for i in remaining_indices]
-                    # Invoke underlying batch only on remaining elements.
                     result = super().batch(
                         pending_inputs,
                         self._patch_config_list(
@@ -257,17 +253,16 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                         return_exceptions=True,
                         **kwargs,
                     )
-                    # Register the results of the inputs that have succeeded, mapping
-                    # back to their original indices.
                     first_exception = None
                     for offset, r in enumerate(result):
+                        orig_idx = remaining_indices[offset]
                         if isinstance(r, Exception):
+                            exceptions_map[orig_idx] = r
                             if not first_exception:
                                 first_exception = r
-                            continue
-                        orig_idx = remaining_indices[offset]
-                        results_map[orig_idx] = r
-                    # If any exception occurred, raise it, to retry the failed ones
+                        else:
+                            results_map[orig_idx] = r
+                            exceptions_map.pop(orig_idx, None)
                     if first_exception:
                         raise first_exception
                 if (
@@ -276,15 +271,19 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                 ):
                     attempt.retry_state.set_result(result)
         except RetryError as e:
-            if result is not_set:
-                result = cast("list[Output]", [e] * len(inputs))
+            retry_error = e
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
+            elif idx in exceptions_map:
+                outputs.append(exceptions_map[idx])
+            elif retry_error is not None:
+                outputs.append(retry_error)
             else:
-                outputs.append(result.pop(0))
+                msg = f"unexpected missing result for input at index {idx}"
+                outputs.append(RuntimeError(msg))
         return outputs
 
     @override
@@ -308,14 +307,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         **kwargs: Any,
     ) -> list[Output | Exception]:
         results_map: dict[int, Output] = {}
+        exceptions_map: dict[int, Exception] = {}
 
-        not_set: list[Output] = []
-        result = not_set
+        retry_error: RetryError | None = None
         try:
             async for attempt in self._async_retrying():
                 with attempt:
-                    # Retry for inputs that have not yet succeeded
-                    # Determine which original indices remain.
                     remaining_indices = [
                         i for i in range(len(inputs)) if i not in results_map
                     ]
@@ -332,17 +329,16 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                         return_exceptions=True,
                         **kwargs,
                     )
-                    # Register the results of the inputs that have succeeded, mapping
-                    # back to their original indices.
                     first_exception = None
                     for offset, r in enumerate(result):
+                        orig_idx = remaining_indices[offset]
                         if isinstance(r, Exception):
+                            exceptions_map[orig_idx] = r
                             if not first_exception:
                                 first_exception = r
-                            continue
-                        orig_idx = remaining_indices[offset]
-                        results_map[orig_idx] = r
-                    # If any exception occurred, raise it, to retry the failed ones
+                        else:
+                            results_map[orig_idx] = r
+                            exceptions_map.pop(orig_idx, None)
                     if first_exception:
                         raise first_exception
                 if (
@@ -351,15 +347,19 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                 ):
                     attempt.retry_state.set_result(result)
         except RetryError as e:
-            if result is not_set:
-                result = cast("list[Output]", [e] * len(inputs))
+            retry_error = e
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
+            elif idx in exceptions_map:
+                outputs.append(exceptions_map[idx])
+            elif retry_error is not None:
+                outputs.append(retry_error)
             else:
-                outputs.append(result.pop(0))
+                msg = f"unexpected missing result for input at index {idx}"
+                outputs.append(RuntimeError(msg))
         return outputs
 
     @override

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3979,6 +3979,67 @@ async def test_async_retry_batch_preserves_order() -> None:
     assert results == [0, 1, 2]
 
 
+def test_retry_batch_mixed_success_failure() -> None:
+    """When some items succeed on retry while others keep failing,
+    the output should map each result to the correct original index.
+    Previously, result.pop(0) consumed items in positional order from
+    the last batch call, mixing up successful and failed results."""
+    call_count: dict[int, int] = {0: 0, 1: 0, 2: 0, 3: 0}
+
+    def flaky(x: int) -> int:
+        call_count[x] += 1
+        if x == 0 and call_count[x] <= 1:
+            msg = "transient"
+            raise ValueError(msg)
+        if x == 2:
+            msg = "permanent"
+            raise ValueError(msg)
+        return x * 10
+
+    runnable = RunnableLambda(flaky)
+    retryable = runnable.with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError,),
+    )
+
+    results = retryable.batch([0, 1, 2, 3], return_exceptions=True)
+
+    assert results[0] == 0
+    assert results[1] == 10
+    assert isinstance(results[2], Exception)
+    assert results[3] == 30
+
+
+async def test_async_retry_batch_mixed_success_failure() -> None:
+    """Async variant of mixed success/failure batch test."""
+    call_count: dict[int, int] = {0: 0, 1: 0, 2: 0, 3: 0}
+
+    def flaky(x: int) -> int:
+        call_count[x] += 1
+        if x == 0 and call_count[x] <= 1:
+            msg = "transient"
+            raise ValueError(msg)
+        if x == 2:
+            msg = "permanent"
+            raise ValueError(msg)
+        return x * 10
+
+    runnable = RunnableLambda(flaky)
+    retryable = runnable.with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError,),
+    )
+
+    results = await retryable.abatch([0, 1, 2, 3], return_exceptions=True)
+
+    assert results[0] == 0
+    assert results[1] == 10
+    assert isinstance(results[2], Exception)
+    assert results[3] == 30
+
+
 async def test_async_retrying(mocker: MockerFixture) -> None:
     def _lambda(x: int) -> int:
         if x == 1:


### PR DESCRIPTION
## Description

Fixes #35475

`RunnableRetry._batch()` and `_abatch()` used `result.pop(0)` to assign exception outputs to inputs that hadn't succeeded. This produced corrupted results when the last retry attempt had a mix of successes and failures: successful items got added to `results_map` but their entries stayed in the `result` list, so subsequent `.pop(0)` calls returned the wrong values.

For example with inputs `[A, B, C, D]` where A fails then succeeds on retry while C always fails:
- Last batch `result = [success_A, exception_C]`
- `success_A` gets added to `results_map`, but stays in `result`
- Final assembly: D (not in `results_map`) pops `success_A` instead of getting its own result

### Changes
- Replaced the `result`/`not_set`/`pop(0)` pattern with an `exceptions_map` dict that tracks failed results by their original input index
- Final assembly looks up each index in `results_map` (successes) then `exceptions_map` (failures), avoiding positional assumptions
- Applied the same fix to both `_batch()` and `_abatch()`
- Removed now-unused `cast` import

### Tests
- Added `test_retry_batch_mixed_success_failure` and its async variant
- Test scenario: 4 inputs where one has a transient failure (succeeds on retry), one always fails, two always succeed
- Verifies each output maps to the correct original input index
