### PR TITLE
fix(core,anthropic): add descriptive messages to bare raise ValueError

### DIFF
--- a/libs/core/langchain_core/document_loaders/langsmith.py
+++ b/libs/core/langchain_core/document_loaders/langsmith.py
@@ -94,7 +94,11 @@ class LangSmithLoader(BaseLoader):
             ValueError: If both `client` and `client_kwargs` are provided.
         """  # noqa: E501
         if client and client_kwargs:
-            raise ValueError
+            msg = (
+                "Cannot provide both 'client' and 'client_kwargs'. "
+                "Pass an existing client or keyword args to create one, not both."
+            )
+            raise ValueError(msg)
         self._client = client or LangSmithClient(**client_kwargs)
         self.content_key = list(content_key.split(".")) if content_key else []
         self.format_content = format_content or _stringify

--- a/libs/core/langchain_core/prompts/few_shot_with_templates.py
+++ b/libs/core/langchain_core/prompts/few_shot_with_templates.py
@@ -110,14 +110,16 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
             return self.examples
         if self.example_selector is not None:
             return self.example_selector.select_examples(kwargs)
-        raise ValueError
+        msg = "One of 'examples' or 'example_selector' must be provided."
+        raise ValueError(msg)
 
     async def _aget_examples(self, **kwargs: Any) -> list[dict]:
         if self.examples is not None:
             return self.examples
         if self.example_selector is not None:
             return await self.example_selector.aselect_examples(kwargs)
-        raise ValueError
+        msg = "One of 'examples' or 'example_selector' must be provided."
+        raise ValueError(msg)
 
     def format(self, **kwargs: Any) -> str:
         """Format the prompt with the inputs.

--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -55,7 +55,11 @@ def _load_template(var_name: str, config: dict) -> dict:
         if template_path.suffix == ".txt":
             template = template_path.read_text(encoding="utf-8")
         else:
-            raise ValueError
+            msg = (
+                f"Unsupported template file format: '{template_path.suffix}'. "
+                "Only '.txt' files are supported."
+            )
+            raise ValueError(msg)
         # Set the template variable to the extracted variable.
         config[var_name] = template
     return config

--- a/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
@@ -35,13 +35,15 @@ def _expand_include_patterns(pattern: str) -> list[str] | None:
 
         end = current.find("}", start)
         if end == -1:
-            raise ValueError
+            msg = f"Unmatched '{{' in brace expansion pattern: '{current}'"
+            raise ValueError(msg)
 
         prefix = current[:start]
         suffix = current[end + 1 :]
         inner = current[start + 1 : end]
         if not inner:
-            raise ValueError
+            msg = f"Empty brace expansion '{{}}' in pattern: '{current}'"
+            raise ValueError(msg)
 
         for option in inner.split(","):
             _expand(prefix + option + suffix)


### PR DESCRIPTION
## Summary
- Add descriptive error messages to bare `raise ValueError` statements in core and anthropic packages
- Bare raises provide no context for debugging, making it hard for users to understand what went wrong
- Files fixed:
  - `libs/core/langchain_core/prompts/few_shot_with_templates.py` — missing examples/example_selector
  - `libs/core/langchain_core/prompts/loading.py` — unsupported template file format
  - `libs/core/langchain_core/document_loaders/langsmith.py` — conflicting client args
  - `libs/partners/anthropic/langchain_anthropic/middleware/file_search.py` — malformed brace expansion

## Test plan
- [x] Error messages describe the condition that triggered them
- [x] No functional behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)