### PR TITLE
fix(openai): use context manager for Image.open to prevent resource leak

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3678,7 +3678,8 @@ def _url_to_size(image_source: str) -> tuple[int, int] | None:
                 return None
 
             # close things (context managers)
-            width, height = Image.open(BytesIO(response.content)).size
+            with Image.open(BytesIO(response.content)) as img:
+                width, height = img.size
             return width, height
         except httpx.TimeoutException:
             logger.warning("Image URL request timed out after %s seconds", timeout)
@@ -3693,7 +3694,8 @@ def _url_to_size(image_source: str) -> tuple[int, int] | None:
     if _is_b64(image_source):
         _, encoded = image_source.split(",", 1)
         data = base64.b64decode(encoded)
-        width, height = Image.open(BytesIO(data)).size
+        with Image.open(BytesIO(data)) as img:
+            width, height = img.size
         return width, height
     return None
 


### PR DESCRIPTION
## Summary
- Convert `Image.open()` calls to use `with` context manager in token counting code
- File descriptors leak if `Image.open()` is not properly closed
- Ironic: line 3696 has comment about "close things (context managers)" but doesn't use one

## Test plan
- [x] Image token counting works correctly with context manager
- [x] File descriptors properly cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)