### PR TITLE
fix(core,openai): replace deprecated asyncio.get_event_loop() in async contexts

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -378,7 +378,7 @@ async def _ahandle_event_for_handler(
             elif handler.run_inline:
                 event(*args, **kwargs)
             else:
-                await asyncio.get_event_loop().run_in_executor(
+                await asyncio.get_running_loop().run_in_executor(
                     None,
                     cast(
                         "Callable",

--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -395,7 +395,7 @@ async def _render_mermaid_using_pyppeteer(
     await browser.close()
 
     if output_file_path is not None:
-        await asyncio.get_event_loop().run_in_executor(
+        await asyncio.get_running_loop().run_in_executor(
             None, Path(output_file_path).write_bytes, img_bytes
         )
 

--- a/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
@@ -133,7 +133,7 @@ def _resolve_sync_and_async_api_keys(
             sync_api_key_value = cast(Callable, api_key)
 
             async def async_api_key_wrapper() -> str:
-                return await asyncio.get_event_loop().run_in_executor(
+                return await asyncio.get_running_loop().run_in_executor(
                     None, cast(Callable, api_key)
                 )
 


### PR DESCRIPTION
Fixes #35726

Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in async function contexts. `get_event_loop()` is deprecated since Python 3.10 and can fail when no event loop exists. Inside `async def`, `get_running_loop()` is the correct and guaranteed-safe replacement.

**Changed files**
- `libs/core/langchain_core/callbacks/manager.py` — `_ahandle_event_for_handler()`
- `libs/core/langchain_core/runnables/graph_mermaid.py` — `_render_mermaid_using_pyppeteer()`
- `libs/partners/openai/langchain_openai/chat_models/_client_utils.py` — `async_api_key_wrapper()`

No behavior change when called from a running event loop.