### PR TITLE
docs: add issue templates link to README resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,6 @@ To improve your LLM application development, pair LangChain with:
 
 - [API Reference](https://reference.langchain.com/python) – Detailed reference on navigating base packages and integrations for LangChain.
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) – Learn how to contribute to LangChain projects and find good first issues.
+- [Issue Templates](https://github.com/langchain-ai/langchain/issues/new/choose) – Use templates to report bugs and include reproducible details for faster triage.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) – Our community guidelines and standards for participation.
 - [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.


### PR DESCRIPTION
## Summary
- add a direct Issue Templates link in README Additional resources
- make issue-first workflow easier to discover for contributors

Closes #35739

## Testing
- docs-only change
