### PR TITLE
fix(openai): correct if/elif chain and UnboundLocalError in _consolidate_calls

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/_compat.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_compat.py
@@ -311,7 +311,7 @@ def _consolidate_calls(items: Iterable[dict[str, Any]]) -> Iterator[dict[str, An
                     pass
                 collapsed["type"] = "web_search_call"
 
-            if current.get("name") == "file_search":
+            elif current.get("name") == "file_search":
                 collapsed = {"id": current["id"]}
                 if "args" in current and "queries" in current["args"]:
                     collapsed["queries"] = current["args"]["queries"]
@@ -392,7 +392,10 @@ def _consolidate_calls(items: Iterable[dict[str, Any]]) -> Iterator[dict[str, An
                     if k not in ("server_label", "error"):
                         collapsed[k] = v
             else:
-                pass
+                # Unknown tool name - yield both items unchanged
+                yield current
+                yield nxt
+                continue
 
             yield collapsed
 


### PR DESCRIPTION
## Summary

Fixes #35694

Two bugs in `_consolidate_calls` in `libs/partners/openai/langchain_openai/chat_models/_compat.py`:

1. **Bare `if` instead of `elif`:** The `file_search` branch uses `if` instead of `elif`, breaking the if/elif chain. After matching `web_search`, execution falls through and also evaluates `file_search`, and the downstream `elif` blocks (`code_interpreter`, `remote_mcp`, `mcp_list_tools`) are only chained to `file_search`, not to the full conditional.

2. **`UnboundLocalError` on unknown tools:** The `else: pass` branch doesn't assign `collapsed`, but `yield collapsed` executes unconditionally after it, raising `UnboundLocalError` for any unrecognized tool name.

## Fix

1. Changed `if` to `elif` on the `file_search` branch to restore the full if/elif chain.
2. In the `else` branch, yield both `current` and `nxt` unchanged and `continue` (skip the `yield collapsed`) to handle unknown tool names gracefully.

## Review notes

- The `if` -> `elif` change on line 314 is the critical fix - without it, `web_search` calls always also evaluate the `file_search` condition, and the remaining branches are disconnected.
- The `else` branch fix prevents a crash on any future or unknown server tool name.

## Test plan

- [x] All 230 existing unit tests in `tests/unit_tests/chat_models/` pass
- [x] `ruff check` and `ruff format --check` pass

This contribution was developed with AI assistance (Claude Code).