### PR TITLE
fix(core): prevent empty args in streaming tool calls from SSE fragmentation

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -540,7 +540,11 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
 
         for chunk in self.tool_call_chunks:
             try:
-                args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}
+                args_ = (
+                    parse_partial_json(chunk["args"])
+                    if chunk["args"] is not None
+                    else {}
+                )
                 if isinstance(args_, dict):
                     tool_calls.append(
                         create_tool_call(


### PR DESCRIPTION
## Summary

- Changes the truthiness check `if chunk["args"]` to `if chunk["args"] is not None` in `AIMessageChunk.tool_calls` property.
- When SSE fragmentation delivers an empty string `""` as `args`, the old truthiness check treated it as falsy and defaulted to `{}`, causing a tool call to be emitted with empty args before the full JSON arrived.
- With the fix, `""` is passed to `parse_partial_json("")` which returns `None`, correctly routing the chunk to `invalid_tool_calls` until more data arrives.

Fixes #35514

## Test plan

- [ ] Verify existing streaming tool call tests pass
- [ ] Test with SSE-fragmented responses where args arrive as empty string before JSON payload

> This PR was developed with AI agent assistance.