### PR TITLE
fix(core): prevent output corruption in RunnableRetry.batch when partial retries succeed

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -233,8 +233,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
     ) -> list[Output | Exception]:
         results_map: dict[int, Output] = {}
 
-        not_set: list[Output] = []
-        result = not_set
+        result: list[Output] = []
         try:
             for attempt in self._sync_retrying():
                 with attempt:
@@ -276,15 +275,14 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                 ):
                     attempt.retry_state.set_result(result)
         except RetryError as e:
-            if result is not_set:
-                result = cast("list[Output]", [e] * len(inputs))
+            retry_error: RetryError = e
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(cast("Output", retry_error))
         return outputs
 
     @override
@@ -309,8 +307,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
     ) -> list[Output | Exception]:
         results_map: dict[int, Output] = {}
 
-        not_set: list[Output] = []
-        result = not_set
+        result: list[Output] = []
         try:
             async for attempt in self._async_retrying():
                 with attempt:
@@ -351,15 +348,14 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                 ):
                     attempt.retry_state.set_result(result)
         except RetryError as e:
-            if result is not_set:
-                result = cast("list[Output]", [e] * len(inputs))
+            retry_error: RetryError = e
 
         outputs: list[Output | Exception] = []
         for idx in range(len(inputs)):
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                outputs.append(cast("Output", retry_error))
         return outputs
 
     @override


### PR DESCRIPTION
## Summary

- Fixes `_batch` and `_abatch` in `RunnableRetry` where `result.pop(0)` on the shortened last-retry result list caused output misalignment.
- When some inputs succeed on earlier retries and are removed from the pending list, the final `result` list is shorter than the original input list. Using `pop(0)` assigned successful results from `result` to failed indices in the output.
- The fix uses the caught `RetryError` exception for any index not in `results_map`, ensuring failed inputs get the error and successful inputs keep their correct results.
- Also removes the unused `not_set` sentinel variable.

Fixes #35475

## Test plan

- [ ] Verify existing retry batch tests pass
- [ ] Test scenario: batch of 3 inputs where input 0 succeeds on attempt 1, input 1 fails all retries, input 2 succeeds on attempt 2 - verify outputs[0] and outputs[2] are correct results, outputs[1] is RetryError

> This PR was developed with AI agent assistance.