### PR TITLE
docs(readme): add issue templates link to Additional Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,5 +72,6 @@ To improve your LLM application development, pair LangChain with:
 
 - [API Reference](https://reference.langchain.com/python) – Detailed reference on navigating base packages and integrations for LangChain.
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) – Learn how to contribute to LangChain projects and find good first issues.
+- [Report a Bug or Request for Feature](https://github.com/langchain-ai/langchain/issues/new/choose) - Found a bug or want to suggest a new feature? Use the issue templates below to help us understand and improve the project.
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) – Our community guidelines and standards for participation.
 - [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.


### PR DESCRIPTION
Fixes #35739

This PR adds a direct link to the Issue Templates page in the README "Additional Resources" section. This helps contributors easily report bugs or request features when starting from the README.

This change only modifies README.md and verifies that the issue template link opens correctly.