### PR TITLE
feat(langchain): add token usage tracking middleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -19,6 +19,10 @@ from langchain.agents.middleware.shell_tool import (
 )
 from langchain.agents.middleware.summarization import SummarizationMiddleware
 from langchain.agents.middleware.todo import TodoListMiddleware
+from langchain.agents.middleware.token_usage_tracking import (
+    TokenBudgetExceededError,
+    TokenUsageTrackingMiddleware,
+)
 from langchain.agents.middleware.tool_call_limit import ToolCallLimitMiddleware
 from langchain.agents.middleware.tool_emulator import LLMToolEmulator
 from langchain.agents.middleware.tool_retry import ToolRetryMiddleware
@@ -67,6 +71,8 @@ __all__ = [
     "ShellToolMiddleware",
     "SummarizationMiddleware",
     "TodoListMiddleware",
+    "TokenBudgetExceededError",
+    "TokenUsageTrackingMiddleware",
     "ToolCallLimitMiddleware",
     "ToolCallRequest",
     "ToolRetryMiddleware",

--- a/libs/langchain_v1/langchain/agents/middleware/token_usage_tracking.py
+++ b/libs/langchain_v1/langchain/agents/middleware/token_usage_tracking.py
@@ -1,0 +1,314 @@
+"""Token usage tracking middleware for agents."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Annotated, Any, Literal
+
+from langchain_core.messages import AIMessage
+from langgraph.channels.untracked_value import UntrackedValue
+from typing_extensions import NotRequired, override
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    PrivateStateAttr,
+    ResponseT,
+    hook_config,
+)
+
+if TYPE_CHECKING:
+    from langgraph.runtime import Runtime
+
+logger = logging.getLogger(__name__)
+
+
+class TokenUsageState(AgentState[ResponseT]):
+    """State schema for `TokenUsageTrackingMiddleware`.
+
+    Extends `AgentState` with token usage tracking fields.
+
+    Type Parameters:
+        ResponseT: The type of the structured response. Defaults to `Any`.
+    """
+
+    thread_input_tokens: NotRequired[Annotated[int, PrivateStateAttr]]
+    thread_output_tokens: NotRequired[Annotated[int, PrivateStateAttr]]
+    thread_total_tokens: NotRequired[Annotated[int, PrivateStateAttr]]
+    run_input_tokens: NotRequired[Annotated[int, UntrackedValue, PrivateStateAttr]]
+    run_output_tokens: NotRequired[Annotated[int, UntrackedValue, PrivateStateAttr]]
+    run_total_tokens: NotRequired[Annotated[int, UntrackedValue, PrivateStateAttr]]
+
+
+def _build_budget_exceeded_message(
+    thread_total: int,
+    run_total: int,
+    thread_budget: int | None,
+    run_budget: int | None,
+) -> str:
+    """Build a message indicating which token budgets were exceeded.
+
+    Args:
+        thread_total: Current thread total token count.
+        run_total: Current run total token count.
+        thread_budget: Thread token budget (if set).
+        run_budget: Run token budget (if set).
+
+    Returns:
+        A formatted message describing which budgets were exceeded.
+    """
+    exceeded = []
+    if thread_budget is not None and thread_total >= thread_budget:
+        exceeded.append(f"thread budget ({thread_total}/{thread_budget} tokens)")
+    if run_budget is not None and run_total >= run_budget:
+        exceeded.append(f"run budget ({run_total}/{run_budget} tokens)")
+    return f"Token budget exceeded: {', '.join(exceeded)}"
+
+
+class TokenBudgetExceededError(Exception):
+    """Exception raised when token budgets are exceeded.
+
+    This exception is raised when the configured exit behavior is `'error'` and either
+    the thread or run token budget has been exceeded.
+    """
+
+    def __init__(
+        self,
+        thread_total: int,
+        run_total: int,
+        thread_budget: int | None,
+        run_budget: int | None,
+    ) -> None:
+        """Initialize the exception with token usage information.
+
+        Args:
+            thread_total: Current thread total token count.
+            run_total: Current run total token count.
+            thread_budget: Thread token budget (if set).
+            run_budget: Run token budget (if set).
+        """
+        self.thread_total = thread_total
+        self.run_total = run_total
+        self.thread_budget = thread_budget
+        self.run_budget = run_budget
+
+        msg = _build_budget_exceeded_message(thread_total, run_total, thread_budget, run_budget)
+        super().__init__(msg)
+
+
+class TokenUsageTrackingMiddleware(
+    AgentMiddleware[TokenUsageState[ResponseT], ContextT, ResponseT]
+):
+    """Tracks cumulative token usage across model calls and optionally enforces budgets.
+
+    This middleware extracts `usage_metadata` from `AIMessage` responses to track
+    input tokens, output tokens, and total tokens at both thread and run levels.
+
+    Token counts are accumulated on each `after_model` call. When a budget is
+    configured, the middleware checks token totals in `before_model` and can
+    either stop the agent gracefully or raise an error.
+
+    Example:
+        ```python
+        from langchain.agents.middleware import TokenUsageTrackingMiddleware
+        from langchain.agents import create_agent
+
+        # Track usage without limits (observability only)
+        tracker = TokenUsageTrackingMiddleware()
+
+        agent = create_agent("openai:gpt-4o", middleware=[tracker])
+        result = await agent.invoke({"messages": [HumanMessage("Hello")]})
+
+        # Access token counts from the state
+        # result["run_total_tokens"], result["thread_total_tokens"], etc.
+        ```
+
+        ```python
+        # Enforce a per-run token budget
+        tracker = TokenUsageTrackingMiddleware(run_budget=10000, exit_behavior="end")
+
+        agent = create_agent("openai:gpt-4o", tools=[search], middleware=[tracker])
+        result = await agent.invoke({"messages": [HumanMessage("Research topic X")]})
+        ```
+    """
+
+    state_schema = TokenUsageState  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        *,
+        thread_budget: int | None = None,
+        run_budget: int | None = None,
+        exit_behavior: Literal["end", "error"] = "end",
+    ) -> None:
+        """Initialize the token usage tracking middleware.
+
+        Args:
+            thread_budget: Maximum total tokens allowed per thread.
+
+                `None` means no limit (tracking only).
+            run_budget: Maximum total tokens allowed per run.
+
+                `None` means no limit (tracking only).
+            exit_behavior: What to do when a budget is exceeded.
+
+                - `'end'`: Jump to the end of the agent execution and inject an
+                    `AIMessage` indicating the budget was exceeded.
+                - `'error'`: Raise a `TokenBudgetExceededError`.
+
+                Only takes effect when at least one budget is set.
+
+        Raises:
+            ValueError: If `exit_behavior` is not `'end'` or `'error'`.
+        """
+        super().__init__()
+
+        if exit_behavior not in {"end", "error"}:
+            msg = f"Invalid exit_behavior: {exit_behavior!r}. Must be 'end' or 'error'."
+            raise ValueError(msg)
+
+        self.thread_budget = thread_budget
+        self.run_budget = run_budget
+        self.exit_behavior = exit_behavior
+
+    @hook_config(can_jump_to=["end"])
+    @override
+    def before_model(
+        self, state: TokenUsageState[ResponseT], runtime: Runtime[ContextT]
+    ) -> dict[str, Any] | None:
+        """Check token budgets before making a model call.
+
+        Args:
+            state: The current agent state containing token counts.
+            runtime: The langgraph runtime.
+
+        Returns:
+            If a budget is exceeded and `exit_behavior` is `'end'`, returns a state
+            update that jumps to end with a budget-exceeded message. Otherwise `None`.
+
+        Raises:
+            TokenBudgetExceededError: If a budget is exceeded and `exit_behavior`
+                is `'error'`.
+        """
+        if self.thread_budget is None and self.run_budget is None:
+            return None
+
+        thread_total = state.get("thread_total_tokens", 0)
+        run_total = state.get("run_total_tokens", 0)
+
+        thread_exceeded = (
+            self.thread_budget is not None and thread_total >= self.thread_budget
+        )
+        run_exceeded = (
+            self.run_budget is not None and run_total >= self.run_budget
+        )
+
+        if thread_exceeded or run_exceeded:
+            if self.exit_behavior == "error":
+                raise TokenBudgetExceededError(
+                    thread_total=thread_total,
+                    run_total=run_total,
+                    thread_budget=self.thread_budget,
+                    run_budget=self.run_budget,
+                )
+            message = _build_budget_exceeded_message(
+                thread_total, run_total, self.thread_budget, self.run_budget
+            )
+            return {"jump_to": "end", "messages": [AIMessage(content=message)]}
+
+        return None
+
+    @hook_config(can_jump_to=["end"])
+    @override
+    async def abefore_model(
+        self,
+        state: TokenUsageState[ResponseT],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Async check token budgets before making a model call.
+
+        Args:
+            state: The current agent state containing token counts.
+            runtime: The langgraph runtime.
+
+        Returns:
+            If a budget is exceeded and `exit_behavior` is `'end'`, returns a state
+            update that jumps to end with a budget-exceeded message. Otherwise `None`.
+
+        Raises:
+            TokenBudgetExceededError: If a budget is exceeded and `exit_behavior`
+                is `'error'`.
+        """
+        return self.before_model(state, runtime)
+
+    @override
+    def after_model(
+        self, state: TokenUsageState[ResponseT], runtime: Runtime[ContextT]
+    ) -> dict[str, Any] | None:
+        """Extract and accumulate token usage from the latest model response.
+
+        Reads `usage_metadata` from the most recent `AIMessage` in the state and
+        increments both thread-level and run-level token counters.
+
+        Args:
+            state: The current agent state.
+            runtime: The langgraph runtime.
+
+        Returns:
+            State updates with incremented token counts, or `None` if no
+            usage metadata is available.
+        """
+        input_tokens, output_tokens, total_tokens = _extract_usage(state)
+
+        if total_tokens == 0:
+            return None
+
+        return {
+            "thread_input_tokens": state.get("thread_input_tokens", 0) + input_tokens,
+            "thread_output_tokens": state.get("thread_output_tokens", 0) + output_tokens,
+            "thread_total_tokens": state.get("thread_total_tokens", 0) + total_tokens,
+            "run_input_tokens": state.get("run_input_tokens", 0) + input_tokens,
+            "run_output_tokens": state.get("run_output_tokens", 0) + output_tokens,
+            "run_total_tokens": state.get("run_total_tokens", 0) + total_tokens,
+        }
+
+    @override
+    async def aafter_model(
+        self, state: TokenUsageState[ResponseT], runtime: Runtime[ContextT]
+    ) -> dict[str, Any] | None:
+        """Async extract and accumulate token usage from the latest model response.
+
+        Args:
+            state: The current agent state.
+            runtime: The langgraph runtime.
+
+        Returns:
+            State updates with incremented token counts, or `None` if no
+            usage metadata is available.
+        """
+        return self.after_model(state, runtime)
+
+
+def _extract_usage(state: TokenUsageState[Any]) -> tuple[int, int, int]:
+    """Extract token usage from the most recent AIMessage in state.
+
+    Args:
+        state: The agent state containing messages.
+
+    Returns:
+        A tuple of (input_tokens, output_tokens, total_tokens).
+        Returns (0, 0, 0) if no usage metadata is found.
+    """
+    messages = state.get("messages", [])
+
+    # Walk backwards to find the latest AIMessage with usage_metadata
+    for msg in reversed(messages):
+        if isinstance(msg, AIMessage) and msg.usage_metadata is not None:
+            return (
+                msg.usage_metadata.get("input_tokens", 0),
+                msg.usage_metadata.get("output_tokens", 0),
+                msg.usage_metadata.get("total_tokens", 0),
+            )
+
+    return (0, 0, 0)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_token_usage_tracking.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_token_usage_tracking.py
@@ -1,0 +1,278 @@
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.tools import tool
+from langgraph.runtime import Runtime
+
+from langchain.agents.middleware.token_usage_tracking import (
+    TokenBudgetExceededError,
+    TokenUsageState,
+    TokenUsageTrackingMiddleware,
+    _build_budget_exceeded_message,
+    _extract_usage,
+)
+
+
+@tool
+def simple_tool(value: str) -> str:
+    """A simple tool."""
+    return value
+
+
+def test_extract_usage_from_ai_message() -> None:
+    """Test extracting usage metadata from an AIMessage."""
+    ai_msg = AIMessage(
+        content="hello",
+        usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+    )
+    state = TokenUsageState(messages=[HumanMessage(content="hi"), ai_msg])
+    assert _extract_usage(state) == (10, 5, 15)
+
+
+def test_extract_usage_no_metadata() -> None:
+    """Test that missing usage_metadata returns zeros."""
+    ai_msg = AIMessage(content="hello")
+    state = TokenUsageState(messages=[HumanMessage(content="hi"), ai_msg])
+    assert _extract_usage(state) == (0, 0, 0)
+
+
+def test_extract_usage_empty_messages() -> None:
+    """Test extraction from empty message list."""
+    state = TokenUsageState(messages=[])
+    assert _extract_usage(state) == (0, 0, 0)
+
+
+def test_extract_usage_picks_latest_ai_message() -> None:
+    """Test that the most recent AIMessage with metadata is used."""
+    old_msg = AIMessage(
+        content="old",
+        usage_metadata={"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+    )
+    new_msg = AIMessage(
+        content="new",
+        usage_metadata={"input_tokens": 50, "output_tokens": 25, "total_tokens": 75},
+    )
+    state = TokenUsageState(messages=[old_msg, HumanMessage(content="q"), new_msg])
+    assert _extract_usage(state) == (50, 25, 75)
+
+
+def test_build_budget_exceeded_message_thread() -> None:
+    """Test budget exceeded message for thread budget."""
+    msg = _build_budget_exceeded_message(
+        thread_total=1000, run_total=500, thread_budget=1000, run_budget=None
+    )
+    assert "thread budget (1000/1000 tokens)" in msg
+
+
+def test_build_budget_exceeded_message_run() -> None:
+    """Test budget exceeded message for run budget."""
+    msg = _build_budget_exceeded_message(
+        thread_total=500, run_total=1000, thread_budget=None, run_budget=1000
+    )
+    assert "run budget (1000/1000 tokens)" in msg
+
+
+def test_build_budget_exceeded_message_both() -> None:
+    """Test budget exceeded message when both budgets exceeded."""
+    msg = _build_budget_exceeded_message(
+        thread_total=2000, run_total=1000, thread_budget=2000, run_budget=1000
+    )
+    assert "thread budget" in msg
+    assert "run budget" in msg
+
+
+def test_middleware_no_budgets_tracking_only() -> None:
+    """Test middleware with no budgets set (tracking only mode)."""
+    middleware = TokenUsageTrackingMiddleware()
+    runtime = Runtime()
+
+    # before_model should always return None with no budgets
+    state = TokenUsageState(
+        messages=[], thread_total_tokens=999999, run_total_tokens=999999
+    )
+    assert middleware.before_model(state, runtime) is None
+
+
+def test_middleware_after_model_accumulates_tokens() -> None:
+    """Test that after_model correctly accumulates token counts."""
+    middleware = TokenUsageTrackingMiddleware()
+    runtime = Runtime()
+
+    ai_msg = AIMessage(
+        content="response",
+        usage_metadata={"input_tokens": 100, "output_tokens": 50, "total_tokens": 150},
+    )
+    state = TokenUsageState(
+        messages=[HumanMessage(content="hi"), ai_msg],
+        thread_input_tokens=200,
+        thread_output_tokens=100,
+        thread_total_tokens=300,
+        run_input_tokens=0,
+        run_output_tokens=0,
+        run_total_tokens=0,
+    )
+
+    result = middleware.after_model(state, runtime)
+    assert result is not None
+    assert result["thread_input_tokens"] == 300  # 200 + 100
+    assert result["thread_output_tokens"] == 150  # 100 + 50
+    assert result["thread_total_tokens"] == 450  # 300 + 150
+    assert result["run_input_tokens"] == 100
+    assert result["run_output_tokens"] == 50
+    assert result["run_total_tokens"] == 150
+
+
+def test_middleware_after_model_no_usage_returns_none() -> None:
+    """Test that after_model returns None when no usage metadata found."""
+    middleware = TokenUsageTrackingMiddleware()
+    runtime = Runtime()
+
+    state = TokenUsageState(messages=[AIMessage(content="no usage")])
+    assert middleware.after_model(state, runtime) is None
+
+
+def test_middleware_after_model_defaults_to_zero() -> None:
+    """Test that after_model initializes counts from zero when state is empty."""
+    middleware = TokenUsageTrackingMiddleware()
+    runtime = Runtime()
+
+    ai_msg = AIMessage(
+        content="first",
+        usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+    )
+    state = TokenUsageState(messages=[ai_msg])
+
+    result = middleware.after_model(state, runtime)
+    assert result is not None
+    assert result["thread_input_tokens"] == 10
+    assert result["thread_output_tokens"] == 5
+    assert result["thread_total_tokens"] == 15
+    assert result["run_input_tokens"] == 10
+    assert result["run_output_tokens"] == 5
+    assert result["run_total_tokens"] == 15
+
+
+def test_middleware_before_model_thread_budget_exceeded_end() -> None:
+    """Test before_model ends agent when thread budget is exceeded."""
+    middleware = TokenUsageTrackingMiddleware(thread_budget=500)
+    runtime = Runtime()
+
+    state = TokenUsageState(messages=[], thread_total_tokens=500)
+    result = middleware.before_model(state, runtime)
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert len(result["messages"]) == 1
+    assert "thread budget (500/500 tokens)" in result["messages"][0].content
+
+
+def test_middleware_before_model_run_budget_exceeded_end() -> None:
+    """Test before_model ends agent when run budget is exceeded."""
+    middleware = TokenUsageTrackingMiddleware(run_budget=1000)
+    runtime = Runtime()
+
+    state = TokenUsageState(messages=[], run_total_tokens=1000)
+    result = middleware.before_model(state, runtime)
+    assert result is not None
+    assert result["jump_to"] == "end"
+    assert "run budget (1000/1000 tokens)" in result["messages"][0].content
+
+
+def test_middleware_before_model_under_budget() -> None:
+    """Test before_model returns None when under budget."""
+    middleware = TokenUsageTrackingMiddleware(thread_budget=1000, run_budget=500)
+    runtime = Runtime()
+
+    state = TokenUsageState(
+        messages=[], thread_total_tokens=100, run_total_tokens=50
+    )
+    assert middleware.before_model(state, runtime) is None
+
+
+def test_middleware_before_model_error_behavior() -> None:
+    """Test before_model raises TokenBudgetExceededError with error behavior."""
+    middleware = TokenUsageTrackingMiddleware(
+        thread_budget=500, exit_behavior="error"
+    )
+    runtime = Runtime()
+
+    state = TokenUsageState(messages=[], thread_total_tokens=500)
+    with pytest.raises(TokenBudgetExceededError) as exc_info:
+        middleware.before_model(state, runtime)
+
+    assert exc_info.value.thread_total == 500
+    assert exc_info.value.thread_budget == 500
+    assert "thread budget" in str(exc_info.value)
+
+
+def test_middleware_before_model_run_budget_error() -> None:
+    """Test before_model raises error when run budget is exceeded."""
+    middleware = TokenUsageTrackingMiddleware(
+        run_budget=200, exit_behavior="error"
+    )
+    runtime = Runtime()
+
+    state = TokenUsageState(messages=[], run_total_tokens=200)
+    with pytest.raises(TokenBudgetExceededError) as exc_info:
+        middleware.before_model(state, runtime)
+
+    assert exc_info.value.run_total == 200
+    assert exc_info.value.run_budget == 200
+
+
+def test_invalid_exit_behavior() -> None:
+    """Test that invalid exit_behavior raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid exit_behavior"):
+        TokenUsageTrackingMiddleware(thread_budget=100, exit_behavior="invalid")  # type: ignore[arg-type]
+
+
+def test_token_budget_exceeded_error_attributes() -> None:
+    """Test TokenBudgetExceededError stores all attributes."""
+    err = TokenBudgetExceededError(
+        thread_total=1000,
+        run_total=500,
+        thread_budget=800,
+        run_budget=400,
+    )
+    assert err.thread_total == 1000
+    assert err.run_total == 500
+    assert err.thread_budget == 800
+    assert err.run_budget == 400
+    assert "thread budget" in str(err)
+    assert "run budget" in str(err)
+
+
+@pytest.mark.asyncio
+async def test_abefore_model_delegates_to_sync() -> None:
+    """Test that abefore_model delegates to before_model."""
+    middleware = TokenUsageTrackingMiddleware(run_budget=100)
+    runtime = Runtime()
+
+    state = TokenUsageState(messages=[], run_total_tokens=100)
+    result = await middleware.abefore_model(state, runtime)
+    assert result is not None
+    assert result["jump_to"] == "end"
+
+
+@pytest.mark.asyncio
+async def test_aafter_model_delegates_to_sync() -> None:
+    """Test that aafter_model delegates to after_model."""
+    middleware = TokenUsageTrackingMiddleware()
+    runtime = Runtime()
+
+    ai_msg = AIMessage(
+        content="resp",
+        usage_metadata={"input_tokens": 20, "output_tokens": 10, "total_tokens": 30},
+    )
+    state = TokenUsageState(messages=[ai_msg])
+    result = await middleware.aafter_model(state, runtime)
+    assert result is not None
+    assert result["run_total_tokens"] == 30
+
+
+def test_extract_usage_partial_metadata() -> None:
+    """Test extraction when usage_metadata has missing keys."""
+    ai_msg = AIMessage(
+        content="partial",
+        usage_metadata={"input_tokens": 5, "output_tokens": 0, "total_tokens": 5},
+    )
+    state = TokenUsageState(messages=[ai_msg])
+    assert _extract_usage(state) == (5, 0, 5)


### PR DESCRIPTION
Fixes #35752

This PR adds a new Token Usage Tracking Middleware to LangChain's agent middleware system. Tracks cumulative token consumption (input, output, total) at thread and run levels with optional budget enforcement.

## Why This Feature
- **Cost Monitoring**: Track API costs in production
- **Budget Enforcement**: Optional token limits per thread/run
- **Full Async Support**: Works with both sync and async agent pipelines

## Files Changed
- `libs/langchain_v1/langchain/agents/middleware/token_usage_tracking.py` - Core middleware
- `libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_token_usage_tracking.py` - 21 unit tests (all passing ✅)
- `libs/langchain_v1/langchain/agents/middleware/__init__.py` - Updated exports

## Testing
All 21 unit tests passing locally. Run:
```bash
make test
make lint
make format