### PR TITLE
fix: add empty results check in EmbeddingRouterChain

### DIFF
--- a/libs/langchain/langchain_classic/chains/router/embedding_router.py
+++ b/libs/langchain/langchain_classic/chains/router/embedding_router.py
@@ -40,6 +40,8 @@ class EmbeddingRouterChain(RouterChain):
     ) -> dict[str, Any]:
         _input = ", ".join([inputs[k] for k in self.routing_keys])
         results = self.vectorstore.similarity_search(_input, k=1)
+        if not results:
+            raise ValueError("No results found from vectorstore")
         return {"next_inputs": inputs, "destination": results[0].metadata["name"]}
 
     @override
@@ -50,6 +52,8 @@ class EmbeddingRouterChain(RouterChain):
     ) -> dict[str, Any]:
         _input = ", ".join([inputs[k] for k in self.routing_keys])
         results = await self.vectorstore.asimilarity_search(_input, k=1)
+        if not results:
+            raise ValueError("No results found from vectorstore")
         return {"next_inputs": inputs, "destination": results[0].metadata["name"]}
 
     @classmethod


### PR DESCRIPTION
## Description
Add bounds checking before accessing `results[0]` to prevent IndexError when vectorstore returns empty results.

## Changes
- Added check for empty results in `_call` method
- Added check for empty results in `_acall` method
- Raises ValueError with clear message when no results found

## Related Issue
Found during automated code analysis (potential IndexError bug)