### PR TITLE
fix: add descriptive error messages to bare ValueError raises

### DIFF
--- a/libs/core/langchain_core/document_loaders/langsmith.py
+++ b/libs/core/langchain_core/document_loaders/langsmith.py
@@ -94,7 +94,7 @@ class LangSmithLoader(BaseLoader):
             ValueError: If both `client` and `client_kwargs` are provided.
         """  # noqa: E501
         if client and client_kwargs:
-            raise ValueError
+            raise ValueError("Cannot specify both 'client' and 'client_kwargs'. Please provide either a pre-configured client or client_kwargs, not both.")
         self._client = client or LangSmithClient(**client_kwargs)
         self.content_key = list(content_key.split(".")) if content_key else []
         self.format_content = format_content or _stringify

--- a/libs/core/langchain_core/prompts/few_shot_with_templates.py
+++ b/libs/core/langchain_core/prompts/few_shot_with_templates.py
@@ -110,14 +110,14 @@ class FewShotPromptWithTemplates(StringPromptTemplate):
             return self.examples
         if self.example_selector is not None:
             return self.example_selector.select_examples(kwargs)
-        raise ValueError
+        raise ValueError("Either 'examples' or 'example_selector' must be provided")
 
     async def _aget_examples(self, **kwargs: Any) -> list[dict]:
         if self.examples is not None:
             return self.examples
         if self.example_selector is not None:
             return await self.example_selector.aselect_examples(kwargs)
-        raise ValueError
+        raise ValueError("Either 'examples' or 'example_selector' must be provided")
 
     def format(self, **kwargs: Any) -> str:
         """Format the prompt with the inputs.

--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -55,7 +55,7 @@ def _load_template(var_name: str, config: dict) -> dict:
         if template_path.suffix == ".txt":
             template = template_path.read_text(encoding="utf-8")
         else:
-            raise ValueError
+            raise ValueError(f"Unsupported template file format: {template_path.suffix}. Only .txt is supported.")
         # Set the template variable to the extracted variable.
         config[var_name] = template
     return config

--- a/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
@@ -35,13 +35,13 @@ def _expand_include_patterns(pattern: str) -> list[str] | None:
 
         end = current.find("}", start)
         if end == -1:
-            raise ValueError
+            raise ValueError(f"Malformed brace expansion: missing closing '}}' in '{current}'")
 
         prefix = current[:start]
         suffix = current[end + 1 :]
         inner = current[start + 1 : end]
         if not inner:
-            raise ValueError
+            raise ValueError(f"Malformed brace expansion: empty braces '{{}}' in '{current}'")
 
         for option in inner.split(","):
             _expand(prefix + option + suffix)


### PR DESCRIPTION
## Summary
Add meaningful error messages to bare `raise ValueError` statements across multiple files to improve debugging experience for users.

## Changes
- **few_shot_with_templates.py**: Add message for missing examples/selector
- **loading.py**: Add message for unsupported template file format  
- **langsmith.py**: Add message for conflicting client args
- **file_search.py**: Add messages for malformed brace expansion

## Files Changed
- `libs/core/langchain_core/prompts/few_shot_with_templates.py`
- `libs/core/langchain_core/prompts/loading.py`
- `libs/core/langchain_core/document_loaders/langsmith.py`
- `libs/partners/anthropic/langchain_anthropic/middleware/file_search.py`

Fixes: langchain-ai/langchain#35727