### PR TITLE
fix(openai): preserve status field in function_call blocks for GPT-OSS compatibility

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4366,6 +4366,7 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                             "name": tool_call["function"]["name"],
                             "arguments": tool_call["function"]["arguments"],
                             "call_id": tool_call["id"],
+                            "status": None,
                         }
                         input_.append(function_call)
 
@@ -4485,7 +4486,12 @@ def _construct_lc_result_from_responses_api(
                         {"type": "refusal", "refusal": content.refusal, "id": output.id}
                     )
         elif output.type == "function_call":
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            # Use exclude_none=False to preserve "status" field (even when
+            # None).  Some OpenAI-compatible servers (e.g. vLLM serving
+            # GPT-OSS models) require "status" to be present in the
+            # function_call block when it is sent back as conversation
+            # history; omitting it causes "No call message found" errors.
+            content_blocks.append(output.model_dump(exclude_none=False, mode="json"))
             try:
                 args = json.loads(output.arguments, strict=False)
                 error = None
@@ -4727,6 +4733,7 @@ def _convert_responses_chunk_to_generation_chunk(
                 "arguments": chunk.item.arguments,
                 "call_id": chunk.item.call_id,
                 "id": chunk.item.id,
+                "status": getattr(chunk.item, "status", None),
                 "index": current_index,
             }
         )

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1727,8 +1727,76 @@ def test__construct_lc_result_from_responses_api_function_call_valid_json() -> N
             "name": "get_weather",
             "arguments": '{"location": "New York", "unit": "celsius"}',
             "call_id": "call_123",
+            "status": None,
         }
     ]
+
+
+def test__construct_lc_result_from_responses_api_function_call_preserves_status() -> (
+    None
+):
+    """Test that function_call status field is preserved (even when None).
+
+    Some OpenAI-compatible servers (e.g. vLLM serving GPT-OSS models) require
+    the "status" field to be present in function_call blocks when they are sent
+    back as conversation history. Omitting it causes "No call message found"
+    errors.  See https://github.com/langchain-ai/langchain/issues/32885
+    """
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseFunctionToolCall(
+                type="function_call",
+                id="func_123",
+                call_id="call_123",
+                name="get_weather",
+                arguments='{"location": "New York"}',
+                # status defaults to None
+            )
+        ],
+    )
+    result = _construct_lc_result_from_responses_api(response)
+    msg = cast(AIMessage, result.generations[0].message)
+    assert isinstance(msg.content, list)
+    assert len(msg.content) == 1
+    block = msg.content[0]
+    assert isinstance(block, dict)
+    assert "status" in block, "status field must be present in function_call block"
+    assert block["status"] is None
+
+    # Verify a round-trip through _construct_responses_api_input preserves status
+    rebuilt = _construct_responses_api_input([msg])
+    assert any(
+        item.get("type") == "function_call" and "status" in item for item in rebuilt
+    ), "status field must survive round-trip through _construct_responses_api_input"
+
+
+def test__construct_responses_api_input_fallback_function_call_includes_status() -> (
+    None
+):
+    """Test that function_call blocks created from tool_calls include status."""
+    tool_calls = [
+        {
+            "id": "call_123",
+            "name": "get_weather",
+            "args": {"location": "San Francisco"},
+            "type": "tool_call",
+        }
+    ]
+    # When content is empty, function_call is reconstructed from tool_calls
+    ai_message = AIMessage(content="", tool_calls=tool_calls)
+    result = _construct_responses_api_input([ai_message])
+    fc_items = [item for item in result if item.get("type") == "function_call"]
+    assert len(fc_items) == 1
+    assert "status" in fc_items[0], (
+        "status field must be present in reconstructed function_call"
+    )
 
 
 def test__construct_lc_result_from_responses_api_function_call_invalid_json() -> None:
@@ -1852,6 +1920,7 @@ def test__construct_lc_result_from_responses_api_complex_response() -> None:
             "call_id": "call_123",
             "name": "get_weather",
             "arguments": '{"location": "New York"}',
+            "status": None,
         },
     ]
 


### PR DESCRIPTION
## Description

Supersedes #35618 with the same fix rebased cleanly on current `master`.

Fixes #32885.

When using OpenAI-compatible servers (for example vLLM serving GPT-OSS models) with the Responses API, the server expects the `status` field to remain present on `function_call` items even when its value is `null`.

Previously, LangChain could drop that field during:
- non-streaming Responses API result conversion
- streaming chunk conversion
- fallback reconstruction from `tool_calls`

That breaks round-tripping of tool call history and can trigger errors like `BadRequestError: No call message found for call_<id>` on GPT-OSS-compatible backends.

## Changes

- preserve `status` in `_construct_lc_result_from_responses_api`
- preserve `status` in streaming `function_call` chunk conversion
- ensure fallback reconstruction in `_construct_responses_api_input` includes `status`
- add targeted regression coverage for status preservation and round-trip behavior

## Validation

- targeted `ruff` on touched files
- targeted pytest for the new regression coverage
- runtime round-trip check showing `function_call` items preserve `status: None`

## Notes

The earlier PR was closed to reduce volume. This resubmission keeps the fix focused to the two OpenAI files only and drops unrelated diff noise.
