### PR TITLE
feat: tracing for wrap model + tool call

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 import itertools
+
+try:
+    from langsmith import traceable  # type: ignore[import-untyped]
+except ImportError:
+    traceable = None
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
@@ -129,6 +134,13 @@ Option 2: Handle dynamic tools in middleware (for tools created at runtime)
                 return handler(request.override(tool=my_dynamic_tool))
             return handler(request)
 """.strip()
+
+def _trace(fn: Callable[..., Any], *, name: str) -> Callable[..., Any]:
+    """Wrap ``fn`` with ``langsmith.traceable`` if available, otherwise return as-is."""
+    if traceable is None:
+        return fn
+    return traceable(name=name)(fn)
+
 
 FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT = [
     # if model profile data are not available, these models are assumed to support
@@ -862,7 +874,10 @@ def create_agent(
     # Chain all wrap_tool_call handlers into a single composed handler
     wrap_tool_call_wrapper = None
     if middleware_w_wrap_tool_call:
-        wrappers = [m.wrap_tool_call for m in middleware_w_wrap_tool_call]
+        wrappers = [
+            _trace(m.wrap_tool_call, name=f"{m.name}.wrap_tool_call")
+            for m in middleware_w_wrap_tool_call
+        ]
         wrap_tool_call_wrapper = _chain_tool_call_wrappers(wrappers)
 
     # Collect middleware with awrap_tool_call or wrap_tool_call hooks
@@ -878,7 +893,10 @@ def create_agent(
     # Chain all awrap_tool_call handlers into a single composed async handler
     awrap_tool_call_wrapper = None
     if middleware_w_awrap_tool_call:
-        async_wrappers = [m.awrap_tool_call for m in middleware_w_awrap_tool_call]
+        async_wrappers = [
+            _trace(m.awrap_tool_call, name=f"{m.name}.awrap_tool_call")
+            for m in middleware_w_awrap_tool_call
+        ]
         awrap_tool_call_wrapper = _chain_async_tool_call_wrappers(async_wrappers)
 
     # Setup tools
@@ -961,13 +979,19 @@ def create_agent(
     # Compose wrap_model_call handlers into a single middleware stack (sync)
     wrap_model_call_handler = None
     if middleware_w_wrap_model_call:
-        sync_handlers = [m.wrap_model_call for m in middleware_w_wrap_model_call]
+        sync_handlers = [
+            _trace(m.wrap_model_call, name=f"{m.name}.wrap_model_call")
+            for m in middleware_w_wrap_model_call
+        ]
         wrap_model_call_handler = _chain_model_call_handlers(sync_handlers)
 
     # Compose awrap_model_call handlers into a single middleware stack (async)
     awrap_model_call_handler = None
     if middleware_w_awrap_model_call:
-        async_handlers = [m.awrap_model_call for m in middleware_w_awrap_model_call]
+        async_handlers = [
+            _trace(m.awrap_model_call, name=f"{m.name}.awrap_model_call")
+            for m in middleware_w_awrap_model_call
+        ]
         awrap_model_call_handler = _chain_async_model_call_handlers(async_handlers)
 
     state_schemas: set[type] = {m.state_schema for m in middleware}

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -133,9 +133,10 @@ Option 2: Handle dynamic tools in middleware (for tools created at runtime)
 """.strip()
 
 
-def _scrub_runtime(inputs: dict[str, Any]) -> dict[str, Any]:
-    """Remove ``runtime`` from request objects before sending to LangSmith."""
+def _scrub_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
+    """Remove ``runtime`` and ``handler`` from trace inputs before sending to LangSmith."""
     filtered = inputs.copy()
+    filtered.pop("handler", None)
     req = filtered.get("request")
     if isinstance(req, (ModelRequest, ToolCallRequest)):
         filtered["request"] = {
@@ -877,7 +878,7 @@ def create_agent(
     wrap_tool_call_wrapper = None
     if middleware_w_wrap_tool_call:
         wrappers = [
-            traceable(name=f"{m.name}.wrap_tool_call", process_inputs=_scrub_runtime)(
+            traceable(name=f"{m.name}.wrap_tool_call", process_inputs=_scrub_inputs)(
                 m.wrap_tool_call
             )
             for m in middleware_w_wrap_tool_call
@@ -898,7 +899,7 @@ def create_agent(
     awrap_tool_call_wrapper = None
     if middleware_w_awrap_tool_call:
         async_wrappers = [
-            traceable(name=f"{m.name}.awrap_tool_call", process_inputs=_scrub_runtime)(
+            traceable(name=f"{m.name}.awrap_tool_call", process_inputs=_scrub_inputs)(
                 m.awrap_tool_call
             )
             for m in middleware_w_awrap_tool_call
@@ -986,7 +987,7 @@ def create_agent(
     wrap_model_call_handler = None
     if middleware_w_wrap_model_call:
         sync_handlers = [
-            traceable(name=f"{m.name}.wrap_model_call", process_inputs=_scrub_runtime)(
+            traceable(name=f"{m.name}.wrap_model_call", process_inputs=_scrub_inputs)(
                 m.wrap_model_call
             )
             for m in middleware_w_wrap_model_call
@@ -997,7 +998,7 @@ def create_agent(
     awrap_model_call_handler = None
     if middleware_w_awrap_model_call:
         async_handlers = [
-            traceable(name=f"{m.name}.awrap_model_call", process_inputs=_scrub_runtime)(
+            traceable(name=f"{m.name}.awrap_model_call", process_inputs=_scrub_inputs)(
                 m.awrap_model_call
             )
             for m in middleware_w_awrap_model_call

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -3,12 +3,6 @@
 from __future__ import annotations
 
 import itertools
-
-try:
-    from langsmith import traceable  # type: ignore[import-untyped]
-except ImportError:
-    traceable = None
-
 from dataclasses import asdict, dataclass, field
 from typing import (
     TYPE_CHECKING,
@@ -29,6 +23,7 @@ from langgraph.constants import END, START
 from langgraph.graph.state import StateGraph
 from langgraph.prebuilt.tool_node import ToolCallWithContext, ToolNode
 from langgraph.types import Command, Send
+from langsmith import traceable
 from typing_extensions import NotRequired, Required, TypedDict
 
 from langchain.agents.middleware.types import (
@@ -145,13 +140,6 @@ def _scrub_runtime(inputs: dict[str, Any]) -> dict[str, Any]:
     if isinstance(req, (ModelRequest, ToolCallRequest)):
         filtered["request"] = {k: v for k, v in asdict(req).items() if k != "runtime"}
     return filtered
-
-
-def _trace_middleware(fn: Callable[..., Any], *, name: str) -> Callable[..., Any]:
-    """Wrap a middleware hook with ``langsmith.traceable``, scrubbing runtime."""
-    if traceable is None:
-        return fn
-    return traceable(name=name, process_inputs=_scrub_runtime)(fn)
 
 
 FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT = [
@@ -887,7 +875,9 @@ def create_agent(
     wrap_tool_call_wrapper = None
     if middleware_w_wrap_tool_call:
         wrappers = [
-            _trace_middleware(m.wrap_tool_call, name=f"{m.name}.wrap_tool_call")
+            traceable(name=f"{m.name}.wrap_tool_call", process_inputs=_scrub_runtime)(
+                m.wrap_tool_call
+            )
             for m in middleware_w_wrap_tool_call
         ]
         wrap_tool_call_wrapper = _chain_tool_call_wrappers(wrappers)
@@ -906,7 +896,9 @@ def create_agent(
     awrap_tool_call_wrapper = None
     if middleware_w_awrap_tool_call:
         async_wrappers = [
-            _trace_middleware(m.awrap_tool_call, name=f"{m.name}.awrap_tool_call")
+            traceable(name=f"{m.name}.awrap_tool_call", process_inputs=_scrub_runtime)(
+                m.awrap_tool_call
+            )
             for m in middleware_w_awrap_tool_call
         ]
         awrap_tool_call_wrapper = _chain_async_tool_call_wrappers(async_wrappers)
@@ -992,7 +984,9 @@ def create_agent(
     wrap_model_call_handler = None
     if middleware_w_wrap_model_call:
         sync_handlers = [
-            _trace_middleware(m.wrap_model_call, name=f"{m.name}.wrap_model_call")
+            traceable(name=f"{m.name}.wrap_model_call", process_inputs=_scrub_runtime)(
+                m.wrap_model_call
+            )
             for m in middleware_w_wrap_model_call
         ]
         wrap_model_call_handler = _chain_model_call_handlers(sync_handlers)
@@ -1001,7 +995,9 @@ def create_agent(
     awrap_model_call_handler = None
     if middleware_w_awrap_model_call:
         async_handlers = [
-            _trace_middleware(m.awrap_model_call, name=f"{m.name}.awrap_model_call")
+            traceable(name=f"{m.name}.awrap_model_call", process_inputs=_scrub_runtime)(
+                m.awrap_model_call
+            )
             for m in middleware_w_awrap_model_call
         ]
         awrap_model_call_handler = _chain_async_model_call_handlers(async_handlers)

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -135,6 +135,7 @@ Option 2: Handle dynamic tools in middleware (for tools created at runtime)
             return handler(request)
 """.strip()
 
+
 def _trace(fn: Callable[..., Any], *, name: str) -> Callable[..., Any]:
     """Wrap ``fn`` with ``langsmith.traceable`` if available, otherwise return as-is."""
     if traceable is None:

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -8,7 +8,8 @@ try:
     from langsmith import traceable  # type: ignore[import-untyped]
 except ImportError:
     traceable = None
-from dataclasses import dataclass, field
+
+from dataclasses import asdict, dataclass, field
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -41,6 +42,7 @@ from langchain.agents.middleware.types import (
     OmitFromSchema,
     ResponseT,
     StateT_co,
+    ToolCallRequest,
     _InputAgentState,
     _OutputAgentState,
 )
@@ -84,7 +86,7 @@ if TYPE_CHECKING:
     from langgraph.store.base import BaseStore
     from langgraph.types import Checkpointer
 
-    from langchain.agents.middleware.types import ToolCallRequest, ToolCallWrapper
+    from langchain.agents.middleware.types import ToolCallWrapper
 
     _ModelCallHandler = Callable[
         [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], ModelResponse]],
@@ -138,14 +140,10 @@ Option 2: Handle dynamic tools in middleware (for tools created at runtime)
 
 def _scrub_runtime(inputs: dict[str, Any]) -> dict[str, Any]:
     """Remove ``runtime`` from request objects before sending to LangSmith."""
-    from langgraph.prebuilt.tool_node import ToolCallRequest
-
     filtered = inputs.copy()
     req = filtered.get("request")
     if isinstance(req, (ModelRequest, ToolCallRequest)):
-        filtered["request"] = {
-            k: v for k, v in req.__dict__.items() if k != "runtime"
-        }
+        filtered["request"] = {k: v for k, v in asdict(req).items() if k != "runtime"}
     return filtered
 
 

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import itertools
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -138,7 +138,9 @@ def _scrub_runtime(inputs: dict[str, Any]) -> dict[str, Any]:
     filtered = inputs.copy()
     req = filtered.get("request")
     if isinstance(req, (ModelRequest, ToolCallRequest)):
-        filtered["request"] = {k: v for k, v in asdict(req).items() if k != "runtime"}
+        filtered["request"] = {
+            f.name: getattr(req, f.name) for f in fields(req) if f.name != "runtime"
+        }
     return filtered
 
 

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -136,11 +136,24 @@ Option 2: Handle dynamic tools in middleware (for tools created at runtime)
 """.strip()
 
 
-def _trace(fn: Callable[..., Any], *, name: str) -> Callable[..., Any]:
-    """Wrap ``fn`` with ``langsmith.traceable`` if available, otherwise return as-is."""
+def _scrub_runtime(inputs: dict[str, Any]) -> dict[str, Any]:
+    """Remove ``runtime`` from request objects before sending to LangSmith."""
+    from langgraph.prebuilt.tool_node import ToolCallRequest
+
+    filtered = inputs.copy()
+    req = filtered.get("request")
+    if isinstance(req, (ModelRequest, ToolCallRequest)):
+        filtered["request"] = {
+            k: v for k, v in req.__dict__.items() if k != "runtime"
+        }
+    return filtered
+
+
+def _trace_middleware(fn: Callable[..., Any], *, name: str) -> Callable[..., Any]:
+    """Wrap a middleware hook with ``langsmith.traceable``, scrubbing runtime."""
     if traceable is None:
         return fn
-    return traceable(name=name)(fn)
+    return traceable(name=name, process_inputs=_scrub_runtime)(fn)
 
 
 FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT = [
@@ -876,7 +889,7 @@ def create_agent(
     wrap_tool_call_wrapper = None
     if middleware_w_wrap_tool_call:
         wrappers = [
-            _trace(m.wrap_tool_call, name=f"{m.name}.wrap_tool_call")
+            _trace_middleware(m.wrap_tool_call, name=f"{m.name}.wrap_tool_call")
             for m in middleware_w_wrap_tool_call
         ]
         wrap_tool_call_wrapper = _chain_tool_call_wrappers(wrappers)
@@ -895,7 +908,7 @@ def create_agent(
     awrap_tool_call_wrapper = None
     if middleware_w_awrap_tool_call:
         async_wrappers = [
-            _trace(m.awrap_tool_call, name=f"{m.name}.awrap_tool_call")
+            _trace_middleware(m.awrap_tool_call, name=f"{m.name}.awrap_tool_call")
             for m in middleware_w_awrap_tool_call
         ]
         awrap_tool_call_wrapper = _chain_async_tool_call_wrappers(async_wrappers)
@@ -981,7 +994,7 @@ def create_agent(
     wrap_model_call_handler = None
     if middleware_w_wrap_model_call:
         sync_handlers = [
-            _trace(m.wrap_model_call, name=f"{m.name}.wrap_model_call")
+            _trace_middleware(m.wrap_model_call, name=f"{m.name}.wrap_model_call")
             for m in middleware_w_wrap_model_call
         ]
         wrap_model_call_handler = _chain_model_call_handlers(sync_handlers)
@@ -990,7 +1003,7 @@ def create_agent(
     awrap_model_call_handler = None
     if middleware_w_awrap_model_call:
         async_handlers = [
-            _trace(m.awrap_model_call, name=f"{m.name}.awrap_model_call")
+            _trace_middleware(m.awrap_model_call, name=f"{m.name}.awrap_model_call")
             for m in middleware_w_awrap_model_call
         ]
         awrap_model_call_handler = _chain_async_model_call_handlers(async_handlers)


### PR DESCRIPTION
Adding tracing for `wrap_model_call` and `wrap_tool_call`
Scrubbing `request.runtime` and `handler` for now

`wrap_model_call`:
<img width="1292" height="433" alt="Screenshot 2026-03-11 at 2 22 31 PM" src="https://github.com/user-attachments/assets/7717ef52-1498-41cf-97da-93e171377c9f" />


`wrap_tool_call`:
<img width="1301" height="664" alt="Screenshot 2026-03-11 at 2 22 50 PM" src="https://github.com/user-attachments/assets/8722b28a-2482-40cf-911e-dae5cd383373" />