### PR TITLE
fix(openai): use context managers for Image.open() to prevent file descriptor leaks

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3694,7 +3694,8 @@ def _url_to_size(image_source: str) -> tuple[int, int] | None:
                 return None
 
             # close things (context managers)
-            width, height = Image.open(BytesIO(response.content)).size
+            with Image.open(BytesIO(response.content)) as img:
+                width, height = img.size
             return width, height
         except httpx.TimeoutException:
             logger.warning("Image URL request timed out after %s seconds", timeout)
@@ -3709,7 +3710,8 @@ def _url_to_size(image_source: str) -> tuple[int, int] | None:
     if _is_b64(image_source):
         _, encoded = image_source.split(",", 1)
         data = base64.b64decode(encoded)
-        width, height = Image.open(BytesIO(data)).size
+        with Image.open(BytesIO(data)) as img:
+            width, height = img.size
         return width, height
     return None
 


### PR DESCRIPTION
Fixes #35728

Wrapped Image.open() calls with context managers to ensure file descriptors are properly cleaned up. This prevents resource leaks when processing images for token counting in vision models.

## Changes
- Line 3697: Added `with` context manager for URL image processing
- Line 3712: Added `with` context manager for base64 image processing

This addresses the comment on line 3696 that said "close things (context managers)" but was not followed.