### PR TITLE
fix(core): avoid premature tool call parsing on empty SSE args

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -540,6 +540,11 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
 
         for chunk in self.tool_call_chunks:
             try:
+                if chunk["args"] is not None and not chunk["args"]:
+                    # Empty-string args indicate that a streaming tool call has
+                    # not emitted its JSON payload yet. Wait for later chunks to
+                    # be merged before attempting to parse it.
+                    continue
                 args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}
                 if isinstance(args_, dict):
                     tool_calls.append(

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -502,3 +502,87 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+
+def test_sse_fragmented_tool_calls_no_premature_parse() -> None:
+    chunk_1 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {
+                "type": "tool_call_chunk",
+                "name": "my_tool",
+                "args": "",
+                "id": "call_34db",
+                "index": 0,
+            }
+        ],
+    )
+    chunk_2 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {
+                "type": "tool_call_chunk",
+                "name": "",
+                "args": "{",
+                "id": "call_34db",
+                "index": 0,
+            }
+        ],
+    )
+    chunk_3 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {
+                "type": "tool_call_chunk",
+                "name": "",
+                "args": '"url": "http://example.com"',
+                "id": "call_34db",
+                "index": 0,
+            }
+        ],
+    )
+    chunk_4 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {
+                "type": "tool_call_chunk",
+                "name": "",
+                "args": "}",
+                "id": "call_34db",
+                "index": 0,
+            }
+        ],
+    )
+    chunk_5 = AIMessageChunk(content="", chunk_position="last")
+
+    assert chunk_1.tool_calls == []
+    assert chunk_1.invalid_tool_calls == []
+
+    full_chunk = chunk_1 + chunk_2 + chunk_3 + chunk_4 + chunk_5
+
+    assert full_chunk.tool_calls == [
+        create_tool_call(
+            name="my_tool",
+            args={"url": "http://example.com"},
+            id="call_34db",
+        )
+    ]
+
+
+def test_no_arg_tool_call_still_works() -> None:
+    chunk = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {
+                "type": "tool_call_chunk",
+                "name": "my_tool",
+                "args": "{}",
+                "id": "call_34db",
+                "index": 0,
+            }
+        ],
+    )
+
+    assert chunk.tool_calls == [
+        create_tool_call(name="my_tool", args={}, id="call_34db")
+    ]


### PR DESCRIPTION
## Summary
- skip tool-call chunks whose `args` field is the empty string, so fragmented SSE tool calls are not parsed into `{}` too early
- keep valid no-argument tool calls working when the provider explicitly sends `args="{}"`
- add regression coverage for fragmented SSE tool-call chunks and for explicit empty-object tool calls

## Why
Issue #35514 reports that streaming providers can emit a first tool-call chunk with `name`/`id` but `args=""`, followed by later chunks that carry the real JSON payload. Python currently parses that first empty string as `{}`, which lets downstream tool execution run too early with empty arguments.

This change defers parsing until the fragmented chunks are merged, matching the documented streaming model and the already-known JS-side behavior.

Fixes #35514.

## Validation
- `uv run --all-groups ruff check langchain_core/messages/ai.py tests/unit_tests/messages/test_ai.py`
- `uv run --group test pytest tests/unit_tests/messages/test_ai.py`
- direct runtime replay that merges SSE-fragmented `tool_call_chunks` into a final parsed tool call
- repeated the full local gate twice consecutively (`16 passed` each pass)