### PR TITLE
docs(langchain): fix stale testing guide link in tests/README.md

### DIFF
--- a/libs/langchain/tests/README.md
+++ b/libs/langchain/tests/README.md
@@ -1,3 +1,3 @@
 # LangChain Tests
 
-[This guide has moved to the docs](https://python.langchain.com/docs/contributing/testing)
+[This guide has moved to the docs](https://docs.langchain.com/oss/python/contributing/code#running-tests)


### PR DESCRIPTION
Fixes [3077](https://github.com/langchain-ai/docs/issues/3077)

The testing guide link in `libs/langchain/tests/README.md` pointed to `python.langchain.com/docs/contributing/testing`, which 308-redirects to the generic LangChain overview page after the docs domain migration. Updated it to the correct destination on the new domain.

No code changes - one-line markdown fix.

Verified by confirming the old URL redirects to an unrelated page and the new URL resolves to the "Running tests" section of the contributing guide.