### PR TITLE
fix(deepseek): accept `base_url` as alias for `api_base`

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -189,9 +189,13 @@ class ChatDeepSeek(BaseChatOpenAI):
     )
     """DeepSeek API key"""
     api_base: str = Field(
+        alias="base_url",
         default_factory=from_env("DEEPSEEK_API_BASE", default=DEFAULT_API_BASE),
     )
-    """DeepSeek API base URL"""
+    """DeepSeek API base URL.
+
+    Automatically read from env variable `DEEPSEEK_API_BASE` if not provided.
+    """
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -104,6 +104,15 @@ class TestChatDeepSeekUnit(ChatModelUnitTests):
 class TestChatDeepSeekCustomUnit:
     """Custom tests specific to DeepSeek chat model."""
 
+    def test_base_url_alias(self) -> None:
+        """Test that `base_url` is accepted as an alias for `api_base`."""
+        chat_model = ChatDeepSeek(
+            model=MODEL_NAME,
+            api_key=SecretStr("api_key"),
+            base_url="http://example.test/v1",
+        )
+        assert chat_model.api_base == "http://example.test/v1"
+
     def test_create_chat_result_with_reasoning_content(self) -> None:
         """Test that reasoning_content is properly extracted from response."""
         chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -338,7 +338,7 @@ class TestChatDeepSeekAzureToolChoice:
         return ChatDeepSeek(
             model="deepseek-chat",
             api_key=SecretStr("test_key"),
-            api_base=endpoint,
+            base_url=endpoint,
         )
 
     def test_is_azure_endpoint_detection(self) -> None:
@@ -365,7 +365,7 @@ class TestChatDeepSeekAzureToolChoice:
             llm = ChatDeepSeek(
                 model="deepseek-chat",
                 api_key=SecretStr("test_key"),
-                api_base=endpoint,
+                base_url=endpoint,
             )
             assert not llm._is_azure_endpoint, f"Expected non-Azure for {endpoint}"
 

--- a/libs/partners/deepseek/uv.lock
+++ b/libs/partners/deepseek/uv.lock
@@ -370,7 +370,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.14"
+version = "1.2.18"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -477,7 +477,7 @@ typing = [{ name = "mypy", specifier = ">=1.10.0,<2.0.0" }]
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.10"
+version = "1.1.11"
 source = { editable = "../openai" }
 dependencies = [
     { name = "langchain-core" },
@@ -488,7 +488,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "langchain-core", editable = "../../core" },
-    { name = "openai", specifier = ">=2.20.0,<3.0.0" },
+    { name = "openai", specifier = ">=2.26.0,<3.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
 ]
 
@@ -819,7 +819,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.21.0"
+version = "2.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -831,9 +831,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/91/2a06c4e9597c338cac1e5e5a8dd6f29e1836fc229c4c523529dca387fda8/openai-2.26.0.tar.gz", hash = "sha256:b41f37c140ae0034a6e92b0c509376d907f3a66109935fba2c1b471a7c05a8fb", size = 666702, upload-time = "2026-03-05T23:17:35.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2e/3f73e8ca53718952222cacd0cf7eecc9db439d020f0c1fe7ae717e4e199a/openai-2.26.0-py3-none-any.whl", hash = "sha256:6151bf8f83802f036117f06cc8a57b3a4da60da9926826cc96747888b57f394f", size = 1136409, upload-time = "2026-03-05T23:17:34.072Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add `base_url` as a Pydantic alias for `ChatDeepSeek.api_base`, so users can pass `base_url=` when constructing the model.