### PR TITLE
refactor(xai): remove redundant `lc_attributes` override

### DIFF
--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -448,19 +448,6 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
         """
         return ["langchain_xai", "chat_models"]
 
-    @property
-    def lc_attributes(self) -> dict[str, Any]:
-        """List of attribute names that should be included in the serialized kwargs.
-
-        These attributes must be accepted by the constructor.
-        """
-        attributes: dict[str, Any] = {}
-
-        if self.xai_api_base:
-            attributes["xai_api_base"] = self.xai_api_base
-
-        return attributes
-
     @classmethod
     def is_lc_serializable(cls) -> bool:
         """Return whether this model can be serialized by LangChain."""


### PR DESCRIPTION
Remove the redundant `lc_attributes` override from `ChatXAI`. The `xai_api_base` field is a declared Pydantic `Field`, so `Serializable.to_json()` already picks it up via its standard field iteration loop (line 225-232 in `serializable.py`). The override was a no-op — it re-inserted the same key with the same value that the base serialization already included.