### PR TITLE
fix: replace deprecated asyncio.get_event_loop() with get_running_loop()

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -378,7 +378,7 @@ async def _ahandle_event_for_handler(
             elif handler.run_inline:
                 event(*args, **kwargs)
             else:
-                await asyncio.get_event_loop().run_in_executor(
+                await asyncio.get_running_loop().run_in_executor(
                     None,
                     cast(
                         "Callable",

--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -395,7 +395,7 @@ async def _render_mermaid_using_pyppeteer(
     await browser.close()
 
     if output_file_path is not None:
-        await asyncio.get_event_loop().run_in_executor(
+        await asyncio.get_running_loop().run_in_executor(
             None, Path(output_file_path).write_bytes, img_bytes
         )
 

--- a/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
@@ -133,7 +133,7 @@ def _resolve_sync_and_async_api_keys(
             sync_api_key_value = cast(Callable, api_key)
 
             async def async_api_key_wrapper() -> str:
-                return await asyncio.get_event_loop().run_in_executor(
+                return await asyncio.get_running_loop().run_in_executor(
                     None, cast(Callable, api_key)
                 )
 


### PR DESCRIPTION
Replace `asyncio.get_event_loop()` with `asyncio.get_running_loop()` in async contexts. The former has been deprecated since Python 3.10 and triggers DeprecationWarning.

## Changes
- libs/core/langchain_core/callbacks/manager.py
- libs/core/langchain_core/runnables/graph_mermaid.py
- libs/partners/openai/langchain_openai/chat_models/_client_utils.py

## Fixes
Fixes #35726