### PR TITLE
core: fix memory leak in get_function_nonlocals

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -11,7 +11,7 @@ import textwrap
 # Cannot move to TYPE_CHECKING as Mapping and Sequence are needed at runtime by
 # RunnableConfigurableFields.
 from collections.abc import Mapping, Sequence  # noqa: TC003
-from functools import lru_cache
+from weakref import WeakKeyDictionary
 from inspect import signature
 from itertools import groupby
 from typing import (
@@ -404,7 +404,9 @@ def get_lambda_source(func: Callable) -> str | None:
     return visitor.source if visitor.count == 1 else name
 
 
-@lru_cache(maxsize=256)
+_function_nonlocals_cache: WeakKeyDictionary[Callable, list[Any]] = WeakKeyDictionary()
+
+
 def get_function_nonlocals(func: Callable) -> list[Any]:
     """Get the nonlocal variables accessed by a function.
 
@@ -414,6 +416,15 @@ def get_function_nonlocals(func: Callable) -> list[Any]:
     Returns:
         The nonlocal variables accessed by the function.
     """
+    try:
+        cached = _function_nonlocals_cache[func]
+    except (KeyError, TypeError):
+        # KeyError: not cached yet
+        # TypeError: func is not weakly referenceable (e.g. bound methods)
+        pass
+    else:
+        return cached
+
     try:
         code = inspect.getsource(func)
         tree = ast.parse(textwrap.dedent(code))
@@ -443,6 +454,12 @@ def get_function_nonlocals(func: Callable) -> list[Any]:
                         values.append(vv)
     except (SyntaxError, TypeError, OSError, SystemError):
         return []
+
+    try:
+        _function_nonlocals_cache[func] = values
+    except TypeError:
+        # func is not weakly referenceable (e.g. bound methods), skip caching
+        pass
 
     return values
 

--- a/libs/core/tests/unit_tests/runnables/test_utils.py
+++ b/libs/core/tests/unit_tests/runnables/test_utils.py
@@ -1,3 +1,5 @@
+import gc
+import weakref
 from collections.abc import Callable
 from typing import Any
 
@@ -73,3 +75,32 @@ def test_nonlocals() -> None:
     assert RunnableLambda(my_func3).deps == [agent]
     assert RunnableLambda(my_func4).deps == [global_agent]
     assert RunnableLambda(func).deps == [nl]
+
+
+def test_get_function_nonlocals_no_memory_leak() -> None:
+    """Test that get_function_nonlocals does not prevent garbage collection.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/30667.
+    The previous @lru_cache decorator held strong references to Callable arguments,
+    preventing garbage collection of bound methods and their parent objects.
+    """
+
+    class HeavyObject:
+        def call(self, x: str) -> str:
+            return x
+
+    obj = HeavyObject()
+    ref = weakref.ref(obj)
+
+    def fn(value: str) -> str:
+        return obj.call(value)
+
+    runnable = RunnableLambda(fn)
+    _ = runnable.deps  # triggers get_function_nonlocals
+
+    del obj
+    del fn
+    del runnable
+    gc.collect()
+
+    assert ref() is None, "HeavyObject was not garbage collected — memory leak"


### PR DESCRIPTION
## Description

Fix memory leak caused by `@lru_cache(maxsize=256)` on `get_function_nonlocals` in `langchain_core/runnables/utils.py`.

### Root cause

`@lru_cache` holds **strong references** to the `Callable` arguments used as cache keys. When bound methods (e.g., `thing.call`) are cached, the entire parent object is retained, preventing garbage collection. In long-running applications that dynamically create `RunnableLambda` instances (e.g., in loops or inference pipelines), this causes unbounded memory growth.

### Fix

Replace `@lru_cache` with a `WeakKeyDictionary`-based cache:

- **Weakly referenceable callables** (regular functions, closures): cached normally, entries are automatically removed when the callable is garbage collected.
- **Non-weakly-referenceable callables** (bound methods, lambdas): computed without caching. This is safe because `RunnableLambda.deps` already uses `@functools.cached_property` for per-instance caching.

This follows the existing pattern in the codebase (`_enums_for_spec` in `configurable.py` already uses `WeakValueDictionary`).

### Tests

- All 6 existing tests in `test_utils.py` pass unchanged.
- Added `test_get_function_nonlocals_no_memory_leak` regression test that verifies objects are garbage collected after `RunnableLambda.deps` is accessed.

Issue: #30667

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>