### PR TITLE
fix(core): remove v__args sentinel from StructuredTool schema

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -366,8 +366,17 @@ def create_schema_from_function(
     )
     # Pydantic adds placeholder virtual fields we need to strip
     valid_properties = []
+    has_named_args_param = "args" in sig.parameters and sig.parameters[
+        "args"
+    ].kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
     for field in get_fields(inferred_model):
-        if not has_args and field == "args":
+        # Pydantic's ValidatedFunction injects a sentinel field named "args" (or
+        # "v__args" when the user function already has a parameter called
+        # "args") to validate unexpected positional arguments. These should not
+        # appear in tool schemas.
+        if field == "v__args":
+            continue
+        if not has_args and field == "args" and not has_named_args_param:
             continue
         if not has_kwargs and field == "kwargs":
             continue

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -522,6 +522,26 @@ def test_structured_tool_from_function_docstring_complex_args() -> None:
     assert structured_tool.description == textwrap.dedent(foo.__doc__).strip()
 
 
+def test_structured_tool_from_function_with_args_param() -> None:
+    """StructuredTool.from_function handles named 'args' parameter correctly."""
+
+    def run_command(working_dir: str, args: list[str], timeout: int = 60) -> str:
+        """Run a command."""
+        return working_dir
+
+    structured_tool = StructuredTool.from_function(run_command)
+    schema = _schema(structured_tool.args_schema)
+    props = schema["properties"]
+
+    assert set(props.keys()) == {"working_dir", "args", "timeout"}
+    assert "v__args" not in props
+    assert props["args"] == {
+        "title": "Args",
+        "type": "array",
+        "items": {"type": "string"},
+    }
+
+
 def test_structured_tool_lambda_multi_args_schema() -> None:
     """Test args schema inference when the tool argument is a lambda function."""
     tool = StructuredTool.from_function(


### PR DESCRIPTION
Fixes #35796

`StructuredTool.from_function` was including Pydantic’s internal `v__args` sentinel in the generated args schema when the wrapped function had a parameter named `args`, causing the real `args` parameter to be dropped and tool schemas to be invalid for some backends. This PR filters out the `v__args` sentinel while preserving a genuine `args` parameter and adds a regression test to cover this case.

**How did you verify your code works?**

- Created a virtual environment and installed `langchain-core` + test deps.
- Ran:

  ```bash
  source .venv/bin/activate
  pytest libs/core/tests/unit_tests/test_tools.py -k "structured_tool_from_function_with_args_param"