### PR TITLE
fix(core): restore original param name when function has arg named 'args'

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -364,8 +364,17 @@ def create_schema_from_function(
         parse_docstring=parse_docstring,
         error_on_invalid_docstring=error_on_invalid_docstring,
     )
-    # Pydantic adds placeholder virtual fields we need to strip
+    # Pydantic adds placeholder virtual fields we need to strip.
+    # When a function has a regular parameter named "args" (or "kwargs"),
+    # Pydantic's ValidatedFunction renames it to "v__args" ("v__kwargs")
+    # to avoid conflict with its own sentinel fields.  We detect this and
+    # map the mangled name back to the original so the JSON schema exposes
+    # the correct parameter name.
+    has_param_named_args = "args" in sig.parameters and not has_args
+    has_param_named_kwargs = "kwargs" in sig.parameters and not has_kwargs
+
     valid_properties = []
+    field_renames: dict[str, str] = {}
     for field in get_fields(inferred_model):
         if not has_args and field == "args":
             continue
@@ -375,8 +384,19 @@ def create_schema_from_function(
         if field == "v__duplicate_kwargs":  # Internal pydantic field
             continue
 
+        # Pydantic sentinel fields created by the v__* rename — skip them
+        if field == "v__args" and not has_param_named_args:
+            continue
+        if field == "v__kwargs" and not has_param_named_kwargs:
+            continue
+
         if field not in filter_args_:
             valid_properties.append(field)
+            # Restore original parameter names mangled by ValidatedFunction
+            if field == "v__args" and has_param_named_args:
+                field_renames[field] = "args"
+            elif field == "v__kwargs" and has_param_named_kwargs:
+                field_renames[field] = "kwargs"
 
     return _create_subset_model(
         model_name,
@@ -384,6 +404,7 @@ def create_schema_from_function(
         list(valid_properties),
         descriptions=arg_descriptions,
         fn_description=description,
+        field_renames=field_renames if field_renames else None,
     )
 
 

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -235,13 +235,16 @@ def _create_subset_model_v2(
     *,
     descriptions: dict | None = None,
     fn_description: str | None = None,
+    field_renames: dict[str, str] | None = None,
 ) -> type[BaseModel]:
     """Create a Pydantic model with a subset of the model fields."""
     descriptions_ = descriptions or {}
+    renames = field_renames or {}
     fields = {}
     for field_name in field_names:
         field = model.model_fields[field_name]
-        description = descriptions_.get(field_name, field.description)
+        output_name = renames.get(field_name, field_name)
+        description = descriptions_.get(output_name, field.description)
         field_kwargs: dict[str, Any] = {"description": description}
         if field.default_factory is not None:
             field_kwargs["default_factory"] = field.default_factory
@@ -250,7 +253,7 @@ def _create_subset_model_v2(
         field_info = FieldInfoV2(**field_kwargs)
         if field.metadata:
             field_info.metadata = field.metadata
-        fields[field_name] = (field.annotation, field_info)
+        fields[output_name] = (field.annotation, field_info)
 
     rtn = cast(
         "type[BaseModel]",
@@ -264,7 +267,7 @@ def _create_subset_model_v2(
     # and using the Annotated type with TypedDict.
     # Comment out the following line, to trigger the relevant test case.
     selected_annotations = [
-        (name, annotation)
+        (renames.get(name, name), annotation)
         for name, annotation in model.__annotations__.items()
         if name in field_names
     ]
@@ -285,6 +288,7 @@ def _create_subset_model(
     *,
     descriptions: dict | None = None,
     fn_description: str | None = None,
+    field_renames: dict[str, str] | None = None,
 ) -> type[BaseModel]:
     """Create subset model using the same pydantic version as the input model.
 
@@ -305,6 +309,7 @@ def _create_subset_model(
         field_names,
         descriptions=descriptions,
         fn_description=fn_description,
+        field_renames=field_renames,
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #35796

When `StructuredTool.from_function` wraps a function with a parameter named `args` (or `kwargs`), Pydantic's `ValidatedFunction` renames it to `v__args` (`v__kwargs`) to avoid clashing with its own sentinel fields. The resulting JSON schema exposes the mangled name instead of the original, which:

1. **Hides the real parameter** from LLMs — the model never learns the parameter exists
2. **Breaks Gemini API** — the spurious `v__args` field has `{type: array, items: {}}`, which Gemini rejects with `INVALID_ARGUMENT: missing field items`

## Root Cause

`create_schema_from_function` already strips Pydantic's sentinel `args`/`kwargs` fields when the function doesn't use `*args`/`**kwargs`. However, it didn't handle the reverse rename: when a regular parameter named `args` exists, Pydantic creates `v__args` — and that slipped through the filter.

## Fix

1. In `create_schema_from_function`: detect when the function has a regular parameter named `args` (or `kwargs`) and build a `field_renames` map (`v__args → args`)
2. In `_create_subset_model_v2`: apply the rename when constructing the output model, so the JSON schema uses the original parameter name

## Verification

```python
from langchain_core.tools import StructuredTool

def run_command(working_dir: str, args: list[str], timeout: int = 60) -> str:
    """Run a command."""
    ...

st = StructuredTool.from_function(run_command)
schema = st.args_schema.model_json_schema()
print(list(schema['properties'].keys()))
# Before: ['working_dir', 'timeout', 'v__args']  ← spurious
# After:  ['working_dir', 'timeout', 'args']      ← correct
```

All existing `test_tools.py` tests pass (31/31 sync tests — the 1 async failure is pre-existing, missing `pytest-asyncio` dep).