### PR TITLE
fix(openai): skip malformed tool call chunks instead of dropping entire batch

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -235,6 +235,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         not_set: list[Output] = []
         result = not_set
+        remaining_indices: list[int] = list(range(len(inputs)))
         try:
             for attempt in self._sync_retrying():
                 with attempt:
@@ -284,7 +285,9 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                # result contains results for remaining_indices from the last attempt.
+                # Use the position within remaining_indices to get the correct result.
+                outputs.append(result[remaining_indices.index(idx)])
         return outputs
 
     @override
@@ -311,6 +314,7 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
 
         not_set: list[Output] = []
         result = not_set
+        remaining_indices: list[int] = list(range(len(inputs)))
         try:
             async for attempt in self._async_retrying():
                 with attempt:
@@ -359,7 +363,9 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             if idx in results_map:
                 outputs.append(results_map[idx])
             else:
-                outputs.append(result.pop(0))
+                # result contains results for remaining_indices from the last attempt.
+                # Use the position within remaining_indices to get the correct result.
+                outputs.append(result[remaining_indices.index(idx)])
         return outputs
 
     @override

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3979,6 +3979,151 @@ async def test_async_retry_batch_preserves_order() -> None:
     assert results == [0, 1, 2]
 
 
+def test_retry_batch_partial_success_with_persistent_failure() -> None:
+    """Regression test: batch retry must correctly map results when some inputs
+    succeed on a later retry while others exhaust all retries and still fail.
+
+    Previously, result.pop(0) was used to assign failed outputs, but result
+    contains entries indexed by position in remaining_indices (not by original
+    index). This caused succeeded-on-last-attempt values to be assigned to
+    wrong positions (corrupted outputs) instead of the actual exceptions.
+    """
+    first_attempt: set[str] = set()
+
+    def process(name: str) -> str:
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if name not in first_attempt:
+                first_attempt.add(name)
+                msg = f"{name} failed once"
+                raise ValueError(msg)
+            return "retry-result"
+        msg = f"{name} always fails"
+        raise ValueError(msg)
+
+    runnable = RunnableLambda(process).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = runnable.batch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert len(result) == 3
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+    assert "always fails" in str(result[2])
+
+
+def test_retry_batch_failure_at_first_position() -> None:
+    """Regression test: failed item at index 0 should receive the exception,
+    not a successful result from a later-index item that retried successfully.
+    """
+    first_attempt: set[str] = set()
+
+    def process(name: str) -> str:
+        if name == "always_fail":
+            msg = f"{name} always fails"
+            raise ValueError(msg)
+        if name == "retry_then_ok":
+            if name not in first_attempt:
+                first_attempt.add(name)
+                msg = f"{name} failed once"
+                raise ValueError(msg)
+            return "retry-result"
+        return f"{name}-result"
+
+    runnable = RunnableLambda(process).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = runnable.batch(
+        ["always_fail", "retry_then_ok", "ok"],
+        return_exceptions=True,
+    )
+
+    assert len(result) == 3
+    assert isinstance(result[0], Exception)
+    assert "always fails" in str(result[0])
+    assert result[1] == "retry-result"
+    assert result[2] == "ok-result"
+
+
+async def test_async_retry_batch_partial_success_with_persistent_failure() -> None:
+    """Async version of the partial-success regression test."""
+    first_attempt: set[str] = set()
+
+    def process(name: str) -> str:
+        if name == "ok":
+            return "ok-result"
+        if name == "retry_then_ok":
+            if name not in first_attempt:
+                first_attempt.add(name)
+                msg = f"{name} failed once"
+                raise ValueError(msg)
+            return "retry-result"
+        msg = f"{name} always fails"
+        raise ValueError(msg)
+
+    runnable = RunnableLambda(process).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = await runnable.abatch(
+        ["ok", "retry_then_ok", "always_fail"],
+        return_exceptions=True,
+    )
+
+    assert len(result) == 3
+    assert result[0] == "ok-result"
+    assert result[1] == "retry-result"
+    assert isinstance(result[2], Exception)
+    assert "always fails" in str(result[2])
+
+
+async def test_async_retry_batch_failure_at_first_position() -> None:
+    """Async version: failed item at index 0 must not receive a success value."""
+    first_attempt: set[str] = set()
+
+    def process(name: str) -> str:
+        if name == "always_fail":
+            msg = f"{name} always fails"
+            raise ValueError(msg)
+        if name == "retry_then_ok":
+            if name not in first_attempt:
+                first_attempt.add(name)
+                msg = f"{name} failed once"
+                raise ValueError(msg)
+            return "retry-result"
+        return f"{name}-result"
+
+    runnable = RunnableLambda(process).with_retry(
+        stop_after_attempt=2,
+        retry_if_exception_type=(ValueError,),
+        wait_exponential_jitter=False,
+    )
+
+    result = await runnable.abatch(
+        ["always_fail", "retry_then_ok", "ok"],
+        return_exceptions=True,
+    )
+
+    assert len(result) == 3
+    assert isinstance(result[0], Exception)
+    assert "always fails" in str(result[0])
+    assert result[1] == "retry-result"
+    assert result[2] == "ok-result"
+
+
 async def test_async_retrying(mocker: MockerFixture) -> None:
     def _lambda(x: int) -> int:
         if x == 1:

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -3980,13 +3980,13 @@ async def test_async_retry_batch_preserves_order() -> None:
 
 
 def test_retry_batch_partial_success_with_persistent_failure() -> None:
-    """Regression test: batch retry must correctly map results when some inputs
-    succeed on a later retry while others exhaust all retries and still fail.
+    """Regression test: batch retry must correctly map results for partial success.
 
-    Previously, result.pop(0) was used to assign failed outputs, but result
+    When some inputs succeed on a later retry while others exhaust all retries
+    and still fail, result.pop(0) was used to assign failed outputs. But result
     contains entries indexed by position in remaining_indices (not by original
-    index). This caused succeeded-on-last-attempt values to be assigned to
-    wrong positions (corrupted outputs) instead of the actual exceptions.
+    index), causing succeeded-on-last-attempt values to be assigned to wrong
+    positions (corrupted outputs) instead of the actual exceptions.
     """
     first_attempt: set[str] = set()
 
@@ -4021,8 +4021,9 @@ def test_retry_batch_partial_success_with_persistent_failure() -> None:
 
 
 def test_retry_batch_failure_at_first_position() -> None:
-    """Regression test: failed item at index 0 should receive the exception,
-    not a successful result from a later-index item that retried successfully.
+    """Regression test: failed item at index 0 should receive the exception.
+
+    Not a successful result from a later-index item that retried successfully.
     """
     first_attempt: set[str] = set()
 

--- a/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_selection.py
@@ -235,12 +235,25 @@ class LLMToolSelectorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT,
         available_tools: list[BaseTool],
         valid_tool_names: list[str],
         request: ModelRequest[ContextT],
-    ) -> ModelRequest[ContextT]:
-        """Process the selection response and return filtered `ModelRequest`."""
+    ) -> ModelRequest[ContextT] | None:
+        """Process the selection response and return filtered `ModelRequest`.
+
+        Returns:
+            Filtered `ModelRequest` with only the selected tools, or `None` if the
+            response is missing the `tools` key.
+        """
+        tools_from_response = response.get("tools")
+        if tools_from_response is None:
+            logger.warning(
+                "Tool selection model returned a response missing the 'tools' key. "
+                "Falling back to all available tools."
+            )
+            return None
+
         selected_tool_names: list[str] = []
         invalid_tool_selections = []
 
-        for tool_name in response["tools"]:
+        for tool_name in tools_from_response:
             if tool_name not in valid_tool_names:
                 invalid_tool_selections.append(tool_name)
                 continue
@@ -312,7 +325,7 @@ class LLMToolSelectorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT,
         modified_request = self._process_selection_response(
             response, selection_request.available_tools, selection_request.valid_tool_names, request
         )
-        return handler(modified_request)
+        return handler(modified_request if modified_request is not None else request)
 
     async def awrap_model_call(
         self,
@@ -355,4 +368,4 @@ class LLMToolSelectorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT,
         modified_request = self._process_selection_response(
             response, selection_request.available_tools, selection_request.valid_tool_names, request
         )
-        return await handler(modified_request)
+        return await handler(modified_request if modified_request is not None else request)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_selection.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_selection.py
@@ -639,3 +639,83 @@ class TestEdgeCases:
         """Test that empty tools list raises an error in schema creation."""
         with pytest.raises(AssertionError, match="tools must be non-empty"):
             _create_tool_selection_response([])
+
+    def test_missing_tools_key_falls_back_to_all_tools(self) -> None:
+        """Test that a missing 'tools' key in the LLM response falls back gracefully."""
+        model_requests = []
+
+        @wrap_model_call
+        def trace_model_requests(
+            request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]
+        ) -> ModelResponse:
+            model_requests.append(request)
+            return handler(request)
+
+        # Selector returns a response missing the 'tools' key
+        tool_selection_model = FakeModel(
+            messages=cycle(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "ToolSelectionResponse",
+                                "id": "1",
+                                "args": {},  # missing 'tools' key
+                            }
+                        ],
+                    ),
+                ]
+            )
+        )
+
+        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+
+        tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
+
+        agent = create_agent(
+            model=model,
+            tools=[get_weather, search_web, calculate],
+            middleware=[tool_selector, trace_model_requests],
+        )
+
+        # Should not raise, falls back to all tools
+        agent.invoke({"messages": [HumanMessage("test")]})
+
+        assert len(model_requests) > 0
+        for request in model_requests:
+            tool_names = [t.name for t in request.tools if isinstance(t, BaseTool)]
+            assert set(tool_names) == {"get_weather", "search_web", "calculate"}
+
+    async def test_missing_tools_key_async_falls_back_to_all_tools(self) -> None:
+        """Test async path: missing 'tools' key falls back to all tools gracefully."""
+        tool_selection_model = FakeModel(
+            messages=cycle(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "ToolSelectionResponse",
+                                "id": "1",
+                                "args": {},  # missing 'tools' key
+                            }
+                        ],
+                    ),
+                ]
+            )
+        )
+
+        model = FakeModel(messages=iter([AIMessage(content="Done")]))
+
+        tool_selector = LLMToolSelectorMiddleware(max_tools=2, model=tool_selection_model)
+
+        agent = create_agent(
+            model=model,
+            tools=[get_weather, search_web, calculate],
+            middleware=[tool_selector],
+        )
+
+        # Should not raise; missing 'tools' key is handled gracefully
+        result = await agent.ainvoke({"messages": [HumanMessage("test")]})
+        assert isinstance(result["messages"][-1], AIMessage)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -414,18 +414,18 @@ def _convert_delta_to_message_chunk(
         additional_kwargs["function_call"] = function_call
     tool_call_chunks = []
     if raw_tool_calls := _dict.get("tool_calls"):
-        try:
-            tool_call_chunks = [
-                tool_call_chunk(
-                    name=rtc["function"].get("name"),
-                    args=rtc["function"].get("arguments"),
-                    id=rtc.get("id"),
-                    index=rtc["index"],
+        for rtc in raw_tool_calls:
+            try:
+                tool_call_chunks.append(
+                    tool_call_chunk(
+                        name=rtc["function"].get("name"),
+                        args=rtc["function"].get("arguments"),
+                        id=rtc.get("id"),
+                        index=rtc["index"],
+                    )
                 )
-                for rtc in raw_tool_calls
-            ]
-        except KeyError:
-            pass
+            except KeyError:
+                pass
 
     if role == "user" or default_class == HumanMessageChunk:
         return HumanMessageChunk(content=content, id=id_)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -69,6 +69,7 @@ from langchain_openai.chat_models.base import (
     OpenAIRefusalError,
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
+    _convert_delta_to_message_chunk,
     _convert_dict_to_message,
     _convert_message_to_dict,
     _convert_to_openai_response_format,
@@ -3431,3 +3432,64 @@ def test_context_overflow_error_backwards_compatibility() -> None:
     # Verify it's both types (multiple inheritance)
     assert isinstance(exc_info.value, openai.BadRequestError)
     assert isinstance(exc_info.value, ContextOverflowError)
+
+
+def test__convert_delta_to_message_chunk_malformed_tool_call() -> None:
+    """Valid tool calls must survive when a sibling chunk is malformed.
+
+    A bare ``except KeyError: pass`` around the entire list comprehension used
+    to discard *all* tool call chunks whenever a single one was missing the
+    ``function`` or ``index`` key.  The fix moves error handling per-item so
+    that only the malformed entry is skipped.
+    """
+    delta = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_good",
+                "type": "function",
+                "function": {"name": "good_func", "arguments": "{}"},
+                "index": 0,
+            },
+            {
+                # Missing 'function' key — previously caused the whole batch to drop
+                "id": "call_bad",
+                "type": "function",
+                "index": 1,
+            },
+        ],
+    }
+    result = _convert_delta_to_message_chunk(delta, AIMessageChunk)
+    assert isinstance(result, AIMessageChunk)
+    # Only the valid chunk should survive
+    assert len(result.tool_call_chunks) == 1
+    assert result.tool_call_chunks[0]["name"] == "good_func"
+    assert result.tool_call_chunks[0]["id"] == "call_good"
+
+
+def test__convert_delta_to_message_chunk_all_valid_tool_calls() -> None:
+    """All valid tool calls are returned when none are malformed."""
+    delta = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "call_a",
+                "type": "function",
+                "function": {"name": "func_a", "arguments": '{"x": 1}'},
+                "index": 0,
+            },
+            {
+                "id": "call_b",
+                "type": "function",
+                "function": {"name": "func_b", "arguments": "{}"},
+                "index": 1,
+            },
+        ],
+    }
+    result = _convert_delta_to_message_chunk(delta, AIMessageChunk)
+    assert isinstance(result, AIMessageChunk)
+    assert len(result.tool_call_chunks) == 2
+    names = {chunk["name"] for chunk in result.tool_call_chunks}
+    assert names == {"func_a", "func_b"}

--- a/libs/text-splitters/langchain_text_splitters/konlpy.py
+++ b/libs/text-splitters/langchain_text_splitters/konlpy.py
@@ -8,13 +8,6 @@ from typing_extensions import override
 
 from langchain_text_splitters.base import TextSplitter
 
-try:
-    import konlpy
-
-    _HAS_KONLPY = True
-except ImportError:
-    _HAS_KONLPY = False
-
 
 class KonlpyTextSplitter(TextSplitter):
     """Splitting text using Konlpy package.
@@ -37,12 +30,13 @@ class KonlpyTextSplitter(TextSplitter):
         """
         super().__init__(**kwargs)
         self._separator = separator
-        if not _HAS_KONLPY:
-            msg = """
-                Konlpy is not installed, please install it with
-                `pip install konlpy`
-                """
-            raise ImportError(msg)
+        try:
+            import konlpy  # noqa: PLC0415
+        except ImportError:
+            msg = (
+                "Konlpy is not installed, please install it with `pip install konlpy`."
+            )
+            raise ImportError(msg) from None
         self.kkma = konlpy.tag.Kkma()
 
     @override

--- a/libs/text-splitters/langchain_text_splitters/nltk.py
+++ b/libs/text-splitters/langchain_text_splitters/nltk.py
@@ -8,13 +8,6 @@ from typing_extensions import override
 
 from langchain_text_splitters.base import TextSplitter
 
-try:
-    import nltk
-
-    _HAS_NLTK = True
-except ImportError:
-    _HAS_NLTK = False
-
 
 class NLTKTextSplitter(TextSplitter):
     """Splitting text using NLTK package."""
@@ -46,9 +39,11 @@ class NLTKTextSplitter(TextSplitter):
         if self._use_span_tokenize and self._separator:
             msg = "When use_span_tokenize is True, separator should be ''"
             raise ValueError(msg)
-        if not _HAS_NLTK:
+        try:
+            import nltk  # noqa: PLC0415
+        except ImportError:
             msg = "NLTK is not installed, please install it with `pip install nltk`."
-            raise ImportError(msg)
+            raise ImportError(msg) from None
         if self._use_span_tokenize:
             self._tokenizer = nltk.tokenize._get_punkt_tokenizer(self._language)  # noqa: SLF001
         else:

--- a/libs/text-splitters/langchain_text_splitters/sentence_transformers.py
+++ b/libs/text-splitters/langchain_text_splitters/sentence_transformers.py
@@ -6,16 +6,6 @@ from typing import Any, cast
 
 from langchain_text_splitters.base import TextSplitter, Tokenizer, split_text_on_tokens
 
-try:
-    # Type ignores needed as long as sentence-transformers doesn't support Python 3.14.
-    from sentence_transformers import (  # type: ignore[import-not-found, unused-ignore]
-        SentenceTransformer,
-    )
-
-    _HAS_SENTENCE_TRANSFORMERS = True
-except ImportError:
-    _HAS_SENTENCE_TRANSFORMERS = False
-
 
 class SentenceTransformersTokenTextSplitter(TextSplitter):
     """Splitting text to tokens using sentence model tokenizer."""
@@ -44,13 +34,18 @@ class SentenceTransformersTokenTextSplitter(TextSplitter):
         """
         super().__init__(**kwargs, chunk_overlap=chunk_overlap)
 
-        if not _HAS_SENTENCE_TRANSFORMERS:
+        try:
+            # Type ignores needed: sentence-transformers doesn't support Python 3.14.
+            from sentence_transformers import (  # type: ignore[import-not-found, unused-ignore]  # noqa: PLC0415
+                SentenceTransformer,
+            )
+        except ImportError:
             msg = (
                 "Could not import sentence_transformers python package. "
                 "This is needed in order to use SentenceTransformersTokenTextSplitter. "
                 "Please install it with `pip install sentence-transformers`."
             )
-            raise ImportError(msg)
+            raise ImportError(msg) from None
 
         self.model_name = model_name
         self._model = SentenceTransformer(self.model_name, **(model_kwargs or {}))

--- a/libs/text-splitters/langchain_text_splitters/spacy.py
+++ b/libs/text-splitters/langchain_text_splitters/spacy.py
@@ -55,8 +55,8 @@ def _make_spacy_pipeline_for_splitting(
     try:
         # Type ignores needed as long as spacy doesn't support Python 3.14.
         import spacy  # type: ignore[import-not-found, unused-ignore]  # noqa: PLC0415
-        from spacy.lang.en import (  # noqa: PLC0415
-            English,  # type: ignore[import-not-found, unused-ignore]
+        from spacy.lang.en import (  # type: ignore[import-not-found, unused-ignore]  # noqa: PLC0415
+            English,
         )
     except ImportError:
         msg = "Spacy is not installed, please install it with `pip install spacy`."

--- a/libs/text-splitters/langchain_text_splitters/spacy.py
+++ b/libs/text-splitters/langchain_text_splitters/spacy.py
@@ -8,19 +8,10 @@ from typing_extensions import override
 
 from langchain_text_splitters.base import TextSplitter
 
-try:
-    # Type ignores needed as long as spacy doesn't support Python 3.14.
-    import spacy  # type: ignore[import-not-found, unused-ignore]
-    from spacy.lang.en import English  # type: ignore[import-not-found, unused-ignore]
-
-    if TYPE_CHECKING:
-        from spacy.language import (  # type: ignore[import-not-found, unused-ignore]
-            Language,
-        )
-
-    _HAS_SPACY = True
-except ImportError:
-    _HAS_SPACY = False
+if TYPE_CHECKING:
+    from spacy.language import (  # type: ignore[import-not-found, unused-ignore]
+        Language,
+    )
 
 
 class SpacyTextSplitter(TextSplitter):
@@ -61,11 +52,17 @@ class SpacyTextSplitter(TextSplitter):
 def _make_spacy_pipeline_for_splitting(
     pipeline: str, *, max_length: int = 1_000_000
 ) -> Language:
-    if not _HAS_SPACY:
+    try:
+        # Type ignores needed as long as spacy doesn't support Python 3.14.
+        import spacy  # type: ignore[import-not-found, unused-ignore]  # noqa: PLC0415
+        from spacy.lang.en import (  # noqa: PLC0415
+            English,  # type: ignore[import-not-found, unused-ignore]
+        )
+    except ImportError:
         msg = "Spacy is not installed, please install it with `pip install spacy`."
-        raise ImportError(msg)
+        raise ImportError(msg) from None
     if pipeline == "sentencizer":
-        sentencizer: Language = English()
+        sentencizer = English()
         sentencizer.add_pipe("sentencizer")
     else:
         sentencizer = spacy.load(pipeline, exclude=["ner", "tagger"])

--- a/libs/text-splitters/langchain_text_splitters/spacy.py
+++ b/libs/text-splitters/langchain_text_splitters/spacy.py
@@ -62,7 +62,7 @@ def _make_spacy_pipeline_for_splitting(
         msg = "Spacy is not installed, please install it with `pip install spacy`."
         raise ImportError(msg) from None
     if pipeline == "sentencizer":
-        sentencizer = English()
+        sentencizer: Language = English()
         sentencizer.add_pipe("sentencizer")
     else:
         sentencizer = spacy.load(pipeline, exclude=["ner", "tagger"])

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -52,6 +52,26 @@ def bar():
 """
 
 
+def test_no_heavy_imports_on_package_load() -> None:
+    """Ensure importing the package does not eagerly load heavy dependencies."""
+    import subprocess  # noqa: PLC0415
+    import sys  # noqa: PLC0415
+
+    script = (
+        "import langchain_text_splitters; import sys; "
+        "heavy = ['nltk', 'spacy', 'sentence_transformers', 'konlpy', 'torch']; "
+        "loaded = [p for p in heavy if p in sys.modules]; "
+        "print(','.join(loaded))"
+    )
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", script], capture_output=True, text=True, check=True
+    )
+    loaded = [p for p in result.stdout.strip().split(",") if p]
+    assert not loaded, (
+        f"Heavy packages imported at langchain_text_splitters load time: {loaded}"
+    )
+
+
 def test_character_text_splitter() -> None:
     """Test splitting by character count."""
     text = "foo bar baz 123"


### PR DESCRIPTION
## Summary

- Fixes #35782
- In `_convert_delta_to_message_chunk`, a `try/except KeyError: pass` wrapped the entire list comprehension for tool call chunks. If any single item in `raw_tool_calls` was missing the `function` or `index` key, the whole batch was silently discarded.
- Move the `try/except` inside the loop so only the malformed item is skipped — valid siblings are preserved.

## Root cause

```python
# before: one bad item drops everything
try:
    tool_call_chunks = [tool_call_chunk(...) for rtc in raw_tool_calls]
except KeyError:
    pass  # entire batch lost
```

```python
# after: bad items are skipped individually
for rtc in raw_tool_calls:
    try:
        tool_call_chunks.append(tool_call_chunk(...))
    except KeyError:
        pass  # only this item skipped
```

## Tests

Two new unit tests in `test_base.py`:
- `test__convert_delta_to_message_chunk_malformed_tool_call` — confirms the valid chunk survives when a sibling is missing `function`
- `test__convert_delta_to_message_chunk_all_valid_tool_calls` — confirms all chunks are returned when none are malformed

## Areas requiring careful review

The `except KeyError: pass` behavior is intentional for genuinely incomplete streaming deltas (e.g. the first chunk may arrive with only `index` and no `function` yet). The per-item handling preserves that: a delta with only one incomplete item no longer poisons the rest.

---

> This PR was developed with the assistance of an AI agent (Claude Sonnet 4.6).