### PR TITLE
fix: handle 'args' parameter name conflict in StructuredTool schema generation

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -334,6 +334,12 @@ def create_schema_from_function(
 
     has_args = False
     has_kwargs = False
+    has_param_named_args = "args" in sig.parameters and sig.parameters["args"].kind not in (
+        inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD
+    )
+    has_param_named_kwargs = "kwargs" in sig.parameters and sig.parameters["kwargs"].kind not in (
+        inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD
+    )
 
     for param in sig.parameters.values():
         if param.kind == param.VAR_POSITIONAL:
@@ -367,12 +373,18 @@ def create_schema_from_function(
     # Pydantic adds placeholder virtual fields we need to strip
     valid_properties = []
     for field in get_fields(inferred_model):
-        if not has_args and field == "args":
+        if not has_args and field == "args" and not has_param_named_args:
             continue
-        if not has_kwargs and field == "kwargs":
+        if not has_kwargs and field == "kwargs" and not has_param_named_kwargs:
             continue
 
         if field == "v__duplicate_kwargs":  # Internal pydantic field
+            continue
+
+        # When a function has a parameter named 'args' or 'kwargs', Pydantic's
+        # ValidatedFunction renames its internal sentinel to 'v__args' or
+        # 'v__kwargs'. These are not real parameters and must be filtered out.
+        if field in ("v__args", "v__kwargs"):
             continue
 
         if field not in filter_args_:


### PR DESCRIPTION
## Summary

- Fixes `StructuredTool.from_function` injecting a spurious `v__args` field and dropping the legitimate `args` parameter when a function parameter is literally named `args`
- Adds filtering for Pydantic's internal `v__args`/`v__kwargs` sentinel fields that leak into the schema when parameter names conflict with Pydantic internals
- Preserves backward compatibility: functions with `*args`/`**kwargs` (VAR_POSITIONAL/VAR_KEYWORD) continue to work as before

## Root cause

In `create_schema_from_function`, the check `not has_args and field == "args"` filters out **any** field named `args` when the function has no `*args`. But when a function has a regular parameter named `args` (e.g., `def run_command(args: list[str])`), Pydantic's `ValidatedFunction` keeps it as `args` in the model while renaming its own internal sentinel to `v__args`. The old code:
1. Incorrectly filtered out the legitimate `args` field
2. Let the spurious `v__args` sentinel pass through into the schema

## Fix

1. Before filtering `args`/`kwargs` fields, check whether the function actually has a regular parameter with that name
2. Always filter out `v__args` and `v__kwargs` (Pydantic's renamed internal sentinels)

## Test plan

- [ ] Verify `StructuredTool.from_function` with a function having `args: list[str]` produces schema with `args` and without `v__args`
- [ ] Verify functions with `*args` (VAR_POSITIONAL) still work correctly
- [ ] Verify functions without any `args` parameter still work correctly
- [ ] Verify same behavior for `kwargs` parameter name

Fixes #35796

🤖 Generated with [Claude Code](https://claude.com/claude-code)