### PR TITLE
fix: include event loop ID in httpx AsyncClient cache key

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
@@ -77,7 +77,7 @@ def _cached_sync_httpx_client(
 
 @lru_cache
 def _cached_async_httpx_client(
-    base_url: str | None, timeout: Any
+    base_url: str | None, timeout: Any, _event_loop_id: int = 0
 ) -> _AsyncHttpxClientWrapper:
     return _build_async_httpx_client(base_url, timeout)
 
@@ -109,7 +109,8 @@ def _get_default_async_httpx_client(
     except TypeError:
         return _build_async_httpx_client(base_url, timeout)
     else:
-        return _cached_async_httpx_client(base_url, timeout)
+        loop_id = id(asyncio.get_event_loop())
+        return _cached_async_httpx_client(base_url, timeout, _event_loop_id=loop_id)
 
 
 def _resolve_sync_and_async_api_keys(


### PR DESCRIPTION
## Summary

- Fixes #35783: `@lru_cache` on `_cached_async_httpx_client` caches by `(base_url, timeout)`, but an `httpx.AsyncClient` is bound to the event loop on which it was created. When multiple threads each call `asyncio.run()` (which creates a fresh event loop), the stale cached client is reused on a different loop, causing `RuntimeError` / connection errors deep in httpcore/anyio.
- Adds `id(asyncio.get_event_loop())` as an additional cache key so each event loop gets its own `AsyncClient` instance, while still sharing within the same loop.

## Changes

**`libs/partners/openai/langchain_openai/chat_models/_client_utils.py`**

1. `_cached_async_httpx_client`: added `_event_loop_id: int = 0` parameter (used only as a cache-key discriminator).
2. `_get_default_async_httpx_client`: passes `id(asyncio.get_event_loop())` as the `_event_loop_id` kwarg when calling the cached function.

The sync client is unaffected since `httpx.Client` does not have event-loop affinity.

## Test plan

- [ ] Run the reproduction script from #35783 (multi-threaded `asyncio.run()` calls) and verify no cross-event-loop errors
- [ ] Verify single-threaded async usage still benefits from client caching (same loop = same client)
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)