### PR TITLE
fix: handle invalid_tool_calls in create_agent routing

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import itertools
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -23,6 +23,7 @@ from langgraph.constants import END, START
 from langgraph.graph.state import StateGraph
 from langgraph.prebuilt.tool_node import ToolCallWithContext, ToolNode
 from langgraph.types import Command, Send
+from langsmith import traceable
 from typing_extensions import NotRequired, Required, TypedDict
 
 from langchain.agents.middleware.types import (
@@ -36,6 +37,7 @@ from langchain.agents.middleware.types import (
     OmitFromSchema,
     ResponseT,
     StateT_co,
+    ToolCallRequest,
     _InputAgentState,
     _OutputAgentState,
 )
@@ -79,7 +81,7 @@ if TYPE_CHECKING:
     from langgraph.store.base import BaseStore
     from langgraph.types import Checkpointer
 
-    from langchain.agents.middleware.types import ToolCallRequest, ToolCallWrapper
+    from langchain.agents.middleware.types import ToolCallWrapper
 
     _ModelCallHandler = Callable[
         [ModelRequest[ContextT], Callable[[ModelRequest[ContextT]], ModelResponse]],
@@ -129,6 +131,19 @@ Option 2: Handle dynamic tools in middleware (for tools created at runtime)
                 return handler(request.override(tool=my_dynamic_tool))
             return handler(request)
 """.strip()
+
+
+def _scrub_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
+    """Remove ``runtime`` and ``handler`` from trace inputs before sending to LangSmith."""
+    filtered = inputs.copy()
+    filtered.pop("handler", None)
+    req = filtered.get("request")
+    if isinstance(req, (ModelRequest, ToolCallRequest)):
+        filtered["request"] = {
+            f.name: getattr(req, f.name) for f in fields(req) if f.name != "runtime"
+        }
+    return filtered
+
 
 FALLBACK_MODELS_WITH_STRUCTURED_OUTPUT = [
     # if model profile data are not available, these models are assumed to support
@@ -862,7 +877,12 @@ def create_agent(
     # Chain all wrap_tool_call handlers into a single composed handler
     wrap_tool_call_wrapper = None
     if middleware_w_wrap_tool_call:
-        wrappers = [m.wrap_tool_call for m in middleware_w_wrap_tool_call]
+        wrappers = [
+            traceable(name=f"{m.name}.wrap_tool_call", process_inputs=_scrub_inputs)(
+                m.wrap_tool_call
+            )
+            for m in middleware_w_wrap_tool_call
+        ]
         wrap_tool_call_wrapper = _chain_tool_call_wrappers(wrappers)
 
     # Collect middleware with awrap_tool_call or wrap_tool_call hooks
@@ -878,7 +898,12 @@ def create_agent(
     # Chain all awrap_tool_call handlers into a single composed async handler
     awrap_tool_call_wrapper = None
     if middleware_w_awrap_tool_call:
-        async_wrappers = [m.awrap_tool_call for m in middleware_w_awrap_tool_call]
+        async_wrappers = [
+            traceable(name=f"{m.name}.awrap_tool_call", process_inputs=_scrub_inputs)(
+                m.awrap_tool_call
+            )
+            for m in middleware_w_awrap_tool_call
+        ]
         awrap_tool_call_wrapper = _chain_async_tool_call_wrappers(async_wrappers)
 
     # Setup tools
@@ -961,13 +986,23 @@ def create_agent(
     # Compose wrap_model_call handlers into a single middleware stack (sync)
     wrap_model_call_handler = None
     if middleware_w_wrap_model_call:
-        sync_handlers = [m.wrap_model_call for m in middleware_w_wrap_model_call]
+        sync_handlers = [
+            traceable(name=f"{m.name}.wrap_model_call", process_inputs=_scrub_inputs)(
+                m.wrap_model_call
+            )
+            for m in middleware_w_wrap_model_call
+        ]
         wrap_model_call_handler = _chain_model_call_handlers(sync_handlers)
 
     # Compose awrap_model_call handlers into a single middleware stack (async)
     awrap_model_call_handler = None
     if middleware_w_awrap_model_call:
-        async_handlers = [m.awrap_model_call for m in middleware_w_awrap_model_call]
+        async_handlers = [
+            traceable(name=f"{m.name}.awrap_model_call", process_inputs=_scrub_inputs)(
+                m.awrap_model_call
+            )
+            for m in middleware_w_awrap_model_call
+        ]
         awrap_model_call_handler = _chain_async_model_call_handlers(async_handlers)
 
     state_schemas: set[type] = {m.state_schema for m in middleware}
@@ -1670,9 +1705,35 @@ def _make_model_to_tools_edge(
 
         tool_message_ids = [m.tool_call_id for m in tool_messages]
 
-        # 3. If the model hasn't called any tools, exit the loop
-        # this is the classic exit condition for an agent loop
+        # 3. If the model hasn't called any tools, check for invalid_tool_calls
+        # before exiting. If there are invalid_tool_calls, convert them to error
+        # ToolMessages so the LLM can see the parsing errors and retry.
         if len(last_ai_message.tool_calls) == 0:
+            invalid_tool_calls = getattr(
+                last_ai_message, "invalid_tool_calls", None
+            )
+            if invalid_tool_calls:
+                error_messages = []
+                for invalid_call in invalid_tool_calls:
+                    tool_call_id = invalid_call.get("id", "")
+                    error_msg = invalid_call.get(
+                        "error", "Unknown tool call parsing error"
+                    )
+                    error_messages.append(
+                        ToolMessage(
+                            content=(
+                                f"Error: Failed to parse tool call arguments. "
+                                f"{error_msg}. Please try again with valid JSON "
+                                f"arguments."
+                            ),
+                            tool_call_id=tool_call_id,
+                            status="error",
+                        )
+                    )
+                # Append error messages to state so the LLM sees them
+                # on the next iteration and can retry
+                state["messages"].extend(error_messages)
+                return model_destination
             return end_destination
 
         pending_tool_calls = [

--- a/libs/langchain_v1/tests/unit_tests/agents/test_invalid_tool_calls.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_invalid_tool_calls.py
@@ -1,0 +1,114 @@
+"""Tests for invalid_tool_calls handling in agent routing."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+
+from langchain.agents.factory import _make_model_to_tools_edge
+
+
+class TestInvalidToolCallsRouting:
+    """Test that _make_model_to_tools_edge handles invalid_tool_calls correctly."""
+
+    def _make_edge(self):
+        return _make_model_to_tools_edge(
+            model_destination="model",
+            structured_output_tools={},
+            end_destination="__end__",
+        )
+
+    def test_exits_when_no_tool_calls_and_no_invalid_tool_calls(self):
+        """Agent should exit when there are no tool_calls and no invalid_tool_calls."""
+        edge = self._make_edge()
+        state = {
+            "messages": [
+                AIMessage(content="Hello!", tool_calls=[], invalid_tool_calls=[]),
+            ]
+        }
+        result = edge(state)
+        assert result == "__end__"
+
+    def test_routes_to_model_when_invalid_tool_calls_present(self):
+        """Agent should route back to model when invalid_tool_calls are present."""
+        edge = self._make_edge()
+        state = {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[],
+                    invalid_tool_calls=[
+                        {
+                            "id": "call-123",
+                            "name": "write_file",
+                            "args": '{"file_path": "test.txt", "content": "Hello"]',
+                            "error": "Expecting ',' delimiter",
+                        }
+                    ],
+                ),
+            ]
+        }
+        result = edge(state)
+        # Should route to model, not exit
+        assert result == "model"
+
+    def test_creates_error_tool_messages_for_invalid_tool_calls(self):
+        """Error ToolMessages should be appended to state for each invalid_tool_call."""
+        edge = self._make_edge()
+        state = {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[],
+                    invalid_tool_calls=[
+                        {
+                            "id": "call-123",
+                            "name": "write_file",
+                            "args": '{"bad json"]',
+                            "error": "Expecting ',' delimiter",
+                        },
+                        {
+                            "id": "call-456",
+                            "name": "read_file",
+                            "args": '{"also bad"}',
+                            "error": "Extra data",
+                        },
+                    ],
+                ),
+            ]
+        }
+        result = edge(state)
+        assert result == "model"
+
+        # Should have appended 2 error ToolMessages
+        tool_messages = [m for m in state["messages"] if isinstance(m, ToolMessage)]
+        assert len(tool_messages) == 2
+        assert tool_messages[0].tool_call_id == "call-123"
+        assert tool_messages[1].tool_call_id == "call-456"
+        assert tool_messages[0].status == "error"
+        assert tool_messages[1].status == "error"
+        assert "Expecting ',' delimiter" in tool_messages[0].content
+        assert "Extra data" in tool_messages[1].content
+
+    def test_normal_tool_calls_still_work(self):
+        """Normal tool_calls should still be routed to tools via Send."""
+        edge = self._make_edge()
+        state = {
+            "messages": [
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "id": "call-789",
+                            "name": "write_file",
+                            "args": {"file_path": "test.txt", "content": "Hello"},
+                        }
+                    ],
+                    invalid_tool_calls=[],
+                ),
+            ]
+        }
+        result = edge(state)
+        # Should return Send objects for pending tool calls
+        assert isinstance(result, list)
+        assert len(result) == 1


### PR DESCRIPTION
## Summary

- Fixes `_make_model_to_tools_edge` in `factory.py` to check for `invalid_tool_calls` when `tool_calls` is empty, instead of silently exiting the agent loop
- When `invalid_tool_calls` are present, converts them to error `ToolMessage` objects and routes back to the model so the LLM can see the parsing errors and retry
- Adds unit tests for the new routing behavior

## Problem

When an LLM returns malformed JSON in tool call arguments (e.g., nested quotes, escape sequences in code), the response contains `invalid_tool_calls` with an empty `tool_calls` list. The routing logic in `_make_model_to_tools_edge` only checks `len(last_ai_message.tool_calls) == 0` and exits the loop, causing the agent to silently fail with no recovery mechanism.

This was previously handled by `AgentExecutor` via `handle_parsing_errors=True`, but was not ported to the new `create_agent` architecture.

## Fix

In `_make_model_to_tools_edge` (line ~1710), when `tool_calls` is empty:
1. Check if `invalid_tool_calls` exists on the `AIMessage`
2. If so, create error `ToolMessage` objects for each invalid call (with `status="error"`)
3. Append them to `state["messages"]` so the LLM sees the errors
4. Route to `model_destination` instead of `end_destination` to allow retry

## Test plan

- [ ] `test_exits_when_no_tool_calls_and_no_invalid_tool_calls` - verifies normal exit behavior unchanged
- [ ] `test_routes_to_model_when_invalid_tool_calls_present` - verifies routing to model on invalid calls
- [ ] `test_creates_error_tool_messages_for_invalid_tool_calls` - verifies error ToolMessages created
- [ ] `test_normal_tool_calls_still_work` - verifies normal tool call routing unaffected

Fixes #33504

🤖 Generated with [Claude Code](https://claude.com/claude-code)