### PR TITLE
fix: handle invalid_tool_calls in agent routing to enable LLM retry

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1091,6 +1091,20 @@ def create_agent(
                         ],
                     }
 
+        # Handle invalid tool calls by converting them to error ToolMessages
+        # so the LLM can see the parsing errors and retry
+        invalid_tool_calls = getattr(output, "invalid_tool_calls", None)
+        if invalid_tool_calls:
+            error_messages = [
+                ToolMessage(
+                    content=f"Error: Failed to parse tool call arguments. {inv.get('error', 'Unknown parsing error')}. Please try again with valid JSON arguments.",
+                    tool_call_id=inv.get("id", ""),
+                    status="error",
+                )
+                for inv in invalid_tool_calls
+            ]
+            return {"messages": [output, *error_messages]}
+
         return {"messages": [output]}
 
     def _get_bound_model(
@@ -1670,9 +1684,14 @@ def _make_model_to_tools_edge(
 
         tool_message_ids = [m.tool_call_id for m in tool_messages]
 
-        # 3. If the model hasn't called any tools, exit the loop
-        # this is the classic exit condition for an agent loop
+        # 3. If the model hasn't called any tools, check for invalid_tool_calls
+        # before exiting. If invalid_tool_calls exist, error ToolMessages have
+        # already been added to state by _handle_model_output, so we route
+        # back to the model for retry.
         if len(last_ai_message.tool_calls) == 0:
+            invalid_tool_calls = getattr(last_ai_message, "invalid_tool_calls", None)
+            if invalid_tool_calls:
+                return model_destination
             return end_destination
 
         pending_tool_calls = [

--- a/libs/langchain_v1/tests/unit_tests/agents/test_invalid_tool_calls.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_invalid_tool_calls.py
@@ -1,0 +1,84 @@
+"""Unit tests for invalid_tool_calls handling in create_agent.
+
+These tests verify that when an LLM returns invalid_tool_calls (e.g., from
+JSON parsing errors), the agent correctly converts them to error ToolMessages
+and routes back to the model for retry instead of silently exiting.
+
+Fixes issue #33504.
+"""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from langchain.agents.factory import (
+    _fetch_last_ai_and_tool_messages,
+    _make_model_to_tools_edge,
+)
+
+
+def test_routing_with_invalid_tool_calls_routes_to_model() -> None:
+    """When tool_calls is empty but invalid_tool_calls exists, route to model."""
+    model_to_tools = _make_model_to_tools_edge(
+        model_destination="model",
+        structured_output_tools={},
+        end_destination="__end__",
+    )
+
+    ai_msg = AIMessage(
+        content="",
+        tool_calls=[],
+        invalid_tool_calls=[
+            {
+                "id": "call-123",
+                "name": "write_file",
+                "args": '{"file_path": "test.txt", "content": "Hello"]',
+                "error": "Expecting ',' delimiter",
+                "type": "invalid_tool_call",
+            }
+        ],
+    )
+    error_tool_msg = ToolMessage(
+        content="Error: Failed to parse tool call arguments.",
+        tool_call_id="call-123",
+        status="error",
+    )
+    state = {"messages": [HumanMessage(content="test"), ai_msg, error_tool_msg]}
+
+    result = model_to_tools(state)
+    assert result == "model", (
+        "Expected routing to model for retry when invalid_tool_calls exist, "
+        f"but got {result!r}"
+    )
+
+
+def test_routing_without_invalid_tool_calls_exits() -> None:
+    """When tool_calls is empty and no invalid_tool_calls, route to end."""
+    model_to_tools = _make_model_to_tools_edge(
+        model_destination="model",
+        structured_output_tools={},
+        end_destination="__end__",
+    )
+
+    ai_msg = AIMessage(content="Done!", tool_calls=[])
+    state = {"messages": [HumanMessage(content="test"), ai_msg]}
+
+    result = model_to_tools(state)
+    assert result == "__end__", (
+        f"Expected routing to __end__ when no tool calls, but got {result!r}"
+    )
+
+
+def test_routing_with_empty_invalid_tool_calls_exits() -> None:
+    """When both tool_calls and invalid_tool_calls are empty, route to end."""
+    model_to_tools = _make_model_to_tools_edge(
+        model_destination="model",
+        structured_output_tools={},
+        end_destination="__end__",
+    )
+
+    ai_msg = AIMessage(content="Done!", tool_calls=[], invalid_tool_calls=[])
+    state = {"messages": [HumanMessage(content="test"), ai_msg]}
+
+    result = model_to_tools(state)
+    assert result == "__end__", (
+        f"Expected routing to __end__ when invalid_tool_calls is empty, but got {result!r}"
+    )


### PR DESCRIPTION
## Summary

- When an LLM returns malformed JSON in tool call arguments, the `AIMessage` contains `invalid_tool_calls` with an empty `tool_calls` list. Previously, `create_agent`'s routing logic only checked `tool_calls` and would silently exit the agent loop, giving the LLM no chance to see the error and retry.
- This PR adds handling for `invalid_tool_calls` in two places:
  1. **`_handle_model_output`**: Converts `invalid_tool_calls` to error `ToolMessage` objects so the LLM can see parsing errors in the conversation history.
  2. **`_make_model_to_tools_edge`**: When `tool_calls` is empty but `invalid_tool_calls` exists, routes back to the model node instead of exiting, enabling retry.
- This restores the `handle_parsing_errors` behavior from the deprecated `AgentExecutor` in the new `create_agent` architecture.

Fixes #33504

## Test plan

- [x] Added unit tests in `test_invalid_tool_calls.py` verifying:
  - Routing to model when `invalid_tool_calls` exist (retry path)
  - Routing to end when no tool calls at all (normal exit)
  - Routing to end when `invalid_tool_calls` is empty list (normal exit)
- [ ] Manual testing with mock model returning `invalid_tool_calls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)