### PR TITLE
fix(core): filter v__args field when function has args parameter

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -375,6 +375,11 @@ def create_schema_from_function(
         if field == "v__duplicate_kwargs":  # Internal pydantic field
             continue
 
+        # Filter out v__args when function has a parameter named "args"
+        # Pydantic v2 adds this virtual field to handle conflict
+        if field == "v__args":
+            continue
+
         if field not in filter_args_:
             valid_properties.append(field)
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3653,3 +3653,31 @@ def test_tool_default_factory_not_required() -> None:
     schema = convert_to_openai_tool(some_func)
     params = schema["function"]["parameters"]
     assert "names" not in params.get("required", [])
+
+
+def test_structured_tool_from_function_with_args_param() -> None:
+    """Test that function parameter named 'args' doesn't create spurious v__args field."""
+
+    def tool_with_args_param(args: str, extra: int = 10) -> str:
+        """A tool with args as parameter name.
+
+        Args:
+            args: The args string.
+            extra: Extra value.
+        """
+        return f"{args}:{extra}"
+
+    tool = StructuredTool.from_function(tool_with_args_param)
+    schema = tool.args_schema
+
+    # Should have 'args' and 'extra' fields, but not 'v__args'
+    fields = schema.model_fields.keys()
+    assert "args" in fields, f"Expected 'args' in fields, got {fields}"
+    assert "extra" in fields, f"Expected 'extra' in fields, got {fields}"
+    assert "v__args" not in fields, f"Unexpected 'v__args' in fields: {fields}"
+    assert "kwargs" not in fields
+    assert "v__duplicate_kwargs" not in fields
+
+    # Verify the tool works correctly
+    result = tool.invoke({"args": "hello", "extra": 5})
+    assert result == "hello:5"

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -146,7 +146,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# This SSL context is equivelent to the default `verify=True`.
+# This SSL context is equivalent to the default `verify=True`.
 # https://www.python-httpx.org/advanced/ssl/#configuring-client-instances
 global_ssl_context = ssl.create_default_context(cafile=certifi.where())
 


### PR DESCRIPTION
## Summary

When a function parameter is named `args`, Pydantic v2 adds a virtual field called `v__args` to handle the naming conflict. This field was not being filtered out, causing spurious fields to appear in the tool's args schema.

This PR adds filtering for the `v__args` field in `create_schema_from_function`, similar to how `v__duplicate_kwargs` is already handled.

## Changes

- Added filtering for `v__args` field in `libs/core/langchain_core/tools/base.py`
- Added test case to verify the fix in `libs/core/tests/unit_tests/test_tools.py`

---

*Disclaimer: This contribution was made with assistance from an AI agent.*