### PR TITLE
fix: Strip v__args/v__kwargs Pydantic v2 internal fields

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -367,9 +367,10 @@ def create_schema_from_function(
     # Pydantic adds placeholder virtual fields we need to strip
     valid_properties = []
     for field in get_fields(inferred_model):
-        if not has_args and field == "args":
+        # Pydantic v2 uses v__args/v__kwargs for params named args/kwargs
+        if not has_args and field == "v__args":
             continue
-        if not has_kwargs and field == "kwargs":
+        if not has_kwargs and field == "v__kwargs":
             continue
 
         if field == "v__duplicate_kwargs":  # Internal pydantic field

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -138,6 +138,27 @@ def test_structured_args() -> None:
     assert structured_api.run(args) == expected_result
 
 
+def test_structured_tool_args_param_not_injected() -> None:
+    """Test that a function param named 'args' doesn't create spurious v__args field.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/35796
+    """
+
+    def run_command(working_dir: str, args: list[str], timeout: int = 60) -> str:
+        """Run a command."""
+        return f"{working_dir} {args} {timeout}"
+
+    st = StructuredTool.from_function(run_command)
+    schema = st.args_schema.model_json_schema()
+    props = list(schema["properties"].keys())
+
+    # 'args' should be present, 'v__args' should NOT be in the schema
+    assert "args" in props, f"'args' should be in properties, got: {props}"
+    assert "v__args" not in props, f"'v__args' should NOT be in properties, got: {props}"
+    assert "working_dir" in props
+    assert "timeout" in props
+
+
 def test_misannotated_base_tool_raises_error() -> None:
     """Test that a BaseTool with the incorrect typehint raises an exception."""
     with pytest.raises(SchemaAnnotationError):


### PR DESCRIPTION
## Summary

Fixes issue #35796: StructuredTool.from_function injects spurious v__args field when function has param named args.

## Problem

The code checked for "args" and "kwargs" but Pydantic v2 creates "v__args" and "v__kwargs" internal fields.

## Fix

Changed to filter the Pydantic v2 internal field names:
```diff
-if not has_args and field == "args":
+if not has_args and field == "v__args":  # Pydantic v2 internal field
     continue
-if not has_kwargs and field == "kwargs":
+if not has_kwargs and field == "v__kwargs":
     continue
```

## Testing

Added regression test: test_structured_tool_args_param_not_injected