### PR TITLE
fix: use loop-aware cache for async httpx clients to prevent cross-event-loop crashes

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/_client_utils.py
+++ b/libs/partners/anthropic/langchain_anthropic/_client_utils.py
@@ -64,14 +64,46 @@ def _get_default_httpx_client(
     return _SyncHttpxClientWrapper(**kwargs)
 
 
-@lru_cache
+# Async httpx clients are cached per event loop to avoid sharing connections
+# across loops, which causes RuntimeError("Event loop is closed").
+# See: https://github.com/langchain-ai/langchain/issues/35783
+_async_httpx_client_cache: dict[
+    tuple[str | None, Any, str | None, int], _AsyncHttpxClientWrapper
+] = {}
+
+
 def _get_default_async_httpx_client(
     *,
     base_url: str | None,
     timeout: Any = _NOT_GIVEN,
     anthropic_proxy: str | None = None,
 ) -> _AsyncHttpxClientWrapper:
-    kwargs: dict[str, Any] = {
+    try:
+        loop_id = id(asyncio.get_running_loop())
+    except RuntimeError:
+        # No running loop — return a fresh client (don't cache).
+        kwargs: dict[str, Any] = {
+            "base_url": base_url
+            or os.environ.get("ANTHROPIC_BASE_URL")
+            or "https://api.anthropic.com",
+        }
+        if timeout is not _NOT_GIVEN:
+            kwargs["timeout"] = timeout
+        if anthropic_proxy is not None:
+            kwargs["proxy"] = anthropic_proxy
+        return _AsyncHttpxClientWrapper(**kwargs)
+
+    key = (base_url, timeout, anthropic_proxy, loop_id)
+    client = _async_httpx_client_cache.get(key)
+    if client is not None and not client.is_closed:
+        return client
+
+    # Clean up stale entries for dead loops before adding a new one.
+    stale_keys = [k for k, v in _async_httpx_client_cache.items() if v.is_closed]
+    for k in stale_keys:
+        del _async_httpx_client_cache[k]
+
+    kwargs = {
         "base_url": base_url
         or os.environ.get("ANTHROPIC_BASE_URL")
         or "https://api.anthropic.com",
@@ -80,4 +112,6 @@ def _get_default_async_httpx_client(
         kwargs["timeout"] = timeout
     if anthropic_proxy is not None:
         kwargs["proxy"] = anthropic_proxy
-    return _AsyncHttpxClientWrapper(**kwargs)
+    client = _AsyncHttpxClientWrapper(**kwargs)
+    _async_httpx_client_cache[key] = client
+    return client

--- a/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
@@ -75,11 +75,36 @@ def _cached_sync_httpx_client(
     return _build_sync_httpx_client(base_url, timeout)
 
 
-@lru_cache
+# Async httpx clients are cached per event loop to avoid sharing connections
+# across loops, which causes RuntimeError("Event loop is closed").
+# See: https://github.com/langchain-ai/langchain/issues/35783
+_async_httpx_client_cache: dict[
+    tuple[str | None, Any, int], _AsyncHttpxClientWrapper
+] = {}
+
+
 def _cached_async_httpx_client(
     base_url: str | None, timeout: Any
 ) -> _AsyncHttpxClientWrapper:
-    return _build_async_httpx_client(base_url, timeout)
+    try:
+        loop_id = id(asyncio.get_running_loop())
+    except RuntimeError:
+        # No running loop — return a fresh client (don't cache).
+        return _build_async_httpx_client(base_url, timeout)
+
+    key = (base_url, timeout, loop_id)
+    client = _async_httpx_client_cache.get(key)
+    if client is not None and not client.is_closed:
+        return client
+
+    # Clean up stale entries for dead loops before adding a new one.
+    stale_keys = [k for k, v in _async_httpx_client_cache.items() if v.is_closed]
+    for k in stale_keys:
+        del _async_httpx_client_cache[k]
+
+    client = _build_async_httpx_client(base_url, timeout)
+    _async_httpx_client_cache[key] = client
+    return client
 
 
 def _get_default_httpx_client(
@@ -100,9 +125,10 @@ def _get_default_httpx_client(
 def _get_default_async_httpx_client(
     base_url: str | None, timeout: Any
 ) -> _AsyncHttpxClientWrapper:
-    """Get default httpx client.
+    """Get default async httpx client.
 
-    Uses cached client unless timeout is `httpx.Timeout`, which is not hashable.
+    Uses a loop-aware cache to avoid sharing connections across event loops.
+    Falls back to a fresh client if timeout is not hashable.
     """
     try:
         hash(timeout)


### PR DESCRIPTION
## Description

Fixes #35783 — `@lru_cache` on `_cached_async_httpx_client()` causes `APIConnectionError` / `RuntimeError("Event loop is closed")` when the cached `AsyncClient` is reused across different event loops.

### Root Cause

`_cached_async_httpx_client()` was decorated with `@lru_cache` keyed by `(base_url, timeout)`, but **ignored event loop identity**. When a cached `AsyncClient` was created in one event loop and later accessed from a different loop (common in multi-threaded applications calling `asyncio.run()`), the underlying httpx transport was bound to the original (now-closed) loop.

The `_AsyncHttpxClientWrapper.__del__` method attempts `asyncio.get_running_loop().create_task(self.aclose())` which silently fails, leaving the client in a broken state for the new loop.

### Fix

Replaced `@lru_cache` with a manual dict-based cache that includes `id(asyncio.get_running_loop())` as part of the cache key:

```python
key = (base_url, timeout, id(asyncio.get_running_loop()))
```

The implementation also:
- Returns a fresh (uncached) client if no event loop is running
- Checks `client.is_closed` before returning cached entries
- Cleans up stale entries for dead loops on each cache miss
- Applied the same fix to `langchain-anthropic` which had the identical bug

### Files Changed

| File | Change |
|------|--------|
| `libs/partners/openai/langchain_openai/chat_models/_client_utils.py` | Loop-aware async client cache |
| `libs/partners/anthropic/langchain_anthropic/_client_utils.py` | Same fix for Anthropic partner |

### Reproduction

```python
import asyncio
from langchain_openai import ChatOpenAI

llm = ChatOpenAI(model="gpt-4o-mini")

# First call creates + caches the AsyncClient for loop A
asyncio.run(llm.ainvoke("Hello"))

# Second call reuses the cached client, but loop A is now dead
asyncio.run(llm.ainvoke("Hello"))  # APIConnectionError before fix
```

### Testing

The fix maintains backward compatibility — the sync `@lru_cache` is unchanged, and the async cache now correctly handles:
- Same loop reuse (cache hit, same as before)
- Cross-loop reuse (cache miss, creates new client)
- No running loop (returns fresh client, no caching)
