### PR TITLE
fix(tools): respect include_injected=False when filter_args is provided

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -344,20 +344,21 @@ def create_schema_from_function(
     inferred_model = validated.model
 
     if filter_args:
-        filter_args_ = filter_args
+        filter_args_ = list(filter_args)
     else:
-        # Handle classmethods and instance methods
         existing_params: list[str] = list(sig.parameters.keys())
         if existing_params and existing_params[0] in {"self", "cls"} and in_class:
             filter_args_ = [existing_params[0], *list(FILTERED_ARGS)]
         else:
             filter_args_ = list(FILTERED_ARGS)
 
-        for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
-                sig.parameters[existing_param].annotation
-            ):
-                filter_args_.append(existing_param)
+    for existing_param in list(sig.parameters.keys()):
+        if (
+            not include_injected
+            and _is_injected_arg_type(sig.parameters[existing_param].annotation)
+            and existing_param not in filter_args_
+        ):
+            filter_args_.append(existing_param)
 
     description, arg_descriptions = _infer_arg_descriptions(
         func,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -61,6 +61,7 @@ from langchain_core.tools.base import (
     _is_message_content_block,
     _is_message_content_type,
     get_all_basemodel_annotations,
+    create_schema_from_function,
 )
 from langchain_core.utils.function_calling import (
     convert_to_openai_function,
@@ -2509,6 +2510,75 @@ def test_tool_injected_arg_with_custom_schema() -> None:
     assert result == "Results for hello with context test_context"
     assert captured["context"] is ctx
     assert captured["context"].value == "test_context"
+
+
+def test_create_schema_filters_injected_when_filter_args_provided() -> None:
+    """Ensure injected args are filtered even when custom filter_args is provided."""
+
+    class SecretContext:
+        def __init__(self, token: str) -> None:
+            self.token = token
+
+    def my_tool(
+        query: str,
+        limit: int,
+        secret: Annotated[SecretContext, InjectedToolArg],
+    ) -> str:
+        """Tool with a normal arg, a filtered arg, and an injected arg."""
+        return f"{query}:{limit}:{secret.token}"
+
+    schema = create_schema_from_function(
+        "MyTool",
+        my_tool,
+        filter_args=["limit"],
+        include_injected=False,
+    )
+
+    properties = set(schema.schema().get("properties", {}).keys())
+
+    assert "query" in properties, (
+        f"Expected 'query' in schema properties, got: {properties}"
+    )
+
+    assert "limit" not in properties, (
+        f"Expected 'limit' to be filtered via filter_args, got: {properties}"
+    )
+
+    assert "secret" not in properties, (
+        f"Expected 'secret' (InjectedToolArg) to be filtered when include_injected=False, "  # noqa: E501
+        f"got: {properties}. This indicates the bug where include_injected=False is "
+        f"ignored when filter_args is also provided."
+    )
+
+
+def test_create_schema_filter_args_list_not_mutated() -> None:
+    """Ensure the caller's filter_args list is not mutated."""
+
+    class SecretContext:
+        def __init__(self, token: str) -> None:
+            self.token = token
+
+    def my_tool(
+        query: str,
+        secret: Annotated[SecretContext, InjectedToolArg],
+    ) -> str:
+        """Tool with an injected arg."""
+        return query
+
+    original_filter_args = ["query"]
+    original_filter_args_copy = list(original_filter_args)
+
+    create_schema_from_function(
+        "MyTool",
+        my_tool,
+        filter_args=original_filter_args,
+        include_injected=False,
+    )
+
+    assert original_filter_args == original_filter_args_copy, (
+        f"filter_args was mutated from {original_filter_args_copy} "
+        f"to {original_filter_args}"
+    )
 
 
 def test_tool_injected_tool_call_id() -> None:


### PR DESCRIPTION
`create_schema_from_function` silently ignored `include_injected=False` when `filter_args` was also provided, causing injected arguments to leak into the generated schema.

Fixes #35831

- Move injected arg filtering outside if/else block so it always runs
- Copy filter_args with list() to avoid mutating caller's sequence
- Add regression tests in test_tools.py

## How did you verify your code works?

Added two regression tests in `libs/core/tests/unit_tests/test_tools.py`:
- `test_create_schema_filters_injected_when_filter_args_provided` — confirms injected args are filtered when both `filter_args` and `include_injected=False` are passed
- `test_create_schema_filter_args_list_not_mutated` — confirms caller's `filter_args` list is not mutated by the function

## Social handles
LinkedIn: https://linkedin.com/in/akash-kumar-7951a2126/