### PR TITLE
fix(openai): preserve non-strict semantics when converting tools to Responses API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3364,7 +3364,13 @@ def _construct_responses_api_payload(
             # chat api: {"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}, "strict": ...}}  # noqa: E501
             # responses api: {"type": "function", "name": "...", "description": "...", "parameters": {...}, "strict": ...}  # noqa: E501
             if tool["type"] == "function" and "function" in tool:
-                new_tools.append({"type": "function", **tool["function"]})
+                func = tool["function"]
+                # Chat Completions API omitting "strict" means non-strict (best-effort).
+                # Responses API omitting "strict" means strict=True by default.
+                # Explicitly set strict=False to preserve Chat Completions semantics.
+                if "strict" not in func:
+                    func = {**func, "strict": False}
+                new_tools.append({"type": "function", **func})
             else:
                 if tool["type"] == "image_generation":
                     # Handle partial images (not yet supported)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -56,6 +56,7 @@ from langchain_openai.chat_models._compat import (
 from langchain_openai.chat_models.base import (
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
+    _construct_responses_api_payload,
     _convert_dict_to_message,
     _convert_message_to_dict,
     _convert_to_openai_response_format,
@@ -2528,3 +2529,67 @@ def test_make_computer_call_output_from_message() -> None:
             }
         ],
     }
+
+
+def test_construct_responses_api_payload_tool_strict_defaults_to_false() -> None:
+    """Tools without explicit strict should default to strict=False in Responses API.
+
+    Chat Completions API: omitting strict means non-strict (best-effort).
+    Responses API: omitting strict means strict=True (per OpenAI docs).
+    We must explicitly set strict=False to preserve Chat Completions semantics.
+    """
+    from langchain_core.messages import HumanMessage
+
+    payload = {
+        "model": "gpt-5",
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                        },
+                        "required": ["city"],
+                    },
+                    # No "strict" key — omitted intentionally
+                },
+            }
+        ],
+    }
+    result = _construct_responses_api_payload([HumanMessage(content="hi")], payload)
+    tool = result["tools"][0]
+    assert tool["strict"] is False, (
+        "Tool without explicit strict should default to strict=False in Responses API"
+    )
+
+
+def test_construct_responses_api_payload_tool_explicit_strict_preserved() -> None:
+    """Explicit strict=True on a tool should be preserved after conversion."""
+    from langchain_core.messages import HumanMessage
+
+    payload = {
+        "model": "gpt-5",
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                        "additionalProperties": False,
+                    },
+                    "strict": True,
+                },
+            }
+        ],
+    }
+    result = _construct_responses_api_payload([HumanMessage(content="hi")], payload)
+    tool = result["tools"][0]
+    assert tool["strict"] is True, "Explicit strict=True should be preserved"


### PR DESCRIPTION
Fixes #35837

## Problem

When `langchain-openai` transparently switches from the Chat Completions API to the Responses API (triggered by `reasoning_effort` or similar parameters), the effective `strict` default for function tools silently changes:

- **Chat Completions API**: omitting `strict` → non-strict (best-effort)
- **Responses API**: omitting `strict` → `strict=True` (per [OpenAI docs](https://platform.openai.com/docs/api-reference/responses/create))

The previous conversion code was:
```python
new_tools.append({"type": "function", **tool["function"]})
```

This preserved the *absence* of `strict`, but the semantics flip. Users calling `bind_tools(tools)` without explicit `strict` get non-strict behavior on Chat Completions but strict behavior on Responses API — without any warning.

With `strict=True`, tools enter structured-outputs mode which only supports a subset of JSON Schema. Tool schemas containing unsupported keywords (e.g. `pattern`, missing `additionalProperties: false`) cause the model to misinterpret constraints as literal values, silently producing broken tool calls.

## Fix

Explicitly set `"strict": False` during conversion when no `strict` value was provided, preserving Chat Completions semantics:

```python
func = tool["function"]
if "strict" not in func:
    func = {**func, "strict": False}
new_tools.append({"type": "function", **func})
```

Explicit `strict=True` is still respected.

## Tests

Added two unit tests to `test_base.py`:
- `test_construct_responses_api_payload_tool_strict_defaults_to_false`: verifies tools without explicit `strict` get `strict=False` after conversion
- `test_construct_responses_api_payload_tool_explicit_strict_preserved`: verifies explicit `strict=True` is preserved