### PR TITLE
feat(anthropic): support custom httpx clients for mTLS / cert-based auth

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -864,6 +864,12 @@ class ChatAnthropic(BaseChatModel):
     default_headers: Mapping[str, str] | None = None
     """Headers to pass to the Anthropic clients, will be used for every API call."""
 
+    http_client: Any | None = Field(default=None, exclude=True)
+    """Optional custom httpx.Client. Useful for mTLS / cert-based auth."""
+
+    http_async_client: Any | None = Field(default=None, exclude=True)
+    """Optional custom httpx.AsyncClient. Useful for mTLS / cert-based auth."""
+
     betas: list[str] | None = None
     """List of beta features to enable. If specified, invocations will be routed
     through `client.beta.messages.create`.
@@ -1068,7 +1074,10 @@ class ChatAnthropic(BaseChatModel):
             http_client_params["timeout"] = client_params["timeout"]
         if self.anthropic_proxy:
             http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_httpx_client(**http_client_params)
+        if self.http_client is not None:
+            http_client = self.http_client
+        else:
+            http_client = _get_default_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,
@@ -1083,7 +1092,10 @@ class ChatAnthropic(BaseChatModel):
             http_client_params["timeout"] = client_params["timeout"]
         if self.anthropic_proxy:
             http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_async_httpx_client(**http_client_params)
+        if self.http_async_client is not None:
+            http_client = self.http_async_client
+        else:
+            http_client = _get_default_async_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, cast
 from unittest.mock import MagicMock, patch
 
 import anthropic
+import httpx
 import pytest
 from anthropic.types import Message, TextBlock, Usage
 from blockbuster import blockbuster_ctx
@@ -126,6 +127,63 @@ def test_anthropic_proxy_from_environment() -> None:
         explicit_proxy = "http://explicit-proxy.com"
         llm = ChatAnthropic(model=MODEL_NAME, anthropic_proxy=explicit_proxy)
         assert llm.anthropic_proxy == explicit_proxy
+
+
+def test_custom_http_client_sync() -> None:
+    """Custom http_client is passed through to anthropic.Client unchanged."""
+    custom = httpx.Client()
+    llm = ChatAnthropic(model=MODEL_NAME, http_client=custom)
+
+    with patch("langchain_anthropic.chat_models.anthropic.Client") as mock_client_cls:
+        _ = llm._client
+        _, kwargs = mock_client_cls.call_args
+        assert kwargs["http_client"] is custom
+
+
+def test_custom_http_client_async() -> None:
+    """Custom http_async_client is passed through to anthropic.AsyncClient unchanged."""
+    custom = httpx.AsyncClient()
+    llm = ChatAnthropic(model=MODEL_NAME, http_async_client=custom)
+
+    with patch(
+        "langchain_anthropic.chat_models.anthropic.AsyncClient"
+    ) as mock_async_cls:
+        _ = llm._async_client
+        _, kwargs = mock_async_cls.call_args
+        assert kwargs["http_client"] is custom
+
+
+def test_default_http_clients_used_when_not_provided() -> None:
+    """Default httpx clients are created when http_client / http_async_client are
+    None.
+    """
+    llm = ChatAnthropic(model=MODEL_NAME)
+
+    with (
+        patch("langchain_anthropic.chat_models._get_default_httpx_client") as mock_sync,
+        patch(
+            "langchain_anthropic.chat_models._get_default_async_httpx_client"
+        ) as mock_async,
+        patch("langchain_anthropic.chat_models.anthropic.Client"),
+        patch("langchain_anthropic.chat_models.anthropic.AsyncClient"),
+    ):
+        _ = llm._client
+        mock_sync.assert_called_once()
+
+        _ = llm._async_client
+        mock_async.assert_called_once()
+
+
+def test_http_client_excluded_from_serialization() -> None:
+    """http_client and http_async_client are excluded from model serialization."""
+    llm = ChatAnthropic(
+        model=MODEL_NAME,
+        http_client=httpx.Client(),
+        http_async_client=httpx.AsyncClient(),
+    )
+    serialized = llm.model_dump()
+    assert "http_client" not in serialized
+    assert "http_async_client" not in serialized
 
 
 def test_set_default_max_tokens() -> None:


### PR DESCRIPTION
Fixes #35843

This PR enables users to inject a custom `httpx.Client` or `httpx.AsyncClient` into `ChatAnthropic`, which is essential for environments requiring mTLS or specific certificate-based authentication.

- **Type of Change**: Feature addition.
- **Breaking Changes**: None.
- **Dependencies**: None.

### 3. Verification
I have run `make format`, `make lint`, and `make test` in `libs/partners/anthropic` and all passed.

### 4. How did you verify your code works?

I added unit tests in `libs/partners/anthropic/tests/unit_tests` to verify:
1. Custom sync/async clients are correctly forwarded to the underlying anthropic library.
2. Default clients are still instantiated once if no custom client is provided.
3. The `http_client` and `http_async_client` fields are correctly excluded from model serialization (`model_dump`) to prevent errors.

---
> This contribution was developed with the assistance of Claude Code (Anthropic).