### PR TITLE
fix(mistralai): warn when streaming with function_calling in with_structured_output

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -1088,6 +1088,18 @@ class ChatMistralAI(BaseChatModel):
                     "Received None."
                 )
                 raise ValueError(msg)
+            if self.streaming:
+                import warnings
+
+                warnings.warn(
+                    "Streaming with method='function_calling' does not support "
+                    "incremental token streaming with Mistral AI. Mistral's API "
+                    "returns tool call arguments as a single complete chunk rather "
+                    "than progressively. Use method='json_schema' instead if you "
+                    "need incremental streaming of structured output.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             # TODO: Update to pass in tool name as tool_choice if/when Mistral supports
             # specifying a tool.
             llm = self.bind_tools(

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -167,6 +167,51 @@ async def test_astream_with_callback() -> None:
         assert callback.last_token == token.content
 
 
+def test_with_structured_output_function_calling_streaming_warns() -> None:
+    """Warn users that function_calling does not support incremental streaming.
+
+    Mistral's API returns tool call arguments as a single complete chunk when
+    streaming with function calling, so streaming yields only one result rather
+    than progressive partial results. The json_schema method should be used
+    for incremental streaming.
+    """
+    from pydantic import BaseModel
+
+    class City(BaseModel):
+        name: str
+        country: str
+
+    chat = ChatMistralAI(model="mistral-small-latest", streaming=True)
+    with pytest.warns(
+        UserWarning,
+        match="method='json_schema'",
+    ):
+        chat.with_structured_output(City, method="function_calling")
+
+
+def test_with_structured_output_function_calling_no_streaming_no_warn() -> None:
+    """No warning when streaming is not enabled."""
+    import warnings
+
+    from pydantic import BaseModel
+
+    class City(BaseModel):
+        name: str
+        country: str
+
+    chat = ChatMistralAI(model="mistral-small-latest", streaming=False)
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        chat.with_structured_output(City, method="function_calling")
+    streaming_warnings = [
+        w
+        for w in caught_warnings
+        if issubclass(w.category, UserWarning)
+        and "json_schema" in str(w.message)
+    ]
+    assert len(streaming_warnings) == 0
+
+
 def test__convert_dict_to_message_tool_call() -> None:
     raw_tool_call = {
         "id": "ssAbar4Dr",


### PR DESCRIPTION
## Summary

Fixes #29860.

When `ChatMistralAI.with_structured_output(schema, method="function_calling")` is used with `streaming=True`, the `.stream()` method returns a single complete result rather than progressive partial results. This is confusing to users who expect incremental streaming behavior.

- Added a `UserWarning` in `with_structured_output()` when `method="function_calling"` and `self.streaming=True` are combined, directing users to use `method="json_schema"` for incremental streaming
- Added two unit tests: one confirming the warning is emitted, one confirming no false-positive warning when streaming is disabled

---

## Root Cause

Mistral's API spec requires that every `ToolCall` in a streaming delta includes the **complete** function name and **complete** arguments. This means streaming with `function_calling` returns the full tool call in a single SSE event, so the output parsers (`PydanticToolsParser`, `JsonOutputKeyToolsParser`) can only emit one result rather than progressively building up the output.

The `json_schema` method outputs regular text content, which Mistral does stream incrementally, enabling the progressive chunk behavior users expect from `.stream()`.

---

## Solution

Emit a `UserWarning` with a clear message pointing users to `method="json_schema"` as the correct approach for incremental streaming. This is the minimal correct fix: it does not break any existing functionality but surfaces the limitation before users encounter confusing behavior.

---

## Testing

- `test_with_structured_output_function_calling_streaming_warns`: verifies the warning is raised when `streaming=True` and `method="function_calling"`
- `test_with_structured_output_function_calling_no_streaming_no_warn`: verifies no spurious streaming warning when `streaming=False`
- All 40 existing unit tests continue to pass

---

## Checklist

- [x] Fixes the root cause (documents Mistral API limitation that cannot be changed in LangChain)
- [x] New tests cover the exact failing scenario from the issue
- [x] All existing tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Read CONTRIBUTING.md and followed its requirements

---

> **Note:** This PR was developed with AI assistance (Claude Code). The root cause analysis, implementation, and tests were reviewed for correctness before submission.