### PR TITLE
ci: cancel other CI runs when `require-issue-link` closes a PR

### DIFF
--- a/.github/workflows/require_issue_link.yml
+++ b/.github/workflows/require_issue_link.yml
@@ -12,6 +12,7 @@
 # - Automatically reopens PRs that were closed by this workflow once the
 #   check passes (e.g. author edits the body to add a valid issue link).
 # - Posts a comment explaining the requirement on failure.
+# - Cancels all other in-progress/queued CI runs for the PR on closure.
 # - Deduplicates comments via an HTML marker so re-runs don't spam.
 #
 # Dependency: tag-external-contributions.yml must run first to apply the
@@ -40,6 +41,7 @@ jobs:
       )
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       pull-requests: write
 
     steps:
@@ -212,6 +214,26 @@ jobs:
                 state: 'closed',
               });
               console.log(`Closed PR #${prNumber}`);
+            }
+
+            // Cancel all other in-progress and queued workflow runs for this PR
+            const headSha = context.payload.pull_request.head.sha;
+            for (const status of ['in_progress', 'queued']) {
+              const runs = await github.paginate(
+                github.rest.actions.listWorkflowRunsForRepo,
+                { owner, repo, head_sha: headSha, status, per_page: 100 },
+              );
+              for (const run of runs) {
+                if (run.id === context.runId) continue;
+                try {
+                  await github.rest.actions.cancelWorkflowRun({
+                    owner, repo, run_id: run.id,
+                  });
+                  console.log(`Cancelled ${status} run ${run.id} (${run.name})`);
+                } catch (err) {
+                  console.log(`Could not cancel run ${run.id}: ${err.message}`);
+                }
+              }
             }
 
             const reason = !hasLink


### PR DESCRIPTION
When the `require_issue_link` workflow closes an external PR for failing the issue-link/assignee check, other CI workflows (lint, tests, integration tests) keep running uselessly. This cancels all of them immediately after closing the PR.

## Changes
- After closing the PR in the `check-issue-link` job's final step, enumerate all `in_progress` and `queued` workflow runs matching the PR's `head_sha` via `actions.listWorkflowRunsForRepo` and cancel each one (skipping self via `context.runId`)
- Add `actions: write` permission to the job to allow cancellation API calls