### PR TITLE
fix: respect include_injected=False when filter_args is provided

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -344,7 +344,7 @@ def create_schema_from_function(
     inferred_model = validated.model
 
     if filter_args:
-        filter_args_ = filter_args
+        filter_args_ = list(filter_args)
     else:
         # Handle classmethods and instance methods
         existing_params: list[str] = list(sig.parameters.keys())
@@ -353,11 +353,13 @@ def create_schema_from_function(
         else:
             filter_args_ = list(FILTERED_ARGS)
 
-        for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
-                sig.parameters[existing_param].annotation
+    if not include_injected:
+        for param_name in sig.parameters:
+            if _is_injected_arg_type(
+                sig.parameters[param_name].annotation
             ):
-                filter_args_.append(existing_param)
+                if param_name not in filter_args_:
+                    filter_args_.append(param_name)
 
     description, arg_descriptions = _infer_arg_descriptions(
         func,


### PR DESCRIPTION
## Summary

Fixes #35831

`create_schema_from_function` silently ignores `include_injected=False` when `filter_args` is also provided, causing injected arguments to leak into the generated schema.

**Root cause:** The injected-arg filtering logic was nested inside the `else` branch of the `if filter_args:` check, so it never ran when the caller supplied explicit `filter_args`.

**Fix:** Move the injected-arg filtering outside the `if/else` block so it always runs when `include_injected=False`, regardless of whether `filter_args` was provided. Also copy `filter_args` to a new list to avoid mutating the caller's input.

## Reproduction

```python
from typing import Annotated
from langchain_core.tools import InjectedToolArg
from langchain_core.utils.function_calling import create_schema_from_function

def my_tool(
    query: str,
    secret: Annotated[str, InjectedToolArg],
):
    pass

schema = create_schema_from_function(
    "MyTool",
    my_tool,
    filter_args=["query"],
    include_injected=False,
)

print(schema.schema()["properties"])
# Before fix: {"secret": ...}  — injected arg leaked
# After fix:  {}
```

## Test plan

- [x] Verified the reproduction case from the issue now produces `{}` as expected
- [ ] Existing unit tests pass (`libs/core/tests/unit_tests/test_tools.py`)