### PR TITLE
fix: respect include_injected=False when filter_args is provided

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -344,7 +344,7 @@ def create_schema_from_function(
     inferred_model = validated.model
 
     if filter_args:
-        filter_args_ = filter_args
+        filter_args_ = list(filter_args)
     else:
         # Handle classmethods and instance methods
         existing_params: list[str] = list(sig.parameters.keys())
@@ -353,10 +353,11 @@ def create_schema_from_function(
         else:
             filter_args_ = list(FILTERED_ARGS)
 
-        for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
-                sig.parameters[existing_param].annotation
-            ):
+    for existing_param in list(sig.parameters.keys()):
+        if not include_injected and _is_injected_arg_type(
+            sig.parameters[existing_param].annotation
+        ):
+            if existing_param not in filter_args_:
                 filter_args_.append(existing_param)
 
     description, arg_descriptions = _infer_arg_descriptions(

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3636,3 +3636,29 @@ def test_tool_args_schema_falsy_defaults() -> None:
     # Invoke with only required argument - falsy defaults should be applied
     result = config_tool.invoke({"name": "test"})
     assert result == "name=test, enabled=False, count=0, prefix=''"
+
+
+def test_create_schema_from_function_include_injected_false_with_filter_args() -> None:
+    """Regression test: include_injected=False must be respected even when
+    filter_args is provided.  See https://github.com/langchain-ai/langchain/issues/35831
+    """
+    from langchain_core.tools.base import create_schema_from_function
+
+    def my_tool(
+        query: str,
+        secret: Annotated[str, InjectedToolArg],
+    ) -> str:
+        return query
+
+    schema = create_schema_from_function(
+        "MyTool",
+        my_tool,
+        filter_args=["query"],
+        include_injected=False,
+    )
+
+    props = schema.model_json_schema().get("properties", {})
+    assert "secret" not in props, (
+        "Injected arg 'secret' should be filtered when include_injected=False, "
+        f"but schema properties are: {props}"
+    )


### PR DESCRIPTION
## Summary

- Fix `create_schema_from_function` ignoring `include_injected=False` when `filter_args` is provided, causing `InjectedToolArg` parameters to leak into the schema
- Move injected-arg filtering outside the `if/else` block so it always runs regardless of whether `filter_args` was supplied
- Copy `filter_args` with `list()` to avoid mutating the caller's sequence

Fixes #35831

## Test plan

- [x] Added regression test `test_create_schema_from_function_include_injected_false_with_filter_args` that verifies injected args are excluded when both `filter_args` and `include_injected=False` are provided
- [x] All 19 existing injected-arg-related tests pass
- [x] Verified the reproduction case from the issue now produces the expected result

🤖 Generated with [Claude Code](https://claude.com/claude-code)