### PR TITLE
fix: add type check in merge_lists for non-dict elements

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -118,7 +118,8 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                         i
                         for i, e_left in enumerate(merged)
                         if (
-                            "index" in e_left
+                            isinstance(e_left, dict)
+                            and "index" in e_left
                             and e_left["index"] == e["index"]  # index matches
                             and (  # IDs not inconsistent
                                 e_left.get("id") in (None, "")


### PR DESCRIPTION
## Summary

Fixes #35259

- `merge_lists` in `langchain_core/utils/_merge.py` crashes with `TypeError: string indices must be integers` when merging streaming chunks that contain a mix of strings and dicts (e.g., Mistral responses with inline citations).
- **Root cause:** The list comprehension checks `"index" in e_left` without first verifying `e_left` is a dict. When `e_left` is a string, Python's `in` operator performs substring matching instead of dict key lookup. If the check passes, `e_left["index"]` fails because string indexing requires integers, not strings.
- **Fix:** Add `isinstance(e_left, dict)` guard before the `"index" in e_left` check to skip non-dict elements during the index-matching scan.

## Reproduction

```python
from langchain_core.utils._merge import merge_lists

merged = [
    "start answer...",
    {"type": "reference", "index": 0, "reference_ids": ["iKcb2CAQ7"]},
    "other answer..."
]
other = [{"type": "reference", "index": 0, "reference_ids": ["DGqzzmqc3"]}]

# Before fix: TypeError: string indices must be integers
# After fix: works correctly
result = merge_lists(merged, other)
```

## Test plan

- [ ] Verify the reproduction case from the issue no longer raises TypeError
- [ ] Existing `merge_lists` tests continue to pass
- [ ] Test with Mistral streaming citations end-to-end (requires Mistral API key)