### PR TITLE
fix: cancel pending tasks in abatch_as_completed on exception/early exit

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1117,15 +1117,23 @@ class Runnable(ABC, Generic[Input, Output]):
                 out = await self.ainvoke(input_, config, **kwargs)
             return (i, out)
 
-        coros = [
-            gated_coro(semaphore, ainvoke_task(i, input_, config))
-            if semaphore
-            else ainvoke_task(i, input_, config)
+        tasks = [
+            asyncio.ensure_future(
+                gated_coro(semaphore, ainvoke_task(i, input_, config))
+                if semaphore
+                else ainvoke_task(i, input_, config)
+            )
             for i, (input_, config) in enumerate(zip(inputs, configs, strict=False))
         ]
 
-        for coro in asyncio.as_completed(coros):
-            yield await coro
+        try:
+            for coro in asyncio.as_completed(tasks):
+                yield await coro
+        finally:
+            for task in tasks:
+                task.cancel()
+            # Suppress CancelledError from any still-running tasks
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def stream(
         self,


### PR DESCRIPTION
## Summary

- Fixes #35419: `abatch_as_completed` does not cancel pending tasks when an exception occurs or the consumer breaks out of the `async for` loop early, causing remaining tasks to run in the background and incur unnecessary API charges.
- Wraps coroutines in `asyncio.Task` objects and adds a `try/finally` block that cancels all remaining tasks when the async generator exits, mirroring the cancellation behavior already present in the sync `batch_as_completed` method.

## Details

The sync `batch_as_completed` already cancels pending `concurrent.futures` in a `finally` block:

```python
try:
    while futures:
        done, futures = wait(futures, return_when=FIRST_COMPLETED)
        while done:
            yield done.pop().result()
finally:
    for future in futures:
        future.cancel()
```

The async version was missing equivalent cleanup. The fix:

1. Uses `asyncio.ensure_future()` to wrap coroutines into `Task` objects (required because bare coroutines returned by `asyncio.as_completed` cannot be cancelled).
2. Adds a `try/finally` around the yield loop that cancels all tasks and awaits them with `return_exceptions=True` to suppress `CancelledError`.

This ensures that when:
- A task raises an exception (and `return_exceptions=False`), or
- The caller breaks out of the `async for` loop early

...all remaining pending tasks are promptly cancelled instead of continuing to run in the background.

## Test plan

- [ ] Verify with the reproduction script from #35419 that "CHARGED" messages no longer appear after the exception
- [ ] Existing tests in `libs/core/tests/unit_tests/runnables/test_concurrency.py` continue to pass
- [ ] Test with `return_exceptions=True` to confirm normal behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>