### PR TITLE
fix(anthropic): use args["path"] instead of args["old_path"] in _handle_rename

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -530,7 +530,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1032,7 +1032,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)


### PR DESCRIPTION
## Summary

Both `_StateClaudeFileToolMiddleware._handle_rename` and `_FilesystemClaudeFileToolMiddleware._handle_rename` read the source path from `args["old_path"]`, but the tool-dispatch logic at line 218 stores it under `args["path"]`:

```python
# line 218 — dispatch builds args with key "path":
args: dict[str, Any] = {"path": path}
```

Both handlers then try `old_path = args["old_path"]`, which raises `KeyError` on every rename command.

## Fix

Change `args["old_path"]` → `args["path"]` in both `_handle_rename` implementations (lines 533 and 1035).

## Repro

```python
from langchain_anthropic.middleware.anthropic_tools import (
    StateClaudeTextEditorMiddleware,
    AnthropicToolsState,
)

middleware = StateClaudeTextEditorMiddleware()
args = {"path": "old_name.txt", "new_path": "new_name.txt"}
state: AnthropicToolsState = {
    "messages": [],
    "text_editor_files": {
        "old_name.txt": {"content": "hello", "modified_at": "2024-01-01T00:00:00+00:00"}
    },
}

# Was: KeyError: "old_path" — now works correctly
middleware._handle_rename(args, state, tool_call_id="abc123")
```

Fixes #35852