### PR TITLE
fix(core): include_injected=False ignored when filter_args is provided in create_schema_from_function

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -344,7 +344,7 @@ def create_schema_from_function(
     inferred_model = validated.model
 
     if filter_args:
-        filter_args_ = filter_args
+        filter_args_ = list(filter_args)  # copy to avoid mutating caller's sequence
     else:
         # Handle classmethods and instance methods
         existing_params: list[str] = list(sig.parameters.keys())
@@ -353,11 +353,13 @@ def create_schema_from_function(
         else:
             filter_args_ = list(FILTERED_ARGS)
 
-        for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
-                sig.parameters[existing_param].annotation
-            ):
-                filter_args_.append(existing_param)
+    # Always apply include_injected filtering, regardless of filter_args.
+    # InjectedToolArg marks arguments that should be hidden from the LLM;
+    # leaking them defeats the purpose of the injection mechanism.
+    if not include_injected:
+        for param_name, param in sig.parameters.items():
+            if _is_injected_arg_type(param.annotation) and param_name not in filter_args_:
+                filter_args_.append(param_name)
 
     description, arg_descriptions = _infer_arg_descriptions(
         func,


### PR DESCRIPTION
## Summary

`create_schema_from_function` silently ignores `include_injected=False` whenever `filter_args` is also provided, causing `InjectedToolArg`-annotated parameters to **leak into the generated schema**.

This defeats the purpose of `InjectedToolArg`, which is to hide sensitive arguments (API keys, session objects, etc.) from the LLM.

## Root cause

The `include_injected` filtering loop was nested inside the `else` branch of the `filter_args` check, so it **never ran** when `filter_args` was provided:

```python
# Before (broken):
if filter_args:
    filter_args_ = filter_args      # ← include_injected filtering never happens here
else:
    ...
    for existing_param in existing_params:
        if not include_injected and _is_injected_arg_type(...):   # ← only runs in else
            filter_args_.append(existing_param)
```

There was also a subtle second bug: `filter_args_ = filter_args` assigned the caller's sequence directly, meaning any later `filter_args_.append(...)` would **mutate the caller's original list**.

## Fix

1. Copy `filter_args` to a new list (`list(filter_args)`) to avoid aliasing/mutation.
2. Move the `include_injected` loop **outside** the `if/else` block so it always runs.

```python
# After (correct):
if filter_args:
    filter_args_ = list(filter_args)   # ← copy, don't alias
else:
    ...

# Always applies, regardless of filter_args:
if not include_injected:
    for param_name, param in sig.parameters.items():
        if _is_injected_arg_type(param.annotation) and param_name not in filter_args_:
            filter_args_.append(param_name)
```

## Repro

```python
from typing import Annotated
from langchain_core.tools import InjectedToolArg
from langchain_core.tools.base import create_schema_from_function

def my_tool(
    query: str,
    secret: Annotated[str, InjectedToolArg],
):
    pass

schema = create_schema_from_function(
    "MyTool",
    my_tool,
    filter_args=["query"],
    include_injected=False,
)

print(schema.schema()["properties"])
# Before fix: {"secret": ...}  ← injected arg leaked
# After fix:  {}               ← correctly hidden
```

Fixes #35831