### PR TITLE
Respect include_injected=False when filter_args is provided

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -343,21 +343,22 @@ def create_schema_from_function(
 
     inferred_model = validated.model
 
+    existing_params: list[str] = list(sig.parameters.keys())
     if filter_args:
-        filter_args_ = filter_args
-    else:
+        filter_args_ = list(filter_args)
+    elif existing_params and existing_params[0] in {"self", "cls"} and in_class:
         # Handle classmethods and instance methods
-        existing_params: list[str] = list(sig.parameters.keys())
-        if existing_params and existing_params[0] in {"self", "cls"} and in_class:
-            filter_args_ = [existing_params[0], *list(FILTERED_ARGS)]
-        else:
-            filter_args_ = list(FILTERED_ARGS)
+        filter_args_ = [existing_params[0], *list(FILTERED_ARGS)]
+    else:
+        filter_args_ = list(FILTERED_ARGS)
 
-        for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
-                sig.parameters[existing_param].annotation
-            ):
-                filter_args_.append(existing_param)
+    for existing_param in existing_params:
+        if (
+            not include_injected
+            and existing_param not in filter_args_
+            and _is_injected_arg_type(sig.parameters[existing_param].annotation)
+        ):
+            filter_args_.append(existing_param)
 
     description, arg_descriptions = _infer_arg_descriptions(
         func,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -60,6 +60,7 @@ from langchain_core.tools.base import (
     _DirectlyInjectedToolArg,
     _is_message_content_block,
     _is_message_content_type,
+    create_schema_from_function,
     get_all_basemodel_annotations,
 )
 from langchain_core.utils.function_calling import (
@@ -2410,6 +2411,28 @@ def test_injected_arg_with_complex_type() -> None:
         return foo.value
 
     assert injected_tool.invoke({"x": 5, "foo": Foo()}) == "bar"
+
+
+def test_create_schema_filters_injected_args_when_filter_args_provided() -> None:
+    """Explicit filter_args should not disable injected-arg filtering."""
+
+    def my_tool(
+        query: str,
+        runtime: Annotated[dict[str, Any], InjectedToolArg()],
+        debug_level: int,
+    ) -> str:
+        return query
+
+    schema = create_schema_from_function(
+        "MyToolSchema",
+        my_tool,
+        filter_args=("debug_level",),
+        include_injected=False,
+    )
+
+    assert schema.model_json_schema()["properties"] == {
+        "query": {"title": "Query", "type": "string"}
+    }
 
 
 @pytest.mark.parametrize("schema_format", ["model", "json_schema"])


### PR DESCRIPTION
## Summary
- keep explicit `filter_args` behavior while still excluding injected arguments when `include_injected=False`
- add a regression test covering `create_schema_from_function()` with both options set

## Testing
- `uv run --group test pytest libs/core/tests/unit_tests/test_tools.py -q -k "create_schema_filters_injected_args_when_filter_args_provided or filter_injected_args or filter_multiple_injected_args or filter_tool_runtime_directly_injected_arg or injected_arg_with_complex_type"`
- `uv run --group lint ruff check libs/core/langchain_core/tools/base.py libs/core/tests/unit_tests/test_tools.py`

Closes #35831