### PR TITLE
fix(anthropic): use args path instead of old_path in _handle_rename

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -530,7 +530,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1032,7 +1032,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)


### PR DESCRIPTION
Fixes KeyError when using rename command in Claude file tool middleware.

The tool dispatch function builds the args dict with the source path stored under the key 'path', but both _handle_rename implementations were reading args['old_path'] which never exists, causing a KeyError on every rename command.

Closes #35852