### PR TITLE
chroma: fail fast on async-client misuse in Chroma constructor

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -6,6 +6,7 @@ It contains the Chroma class which is a vector store for handling various tasks.
 from __future__ import annotations
 
 import base64
+import inspect
 import logging
 import uuid
 from collections.abc import Callable, Iterable, Sequence
@@ -367,6 +368,21 @@ class Chroma(VectorStore):
             raise ValueError(msg)
 
         if client is not None:
+            if inspect.iscoroutine(client):
+                msg = (
+                    "`client` is a coroutine. Chroma expects a synchronous "
+                    "`chromadb.ClientAPI` instance."
+                )
+                raise ValueError(msg)
+            if inspect.iscoroutinefunction(
+                getattr(client, "get_or_create_collection", None)
+            ):
+                msg = (
+                    "Asynchronous Chroma clients are not supported by "
+                    "`langchain_chroma.Chroma` yet. Please pass a synchronous "
+                    "`chromadb.ClientAPI` (e.g., `chromadb.HttpClient`)."
+                )
+                raise ValueError(msg)
             self._client = client
 
         # PersistentClient

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -1,3 +1,4 @@
+import pytest
 from langchain_core.embeddings.fake import (
     FakeEmbeddings,
 )
@@ -28,3 +29,31 @@ def test_similarity_search() -> None:
     output = docsearch.similarity_search("foo", k=1)
     docsearch.delete_collection()
     assert len(output) == 1
+
+
+def test_init_rejects_coroutine_client() -> None:
+    """Passing a coroutine as `client` should fail with a clear message."""
+
+    async def _build_client() -> object:
+        return object()
+
+    client_coro = _build_client()
+    try:
+        with pytest.raises(ValueError, match="`client` is a coroutine"):
+            Chroma(client=client_coro)
+    finally:
+        client_coro.close()
+
+
+def test_init_rejects_async_client_api_like_object() -> None:
+    """Async Chroma-style clients should fail fast instead of raising obscure errors."""
+
+    class _AsyncClientLike:
+        async def get_or_create_collection(self, **_kwargs: object) -> object:
+            return object()
+
+    with pytest.raises(
+        ValueError,
+        match="Asynchronous Chroma clients are not supported",
+    ):
+        Chroma(client=_AsyncClientLike())


### PR DESCRIPTION
## Summary
This PR improves `langchain_chroma.Chroma` initialization error handling when users pass an async Chroma client shape to the sync constructor.

## What changed
- Detect and reject `client` values that are coroutine objects.
- Detect and reject async-style clients (`get_or_create_collection` is async).
- Raise actionable `ValueError` messages instead of surfacing a later `AttributeError`.
- Add unit tests for both error paths.

## Why
Issue [#30704](https://github.com/langchain-ai/langchain/issues/30704) currently reports an opaque init-time error for async client usage. This patch does not add async client support yet, but it makes the failure mode explicit and easier to debug.

## Tests
- `uv run --group lint ruff check langchain_chroma/vectorstores.py tests/unit_tests/test_vectorstores.py`
- `uv run --group test pytest -q tests/unit_tests/test_vectorstores.py -q`

Related to #30704