### PR TITLE
partners: Add Joy trust network integration

### DIFF
--- a/libs/partners/joy/LICENSE
+++ b/libs/partners/joy/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joy Trust Network
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/partners/joy/README.md
+++ b/libs/partners/joy/README.md
@@ -1,0 +1,72 @@
+# langchain-joy
+
+LangChain integration for [Joy](https://choosejoy.com.au), a decentralized trust network for AI agents.
+
+## Overview
+
+Joy enables AI agents to verify each other's trustworthiness before collaboration. Agents build reputation through vouches from other trusted agents, similar to a web-of-trust model.
+
+This package provides:
+- **JoyTrustVerifier**: Verify agent trust scores before delegation
+- **JoyTrustTool**: LangChain tool for trust verification in agent workflows
+- **JoyDiscoverTool**: LangChain tool for discovering trusted agents
+
+## Installation
+
+```bash
+pip install langchain-joy
+```
+
+## Quick Start
+
+### Verify an Agent
+
+```python
+from langchain_joy import JoyTrustVerifier
+
+verifier = JoyTrustVerifier(min_trust_score=0.5)
+
+# Simple check
+if verifier.should_trust("ag_xxx"):
+    # Safe to delegate
+    pass
+
+# Detailed verification
+result = verifier.verify_agent("ag_xxx")
+print(f"Score: {result.trust_score}, Vouches: {result.vouch_count}")
+```
+
+### Use as Tools
+
+```python
+from langchain_joy import JoyTrustTool, JoyDiscoverTool
+from langchain.agents import AgentExecutor
+
+# Add to your agent's tools
+tools = [JoyTrustTool(), JoyDiscoverTool()]
+
+# The agent can now verify other agents before delegating
+```
+
+### Discover Trusted Agents
+
+```python
+from langchain_joy import JoyTrustVerifier
+
+verifier = JoyTrustVerifier(min_trust_score=1.0)
+
+# Find trusted agents with specific capabilities
+agents = verifier.discover_trusted_agents(capability="github", limit=5)
+for agent in agents:
+    print(f"{agent.agent_id}: score={agent.trust_score}")
+```
+
+## Environment Variables
+
+- `JOY_API_URL`: Joy API endpoint (default: https://joy-connect.fly.dev)
+- `JOY_API_KEY`: Your Joy API key (optional, for authenticated operations)
+
+## Learn More
+
+- [Joy Documentation](https://choosejoy.com.au/docs)
+- [Joy Network](https://choosejoy.com.au)

--- a/libs/partners/joy/langchain_joy/__init__.py
+++ b/libs/partners/joy/langchain_joy/__init__.py
@@ -1,0 +1,31 @@
+"""LangChain integration for Joy trust network.
+
+Joy is a decentralized trust network where AI agents vouch for each other.
+This integration enables LangChain agents to verify trustworthiness before
+delegating tasks or collaborating with other agents.
+
+Example:
+    from langchain_joy import JoyTrustVerifier
+
+    verifier = JoyTrustVerifier(min_trust_score=0.5)
+
+    # Check if an agent should be trusted
+    if verifier.should_trust("ag_xxx"):
+        # Safe to delegate
+        pass
+
+    # Use as a tool in your agent
+    from langchain_joy import JoyTrustTool, JoyDiscoverTool
+
+    tools = [JoyTrustTool(), JoyDiscoverTool()]
+"""
+
+from langchain_joy.tools import JoyDiscoverTool, JoyTrustTool
+from langchain_joy.verifier import JoyTrustVerifier, TrustVerificationError
+
+__all__ = [
+    "JoyTrustVerifier",
+    "TrustVerificationError",
+    "JoyTrustTool",
+    "JoyDiscoverTool",
+]

--- a/libs/partners/joy/langchain_joy/tools.py
+++ b/libs/partners/joy/langchain_joy/tools.py
@@ -1,0 +1,173 @@
+"""LangChain tools for Joy trust network."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Type
+
+import httpx
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+JOY_API_URL = "https://joy-connect.fly.dev"
+
+
+class JoyTrustInput(BaseModel):
+    """Input for Joy trust verification tool."""
+
+    agent_id: str = Field(description="The Joy agent ID to verify (e.g., 'ag_xxx')")
+    min_trust_score: float = Field(
+        default=0.5,
+        description="Minimum trust score required (0.0-2.0)",
+    )
+
+
+class JoyTrustTool(BaseTool):
+    """Tool for verifying agent trustworthiness using Joy network.
+
+    Use this tool to check if an AI agent should be trusted before
+    delegating tasks or sharing sensitive information.
+
+    Example:
+        from langchain_joy import JoyTrustTool
+
+        tool = JoyTrustTool()
+        result = tool.invoke({"agent_id": "ag_xxx", "min_trust_score": 0.5})
+    """
+
+    name: str = "joy_trust_verify"
+    description: str = (
+        "Verify if an AI agent is trustworthy using the Joy trust network. "
+        "Returns trust score, vouch count, and whether the agent meets "
+        "your minimum trust threshold. Use before delegating sensitive tasks."
+    )
+    args_schema: Type[BaseModel] = JoyTrustInput
+
+    def _run(
+        self,
+        agent_id: str,
+        min_trust_score: float = 0.5,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Verify an agent's trust status."""
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                response = client.get(
+                    f"{JOY_API_URL}/agents/{agent_id}",
+                    headers={"User-Agent": "langchain-joy/0.1.0"},
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            trust_score = float(data.get("trust_score", 0))
+            vouch_count = int(data.get("vouch_count", 0))
+            verified = data.get("verified", False)
+            capabilities = data.get("capabilities", [])
+
+            is_trusted = trust_score >= min_trust_score
+
+            return (
+                f"Agent: {agent_id}\n"
+                f"Trusted: {is_trusted}\n"
+                f"Trust Score: {trust_score:.2f} (min: {min_trust_score})\n"
+                f"Vouch Count: {vouch_count}\n"
+                f"Verified: {verified}\n"
+                f"Capabilities: {', '.join(capabilities[:5])}"
+            )
+
+        except Exception as e:
+            return f"Trust verification failed: {e}"
+
+
+class JoyDiscoverInput(BaseModel):
+    """Input for Joy agent discovery tool."""
+
+    capability: str = Field(
+        default="",
+        description="Capability to search for (e.g., 'github', 'email', 'code')",
+    )
+    query: str = Field(
+        default="",
+        description="Free text search query",
+    )
+    min_trust_score: float = Field(
+        default=0.5,
+        description="Minimum trust score required (0.0-2.0)",
+    )
+    limit: int = Field(
+        default=5,
+        description="Maximum number of agents to return",
+    )
+
+
+class JoyDiscoverTool(BaseTool):
+    """Tool for discovering trusted agents from Joy network.
+
+    Use this tool to find AI agents with specific capabilities
+    that meet your trust requirements.
+
+    Example:
+        from langchain_joy import JoyDiscoverTool
+
+        tool = JoyDiscoverTool()
+        result = tool.invoke({"capability": "github", "min_trust_score": 1.0})
+    """
+
+    name: str = "joy_discover_agents"
+    description: str = (
+        "Discover trusted AI agents from the Joy network. "
+        "Search by capability (e.g., 'github', 'email') or free text query. "
+        "Returns agents that meet your minimum trust threshold."
+    )
+    args_schema: Type[BaseModel] = JoyDiscoverInput
+
+    def _run(
+        self,
+        capability: str = "",
+        query: str = "",
+        min_trust_score: float = 0.5,
+        limit: int = 5,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Discover trusted agents."""
+        try:
+            params: dict[str, Any] = {"limit": limit}
+            if capability:
+                params["capability"] = capability
+            if query:
+                params["query"] = query
+
+            with httpx.Client(timeout=30.0) as client:
+                response = client.get(
+                    f"{JOY_API_URL}/agents/discover",
+                    params=params,
+                    headers={"User-Agent": "langchain-joy/0.1.0"},
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            agents = data.get("agents", [])
+
+            # Filter by trust score
+            trusted = [
+                a
+                for a in agents
+                if float(a.get("trust_score", 0)) >= min_trust_score
+            ]
+
+            if not trusted:
+                return f"No trusted agents found for capability='{capability}' query='{query}'"
+
+            lines = [f"Found {len(trusted)} trusted agents:\n"]
+            for agent in trusted[:limit]:
+                lines.append(
+                    f"- {agent.get('name', 'Unknown')} ({agent.get('id')})\n"
+                    f"  Score: {agent.get('trust_score', 0):.2f}, "
+                    f"Vouches: {agent.get('vouch_count', 0)}\n"
+                    f"  Capabilities: {', '.join(agent.get('capabilities', [])[:3])}"
+                )
+
+            return "\n".join(lines)
+
+        except Exception as e:
+            return f"Agent discovery failed: {e}"

--- a/libs/partners/joy/langchain_joy/verifier.py
+++ b/libs/partners/joy/langchain_joy/verifier.py
@@ -1,0 +1,260 @@
+"""Joy trust verification for LangChain agents."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Optional
+
+import httpx
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+JOY_API_URL = "https://joy-connect.fly.dev"
+
+
+class TrustVerificationError(Exception):
+    """Raised when trust verification fails."""
+
+    pass
+
+
+@dataclass
+class VerificationResult:
+    """Result of agent trust verification."""
+
+    is_trusted: bool
+    agent_id: str
+    trust_score: float
+    vouch_count: int
+    verified: bool
+    capabilities: list[str]
+    error: Optional[str] = None
+
+
+class JoyTrustVerifier:
+    """Verify agent trust using Joy network.
+
+    Joy is a decentralized trust network where agents vouch for each other.
+    This verifier checks an agent's trust score before allowing delegation.
+
+    Example:
+        verifier = JoyTrustVerifier(min_trust_score=0.5)
+
+        # Simple check
+        if verifier.should_trust("ag_xxx"):
+            delegate_task(agent)
+
+        # Detailed verification
+        result = verifier.verify_agent("ag_xxx")
+        print(f"Score: {result.trust_score}, Vouches: {result.vouch_count}")
+    """
+
+    def __init__(
+        self,
+        api_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        min_trust_score: float = 0.5,
+        require_verified: bool = False,
+    ) -> None:
+        """Initialize Joy verifier.
+
+        Args:
+            api_url: Joy API URL (default: from JOY_API_URL env or production)
+            api_key: Joy API key (default: from JOY_API_KEY env)
+            min_trust_score: Minimum trust score to consider agent trusted (0.0-2.0)
+            require_verified: If True, only trust agents with verified badge
+        """
+        self.api_url = (
+            api_url or os.getenv("JOY_API_URL") or JOY_API_URL
+        ).rstrip("/")
+        self.api_key = api_key or os.getenv("JOY_API_KEY")
+        self.min_trust_score = min_trust_score
+        self.require_verified = require_verified
+        self._client: Optional[httpx.Client] = None
+
+    def _get_client(self) -> httpx.Client:
+        """Get or create HTTP client."""
+        if self._client is None:
+            self._client = httpx.Client(timeout=30.0)
+        return self._client
+
+    def _request(self, method: str, path: str, **kwargs: object) -> dict:
+        """Make HTTP request to Joy API."""
+        client = self._get_client()
+        url = f"{self.api_url}{path}"
+
+        headers = dict(kwargs.pop("headers", {}) or {})  # type: ignore[arg-type]
+        headers["User-Agent"] = "langchain-joy/0.1.0"
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+
+        response = client.request(method, url, headers=headers, **kwargs)  # type: ignore[arg-type]
+        response.raise_for_status()
+        return response.json()
+
+    def verify_agent(self, agent_id: str) -> VerificationResult:
+        """Verify an agent's trust status.
+
+        Args:
+            agent_id: Joy agent ID to verify (e.g., "ag_xxx")
+
+        Returns:
+            VerificationResult with trust details
+        """
+        try:
+            data = self._request("GET", f"/agents/{agent_id}")
+
+            trust_score = float(data.get("trust_score", 0))
+            vouch_count = int(data.get("vouch_count", 0))
+            verified = bool(data.get("verified", False))
+            capabilities = data.get("capabilities", [])
+
+            # Determine if trusted based on criteria
+            is_trusted = trust_score >= self.min_trust_score
+            if self.require_verified and not verified:
+                is_trusted = False
+
+            return VerificationResult(
+                is_trusted=is_trusted,
+                agent_id=agent_id,
+                trust_score=trust_score,
+                vouch_count=vouch_count,
+                verified=verified,
+                capabilities=capabilities,
+            )
+
+        except Exception as e:
+            logger.exception("Trust verification failed for %s", agent_id)
+            return VerificationResult(
+                is_trusted=False,
+                agent_id=agent_id,
+                trust_score=0.0,
+                vouch_count=0,
+                verified=False,
+                capabilities=[],
+                error=str(e),
+            )
+
+    def should_trust(self, agent_id: str) -> bool:
+        """Simple check if an agent should be trusted.
+
+        Args:
+            agent_id: Joy agent ID to check
+
+        Returns:
+            True if agent meets trust criteria
+        """
+        result = self.verify_agent(agent_id)
+        return result.is_trusted
+
+    def verify_before_delegation(
+        self,
+        agent_id: str,
+        required_capabilities: Optional[list[str]] = None,
+    ) -> bool:
+        """Verify agent before delegating a task.
+
+        Args:
+            agent_id: Joy agent ID to verify
+            required_capabilities: List of capabilities the agent must have
+
+        Returns:
+            True if agent is trusted and has required capabilities
+
+        Raises:
+            TrustVerificationError: If agent fails verification
+        """
+        result = self.verify_agent(agent_id)
+
+        # Surface API errors
+        if result.error:
+            raise TrustVerificationError(
+                f"Trust verification failed for {agent_id}: {result.error}"
+            )
+
+        if not result.is_trusted:
+            raise TrustVerificationError(
+                f"Agent {agent_id} not trusted: "
+                f"score={result.trust_score} (min={self.min_trust_score})"
+            )
+
+        if required_capabilities:
+            missing = set(required_capabilities) - set(result.capabilities)
+            if missing:
+                raise TrustVerificationError(
+                    f"Agent {agent_id} missing capabilities: {missing}"
+                )
+
+        return True
+
+    def discover_trusted_agents(
+        self,
+        capability: Optional[str] = None,
+        query: Optional[str] = None,
+        limit: int = 10,
+    ) -> list[VerificationResult]:
+        """Discover trusted agents from Joy network.
+
+        Args:
+            capability: Filter by capability (e.g., "code", "research")
+            query: Search query
+            limit: Maximum results
+
+        Returns:
+            List of VerificationResult for trusted agents
+        """
+        params: dict[str, object] = {"limit": limit}
+        if capability:
+            params["capability"] = capability
+        if query:
+            params["query"] = query
+
+        try:
+            data = self._request("GET", "/agents/discover", params=params)
+            agents = data.get("agents", [])
+
+            results = []
+            for agent in agents:
+                trust_score = float(agent.get("trust_score", 0))
+                verified = bool(agent.get("verified", False))
+
+                is_trusted = trust_score >= self.min_trust_score
+                if self.require_verified and not verified:
+                    is_trusted = False
+
+                if is_trusted:
+                    results.append(
+                        VerificationResult(
+                            is_trusted=True,
+                            agent_id=agent.get("id", ""),
+                            trust_score=trust_score,
+                            vouch_count=int(agent.get("vouch_count", 0)),
+                            verified=verified,
+                            capabilities=agent.get("capabilities", []),
+                        )
+                    )
+
+            return results
+
+        except Exception as e:
+            logger.exception("Agent discovery failed")
+            return []
+
+    def close(self) -> None:
+        """Close HTTP client."""
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> "JoyTrustVerifier":
+        """Context manager entry."""
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Context manager exit."""
+        self.close()

--- a/libs/partners/joy/pyproject.toml
+++ b/libs/partners/joy/pyproject.toml
@@ -1,0 +1,59 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langchain-joy"
+version = "0.1.0"
+description = "LangChain integration for Joy trust network - verify agent trustworthiness before delegation"
+license = { text = "MIT" }
+readme = "README.md"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+requires-python = ">=3.10.0,<4.0.0"
+dependencies = [
+    "langchain-core>=1.0.0,<2.0.0",
+    "httpx>=0.25.0,<1.0.0",
+]
+
+[project.urls]
+Homepage = "https://choosejoy.com.au"
+Repository = "https://github.com/langchain-ai/langchain"
+Issues = "https://github.com/langchain-ai/langchain/issues"
+
+[dependency-groups]
+test = [
+    "pytest>=7.3.0,<8.0.0",
+    "pytest-mock>=3.10.0,<4.0.0",
+    "pytest-asyncio>=0.21.1,<1.0.0",
+    "langchain-core",
+    "langchain-tests",
+]
+lint = ["ruff>=0.13.1,<0.14.0"]
+dev = ["langchain-core"]
+typing = [
+    "mypy>=1.10.0,<2.0.0",
+    "langchain-core",
+]
+
+[tool.uv.sources]
+langchain-core = { path = "../../core", editable = true }
+langchain-tests = { path = "../../standard-tests", editable = true }
+
+[tool.mypy]
+disallow_untyped_defs = "True"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/libs/partners/joy/tests/__init__.py
+++ b/libs/partners/joy/tests/__init__.py
@@ -1,0 +1,1 @@
+# Empty file - marks this directory as a Python package so pytest can find tests

--- a/libs/partners/joy/tests/test_tools.py
+++ b/libs/partners/joy/tests/test_tools.py
@@ -1,0 +1,41 @@
+"""Tests for Joy LangChain tools.
+
+These tests verify the tools work correctly against the live Joy API.
+"""
+
+import pytest
+
+from langchain_joy import JoyDiscoverTool, JoyTrustTool
+
+
+def test_trust_tool_init() -> None:
+    """Test JoyTrustTool initializes correctly."""
+    tool = JoyTrustTool()
+    assert tool.name == "joy_trust_verify"
+    assert "trust" in tool.description.lower()
+
+
+def test_discover_tool_init() -> None:
+    """Test JoyDiscoverTool initializes correctly."""
+    tool = JoyDiscoverTool()
+    assert tool.name == "joy_discover_agents"
+    assert "discover" in tool.description.lower()
+
+
+@pytest.mark.requires("httpx")
+def test_trust_tool_invoke() -> None:
+    """Test JoyTrustTool against live API."""
+    tool = JoyTrustTool()
+    # Use a known agent ID from Joy network
+    result = tool.invoke({"agent_id": "ag_229e507d7d87f35cc2bc17ea"})
+    assert "Trust Score" in result
+    assert "Trusted" in result
+
+
+@pytest.mark.requires("httpx")
+def test_discover_tool_invoke() -> None:
+    """Test JoyDiscoverTool against live API."""
+    tool = JoyDiscoverTool()
+    result = tool.invoke({"capability": "github", "limit": 3})
+    # Should find at least one agent or return "No trusted agents"
+    assert "agents" in result.lower() or "found" in result.lower()


### PR DESCRIPTION
## Summary

Adds `langchain-joy` partner package for agent trust verification using the [Joy](https://choosejoy.com.au) trust network.

Joy is a decentralized trust network where AI agents vouch for each other. This integration enables LangChain agents to verify trustworthiness before delegation.

## Components

- **JoyTrustVerifier**: Programmatic trust verification
- **JoyTrustTool**: LangChain tool for trust checks in agent workflows  
- **JoyDiscoverTool**: LangChain tool for discovering trusted agents

## Usage

```python
from langchain_joy import JoyTrustVerifier, JoyTrustTool

# Programmatic verification
verifier = JoyTrustVerifier(min_trust_score=0.5)
if verifier.should_trust("ag_xxx"):
    # Safe to delegate
    pass

# As a tool in agent workflows
tools = [JoyTrustTool(), JoyDiscoverTool()]
```

## Why This Matters

As AI agents collaborate more, there's no standard way to verify which agents are reliable. Joy provides a reputation layer where agents build trust through vouches from other trusted agents.

## Test Plan

- [x] JoyTrustVerifier connects to Joy API
- [x] JoyTrustTool returns formatted trust data
- [x] JoyDiscoverTool finds agents by capability
- [x] Error handling for API failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)