### PR TITLE
fix(core): create independent dicts in BaseLLM metadata_list construction

### DIFF
--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -945,7 +945,7 @@ class BaseLLM(BaseLanguageModel[str], ABC):
             callbacks = cast("list[Callbacks]", callbacks)
             tags_list = cast("list[list[str] | None]", tags or ([None] * len(prompts)))
             metadata_list = cast(
-                "list[dict[str, Any] | None]", metadata or ([{}] * len(prompts))
+                "list[dict[str, Any] | None]", metadata or ([{} for _ in range(len(prompts))])
             )
             run_name_list = run_name or cast(
                 "list[str | None]", ([None] * len(prompts))
@@ -1209,7 +1209,7 @@ class BaseLLM(BaseLanguageModel[str], ABC):
             callbacks = cast("list[Callbacks]", callbacks)
             tags_list = cast("list[list[str] | None]", tags or ([None] * len(prompts)))
             metadata_list = cast(
-                "list[dict[str, Any] | None]", metadata or ([{}] * len(prompts))
+                "list[dict[str, Any] | None]", metadata or ([{} for _ in range(len(prompts))])
             )
             run_name_list = run_name or cast(
                 "list[str | None]", ([None] * len(prompts))


### PR DESCRIPTION
## Summary

Replace `[{}] * len(prompts)` with `[{} for _ in range(len(prompts))]` in `BaseLLM.generate()` and `BaseLLM.agenerate()` to prevent shared mutable dict references.

## Bug Description

The old pattern creates N references to the same dict object. If any downstream code mutates one entry's metadata dict, all entries are silently corrupted.

This is a common Python pitfall: `[{}] * 3` produces `[{}, {}, {}]` where all three elements point to the same object.

## Changes

- `libs/core/langchain_core/language_models/llms.py`: Line ~948 and ~1212

## Testing

Verified that the fix creates independent dicts:
```python
# Old (buggy):
old = [{}] * 3
old[0]["key"] = "value"
# Result: [{"key": "value"}, {"key": "value"}, {"key": "value"}]

# Fixed:
fixed = [{} for _ in range(3)]
fixed[0]["key"] = "value"
# Result: [{"key": "value"}, {}, {}]
```

Fixes: langchain-ai/langchain#35900