### PR TITLE
fix(tools): apply include_injected=False even when filter_args is provided

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -344,7 +344,8 @@ def create_schema_from_function(
     inferred_model = validated.model
 
     if filter_args:
-        filter_args_ = filter_args
+        # Copy to avoid mutating the caller's list when we append injected args below
+        filter_args_ = list(filter_args)
     else:
         # Handle classmethods and instance methods
         existing_params: list[str] = list(sig.parameters.keys())
@@ -353,10 +354,13 @@ def create_schema_from_function(
         else:
             filter_args_ = list(FILTERED_ARGS)
 
-        for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
-                sig.parameters[existing_param].annotation
-            ):
+    # Always filter injected args when include_injected=False, regardless of
+    # whether a custom filter_args list was provided.
+    for existing_param in sig.parameters:
+        if not include_injected and _is_injected_arg_type(
+            sig.parameters[existing_param].annotation
+        ):
+            if existing_param not in filter_args_:
                 filter_args_.append(existing_param)
 
     description, arg_descriptions = _infer_arg_descriptions(


### PR DESCRIPTION
## Problem

`create_schema_from_function` silently ignores `include_injected=False` when `filter_args` is also provided:

```python
from typing import Annotated
from langchain_core.tools import InjectedToolArg
from langchain_core.utils.function_calling import create_schema_from_function

def my_tool(query: str, secret: Annotated[str, InjectedToolArg]):
    pass

schema = create_schema_from_function(
    "MyTool",
    my_tool,
    filter_args=["query"],
    include_injected=False,
)
print(schema.schema()["properties"])
# Expected: {}
# Actual:   {"secret": ...}  ← injected arg leaked
```

**Root cause:** The injected-arg filtering loop was nested inside the `else` branch of the `filter_args` check, so it never ran when the caller supplied a custom `filter_args` list.

`InjectedToolArg` is designed to hide sensitive arguments (API keys, sessions, internal context) from the LLM. When they leak into the schema, the LLM may attempt to fill them in — defeating the purpose of `InjectedToolArg`.

## Fix

- Move the injected-arg filtering loop outside the `if/else` block so it always executes.
- Copy `filter_args` to a local list before appending, avoiding mutation of the caller's sequence.

Fixes #35831