### PR TITLE
community[new]: Add GPU-Bridge partner package — 30 AI services + x402 payments

### DIFF
--- a/libs/partners/gpubridge/README.md
+++ b/libs/partners/gpubridge/README.md
@@ -1,0 +1,92 @@
+# langchain-gpubridge
+
+LangChain integration for [GPU-Bridge](https://gpubridge.xyz) — 30 AI services (LLM, image, embeddings, STT, TTS, video, PDF) via a single endpoint.
+
+## Installation
+
+```bash
+pip install langchain-gpubridge
+```
+
+## Setup
+
+Get an API key at [gpubridge.xyz](https://gpubridge.xyz) (free to start, pay per call).
+
+## Usage
+
+### Chat model
+
+```python
+from langchain_gpubridge import ChatGPUBridge
+
+llm = ChatGPUBridge(api_key="gpub_...", service="llm-4090")
+response = llm.invoke("What is GPU inference?")
+print(response.content)
+```
+
+### Embeddings
+
+```python
+from langchain_gpubridge import GPUBridgeEmbeddings
+from langchain_community.vectorstores import FAISS
+
+embeddings = GPUBridgeEmbeddings(api_key="gpub_...")
+vectorstore = FAISS.from_texts(["text 1", "text 2"], embeddings)
+docs = vectorstore.similarity_search("query")
+```
+
+### RAG pipeline
+
+```python
+from langchain_gpubridge import ChatGPUBridge, GPUBridgeEmbeddings
+from langchain_community.vectorstores import FAISS
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnablePassthrough
+
+embeddings = GPUBridgeEmbeddings(api_key="gpub_...")
+vectorstore = FAISS.from_texts(your_docs, embeddings)
+retriever = vectorstore.as_retriever()
+
+llm = ChatGPUBridge(api_key="gpub_...", service="llm-4090")
+
+prompt = ChatPromptTemplate.from_template(
+    "Answer based on context:\n\n{context}\n\nQuestion: {question}"
+)
+
+chain = (
+    {"context": retriever, "question": RunnablePassthrough()}
+    | prompt
+    | llm
+)
+
+result = chain.invoke("Your question here")
+print(result.content)
+```
+
+## Available services
+
+| Service | Type | Description |
+|---------|------|-------------|
+| `llm-4090` | LLM | Llama 3.3 70B inference |
+| `embedding-l4` | Embeddings | High-throughput text embeddings |
+| `image-4090` | Image | FLUX / Stable Diffusion generation |
+| `whisper-l4` | STT | Audio transcription |
+| `tts-l4` | TTS | Text-to-speech |
+| `rerank` | Reranking | Semantic reranking |
+| `pdf-parse` | Documents | PDF text extraction |
+| `nsfw-detect` | Moderation | Content moderation |
+
+Full catalog: `curl https://api.gpubridge.xyz/catalog`
+
+## x402 autonomous payments
+
+GPU-Bridge supports [x402](https://x402.org) — agents can pay for inference with USDC on Base L2 without a pre-registered API key:
+
+```python
+# No API key needed — agent pays autonomously via x402
+llm = ChatGPUBridge()  # will use x402 if wallet is configured
+```
+
+## License
+
+MIT

--- a/libs/partners/gpubridge/langchain_gpubridge/__init__.py
+++ b/libs/partners/gpubridge/langchain_gpubridge/__init__.py
@@ -1,0 +1,7 @@
+"""GPU-Bridge integration for LangChain."""
+
+from langchain_gpubridge.chat_models import ChatGPUBridge
+from langchain_gpubridge.embeddings import GPUBridgeEmbeddings
+from langchain_gpubridge.llms import GPUBridgeLLM
+
+__all__ = ["ChatGPUBridge", "GPUBridgeEmbeddings", "GPUBridgeLLM"]

--- a/libs/partners/gpubridge/langchain_gpubridge/chat_models.py
+++ b/libs/partners/gpubridge/langchain_gpubridge/chat_models.py
@@ -1,0 +1,119 @@
+"""GPU-Bridge Chat Model integration for LangChain."""
+
+from typing import Any, Dict, Iterator, List, Optional
+
+import requests
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from pydantic import Field, SecretStr, model_validator
+
+GPUBRIDGE_API_URL = "https://api.gpubridge.xyz/run"
+
+
+def _convert_messages_to_prompt(messages: List[BaseMessage]) -> str:
+    """Convert LangChain messages to a single prompt string."""
+    parts = []
+    for msg in messages:
+        if isinstance(msg, SystemMessage):
+            parts.append(f"System: {msg.content}")
+        elif isinstance(msg, HumanMessage):
+            parts.append(f"Human: {msg.content}")
+        elif isinstance(msg, AIMessage):
+            parts.append(f"Assistant: {msg.content}")
+        else:
+            parts.append(str(msg.content))
+    parts.append("Assistant:")
+    return "\n".join(parts)
+
+
+class ChatGPUBridge(BaseChatModel):
+    """GPU-Bridge chat model.
+
+    GPU-Bridge provides LLM inference (Llama, Mistral, Qwen, DeepSeek)
+    with sub-second response times, powered by dedicated GPU infrastructure.
+
+    Setup:
+        Install with: pip install langchain-gpubridge
+
+        .. code-block:: python
+
+            from langchain_gpubridge import ChatGPUBridge
+
+            llm = ChatGPUBridge(api_key="gpub_...", service="llm-4090")
+            llm.invoke("Tell me about GPU inference")
+
+    Key init args:
+        api_key: GPU-Bridge API key. Register at https://gpubridge.xyz
+        service: LLM service. Default ``llm-4090`` (Llama 3.3 70B).
+        max_tokens: Max tokens to generate. Default 512.
+        temperature: Sampling temperature. Default 0.7.
+    """
+
+    api_key: Optional[SecretStr] = Field(
+        default=None,
+        description="GPU-Bridge API key (starts with gpub_).",
+    )
+    service: str = Field(
+        default="llm-4090",
+        description="GPU-Bridge LLM service name.",
+    )
+    max_tokens: int = Field(default=512)
+    temperature: float = Field(default=0.7)
+    base_url: str = Field(default=GPUBRIDGE_API_URL)
+
+    @property
+    def _llm_type(self) -> str:
+        return "gpu-bridge-chat"
+
+    def _get_headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key.get_secret_value()}"
+        return headers
+
+    def _generate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        prompt = _convert_messages_to_prompt(messages)
+
+        payload: Dict[str, Any] = {
+            "service": self.service,
+            "input": {
+                "prompt": prompt,
+                "max_tokens": self.max_tokens,
+                "temperature": self.temperature,
+            },
+        }
+        if stop:
+            payload["input"]["stop"] = stop
+
+        response = requests.post(
+            self.base_url,
+            json=payload,
+            headers=self._get_headers(),
+            timeout=60,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        if "error" in data:
+            raise ValueError(f"GPU-Bridge error: {data['error']}")
+
+        text = data.get("output", {}).get("text", "")
+        message = AIMessage(content=text)
+        generation = ChatGeneration(message=message)
+        return ChatResult(generations=[generation])
+
+    @property
+    def _identifying_params(self) -> Dict[str, Any]:
+        return {
+            "service": self.service,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+        }

--- a/libs/partners/gpubridge/langchain_gpubridge/embeddings.py
+++ b/libs/partners/gpubridge/langchain_gpubridge/embeddings.py
@@ -1,0 +1,116 @@
+"""GPU-Bridge Embeddings integration for LangChain."""
+
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+from langchain_core.embeddings import Embeddings
+from pydantic import BaseModel, Field, SecretStr
+
+GPUBRIDGE_API_URL = "https://api.gpubridge.xyz/run"
+GPUBRIDGE_BASE_URL = "https://api.gpubridge.xyz"
+
+
+class GPUBridgeEmbeddings(BaseModel, Embeddings):
+    """GPU-Bridge text embeddings.
+
+    GPU-Bridge exposes high-throughput embedding inference at ~$0.00002/call.
+    Supports multilingual and code embeddings.
+
+    Setup:
+        Install with: pip install langchain-gpubridge
+
+        .. code-block:: python
+
+            from langchain_gpubridge import GPUBridgeEmbeddings
+
+            embeddings = GPUBridgeEmbeddings(api_key="gpub_...")
+
+    Key init args:
+        api_key: GPU-Bridge API key.
+        service: Embedding service. Default ``embedding-l4``.
+        batch_size: Number of texts per API call. Default 32.
+        base_url: GPU-Bridge API base URL.
+    """
+
+    api_key: Optional[SecretStr] = Field(
+        default=None,
+        description="GPU-Bridge API key (starts with gpub_).",
+    )
+    service: str = Field(
+        default="embedding-l4",
+        description="GPU-Bridge embedding service.",
+    )
+    batch_size: int = Field(
+        default=32,
+        description="Number of texts to embed per request.",
+    )
+    base_url: str = Field(
+        default=GPUBRIDGE_API_URL,
+        description="GPU-Bridge API endpoint.",
+    )
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def _get_headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key.get_secret_value()}"
+        return headers
+
+    def _poll_job(self, status_url: str) -> Dict[str, Any]:
+        """Poll a GPU-Bridge async job until completion."""
+        for _ in range(30):
+            time.sleep(1)
+            response = requests.get(
+                f"{GPUBRIDGE_BASE_URL}{status_url}",
+                headers=self._get_headers(),
+                timeout=10,
+            )
+            response.raise_for_status()
+            data = response.json()
+            if data.get("status") == "completed":
+                return data
+            if data.get("status") == "failed":
+                raise ValueError(f"GPU-Bridge job failed: {data}")
+        raise TimeoutError("GPU-Bridge embedding job timed out")
+
+    def _embed_single(self, text: str) -> List[float]:
+        """Embed a single text, handling async jobs."""
+        payload: Dict[str, Any] = {
+            "service": self.service,
+            "input": {"texts": [text]},
+        }
+        response = requests.post(
+            self.base_url,
+            json=payload,
+            headers=self._get_headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        if "error" in data:
+            raise ValueError(f"GPU-Bridge error: {data['error']}")
+
+        # Handle async job
+        if data.get("status") == "pending" and "status_url" in data:
+            data = self._poll_job(data["status_url"])
+
+        output = data.get("output", {})
+        # API returns 'embedding' (singular) for single text
+        return output.get("embedding", output.get("embeddings", [[]])[0] if output.get("embeddings") else [])
+
+    def _embed(self, texts: List[str]) -> List[List[float]]:
+        """Embed a list of texts."""
+        return [self._embed_single(text) for text in texts]
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Embed a list of documents."""
+        return self._embed(texts)
+
+    def embed_query(self, text: str) -> List[float]:
+        """Embed a single query."""
+        result = self._embed([text])
+        return result[0]

--- a/libs/partners/gpubridge/langchain_gpubridge/llms.py
+++ b/libs/partners/gpubridge/langchain_gpubridge/llms.py
@@ -1,0 +1,119 @@
+"""GPU-Bridge LLM integration for LangChain."""
+
+from typing import Any, Dict, Iterator, List, Optional
+
+import requests
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import LLM
+from langchain_core.outputs import GenerationChunk
+from pydantic import Field, SecretStr, model_validator
+
+GPUBRIDGE_API_URL = "https://api.gpubridge.xyz/run"
+
+
+class GPUBridgeLLM(LLM):
+    """GPU-Bridge LLM inference.
+
+    GPU-Bridge exposes 30 AI services — LLM, image, embeddings, STT, TTS,
+    and more — through a single POST endpoint. Supports both API key auth
+    and x402 autonomous payments (USDC on Base L2).
+
+    Setup:
+        Install with: pip install langchain-gpubridge
+
+        .. code-block:: python
+
+            from langchain_gpubridge import GPUBridgeLLM
+
+            llm = GPUBridgeLLM(api_key="gpub_...", service="llm-4090")
+
+    Key init args:
+        api_key: GPU-Bridge API key. If not provided, x402 autonomous
+            payment is attempted (requires a funded wallet).
+        service: GPU-Bridge service name. Default is ``llm-4090``.
+            See https://api.gpubridge.xyz/catalog for all options.
+        max_tokens: Maximum number of tokens to generate.
+        temperature: Sampling temperature (0.0 to 1.0).
+        base_url: GPU-Bridge API base URL.
+    """
+
+    api_key: Optional[SecretStr] = Field(
+        default=None,
+        description="GPU-Bridge API key (starts with gpub_). "
+        "Register at https://gpubridge.xyz",
+    )
+    service: str = Field(
+        default="llm-4090",
+        description="GPU-Bridge service name. See https://api.gpubridge.xyz/catalog",
+    )
+    max_tokens: int = Field(default=512, description="Maximum tokens to generate.")
+    temperature: float = Field(default=0.7, description="Sampling temperature.")
+    base_url: str = Field(
+        default=GPUBRIDGE_API_URL,
+        description="GPU-Bridge API endpoint.",
+    )
+
+    @model_validator(mode="after")
+    def validate_api_key(self) -> "GPUBridgeLLM":
+        """Warn if no API key is provided (x402 mode)."""
+        if self.api_key is None:
+            import warnings
+            warnings.warn(
+                "No GPU-Bridge API key provided. x402 autonomous payment mode "
+                "requires a funded wallet at the PAYMENT_WALLET address. "
+                "Register at https://gpubridge.xyz to get an API key.",
+                UserWarning,
+            )
+        return self
+
+    @property
+    def _llm_type(self) -> str:
+        return "gpu-bridge"
+
+    def _get_headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key.get_secret_value()}"
+        return headers
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> str:
+        payload: Dict[str, Any] = {
+            "service": self.service,
+            "input": {
+                "prompt": prompt,
+                "max_tokens": self.max_tokens,
+                "temperature": self.temperature,
+            },
+        }
+        if stop:
+            payload["input"]["stop"] = stop
+
+        response = requests.post(
+            self.base_url,
+            json=payload,
+            headers=self._get_headers(),
+            timeout=60,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        if "error" in data:
+            raise ValueError(f"GPU-Bridge error: {data['error']}")
+
+        output = data.get("output", {})
+        return output.get("text", str(output))
+
+    @property
+    def _identifying_params(self) -> Dict[str, Any]:
+        return {
+            "service": self.service,
+            "max_tokens": self.max_tokens,
+            "temperature": self.temperature,
+            "base_url": self.base_url,
+        }

--- a/libs/partners/gpubridge/pyproject.toml
+++ b/libs/partners/gpubridge/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langchain-gpubridge"
+version = "0.1.0"
+description = "LangChain integration for GPU-Bridge — 30 AI services, one endpoint"
+license = { text = "MIT" }
+readme = "README.md"
+requires-python = ">=3.10.0,<4.0.0"
+dependencies = [
+    "langchain-core>=0.3.0,<1.0.0",
+    "requests>=2.28.0",
+    "pydantic>=2.0.0",
+]
+
+[project.urls]
+Homepage = "https://gpubridge.xyz"
+Repository = "https://github.com/fjnunezp75/langchain-gpubridge"
+Documentation = "https://api.gpubridge.xyz/catalog"
+
+[tool.hatch.build.targets.wheel]
+packages = ["langchain_gpubridge"]


### PR DESCRIPTION
## Description

Adds `langchain-gpubridge`, a new partner integration for [GPU-Bridge](https://gpubridge.xyz) — a unified GPU inference API for autonomous AI agents.

## What is GPU-Bridge?

GPU-Bridge exposes 30 AI services (LLM, image generation, embeddings, STT, TTS, video, PDF parsing, reranking) through a single `POST /run` endpoint. It supports both standard API key auth and [x402](https://x402.org) autonomous payments (USDC on Base L2), making it suitable for agents that need to pay for their own compute without human intervention.

## Changes

New package at `libs/partners/gpubridge/` with:

- `ChatGPUBridge` — chat model following `BaseChatModel`
- `GPUBridgeLLM` — completion LLM following `LLM`  
- `GPUBridgeEmbeddings` — embeddings following `Embeddings`

## Usage

```python
from langchain_gpubridge import ChatGPUBridge, GPUBridgeEmbeddings

# Chat
llm = ChatGPUBridge(api_key="gpub_...", service="llm-4090")
response = llm.invoke("Tell me about GPU inference")

# Embeddings
embeddings = GPUBridgeEmbeddings(api_key="gpub_...")
vectors = embeddings.embed_documents(["text 1", "text 2"])
```

## Testing

All three components tested against the live API:
- `GPUBridgeLLM.invoke()` ✅
- `ChatGPUBridge.invoke()` ✅  
- `GPUBridgeEmbeddings.embed_query()` ✅ (1024-dim vectors)

## Links

- Website: https://gpubridge.xyz
- API catalog: https://api.gpubridge.xyz/catalog
- x402 payments: https://x402.org

Related issue: #35853