### PR TITLE
feat(langchain): Added proactive behaviour to ToolCallLimitMiddleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/tool_call_limit.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_call_limit.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from langchain_core.messages import AIMessage, ToolCall, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
 from langgraph.channels.untracked_value import UntrackedValue
 from langgraph.typing import ContextT
 from typing_extensions import NotRequired, override
@@ -12,12 +12,16 @@ from typing_extensions import NotRequired, override
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
+    ModelRequest,
+    ModelResponse,
     PrivateStateAttr,
     ResponseT,
     hook_config,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from langgraph.runtime import Runtime
 
 ExitBehavior = Literal["continue", "error", "end"]
@@ -65,6 +69,33 @@ def _build_tool_message_content(tool_name: str | None) -> str:
     if tool_name:
         return f"Tool call limit exceeded. Do not call '{tool_name}' again."
     return "Tool call limit exceeded. Do not make additional tool calls."
+
+
+def _build_warning_content(remaining: int, tool_name: str | None) -> str:
+    """Build the warning message injected before a model call.
+
+    This message is sent to the model ephemerally via `wrap_model_call` to give
+    it advance notice of how many tool calls remain.
+
+    Args:
+        remaining: Number of tool calls remaining. Values <= 0 mean the budget
+            is exhausted.
+        tool_name: Tool name being limited (if specific tool), or `None` for
+            all tools.
+
+    Returns:
+        A warning string for the model.
+    """
+    tool_desc = f" for '{tool_name}'" if tool_name else ""
+    if remaining <= 0:
+        return (
+            f"[System notice: You have exhausted your tool call budget{tool_desc}. "
+            "Do NOT call any more tools. Summarize what you have so far.]"
+        )
+    return (
+        f"[System notice: You have {remaining} tool call(s) remaining{tool_desc}. "
+        "Plan your tool usage carefully.]"
+    )
 
 
 def _build_final_ai_message_content(
@@ -194,6 +225,23 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
                 print(f"Search limit exceeded: {e}")
             ```
 
+        !!! example "Proactive warnings before limit is reached"
+
+            ```python
+            # Warn the model when approaching the limit
+            limiter = ToolCallLimitMiddleware(
+                run_limit=10,
+                proactive=True,
+                warning_threshold=5,
+            )
+
+            agent = create_agent("openai:gpt-4o", middleware=[limiter])
+            # The model will receive ephemeral warnings like
+            # "[System notice: You have 3 tool call(s) remaining...]"
+            # starting when remaining calls <= 5. The warnings do NOT
+            # persist in the conversation state.
+            ```
+
     """
 
     state_schema = ToolCallLimitState  # type: ignore[assignment]
@@ -205,6 +253,8 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
         thread_limit: int | None = None,
         run_limit: int | None = None,
         exit_behavior: ExitBehavior = "continue",
+        proactive: bool = False,
+        warning_threshold: int = 5,
     ) -> None:
         """Initialize the tool call limit middleware.
 
@@ -225,9 +275,18 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
                     `NotImplementedError` if there are multiple parallel tool
                     calls to other tools or multiple pending tool calls.
 
+            proactive: If `True`, inject an ephemeral warning message into the model
+                request when the remaining tool call budget is at or below
+                `warning_threshold`. The warning is added via `wrap_model_call` /
+                `awrap_model_call` and does **not** persist in the conversation state.
+            warning_threshold: When `proactive` is `True`, start injecting warnings
+                once the number of remaining calls is at or below this value.
+                Must be >= 0.
+
         Raises:
             ValueError: If both limits are `None`, if `exit_behavior` is invalid,
-                or if `run_limit` exceeds `thread_limit`.
+                if `run_limit` exceeds `thread_limit`, or if `warning_threshold`
+                is negative.
         """
         super().__init__()
 
@@ -247,10 +306,16 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
             )
             raise ValueError(msg)
 
+        if warning_threshold < 0:
+            msg = f"warning_threshold must be >= 0, got {warning_threshold}"
+            raise ValueError(msg)
+
         self.tool_name = tool_name
         self.thread_limit = thread_limit
         self.run_limit = run_limit
         self.exit_behavior = exit_behavior
+        self.proactive = proactive
+        self.warning_threshold = warning_threshold
 
     @property
     def name(self) -> str:
@@ -288,6 +353,33 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
             True if this middleware should track this tool call.
         """
         return self.tool_name is None or tool_call["name"] == self.tool_name
+
+    def _remaining_calls(self, state: ToolCallLimitState[ResponseT]) -> float:
+        """Calculate the number of remaining tool calls before a limit is hit.
+
+        Uses the tighter (minimum) of the thread and run limits. Returns
+        `float('inf')` when neither limit is configured (should not happen
+        after `__init__` validation).
+
+        Args:
+            state: The current agent state containing tool call counts.
+
+        Returns:
+            The number of remaining calls (may be negative if counts include
+            blocked attempts).
+        """
+        count_key = self.tool_name or "__all__"
+        remaining: float = float("inf")
+
+        if self.thread_limit is not None:
+            thread_count = state.get("thread_tool_call_count", {}).get(count_key, 0)
+            remaining = min(remaining, self.thread_limit - thread_count)
+
+        if self.run_limit is not None:
+            run_count = state.get("run_tool_call_count", {}).get(count_key, 0)
+            remaining = min(remaining, self.run_limit - run_count)
+
+        return remaining
 
     def _separate_tool_calls(
         self, tool_calls: list[ToolCall], thread_count: int, run_count: int
@@ -486,3 +578,64 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
                 and there are multiple tool calls.
         """
         return self.after_model(state, runtime)
+
+    @override
+    def wrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
+    ) -> ModelResponse[ResponseT] | AIMessage:
+        """Optionally inject a proactive warning before the model call.
+
+        When `proactive` is `True` and the remaining tool call budget is at or
+        below `warning_threshold`, an ephemeral `HumanMessage` warning is appended
+        to the model request via `request.override(messages=...)`. The warning
+        never enters the conversation state.
+
+        Args:
+            request: Model request to execute.
+            handler: Callback that executes the model request.
+
+        Returns:
+            The result of invoking the handler, with or without the injected
+            warning.
+        """
+        if not self.proactive:
+            return handler(request)
+
+        remaining = self._remaining_calls(request.state)  # type: ignore[arg-type]
+        if remaining > self.warning_threshold:
+            return handler(request)
+
+        warning = _build_warning_content(int(remaining), self.tool_name)
+        return handler(
+            request.override(messages=[*request.messages, HumanMessage(content=warning)])
+        )
+
+    @override
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT] | AIMessage:
+        """Async version of `wrap_model_call`.
+
+        Args:
+            request: Model request to execute.
+            handler: Async callback that executes the model request.
+
+        Returns:
+            The result of invoking the handler, with or without the injected
+            warning.
+        """
+        if not self.proactive:
+            return await handler(request)
+
+        remaining = self._remaining_calls(request.state)  # type: ignore[arg-type]
+        if remaining > self.warning_threshold:
+            return await handler(request)
+
+        warning = _build_warning_content(int(remaining), self.tool_name)
+        return await handler(
+            request.override(messages=[*request.messages, HumanMessage(content=warning)])
+        )

--- a/libs/langchain_v1/langchain/agents/middleware/tool_call_limit.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_call_limit.py
@@ -98,6 +98,68 @@ def _build_warning_content(remaining: int, tool_name: str | None) -> str:
     )
 
 
+def _build_initial_context(
+    thread_limit: int | None,
+    run_limit: int | None,
+    warning_threshold: int | list[int],
+    tool_name: str | None,
+) -> str:
+    """Build the initial context message injected on the first model call of a run.
+
+    This message informs the model about the configured tool call limits and
+    warning thresholds so it can plan tool usage from the start.
+
+    Args:
+        thread_limit: Maximum tool calls allowed per thread, or ``None``.
+        run_limit: Maximum tool calls allowed per run, or ``None``.
+        warning_threshold: Warning threshold value(s).
+        tool_name: Tool name being limited (if specific tool), or ``None`` for
+            all tools.
+
+    Returns:
+        A context string for the model.
+    """
+    tool_desc = f" for '{tool_name}'" if tool_name else ""
+    parts = [f"[System notice: Tool call limits are active{tool_desc}."]
+
+    if run_limit is not None:
+        parts.append(f"Run limit: {run_limit} calls.")
+    if thread_limit is not None:
+        parts.append(f"Thread limit (persistent across runs): {thread_limit} calls.")
+
+    if isinstance(warning_threshold, list):
+        thresholds_str = ", ".join(str(t) for t in sorted(warning_threshold, reverse=True))
+        parts.append(f"You will receive warnings when remaining calls reach: {thresholds_str}.")
+    else:
+        parts.append(f"You will receive warnings when {warning_threshold} or fewer calls remain.")
+
+    parts.append("Plan your tool usage accordingly.]")
+    return " ".join(parts)
+
+
+def _validate_warning_threshold(warning_threshold: int | list[int]) -> None:
+    """Validate the ``warning_threshold`` parameter.
+
+    Args:
+        warning_threshold: The value to validate. Must be a non-negative `int` or a
+            non-empty `list[int]` with all elements >= 0.
+
+    Raises:
+        ValueError: If `warning_threshold` is an empty list, contains negative
+            values, or is a negative integer.
+    """
+    if isinstance(warning_threshold, list):
+        if not warning_threshold:
+            msg = "warning_threshold list must not be empty"
+            raise ValueError(msg)
+        if any(t < 0 for t in warning_threshold):
+            msg = f"All warning_threshold values must be >= 0, got {warning_threshold}"
+            raise ValueError(msg)
+    elif warning_threshold < 0:
+        msg = f"warning_threshold must be >= 0, got {warning_threshold}"
+        raise ValueError(msg)
+
+
 def _build_final_ai_message_content(
     thread_count: int,
     run_count: int,
@@ -254,7 +316,7 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
         run_limit: int | None = None,
         exit_behavior: ExitBehavior = "continue",
         proactive: bool = False,
-        warning_threshold: int = 5,
+        warning_threshold: int | list[int] = 5,
     ) -> None:
         """Initialize the tool call limit middleware.
 
@@ -279,9 +341,12 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
                 request when the remaining tool call budget is at or below
                 `warning_threshold`. The warning is added via `wrap_model_call` /
                 `awrap_model_call` and does **not** persist in the conversation state.
-            warning_threshold: When `proactive` is `True`, start injecting warnings
-                once the number of remaining calls is at or below this value.
-                Must be >= 0.
+
+            warning_threshold: When `proactive` is `True`, controls when warnings
+                are injected. If an `int`, warnings fire when remaining calls
+                are at or below this value. If a `list[int]`, warnings fire only
+                when remaining calls exactly match a value in the list.
+                All values must be >= 0.
 
         Raises:
             ValueError: If both limits are `None`, if `exit_behavior` is invalid,
@@ -306,9 +371,7 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
             )
             raise ValueError(msg)
 
-        if warning_threshold < 0:
-            msg = f"warning_threshold must be >= 0, got {warning_threshold}"
-            raise ValueError(msg)
+        _validate_warning_threshold(warning_threshold)
 
         self.tool_name = tool_name
         self.thread_limit = thread_limit
@@ -380,6 +443,33 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
             remaining = min(remaining, self.run_limit - run_count)
 
         return remaining
+
+    def _is_first_model_call_of_run(self, state: ToolCallLimitState[ResponseT]) -> bool:
+        """Check if this is the first model call of the current run.
+
+        Args:
+            state: The current agent state.
+
+        Returns:
+            True if no tool calls have been tracked for this run yet.
+        """
+        count_key = self.tool_name or "__all__"
+        return state.get("run_tool_call_count", {}).get(count_key, 0) == 0
+
+    def _should_warn(self, remaining: float) -> bool:
+        """Check if a warning should be injected based on remaining calls.
+
+        Args:
+            remaining: Number of remaining tool calls.
+
+        Returns:
+            True if a warning should be injected.
+        """
+        if remaining == float("inf"):
+            return False
+        if isinstance(self.warning_threshold, list):
+            return int(remaining) in self.warning_threshold
+        return remaining <= self.warning_threshold
 
     def _separate_tool_calls(
         self, tool_calls: list[ToolCall], thread_count: int, run_count: int
@@ -587,10 +677,13 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
     ) -> ModelResponse[ResponseT] | AIMessage:
         """Optionally inject a proactive warning before the model call.
 
-        When `proactive` is `True` and the remaining tool call budget is at or
-        below `warning_threshold`, an ephemeral `HumanMessage` warning is appended
-        to the model request via `request.override(messages=...)`. The warning
-        never enters the conversation state.
+        When `proactive` is `True`:
+        - On the first model call of a run,
+          an ephemeral `HumanMessage` with initial context about limits is injected.
+        - When the remaining tool call budget triggers `_should_warn`, an ephemeral
+          warning `HumanMessage` is injected instead.
+
+        Neither message persists in the conversation state.
 
         Args:
             request: Model request to execute.
@@ -604,13 +697,22 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
             return handler(request)
 
         remaining = self._remaining_calls(request.state)  # type: ignore[arg-type]
-        if remaining > self.warning_threshold:
-            return handler(request)
 
-        warning = _build_warning_content(int(remaining), self.tool_name)
-        return handler(
-            request.override(messages=[*request.messages, HumanMessage(content=warning)])
-        )
+        if self._should_warn(remaining):
+            warning = _build_warning_content(int(remaining), self.tool_name)
+            return handler(
+                request.override(messages=[*request.messages, HumanMessage(content=warning)])
+            )
+
+        if self._is_first_model_call_of_run(request.state):  # type: ignore[arg-type]
+            context = _build_initial_context(
+                self.thread_limit, self.run_limit, self.warning_threshold, self.tool_name
+            )
+            return handler(
+                request.override(messages=[*request.messages, HumanMessage(content=context)])
+            )
+
+        return handler(request)
 
     @override
     async def awrap_model_call(
@@ -632,10 +734,19 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
             return await handler(request)
 
         remaining = self._remaining_calls(request.state)  # type: ignore[arg-type]
-        if remaining > self.warning_threshold:
-            return await handler(request)
 
-        warning = _build_warning_content(int(remaining), self.tool_name)
-        return await handler(
-            request.override(messages=[*request.messages, HumanMessage(content=warning)])
-        )
+        if self._should_warn(remaining):
+            warning = _build_warning_content(int(remaining), self.tool_name)
+            return await handler(
+                request.override(messages=[*request.messages, HumanMessage(content=warning)])
+            )
+
+        if self._is_first_model_call_of_run(request.state):  # type: ignore[arg-type]
+            context = _build_initial_context(
+                self.thread_limit, self.run_limit, self.warning_threshold, self.tool_name
+            )
+            return await handler(
+                request.override(messages=[*request.messages, HumanMessage(content=context)])
+            )
+
+        return await handler(request)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py
@@ -1,5 +1,9 @@
 """Unit tests for ToolCallLimitMiddleware."""
 
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
 from langchain_core.tools import tool
@@ -11,6 +15,7 @@ from langchain.agents.middleware.tool_call_limit import (
     ToolCallLimitMiddleware,
     ToolCallLimitState,
 )
+from langchain.agents.middleware.types import ModelRequest
 from tests.unit_tests.agents.model import FakeToolCallingModel
 
 
@@ -815,3 +820,261 @@ def test_parallel_mixed_tool_calls_with_specific_tool_limit() -> None:
     assert len(search_success) == 1, "Should have 1 successful search call"
     assert len(search_blocked) == 2, "Should have 2 blocked search calls"
     assert len(calc_success) == 2, "All calculator calls should succeed (not limited)"
+
+
+# ---------------------------------------------------------------------------
+# Proactive warning tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeHandler:
+    """Captures the ModelRequest passed to a wrap_model_call handler."""
+
+    def __init__(self, response: Any = None) -> None:
+        self.captured_request: Any = None
+        self._response = response
+
+    def __call__(self, request: Any) -> Any:
+        self.captured_request = request
+        return self._response
+
+
+class _FakeAsyncHandler:
+    """Async version of _FakeHandler."""
+
+    def __init__(self, response: Any = None) -> None:
+        self.captured_request: Any = None
+        self._response = response
+
+    async def __call__(self, request: Any) -> Any:
+        self.captured_request = request
+        return self._response
+
+
+def _make_request(
+    *,
+    thread_tool_call_count: dict[str, int] | None = None,
+    run_tool_call_count: dict[str, int] | None = None,
+    messages: list | None = None,
+) -> Any:
+    """Build a minimal ModelRequest-like object for unit testing wrap_model_call.
+
+    Uses the real ModelRequest class.
+    """
+    state = ToolCallLimitState(
+        messages=messages or [HumanMessage("hi")],
+    )
+    if thread_tool_call_count is not None:
+        state["thread_tool_call_count"] = thread_tool_call_count
+    if run_tool_call_count is not None:
+        state["run_tool_call_count"] = run_tool_call_count
+
+    return ModelRequest(
+        model=None,  # type: ignore[arg-type]
+        messages=messages or [HumanMessage("hi")],
+        state=state,
+    )
+
+
+def test_proactive_disabled_by_default() -> None:
+    """Default middleware (proactive=False) passes request through unmodified."""
+    middleware = ToolCallLimitMiddleware(run_limit=5)
+    handler = _FakeHandler(response="ok")
+    request = _make_request(run_tool_call_count={"__all__": 4})
+
+    result = middleware.wrap_model_call(request, handler)
+
+    assert result == "ok"
+    assert handler.captured_request is request, "Request should be passed through unmodified"
+
+
+def test_proactive_warning_injected() -> None:
+    """Warning is injected when remaining calls <= threshold."""
+    middleware = ToolCallLimitMiddleware(run_limit=5, proactive=True, warning_threshold=3)
+    handler = _FakeHandler(response="ok")
+    # 3 calls used → 2 remaining → 2 <= 3 → warning fires
+    request = _make_request(run_tool_call_count={"__all__": 3})
+
+    middleware.wrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    assert captured is not request, "Should be a new overridden request"
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "2 tool call(s) remaining" in last_msg.content
+
+
+def test_proactive_no_warning_above_threshold() -> None:
+    """No warning when remaining calls > threshold."""
+    middleware = ToolCallLimitMiddleware(run_limit=5, proactive=True, warning_threshold=3)
+    handler = _FakeHandler(response="ok")
+    # 0 calls used → 5 remaining → 5 > 3 → no warning
+    request = _make_request(run_tool_call_count={"__all__": 0})
+
+    middleware.wrap_model_call(request, handler)
+
+    assert handler.captured_request is request, "Request should be passed through unmodified"
+
+
+def test_proactive_warning_at_exact_threshold() -> None:
+    """Warning fires when remaining == threshold."""
+    middleware = ToolCallLimitMiddleware(run_limit=5, proactive=True, warning_threshold=3)
+    handler = _FakeHandler(response="ok")
+    # 2 calls used → 3 remaining → 3 <= 3 → warning fires
+    request = _make_request(run_tool_call_count={"__all__": 2})
+
+    middleware.wrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    assert captured is not request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "3 tool call(s) remaining" in last_msg.content
+
+
+def test_proactive_exhausted_message() -> None:
+    """Warning says 'exhausted' when remaining == 0."""
+    middleware = ToolCallLimitMiddleware(run_limit=5, proactive=True, warning_threshold=3)
+    handler = _FakeHandler(response="ok")
+    # 5 calls used → 0 remaining
+    request = _make_request(run_tool_call_count={"__all__": 5})
+
+    middleware.wrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "exhausted" in last_msg.content
+    assert "Do NOT" in last_msg.content
+
+
+def test_proactive_with_tool_name() -> None:
+    """Warning mentions the specific tool name when configured."""
+    middleware = ToolCallLimitMiddleware(
+        tool_name="search", run_limit=3, proactive=True, warning_threshold=2
+    )
+    handler = _FakeHandler(response="ok")
+    # 2 calls used → 1 remaining
+    request = _make_request(run_tool_call_count={"search": 2})
+
+    middleware.wrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "'search'" in last_msg.content
+
+
+def test_proactive_threshold_zero() -> None:
+    """With threshold=0, warning only fires when remaining=0 (exhausted)."""
+    middleware = ToolCallLimitMiddleware(run_limit=3, proactive=True, warning_threshold=0)
+    handler = _FakeHandler(response="ok")
+
+    # 2 calls used → 1 remaining → 1 > 0 → no warning
+    request = _make_request(run_tool_call_count={"__all__": 2})
+    middleware.wrap_model_call(request, handler)
+    assert handler.captured_request is request
+
+    # 3 calls used → 0 remaining → 0 <= 0 → warning fires
+    handler2 = _FakeHandler(response="ok")
+    request2 = _make_request(run_tool_call_count={"__all__": 3})
+    middleware.wrap_model_call(request2, handler2)
+    assert handler2.captured_request is not request2
+    assert "exhausted" in handler2.captured_request.messages[-1].content
+
+
+def test_proactive_negative_threshold_raises() -> None:
+    """Negative warning_threshold raises ValueError."""
+    with pytest.raises(ValueError, match="warning_threshold must be >= 0"):
+        ToolCallLimitMiddleware(run_limit=5, warning_threshold=-1)
+
+
+def test_remaining_calls_both_limits() -> None:
+    """_remaining_calls returns the minimum of thread and run remaining."""
+    middleware = ToolCallLimitMiddleware(
+        thread_limit=10, run_limit=5, proactive=True, warning_threshold=5
+    )
+    # thread: 10 - 7 = 3, run: 5 - 2 = 3 → min = 3
+    state = ToolCallLimitState(
+        messages=[HumanMessage("hi")],
+        thread_tool_call_count={"__all__": 7},
+        run_tool_call_count={"__all__": 2},
+    )
+    assert middleware._remaining_calls(state) == 3
+
+    # thread: 10 - 9 = 1, run: 5 - 0 = 5 → min = 1
+    state2 = ToolCallLimitState(
+        messages=[HumanMessage("hi")],
+        thread_tool_call_count={"__all__": 9},
+        run_tool_call_count={"__all__": 0},
+    )
+    assert middleware._remaining_calls(state2) == 1
+
+    # thread: 10 - 2 = 8, run: 5 - 4 = 1 → min = 1
+    state3 = ToolCallLimitState(
+        messages=[HumanMessage("hi")],
+        thread_tool_call_count={"__all__": 2},
+        run_tool_call_count={"__all__": 4},
+    )
+    assert middleware._remaining_calls(state3) == 1
+
+
+@pytest.mark.asyncio
+async def test_proactive_awrap_model_call() -> None:
+    """Async wrap_model_call injects warning identically to sync version."""
+    middleware = ToolCallLimitMiddleware(run_limit=5, proactive=True, warning_threshold=3)
+    handler = _FakeAsyncHandler(response="ok")
+    request = _make_request(run_tool_call_count={"__all__": 3})
+
+    result = await middleware.awrap_model_call(request, handler)
+
+    assert result == "ok"
+    captured = handler.captured_request
+    assert captured is not request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "2 tool call(s) remaining" in last_msg.content
+
+
+def test_proactive_warning_with_create_agent() -> None:
+    """Integration test: proactive warning reaches model but doesn't pollute state."""
+
+    @tool
+    def search(query: str) -> str:
+        """Search for information."""
+        return f"Results for {query}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="search", args={"query": "q1"}, id="1")],
+            [ToolCall(name="search", args={"query": "q2"}, id="2")],
+            [],
+        ]
+    )
+
+    limiter = ToolCallLimitMiddleware(
+        run_limit=3, proactive=True, warning_threshold=2, exit_behavior="continue"
+    )
+    agent = create_agent(
+        model=model,
+        tools=[search],
+        middleware=[limiter],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Question")]},
+        {"configurable": {"thread_id": "proactive_test"}},
+    )
+
+    # Warning should NOT appear as a HumanMessage in the final state
+    human_messages = [msg for msg in result["messages"] if isinstance(msg, HumanMessage)]
+    for msg in human_messages:
+        assert isinstance(msg.content, str)
+        assert "System notice" not in msg.content, (
+            "Proactive warning should not persist in conversation state"
+        )
+
+    # Agent should complete normally with tool results
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert len(tool_messages) >= 1, "Agent should have executed at least one tool call"

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py
@@ -905,11 +905,11 @@ def test_proactive_warning_injected() -> None:
 
 
 def test_proactive_no_warning_above_threshold() -> None:
-    """No warning when remaining calls > threshold."""
+    """No injection when not the first call of the run and remaining calls > threshold."""
     middleware = ToolCallLimitMiddleware(run_limit=5, proactive=True, warning_threshold=3)
     handler = _FakeHandler(response="ok")
-    # 0 calls used → 5 remaining → 5 > 3 → no warning
-    request = _make_request(run_tool_call_count={"__all__": 0})
+    # 1 call already made (not first call) → 4 remaining → 4 > 3 → no injection
+    request = _make_request(run_tool_call_count={"__all__": 1})
 
     middleware.wrap_model_call(request, handler)
 
@@ -1078,3 +1078,213 @@ def test_proactive_warning_with_create_agent() -> None:
     # Agent should complete normally with tool results
     tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
     assert len(tool_messages) >= 1, "Agent should have executed at least one tool call"
+
+
+def test_proactive_initial_context_injected() -> None:
+    """First model call of a run injects initial context when above warning threshold."""
+    middleware = ToolCallLimitMiddleware(run_limit=10, proactive=True, warning_threshold=3)
+    handler = _FakeHandler(response="ok")
+    # First call: run_count=0 → remaining=10 > 3 → initial context fires
+
+    request = _make_request(run_tool_call_count={})
+    middleware.wrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    assert captured is not request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "Tool call limits are active" in last_msg.content
+    assert "Run limit: 10" in last_msg.content
+
+
+def test_proactive_initial_context_not_on_subsequent_calls() -> None:
+    """Subsequent model calls (run_count > 0) do not inject initial context."""
+    middleware = ToolCallLimitMiddleware(run_limit=10, proactive=True, warning_threshold=3)
+    handler = _FakeHandler(response="ok")
+    # Not first call: run_count=2 → remaining=8 > 3 → no injection
+    request = _make_request(run_tool_call_count={"__all__": 2})
+
+    middleware.wrap_model_call(request, handler)
+
+    assert handler.captured_request is request, "Request should be passed through unmodified"
+
+
+def test_proactive_initial_context_skipped_when_in_warning_zone() -> None:
+    """First call in warning zone gets warning only, not initial context."""
+    middleware = ToolCallLimitMiddleware(run_limit=3, proactive=True, warning_threshold=5)
+    handler = _FakeHandler(response="ok")
+    # First call: run_count=0 → remaining=3 ≤ 5 → warning fires (not initial context)
+    request = _make_request(run_tool_call_count={})
+
+    middleware.wrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "3 tool call(s) remaining" in last_msg.content
+    assert "Tool call limits are active" not in last_msg.content
+
+
+def test_proactive_initial_context_with_tool_name() -> None:
+    """Initial context message mentions the specific tool name."""
+    middleware = ToolCallLimitMiddleware(
+        tool_name="search", run_limit=8, proactive=True, warning_threshold=2
+    )
+    handler = _FakeHandler(response="ok")
+    request = _make_request(run_tool_call_count={})
+
+    middleware.wrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "'search'" in last_msg.content
+    assert "Run limit: 8" in last_msg.content
+
+
+def test_proactive_initial_context_message_content() -> None:
+    """Initial context includes thread_limit, run_limit, and warning_threshold."""
+    middleware = ToolCallLimitMiddleware(
+        thread_limit=20, run_limit=10, proactive=True, warning_threshold=4
+    )
+    handler = _FakeHandler(response="ok")
+    request = _make_request(run_tool_call_count={})
+
+    middleware.wrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    content = last_msg.content
+    assert "Run limit: 10" in content
+    assert "Thread limit (persistent across runs): 20" in content
+    assert "4 or fewer calls remain" in content
+
+
+@pytest.mark.asyncio
+async def test_proactive_initial_context_async() -> None:
+    """Async wrap_model_call injects initial context identically to sync version."""
+    middleware = ToolCallLimitMiddleware(run_limit=10, proactive=True, warning_threshold=3)
+    handler = _FakeAsyncHandler(response="ok")
+    request = _make_request(run_tool_call_count={})
+
+    await middleware.awrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    assert captured is not request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "Tool call limits are active" in last_msg.content
+
+
+def test_warning_threshold_list_exact_match() -> None:
+    """List threshold fires only at exact remaining counts."""
+    middleware = ToolCallLimitMiddleware(run_limit=10, proactive=True, warning_threshold=[5, 2])
+    handler = _FakeHandler(response="ok")
+
+    # remaining=5 → exact match → warning fires
+    request = _make_request(run_tool_call_count={"__all__": 5})
+    middleware.wrap_model_call(request, handler)
+    captured = handler.captured_request
+    assert captured is not request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "5 tool call(s) remaining" in last_msg.content
+
+    # remaining=2 → exact match → warning fires
+    handler2 = _FakeHandler(response="ok")
+    request2 = _make_request(run_tool_call_count={"__all__": 8})
+    middleware.wrap_model_call(request2, handler2)
+    captured2 = handler2.captured_request
+    last_msg2 = captured2.messages[-1]
+    assert isinstance(last_msg2, HumanMessage)
+    assert "2 tool call(s) remaining" in last_msg2.content
+
+
+def test_warning_threshold_list_no_warn_between() -> None:
+    """No warning at remaining counts not in the list."""
+    middleware = ToolCallLimitMiddleware(run_limit=10, proactive=True, warning_threshold=[5, 2])
+    handler = _FakeHandler(response="ok")
+
+    # remaining=4 → not in [5, 2] → no warning (also not first call)
+    request = _make_request(run_tool_call_count={"__all__": 6})
+    middleware.wrap_model_call(request, handler)
+    assert handler.captured_request is request, "Request should pass through unmodified"
+
+
+def test_warning_threshold_list_validation() -> None:
+    """Empty list and negative elements raise ValueError."""
+    with pytest.raises(ValueError, match="must not be empty"):
+        ToolCallLimitMiddleware(run_limit=5, warning_threshold=[])
+
+    with pytest.raises(ValueError, match="must be >= 0"):
+        ToolCallLimitMiddleware(run_limit=5, warning_threshold=[3, -1])
+
+
+def test_warning_threshold_list_with_tool_name() -> None:
+    """List threshold works with tool_name filtering."""
+    middleware = ToolCallLimitMiddleware(
+        tool_name="search", run_limit=6, proactive=True, warning_threshold=[3, 1]
+    )
+    handler = _FakeHandler(response="ok")
+
+    # remaining=3 for "search" → exact match → warning fires
+    request = _make_request(run_tool_call_count={"search": 3})
+    middleware.wrap_model_call(request, handler)
+    captured = handler.captured_request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "'search'" in last_msg.content
+    assert "3 tool call(s) remaining" in last_msg.content
+
+
+def test_warning_threshold_int_backward_compat() -> None:
+    """Integer threshold retains existing <= behavior."""
+    middleware = ToolCallLimitMiddleware(run_limit=10, proactive=True, warning_threshold=3)
+    handler = _FakeHandler(response="ok")
+
+    # remaining=3 → 3 <= 3 → warning fires
+    request = _make_request(run_tool_call_count={"__all__": 7})
+    middleware.wrap_model_call(request, handler)
+    captured = handler.captured_request
+    assert captured is not request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "3 tool call(s) remaining" in last_msg.content
+
+    # remaining=2 → 2 <= 3 → warning also fires
+    handler2 = _FakeHandler(response="ok")
+    request2 = _make_request(run_tool_call_count={"__all__": 8})
+    middleware.wrap_model_call(request2, handler2)
+    captured2 = handler2.captured_request
+    assert captured2 is not request2
+
+
+@pytest.mark.asyncio
+async def test_warning_threshold_list_async() -> None:
+    """Async wrap_model_call works with list threshold."""
+    middleware = ToolCallLimitMiddleware(run_limit=10, proactive=True, warning_threshold=[5, 2])
+    handler = _FakeAsyncHandler(response="ok")
+
+    # remaining=5 → exact match → warning fires
+    request = _make_request(run_tool_call_count={"__all__": 5})
+    await middleware.awrap_model_call(request, handler)
+    captured = handler.captured_request
+    assert captured is not request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "5 tool call(s) remaining" in last_msg.content
+
+
+def test_proactive_initial_context_with_list_threshold() -> None:
+    """Initial context message correctly describes list-based thresholds."""
+    middleware = ToolCallLimitMiddleware(run_limit=10, proactive=True, warning_threshold=[5, 3, 1])
+    handler = _FakeHandler(response="ok")
+    request = _make_request(run_tool_call_count={})
+
+    middleware.wrap_model_call(request, handler)
+
+    captured = handler.captured_request
+    last_msg = captured.messages[-1]
+    assert isinstance(last_msg, HumanMessage)
+    assert "5, 3, 1" in last_msg.content


### PR DESCRIPTION
Fixes #35766

### Description of changes
Add proactive suuport to `ToolCallLimitMiddleware`: adds `proactive` and
`warning_threshold` parameters to inject ephemeral limit-awareness messages before model
calls, including initial context on the first call of each run and warnings as the budget
runs low. Also extends `warning_threshold` to accept `list[int]` for discrete warning points.


### Background
`ToolCallLimitMiddleware` was purely reactive. It only acted after tool calls limit were reached. This has few problems: 
1. This might make LLM to utilize tools less effectively since it is not aware of tool limit from the beginning. When the limit is reached we panick the LLM by sending tool call limit reached message all of a sudden which it was not aware of

2. The reactive way of detecting tool call limit leads to additional tool call which doesn't get used.


### Changes Summary
 - Two new keyword-only params (proactive: bool = False, warning_threshold: int = 5) and implements wrap_model_call / awrap_model_call to inject an ephemeral HumanMessage warning via request.override(messages=...) when the remaining threshold condition is met.
  - Key design decision: uses wrap_model_call (not before_model) because before_model returns persistent state updates via add_messages reducer - repeated warnings would accumulate in history. wrap_model_call + request.override() keeps warnings ephemeral, following the same pattern as ContextEditingMiddleware.
 - In the beginning of each run LLM is provided with the details of tool call limit so that LLM has idea right from the beginning about tool call limit and later based of `warning_threshold` warning messages are injected to inform LLM about the available budget
 - Backward-compatible: proactive defaults to False and warning_builder defaults to None, so existing behavior is unchanged.

### How I verified the changes:
 - Added 28 new unit tests which includes initial context injection, subsequent warning messages based on int and list based warning_threshold, backward compatibility checks, tool-name variant
 - Overall 41 tests in `test_tool_call_limit.py` -- all passed.
 - Ran `make test`, `make format` & `make lint`

This PR is built on top of @pawel-twardziak initial [PR](https://github.com/langchain-ai/langchain/pull/35894). Thanks for the inital code setup. 