### PR TITLE
fix(openai): add strict=False when not specified for Responses API + tests

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3999,7 +3999,14 @@ def _construct_responses_api_payload(
             # responses api: {"type": "function", "name": "...", "description": "...", "parameters": {...}, "strict": ...}  # noqa: E501
             if tool["type"] == "function" and "function" in tool:
                 extra = {k: v for k, v in tool.items() if k not in ("type", "function")}
-                new_tools.append({"type": "function", **tool["function"], **extra})
+                func = tool["function"]
+                # Responses API defaults strict=True, but Chat Completions defaults
+                # to non-strict (false). Preserve the original semantics by explicitly
+                # setting strict=False when not specified.
+                # See https://github.com/langchain-ai/langchain/issues/35837
+                if "strict" not in func:
+                    func = {**func, "strict": False}
+                new_tools.append({"type": "function", **func, **extra})
             else:
                 if tool["type"] == "image_generation":
                     # Handle partial images (not yet supported)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_strict.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_strict.py
@@ -1,0 +1,84 @@
+"""Tests for strict parameter handling in Responses API"""
+
+import pytest
+from langchain_core.messages import HumanMessage
+from langchain_openai.chat_models.base import _construct_responses_api_payload
+
+
+class TestStrictParameter:
+    def test_strict_false_added_when_not_specified(self):
+        """Test that strict=False is added when not specified in tool definition."""
+        messages = [HumanMessage(content="test")]
+        payload = {
+            "model": "gpt-5",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "test_tool",
+                        "description": "A test tool",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                        },
+                    },
+                }
+            ],
+        }
+
+        result = _construct_responses_api_payload(messages, payload)
+
+        # strict should be added as False
+        assert result["tools"][0]["strict"] is False
+
+    def test_strict_preserved_when_explicitly_set(self):
+        """Test that explicit strict value is preserved."""
+        messages = [HumanMessage(content="test")]
+        payload = {
+            "model": "gpt-5",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "test_tool",
+                        "description": "A test tool",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                        },
+                        "strict": True,
+                    },
+                }
+            ],
+        }
+
+        result = _construct_responses_api_payload(messages, payload)
+
+        # strict should be preserved as True
+        assert result["tools"][0]["strict"] is True
+
+    def test_strict_false_preserved_when_explicitly_set(self):
+        """Test that explicit strict=False is preserved."""
+        messages = [HumanMessage(content="test")]
+        payload = {
+            "model": "gpt-5",
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "test_tool",
+                        "description": "A test tool",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"query": {"type": "string"}},
+                        },
+                        "strict": False,
+                    },
+                }
+            ],
+        }
+
+        result = _construct_responses_api_payload(messages, payload)
+
+        # strict should be preserved as False
+        assert result["tools"][0]["strict"] is False


### PR DESCRIPTION
## Summary

This PR addresses Copilot's review feedback on PR #1, adding unit tests to verify the strict parameter handling.

## Changes

1. **Code fix**: Added logic to explicitly set strict=False when not specified in tool definition, preserving Chat Completions API semantics.

2. **Unit tests**: Added 	est_responses_strict.py with three test cases:
   - 	est_strict_false_added_when_not_specified: Verifies strict=False is added
   - 	est_strict_preserved_when_explicitly_set: Verifies explicit strict=True is preserved
   - 	est_strict_false_preserved_when_explicitly_set: Verifies explicit strict=False is preserved

## Why

Responses API defaults strict=True, but Chat Completions defaults to false. This fix ensures tools with regex patterns or complex JSON schemas continue to work when switching to Responses API.