### PR TITLE
fix(core): fix nested subgraph rendering for 3+ levels with draw_mermaid

### DIFF
--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -233,18 +233,52 @@ def draw_mermaid(
         add_subgraph(edges_, prefix)
         seen_subgraphs.add(prefix)
 
-    # Add empty subgraphs (subgraphs with no internal edges)
+    # Add empty subgraphs (subgraphs with no internal edges).
+    # Multi-level prefixes (e.g. "parent:child") require nested subgraph blocks,
+    # so we expand all ancestor levels and recurse depth-first.
     if with_styles:
-        for prefix, subgraph_node in subgraph_nodes.items():
-            if ":" not in prefix and prefix not in seen_subgraphs:
-                mermaid_graph += f"\tsubgraph {prefix}\n"
+        # Collect all prefix levels needed, including virtual ancestors that have
+        # no nodes of their own but are required to wrap deeper subgraphs.
+        all_unseen_prefixes: set[str] = set()
+        for prefix in subgraph_nodes:
+            if prefix not in seen_subgraphs:
+                parts = prefix.split(":")
+                for i in range(1, len(parts) + 1):
+                    all_unseen_prefixes.add(":".join(parts[:i]))
 
-                # Add nodes that belong to this subgraph
-                for key, node in subgraph_node.items():
+        def add_empty_subgraph_recursive(prefix: str) -> None:
+            nonlocal mermaid_graph
+            if prefix in seen_subgraphs:
+                return
+            subgraph_name = (
+                prefix.rsplit(":", maxsplit=1)[-1] if ":" in prefix else prefix
+            )
+            mermaid_graph += f"\tsubgraph {subgraph_name}\n"
+            # Mark as seen before recursing to prevent duplicate rendering.
+            seen_subgraphs.add(prefix)
+
+            # Add nodes that belong directly to this subgraph level.
+            if prefix in subgraph_nodes:
+                for key, node in subgraph_nodes[prefix].items():
                     mermaid_graph += render_node(key, node)
 
-                mermaid_graph += "\tend\n"
-                seen_subgraphs.add(prefix)
+            # Recurse into direct child subgraphs (one level deeper).
+            for child_prefix in sorted(all_unseen_prefixes):
+                if child_prefix in seen_subgraphs:
+                    continue
+                parent_of_child = (
+                    child_prefix.rsplit(":", maxsplit=1)[0]
+                    if ":" in child_prefix
+                    else ""
+                )
+                if parent_of_child == prefix:
+                    add_empty_subgraph_recursive(child_prefix)
+
+            mermaid_graph += "\tend\n"
+
+        for prefix in sorted(all_unseen_prefixes):
+            if ":" not in prefix and prefix not in seen_subgraphs:
+                add_empty_subgraph_recursive(prefix)
 
     # Add custom styles for nodes
     if with_styles:

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_graph.ambr
@@ -1,4 +1,27 @@
 # serializer version: 1
+# name: test_deep_single_node_subgraph_mermaid[mermaid]
+  '''
+  ---
+  config:
+    flowchart:
+      curve: linear
+  ---
+  graph TD;
+  	__start__([<p>__start__</p>]):::first
+  	__end__([<p>__end__</p>]):::last
+  	__start__ --> parent\3achild\3agrandchild;
+  	parent\3achild\3agrandchild --> __end__;
+  	subgraph parent
+  	subgraph child
+  	parent\3achild\3agrandchild(grandchild)
+  	end
+  	end
+  	classDef default fill:#f2f0ff,line-height:1.2
+  	classDef first fill-opacity:0
+  	classDef last fill:#bfb6fc
+  
+  '''
+# ---
 # name: test_double_nested_subgraph_mermaid[mermaid]
   '''
   ---

--- a/libs/core/tests/unit_tests/runnables/test_graph.py
+++ b/libs/core/tests/unit_tests/runnables/test_graph.py
@@ -455,6 +455,51 @@ def test_triple_nested_subgraph_mermaid(snapshot: SnapshotAssertion) -> None:
     assert graph.draw_mermaid() == snapshot(name="mermaid")
 
 
+def test_deep_single_node_subgraph_mermaid(snapshot: SnapshotAssertion) -> None:
+    """3-level nesting with no internal edges should render nested subgraph boxes.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/35492.
+    When the only internal node is ``parent:child:grandchild``, all edges connect
+    nodes across subgraph boundaries so ``draw_mermaid`` took the "empty subgraphs"
+    code path.  The previous condition ``if ":" not in prefix`` skipped multi-level
+    prefixes entirely, producing flat escaped IDs instead of nested subgraph boxes.
+    """
+    empty_data = BaseModel
+    nodes = {
+        "__start__": Node(
+            id="__start__", name="__start__", data=empty_data, metadata=None
+        ),
+        "parent:child:grandchild": Node(
+            id="parent:child:grandchild",
+            name="grandchild",
+            data=empty_data,
+            metadata=None,
+        ),
+        "__end__": Node(id="__end__", name="__end__", data=empty_data, metadata=None),
+    }
+    edges = [
+        Edge(
+            source="__start__",
+            target="parent:child:grandchild",
+            data=None,
+            conditional=False,
+        ),
+        Edge(
+            source="parent:child:grandchild",
+            target="__end__",
+            data=None,
+            conditional=False,
+        ),
+    ]
+    graph = Graph(nodes, edges)
+    result = graph.draw_mermaid()
+    assert result == snapshot(name="mermaid")
+    # The rendered output must contain proper nested subgraph boxes, not flat
+    # escaped IDs like ``parent\3achild\3agrandchild`` as a bare node label.
+    assert "subgraph parent" in result
+    assert "subgraph child" in result
+
+
 def test_single_node_subgraph_mermaid(snapshot: SnapshotAssertion) -> None:
     empty_data = BaseModel
     nodes = {


### PR DESCRIPTION
## Summary

Fixes #35492.

Replaces the flat "empty subgraphs" loop in `draw_mermaid` with a recursive helper that correctly renders `subgraph`/`end` nesting for 3+ level deep graphs where no subgraph has internal edges.

## Root Cause

`draw_mermaid` has two rendering paths for subgraphs:

1. **`add_subgraph()` (recursive)** — handles subgraphs that contain edges between their own nodes.
2. **"empty subgraphs" loop** — handles subgraphs whose nodes only connect to nodes outside the subgraph.

The bug lives in path 2. The loop contained:

```python
if ":" not in prefix and prefix not in seen_subgraphs:
```

For 3+ level nesting (e.g. `parent:child:grandchild` as the single internal node), the prefix is `parent:child` — a multi-level key containing a colon. The condition `":" not in prefix` evaluates to `False`, so the subgraph box for both `parent` and `child` is **never emitted**. The node renders as a flat, escaped ID (`parent\3achild\3agrandchild`) rather than being nested inside proper `subgraph` boxes.

2-level nesting (`sub:leaf`) was unaffected because its prefix is `sub` — no colon.

## Solution

Replaced the flat loop with a recursive helper `add_empty_subgraph_recursive`:

1. Before the loop, expand every unseen prefix into all ancestor levels (e.g. `parent:child` → `{"parent", "parent:child"}`).
2. Start from each top-level prefix (no colon) and recurse into direct children, emitting `subgraph`/`end` pairs at each depth.
3. Nodes are still rendered with the same single-tab indent as before — no snapshot changes for existing 2-level tests.

## Testing

- Added `test_deep_single_node_subgraph_mermaid` reproducing the exact scenario from the issue: a 3-level graph (`__start__ → parent:child:grandchild → __end__`) with no internal subgraph edges.
- All 22 existing graph unit tests pass unchanged.
- Assertions verify both `subgraph parent` and `subgraph child` appear in the output.

```
pytest libs/core/tests/unit_tests/runnables/test_graph.py -v
# 22 passed
```

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New test covers the exact failing scenario from the issue
- [x] All existing tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions
- [x] Read CONTRIBUTING.md

> **Note**: This PR was created with the assistance of an AI agent (Claude Code). The root cause analysis, implementation, and tests were reviewed and verified by running the full test suite locally.