### PR TITLE
feat(openrouter): add support for Anthropic automatic caching

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
@@ -233,6 +234,12 @@ class ChatOpenRouter(BaseChatModel):
     model_kwargs: dict[str, Any] = Field(default_factory=dict)
     """Any extra model parameters for the OpenRouter API."""
 
+    cache_control: dict[str, Any] | None = None
+    """Top-level cache control settings for Anthropic automatic caching.
+
+    Example: `{"type": "ephemeral"}`
+    """
+
     reasoning: dict[str, Any] | None = None
     """Reasoning settings to pass to OpenRouter.
 
@@ -276,7 +283,9 @@ class ChatOpenRouter(BaseChatModel):
     def build_extra(cls, values: dict[str, Any]) -> Any:
         """Build extra kwargs from additional params that were passed in."""
         all_required_field_names = get_pydantic_field_names(cls)
-        extra = values.get("model_kwargs", {})
+        extra = dict(values.get("model_kwargs", {}))
+        if "cache_control" in extra and "cache_control" not in values:
+            values["cache_control"] = extra.pop("cache_control")
         for field_name in list(values):
             if field_name in extra:
                 msg = f"Found {field_name} supplied twice."
@@ -387,6 +396,7 @@ class ChatOpenRouter(BaseChatModel):
             "max_tokens": self.max_tokens,
             "top_p": self.top_p,
             "streaming": self.streaming,
+            "cache_control": self.cache_control,
             "reasoning": self.reasoning,
             "openrouter_provider": self.openrouter_provider,
             "route": self.route,
@@ -427,6 +437,7 @@ class ChatOpenRouter(BaseChatModel):
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs}
         _strip_internal_kwargs(params)
+        _validate_sdk_request_param_support(self.client, "send", params)
         sdk_messages = _wrap_messages_for_sdk(message_dicts)
         response = self.client.chat.send(messages=sdk_messages, **params)
         return self._create_chat_result(response)
@@ -446,6 +457,7 @@ class ChatOpenRouter(BaseChatModel):
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs}
         _strip_internal_kwargs(params)
+        _validate_sdk_request_param_support(self.client, "send_async", params)
         sdk_messages = _wrap_messages_for_sdk(message_dicts)
         response = await self.client.chat.send_async(messages=sdk_messages, **params)
         return self._create_chat_result(response)
@@ -462,6 +474,7 @@ class ChatOpenRouter(BaseChatModel):
         if self.stream_usage:
             params["stream_options"] = {"include_usage": True}
         _strip_internal_kwargs(params)
+        _validate_sdk_request_param_support(self.client, "send", params)
         sdk_messages = _wrap_messages_for_sdk(message_dicts)
 
         default_chunk_class: type[BaseMessageChunk] = AIMessageChunk
@@ -548,6 +561,7 @@ class ChatOpenRouter(BaseChatModel):
         if self.stream_usage:
             params["stream_options"] = {"include_usage": True}
         _strip_internal_kwargs(params)
+        _validate_sdk_request_param_support(self.client, "send_async", params)
         sdk_messages = _wrap_messages_for_sdk(message_dicts)
 
         default_chunk_class: type[BaseMessageChunk] = AIMessageChunk
@@ -653,6 +667,8 @@ class ChatOpenRouter(BaseChatModel):
             params["n"] = self.n
         if self.stop is not None:
             params["stop"] = self.stop
+        if self.cache_control is not None:
+            params["cache_control"] = self.cache_control
         # OpenRouter-specific params
         if self.reasoning is not None:
             params["reasoning"] = self.reasoning
@@ -906,6 +922,41 @@ class ChatOpenRouter(BaseChatModel):
 
 def _is_pydantic_class(obj: Any) -> bool:
     return isinstance(obj, type) and is_basemodel_subclass(obj)
+
+
+def _sdk_supports_request_param(method: Callable[..., Any], param_name: str) -> bool:
+    """Return whether an SDK method accepts a given request parameter."""
+    try:
+        signature = inspect.signature(method)
+    except (TypeError, ValueError):
+        return True
+
+    for parameter in signature.parameters.values():
+        if parameter.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if parameter.name == param_name:
+            return True
+    return False
+
+
+def _validate_sdk_request_param_support(
+    client: Any, method_name: str, params: Mapping[str, Any]
+) -> None:
+    """Raise a clear error when the installed SDK is too old for `cache_control`."""
+    if "cache_control" not in params:
+        return
+
+    chat_client = getattr(client, "chat", None)
+    method = getattr(chat_client, method_name, None)
+    if method is None or _sdk_supports_request_param(method, "cache_control"):
+        return
+
+    msg = (
+        "The installed `openrouter` Python SDK does not support the "
+        "`cache_control` request parameter. Upgrade the `openrouter` package "
+        "to a version that supports Anthropic automatic caching."
+    )
+    raise ValueError(msg)
 
 
 def _strip_internal_kwargs(params: dict[str, Any]) -> None:

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -500,6 +500,18 @@ class TestMockedGenerate:
         call_kwargs = model.client.chat.send.call_args[1]
         assert call_kwargs["stream"] is True
 
+    def test_stream_forwards_cache_control(self) -> None:
+        """Test that stream forwards cache_control to the SDK."""
+        model = _make_model(cache_control={"type": "ephemeral"})
+        model.client = MagicMock()
+        model.client.chat.send.return_value = _MockSyncStream(
+            [dict(c) for c in _STREAM_CHUNKS]
+        )
+
+        list(model.stream("Hello"))
+        call_kwargs = model.client.chat.send.call_args[1]
+        assert call_kwargs["cache_control"] == {"type": "ephemeral"}
+
     def test_invoke_with_streaming_flag(self) -> None:
         """Test that invoke delegates to stream when streaming=True."""
         model = _make_model(streaming=True)
@@ -674,6 +686,32 @@ class TestRequestPayload:
 
         model.invoke("Hi")
         call_kwargs = model.client.chat.send.call_args[1]
+        assert call_kwargs["top_k"] == 50
+
+    def test_cache_control_forwarded(self) -> None:
+        """Test that cache_control is included in the SDK call."""
+        model = _make_model(cache_control={"type": "ephemeral"})
+        model.client = MagicMock()
+        model.client.chat.send.return_value = _make_sdk_response(_SIMPLE_RESPONSE_DICT)
+
+        model.invoke("Hi")
+        call_kwargs = model.client.chat.send.call_args[1]
+        assert call_kwargs["cache_control"] == {"type": "ephemeral"}
+
+    def test_cache_control_in_model_kwargs_is_backward_compatible(self) -> None:
+        """Test that cache_control can still be provided through model_kwargs."""
+        model = _make_model(
+            model_kwargs={"cache_control": {"type": "ephemeral"}, "top_k": 50}
+        )
+        model.client = MagicMock()
+        model.client.chat.send.return_value = _make_sdk_response(_SIMPLE_RESPONSE_DICT)
+
+        assert model.cache_control == {"type": "ephemeral"}
+        assert model.model_kwargs == {"top_k": 50}
+
+        model.invoke("Hi")
+        call_kwargs = model.client.chat.send.call_args[1]
+        assert call_kwargs["cache_control"] == {"type": "ephemeral"}
         assert call_kwargs["top_k"] == 50
 
     def test_stop_sequences_in_payload(self) -> None:
@@ -1811,6 +1849,27 @@ class TestErrorPaths:
         """Test that a known field passed in model_kwargs raises."""
         with pytest.raises(ValueError, match="should be specified explicitly"):
             _make_model(model_kwargs={"model_name": "some-model"})
+
+    def test_cache_control_requires_supported_sdk(self) -> None:
+        """Test that cache_control raises a clear error on older SDKs."""
+
+        class _UnsupportedChat:
+            def send(self, messages: list[dict[str, Any]]) -> None:
+                return None
+
+        unsupported_client = type(
+            "_UnsupportedClient",
+            (),
+            {"chat": _UnsupportedChat()},
+        )()
+
+        model = _make_model(
+            cache_control={"type": "ephemeral"},
+            client=unsupported_client,
+        )
+
+        with pytest.raises(ValueError, match="does not support the `cache_control`"):
+            model.invoke("Hi")
 
     def test_max_retries_zero_disables_retries(self) -> None:
         """Test that max_retries=0 does not configure retry."""


### PR DESCRIPTION
feat(openrouter): add cache_control support for Anthropic caching

Fixes #35920

Description:
I added the cache_control parameter to the ChatOpenRouter class to allow it to be passed correctly to OpenRouter without validation errors.

How did you verify your code works?
I added a new unit test in libs/partners/openrouter/tests/unit_tests/chat_models.py to verify the cache_control field in the request payload. I ran the unit tests locally using pytest and confirmed that all 203 tests in the openrouter package passed.

LinkedIn: https://linkedin.com/in/tamarazriel