### PR TITLE
fix(core): add validation for empty result list in parse_result methods

### DIFF
--- a/libs/core/langchain_core/output_parsers/base.py
+++ b/libs/core/langchain_core/output_parsers/base.py
@@ -261,6 +261,11 @@ class BaseOutputParser(
         Returns:
             Structured output.
         """
+        if not result:
+            from langchain_core.exceptions import OutputParserException
+
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         return self.parse(result[0].text)
 
     @abstractmethod

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -76,6 +76,9 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
         Raises:
             OutputParserException: If the output is not valid JSON.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         text = result[0].text
         text = text.strip()
         if partial:

--- a/libs/core/langchain_core/output_parsers/openai_functions.py
+++ b/libs/core/langchain_core/output_parsers/openai_functions.py
@@ -39,6 +39,9 @@ class OutputFunctionsParser(BaseGenerationOutputParser[Any]):
         Raises:
             OutputParserException: If the output is not valid JSON.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         generation = result[0]
         if not isinstance(generation, ChatGeneration):
             msg = "This output parser can only be used with a chat generation."
@@ -90,6 +93,9 @@ class JsonOutputFunctionsParser(BaseCumulativeTransformOutputParser[Any]):
         Raises:
             OutputParserException: If the output is not valid JSON.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         if len(result) != 1:
             msg = f"Expected exactly one result, but got {len(result)}"
             raise OutputParserException(msg)

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -181,6 +181,9 @@ class JsonOutputToolsParser(BaseCumulativeTransformOutputParser[Any]):
         Raises:
             OutputParserException: If the output is not valid JSON.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         generation = result[0]
         if not isinstance(generation, ChatGeneration):
             msg = "This output parser can only be used with a chat generation."
@@ -244,6 +247,9 @@ class JsonOutputKeyToolsParser(JsonOutputToolsParser):
         Returns:
             The parsed tool calls.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         generation = result[0]
         if not isinstance(generation, ChatGeneration):
             msg = "This output parser can only be used with a chat generation."


### PR DESCRIPTION
## Summary

Add validation to prevent IndexError when an empty list is passed to `parse_result` methods in output parsers. Now raises `OutputParserException` with a clear error message instead.

This contribution was made with assistance from an AI agent.

## Changes

- Added validation in `BaseOutputParser.parse_result()` to check for empty result list
- Added validation in `JsonOutputParser.parse_result()` 
- Added validation in `OutputFunctionsParser.parse_result()`
- Added validation in `JsonOutputFunctionsParser.parse_result()`
- Added validation in `JsonOutputToolsParser.parse_result()`
- Added validation in `JsonOutputKeyToolsParser.parse_result()`

## Why

Previously, passing an empty list to these methods would result in an unhelpful `IndexError: list index out of range`. The fix provides a clear error message: "parse_result requires a non-empty list of Generation objects."

Files changed: 4
Lines added: 20