### PR TITLE
fix: validate empty result lists in parse_result methods

### DIFF
--- a/libs/core/langchain_core/output_parsers/base.py
+++ b/libs/core/langchain_core/output_parsers/base.py
@@ -261,6 +261,11 @@ class BaseOutputParser(
         Returns:
             Structured output.
         """
+        if not result:
+            from langchain_core.exceptions import OutputParserException
+
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         return self.parse(result[0].text)
 
     @abstractmethod

--- a/libs/core/langchain_core/output_parsers/json.py
+++ b/libs/core/langchain_core/output_parsers/json.py
@@ -76,6 +76,9 @@ class JsonOutputParser(BaseCumulativeTransformOutputParser[Any]):
         Raises:
             OutputParserException: If the output is not valid JSON.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         text = result[0].text
         text = text.strip()
         if partial:

--- a/libs/core/langchain_core/output_parsers/openai_functions.py
+++ b/libs/core/langchain_core/output_parsers/openai_functions.py
@@ -39,6 +39,9 @@ class OutputFunctionsParser(BaseGenerationOutputParser[Any]):
         Raises:
             OutputParserException: If the output is not valid JSON.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         generation = result[0]
         if not isinstance(generation, ChatGeneration):
             msg = "This output parser can only be used with a chat generation."
@@ -90,6 +93,9 @@ class JsonOutputFunctionsParser(BaseCumulativeTransformOutputParser[Any]):
         Raises:
             OutputParserException: If the output is not valid JSON.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         if len(result) != 1:
             msg = f"Expected exactly one result, but got {len(result)}"
             raise OutputParserException(msg)

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -181,6 +181,9 @@ class JsonOutputToolsParser(BaseCumulativeTransformOutputParser[Any]):
         Raises:
             OutputParserException: If the output is not valid JSON.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         generation = result[0]
         if not isinstance(generation, ChatGeneration):
             msg = "This output parser can only be used with a chat generation."
@@ -244,6 +247,9 @@ class JsonOutputKeyToolsParser(JsonOutputToolsParser):
         Returns:
             The parsed tool calls.
         """
+        if not result:
+            msg = "parse_result requires a non-empty list of Generation objects."
+            raise OutputParserException(msg)
         generation = result[0]
         if not isinstance(generation, ChatGeneration):
             msg = "This output parser can only be used with a chat generation."


### PR DESCRIPTION
Added validation at the start of parse_result methods to check if the result list is empty and raise a clear OutputParserException with helpful error message.