### PR TITLE
fix(openai): extract reasoning_content from vLLM-served Qwen models

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -203,6 +203,9 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
                     )
         if audio := _dict.get("audio"):
             additional_kwargs["audio"] = audio
+        # Extract reasoning_content from vLLM-served Qwen models
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = reasoning_content
         return AIMessage(
             content=content,
             additional_kwargs=additional_kwargs,
@@ -413,6 +416,9 @@ def _convert_delta_to_message_chunk(
         if "name" in function_call and function_call["name"] is None:
             function_call["name"] = ""
         additional_kwargs["function_call"] = function_call
+    # Extract reasoning_content from vLLM-served Qwen models (streaming)
+    if reasoning_content := _dict.get("reasoning_content"):
+        additional_kwargs["reasoning_content"] = reasoning_content
     tool_call_chunks = []
     if raw_tool_calls := _dict.get("tool_calls"):
         try:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -69,6 +69,7 @@ from langchain_openai.chat_models.base import (
     OpenAIRefusalError,
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
+    _convert_delta_to_message_chunk,
     _convert_dict_to_message,
     _convert_message_to_dict,
     _convert_to_openai_response_format,
@@ -314,6 +315,51 @@ def test__convert_dict_to_message_tool_call() -> None:
         reverted_message_dict["tool_calls"], key=lambda x: x["id"]
     )
     assert reverted_message_dict == message
+
+
+def test__convert_dict_to_message_ai_with_reasoning_content() -> None:
+    """Test that reasoning_content from vLLM-served Qwen models is extracted."""
+    message = {
+        "role": "assistant",
+        "content": "The answer is 42.",
+        "reasoning_content": "Let me think about this...",
+    }
+    result = _convert_dict_to_message(message)
+    expected_output = AIMessage(
+        content="The answer is 42.",
+        additional_kwargs={"reasoning_content": "Let me think about this..."},
+    )
+    assert result == expected_output
+
+
+def test__convert_dict_to_message_ai_with_reasoning_content_only() -> None:
+    """Test that reasoning_content is extracted even when content is empty."""
+    message = {
+        "role": "assistant",
+        "content": "",
+        "reasoning_content": "Let me think about this...",
+    }
+    result = _convert_dict_to_message(message)
+    expected_output = AIMessage(
+        content="",
+        additional_kwargs={"reasoning_content": "Let me think about this..."},
+    )
+    assert result == expected_output
+
+
+def test__convert_delta_to_message_chunk_with_reasoning_content() -> None:
+    """Test that reasoning_content is extracted from streaming delta."""
+    delta = {
+        "role": "assistant",
+        "content": "The answer is 42.",
+        "reasoning_content": "Let me think about this...",
+    }
+    result = _convert_delta_to_message_chunk(delta, AIMessageChunk)
+    expected_output = AIMessageChunk(
+        content="The answer is 42.",
+        additional_kwargs={"reasoning_content": "Let me think about this..."},
+    )
+    assert result == expected_output
 
 
 class MockAsyncContextManager:


### PR DESCRIPTION
## Description

This PR adds support for extracting reasoning_content field from responses when using ChatOpenAI with vLLM-served Qwen models that use the reasoning parser (--reasoning-parser qwen3).

### Problem

When using vLLM to serve Qwen models with the reasoning parser enabled, the model output is split into reasoning_content and content fields. Previously, LangChain's ChatOpenAI only extracted the content field, silently dropping reasoning_content. This caused empty responses when the model only returned reasoning content.

### Solution

Extract reasoning_content from the response message and store it in additional_kwargs:

- Updated _convert_dict_to_message() to extract reasoning_content
- Updated _convert_delta_to_message_chunk() to extract reasoning_content for streaming responses

### Tests

Added unit tests to verify:
- reasoning_content is extracted alongside content
- reasoning_content is extracted even when content is empty
- reasoning_content is extracted from streaming delta chunks

### Related Issue

Fixes #35820

### AI Disclosure

This contribution was made with assistance from an AI agent (ClawOSS).
