### PR TITLE
fix(openai): preserve strict=False default when converting tools to Responses API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3999,7 +3999,13 @@ def _construct_responses_api_payload(
             # responses api: {"type": "function", "name": "...", "description": "...", "parameters": {...}, "strict": ...}  # noqa: E501
             if tool["type"] == "function" and "function" in tool:
                 extra = {k: v for k, v in tool.items() if k not in ("type", "function")}
-                new_tools.append({"type": "function", **tool["function"], **extra})
+                new_tool = {"type": "function", **tool["function"], **extra}
+                # Chat API defaults to strict=False, but Responses API defaults to
+                # strict=True. Explicitly set strict=False to preserve the default
+                # behavior when not specified.
+                if "strict" not in new_tool:
+                    new_tool["strict"] = False
+                new_tools.append(new_tool)
             else:
                 if tool["type"] == "image_generation":
                     # Handle partial images (not yet supported)


### PR DESCRIPTION
## Summary

When converting tools from Chat API format to Responses API format in `_construct_responses_api_payload`, the `strict` field was not being preserved. The Chat API defaults to `strict=False`, but the Responses API defaults to `strict=True`. This caused a silent behavior change where tools that should default to non-strict mode would be treated as strict.

## Fix

This fix explicitly sets `strict=False` when the field is not specified in the tool definition, preserving the expected default behavior.

## Related Issue

- _construct_responses_api_payload silently changes tool strict mode default from false to true

## Changes

- Modified `libs/partners/openai/langchain_openai/chat_models/base.py` to explicitly set `strict=False` when converting tools to Responses API format if `strict` is not already specified.