### PR TITLE
fix(anthropic): correct args key in _handle_rename methods

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -530,7 +530,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1032,7 +1032,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)


### PR DESCRIPTION
Fixes #35852

The _handle_rename methods in both StateClaudeTextEditorMiddleware and FilesystemClaudeTextEditorMiddleware were incorrectly reading args['old_path'] when the tool dispatch builds args with key 'path'.

Changed args['old_path'] to args['path'] in both methods (lines 533 and 1035).

This was causing KeyError: 'old_path' on every rename command invocation.