### PR TITLE
chore: add return type hint in beta_decorator.py

### DIFF
--- a/libs/core/langchain_core/_api/beta_decorator.py
+++ b/libs/core/langchain_core/_api/beta_decorator.py
@@ -63,7 +63,7 @@ def beta(
     Example:
         ```python
         @beta
-        def the_function_to_annotate():
+        def the_function_to_annotate() -> None:
             pass
         ```
     """


### PR DESCRIPTION
## Summary
Added return type hints to functions in `libs/core/langchain_core/_api/beta_decorator.py`.

## Changes
- Add return type hint `-> None` to function

## Type of Change
- [x] Code quality improvement (type hints)
- [ ] Bug fix
- [ ] New feature

Adding type hints improves IDE support, catches bugs earlier, and makes the codebase more maintainable.
No functional changes — only type annotations added.
