### PR TITLE
fix(core): create_schema_from_function ignores include_injected when filter_args provided

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -344,7 +344,7 @@ def create_schema_from_function(
     inferred_model = validated.model
 
     if filter_args:
-        filter_args_ = filter_args
+        filter_args_ = list(filter_args)
     else:
         # Handle classmethods and instance methods
         existing_params: list[str] = list(sig.parameters.keys())
@@ -353,11 +353,10 @@ def create_schema_from_function(
         else:
             filter_args_ = list(FILTERED_ARGS)
 
-        for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
-                sig.parameters[existing_param].annotation
-            ):
-                filter_args_.append(existing_param)
+    if not include_injected:
+        for param_name, param in sig.parameters.items():
+            if _is_injected_arg_type(param.annotation):
+                filter_args_.append(param_name)
 
     description, arg_descriptions = _infer_arg_descriptions(
         func,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2412,6 +2412,60 @@ def test_injected_arg_with_complex_type() -> None:
     assert injected_tool.invoke({"x": 5, "foo": Foo()}) == "bar"
 
 
+def test_injected_arg_excluded_when_filter_args_provided() -> None:
+    """Test that InjectedToolArg params are excluded even when filter_args is set.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/35831.
+    """
+    from langchain_core.tools.base import create_schema_from_function
+
+    def my_func(
+        x: int,
+        y: str,
+        hidden: str = "h",
+        injected: Annotated[Any, InjectedToolArg] = None,
+    ) -> str:
+        """A test function."""
+        return "ok"
+
+    schema = create_schema_from_function(
+        "MyFunc",
+        my_func,
+        filter_args=["hidden"],
+        include_injected=False,
+    )
+    field_names = set(schema.model_fields.keys())
+    # 'hidden' should be filtered by filter_args,
+    # 'injected' should be filtered because include_injected=False.
+    assert "hidden" not in field_names, "filter_args should exclude 'hidden'"
+    assert "injected" not in field_names, (
+        "InjectedToolArg param should be excluded when include_injected=False, "
+        "even when filter_args is provided"
+    )
+    assert field_names == {"x", "y"}
+
+
+def test_filter_args_not_mutated() -> None:
+    """Test that passing filter_args does not mutate the caller's list."""
+    from langchain_core.tools.base import create_schema_from_function
+
+    def my_func(
+        x: int,
+        injected: Annotated[Any, InjectedToolArg] = None,
+    ) -> str:
+        """A test function."""
+        return "ok"
+
+    original = ["some_arg"]
+    create_schema_from_function(
+        "MyFunc",
+        my_func,
+        filter_args=original,
+        include_injected=False,
+    )
+    assert original == ["some_arg"], "filter_args list should not be mutated"
+
+
 @pytest.mark.parametrize("schema_format", ["model", "json_schema"])
 def test_tool_allows_extra_runtime_args_with_custom_schema(
     schema_format: Literal["model", "json_schema"],


### PR DESCRIPTION
## Summary

- Fix `create_schema_from_function` ignoring `include_injected=False` when `filter_args` is provided
- The injected-arg filtering loop was nested inside the `else` branch of the `filter_args` check, so `InjectedToolArg` parameters leaked into the schema whenever `filter_args` was also supplied
- Move the injected-arg filtering outside the `if/else` block so it always runs, and copy `filter_args` to avoid mutating the caller's sequence

Fixes #35831

## Test plan

- [x] Added `test_injected_arg_excluded_when_filter_args_provided` — verifies injected args are excluded from schema even when `filter_args` is set
- [x] Added `test_filter_args_not_mutated` — verifies the caller's `filter_args` list is not mutated
- [x] All 19 existing injected-arg tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)