### PR TITLE
fix(model-profiles): use posix-compatible substitution in makefile

### DIFF
--- a/libs/model-profiles/Makefile
+++ b/libs/model-profiles/Makefile
@@ -30,7 +30,7 @@ refresh-profiles:
 	@for entry in $(PROFILE_PROVIDERS); do \
 		partner=$${entry%%=*}; \
 		provider=$${entry##*=}; \
-		data_dir="../partners/$${partner}/langchain_$${partner//-/_}/data"; \
+		data_dir="../partners/$${partner}/langchain_$$(echo "$${partner}" | tr '-' '_')/data"; \
 		echo "--- Refreshing $${partner} (provider: $${provider}) ---"; \
 		echo y | UV_FROZEN=false uv run langchain-profiles refresh \
 			--provider "$${provider}" \


### PR DESCRIPTION
The `refresh_model_profiles` CI workflow has been failing daily since the `refresh-profiles` Makefile target was added. `make` runs recipes with `/bin/sh`, which is dash on Ubuntu CI runners — and `${var//pattern/replacement}` is a bash-only construct that dash rejects with `Bad substitution`.

## Changes
- Replace bash-ism `$${partner//-/_}` with POSIX-compatible `$$(echo "$${partner}" | tr '-' '_')` in the `refresh-profiles` target's `data_dir` construction