### PR TITLE
fix(anthropic): correct KeyError in _handle_rename - use 'path' instead of 'old_path'

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -530,7 +530,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1032,7 +1032,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -449,3 +449,35 @@ class TestSystemMessageHandling:
         assert captured_request.system_message is not None
         assert "Existing instructions." in captured_request.system_message.text
         assert custom_prompt in captured_request.system_message.text
+
+
+class TestTextEditorRename:
+    """Test text editor rename command fix."""
+
+    def test_rename_uses_correct_args_key(self) -> None:
+        """Test that rename command uses 'path' key instead of 'old_path'."""
+        middleware = StateClaudeTextEditorMiddleware()
+        
+        # Simulate args as built by dispatch (uses 'path', not 'old_path')
+        args = {"path": "/old_name.txt", "new_path": "/new_name.txt"}
+        
+        state: AnthropicToolsState = {
+            "messages": [],
+            "text_editor_files": {
+                "/old_name.txt": {
+                    "content": "test content",
+                    "modified_at": "2024-01-01T00:00:00+00:00"
+                }
+            },
+        }
+        
+        # Should not raise KeyError
+        result = middleware._handle_rename(args, state, tool_call_id="test123")
+        
+        # Verify the rename happened
+        assert isinstance(result, Command)
+        assert "update" in result
+        updated_files = result["update"]["text_editor_files"]
+        assert "/new_name.txt" in updated_files
+        assert "/old_name.txt" not in updated_files
+        assert updated_files["/new_name.txt"]["content"] == "test content"


### PR DESCRIPTION
Fixes #35852

## Description

Fixed KeyError that prevented Claude file tool rename commands from working.

## Root Cause

The tool dispatch function builds the args dict with the source path stored under the key `path` (line 218), but both `_handle_rename` implementations were incorrectly reading it as `args["old_path"]`, causing KeyError on every rename command.

## Changes

- Fixed `_StateClaudeFileToolMiddleware._handle_rename` (line 533)
- Fixed `_FilesystemClaudeFileToolMiddleware._handle_rename` (line 1035)
- Added unit test to verify the fix

## Testing

- Added test case that reproduces the original issue
- Test passes with the fix applied
- No breaking changes to existing functionality