### PR TITLE
docs(examples): add agentic contract analyzer example using FAISS

### DIFF
--- a/examples/agentic_contract_analyzer/README.md
+++ b/examples/agentic_contract_analyzer/README.md
@@ -1,0 +1,16 @@
+# Agentic Contract Analyzer (LangChain Example)
+
+This example demonstrates how to build a simple contract analysis system using LangChain and FAISS.
+
+Features:
+- Contract clause storage
+- Vector search with FAISS
+- Query answering using LLMs
+
+Example Query:
+"What is the termination policy?"
+
+Technologies Used:
+- LangChain
+- FAISS Vector Store
+- LLMs

--- a/examples/agentic_contract_analyzer/app.py
+++ b/examples/agentic_contract_analyzer/app.py
@@ -1,0 +1,25 @@
+from langchain.chat_models import init_chat_model
+from langchain.vectorstores import FAISS
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.schema import Document
+
+docs = [
+    Document(page_content="Payment must be made within 30 days."),
+    Document(page_content="Termination requires 60 days notice."),
+]
+
+embeddings = OpenAIEmbeddings()
+
+vectorstore = FAISS.from_documents(docs, embeddings)
+
+query = "What is the termination policy?"
+
+results = vectorstore.similarity_search(query)
+
+model = init_chat_model("openai:gpt-4o-mini")
+
+response = model.invoke(
+    f"Answer based on contract: {results[0].page_content}"
+)
+
+print(response)

--- a/libs/langchain/tests/unit_tests/vectorstores/test_contract_clause_search.py
+++ b/libs/langchain/tests/unit_tests/vectorstores/test_contract_clause_search.py
@@ -1,0 +1,18 @@
+from langchain.vectorstores import FAISS
+from langchain.schema import Document
+from langchain.embeddings.fake import FakeEmbeddings
+
+
+def test_contract_clause_search():
+    docs = [
+        Document(page_content="Payment must be made within 30 days."),
+        Document(page_content="Termination requires 60 days notice."),
+    ]
+
+    embeddings = FakeEmbeddings(size=32)
+
+    vectorstore = FAISS.from_documents(docs, embeddings)
+
+    results = vectorstore.similarity_search("termination")
+
+    assert "Termination" in results[0].page_content


### PR DESCRIPTION
Adds a small example demonstrating how to build a simple contract clause search system using LangChain and FAISS.

Fixes #0