### PR TITLE
fix(core): remove trailing space from error message URL

### DIFF
--- a/libs/core/langchain_core/exceptions.py
+++ b/libs/core/langchain_core/exceptions.py
@@ -107,5 +107,5 @@ def create_message(*, message: str, error_code: ErrorCode) -> str:
     return (
         f"{message}\n"
         "For troubleshooting, visit: https://docs.langchain.com/oss/python/langchain"
-        f"/errors/{error_code.value} "
+        f"/errors/{error_code.value}"
     )


### PR DESCRIPTION
Fixed trailing space in error message URL that caused 404 errors.