### PR TITLE
docs(langchain): add runtime evidence export example

### DIFF
--- a/examples/runtime_evidence_export.py
+++ b/examples/runtime_evidence_export.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from langchain_core.callbacks import CallbackManager
+from langchain_core.runnables import RunnableLambda
+
+from agent_evidence.integrations.langchain import EvidenceCallbackHandler
+from agent_evidence.recorder import EvidenceRecorder
+from agent_evidence.storage.local import LocalEvidenceStore
+
+
+output_dir = Path("./evidence_bundle")
+store = LocalEvidenceStore(output_dir / "events.jsonl")
+callback = EvidenceCallbackHandler(recorder=EvidenceRecorder(store))
+
+manager = CallbackManager([callback])
+chain = RunnableLambda(lambda text: text.upper()).with_config(
+    {"callbacks": manager.handlers, "run_name": "runtime-evidence-demo"}
+)
+
+result = chain.invoke("hello")
+print(result)
+print(f"Evidence events written to {store.path}")


### PR DESCRIPTION
Resolves #35973

This PR adds a minimal example demonstrating how LangChain agent runs can be exported as verifiable evidence bundles using AEP (Agent Evidence Profile).

The goal is not to modify LangChain internals but to show how callback hooks can produce runtime evidence artifacts.

Repo:
https://github.com/joy7758/agent-evidence

Artifact:
https://doi.org/10.5281/zenodo.19055948
