### PR TITLE
fix(anthropic): correct args key in _handle_rename from 'old_path' to 'path'

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -530,7 +530,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1032,7 +1032,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -266,9 +266,10 @@ class TestFileOperations:
             },
         }
 
+        # The tool builds args with "path" key (not "old_path")
         args = {
             "command": "rename",
-            "old_path": "/memories/old.txt",
+            "path": "/memories/old.txt",
             "new_path": "/memories/new.txt",
         }
         result = middleware._handle_rename(args, state, "test_id")


### PR DESCRIPTION
## Issue

Fixes #35852

The _handle_rename methods in both _StateClaudeFileToolMiddleware and _FilesystemClaudeFileToolMiddleware raised KeyError: 'old_path' on every rename command.

## Root Cause

The tool dispatch function builds the args dict with the source path under the key 'path' (line 218 in anthropic_tools.py):

```python
args: dict[str, Any] = {'path': path}
```

But both _handle_rename implementations incorrectly tried to read args['old_path']:

```python
old_path = args['old_path']  # KeyError: 'old_path'
```

## Fix

Changed both methods to use the correct key:

```python
old_path = args['path']  # Correct key
```

## Changes

- libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py: Fixed key in both _handle_rename methods
- libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py: Fixed test that was incorrectly using old_path

## Verification

All 20 existing tests pass, including the corrected test_rename_operation.