### PR TITLE
fix: correct error message from comparators to operators

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -39,7 +39,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed comparator {func}. Allowed "
-                f"comparators are {self.allowed_comparators}"
+                f"operators are {self.allowed_comparators}"
             )
             raise ValueError(msg)
 

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
Fixed error message in _validate_func method - changed comparators to operators.