### PR TITLE
fix(core): prevent cross-type content block merging in `merge_lists`

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -120,6 +120,16 @@ def merge_lists(left: list | None, *others: list | None) -> list | None:
                         if (
                             "index" in e_left
                             and e_left["index"] == e["index"]  # index matches
+                            # Prevent text blocks from merging with non-text
+                            # blocks that happen to share the same index (e.g.,
+                            # streaming text at index 0 vs tool_call_chunk at
+                            # index 0 from the API). This is a text-vs-
+                            # everything-else partition; non-text blocks at the
+                            # same index may still merge with each other.
+                            and (
+                                (e_left.get("type") == "text")
+                                == (e.get("type") == "text")
+                            )
                             and (  # IDs not inconsistent
                                 e_left.get("id") in (None, "")
                                 or e.get("id") in (None, "")

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -433,6 +433,27 @@ def test_generation_chunk_addition_type_error() -> None:
             [{"no_index": "b"}],
             [{"no_index": "a"}, {"no_index": "b"}],
         ),
+        # Text and non-text blocks with same index should NOT merge
+        (
+            [{"index": 0, "type": "text", "text": "hello"}],
+            [{"index": 0, "type": "tool_call_chunk", "name": "foo", "args": "{}"}],
+            [
+                {"index": 0, "type": "text", "text": "hello"},
+                {"index": 0, "type": "tool_call_chunk", "name": "foo", "args": "{}"},
+            ],
+        ),
+        # Two text blocks with same index should still merge
+        (
+            [{"index": 0, "type": "text", "text": "hel"}],
+            [{"index": 0, "type": "text", "text": "lo"}],
+            [{"index": 0, "type": "text", "text": "hello"}],
+        ),
+        # Two non-text blocks with same index should still merge
+        (
+            [{"index": 0, "type": "tool_call_chunk", "args": '{"a'}],
+            [{"index": 0, "type": "tool_call_chunk", "args": '": 1}'}],
+            [{"index": 0, "type": "tool_call_chunk", "args": '{"a": 1}'}],
+        ),
     ],
 )
 def test_merge_lists(


### PR DESCRIPTION
`merge_lists` merges dicts by matching `index` values but does not check `type`. When a model returns both text and tool calls in a streaming response with `output_version="v1"`, text blocks (`index: 0` from the streaming wrapper) and `tool_call_chunk` blocks (`index: 0` from the API) merge into a single corrupt dict with `type: "text"` carrying orphaned `name`/`args`/`id` fields. The `init_tool_calls` validator cannot find `type: "tool_call_chunk"` to promote, so tool calls silently vanish from `content_blocks`.

This affects `BaseChatOpenAI` subclassers without registered block translators and any model that returns text alongside tool calls (e.g., GLM-5 via Baseten). Related to #32888 which proposes the broader fix of raising on `type` conflicts in `merge_dicts`.

## Changes
- Add a type guard to `merge_lists` index-matching: prevent merging when one block has `type: "text"` and the other does not — a text-vs-everything-else partition that keeps text and tool_call_chunk blocks separate so `init_tool_calls` can promote them correctly. Non-text blocks at the same index (e.g., Anthropic's `tool_use` + `input_json_delta`) still merge as before.

---

Revert https://github.com/basetenlabs/langchain-baseten/pull/6 when released