### PR TITLE
fix(openai): detect invalid tool argument type

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -68,6 +68,14 @@ def parse_tool_call(
                 f"Received JSONDecodeError {e}"
             )
             raise OutputParserException(msg) from e
+
+    if not isinstance(function_args, dict):
+        msg = (
+            f"Function {raw_tool_call['function']['name']} arguments:\n\n"
+            f"{arguments}\n\nmust be a dictionary"
+        )
+        raise OutputParserException(msg)
+
     parsed = {
         "name": raw_tool_call["function"]["name"] or "",
         "args": function_args or {},

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4491,8 +4491,10 @@ def _construct_lc_result_from_responses_api(
             content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
             try:
                 args = json.loads(output.arguments, strict=False)
+                if not isinstance(args, dict):
+                    raise TypeError("Arguments must be a dictionary")
                 error = None
-            except JSONDecodeError as e:
+            except (JSONDecodeError, TypeError) as e:
                 args = output.arguments
                 error = str(e)
             if error is None:


### PR DESCRIPTION
Fixes #35990 

tool arguments that can be deserialized via `json.loads` is not necessarily a dict. Other types will trigger ValidationError of AIMessage. This PR checks the argument is a dict.