### PR TITLE
fix(agents): change messages type from list[AnyMessage] to Sequence[BaseMessage]

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -77,7 +77,7 @@ class _ModelRequestOverrides(TypedDict, total=False):
 
     model: BaseChatModel
     system_message: SystemMessage | None
-    messages: list[AnyMessage]
+    messages: Sequence[BaseMessage]
     tool_choice: Any | None
     tools: list[BaseTool | dict[str, Any]]
     response_format: ResponseFormat[Any] | None
@@ -94,7 +94,7 @@ class ModelRequest(Generic[ContextT]):
     """
 
     model: BaseChatModel
-    messages: list[AnyMessage]  # excluding system message
+    messages: Sequence[BaseMessage]  # excluding system message
     system_message: SystemMessage | None
     tool_choice: Any | None
     tools: list[BaseTool | dict[str, Any]]
@@ -107,7 +107,7 @@ class ModelRequest(Generic[ContextT]):
         self,
         *,
         model: BaseChatModel,
-        messages: list[AnyMessage],
+        messages: Sequence[BaseMessage],
         system_message: SystemMessage | None = None,
         system_prompt: str | None = None,
         tool_choice: Any | None = None,


### PR DESCRIPTION
Fixes #35971

ModelRequest.override(messages=...) rejected list[BaseMessage] due to Python's list invariance. Since list is invariant, list[BaseMessage] cannot be assigned to list[AnyMessage] even though BaseMessage is the parent type.

Changed messages type annotations from list[AnyMessage] to Sequence[BaseMessage] in three locations:
- _ModelRequestOverrides.messages (TypedDict)
- ModelRequest.messages (dataclass field)  
- ModelRequest.__init__.messages (parameter)

Sequence is covariant (read-only), so Sequence[BaseMessage] correctly accepts list[AIMessage], list[HumanMessage], list[BaseMessage], etc.
