### PR TITLE
fix: correct error message from operators to comparators

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -39,7 +39,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed comparator {func}. Allowed "
-                f"comparators are {self.allowed_comparators}"
+                f"operators are {self.allowed_comparators}"
             )
             raise ValueError(msg)
 

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -39,7 +39,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed comparator {func}. Allowed "
-                f"operators are {self.allowed_comparators}"
+                f"comparators are {self.allowed_comparators}"
             )
             raise ValueError(msg)
 


### PR DESCRIPTION
Fixed error message in _validate_func method - changed operators to comparators.