### PR TITLE
fix(openai): non-dict tool arguments should be set invalid

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4491,8 +4491,11 @@ def _construct_lc_result_from_responses_api(
             content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
             try:
                 args = json.loads(output.arguments, strict=False)
+                if not isinstance(args, dict):
+                    _error_msg = "Arguments must be a dictionary"
+                    raise TypeError(_error_msg)
                 error = None
-            except JSONDecodeError as e:
+            except (JSONDecodeError, TypeError) as e:
                 args = output.arguments
                 error = str(e)
             if error is None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1768,6 +1768,43 @@ def test__construct_lc_result_from_responses_api_function_call_invalid_json() ->
     assert _FUNCTION_CALL_IDS_MAP_KEY in result.generations[0].message.additional_kwargs
 
 
+def test__construct_lc_result_from_responses_api_function_call_non_dict_args() -> None:
+    """Test a response with valid JSON but non-dict function call arguments.
+
+    Tool call arguments must be a dict. Non-dict types (e.g., string, list, int)
+    should be treated as invalid tool calls.
+    """
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseFunctionToolCall(
+                type="function_call",
+                id="func_123",
+                call_id="call_123",
+                name="get_weather",
+                arguments='"not a dict"',
+            )
+        ],
+    )
+
+    result = _construct_lc_result_from_responses_api(response, output_version="v0")
+
+    msg: AIMessage = cast(AIMessage, result.generations[0].message)
+    assert len(msg.invalid_tool_calls) == 1
+    assert msg.invalid_tool_calls[0]["type"] == "invalid_tool_call"
+    assert msg.invalid_tool_calls[0]["name"] == "get_weather"
+    assert msg.invalid_tool_calls[0]["id"] == "call_123"
+    assert msg.invalid_tool_calls[0]["args"] == '"not a dict"'
+    assert "Arguments must be a dictionary" in msg.invalid_tool_calls[0]["error"]
+    assert _FUNCTION_CALL_IDS_MAP_KEY in result.generations[0].message.additional_kwargs
+
+
 def test__construct_lc_result_from_responses_api_complex_response() -> None:
     """Test a complex response with multiple output types."""
     response = Response(


### PR DESCRIPTION
Fixes #35990

When tool call arguments are valid JSON but deserialize to non-dict types (e.g., string "abc", list [], number 123), they should be treated as invalid tool calls rather than causing ValidationError on AIMessage.

The ToolCall TypedDict requires args to be dict[str, Any]. Previously, the code only caught JSONDecodeError, allowing non-dict values to pass through and fail validation when creating the AIMessage.

Changes:
- Added isinstance(args, dict) check after json.loads()
- Added TypeError to the exception tuple being caught
- Added test for non-dict arguments case