### PR TITLE
fix(anthropic): correct KeyError in _handle_rename - use 'path' instead of 'old_path'

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -530,7 +530,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1032,7 +1032,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -449,3 +449,35 @@ class TestSystemMessageHandling:
         assert captured_request.system_message is not None
         assert "Existing instructions." in captured_request.system_message.text
         assert custom_prompt in captured_request.system_message.text
+
+
+class TestTextEditorRename:
+    """Test text editor rename command fix."""
+
+    def test_rename_uses_correct_args_key(self) -> None:
+        """Test that rename command uses 'path' key instead of 'old_path'."""
+        middleware = StateClaudeTextEditorMiddleware()
+        
+        # Simulate args as built by dispatch (uses 'path', not 'old_path')
+        args = {"path": "/old_name.txt", "new_path": "/new_name.txt"}
+        
+        state: AnthropicToolsState = {
+            "messages": [],
+            "text_editor_files": {
+                "/old_name.txt": {
+                    "content": "test content",
+                    "modified_at": "2024-01-01T00:00:00+00:00"
+                }
+            },
+        }
+        
+        # Should not raise KeyError
+        result = middleware._handle_rename(args, state, tool_call_id="test123")
+        
+        # Verify the rename happened
+        assert isinstance(result, Command)
+        assert "update" in result
+        updated_files = result["update"]["text_editor_files"]
+        assert "/new_name.txt" in updated_files
+        assert "/old_name.txt" not in updated_files
+        assert updated_files["/new_name.txt"]["content"] == "test content"


### PR DESCRIPTION
Fixes #35852

## Description
Corrects a `KeyError` in the `_handle_rename` method of both `StateClaudeFileToolMiddleware` and `FilesystemClaudeFileToolMiddleware` in `libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py`.

## Problem
The tool dispatch function builds the `args` dict with the source path stored under the key `"path"` (line 218):
```python
args: dict[str, Any] = {"path": path}
```

But both `_handle_rename` implementations incorrectly try to access `args["old_path"]`, causing a `KeyError` on every rename command.

## Solution
Changed both implementations to use the correct key `"path"`:
```python
# Before (broken):
old_path = args["old_path"]

# After (correct):
old_path = args["path"]
```

## Changes
- Fix `_StateClaudeFileToolMiddleware._handle_rename` (line 533)
- Fix `_FilesystemClaudeFileToolMiddleware._handle_rename` (line 1035)

## Testing
- Verified the args dict structure matches what's built by the tool dispatch
- Aligned with the reproduction case in #35852

## Type of Change
- [x] Bug fix (fixes #35852)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update