### PR TITLE
fix(core): handle float type in merge_dicts, merge_obj, and _dict_int_op

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,7 +68,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to
@@ -201,6 +201,8 @@ def merge_obj(left: Any, right: Any) -> Any:
         return merge_lists(left, right)
     if left == right:
         return left
+    if isinstance(left, (int, float)):
+        return left + right
     msg = (
         f"Unable to merge {left=} and {right=}. Both must be of type str, dict, or "
         f"list, or else be two equal objects."

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,14 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # Float fields should be summed (e.g., cost, score)
+        ({"score": 0.5}, {"score": 0.3}, {"score": 0.8}),
+        ({"total_cost": 0.01}, {"total_cost": 0.02}, {"total_cost": 0.03}),
+        # Float 'index' should be preserved, not summed
+        ({"index": 0.0}, {"index": 1.0}, {"index": 1.0}),
+        # Float 'created'/'timestamp' should be preserved, not summed
+        ({"created": 1700000000.5}, {"created": 1700000001.5}, {"created": 1700000001.5}),
+        ({"timestamp": 100.0}, {"timestamp": 200.0}, {"timestamp": 200.0}),
     ],
 )
 def test_merge_dicts(
@@ -474,10 +482,13 @@ def test_merge_lists_all_none() -> None:
         ({"a": 1}, {"b": 2}, {"a": 1, "b": 2}),
         # List merge
         ([1, 2], [3], [1, 2, 3]),
-        # Equal values
+    # Equal values
         (42, 42, 42),
         (3.14, 3.14, 3.14),
         (True, True, True),
+        # Numeric addition
+        (10, 5, 15),
+        (0.5, 0.3, 0.8),
     ],
 )
 def test_merge_obj(left: Any, right: Any, expected: Any) -> None:
@@ -494,7 +505,7 @@ def test_merge_obj_type_mismatch() -> None:
 def test_merge_obj_unmergeable_values() -> None:
     """Test `merge_obj` raises `ValueError` on unmergeable values."""
     with pytest.raises(ValueError, match="Unable to merge"):
-        merge_obj(1, 2)  # Different integers
+        merge_obj({1, 2}, {3, 4})  # Sets are not mergeable
 
 
 def test_merge_obj_tuple_raises() -> None:


### PR DESCRIPTION
## Description

`merge_dicts()` and `merge_obj()` in `libs/core/langchain_core/utils/_merge.py`, as well as `_dict_int_op()` in `libs/core/langchain_core/utils/usage.py`, handle `int` types but **not `float`**. When these functions encounter `float` values, they fall through to error branches and raise `TypeError` or `ValueError`.

```python
from langchain_core.utils._merge import merge_dicts

merge_dicts({"score": 0.5}, {"score": 0.3})  # ❌ TypeError
```

This affects streaming scenarios where LLM providers return float fields in `generation_info`, `additional_kwargs`, or `UsageMetadata` (e.g., `logprob`, `score`, safety scores, cost fields, etc.). During chunk aggregation via `ChatGenerationChunk.__add__()` → `merge_dicts()`, or `UsageMetadata.__add__()` → `_dict_int_op()`, these float fields cause the stream to crash.

## Changes

### `libs/core/langchain_core/utils/_merge.py`
- **`merge_dicts()`**: Changed `isinstance(merged[right_k], int)` to `isinstance(merged[right_k], (int, float))` so that float values are summed (or preserved for special keys like `index`, `created`, `timestamp`) instead of raising `TypeError`.
- **`merge_obj()`**: Added `isinstance(left, (int, float))` check **after** the equality check, so unequal numeric values are summed instead of raising `ValueError`. The ordering is important — equal values (including `True == True`, `42 == 42`, `3.14 == 3.14`) are handled by the equality branch first, and only unequal numeric values reach the addition branch.

### `libs/core/langchain_core/utils/usage.py`
- **`_dict_int_op()`**: Changed `isinstance(..., int)` to `isinstance(..., (int, float))` so that float values in `UsageMetadata` (e.g., cost fields, timing data) are correctly handled during aggregation.
- Updated type annotations (`Callable[[int, int], int]` → `Callable[[float, float], float]`), docstrings, and error messages to reflect float support.

### `libs/core/tests/unit_tests/utils/test_utils.py`
- Added regression tests for float values in `test_merge_dicts` (summing, preserved special keys like `index`/`created`/`timestamp`).
- Added regression tests for numeric addition in `test_merge_obj` (`int` and `float`).
- Updated `test_merge_obj_unmergeable_values` to use `set` instead of different integers (since different integers are now correctly summed).

### `libs/core/tests/unit_tests/utils/test_usage.py`
- Added `test_dict_int_op_float_add` — tests pure float addition.
- Added `test_dict_int_op_mixed_int_float` — tests mixed int/float addition.
- Added `test_dict_int_op_nested_float` — tests nested dictionaries with float values.
- Updated error message assertion to match new "int, and float" wording.

## Design Note

As @Jairooh correctly pointed out, `isinstance(x, int)` returns `True` for `bool` in Python. In `merge_obj()`, this is safely handled because `bool` equality (`True == True`) is caught by the `left == right` branch **before** reaching the numeric addition branch. For `merge_dicts()`, the same ordering applies. This is a key design choice — the competing PR #36048 placed the numeric check **before** the equality check, causing `42 + 42 = 84` and `True + True = 2` failures.

Regarding floating-point precision concerns: the current approach mirrors the existing `int` addition semantics. For use cases where last-value or max semantics are preferred over summation, that would be a separate feature/configuration beyond this bug fix.

## Issue

Fixes #36011
Fixes #36015

## Related

- #17376 — Originally reported in 2024, closed as `not_planned`
- PR #16605 — Added `int` support but omitted `float`
- #36015 — `_dict_int_op` raises ValueError for float values in `UsageMetadata`