### PR TITLE
fix(core): handle float values in merge_dicts

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -77,6 +77,11 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                     merged[right_k] = right_v
                 else:
                     merged[right_k] += right_v
+            elif isinstance(merged[right_k], float):
+                # Handle float values using last-wins strategy
+                # Float values like logprob, score, safety scores should not be
+                # accumulated during streaming chunk aggregation
+                merged[right_k] = right_v
             else:
                 msg = (
                     f"Additional kwargs key {right_k} already exists in left dict and "


### PR DESCRIPTION
## Summary

Fixes #36011 - Bug: `merge_dicts` raises TypeError for float values during streaming chunk aggregation

## Changes

- Add float type handling in `merge_dicts()` function
- Use last-wins strategy for float values (e.g., logprob, score, safety scores)
- Fixes TypeError when streaming chunks contain unequal float values

## Test

```python
from langchain_core.utils._merge import merge_dicts

# Previously raised TypeError
result = merge_dicts({"score": 0.5}, {"score": 0.3})
# Now returns: {"score": 0.3}
```