### PR TITLE
fix(core): handle float type in _dict_int_op for UsageMetadata aggregation

### DIFF
--- a/libs/core/langchain_core/utils/usage.py
+++ b/libs/core/langchain_core/utils/usage.py
@@ -12,17 +12,17 @@ def _dict_int_op(
     depth: int = 0,
     max_depth: int = 100,
 ) -> dict:
-    """Apply an integer operation to corresponding values in two dictionaries.
+    """Apply a numeric operation to corresponding values in two dictionaries.
 
-    Recursively combines two dictionaries by applying the given operation to integer
-    values at matching keys.
+    Recursively combines two dictionaries by applying the given operation to numeric
+    (int or float) values at matching keys.
 
     Supports nested dictionaries.
 
     Args:
         left: First dictionary to combine.
         right: Second dictionary to combine.
-        op: Binary operation function to apply to integer values.
+        op: Binary operation function to apply to numeric values.
         default: Default value to use when a key is missing from a dictionary.
         depth: Current recursion depth (used internally).
         max_depth: Maximum recursion depth (to prevent infinite loops).
@@ -38,8 +38,8 @@ def _dict_int_op(
         raise ValueError(msg)
     combined: dict = {}
     for k in set(left).union(right):
-        if isinstance(left.get(k, default), int) and isinstance(
-            right.get(k, default), int
+        if isinstance(left.get(k, default), (int, float)) and isinstance(
+            right.get(k, default), (int, float)
         ):
             combined[k] = op(left.get(k, default), right.get(k, default))
         elif isinstance(left.get(k, {}), dict) and isinstance(right.get(k, {}), dict):
@@ -54,7 +54,8 @@ def _dict_int_op(
         else:
             types = [type(d[k]) for d in (left, right) if k in d]
             msg = (
-                f"Unknown value types: {types}. Only dict and int values are supported."
+                f"Unknown value types: {types}. Only dict, int, and float values are"
+                " supported."
             )
             raise ValueError(msg)  # noqa: TRY004
     return combined

--- a/libs/core/tests/unit_tests/utils/test_usage.py
+++ b/libs/core/tests/unit_tests/utils/test_usage.py
@@ -35,11 +35,51 @@ def test_dict_int_op_max_depth_exceeded() -> None:
         _dict_int_op(left, right, operator.add, max_depth=2)
 
 
+def test_dict_int_op_float_add() -> None:
+    """Test that float values are handled correctly."""
+    left = {"tokens": 10, "cost": 0.05}
+    right = {"tokens": 20, "cost": 0.03}
+    result = _dict_int_op(left, right, operator.add)
+    assert result == {"tokens": 30, "cost": pytest.approx(0.08)}
+
+
+def test_dict_int_op_float_subtract() -> None:
+    """Test that float subtraction works correctly."""
+    left = {"tokens": 10, "cost": 0.05}
+    right = {"tokens": 3, "cost": 0.02}
+    result = _dict_int_op(left, right, lambda x, y: max(x - y, 0))
+    assert result == {"tokens": 7, "cost": pytest.approx(0.03)}
+
+
+def test_dict_int_op_mixed_int_float() -> None:
+    """Test that mixed int and float values are handled correctly."""
+    left = {"tokens": 10, "cost": 0}  # cost is int (e.g., from cache init)
+    right = {"tokens": 20, "cost": 0.005}  # cost is float (e.g., from provider)
+    result = _dict_int_op(left, right, operator.add)
+    assert result == {"tokens": 30, "cost": pytest.approx(0.005)}
+
+
+def test_dict_int_op_nested_float() -> None:
+    """Test that nested dicts with float values work correctly."""
+    left = {"usage": {"tokens": 10, "cost": 0.05}}
+    right = {"usage": {"tokens": 20, "cost": 0.03}}
+    result = _dict_int_op(left, right, operator.add)
+    assert result == {"usage": {"tokens": 30, "cost": pytest.approx(0.08)}}
+
+
+def test_dict_int_op_float_only_one_side() -> None:
+    """Test float field present in only one dict."""
+    left = {"tokens": 10, "cost": 0.05}
+    right = {"tokens": 20}
+    result = _dict_int_op(left, right, operator.add)
+    assert result == {"tokens": 30, "cost": pytest.approx(0.05)}
+
+
 def test_dict_int_op_invalid_types() -> None:
     left = {"a": 1, "b": "string"}
     right = {"a": 2, "b": 3}
     with pytest.raises(
         ValueError,
-        match="Only dict and int values are supported",
+        match="Only dict, int, and float values are supported",
     ):
         _dict_int_op(left, right, operator.add)


### PR DESCRIPTION
## Description

`_dict_int_op()` in `libs/core/langchain_core/utils/usage.py` handles `int` and `dict` types but **not `float`**. When two dictionaries contain the same key with `float` values, the function raises `ValueError`.

This affects streaming scenarios where LLM providers include float fields in `UsageMetadata` (e.g., `total_cost`, pricing fields, or any custom float metric). During chunk aggregation via `add_usage()` → `_dict_int_op()`, these float fields cause the aggregation to crash.

**Error:**
```
ValueError: Unknown value types: [<class 'float'>]. Only dict and int values are supported.
```

**All 4 float scenarios crash:**
- Direct float values in dicts
- `UsageMetadata` with float `total_cost` on both sides
- Float field present on only one side (default=0 is int, other side is float)
- Mixed int (from cache init `total_cost=0`) + float (from provider `total_cost=0.005`)

This is the same class of bug as #36011 (`merge_dicts` missing float support), but in a different function.

## Changes

1. Change `isinstance(..., int)` to `isinstance(..., (int, float))` in `_dict_int_op()`
2. Update docstring to reflect numeric (int/float) support
3. Update error message to mention float
4. Add 5 regression tests for float values (add, subtract, mixed int/float, nested, one-sided)
5. Update existing `test_dict_int_op_invalid_types` error message match

## Issue

Fixes #36015

## Dependencies

None