### PR TITLE
fix(openai): skip context_management for Azure endpoint (#35464)

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1104,6 +1104,15 @@ class BaseChatOpenAI(BaseChatModel):
     @property
     def _default_params(self) -> dict[str, Any]:
         """Get the default parameters for calling OpenAI API."""
+        # Azure endpoint does not support context_management (e.g. compact_threshold)
+        context_management = self.context_management
+        if (
+            context_management is not None
+            and self.openai_api_base
+            and "azure" in self.openai_api_base.lower()
+        ):
+            context_management = None
+
         exclude_if_none = {
             "presence_penalty": self.presence_penalty,
             "frequency_penalty": self.frequency_penalty,
@@ -1120,7 +1129,7 @@ class BaseChatOpenAI(BaseChatModel):
             "reasoning_effort": self.reasoning_effort,
             "reasoning": self.reasoning,
             "verbosity": self.verbosity,
-            "context_management": self.context_management,
+            "context_management": context_management,
             "include": self.include,
             "service_tier": self.service_tier,
             "truncation": self.truncation,

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -97,6 +97,30 @@ def test_openai_model_param() -> None:
     assert llm.max_tokens == 10
 
 
+def test_context_management_excluded_for_azure_base_url() -> None:
+    """Azure endpoint does not support context_management (e.g. compact_threshold)."""
+    llm = ChatOpenAI(
+        model="gpt-4",
+        base_url="https://my-resource.openai.azure.com/openai/v1/",
+        context_management=[{"type": "compaction", "compact_threshold": 100_000}],
+    )
+    params = llm._default_params
+    assert "context_management" not in params
+
+
+def test_context_management_included_for_non_azure_base_url() -> None:
+    """Non-Azure endpoints receive context_management when set."""
+    llm = ChatOpenAI(
+        model="gpt-4",
+        base_url="https://api.openai.com/v1/",
+        context_management=[{"type": "compaction", "compact_threshold": 100_000}],
+    )
+    params = llm._default_params
+    assert params["context_management"] == [
+        {"type": "compaction", "compact_threshold": 100_000}
+    ]
+
+
 @pytest.mark.parametrize("async_api", [True, False])
 def test_streaming_attribute_should_stream(async_api: bool) -> None:
     llm = ChatOpenAI(model="foo", streaming=True)


### PR DESCRIPTION
## Summary
Fixes #35464

Azure endpoint does not support `context_management` (e.g. `compact_threshold`). When `base_url` contains "azure", exclude `context_management` from API params to prevent `compact_threshold is not enabled` error.

## Root cause
ChatOpenAI with `base_url` pointing to Azure and `context_management=[{"type": "compaction", "compact_threshold": 100_000}]` sends the param to the API. Azure returns 400: `compact_threshold is not enabled`.

## Changes
- In `_default_params`, when `openai_api_base` contains "azure", set `context_management` to `None` so it is excluded from the request.
- Added unit tests for Azure and non-Azure cases.

## Testing
- `test_context_management_excluded_for_azure_base_url`: verifies context_management is not in params when base_url contains azure
- `test_context_management_included_for_non_azure_base_url`: verifies context_management is passed for non-Azure endpoints

Made with [Cursor](https://cursor.com)