### PR TITLE
fix: add float support to merge_dicts for streaming chunk aggregation

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,7 +68,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to


### PR DESCRIPTION
## Summary

Fixes #36011 - `merge_dicts` raises TypeError for float values during streaming chunk aggregation.

## Problem

When calling `merge_dicts({"score": 0.5}, {"score": 0.3})`, a TypeError is raised because float values are not handled:

```
TypeError: Additional kwargs key score already exists in left dict and value has unsupported type <class "float">.
```

## Solution

Add `float` to the isinstance check alongside `int`. Float values use the same last-wins strategy as int for non-accumulation fields.

## Testing

```python
from langchain_core.utils._merge import merge_dicts

# Before: raises TypeError
# After: returns {"score": 0.3}
merge_dicts({"score": 0.5}, {"score": 0.3})
```