### PR TITLE
fix: Allow list[BaseMessage] in ModelRequest.override(messages=)

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -39,7 +39,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed comparator {func}. Allowed "
-                f"comparators are {self.allowed_comparators}"
+                f"operators are {self.allowed_comparators}"
             )
             raise ValueError(msg)
 

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -39,7 +39,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed comparator {func}. Allowed "
-                f"operators are {self.allowed_comparators}"
+                f"comparators are {self.allowed_comparators}"
             )
             raise ValueError(msg)
 

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -77,7 +77,7 @@ class _ModelRequestOverrides(TypedDict, total=False):
 
     model: BaseChatModel
     system_message: SystemMessage | None
-    messages: list[AnyMessage]
+    messages: Sequence[BaseMessage]
     tool_choice: Any | None
     tools: list[BaseTool | dict[str, Any]]
     response_format: ResponseFormat[Any] | None
@@ -94,7 +94,7 @@ class ModelRequest(Generic[ContextT]):
     """
 
     model: BaseChatModel
-    messages: list[AnyMessage]  # excluding system message
+    messages: Sequence[BaseMessage]  # excluding system message
     system_message: SystemMessage | None
     tool_choice: Any | None
     tools: list[BaseTool | dict[str, Any]]
@@ -107,7 +107,7 @@ class ModelRequest(Generic[ContextT]):
         self,
         *,
         model: BaseChatModel,
-        messages: list[AnyMessage],
+        messages: Sequence[BaseMessage],
         system_message: SystemMessage | None = None,
         system_prompt: str | None = None,
         tool_choice: Any | None = None,
@@ -121,7 +121,7 @@ class ModelRequest(Generic[ContextT]):
 
         Args:
             model: The chat model to use.
-            messages: List of messages (excluding system prompt).
+            messages: Sequence of messages (excluding system prompt).
             tool_choice: Tool choice configuration.
             tools: List of available tools.
             response_format: Response format specification.


### PR DESCRIPTION
## Summary

Change messages type from list[AnyMessage] to Sequence[BaseMessage] in _ModelRequestOverrides and ModelRequest to fix type invariance issue reported in #35971.

## Problem

Since list is invariant in Python type system, passing list[BaseMessage] (common when filtering/transforming messages) failed type checking.

## Solution

Using Sequence (covariant/read-only) correctly models the input-only usage in override().

## Changes

- _ModelRequestOverrides.messages: list[AnyMessage] -> Sequence[BaseMessage]
- ModelRequest.messages: list[AnyMessage] -> Sequence[BaseMessage]

Fixes #35971