### PR TITLE
fix(core): support float values in _dict_int_op

### DIFF
--- a/libs/core/langchain_core/utils/usage.py
+++ b/libs/core/langchain_core/utils/usage.py
@@ -6,23 +6,23 @@ from collections.abc import Callable
 def _dict_int_op(
     left: dict,
     right: dict,
-    op: Callable[[int, int], int],
+    op: Callable[[int | float, int | float], int | float],
     *,
-    default: int = 0,
+    default: int | float = 0,
     depth: int = 0,
     max_depth: int = 100,
 ) -> dict:
-    """Apply an integer operation to corresponding values in two dictionaries.
+    """Apply a numeric operation to corresponding values in two dictionaries.
 
-    Recursively combines two dictionaries by applying the given operation to integer
-    values at matching keys.
+    Recursively combines two dictionaries by applying the given operation to numeric
+    values (int or float) at matching keys.
 
     Supports nested dictionaries.
 
     Args:
         left: First dictionary to combine.
         right: Second dictionary to combine.
-        op: Binary operation function to apply to integer values.
+        op: Binary operation function to apply to numeric values.
         default: Default value to use when a key is missing from a dictionary.
         depth: Current recursion depth (used internally).
         max_depth: Maximum recursion depth (to prevent infinite loops).
@@ -38,8 +38,8 @@ def _dict_int_op(
         raise ValueError(msg)
     combined: dict = {}
     for k in set(left).union(right):
-        if isinstance(left.get(k, default), int) and isinstance(
-            right.get(k, default), int
+        if isinstance(left.get(k, default), (int, float)) and isinstance(
+            right.get(k, default), (int, float)
         ):
             combined[k] = op(left.get(k, default), right.get(k, default))
         elif isinstance(left.get(k, {}), dict) and isinstance(right.get(k, {}), dict):
@@ -54,7 +54,7 @@ def _dict_int_op(
         else:
             types = [type(d[k]) for d in (left, right) if k in d]
             msg = (
-                f"Unknown value types: {types}. Only dict and int values are supported."
+                f"Unknown value types: {types}. Only dict and numeric (int/float) values are supported."
             )
             raise ValueError(msg)  # noqa: TRY004
     return combined


### PR DESCRIPTION
## Summary

This PR fixes issue #36015 by adding float support to the `_dict_int_op` function in `langchain_core/utils/usage.py`.

## Changes

1. Changed `isinstance` check from `int` to `(int, float)` to support both integer and float values
2. Updated type hints for the `op` parameter from `Callable[[int, int], int]` to `Callable[[int | float, int | float], int | float]`
3. Updated `default` parameter type to `int | float`
4. Updated docstring to reflect numeric (int/float) support
5. Updated error message to mention "numeric (int/float)" instead of just "int"

## Testing

The fix enables the following scenarios that previously crashed:

```python
import operator
from langchain_core.utils.usage import _dict_int_op

# Float values now work
_dict_int_op({"tokens": 10, "cost": 0.05}, {"tokens": 20, "cost": 0.03}, operator.add)
# Returns: {"tokens": 30, "cost": 0.08}
```

Fixes #36015