### PR TITLE
fix(core): support float values in merge_dicts and _dict_int_op

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,7 +68,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to

--- a/libs/core/langchain_core/utils/usage.py
+++ b/libs/core/langchain_core/utils/usage.py
@@ -6,23 +6,23 @@ from collections.abc import Callable
 def _dict_int_op(
     left: dict,
     right: dict,
-    op: Callable[[int, int], int],
+    op: Callable[[float, float], float],
     *,
     default: int = 0,
     depth: int = 0,
     max_depth: int = 100,
 ) -> dict:
-    """Apply an integer operation to corresponding values in two dictionaries.
+    """Apply a numeric operation to corresponding values in two dictionaries.
 
-    Recursively combines two dictionaries by applying the given operation to integer
-    values at matching keys.
+    Recursively combines two dictionaries by applying the given operation to numeric
+    (int or float) values at matching keys.
 
     Supports nested dictionaries.
 
     Args:
         left: First dictionary to combine.
         right: Second dictionary to combine.
-        op: Binary operation function to apply to integer values.
+        op: Binary operation function to apply to numeric values.
         default: Default value to use when a key is missing from a dictionary.
         depth: Current recursion depth (used internally).
         max_depth: Maximum recursion depth (to prevent infinite loops).
@@ -38,8 +38,8 @@ def _dict_int_op(
         raise ValueError(msg)
     combined: dict = {}
     for k in set(left).union(right):
-        if isinstance(left.get(k, default), int) and isinstance(
-            right.get(k, default), int
+        if isinstance(left.get(k, default), (int, float)) and isinstance(
+            right.get(k, default), (int, float)
         ):
             combined[k] = op(left.get(k, default), right.get(k, default))
         elif isinstance(left.get(k, {}), dict) and isinstance(right.get(k, {}), dict):
@@ -54,7 +54,8 @@ def _dict_int_op(
         else:
             types = [type(d[k]) for d in (left, right) if k in d]
             msg = (
-                f"Unknown value types: {types}. Only dict and int values are supported."
+                f"Unknown value types: {types}. "
+                f"Only dict, int, and float values are supported."
             )
             raise ValueError(msg)  # noqa: TRY004
     return combined


### PR DESCRIPTION
Fixes #36011
Fixes #36015

`merge_dicts()` in `_merge.py` and `_dict_int_op()` in `usage.py` both only handled `int` values but not `float`. This causes runtime errors when streaming chunks or `UsageMetadata` contain float fields.

**`merge_dicts` (`_merge.py`):** The `isinstance(merged[right_k], int)` check on line 71 fell through to the error branch for float values, raising `TypeError: Additional kwargs key X already exists in left dict and value has unsupported type <class 'float'>`. This affects any LLM provider that returns float fields in `generation_info` or `additional_kwargs` (e.g. `logprob`, `score`, `cost`).

**`_dict_int_op` (`usage.py`):** The `isinstance(..., int)` checks raised `ValueError: Unknown value types: [<class 'float'>]. Only dict and int values are supported.` for float fields in `UsageMetadata` (e.g. `total_cost`) during `add_usage()` aggregation.

**Fix:** Change `isinstance(..., int)` to `isinstance(..., (int, float))` in both functions. Also update the `_dict_int_op` docstring and error message to reflect float support.