### PR TITLE
fix: add float support to merge_dicts and merge_obj

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,7 +68,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to
@@ -199,6 +199,9 @@ def merge_obj(left: Any, right: Any) -> Any:
         return merge_dicts(left, right)
     if isinstance(left, list):
         return merge_lists(left, right)
+    if isinstance(left, (int, float)):
+        # For numeric types, sum the values (consistent with merge_dicts behavior)
+        return left + right
     if left == right:
         return left
     msg = (


### PR DESCRIPTION
## Summary

Fixes issue #36011: `merge_dicts` raises `TypeError` for float values during streaming chunk aggregation.

## Changes

1. **`merge_dicts()`**: Changed `isinstance(merged[right_k], int)` to `isinstance(merged[right_k], (int, float))` to handle float values the same way as integers.

2. **`merge_obj()`**: Added numeric type handling for `int` and `float` - now sums numeric values (consistent with `merge_dicts` behavior).

## Root Cause

The function handled `str`, `dict`, `list`, equal values, and `int` types — but not `float`. When two dicts contain the same key with unequal `float` values (e.g., `logprob`, `score`, safety scores, cost fields in streaming), the function falls through to the final `else` branch and raises a `TypeError`.

## Testing

This fix enables the following to work without errors:

```python
from langchain_core.utils._merge import merge_dicts

# Now works!
merge_dicts({"score": 0.5}, {"score": 0.3})  # Returns {"score": 0.8}
merge_dicts({"logprob": -1.2}, {"logprob": -0.8})  # Returns {"logprob": -2.0}
```

## Related

- Issue #36011
- Historical: Issue #17376 (2024) reported same bug for int
- PR #16605 added int support but omitted float