### PR TITLE
ci: use codspeed `walltime` mode for slow partners

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -127,7 +127,21 @@ def _get_configs_for_single_dir(job: str, dir_: str) -> List[Dict[str, str]]:
         return _get_pydantic_test_configs(dir_)
 
     if job == "codspeed":
-        py_versions = ["3.13"]
+        # CPU simulation (<1% variance, Valgrind-based) is the default.
+        # Partners with heavy SDK inits use walltime instead to keep CI fast.
+        CODSPEED_WALLTIME_DIRS = {
+            "libs/core",
+            "libs/partners/fireworks",  # ~328s under simulation
+            "libs/partners/openai",  # 6 benchmarks, ~6 min under simulation
+        }
+        mode = "walltime" if dir_ in CODSPEED_WALLTIME_DIRS else "simulation"
+        return [
+            {
+                "working-directory": dir_,
+                "python-version": "3.13",
+                "codspeed-mode": mode,
+            }
+        ]
     elif dir_ == "libs/core":
         py_versions = ["3.10", "3.11", "3.12", "3.13", "3.14"]
     # custom logic for specific directories

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -236,7 +236,7 @@ jobs:
             else
               uv run --no-sync pytest ./tests/unit_tests/ -m benchmark --codspeed
             fi
-          mode: ${{ matrix.job-configs.working-directory == 'libs/core' && 'walltime' || 'simulation' }}
+          mode: ${{ matrix.job-configs.codspeed-mode }}
 
   # Final status check - ensures all required jobs passed before allowing merge
   ci_success:


### PR DESCRIPTION
Speed up CodSpeed benchmarks for partners with heavy SDK inits by switching them to walltime mode. `fireworks` takes ~328s and `openai` ~6 min under CPU simulation (Valgrind-based) — walltime is noisier but more than adequate for detecting init-time regressions on these packages.

## Changes
- Add `CODSPEED_WALLTIME_DIRS` set in `_get_configs_for_single_dir` that routes `libs/core`, `libs/partners/fireworks`, and `libs/partners/openai` to walltime mode; all other partners default to `simulation`
- Emit a `codspeed-mode` field in the CodSpeed matrix config and consume it as `${{ matrix.job-configs.codspeed-mode }}` in the workflow, replacing the inline ternary
