### PR TITLE
ci(infra): drop redundant opened trigger from issue-link check

### DIFF
--- a/.github/workflows/require_issue_link.yml
+++ b/.github/workflows/require_issue_link.yml
@@ -16,15 +16,15 @@
 # - Deduplicates comments via an HTML marker so re-runs don't spam.
 #
 # Dependency: pr_labeler.yml must run first to apply the "external" label
-# on new PRs. Both workflows trigger on pull_request_target opened events;
-# this workflow additionally listens for the "labeled" event to chain off
-# the external classification.
+# on new PRs. This workflow chains off that classification via the "labeled"
+# event. It does NOT trigger on "opened" because new PRs have no labels yet,
+# so the job-level gate would always skip — producing noisy "Skipped" checks.
 
 name: Require Issue Link
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, labeled]
+    types: [edited, reopened, labeled]
 
 permissions:
   contents: read


### PR DESCRIPTION
Remove `opened` from the `require_issue_link.yml` trigger list. New PRs never have labels at creation time, so the job-level `if` (which requires the `external` label) always evaluated to skip — producing a noisy "Skipped" check on every internal PR. Enforcement chains through `pr_labeler.yml` → `labeled` event, making `opened` a no-op.

## Changes
- Drop `opened` from `pull_request_target.types` in `require_issue_link.yml` — only `edited`, `reopened`, and `labeled` remain
- Update header comment to document why `opened` is intentionally excluded