### PR TITLE
fix(openai): treat non-dict JSON tool arguments as invalid tool calls

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,11 +68,12 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to
                 # - created/timestamp: temporal values that shouldn't be accumulated
+                # Note: float support added to fix streaming with float values in generation_info
                 if right_k in {"index", "created", "timestamp"}:
                     merged[right_k] = right_v
                 else:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4492,17 +4492,28 @@ def _construct_lc_result_from_responses_api(
             try:
                 args = json.loads(output.arguments, strict=False)
                 error = None
-            except JSONDecodeError as e:
+            except (JSONDecodeError, TypeError) as e:
                 args = output.arguments
                 error = str(e)
             if error is None:
-                tool_call = {
-                    "type": "tool_call",
-                    "name": output.name,
-                    "args": args,
-                    "id": output.call_id,
-                }
-                tool_calls.append(tool_call)
+                if not isinstance(args, dict):
+                    error = f"Expected dict, got {type(args).__name__}"
+                    tool_call = {
+                        "type": "invalid_tool_call",
+                        "name": output.name,
+                        "args": args,
+                        "id": output.call_id,
+                        "error": error,
+                    }
+                    invalid_tool_calls.append(tool_call)
+                else:
+                    tool_call = {
+                        "type": "tool_call",
+                        "name": output.name,
+                        "args": args,
+                        "id": output.call_id,
+                    }
+                    tool_calls.append(tool_call)
             else:
                 tool_call = {
                     "type": "invalid_tool_call",


### PR DESCRIPTION
## Why

json.loads() successfully parses valid JSON that is not a dict. This fix adds isinstance check after json.loads.

Fixes #36052