### PR TITLE
fix(agents): use Sequence[AnyMessage] in _ModelRequestOverrides to fix list invariance error

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -77,7 +77,7 @@ class _ModelRequestOverrides(TypedDict, total=False):
 
     model: BaseChatModel
     system_message: SystemMessage | None
-    messages: list[AnyMessage]
+    messages: Sequence[AnyMessage]
     tool_choice: Any | None
     tools: list[BaseTool | dict[str, Any]]
     response_format: ResponseFormat[Any] | None


### PR DESCRIPTION
## Summary

Fixes #35971

Python generics with `list` are invariant, so `list[HumanMessage]` is not assignable to `list[AnyMessage]` even though `HumanMessage` extends `BaseMessage`. This caused a type error when calling `ModelRequest.override(messages=[HumanMessage(...)])`.

Using `Sequence[AnyMessage]` resolves the issue because `Sequence` is covariant in its type parameter.

## Changes

Changed `messages: list[AnyMessage]` → `messages: Sequence[AnyMessage]` in `_ModelRequestOverrides` TypedDict.

`Sequence` was already imported from `collections.abc` in the module.

## Before

```python
request.override(messages=[HumanMessage(content="hi")])  # TypeError: list[HumanMessage] incompatible with list[AnyMessage]
```

## After

```python
request.override(messages=[HumanMessage(content="hi")])  # OK
```