### PR TITLE
Fixed KeyError in _handle_rename by using correct args key

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -530,7 +530,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1032,7 +1032,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)


### PR DESCRIPTION
## Summary

Fixes #35852

- The tool dispatch function in `anthropic_tools.py` builds the `args` dict with the source file path under key `"path"` (line 218 and 720), but both `_handle_rename` implementations (in `_StateClaudeFileToolMiddleware` and `_FilesystemClaudeFileToolMiddleware`) read `args["old_path"]`, which is never set.
- This causes a `KeyError: 'old_path'` whenever the `rename` command is invoked.
- Fixed by changing `args["old_path"]` to `args["path"]` in both `_handle_rename` methods.

## Test plan

- [x] Verify that the `args` dict is built with `"path"` as the key for the source path in both dispatch functions
- [x] Verify that `"new_path"` is correctly set when `new_path` is provided
- [ ] Run rename operations through both `_StateClaudeFileToolMiddleware` and `_FilesystemClaudeFileToolMiddleware` to confirm no KeyError

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>