### PR TITLE
fix(core): make uuid-utils optional for pyodide/emscripten support

### DIFF
--- a/libs/core/langchain_core/utils/uuid.py
+++ b/libs/core/langchain_core/utils/uuid.py
@@ -1,20 +1,72 @@
-"""UUID utility functions.
-
-This module exports a uuid7 function to generate monotonic, time-ordered UUIDs
-for tracing and similar operations.
-"""
+"""UUID utility functions."""
 
 from __future__ import annotations
 
+import os
+import threading
+import time
 import typing
 from uuid import UUID
 
-from uuid_utils.compat import uuid7 as _uuid_utils_uuid7
+try:
+    from uuid_utils.compat import uuid7 as _uuid_utils_uuid7
 
-if typing.TYPE_CHECKING:
-    from uuid import UUID
+    _HAS_UUID_UTILS = True
+except ImportError:
+    _HAS_UUID_UTILS = False
 
 _NANOS_PER_SECOND: typing.Final = 1_000_000_000
+_MAX_COUNTER: typing.Final = 0x3FFFFFFFFFF
+
+_lock: threading.Lock = threading.Lock()
+_last_ms: int = 0
+_counter: int = 0
+
+
+def _new_counter() -> int:
+    """Return a fresh random 42-bit counter value with the MSB cleared."""
+    return int.from_bytes(os.urandom(6), "big") & 0x1FFFFFFFFFF
+
+
+def _uuid7_python(ms: int) -> UUID:
+    """Generate a UUIDv7 using a pure-Python implementation.
+
+    Args:
+        ms: Unix timestamp in milliseconds.
+
+    Returns:
+        A UUIDv7 object.
+    """
+    global _last_ms, _counter  # noqa: PLW0603
+
+    with _lock:
+        if ms > _last_ms:
+            _last_ms = ms
+            _counter = _new_counter()
+        else:
+            ms = _last_ms
+            _counter += 1
+            if _counter > _MAX_COUNTER:
+                _last_ms += 1
+                ms = _last_ms
+                _counter = _new_counter()
+
+        current_ms = ms
+        current_counter = _counter
+
+    random_tail = int.from_bytes(os.urandom(4), "big")
+    counter_hi = (current_counter >> 30) & 0xFFF
+    counter_lo = current_counter & 0x3FFFFFFF
+
+    uuid_int = (
+        (current_ms & 0xFFFFFFFFFFFF) << 80
+        | 0x7 << 76
+        | counter_hi << 64
+        | 0b10 << 62
+        | counter_lo << 32
+        | random_tail
+    )
+    return UUID(int=uuid_int)
 
 
 def _to_timestamp_and_nanos(nanoseconds: int) -> tuple[int, int]:
@@ -28,30 +80,26 @@ def uuid7(nanoseconds: int | None = None) -> UUID:
 
     UUIDv7 objects feature monotonicity within a millisecond.
 
+    Uses ``uuid-utils`` when available, falling back to a pure-Python
+    implementation for environments where compiled extensions are unavailable
+    (e.g. Pyodide/WebAssembly).
+
     Args:
         nanoseconds: Optional ns timestamp. If not provided, uses current time.
 
     Returns:
         A UUIDv7 object.
     """
-    # --- 48 ---   -- 4 --   --- 12 ---   -- 2 --   --- 30 ---   - 32 -
-    # unix_ts_ms | version | counter_hi | variant | counter_lo | random
-    #
-    # 'counter = counter_hi | counter_lo' is a 42-bit counter constructed
-    # with Method 1 of RFC 9562, §6.2, and its MSB is set to 0.
-    #
-    # 'random' is a 32-bit random value regenerated for every new UUID.
-    #
-    # If multiple UUIDs are generated within the same millisecond, the LSB
-    # of 'counter' is incremented by 1. When overflowing, the timestamp is
-    # advanced and the counter is reset to a random 42-bit integer with MSB
-    # set to 0.
+    if _HAS_UUID_UTILS:
+        if nanoseconds is None:
+            return _uuid_utils_uuid7()
+        seconds, nanos = _to_timestamp_and_nanos(nanoseconds)
+        return _uuid_utils_uuid7(timestamp=seconds, nanos=nanos)
 
-    # For now, just delegate to the uuid_utils implementation
-    if nanoseconds is None:
-        return _uuid_utils_uuid7()
-    seconds, nanos = _to_timestamp_and_nanos(nanoseconds)
-    return _uuid_utils_uuid7(timestamp=seconds, nanos=nanos)
+    ms = (
+        time.time_ns() // 1_000_000 if nanoseconds is None else nanoseconds // 1_000_000
+    )
+    return _uuid7_python(ms)
 
 
 __all__ = ["uuid7"]

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "typing-extensions>=4.7.0,<5.0.0",
     "packaging>=23.2.0",
     "pydantic>=2.7.4,<3.0.0",
-    "uuid-utils>=0.12.0,<1.0",
+    "uuid-utils>=0.12.0,<1.0; sys_platform != 'emscripten'",
 ]
 
 [project.urls]

--- a/libs/core/tests/unit_tests/utils/test_uuid_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_uuid_utils.py
@@ -1,7 +1,9 @@
 import time
 from uuid import UUID
 
-from langchain_core.utils.uuid import uuid7
+import pytest
+
+from langchain_core.utils.uuid import _uuid7_python, uuid7
 
 
 def _uuid_v7_ms(uuid_obj: UUID | str) -> int:
@@ -12,6 +14,18 @@ def _uuid_v7_ms(uuid_obj: UUID | str) -> int:
     """
     s = str(uuid_obj).replace("-", "")
     return int(s[:12], 16)
+
+
+def _uuid_v7_version(uuid_obj: UUID | str) -> int:
+    """Extract the version nibble (bits 48-51) from a UUID hex string."""
+    s = str(uuid_obj).replace("-", "")
+    return int(s[12], 16)
+
+
+def _uuid_v7_variant(uuid_obj: UUID | str) -> int:
+    """Extract the two variant bits (bits 64-65) from a UUID hex string."""
+    s = str(uuid_obj).replace("-", "")
+    return (int(s[16], 16) >> 2) & 0b11
 
 
 def test_uuid7() -> None:
@@ -35,3 +49,61 @@ def test_monotonicity() -> None:
             msg = f"UUIDs are not monotonic: {last} versus {i}"
             raise RuntimeError(msg)
         last = i
+
+
+# ---------------------------------------------------------------------------
+# Tests for the pure-Python fallback (_uuid7_python)
+# ---------------------------------------------------------------------------
+
+
+def test_python_fallback_timestamp() -> None:
+    """Pure-Python fallback embeds the correct ms timestamp."""
+    ns = time.time_ns()
+    ms = ns // 1_000_000
+    result = _uuid7_python(ms)
+    assert _uuid_v7_ms(result) == ms
+
+
+def test_python_fallback_version_and_variant() -> None:
+    """Pure-Python fallback sets version=7 and RFC 4122 variant bits."""
+    result = _uuid7_python(time.time_ns() // 1_000_000)
+    assert _uuid_v7_version(result) == 7
+    assert _uuid_v7_variant(result) == 0b10
+
+
+def test_python_fallback_returns_uuid() -> None:
+    """Pure-Python fallback returns a UUID instance."""
+    result = _uuid7_python(time.time_ns() // 1_000_000)
+    assert isinstance(result, UUID)
+
+
+def test_python_fallback_monotonicity() -> None:
+    """Pure-Python fallback UUIDs are monotonically increasing."""
+    last = ""
+    for n in range(10_000):
+        i = str(_uuid7_python(time.time_ns() // 1_000_000))
+        if n > 0 and i <= last:
+            msg = f"Pure-Python UUIDs are not monotonic: {last} versus {i}"
+            raise RuntimeError(msg)
+        last = i
+
+
+def test_python_fallback_same_ms_monotonicity() -> None:
+    """Within a fixed millisecond the counter increments produce monotonic UUIDs."""
+    fixed_ms = time.time_ns() // 1_000_000
+    results = [str(_uuid7_python(fixed_ms)) for _ in range(1_000)]
+    assert results == sorted(results), "UUIDs within same ms are not monotonic"
+
+
+@pytest.mark.parametrize("ms_offset", [-1, 0, 1])
+def test_python_fallback_clock_regression(ms_offset: int) -> None:
+    """Clock regression is handled gracefully — output is always monotonic."""
+    # Generate a baseline UUID first to set _last_ms
+    base_ms = time.time_ns() // 1_000_000
+    first = str(_uuid7_python(base_ms))
+    # Now call with base_ms again (regression / same ms)
+    second = str(_uuid7_python(base_ms + ms_offset))
+    assert second > first, (
+        f"UUID not monotonic after clock regression (offset={ms_offset}): "
+        f"{first} vs {second}"
+    )

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy'",
@@ -1002,7 +1002,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "tenacity" },
     { name = "typing-extensions" },
-    { name = "uuid-utils" },
+    { name = "uuid-utils", marker = "sys_platform != 'emscripten'" },
 ]
 
 [package.dev-dependencies]
@@ -1048,7 +1048,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=5.3.0,<7.0.0" },
     { name = "tenacity", specifier = ">=8.1.0,!=8.4.0,<10.0.0" },
     { name = "typing-extensions", specifier = ">=4.7.0,<5.0.0" },
-    { name = "uuid-utils", specifier = ">=0.12.0,<1.0" },
+    { name = "uuid-utils", marker = "sys_platform != 'emscripten'", specifier = ">=0.12.0,<1.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Why

Fixes #35881

`langchain-core` depends on `uuid-utils`, a Rust-compiled package that has
no Pyodide/WebAssembly wheel. When users try to install `langchain` in
[Pyodide](https://pyodide.org) (CPython on WebAssembly/Emscripten),
`micropip` fails with:

> ValueError: Can't find a pure Python 3 wheel for: 'uuid-utils<1.0,>=0.12.0'

## Changes

- **`pyproject.toml`**: Added `sys_platform != 'emscripten'` marker to the
  `uuid-utils` dependency so it is skipped on Pyodide, where
  `sys.platform == 'emscripten'`.

- **`langchain_core/utils/uuid.py`**: Changed the `uuid-utils` import to a
  `try/except ImportError` guard and added a pure-Python UUIDv7 fallback
  (`_uuid7_python`). The fallback implements RFC 9562 §5.7 Method 1 with a
  monotonic 42-bit counter, thread-safe clock-regression handling, and a
  32-bit random tail — matching the behaviour of the `uuid-utils` implementation.

- **`tests/unit_tests/utils/test_uuid_utils.py`**: Added 6 new tests covering
  the pure-Python fallback (timestamp accuracy, version/variant fields, return
  type, monotonicity, same-millisecond ordering, and clock-regression handling).

## Areas needing review

- The pure-Python UUIDv7 bit layout in `_uuid7_python` — specifically the
  counter split (12-bit `counter_hi` / 30-bit `counter_lo`) and the variant
  bits should be verified against RFC 9562 §5.7.
- Note: `langsmith` also requires `uuid-utils` and `orjson`, and
  `langgraph-checkpoint` requires `ormsgpack` — full Pyodide support will
  additionally require changes in those external repos.

---

> This contribution was developed with the assistance of GitHub Copilot (AI).