### PR TITLE
feat(middleware): add Cisco AI Defense middleware for LLM and tool inspection

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -2,6 +2,11 @@
 
 from langgraph.runtime import Runtime
 
+from langchain.agents.middleware.cisco_ai_defense import (
+    CiscoAIDefenseError,
+    CiscoAIDefenseMiddleware,
+    CiscoAIDefenseToolMiddleware,
+)
 from langchain.agents.middleware.context_editing import ClearToolUsesEdit, ContextEditingMiddleware
 from langchain.agents.middleware.file_search import FilesystemFileSearchMiddleware
 from langchain.agents.middleware.human_in_the_loop import (
@@ -46,6 +51,9 @@ from langchain.agents.middleware.types import (
 __all__ = [
     "AgentMiddleware",
     "AgentState",
+    "CiscoAIDefenseError",
+    "CiscoAIDefenseMiddleware",
+    "CiscoAIDefenseToolMiddleware",
     "ClearToolUsesEdit",
     "CodexSandboxExecutionPolicy",
     "ContextEditingMiddleware",

--- a/libs/langchain_v1/langchain/agents/middleware/cisco_ai_defense.py
+++ b/libs/langchain_v1/langchain/agents/middleware/cisco_ai_defense.py
@@ -1,0 +1,587 @@
+"""Cisco AI Defense middleware for agent security inspection.
+
+Provides two middleware classes that inspect LLM and tool traffic against
+`Cisco AI Defense <https://developer.cisco.com/docs/ai-defense/overview/>`_
+security policies:
+
+* :class:`CiscoAIDefenseMiddleware` — inspects LLM inputs and outputs via
+  ``before_model`` / ``after_model`` hooks.
+* :class:`CiscoAIDefenseToolMiddleware` — inspects tool call requests and
+  responses via ``wrap_tool_call``.
+
+Users compose them independently:
+
+.. code-block:: python
+
+    from langchain.agents import create_agent
+    from langchain.agents.middleware import (
+        CiscoAIDefenseMiddleware,
+        CiscoAIDefenseToolMiddleware,
+    )
+
+    # LLM inspection only
+    agent = create_agent(
+        "openai:gpt-4.1",
+        middleware=[CiscoAIDefenseMiddleware(api_key="...")],
+    )
+
+    # LLM + tool inspection
+    agent = create_agent(
+        "openai:gpt-4.1",
+        tools=[my_tool],
+        middleware=[
+            CiscoAIDefenseMiddleware(api_key="..."),
+            CiscoAIDefenseToolMiddleware(api_key="..."),
+        ],
+    )
+
+Requires the ``aidefense`` package (``pip install aidefense``).  The import
+is deferred so the package is only required at runtime, not at import time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, Literal
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    ResponseT,
+    hook_config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from langgraph.runtime import Runtime
+    from langgraph.types import Command
+
+logger = logging.getLogger(__name__)
+
+_REGION_ALIASES: dict[str, str] = {
+    "us": "us-west-2",
+    "eu": "eu-central-1",
+    "apj": "ap-northeast-1",
+}
+
+
+def _normalize_region(region: str) -> str:
+    return _REGION_ALIASES.get(region.strip().lower(), region)
+
+
+class CiscoAIDefenseError(RuntimeError):
+    """Raised when Cisco AI Defense flags content and ``exit_behavior`` is ``"error"``."""
+
+    def __init__(
+        self,
+        *,
+        content: str,
+        stage: str,
+        classifications: list[str],
+        message: str,
+    ) -> None:
+        super().__init__(message)
+        self.content = content
+        self.stage = stage
+        self.classifications = classifications
+
+
+class CiscoAIDefenseMiddleware(
+    AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT],
+):
+    """Inspect LLM inputs and outputs against Cisco AI Defense policies.
+
+    This middleware calls the Cisco AI Defense Chat Inspection API before and
+    after every model invocation.  When a policy violation is detected the
+    middleware reacts according to ``exit_behavior``:
+
+    * ``"end"`` — jump to the end node with a violation message (default).
+    * ``"error"`` — raise :class:`CiscoAIDefenseError`.
+
+    Example:
+        .. code-block:: python
+
+            from langchain.agents import create_agent
+            from langchain.agents.middleware import CiscoAIDefenseMiddleware
+
+            agent = create_agent(
+                "openai:gpt-4.1",
+                middleware=[
+                    CiscoAIDefenseMiddleware(
+                        api_key="your-cisco-ai-defense-api-key",
+                        region="us",
+                        exit_behavior="end",
+                    ),
+                ],
+            )
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        region: str = "us",
+        check_input: bool = True,
+        check_output: bool = True,
+        exit_behavior: Literal["end", "error"] = "end",
+        fail_open: bool = True,
+        timeout: int = 30,
+    ) -> None:
+        """Create the middleware.
+
+        Args:
+            api_key: Cisco AI Defense API key.
+            region: AI Defense region — short aliases ``"us"``, ``"eu"``,
+                ``"apj"`` are accepted and normalized automatically.
+            check_input: Inspect user messages before the model call.
+            check_output: Inspect AI messages after the model call.
+            exit_behavior: How to handle violations.
+                ``"end"`` jumps to the end node with a message.
+                ``"error"`` raises :class:`CiscoAIDefenseError`.
+            fail_open: When ``True`` (default), allow the request if the
+                inspection API is unreachable.  When ``False``, treat API
+                errors as violations.
+            timeout: Inspection API timeout in seconds.
+        """
+        super().__init__()
+        if exit_behavior not in ("end", "error"):
+            msg = f"Invalid exit_behavior: {exit_behavior!r}. Must be 'end' or 'error'."
+            raise ValueError(msg)
+
+        self.api_key = api_key
+        self.region = _normalize_region(region)
+        self.check_input = check_input
+        self.check_output = check_output
+        self.exit_behavior = exit_behavior
+        self.fail_open = fail_open
+        self.timeout = timeout
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            from aidefense.config import Config
+            from aidefense.runtime import ChatInspectionClient
+
+            config = Config(region=self.region, timeout=self.timeout)
+            self._client = ChatInspectionClient(api_key=self.api_key, config=config)
+        return self._client
+
+    @hook_config(can_jump_to=["end"])
+    def before_model(
+        self,
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Inspect input messages before the model call.
+
+        Args:
+            state: Current agent state.
+            runtime: Agent runtime context.
+
+        Returns:
+            State update to block the request, or ``None`` to continue.
+        """
+        if not self.check_input:
+            return None
+
+        messages = state.get("messages", [])
+        if not messages:
+            return None
+
+        result = self._inspect(messages)
+        if result is not None and not result.is_safe:
+            return self._apply_violation(messages, stage="input", result=result)
+        return None
+
+    @hook_config(can_jump_to=["end"])
+    async def abefore_model(
+        self,
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Async inspect input messages before the model call.
+
+        Args:
+            state: Current agent state.
+            runtime: Agent runtime context.
+
+        Returns:
+            State update to block the request, or ``None`` to continue.
+        """
+        if not self.check_input:
+            return None
+
+        messages = state.get("messages", [])
+        if not messages:
+            return None
+
+        result = await asyncio.to_thread(self._inspect, messages)
+        if result is not None and not result.is_safe:
+            return self._apply_violation(messages, stage="input", result=result)
+        return None
+
+    @hook_config(can_jump_to=["end"])
+    def after_model(
+        self,
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Inspect AI messages after the model call.
+
+        Args:
+            state: Current agent state.
+            runtime: Agent runtime context.
+
+        Returns:
+            State update to block the response, or ``None`` to continue.
+        """
+        if not self.check_output:
+            return None
+
+        messages = state.get("messages", [])
+        if not messages:
+            return None
+
+        result = self._inspect(messages)
+        if result is not None and not result.is_safe:
+            return self._apply_violation(messages, stage="output", result=result)
+        return None
+
+    @hook_config(can_jump_to=["end"])
+    async def aafter_model(
+        self,
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Async inspect AI messages after the model call.
+
+        Args:
+            state: Current agent state.
+            runtime: Agent runtime context.
+
+        Returns:
+            State update to block the response, or ``None`` to continue.
+        """
+        if not self.check_output:
+            return None
+
+        messages = state.get("messages", [])
+        if not messages:
+            return None
+
+        result = await asyncio.to_thread(self._inspect, messages)
+        if result is not None and not result.is_safe:
+            return self._apply_violation(messages, stage="output", result=result)
+        return None
+
+    # -- internals ---------------------------------------------------------
+
+    def _inspect(self, messages: list[BaseMessage]) -> Any | None:
+        """Run chat inspection with fail-open protection."""
+        from aidefense.runtime.models import Message, Role
+
+        converted = []
+        for msg in messages:
+            if isinstance(msg, HumanMessage):
+                role = Role.USER
+            elif isinstance(msg, AIMessage):
+                role = Role.ASSISTANT
+            else:
+                role = Role.SYSTEM
+            converted.append(Message(role=role, content=str(msg.content)))
+
+        try:
+            return self._get_client().inspect_conversation(converted)
+        except Exception:
+            if self.fail_open:
+                logger.warning(
+                    "Cisco AI Defense inspection failed (fail_open=True), allowing request",
+                    exc_info=True,
+                )
+                return None
+            raise
+
+    def _apply_violation(
+        self,
+        messages: list[BaseMessage],
+        *,
+        stage: str,
+        result: Any,
+    ) -> dict[str, Any] | None:
+        classifications = (
+            [str(c) for c in result.classifications] if result.classifications else []
+        )
+        violation_text = (
+            f"This request was blocked by Cisco AI Defense ({stage} policy violation). "
+            f"Classifications: {', '.join(classifications) or 'unspecified'}."
+        )
+
+        if self.exit_behavior == "error":
+            last_content = str(messages[-1].content) if messages else ""
+            raise CiscoAIDefenseError(
+                content=last_content,
+                stage=stage,
+                classifications=classifications,
+                message=violation_text,
+            )
+
+        return {
+            "jump_to": "end",
+            "messages": [AIMessage(content=violation_text)],
+        }
+
+
+class CiscoAIDefenseToolMiddleware(
+    AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT],
+):
+    """Inspect tool call requests and responses against Cisco AI Defense policies.
+
+    This middleware wraps every tool call with pre-call (request) and post-call
+    (response) inspection via the Cisco AI Defense MCP Inspection API.
+
+    It covers all tool types uniformly — LangChain ``@tool`` functions, MCP
+    tools, and any tool executed through the agent's tool node.
+
+    Example:
+        .. code-block:: python
+
+            from langchain.agents import create_agent
+            from langchain.agents.middleware import CiscoAIDefenseToolMiddleware
+
+            agent = create_agent(
+                "openai:gpt-4.1",
+                tools=[my_tool],
+                middleware=[
+                    CiscoAIDefenseToolMiddleware(
+                        api_key="your-cisco-ai-defense-api-key",
+                        region="us",
+                    ),
+                ],
+            )
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        region: str = "us",
+        inspect_requests: bool = True,
+        inspect_responses: bool = True,
+        exit_behavior: Literal["end", "error"] = "end",
+        fail_open: bool = True,
+        timeout: int = 30,
+    ) -> None:
+        """Create the tool inspection middleware.
+
+        Args:
+            api_key: Cisco AI Defense API key.
+            region: AI Defense region — ``"us"``, ``"eu"``, ``"apj"`` accepted.
+            inspect_requests: Inspect tool call arguments before execution.
+            inspect_responses: Inspect tool results after execution.
+            exit_behavior: ``"end"`` returns a blocking ToolMessage.
+                ``"error"`` raises :class:`CiscoAIDefenseError`.
+            fail_open: Allow the tool call when the inspection API is
+                unreachable.
+            timeout: Inspection API timeout in seconds.
+        """
+        super().__init__()
+        if exit_behavior not in ("end", "error"):
+            msg = f"Invalid exit_behavior: {exit_behavior!r}. Must be 'end' or 'error'."
+            raise ValueError(msg)
+
+        self.api_key = api_key
+        self.region = _normalize_region(region)
+        self.inspect_requests = inspect_requests
+        self.inspect_responses = inspect_responses
+        self.exit_behavior = exit_behavior
+        self.fail_open = fail_open
+        self.timeout = timeout
+        self._client: Any = None
+
+    def _get_client(self) -> Any:
+        if self._client is None:
+            from aidefense.config import Config
+            from aidefense.runtime import MCPInspectionClient
+
+            config = Config(region=self.region, timeout=self.timeout)
+            self._client = MCPInspectionClient(api_key=self.api_key, config=config)
+        return self._client
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Inspect tool calls before and after execution.
+
+        Args:
+            request: Tool call request.
+            handler: Callback that executes the tool.
+
+        Returns:
+            Tool result or a blocking ``ToolMessage`` on violation.
+        """
+        tool_name = request.tool_call.get("name", "unknown")
+        tool_args = request.tool_call.get("args", {})
+        tool_call_id = str(request.tool_call.get("id", f"blocked-{tool_name}"))
+
+        if self.inspect_requests:
+            result = self._inspect_tool_call(tool_name, tool_args)
+            if result is not None and not self._is_safe(result):
+                return self._apply_tool_violation(
+                    tool_name, tool_call_id, "request", result,
+                )
+
+        tool_result = handler(request)
+
+        if self.inspect_responses:
+            result_data = self._extract_result_data(tool_result)
+            if result_data is not None:
+                result = self._inspect_response(tool_name, tool_args, result_data)
+                if result is not None and not self._is_safe(result):
+                    return self._apply_tool_violation(
+                        tool_name, tool_call_id, "response", result,
+                    )
+
+        return tool_result
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Any],
+    ) -> ToolMessage | Command[Any]:
+        """Async inspect tool calls before and after execution.
+
+        Args:
+            request: Tool call request.
+            handler: Async callback that executes the tool.
+
+        Returns:
+            Tool result or a blocking ``ToolMessage`` on violation.
+        """
+        tool_name = request.tool_call.get("name", "unknown")
+        tool_args = request.tool_call.get("args", {})
+        tool_call_id = str(request.tool_call.get("id", f"blocked-{tool_name}"))
+
+        if self.inspect_requests:
+            result = await asyncio.to_thread(
+                self._inspect_tool_call, tool_name, tool_args,
+            )
+            if result is not None and not self._is_safe(result):
+                return self._apply_tool_violation(
+                    tool_name, tool_call_id, "request", result,
+                )
+
+        tool_result = await handler(request)
+
+        if self.inspect_responses:
+            result_data = self._extract_result_data(tool_result)
+            if result_data is not None:
+                result = await asyncio.to_thread(
+                    self._inspect_response, tool_name, tool_args, result_data,
+                )
+                if result is not None and not self._is_safe(result):
+                    return self._apply_tool_violation(
+                        tool_name, tool_call_id, "response", result,
+                    )
+
+        return tool_result
+
+    # -- internals ---------------------------------------------------------
+
+    def _inspect_tool_call(
+        self, tool_name: str, arguments: dict[str, Any],
+    ) -> Any | None:
+        try:
+            return self._get_client().inspect_tool_call(
+                tool_name=tool_name, arguments=arguments,
+            )
+        except Exception:
+            if self.fail_open:
+                logger.warning(
+                    "Cisco AI Defense tool inspection failed (fail_open=True), "
+                    "allowing tool call: %s",
+                    tool_name,
+                    exc_info=True,
+                )
+                return None
+            raise
+
+    def _inspect_response(
+        self,
+        tool_name: str,
+        arguments: dict[str, Any],
+        result_data: dict[str, Any],
+    ) -> Any | None:
+        try:
+            return self._get_client().inspect_response(
+                result_data=result_data,
+                method="tools/call",
+                params={"name": tool_name, "arguments": arguments},
+            )
+        except Exception:
+            if self.fail_open:
+                logger.warning(
+                    "Cisco AI Defense tool response inspection failed "
+                    "(fail_open=True), allowing result: %s",
+                    tool_name,
+                    exc_info=True,
+                )
+                return None
+            raise
+
+    @staticmethod
+    def _is_safe(result: Any) -> bool:
+        if hasattr(result, "result") and result.result is not None:
+            return result.result.is_safe
+        if hasattr(result, "error") and result.error is not None:
+            return False
+        return True
+
+    def _apply_tool_violation(
+        self,
+        tool_name: str,
+        tool_call_id: str,
+        direction: str,
+        result: Any,
+    ) -> ToolMessage:
+        violation_text = (
+            f"Tool call '{tool_name}' was blocked by Cisco AI Defense "
+            f"({direction} policy violation)."
+        )
+
+        if self.exit_behavior == "error":
+            raise CiscoAIDefenseError(
+                content=f"{tool_name}({direction})",
+                stage=f"tool_{direction}",
+                classifications=[],
+                message=violation_text,
+            )
+
+        return ToolMessage(content=violation_text, tool_call_id=tool_call_id)
+
+    @staticmethod
+    def _extract_result_data(
+        tool_result: ToolMessage | Command[Any],
+    ) -> dict[str, Any] | None:
+        if isinstance(tool_result, ToolMessage):
+            content = tool_result.content
+            if isinstance(content, str):
+                return {"content": [{"type": "text", "text": content}]}
+            if isinstance(content, dict):
+                return content
+            return {"content": str(content)}
+        return None
+
+
+__all__ = [
+    "CiscoAIDefenseError",
+    "CiscoAIDefenseMiddleware",
+    "CiscoAIDefenseToolMiddleware",
+]

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_cisco_ai_defense.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_cisco_ai_defense.py
@@ -1,0 +1,326 @@
+"""Tests for CiscoAIDefenseMiddleware and CiscoAIDefenseToolMiddleware."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.runtime import Runtime
+
+from langchain.agents.middleware.cisco_ai_defense import (
+    CiscoAIDefenseError,
+    CiscoAIDefenseMiddleware,
+    CiscoAIDefenseToolMiddleware,
+)
+from langchain.agents.middleware.types import AgentState
+
+
+# ---------------------------------------------------------------------------
+# Fakes for aidefense API responses
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FakeInspectResponse:
+    is_safe: bool
+    classifications: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FakeMCPInspectResult:
+    is_safe: bool
+    classifications: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FakeMCPInspectResponse:
+    result: FakeMCPInspectResult | None = None
+    error: Any = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _state_with_messages(messages: list) -> AgentState:
+    return {"messages": messages}
+
+
+def _make_runtime() -> Runtime:
+    return Runtime()
+
+
+def _mock_chat_client(*, is_safe: bool, classifications: list[str] | None = None):
+    client = MagicMock()
+    client.inspect_conversation.return_value = FakeInspectResponse(
+        is_safe=is_safe,
+        classifications=classifications or [],
+    )
+    return client
+
+
+def _mock_mcp_client(*, is_safe: bool):
+    client = MagicMock()
+    safe_result = FakeMCPInspectResponse(
+        result=FakeMCPInspectResult(is_safe=is_safe),
+    )
+    client.inspect_tool_call.return_value = safe_result
+    client.inspect_response.return_value = safe_result
+    return client
+
+
+# ===================================================================
+# CiscoAIDefenseMiddleware tests
+# ===================================================================
+
+
+class TestCiscoAIDefenseMiddleware:
+    """Unit tests for the LLM inspection middleware."""
+
+    def _middleware(self, **overrides: Any) -> CiscoAIDefenseMiddleware:
+        defaults: dict[str, Any] = {
+            "api_key": "test-key",
+            "region": "us",
+            "exit_behavior": "end",
+        }
+        defaults.update(overrides)
+        return CiscoAIDefenseMiddleware(**defaults)
+
+    def test_before_model_safe_input_passes(self) -> None:
+        mw = self._middleware()
+        mw._client = _mock_chat_client(is_safe=True)
+
+        state = _state_with_messages([HumanMessage("hello")])
+        result = mw.before_model(state, _make_runtime())
+
+        assert result is None
+
+    def test_before_model_unsafe_input_blocks(self) -> None:
+        mw = self._middleware()
+        mw._client = _mock_chat_client(
+            is_safe=False, classifications=["prompt_injection"],
+        )
+
+        state = _state_with_messages([HumanMessage("DROP TABLE users")])
+        result = mw.before_model(state, _make_runtime())
+
+        assert result is not None
+        assert result["jump_to"] == "end"
+        assert len(result["messages"]) == 1
+        assert "blocked" in result["messages"][0].content.lower()
+        assert "prompt_injection" in result["messages"][0].content
+
+    def test_before_model_unsafe_input_raises(self) -> None:
+        mw = self._middleware(exit_behavior="error")
+        mw._client = _mock_chat_client(
+            is_safe=False, classifications=["jailbreak"],
+        )
+
+        state = _state_with_messages([HumanMessage("bad")])
+        with pytest.raises(CiscoAIDefenseError, match="blocked"):
+            mw.before_model(state, _make_runtime())
+
+    def test_after_model_safe_output_passes(self) -> None:
+        mw = self._middleware()
+        mw._client = _mock_chat_client(is_safe=True)
+
+        state = _state_with_messages([
+            HumanMessage("hello"),
+            AIMessage("Hi there!"),
+        ])
+        result = mw.after_model(state, _make_runtime())
+
+        assert result is None
+
+    def test_after_model_unsafe_output_blocks(self) -> None:
+        mw = self._middleware()
+        mw._client = _mock_chat_client(
+            is_safe=False, classifications=["pii_leak"],
+        )
+
+        state = _state_with_messages([
+            HumanMessage("hello"),
+            AIMessage("Here is the SSN: 123-45-6789"),
+        ])
+        result = mw.after_model(state, _make_runtime())
+
+        assert result is not None
+        assert result["jump_to"] == "end"
+        assert "pii_leak" in result["messages"][0].content
+
+    def test_off_mode_check_input_false(self) -> None:
+        mw = self._middleware(check_input=False)
+        mw._client = _mock_chat_client(is_safe=False)
+
+        state = _state_with_messages([HumanMessage("anything")])
+        result = mw.before_model(state, _make_runtime())
+
+        assert result is None
+        mw._client.inspect_conversation.assert_not_called()
+
+    def test_fail_open_on_api_error(self) -> None:
+        mw = self._middleware(fail_open=True)
+        mw._client = MagicMock()
+        mw._client.inspect_conversation.side_effect = ConnectionError("timeout")
+
+        state = _state_with_messages([HumanMessage("hello")])
+        result = mw.before_model(state, _make_runtime())
+
+        assert result is None
+
+    def test_fail_closed_on_api_error(self) -> None:
+        mw = self._middleware(fail_open=False)
+        mw._client = MagicMock()
+        mw._client.inspect_conversation.side_effect = ConnectionError("timeout")
+
+        state = _state_with_messages([HumanMessage("hello")])
+        with pytest.raises(ConnectionError, match="timeout"):
+            mw.before_model(state, _make_runtime())
+
+    def test_invalid_exit_behavior(self) -> None:
+        with pytest.raises(ValueError, match="Invalid exit_behavior"):
+            self._middleware(exit_behavior="invalid")
+
+    def test_region_normalization(self) -> None:
+        mw = self._middleware(region="eu")
+        assert mw.region == "eu-central-1"
+
+        mw2 = self._middleware(region="apj")
+        assert mw2.region == "ap-northeast-1"
+
+        mw3 = self._middleware(region="us-east-1")
+        assert mw3.region == "us-east-1"
+
+
+# ===================================================================
+# CiscoAIDefenseToolMiddleware tests
+# ===================================================================
+
+
+class TestCiscoAIDefenseToolMiddleware:
+    """Unit tests for the tool/MCP inspection middleware."""
+
+    def _middleware(self, **overrides: Any) -> CiscoAIDefenseToolMiddleware:
+        defaults: dict[str, Any] = {
+            "api_key": "test-key",
+            "region": "us",
+            "exit_behavior": "end",
+        }
+        defaults.update(overrides)
+        return CiscoAIDefenseToolMiddleware(**defaults)
+
+    @staticmethod
+    def _make_request(
+        name: str = "my_tool",
+        args: dict | None = None,
+        call_id: str = "call-1",
+    ) -> MagicMock:
+        req = MagicMock()
+        req.tool_call = {
+            "name": name,
+            "args": args or {},
+            "id": call_id,
+        }
+        return req
+
+    @staticmethod
+    def _make_handler(content: str = "tool result") -> MagicMock:
+        handler = MagicMock()
+        handler.return_value = ToolMessage(content=content, tool_call_id="call-1")
+        return handler
+
+    def test_tool_safe_request_passes(self) -> None:
+        mw = self._middleware()
+        mw._client = _mock_mcp_client(is_safe=True)
+
+        request = self._make_request()
+        handler = self._make_handler()
+
+        result = mw.wrap_tool_call(request, handler)
+
+        handler.assert_called_once_with(request)
+        assert isinstance(result, ToolMessage)
+        assert result.content == "tool result"
+
+    def test_tool_unsafe_request_blocks(self) -> None:
+        mw = self._middleware()
+        mw._client = _mock_mcp_client(is_safe=False)
+
+        request = self._make_request(name="exec_cmd")
+        handler = self._make_handler()
+
+        result = mw.wrap_tool_call(request, handler)
+
+        handler.assert_not_called()
+        assert isinstance(result, ToolMessage)
+        assert "blocked" in result.content.lower()
+        assert result.tool_call_id == "call-1"
+
+    def test_tool_unsafe_response_blocks(self) -> None:
+        mw = self._middleware(inspect_requests=False)
+        safe_client = MagicMock()
+        unsafe_resp = FakeMCPInspectResponse(
+            result=FakeMCPInspectResult(is_safe=False),
+        )
+        safe_client.inspect_response.return_value = unsafe_resp
+        mw._client = safe_client
+
+        request = self._make_request()
+        handler = self._make_handler(content="SSN: 123-45-6789")
+
+        result = mw.wrap_tool_call(request, handler)
+
+        handler.assert_called_once()
+        assert isinstance(result, ToolMessage)
+        assert "blocked" in result.content.lower()
+
+    def test_tool_inspect_requests_only(self) -> None:
+        mw = self._middleware(inspect_responses=False)
+        mw._client = _mock_mcp_client(is_safe=True)
+
+        request = self._make_request()
+        handler = self._make_handler()
+
+        result = mw.wrap_tool_call(request, handler)
+
+        mw._client.inspect_tool_call.assert_called_once()
+        mw._client.inspect_response.assert_not_called()
+        assert result.content == "tool result"
+
+    def test_tool_fail_open(self) -> None:
+        mw = self._middleware(fail_open=True)
+        mw._client = MagicMock()
+        mw._client.inspect_tool_call.side_effect = ConnectionError("timeout")
+
+        request = self._make_request()
+        handler = self._make_handler()
+
+        result = mw.wrap_tool_call(request, handler)
+
+        handler.assert_called_once()
+        assert result.content == "tool result"
+
+    def test_tool_fail_closed(self) -> None:
+        mw = self._middleware(fail_open=False)
+        mw._client = MagicMock()
+        mw._client.inspect_tool_call.side_effect = ConnectionError("timeout")
+
+        request = self._make_request()
+        handler = self._make_handler()
+
+        with pytest.raises(ConnectionError, match="timeout"):
+            mw.wrap_tool_call(request, handler)
+
+    def test_tool_unsafe_request_raises_error(self) -> None:
+        mw = self._middleware(exit_behavior="error")
+        mw._client = _mock_mcp_client(is_safe=False)
+
+        request = self._make_request(name="danger_tool")
+        handler = self._make_handler()
+
+        with pytest.raises(CiscoAIDefenseError, match="blocked"):
+            mw.wrap_tool_call(request, handler)
+
+        handler.assert_not_called()


### PR DESCRIPTION
Fixes #36069

## Summary

Add two new middleware classes that integrate [Cisco AI Defense](https://developer.cisco.com/docs/ai-defense/overview/) security policies into LangChain agents:

- **`CiscoAIDefenseMiddleware`** — inspects LLM inputs and outputs via `before_model` / `after_model` hooks using the Cisco AI Defense Chat Inspection API.
- **`CiscoAIDefenseToolMiddleware`** — inspects tool call requests and responses via `wrap_tool_call` using the Cisco AI Defense MCP Inspection API.

### Key features

- **Composable**: use either middleware independently (LLM-only, tool-only) or both together.
- **Sync + async**: implements both sync and async hooks (`before_model` / `abefore_model`, `after_model` / `aafter_model`, `wrap_tool_call` / `awrap_tool_call`).
- **`exit_behavior`**: `"end"` (jump to end with a blocking message) or `"error"` (raise `CiscoAIDefenseError`).
- **Fail-open / fail-closed**: configurable via `fail_open` parameter — when the AI Defense API is unreachable, either allow the request through (fail-open) or propagate the error (fail-closed).
- **Region aliases**: short aliases `"us"`, `"eu"`, `"apj"` are normalized automatically.
- **Lazy import**: `aidefense` is imported inside methods (not at module level), so it remains an optional dependency.

### Configuration

Install the optional dependency:

```bash
pip install aidefense
```

### Minimal examples

**LLM inspection only:**

```python
from langchain.agents import create_agent
from langchain.agents.middleware import CiscoAIDefenseMiddleware

agent = create_agent(
    "openai:gpt-4.1",
    middleware=[
        CiscoAIDefenseMiddleware(
            api_key="your-cisco-ai-defense-api-key",
            region="us",               # or "eu", "apj", or full region name
            check_input=True,           # inspect user messages (default)
            check_output=True,          # inspect AI responses (default)
            exit_behavior="end",        # "end" or "error"
            fail_open=True,             # allow request if API unreachable
        ),
    ],
)
```

**Tool inspection only:**

```python
from langchain.agents import create_agent
from langchain.agents.middleware import CiscoAIDefenseToolMiddleware

agent = create_agent(
    "openai:gpt-4.1",
    tools=[my_tool],
    middleware=[
        CiscoAIDefenseToolMiddleware(
            api_key="your-cisco-ai-defense-api-key",
            region="us",
            inspect_requests=True,      # inspect tool call args (default)
            inspect_responses=True,     # inspect tool results (default)
            exit_behavior="end",
            fail_open=True,
        ),
    ],
)
```

**Both LLM + tool inspection:**

```python
from langchain.agents import create_agent
from langchain.agents.middleware import (
    CiscoAIDefenseMiddleware,
    CiscoAIDefenseToolMiddleware,
)

agent = create_agent(
    "openai:gpt-4.1",
    tools=[my_tool],
    middleware=[
        CiscoAIDefenseMiddleware(api_key="...", region="us"),
        CiscoAIDefenseToolMiddleware(api_key="...", region="us"),
    ],
)
```

### Files changed

| File | Change |
|------|--------|
| `libs/langchain_v1/langchain/agents/middleware/cisco_ai_defense.py` | New — middleware implementation |
| `libs/langchain_v1/langchain/agents/middleware/__init__.py` | Added imports and `__all__` entries |
| `libs/langchain_v1/langchain/agents/middleware/docs/cisco_ai_defense.mdx` | New — MDX documentation |
| `libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_cisco_ai_defense.py` | New — 19 unit tests |

### Dependencies

`aidefense` is an **optional** dependency (lazy-imported). No changes to `pyproject.toml` are needed — users install it separately when they want to use this middleware.

### Test plan

- [x] 19 unit tests with mocked `aidefense` client covering:
  - Safe input/output passthrough
  - Unsafe input/output blocking (`exit_behavior="end"`)
  - Unsafe input raising exceptions (`exit_behavior="error"`)
  - `check_input=False` skips inspection
  - Fail-open allows request on API error
  - Fail-closed propagates API error
  - Region alias normalization
  - Tool safe/unsafe request and response inspection
  - Tool fail-open/closed
  - Tool `exit_behavior="error"`
  - Request-only and response-only inspection modes