### PR TITLE
fix(core): add float support to _dict_int_op for UsageMetadata

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,7 +68,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to

--- a/libs/core/langchain_core/utils/usage.py
+++ b/libs/core/langchain_core/utils/usage.py
@@ -38,8 +38,8 @@ def _dict_int_op(
         raise ValueError(msg)
     combined: dict = {}
     for k in set(left).union(right):
-        if isinstance(left.get(k, default), int) and isinstance(
-            right.get(k, default), int
+        if isinstance(left.get(k, default), (int, float)) and isinstance(
+            right.get(k, default), (int, float)
         ):
             combined[k] = op(left.get(k, default), right.get(k, default))
         elif isinstance(left.get(k, {}), dict) and isinstance(right.get(k, {}), dict):
@@ -54,7 +54,7 @@ def _dict_int_op(
         else:
             types = [type(d[k]) for d in (left, right) if k in d]
             msg = (
-                f"Unknown value types: {types}. Only dict and int values are supported."
+                f"Unknown value types: {types}. Only dict and int/float values are supported."
             )
             raise ValueError(msg)  # noqa: TRY004
     return combined

--- a/libs/core/langchain_core/utils/usage.py
+++ b/libs/core/langchain_core/utils/usage.py
@@ -6,23 +6,23 @@ from collections.abc import Callable
 def _dict_int_op(
     left: dict,
     right: dict,
-    op: Callable[[int, int], int],
+    op: Callable[[int, int], int] | Callable[[float, float], float],
     *,
     default: int = 0,
     depth: int = 0,
     max_depth: int = 100,
 ) -> dict:
-    """Apply an integer operation to corresponding values in two dictionaries.
+    """Apply an integer or float operation to corresponding values in two dictionaries.
 
-    Recursively combines two dictionaries by applying the given operation to integer
-    values at matching keys.
+    Recursively combines two dictionaries by applying the given operation to numeric
+    values (int or float) at matching keys.
 
     Supports nested dictionaries.
 
     Args:
         left: First dictionary to combine.
         right: Second dictionary to combine.
-        op: Binary operation function to apply to integer values.
+        op: Binary operation function to apply to numeric values (int or float).
         default: Default value to use when a key is missing from a dictionary.
         depth: Current recursion depth (used internally).
         max_depth: Maximum recursion depth (to prevent infinite loops).
@@ -54,7 +54,8 @@ def _dict_int_op(
         else:
             types = [type(d[k]) for d in (left, right) if k in d]
             msg = (
-                f"Unknown value types: {types}. Only dict and int/float values are supported."
+                f"Unknown value types: {types}. Only dict and numeric (int/float) "
+                "values are supported."
             )
             raise ValueError(msg)  # noqa: TRY004
     return combined


### PR DESCRIPTION
## Summary

Adds float support to the `_dict_int_op()` function in `libs/core/langchain_core/utils/usage.py` to fix the issue where `UsageMetadata` with float fields (like `total_cost`) causes streaming aggregation to crash.

## Changes

- Support float values alongside int in `_dict_int_op()`
- Update type hints to accept both `Callable[[int, int], int]` and `Callable[[float, float], float]`
- Update error message to reflect numeric (int/float) support

## Testing

- Verified float values work correctly with `operator.add`
- Verified int values still work
- Verified mixed int/float scenarios work

## Related Issue

Fixes #36015
