### PR TITLE
fix: route non-dict tool arguments to invalid_tool_calls

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4491,8 +4491,13 @@ def _construct_lc_result_from_responses_api(
             content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
             try:
                 args = json.loads(output.arguments, strict=False)
+                if not isinstance(args, dict):
+                    raise TypeError(
+                        f"Tool call arguments must be a dict, "
+                        f"got {type(args).__name__}"
+                    )
                 error = None
-            except JSONDecodeError as e:
+            except (JSONDecodeError, TypeError) as e:
                 args = output.arguments
                 error = str(e)
             if error is None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3638,3 +3638,53 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test__construct_lc_result_from_responses_api_function_call_non_dict_args() -> None:
+    """Test that non-dict tool arguments are routed to invalid_tool_calls.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/35990.
+    json.loads can return non-dict types (e.g. a JSON string or list) which
+    would cause a ValidationError on AIMessage since ToolCall.args must be a
+    dict.  These should be treated as invalid tool calls instead.
+    """
+    for args_json, description in [
+        ('"just a string"', "string argument"),
+        ("[1, 2, 3]", "list argument"),
+        ("42", "integer argument"),
+        ("true", "boolean argument"),
+    ]:
+        response = Response(
+            id="resp_123",
+            created_at=1234567890,
+            model="gpt-4o",
+            object="response",
+            parallel_tool_calls=True,
+            tools=[],
+            tool_choice="auto",
+            output=[
+                ResponseFunctionToolCall(
+                    type="function_call",
+                    id="func_123",
+                    call_id="call_123",
+                    name="get_weather",
+                    arguments=args_json,
+                )
+            ],
+        )
+
+        result = _construct_lc_result_from_responses_api(
+            response, output_version="v0"
+        )
+
+        msg: AIMessage = cast(AIMessage, result.generations[0].message)
+        assert len(msg.tool_calls) == 0, (
+            f"Non-dict args ({description}) should not appear in tool_calls"
+        )
+        assert len(msg.invalid_tool_calls) == 1, (
+            f"Non-dict args ({description}) should appear in invalid_tool_calls"
+        )
+        assert msg.invalid_tool_calls[0]["name"] == "get_weather"
+        assert msg.invalid_tool_calls[0]["id"] == "call_123"
+        assert msg.invalid_tool_calls[0]["args"] == args_json
+        assert "must be a dict" in msg.invalid_tool_calls[0]["error"]


### PR DESCRIPTION
## Description

Fixes #35990.

`json.loads()` can successfully parse JSON that deserializes to non-dict types (strings, lists, integers, booleans). When this happens for tool call arguments in the Responses API path, the non-dict value is assigned to `ToolCall.args` which requires a `dict[str, Any]`, causing a `ValidationError` on `AIMessage` construction.

This PR adds an `isinstance(args, dict)` check after `json.loads()`. Non-dict results now raise a `TypeError` that is caught alongside `JSONDecodeError`, routing the malformed tool call to `invalid_tool_calls` instead of crashing.

### Changes

- **`libs/partners/openai/langchain_openai/chat_models/base.py`**: Added `isinstance(args, dict)` check after `json.loads()` in `_construct_lc_result_from_responses_api()`. Changed `except JSONDecodeError` to `except (JSONDecodeError, TypeError)`.
- **`libs/partners/openai/tests/unit_tests/chat_models/test_base.py`**: Added parameterized test covering string, list, integer, and boolean JSON arguments — all verified to route to `invalid_tool_calls`.