### PR TITLE
fix: route non-dict tool arguments to invalid_tool_calls

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -61,6 +61,14 @@ def parse_tool_call(
     else:
         try:
             function_args = json.loads(arguments, strict=strict)
+            if not isinstance(function_args, dict):
+                msg = (
+                    f"Function {raw_tool_call['function']['name']} arguments:\n\n"
+                    f"{arguments}\n\nare not a JSON object (got "
+                    f"{type(function_args).__name__}). "
+                    f"Tool call arguments must be a dict."
+                )
+                raise OutputParserException(msg)
         except JSONDecodeError as e:
             msg = (
                 f"Function {raw_tool_call['function']['name']} arguments:\n\n"

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -1426,6 +1426,29 @@ def test_parse_tool_call_partial_mode_with_none_arguments() -> None:
     assert result is None
 
 
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        '["a", "b", "c"]',  # list
+        '"just a string"',  # string
+        "42",  # number
+        "true",  # boolean
+        "null",  # null
+    ],
+    ids=["list", "string", "number", "boolean", "null"],
+)
+def test_parse_tool_call_non_dict_arguments(arguments: str) -> None:
+    """Test that non-dict JSON arguments raise OutputParserException."""
+    raw_tool_call = {
+        "function": {"arguments": arguments, "name": "myTool"},
+        "id": "call_456",
+        "type": "function",
+    }
+
+    with pytest.raises(OutputParserException, match="not a JSON object"):
+        parse_tool_call(raw_tool_call, return_id=True)
+
+
 @pytest.mark.parametrize("partial", [False, True])
 def test_pydantic_tools_parser_unknown_tool_raises_output_parser_exception(
     partial: bool,  # noqa: FBT001

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4491,8 +4491,13 @@ def _construct_lc_result_from_responses_api(
             content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
             try:
                 args = json.loads(output.arguments, strict=False)
+                if not isinstance(args, dict):
+                    raise TypeError(
+                        f"Tool call arguments must be a dict, "
+                        f"got {type(args).__name__}"
+                    )
                 error = None
-            except JSONDecodeError as e:
+            except (JSONDecodeError, TypeError) as e:
                 args = output.arguments
                 error = str(e)
             if error is None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1768,6 +1768,52 @@ def test__construct_lc_result_from_responses_api_function_call_invalid_json() ->
     assert _FUNCTION_CALL_IDS_MAP_KEY in result.generations[0].message.additional_kwargs
 
 
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        '["a", "b", "c"]',  # list
+        '"just a string"',  # string
+        "42",  # number
+        "true",  # boolean
+        "null",  # null
+    ],
+    ids=["list", "string", "number", "boolean", "null"],
+)
+def test__construct_lc_result_from_responses_api_function_call_non_dict_args(
+    arguments: str,
+) -> None:
+    """Test that non-dict tool arguments are routed to invalid_tool_calls."""
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseFunctionToolCall(
+                type="function_call",
+                id="func_123",
+                call_id="call_123",
+                name="get_weather",
+                arguments=arguments,
+            )
+        ],
+    )
+
+    result = _construct_lc_result_from_responses_api(response, output_version="v0")
+
+    msg: AIMessage = cast(AIMessage, result.generations[0].message)
+    assert len(msg.tool_calls) == 0
+    assert len(msg.invalid_tool_calls) == 1
+    assert msg.invalid_tool_calls[0]["type"] == "invalid_tool_call"
+    assert msg.invalid_tool_calls[0]["name"] == "get_weather"
+    assert msg.invalid_tool_calls[0]["id"] == "call_123"
+    assert msg.invalid_tool_calls[0]["args"] == arguments
+    assert "error" in msg.invalid_tool_calls[0]
+
+
 def test__construct_lc_result_from_responses_api_complex_response() -> None:
     """Test a complex response with multiple output types."""
     response = Response(


### PR DESCRIPTION
## Description

Fixes #35990

`json.loads` can return valid JSON that isn't a dict (e.g. lists, strings, numbers, booleans, `null`). When tool call arguments deserialize to a non-dict type, `AIMessage` raises a `ValidationError` because `ToolCall.args` requires `dict[str, Any]`.

This PR adds an `isinstance(args, dict)` check after `json.loads` so that non-dict results are routed to `invalid_tool_calls` with a clear error message, matching the existing behavior for `JSONDecodeError`.

### Changes

**`langchain-openai`** (`libs/partners/openai/langchain_openai/chat_models/base.py`):
- In the Response API path (`_construct_lc_result_from_responses_api`), raise `TypeError` when parsed args are not a dict, caught alongside `JSONDecodeError`

**`langchain-core`** (`libs/core/langchain_core/output_parsers/openai_tools.py`):
- In `parse_tool_call`, raise `OutputParserException` when parsed args are not a dict (before returning to callers that route exceptions to `invalid_tool_calls`)

### Tests

- 5 parametrized tests for the Response API path (list, string, number, boolean, null)
- 5 parametrized tests for `parse_tool_call` (same types)

All verify that non-dict arguments produce `invalid_tool_calls` entries (or `OutputParserException`) instead of `ValidationError`.