### PR TITLE
fix(core,openai): route non-dict tool arguments to invalid_tool_calls

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -365,13 +365,18 @@ def default_tool_parser(
         function_name = raw_tool_call["function"]["name"]
         try:
             function_args = json.loads(raw_tool_call["function"]["arguments"])
+            if not isinstance(function_args, dict):
+                raise TypeError(
+                    f"Tool call arguments must be a dict, "
+                    f"got {type(function_args).__name__}"
+                )
             parsed = tool_call(
                 name=function_name or "",
                 args=function_args or {},
                 id=raw_tool_call.get("id"),
             )
             tool_calls.append(parsed)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, TypeError):
             invalid_tool_calls.append(
                 invalid_tool_call(
                     name=function_name,

--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -61,6 +61,13 @@ def parse_tool_call(
     else:
         try:
             function_args = json.loads(arguments, strict=strict)
+            if not isinstance(function_args, dict):
+                msg = (
+                    f"Function {raw_tool_call['function']['name']} arguments:\n\n"
+                    f"{arguments}\n\nare not a JSON object (dict). "
+                    f"Got {type(function_args).__name__} instead."
+                )
+                raise OutputParserException(msg)
         except JSONDecodeError as e:
             msg = (
                 f"Function {raw_tool_call['function']['name']} arguments:\n\n"

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -11,6 +11,9 @@ from langchain_core.messages.ai import (
     add_usage,
     subtract_usage,
 )
+import pytest
+
+from langchain_core.messages.tool import default_tool_parser
 from langchain_core.messages.tool import invalid_tool_call as create_invalid_tool_call
 from langchain_core.messages.tool import tool_call as create_tool_call
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
@@ -502,3 +505,31 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        "[1, 2, 3]",
+        '"just a string"',
+        "42",
+        "true",
+        "null",
+    ],
+)
+def test_default_tool_parser_non_dict_args_are_invalid(arguments: str) -> None:
+    """Non-dict JSON tool arguments should be routed to invalid_tool_calls."""
+    raw_tool_calls = [
+        {
+            "function": {"arguments": arguments, "name": "get_weather"},
+            "id": "call_123",
+            "type": "function",
+        }
+    ]
+
+    tool_calls, invalid_tool_calls = default_tool_parser(raw_tool_calls)
+
+    assert len(tool_calls) == 0, "Non-dict args should not produce valid tool calls"
+    assert len(invalid_tool_calls) == 1, "Non-dict args should produce invalid tool call"
+    assert invalid_tool_calls[0]["name"] == "get_weather"
+    assert invalid_tool_calls[0]["id"] == "call_123"

--- a/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_openai_tools.py
@@ -1426,6 +1426,28 @@ def test_parse_tool_call_partial_mode_with_none_arguments() -> None:
     assert result is None
 
 
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        "[1, 2, 3]",
+        '"just a string"',
+        "42",
+        "true",
+        "null",
+    ],
+)
+def test_parse_tool_call_with_non_dict_arguments(arguments: str) -> None:
+    """Test parse_tool_call raises OutputParserException for non-dict JSON args."""
+    raw_tool_call = {
+        "function": {"arguments": arguments, "name": "myTool"},
+        "id": "call_123",
+        "type": "function",
+    }
+
+    with pytest.raises(OutputParserException, match="not a JSON object"):
+        parse_tool_call(raw_tool_call, return_id=True)
+
+
 @pytest.mark.parametrize("partial", [False, True])
 def test_pydantic_tools_parser_unknown_tool_raises_output_parser_exception(
     partial: bool,  # noqa: FBT001

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4491,8 +4491,13 @@ def _construct_lc_result_from_responses_api(
             content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
             try:
                 args = json.loads(output.arguments, strict=False)
+                if not isinstance(args, dict):
+                    raise TypeError(
+                        f"Tool call arguments must be a dict, "
+                        f"got {type(args).__name__}"
+                    )
                 error = None
-            except JSONDecodeError as e:
+            except (JSONDecodeError, TypeError) as e:
                 args = output.arguments
                 error = str(e)
             if error is None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1768,6 +1768,55 @@ def test__construct_lc_result_from_responses_api_function_call_invalid_json() ->
     assert _FUNCTION_CALL_IDS_MAP_KEY in result.generations[0].message.additional_kwargs
 
 
+@pytest.mark.parametrize(
+    "arguments,description",
+    [
+        ("[1, 2, 3]", "JSON array"),
+        ('"just a string"', "JSON string"),
+        ("42", "JSON number"),
+        ("true", "JSON boolean"),
+        ("null", "JSON null"),
+    ],
+)
+def test__construct_lc_result_from_responses_api_non_dict_tool_args(
+    arguments: str, description: str
+) -> None:
+    """Test that non-dict JSON tool arguments are routed to invalid_tool_calls."""
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseFunctionToolCall(
+                type="function_call",
+                id="func_123",
+                call_id="call_123",
+                name="get_weather",
+                arguments=arguments,
+            )
+        ],
+    )
+
+    result = _construct_lc_result_from_responses_api(response, output_version="v0")
+
+    msg: AIMessage = cast(AIMessage, result.generations[0].message)
+    assert len(msg.tool_calls) == 0, (
+        f"{description} should not be in tool_calls"
+    )
+    assert len(msg.invalid_tool_calls) == 1, (
+        f"{description} should be in invalid_tool_calls"
+    )
+    assert msg.invalid_tool_calls[0]["type"] == "invalid_tool_call"
+    assert msg.invalid_tool_calls[0]["name"] == "get_weather"
+    assert msg.invalid_tool_calls[0]["id"] == "call_123"
+    assert msg.invalid_tool_calls[0]["args"] == arguments
+    assert msg.invalid_tool_calls[0]["error"] is not None
+
+
 def test__construct_lc_result_from_responses_api_complex_response() -> None:
     """Test a complex response with multiple output types."""
     response = Response(


### PR DESCRIPTION
## Description

Fixes #35990

`json.loads()` successfully parses valid JSON that is not a dict — arrays, strings, numbers, booleans, and null are all valid JSON. The current code only catches `JSONDecodeError`, so any of these non-dict results are passed directly as `args` in a `tool_call` entry. This causes a `ValidationError` on `AIMessage` construction because `ToolCall.args` is typed as `dict[str, Any]`.

## Changes

Added `isinstance(args, dict)` checks after `json.loads()` in three locations:

1. **`langchain_core.messages.tool.default_tool_parser`** — catches `TypeError` alongside `JSONDecodeError`, routes non-dict args to `invalid_tool_calls`
2. **`langchain_core.output_parsers.openai_tools.parse_tool_call`** — raises `OutputParserException` for non-dict args (consistent with existing `JSONDecodeError` handling)
3. **`langchain_openai.chat_models.base`** (Responses API handler) — catches `TypeError` alongside `JSONDecodeError`, routes non-dict args to `invalid_tool_calls`

## Tests

Added parametrized tests covering all 5 non-dict JSON types (array, string, number, boolean, null) in:
- `libs/core/tests/unit_tests/messages/test_ai.py` — `default_tool_parser`
- `libs/core/tests/unit_tests/output_parsers/test_openai_tools.py` — `parse_tool_call`
- `libs/partners/openai/tests/unit_tests/chat_models/test_base.py` — Responses API handler

All 15 new tests pass. Existing tests unaffected.