### PR TITLE
update exa search tool: default to auto search type, improve description

### DIFF
--- a/libs/partners/exa/langchain_exa/retrievers.py
+++ b/libs/partners/exa/langchain_exa/retrievers.py
@@ -1,4 +1,8 @@
-from typing import Any, Literal, Optional, Union
+"""Retriever using Exa Search API."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
 
 from exa_py import Exa  # type: ignore[untyped-import]
 from exa_py.api import (
@@ -27,6 +31,8 @@ def _get_metadata(result: Any) -> dict[str, Any]:
         metadata["highlights"] = result.highlights
     if getattr(result, "highlight_scores"):
         metadata["highlight_scores"] = result.highlight_scores
+    if getattr(result, "summary"):
+        metadata["summary"] = result.summary
     return metadata
 
 
@@ -34,47 +40,53 @@ class ExaSearchRetriever(BaseRetriever):
     """Exa Search retriever."""
 
     k: int = 10  # num_results
-    """The number of search results to return."""
-    include_domains: Optional[list[str]] = None
+    """The number of search results to return (1 to 100)."""
+    include_domains: list[str] | None = None
     """A list of domains to include in the search."""
-    exclude_domains: Optional[list[str]] = None
+    exclude_domains: list[str] | None = None
     """A list of domains to exclude from the search."""
-    start_crawl_date: Optional[str] = None
+    start_crawl_date: str | None = None
     """The start date for the crawl (in YYYY-MM-DD format)."""
-    end_crawl_date: Optional[str] = None
+    end_crawl_date: str | None = None
     """The end date for the crawl (in YYYY-MM-DD format)."""
-    start_published_date: Optional[str] = None
+    start_published_date: str | None = None
     """The start date for when the document was published (in YYYY-MM-DD format)."""
-    end_published_date: Optional[str] = None
+    end_published_date: str | None = None
     """The end date for when the document was published (in YYYY-MM-DD format)."""
-    use_autoprompt: Optional[bool] = None
+    use_autoprompt: bool | None = None
     """Whether to use autoprompt for the search."""
-    type: str = "neural"
-    """The type of search, 'keyword' or 'neural'. Default: neural"""
-    highlights: Optional[Union[HighlightsContentsOptions, bool]] = None
+    type: str = "auto"
+    """The type of search, 'auto', 'neural', or 'keyword'. Default: auto"""
+    highlights: HighlightsContentsOptions | bool | None = None
     """Whether to set the page content to the highlights of the results."""
-    text_contents_options: Union[TextContentsOptions, Literal[True]] = True
-    """How to set the page content of the results"""
+    text_contents_options: TextContentsOptions | dict[str, Any] | Literal[True] = True
+    """How to set the page content of the results. Can be True or a dict with options
+    like max_characters."""
+    livecrawl: Literal["always", "fallback", "never"] | None = None
+    """Option to crawl live webpages if content is not in the index. Options: "always",
+    "fallback", "never"."""
+    summary: bool | dict[str, str] | None = None
+    """Whether to include a summary of the content. Can be a boolean or a dict with a
+    custom query."""
 
-    client: Exa = Field(default=None)
-    exa_api_key: SecretStr = Field(default=None)
-    exa_base_url: Optional[str] = None
+    client: Exa = Field(default=None)  # type: ignore[assignment]
+    exa_api_key: SecretStr = Field(default=SecretStr(""))
+    exa_base_url: str | None = None
 
     @model_validator(mode="before")
     @classmethod
     def validate_environment(cls, values: dict) -> Any:
         """Validate the environment."""
-        values = initialize_client(values)
-        return values
+        return initialize_client(values)
 
     def _get_relevant_documents(
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun
     ) -> list[Document]:
-        response = self.client.search_and_contents(  # type: ignore[misc]
+        response = self.client.search_and_contents(  # type: ignore[call-overload]
             query,
             num_results=self.k,
             text=self.text_contents_options,
-            highlights=self.highlights,  # type: ignore
+            highlights=self.highlights,
             include_domains=self.include_domains,
             exclude_domains=self.exclude_domains,
             start_crawl_date=self.start_crawl_date,
@@ -82,7 +94,10 @@ class ExaSearchRetriever(BaseRetriever):
             start_published_date=self.start_published_date,
             end_published_date=self.end_published_date,
             use_autoprompt=self.use_autoprompt,
-        )
+            livecrawl=self.livecrawl,
+            summary=self.summary,
+            type=self.type,
+        )  # type: ignore[call-overload, misc]
 
         results = response.results
 

--- a/libs/partners/exa/langchain_exa/tools.py
+++ b/libs/partners/exa/langchain_exa/tools.py
@@ -1,6 +1,8 @@
 """Tool for the Exa Search API."""
 
-from typing import Any, Optional, Union
+from __future__ import annotations
+
+from typing import Any, Literal
 
 from exa_py import Exa  # type: ignore[untyped-import]
 from exa_py.api import (
@@ -17,82 +19,133 @@ from langchain_exa._utilities import initialize_client
 
 
 class ExaSearchResults(BaseTool):  # type: ignore[override]
-    """Exa Search tool.
+    r"""Exa Search tool.
 
     Setup:
-        Install ``langchain-exa`` and set environment variable ``EXA_API_KEY``.
+        Install `langchain-exa` and set environment variable `EXA_API_KEY`.
 
-        .. code-block:: bash
-
-            pip install -U langchain-exa
-            export EXA_API_KEY="your-api-key"
+        ```bash
+        pip install -U langchain-exa
+        export EXA_API_KEY="your-api-key"
+        ```
 
     Instantiation:
-        .. code-block:: python
+        ```python
+        from langchain-exa import ExaSearchResults
 
-            from langchain-exa import ExaSearchResults
-
-            tool = ExaSearchResults()
+        tool = ExaSearchResults()
+        ```
 
     Invocation with args:
-        .. code-block:: python
+        ```python
+        tool.invoke({"query": "what is the weather in SF", "num_results": 1})
+        ```
 
-            tool.invoke({"query":"what is the weather in SF","num_results":1})
-
-        .. code-block:: python
-
-            SearchResponse(results=[Result(url='https://www.wunderground.com/weather/37.8,-122.4', id='https://www.wunderground.com/weather/37.8,-122.4', title='San Francisco, CA Weather Conditionsstar_ratehome', score=0.1843988299369812, published_date='2023-02-23T01:17:06.594Z', author=None, text='The time period when the sun is no more than 6 degrees below the horizon at either sunrise or sunset. The horizon should be clearly defined and the brightest stars should be visible under good atmospheric conditions (i.e. no moonlight, or other lights). One still should be able to carry on ordinary outdoor activities. The time period when the sun is between 6 and 12 degrees below the horizon at either sunrise or sunset. The horizon is well defined and the outline of objects might be visible without artificial light. Ordinary outdoor activities are not possible at this time without extra illumination. The time period when the sun is between 12 and 18 degrees below the horizon at either sunrise or sunset. The sun does not contribute to the illumination of the sky before this time in the morning, or after this time in the evening. In the beginning of morning astronomical twilight and at the end of astronomical twilight in the evening, sky illumination is very faint, and might be undetectable. The time of Civil Sunset minus the time of Civil Sunrise. The time of Actual Sunset minus the time of Actual Sunrise. The change in length of daylight between today and tomorrow is also listed when available.', highlights=None, highlight_scores=None, summary=None)], autoprompt_string=None)
+        ```python
+        SearchResponse(
+            results=[
+                Result(
+                    url="https://www.wunderground.com/weather/37.8,-122.4",
+                    id="https://www.wunderground.com/weather/37.8,-122.4",
+                    title="San Francisco, CA Weather Conditionsstar_ratehome",
+                    score=0.1843988299369812,
+                    published_date="2023-02-23T01:17:06.594Z",
+                    author=None,
+                    text="The time period when the sun is no more than 6 degrees below the horizon at either sunrise or sunset. The horizon should be clearly defined and the brightest stars should be visible under good atmospheric conditions (i.e. no moonlight, or other lights). One still should be able to carry on ordinary outdoor activities. The time period when the sun is between 6 and 12 degrees below the horizon at either sunrise or sunset. The horizon is well defined and the outline of objects might be visible without artificial light. Ordinary outdoor activities are not possible at this time without extra illumination. The time period when the sun is between 12 and 18 degrees below the horizon at either sunrise or sunset. The sun does not contribute to the illumination of the sky before this time in the morning, or after this time in the evening. In the beginning of morning astronomical twilight and at the end of astronomical twilight in the evening, sky illumination is very faint, and might be undetectable. The time of Civil Sunset minus the time of Civil Sunrise. The time of Actual Sunset minus the time of Actual Sunrise. The change in length of daylight between today and tomorrow is also listed when available.",
+                    highlights=None,
+                    highlight_scores=None,
+                    summary=None,
+                )
+            ],
+            autoprompt_string=None,
+        )
+        ```
 
     Invocation with ToolCall:
 
-        .. code-block:: python
+        ```python
+        tool.invoke(
+            {
+                "args": {"query": "what is the weather in SF", "num_results": 1},
+                "id": "1",
+                "name": tool.name,
+                "type": "tool_call",
+            }
+        )
+        ```
 
-            tool.invoke({"args": {"query":"what is the weather in SF","num_results":1}, "id": "1", "name": tool.name, "type": "tool_call"})
-
-        .. code-block:: python
-
-            ToolMessage(content='Title: San Francisco, CA Weather Conditionsstar_ratehome\nURL: https://www.wunderground.com/weather/37.8,-122.4\nID: https://www.wunderground.com/weather/37.8,-122.4\nScore: 0.1843988299369812\nPublished Date: 2023-02-23T01:17:06.594Z\nAuthor: None\nText: The time period when the sun is no more than 6 degrees below the horizon at either sunrise or sunset. The horizon should be clearly defined and the brightest stars should be visible under good atmospheric conditions (i.e. no moonlight, or other lights). One still should be able to carry on ordinary outdoor activities. The time period when the sun is between 6 and 12 degrees below the horizon at either sunrise or sunset. The horizon is well defined and the outline of objects might be visible without artificial light. Ordinary outdoor activities are not possible at this time without extra illumination. The time period when the sun is between 12 and 18 degrees below the horizon at either sunrise or sunset. The sun does not contribute to the illumination of the sky before this time in the morning, or after this time in the evening. In the beginning of morning astronomical twilight and at the end of astronomical twilight in the evening, sky illumination is very faint, and might be undetectable. The time of Civil Sunset minus the time of Civil Sunrise. The time of Actual Sunset minus the time of Actual Sunrise. The change in length of daylight between today and tomorrow is also listed when available.\nHighlights: None\nHighlight Scores: None\nSummary: None\n', name='exa_search_results_json', tool_call_id='1')
-
+        ```python
+        ToolMessage(
+            content="Title: San Francisco, CA Weather Conditionsstar_ratehome\nURL: https://www.wunderground.com/weather/37.8,-122.4\nID: https://www.wunderground.com/weather/37.8,-122.4\nScore: 0.1843988299369812\nPublished Date: 2023-02-23T01:17:06.594Z\nAuthor: None\nText: The time period when the sun is no more than 6 degrees below the horizon at either sunrise or sunset. The horizon should be clearly defined and the brightest stars should be visible under good atmospheric conditions (i.e. no moonlight, or other lights). One still should be able to carry on ordinary outdoor activities. The time period when the sun is between 6 and 12 degrees below the horizon at either sunrise or sunset. The horizon is well defined and the outline of objects might be visible without artificial light. Ordinary outdoor activities are not possible at this time without extra illumination. The time period when the sun is between 12 and 18 degrees below the horizon at either sunrise or sunset. The sun does not contribute to the illumination of the sky before this time in the morning, or after this time in the evening. In the beginning of morning astronomical twilight and at the end of astronomical twilight in the evening, sky illumination is very faint, and might be undetectable. The time of Civil Sunset minus the time of Civil Sunrise. The time of Actual Sunset minus the time of Actual Sunrise. The change in length of daylight between today and tomorrow is also listed when available.\nHighlights: None\nHighlight Scores: None\nSummary: None\n",
+            name="exa_search_results_json",
+            tool_call_id="1",
+        )
+        ```
     """  # noqa: E501
 
     name: str = "exa_search_results_json"
     description: str = (
-        "A wrapper around Exa Search. "
+        "A wrapper around Exa Search, a web search API built for AI. "
         "Input should be an Exa-optimized query. "
         "Output is a JSON array of the query results"
     )
-    client: Exa = Field(default=None)
-    exa_api_key: SecretStr = Field(default=None)
+    client: Exa = Field(default=None)  # type: ignore[assignment]
+    exa_api_key: SecretStr = Field(default=SecretStr(""))
 
     @model_validator(mode="before")
     @classmethod
     def validate_environment(cls, values: dict) -> Any:
         """Validate the environment."""
-        values = initialize_client(values)
-        return values
+        return initialize_client(values)
 
     def _run(
         self,
         query: str,
-        num_results: int,
-        text_contents_options: Optional[Union[TextContentsOptions, bool]] = None,
-        highlights: Optional[Union[HighlightsContentsOptions, bool]] = None,
-        include_domains: Optional[list[str]] = None,
-        exclude_domains: Optional[list[str]] = None,
-        start_crawl_date: Optional[str] = None,
-        end_crawl_date: Optional[str] = None,
-        start_published_date: Optional[str] = None,
-        end_published_date: Optional[str] = None,
-        use_autoprompt: Optional[bool] = None,
-        run_manager: Optional[CallbackManagerForToolRun] = None,
-    ) -> Union[list[dict], str]:
-        """Use the tool."""
+        num_results: int = 10,
+        text_contents_options: TextContentsOptions  # noqa: FBT001
+        | dict[str, Any]
+        | bool
+        | None = None,
+        highlights: HighlightsContentsOptions | bool | None = None,  # noqa: FBT001
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        start_crawl_date: str | None = None,
+        end_crawl_date: str | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+        use_autoprompt: bool | None = None,  # noqa: FBT001
+        livecrawl: Literal["always", "fallback", "never"] | None = None,
+        summary: bool | dict[str, str] | None = None,  # noqa: FBT001
+        type: Literal["auto", "neural", "keyword"] | None = None,  # noqa: A002
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> list[dict] | str:
+        # TODO: rename `type` to something else, as it is a reserved keyword
+        """Use the tool.
+
+        Args:
+            query: The search query.
+            num_results: The number of search results to return (1 to 100). Default: 10
+            text_contents_options: How to set the page content of the results. Can be True or a dict with options like max_characters.
+            highlights: Whether to include highlights in the results.
+            include_domains: A list of domains to include in the search.
+            exclude_domains: A list of domains to exclude from the search.
+            start_crawl_date: The start date for the crawl (in YYYY-MM-DD format).
+            end_crawl_date: The end date for the crawl (in YYYY-MM-DD format).
+            start_published_date: The start date for when the document was published (in YYYY-MM-DD format).
+            end_published_date: The end date for when the document was published (in YYYY-MM-DD format).
+            use_autoprompt: Whether to use autoprompt for the search.
+            livecrawl: Option to crawl live webpages if content is not in the index. Options: "always", "fallback", "never"
+            summary: Whether to include a summary of the content. Can be a boolean or a dict with a custom query.
+            type: The type of search, 'auto', 'neural', or 'keyword'.
+            run_manager: The run manager for callbacks.
+
+        """  # noqa: E501
         try:
             return self.client.search_and_contents(
                 query,
                 num_results=num_results,
-                text=text_contents_options,  # type: ignore
-                highlights=highlights,  # type: ignore
+                text=text_contents_options,
+                highlights=highlights,
                 include_domains=include_domains,
                 exclude_domains=exclude_domains,
                 start_crawl_date=start_crawl_date,
@@ -100,7 +153,10 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
                 start_published_date=start_published_date,
                 end_published_date=end_published_date,
                 use_autoprompt=use_autoprompt,
-            )  # type: ignore
+                livecrawl=livecrawl,
+                summary=summary,
+                type=type,
+            )  # type: ignore[call-overload, misc]
         except Exception as e:
             return repr(e)
 
@@ -114,40 +170,63 @@ class ExaFindSimilarResults(BaseTool):  # type: ignore[override]
         "Input should be an Exa-optimized query. "
         "Output is a JSON array of the query results"
     )
-    client: Exa = Field(default=None)
-    exa_api_key: SecretStr = Field(default=None)
-    exa_base_url: Optional[str] = None
+    client: Exa = Field(default=None)  # type: ignore[assignment]
+    exa_api_key: SecretStr = Field(default=SecretStr(""))
+    exa_base_url: str | None = None
 
     @model_validator(mode="before")
     @classmethod
     def validate_environment(cls, values: dict) -> Any:
         """Validate the environment."""
-        values = initialize_client(values)
-        return values
+        return initialize_client(values)
 
     def _run(
         self,
         url: str,
-        num_results: int,
-        text_contents_options: Optional[Union[TextContentsOptions, bool]] = None,
-        highlights: Optional[Union[HighlightsContentsOptions, bool]] = None,
-        include_domains: Optional[list[str]] = None,
-        exclude_domains: Optional[list[str]] = None,
-        start_crawl_date: Optional[str] = None,
-        end_crawl_date: Optional[str] = None,
-        start_published_date: Optional[str] = None,
-        end_published_date: Optional[str] = None,
-        exclude_source_domain: Optional[bool] = None,
-        category: Optional[str] = None,
-        run_manager: Optional[CallbackManagerForToolRun] = None,
-    ) -> Union[list[dict], str]:
-        """Use the tool."""
+        num_results: int = 10,
+        text_contents_options: TextContentsOptions  # noqa: FBT001
+        | dict[str, Any]
+        | bool
+        | None = None,
+        highlights: HighlightsContentsOptions | bool | None = None,  # noqa: FBT001
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        start_crawl_date: str | None = None,
+        end_crawl_date: str | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+        exclude_source_domain: bool | None = None,  # noqa: FBT001
+        category: str | None = None,
+        livecrawl: Literal["always", "fallback", "never"] | None = None,
+        summary: bool | dict[str, str] | None = None,  # noqa: FBT001
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> list[dict] | str:
+        """Use the tool.
+
+        Args:
+            url: The URL to find similar pages for.
+            num_results: The number of search results to return (1 to 100). Default: 10
+            text_contents_options: How to set the page content of the results. Can be True or a dict with options like max_characters.
+            highlights: Whether to include highlights in the results.
+            include_domains: A list of domains to include in the search.
+            exclude_domains: A list of domains to exclude from the search.
+            start_crawl_date: The start date for the crawl (in YYYY-MM-DD format).
+            end_crawl_date: The end date for the crawl (in YYYY-MM-DD format).
+            start_published_date: The start date for when the document was published (in YYYY-MM-DD format).
+            end_published_date: The end date for when the document was published (in YYYY-MM-DD format).
+            exclude_source_domain: If `True`, exclude pages from the same domain as the source URL.
+            category: Filter for similar pages by category.
+            livecrawl: Option to crawl live webpages if content is not in the index. Options: "always", "fallback", "never"
+            summary: Whether to include a summary of the content. Can be a boolean or a dict with a custom query.
+            run_manager: The run manager for callbacks.
+
+        """  # noqa: E501
         try:
             return self.client.find_similar_and_contents(
                 url,
                 num_results=num_results,
-                text=text_contents_options,  # type: ignore
-                highlights=highlights,  # type: ignore
+                text=text_contents_options,
+                highlights=highlights,
                 include_domains=include_domains,
                 exclude_domains=exclude_domains,
                 start_crawl_date=start_crawl_date,
@@ -156,6 +235,8 @@ class ExaFindSimilarResults(BaseTool):  # type: ignore[override]
                 end_published_date=end_published_date,
                 exclude_source_domain=exclude_source_domain,
                 category=category,
-            )  # type: ignore
+                livecrawl=livecrawl,
+                summary=summary,
+            )  # type: ignore[call-overload, misc]
         except Exception as e:
             return repr(e)


### PR DESCRIPTION
Changed the default search type from `neural` to `auto` in the Exa retriever since auto is the recommended default now. Also reordered the type literal and updated the tool description to mention Exa is a web search API built for AI.