### PR TITLE
fix(core): preserve parent callback lineage in fallbacks

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -193,7 +193,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     output = context.run(
                         runnable.invoke,
                         input,
-                        config,
+                        child_config,
                         **kwargs,
                     )
             except self.exceptions_to_handle as e:
@@ -244,7 +244,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     input[self.exception_key] = last_error  # type: ignore[index]
                 child_config = patch_config(config, callbacks=run_manager.get_child())
                 with set_config_context(child_config) as context:
-                    coro = context.run(runnable.ainvoke, input, config, **kwargs)
+                    coro = context.run(runnable.ainvoke, input, child_config, **kwargs)
                     output = await coro_with_context(coro, context)
             except self.exceptions_to_handle as e:
                 if first_error is None:

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -28,6 +28,7 @@ from langchain_core.runnables import (
     RunnableWithFallbacks,
 )
 from langchain_core.tools import BaseTool
+from tests.unit_tests.runnables.test_runnable import FakeTracer
 
 
 @pytest.fixture
@@ -400,3 +401,43 @@ def test_fallbacks_getattr_runnable_output() -> None:
         for fallback in llm_with_fallbacks_with_tools.fallbacks
     )
     assert llm_with_fallbacks_with_tools.runnable.kwargs["tools"] == []
+
+
+def test_fallbacks_invoke_preserves_parent_run_id() -> None:
+    def fail(_: str) -> str:
+        msg = "fail"
+        raise ValueError(msg)
+
+    def succeed(value: str) -> str:
+        return value
+
+    runnable = RunnableLambda(fail).with_fallbacks([RunnableLambda(succeed)])
+    tracer = FakeTracer()
+
+    assert runnable.invoke("hello", {"callbacks": [tracer]}) == "hello"
+
+    root_runs = [run for run in tracer.runs if run.parent_run_id is None]
+    assert len(root_runs) == 1
+    parent_run = root_runs[0]
+    assert [child.name for child in parent_run.child_runs] == ["fail", "succeed"]
+    assert all(child.parent_run_id == parent_run.id for child in parent_run.child_runs)
+
+
+async def test_fallbacks_ainvoke_preserves_parent_run_id() -> None:
+    async def afail(_: str) -> str:
+        msg = "fail"
+        raise ValueError(msg)
+
+    async def apass(value: str) -> str:
+        return value
+
+    runnable = RunnableLambda(afail).with_fallbacks([RunnableLambda(apass)])
+    tracer = FakeTracer()
+
+    assert await runnable.ainvoke("hello", {"callbacks": [tracer]}) == "hello"
+
+    root_runs = [run for run in tracer.runs if run.parent_run_id is None]
+    assert len(root_runs) == 1
+    parent_run = root_runs[0]
+    assert [child.name for child in parent_run.child_runs] == ["afail", "apass"]
+    assert all(child.parent_run_id == parent_run.id for child in parent_run.child_runs)


### PR DESCRIPTION
Fixes #36072

Pass the patched child callback config into fallback child runnables so callback events keep the fallback run as `parent_run_id`. Adds focused sync and async regression tests covering `invoke()` and `ainvoke()`.
