### PR TITLE
ci: skip dev/test/lint groups when installing langchain-profiles CLI

### DIFF
--- a/.github/workflows/_refresh_model_profiles.yml
+++ b/.github/workflows/_refresh_model_profiles.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: "📦 Install langchain-profiles CLI"
         working-directory: ${{ steps.cli.outputs.dir }}
-        run: uv sync
+        run: uv sync --no-group test --no-group dev --no-group lint
 
       - name: "✅ Validate providers input"
         env:


### PR DESCRIPTION
The reusable refresh_model_profiles workflow sparse-checks out only libs/model-profiles from the langchain monorepo. `uv sync` fails because the test/dev/lint dependency groups reference sibling editable packages (../langchain_v1, ../core) that aren't present in the sparse checkout.

Restrict to the default dependency group so only the runtime deps (httpx, tomli, typing-extensions) are installed — which is all the CLI needs.