### PR TITLE
ci: add `--frozen` to uv sync/run in `refresh_model_profiles`

### DIFF
--- a/.github/workflows/_refresh_model_profiles.yml
+++ b/.github/workflows/_refresh_model_profiles.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: "📦 Install langchain-profiles CLI"
         working-directory: ${{ steps.cli.outputs.dir }}
-        run: uv sync --no-group test --no-group dev --no-group lint
+        run: uv sync --frozen --no-group test --no-group dev --no-group lint
 
       - name: "✅ Validate providers input"
         env:
@@ -154,7 +154,7 @@ jobs:
             provider=$(echo "${row}" | jq -r '.provider')
             data_dir=$(echo "${row}" | jq -r '.data_dir')
             echo "--- Refreshing ${provider} -> ${data_dir} ---"
-            if ! echo y | uv run --project "${cli_dir}" \
+            if ! echo y | uv run --frozen --project "${cli_dir}" \
               langchain-profiles refresh \
               --provider "${provider}" \
               --data-dir "${GITHUB_WORKSPACE}/${data_dir}"; then


### PR DESCRIPTION
`--no-group test --no-group dev --no-group lint` only controls which groups get *installed*; uv still resolves the full dependency graph (all groups) and tries to generate metadata for editable sources like `../langchain_v1`. In a sparse checkout these paths don't exist.

`--frozen` skips re-resolution entirely and uses the existing lock, so the missing editable paths are never accessed.