### PR TITLE
ci: suppress pytest streaming output in CI

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: "🧪 Run Core Unit Tests"
         shell: bash
         run: |
-          make test
+          make test PYTEST_EXTRA=-q
 
       - name: "🔍 Calculate Minimum Dependency Versions"
         working-directory: ${{ inputs.working-directory }}
@@ -69,7 +69,7 @@ jobs:
           MIN_VERSIONS: ${{ steps.min-version.outputs.min-versions }}
         run: |
           VIRTUAL_ENV=.venv uv pip install $MIN_VERSIONS
-          make tests
+          make tests PYTEST_EXTRA=-q
         working-directory: ${{ inputs.working-directory }}
 
       - name: "🧹 Verify Clean Working Directory"

--- a/libs/core/Makefile
+++ b/libs/core/Makefile
@@ -5,6 +5,7 @@ all: help
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 .EXPORT_ALL_VARIABLES:
 UV_FROZEN = true
@@ -16,7 +17,7 @@ test tests:
 	-u LANGSMITH_API_KEY \
 	-u LANGSMITH_TRACING \
 	-u LANGCHAIN_PROJECT \
-	uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest -n auto $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test_watch:
 	env \

--- a/libs/langchain/Makefile
+++ b/libs/langchain/Makefile
@@ -9,6 +9,7 @@ all: help
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 .EXPORT_ALL_VARIABLES:
 UV_FROZEN = true
@@ -22,10 +23,10 @@ coverage:
 		$(TEST_FILE)
 
 test tests:
-	uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest -n auto $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 extended_tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket --only-extended tests/unit_tests
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket --only-extended tests/unit_tests
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -x --disable-socket --allow-unix-socket --disable-warnings tests/unit_tests

--- a/libs/langchain_v1/Makefile
+++ b/libs/langchain_v1/Makefile
@@ -15,6 +15,7 @@ stop_services:
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 .EXPORT_ALL_VARIABLES:
 UV_FROZEN = true
@@ -37,13 +38,13 @@ coverage_agents:
 		--cov-report=html:htmlcov \
 
 test:
-	make start_services && LANGGRAPH_TEST_FAST=0 uv run --no-sync --active --group test pytest -n auto --disable-socket --allow-unix-socket $(TEST_FILE) --cov-report term-missing:skip-covered --snapshot-update; \
+	make start_services && LANGGRAPH_TEST_FAST=0 uv run --no-sync --active --group test pytest -n auto $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE) --cov-report term-missing:skip-covered --snapshot-update; \
 	EXIT_CODE=$$?; \
 	make stop_services; \
 	exit $$EXIT_CODE
 
 test_fast:
-	LANGGRAPH_TEST_FAST=1 uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(TEST_FILE)
+	LANGGRAPH_TEST_FAST=1 uv run --group test pytest -n auto $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 extended_tests:
 	make start_services && LANGGRAPH_TEST_FAST=0 uv run --group test pytest --disable-socket --allow-unix-socket --only-extended tests/unit_tests; \

--- a/libs/model-profiles/Makefile
+++ b/libs/model-profiles/Makefile
@@ -39,12 +39,13 @@ refresh-profiles:
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 # unit tests are run with the --disable-socket flag to prevent network calls
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)

--- a/libs/model-profiles/uv.lock
+++ b/libs/model-profiles/uv.lock
@@ -527,7 +527,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.19"
+version = "1.2.20"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/anthropic/Makefile
+++ b/libs/partners/anthropic/Makefile
@@ -8,10 +8,11 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test tests:
-	uv run --group test pytest -vvv --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest -vvv $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest -n auto -vvv --timeout 30 $(TEST_FILE)

--- a/libs/partners/chroma/Makefile
+++ b/libs/partners/chroma/Makefile
@@ -8,10 +8,11 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 integration_test integration_tests: TEST_FILE = tests/integration_tests/
 
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest $(TEST_FILE)

--- a/libs/partners/deepseek/Makefile
+++ b/libs/partners/deepseek/Makefile
@@ -8,12 +8,13 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 integration_test integration_tests: TEST_FILE = tests/integration_tests/
 
 
 # unit tests are run with the --disable-socket flag to prevent network calls
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/exa/Makefile
+++ b/libs/partners/exa/Makefile
@@ -8,14 +8,15 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_tests: TEST_FILE=tests/integration_tests/
 
 test integration_tests:
-	uv run --group test --group test_integration pytest $(TEST_FILE)
+	uv run --group test --group test_integration pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 tests:
-	uv run --group test pytest $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/fireworks/Makefile
+++ b/libs/partners/fireworks/Makefile
@@ -8,10 +8,11 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 integration_test integration_tests: TEST_FILE = tests/integration_tests/
 
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)

--- a/libs/partners/groq/Makefile
+++ b/libs/partners/groq/Makefile
@@ -8,11 +8,12 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest --retries 3 --retry-delay 1 $(TEST_FILE)

--- a/libs/partners/huggingface/Makefile
+++ b/libs/partners/huggingface/Makefile
@@ -8,11 +8,12 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest $(TEST_FILE)

--- a/libs/partners/mistralai/Makefile
+++ b/libs/partners/mistralai/Makefile
@@ -9,11 +9,12 @@ UV_FROZEN = true
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 INTEGRATION_TEST_FILE ?= tests/integration_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=$(INTEGRATION_TEST_FILE)
 
 test tests:
-	uv run --group test pytest $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/nomic/Makefile
+++ b/libs/partners/nomic/Makefile
@@ -8,14 +8,15 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_tests: TEST_FILE = tests/integration_tests/
 
 test integration_tests:
-	uv run --group test --group test_integration pytest $(TEST_FILE)
+	uv run --group test --group test_integration pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 tests:
-	uv run --group test pytest $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/ollama/Makefile
+++ b/libs/partners/ollama/Makefile
@@ -8,6 +8,7 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 integration_test: TEST_FILE = tests/integration_tests/
 # TODO(erick) configure ollama server to run in CI, in separate repo
 
@@ -18,7 +19,7 @@ OLLAMA_REASONING_TEST_MODEL ?= deepseek-r1:1.5b
 
 # unit tests are run with the --disable-socket flag to prevent network calls
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -8,6 +8,7 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
@@ -21,7 +22,7 @@ test tests:
 	@if [ ! -f tiktoken_cache/fb374d419588a4632f3f557e76b4b70aebbca790 ]; then \
 		curl -o tiktoken_cache/fb374d419588a4632f3f557e76b4b70aebbca790 https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken; \
 	fi
-	TIKTOKEN_CACHE_DIR=tiktoken_cache uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	TIKTOKEN_CACHE_DIR=tiktoken_cache uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)

--- a/libs/partners/openrouter/Makefile
+++ b/libs/partners/openrouter/Makefile
@@ -8,12 +8,13 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 integration_test integration_tests: TEST_FILE = tests/integration_tests/
 
 
 # unit tests are run with the --disable-socket flag to prevent network calls
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/perplexity/Makefile
+++ b/libs/partners/perplexity/Makefile
@@ -8,11 +8,12 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/qdrant/Makefile
+++ b/libs/partners/qdrant/Makefile
@@ -8,11 +8,12 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE = tests/integration_tests/
 
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest $(TEST_FILE)

--- a/libs/partners/xai/Makefile
+++ b/libs/partners/xai/Makefile
@@ -8,11 +8,12 @@ UV_FROZEN = true
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 test tests:
-	uv run --group test pytest --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/standard-tests/Makefile
+++ b/libs/standard-tests/Makefile
@@ -9,11 +9,12 @@ UV_FROZEN = true
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 INTEGRATION_TEST_FILE ?= tests/integration_tests/
+PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=$(INTEGRATION_TEST_FILE)
 
 test tests:
-	uv run --group test pytest $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest $(TEST_FILE)

--- a/libs/text-splitters/Makefile
+++ b/libs/text-splitters/Makefile
@@ -5,12 +5,13 @@ all: help
 
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
+PYTEST_EXTRA ?=
 
 .EXPORT_ALL_VARIABLES:
 UV_FROZEN = true
 
 test tests:
-	uv run --group test pytest -n auto --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest -n auto $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest tests/integration_tests/


### PR DESCRIPTION
Reduce CI log noise by suppressing pytest's per-test dot/verbose streaming output. The `_test.yml` workflow now passes `PYTEST_EXTRA=-q` to `make test`, which overrides the default verbosity with quiet mode — failures still print in full, but the thousands of `.......` progress lines are gone. Local `make test` is unaffected since `PYTEST_EXTRA` defaults empty.

## Changes
- Add `PYTEST_EXTRA ?=` variable to all 21 package Makefiles and inject it into each `test` target's pytest invocation
- Pass `PYTEST_EXTRA=-q` in `_test.yml` for both the main test step and the min-version retest step
