### PR TITLE
fix: RunnableWithFallbacks passes child_config to child runnables

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -193,7 +193,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     output = context.run(
                         runnable.invoke,
                         input,
-                        config,
+                        child_config,
                         **kwargs,
                     )
             except self.exceptions_to_handle as e:
@@ -244,7 +244,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     input[self.exception_key] = last_error  # type: ignore[index]
                 child_config = patch_config(config, callbacks=run_manager.get_child())
                 with set_config_context(child_config) as context:
-                    coro = context.run(runnable.ainvoke, input, config, **kwargs)
+                    coro = context.run(runnable.ainvoke, input, child_config, **kwargs)
                     output = await coro_with_context(coro, context)
             except self.exceptions_to_handle as e:
                 if first_error is None:


### PR DESCRIPTION
## Summary

Fixes a regression where `RunnableWithFallbacks.invoke()` was passing `config` instead of `child_config` to child runnables, causing child callback events to receive `parent_run_id=None` instead of the fallback chain's run_id.

## Changes

- Fixed `config` → `child_config` in `invoke()` method
- Fixed `config` → `child_config` in `ainvoke()` method

## Testing

- Verified child callback events now receive correct parent_run_id
- Syntax validation passed

Fixes langchain-ai/langchain#36072