### PR TITLE
fix(core): respect include_injected=False in create_schema_from_function

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -344,7 +344,7 @@ def create_schema_from_function(
     inferred_model = validated.model
 
     if filter_args:
-        filter_args_ = filter_args
+        filter_args_ = list(filter_args)
     else:
         # Handle classmethods and instance methods
         existing_params: list[str] = list(sig.parameters.keys())
@@ -353,10 +353,12 @@ def create_schema_from_function(
         else:
             filter_args_ = list(FILTERED_ARGS)
 
+    if not include_injected:
+        existing_params = list(sig.parameters.keys())
         for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
+            if _is_injected_arg_type(
                 sig.parameters[existing_param].annotation
-            ):
+            ) and existing_param not in filter_args_:
                 filter_args_.append(existing_param)
 
     description, arg_descriptions = _infer_arg_descriptions(

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3653,3 +3653,50 @@ def test_tool_default_factory_not_required() -> None:
     schema = convert_to_openai_tool(some_func)
     params = schema["function"]["parameters"]
     assert "names" not in params.get("required", [])
+
+
+def test_create_schema_from_function_include_injected_false_with_filter_args() -> None:
+    """Regression test for #35831.
+
+    create_schema_from_function should respect include_injected=False even when
+    filter_args is explicitly provided.
+    """
+    from typing import Annotated
+
+    from langchain_core.tools.base import InjectedToolArg, create_schema_from_function
+
+    def my_func(
+        x: int,
+        y: str,
+        injected_param: Annotated[str, InjectedToolArg],
+    ) -> str:
+        """A function with an injected parameter."""
+        return f"{x} {y} {injected_param}"
+
+    # With filter_args provided and include_injected=False:
+    # injected_param should be excluded from the schema
+    schema = create_schema_from_function(
+        "MyFunc",
+        my_func,
+        filter_args=["x"],  # explicitly filter out 'x'
+        include_injected=False,
+    )
+    fields = list(schema.model_fields.keys())
+    assert "x" not in fields, "x should be filtered by filter_args"
+    assert "injected_param" not in fields, (
+        "injected_param should be filtered because include_injected=False"
+    )
+    assert "y" in fields, "y should remain in schema"
+
+    # Without filter_args and include_injected=False: same expectation
+    schema2 = create_schema_from_function(
+        "MyFunc2",
+        my_func,
+        include_injected=False,
+    )
+    fields2 = list(schema2.model_fields.keys())
+    assert "injected_param" not in fields2, (
+        "injected_param should be filtered when include_injected=False"
+    )
+    assert "y" in fields2
+    assert "x" in fields2


### PR DESCRIPTION
Fixes #35831

## Problem

`create_schema_from_function` has a conditional branch:

```python
if filter_args:
    filter_args_ = filter_args  # injected-check block is skipped!
else:
    ...
    for existing_param in existing_params:
        if not include_injected and _is_injected_arg_type(...):
            filter_args_.append(existing_param)
```

When `filter_args` is provided (truthy), the `else` block — which adds `InjectedToolArg`-annotated parameters to `filter_args_` when `include_injected=False` — is never executed. As a result, injected parameters appear in the generated schema even when `include_injected=False`.

## Fix

Moved the `include_injected` check outside the `if/else` block so it always runs regardless of whether `filter_args` was provided:

```python
if filter_args:
    filter_args_ = list(filter_args)
else:
    ...

if not include_injected:
    existing_params = list(sig.parameters.keys())
    for existing_param in existing_params:
        if _is_injected_arg_type(...) and existing_param not in filter_args_:
            filter_args_.append(existing_param)
```

## Tests

Added regression test `test_create_schema_from_function_include_injected_false_with_filter_args` that verifies:
1. When `filter_args` is provided + `include_injected=False`: injected params are excluded
2. When `filter_args` is not provided + `include_injected=False`: injected params are excluded (existing behaviour preserved)