### PR TITLE
fix: preserve namespace in streaming function_call content blocks

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4723,16 +4723,17 @@ def _convert_responses_chunk_to_generation_chunk(
                 "index": current_index,
             }
         )
-        content.append(
-            {
-                "type": "function_call",
-                "name": chunk.item.name,
-                "arguments": chunk.item.arguments,
-                "call_id": chunk.item.call_id,
-                "id": chunk.item.id,
-                "index": current_index,
-            }
-        )
+        content_block = {
+            "type": "function_call",
+            "name": chunk.item.name,
+            "arguments": chunk.item.arguments,
+            "call_id": chunk.item.call_id,
+            "id": chunk.item.id,
+            "index": current_index,
+        }
+        if hasattr(chunk.item, "namespace") and chunk.item.namespace:
+            content_block["namespace"] = chunk.item.namespace
+        content.append(content_block)
     elif chunk.type == "response.output_item.done" and chunk.item.type in (
         "compaction",
         "web_search_call",


### PR DESCRIPTION
## Summary
Fixes #36096.
**Root cause:** `_convert_responses_chunk_to_generation_chunk()` did not copy the `namespace` field from `chunk.item` into the content block dict for `function_call` type blocks. The non-streaming path uses `output.model_dump(exclude_none=True)` which preserves `namespace`, but the streaming path manually constructs the dict and omits it.
**Fix:** Added `namespace` to the content block dict when present on `chunk.item`, matching the non-streaming behavior.
## Changes
- `libs/partners/openai/langchain_openai/chat_models/base.py`: Added namespace field to streaming function_call content blocks
## Testing
- Verified fix addresses reported scenario (namespace preserved in streaming round-trip)
- Change is minimal and follows existing code patterns

Made with [Cursor](https://cursor.com)