### PR TITLE
fix: pass child_config in RunnableWithFallbacks invoke/ainvoke

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -193,7 +193,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     output = context.run(
                         runnable.invoke,
                         input,
-                        config,
+                        child_config,
                         **kwargs,
                     )
             except self.exceptions_to_handle as e:
@@ -244,7 +244,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     input[self.exception_key] = last_error  # type: ignore[index]
                 child_config = patch_config(config, callbacks=run_manager.get_child())
                 with set_config_context(child_config) as context:
-                    coro = context.run(runnable.ainvoke, input, config, **kwargs)
+                    coro = context.run(runnable.ainvoke, input, child_config, **kwargs)
                     output = await coro_with_context(coro, context)
             except self.exceptions_to_handle as e:
                 if first_error is None:


### PR DESCRIPTION
## Summary

Fixes #36072

PR #25550 introduced a regression where `RunnableWithFallbacks.invoke()` and `ainvoke()` pass `config` (the parent config) instead of `child_config` to child runnables, causing `parent_run_id` to be lost in callback events.

- In `invoke()`: changed `context.run(runnable.invoke, input, config, ...)` to `context.run(runnable.invoke, input, child_config, ...)`
- In `ainvoke()`: changed `context.run(runnable.ainvoke, input, config, ...)` to `context.run(runnable.ainvoke, input, child_config, ...)`

This restores the correct callback hierarchy by ensuring child runnables receive `child_config` (which includes the proper `parent_run_id` from `run_manager.get_child()`), consistent with how `batch()`, `abatch()`, and `astream()` already work.

## Test plan

- [x] Verify `invoke()` passes `child_config` to child runnables
- [x] Verify `ainvoke()` passes `child_config` to child runnables
- [x] Confirmed `batch()`, `abatch()`, and `astream()` already use `child_config` correctly
- [ ] Existing unit tests for `RunnableWithFallbacks` should continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)