### PR TITLE
core: fix TypeError when merging float values in merge_dicts

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,7 +68,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to
@@ -201,6 +201,8 @@ def merge_obj(left: Any, right: Any) -> Any:
         return merge_lists(left, right)
     if left == right:
         return left
+    if isinstance(left, (int, float)):
+        return left + right
     msg = (
         f"Unable to merge {left=} and {right=}. Both must be of type str, dict, or "
         f"list, or else be two equal objects."

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,10 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # Float fields should be summed
+        ({"score": 0.5}, {"score": 0.3}, {"score": 0.8}),
+        ({"weight": 1.2}, {"weight": 2.4}, {"weight": 3.6}),
+        ({"index": 0.5}, {"index": 1.5}, {"index": 1.5}),
     ],
 )
 def test_merge_dicts(


### PR DESCRIPTION
## Summary
When merging dicts (e.g., streaming chunks that contain float fields like `logprob`, `score`, or safety metrics), `merge_dicts` would raise a `TypeError: Additional kwargs key score already exists in left dict and value has unsupported type <class 'float'>`.

This PR changes the type checking from `isinstance(merged[right_k], int)` to `isinstance(merged[right_k], (int, float))` in both `merge_dicts` and `merge_obj`. Tests have been added to verify that float fields sum correctly while preserving temporal fields (if they happen to be float).

Fixes #36011.