### PR TITLE
fix(core): handle float type in merge_dicts, merge_obj, and _dict_int_op

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,7 +68,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to
@@ -201,6 +201,8 @@ def merge_obj(left: Any, right: Any) -> Any:
         return merge_lists(left, right)
     if left == right:
         return left
+    if isinstance(left, (int, float)):
+        return left + right
     msg = (
         f"Unable to merge {left=} and {right=}. Both must be of type str, dict, or "
         f"list, or else be two equal objects."

--- a/libs/core/langchain_core/utils/usage.py
+++ b/libs/core/langchain_core/utils/usage.py
@@ -38,8 +38,8 @@ def _dict_int_op(
         raise ValueError(msg)
     combined: dict = {}
     for k in set(left).union(right):
-        if isinstance(left.get(k, default), int) and isinstance(
-            right.get(k, default), int
+        if isinstance(left.get(k, default), (int, float)) and isinstance(
+            right.get(k, default), (int, float)
         ):
             combined[k] = op(left.get(k, default), right.get(k, default))
         elif isinstance(left.get(k, {}), dict) and isinstance(right.get(k, {}), dict):
@@ -54,7 +54,8 @@ def _dict_int_op(
         else:
             types = [type(d[k]) for d in (left, right) if k in d]
             msg = (
-                f"Unknown value types: {types}. Only dict and int values are supported."
+                f"Unknown value types: {types}. Only dict, int, and float values are"
+                " supported."
             )
             raise ValueError(msg)  # noqa: TRY004
     return combined

--- a/libs/core/tests/unit_tests/utils/test_usage.py
+++ b/libs/core/tests/unit_tests/utils/test_usage.py
@@ -35,11 +35,25 @@ def test_dict_int_op_max_depth_exceeded() -> None:
         _dict_int_op(left, right, operator.add, max_depth=2)
 
 
+def test_dict_int_op_float() -> None:
+    left = {"a": 0.5, "b": 1.2}
+    right = {"b": 0.3, "c": 0.4}
+    result = _dict_int_op(left, right, operator.add)
+    assert result == {"a": 0.5, "b": 1.5, "c": 0.4}
+
+
+def test_dict_int_op_mixed_int_float() -> None:
+    left = {"a": 1, "b": 0.5}
+    right = {"a": 2, "b": 0.3}
+    result = _dict_int_op(left, right, operator.add)
+    assert result == {"a": 3, "b": 0.8}
+
+
 def test_dict_int_op_invalid_types() -> None:
     left = {"a": 1, "b": "string"}
     right = {"a": 2, "b": 3}
     with pytest.raises(
         ValueError,
-        match="Only dict and int values are supported",
+        match="Only dict, int, and float values are supported",
     ):
         _dict_int_op(left, right, operator.add)

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,18 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # Float fields should be summed like int fields
+        ({"score": 0.5}, {"score": 0.3}, {"score": 0.8}),
+        ({"logprob": -1.2}, {"logprob": -0.5}, {"logprob": -1.7}),
+        # Mixed int and float should raise TypeError (different types)
+        (
+            {"val": 1},
+            {"val": 0.5},
+            pytest.raises(
+                TypeError,
+                match="already exists in this message, but with a different type",
+            ),
+        ),
     ],
 )
 def test_merge_dicts(
@@ -478,6 +490,11 @@ def test_merge_lists_all_none() -> None:
         (42, 42, 42),
         (3.14, 3.14, 3.14),
         (True, True, True),
+        # Unequal int values should be summed
+        (1, 2, 3),
+        # Unequal float values should be summed
+        (0.5, 0.3, 0.8),
+        (-1.2, -0.5, -1.7),
     ],
 )
 def test_merge_obj(left: Any, right: Any, expected: Any) -> None:
@@ -494,7 +511,7 @@ def test_merge_obj_type_mismatch() -> None:
 def test_merge_obj_unmergeable_values() -> None:
     """Test `merge_obj` raises `ValueError` on unmergeable values."""
     with pytest.raises(ValueError, match="Unable to merge"):
-        merge_obj(1, 2)  # Different integers
+        merge_obj(object(), object())  # Non-mergeable types
 
 
 def test_merge_obj_tuple_raises() -> None:


### PR DESCRIPTION
## Description

`merge_dicts` raises `TypeError` for float values (e.g., `logprobs`, confidence scores) during streaming chunk aggregation because the `isinstance` guard only checks for `int`. The same gap exists in `merge_obj` and `_dict_int_op`.

This PR extends the `isinstance` checks from `int` to `(int, float)` in all three functions, and adds a numeric accumulation branch to `merge_obj` for unequal int/float values.

Fixes #36011
Fixes #36015

## Changes

- `_merge.py` `merge_dicts`: `isinstance(merged[right_k], int)` -> `isinstance(merged[right_k], (int, float))`
- `_merge.py` `merge_obj`: add `isinstance(left, (int, float))` branch to sum unequal numeric values
- `usage.py` `_dict_int_op`: extend isinstance checks from `int` to `(int, float)`
- Updated error message in `_dict_int_op` to mention float
- Added test cases for float merging in all three functions

## Testing

```bash
cd libs/core && make format lint test
```

All pass. New test cases cover:
- `merge_dicts({"score": 0.5}, {"score": 0.3})` returns `{"score": 0.8}`
- `merge_obj(0.5, 0.3)` returns `0.8`
- `_dict_int_op({"a": 0.5, "b": 1.2}, {"b": 0.3, "c": 0.4}, operator.add)` returns expected result
- Mixed int/float dicts in `_dict_int_op`
- Type mismatch (int left, float right) in `merge_dicts` still raises TypeError

This contribution was developed with AI assistance (Claude Code + Codex).