### PR TITLE
feat(anthropic): add http_client and http_async_client fields to ChatAnthropic

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -802,6 +802,20 @@ class ChatAnthropic(BaseChatModel):
     variable.
     """
 
+    http_client: Any | None = Field(default=None, exclude=True)
+    """Optional `httpx.Client`. Passed directly to `anthropic.Client`.
+
+    Only used for sync invocations. Must specify `http_async_client` as well
+    if you'd like a custom client for async invocations.
+    """
+
+    http_async_client: Any | None = Field(default=None, exclude=True)
+    """Optional `httpx.AsyncClient`. Passed directly to `anthropic.AsyncClient`.
+
+    Only used for async invocations. Must specify `http_client` as well if
+    you'd like a custom client for sync invocations.
+    """
+
     default_headers: Mapping[str, str] | None = None
     """Headers to pass to the Anthropic clients, will be used for every API call."""
 
@@ -1004,12 +1018,15 @@ class ChatAnthropic(BaseChatModel):
     @cached_property
     def _client(self) -> anthropic.Client:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
-        if "timeout" in client_params:
-            http_client_params["timeout"] = client_params["timeout"]
-        if self.anthropic_proxy:
-            http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_httpx_client(**http_client_params)
+        if self.http_client is not None:
+            http_client = self.http_client
+        else:
+            http_client_params = {"base_url": client_params["base_url"]}
+            if "timeout" in client_params:
+                http_client_params["timeout"] = client_params["timeout"]
+            if self.anthropic_proxy:
+                http_client_params["anthropic_proxy"] = self.anthropic_proxy
+            http_client = _get_default_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,
@@ -1019,12 +1036,15 @@ class ChatAnthropic(BaseChatModel):
     @cached_property
     def _async_client(self) -> anthropic.AsyncClient:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
-        if "timeout" in client_params:
-            http_client_params["timeout"] = client_params["timeout"]
-        if self.anthropic_proxy:
-            http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_async_httpx_client(**http_client_params)
+        if self.http_async_client is not None:
+            http_client = self.http_async_client
+        else:
+            http_client_params = {"base_url": client_params["base_url"]}
+            if "timeout" in client_params:
+                http_client_params["timeout"] = client_params["timeout"]
+            if self.anthropic_proxy:
+                http_client_params["anthropic_proxy"] = self.anthropic_proxy
+            http_client = _get_default_async_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -128,6 +128,35 @@ def test_anthropic_proxy_from_environment() -> None:
         assert llm.anthropic_proxy == explicit_proxy
 
 
+def test_http_client_injection() -> None:
+    """Test that custom httpx clients are passed through to anthropic clients."""
+    import httpx
+
+    custom_sync = httpx.Client()
+    llm = ChatAnthropic(model=MODEL_NAME, http_client=custom_sync)
+    assert llm._client._client is custom_sync
+    custom_sync.close()
+
+
+def test_http_async_client_injection() -> None:
+    """Test that custom async httpx client is passed through."""
+    import httpx
+
+    custom_async = httpx.AsyncClient()
+    llm = ChatAnthropic(model=MODEL_NAME, http_async_client=custom_async)
+    assert llm._async_client._client is custom_async
+
+
+def test_http_client_default_none() -> None:
+    """Test that default behavior is unchanged when http_client is None."""
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.http_client is None
+    assert llm.http_async_client is None
+    # Clients should still be created normally
+    assert llm._client is not None
+    assert llm._async_client is not None
+
+
 def test_set_default_max_tokens() -> None:
     """Test the set_default_max_tokens function."""
     # Test claude-sonnet-4-5 models


### PR DESCRIPTION
## Description

Adds `http_client` and `http_async_client` fields to `ChatAnthropic`, matching the pattern already established in `ChatOpenAI`. This lets users inject custom `httpx.Client`/`httpx.AsyncClient` instances for mTLS, cert pinning, proxy tunneling, or test mocking.

When the fields are `None` (default), behavior is identical to the current implementation - a default httpx client is created via `_get_default_httpx_client()`.

Fixes #36056

## Changes

- Added `http_client: Any | None` and `http_async_client: Any | None` fields with `Field(default=None, exclude=True)`
- Modified `_client` cached property to use injected `http_client` when provided, skipping default client construction
- Modified `_async_client` cached property to use injected `http_async_client` when provided
- Added unit tests verifying injection passthrough and default behavior preservation

## Testing

```bash
cd libs/partners/anthropic && make format lint test
```

All 81 unit tests pass (3 new). No changes to `uv.lock` or `pyproject.toml`.

This contribution was developed with AI assistance (Claude Code + Codex).