### PR TITLE
fix(openrouter): pass strict to convert_to_json_schema in json_schema structured output

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -859,7 +859,7 @@ class ChatOpenRouter(BaseChatModel):
                     "Received None."
                 )
                 raise ValueError(msg)
-            json_schema = convert_to_json_schema(schema)
+            json_schema = convert_to_json_schema(schema, strict=strict)
             schema_name = json_schema.get("title", "")
             json_schema_spec: dict[str, Any] = {
                 "name": schema_name,

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -905,7 +905,12 @@ class TestWithStructuredOutput:
         assert tools[0]["function"]["strict"] is True
 
     def test_with_structured_output_strict_json_schema(self) -> None:
-        """Test that strict is forwarded for json_schema method."""
+        """Test that strict=True sets strict flag and adds additionalProperties: false.
+
+        convert_to_json_schema must receive strict so it injects
+        additionalProperties: false — without it the OpenRouter API cannot
+        guarantee schema enforcement even when strict is requested.
+        """
         model = _make_model()
         structured = model.with_structured_output(
             GenerateUsername, method="json_schema", strict=True
@@ -914,6 +919,7 @@ class TestWithStructuredOutput:
         assert isinstance(bound, RunnableBinding)
         rf = bound.kwargs["response_format"]
         assert rf["json_schema"]["strict"] is True
+        assert rf["json_schema"]["schema"].get("additionalProperties") is False
 
     def test_with_structured_output_json_mode_with_strict_warns_and_forwards(
         self,
@@ -996,7 +1002,9 @@ class TestWithStructuredOutput:
         structured.invoke([HumanMessage(content="Generate a username")])
 
         call_kwargs = model.client.chat.send.call_args[1]
-        assert call_kwargs["response_format"]["json_schema"]["strict"] is True
+        rf = call_kwargs["response_format"]
+        assert rf["json_schema"]["strict"] is True
+        assert rf["json_schema"]["schema"].get("additionalProperties") is False
 
 
 # ===========================================================================

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -932,6 +932,72 @@ class TestWithStructuredOutput:
         assert rf["type"] == "json_schema"
         assert rf["json_schema"]["strict"] is True
 
+    def test_with_structured_output_json_schema_response_format_reaches_sdk(
+        self,
+    ) -> None:
+        """Test that response_format is forwarded all the way to client.chat.send().
+
+        The existing tests only verify that response_format is stored in
+        RunnableBinding.kwargs (the binding layer).  This test drives the full
+        invocation — bind() → _generate() → _create_message_dicts() →
+        client.chat.send() — and asserts that response_format is present in
+        the actual SDK call, and that ls_structured_output_format is stripped.
+        """
+        model = _make_model()
+        model.client = MagicMock()
+        json_content = '{"name": "alice_42", "hair_color": "brown"}'
+        model.client.chat.send.return_value = _make_sdk_response(
+            {
+                **_SIMPLE_RESPONSE_DICT,
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": json_content},
+                        "finish_reason": "stop",
+                        "index": 0,
+                    }
+                ],
+            }
+        )
+        structured = model.with_structured_output(
+            GenerateUsername, method="json_schema"
+        )
+        structured.invoke([HumanMessage(content="Generate a username")])
+
+        call_kwargs = model.client.chat.send.call_args[1]
+        assert "response_format" in call_kwargs, (
+            "response_format was not forwarded to client.chat.send()"
+        )
+        assert "ls_structured_output_format" not in call_kwargs
+        rf = call_kwargs["response_format"]
+        assert rf["type"] == "json_schema"
+        assert rf["json_schema"]["name"] == "GenerateUsername"
+        assert "schema" in rf["json_schema"]
+
+    def test_with_structured_output_json_schema_strict_reaches_sdk(self) -> None:
+        """Test that strict=True is forwarded inside response_format to chat.send()."""
+        model = _make_model()
+        model.client = MagicMock()
+        json_content = '{"name": "alice_42", "hair_color": "brown"}'
+        model.client.chat.send.return_value = _make_sdk_response(
+            {
+                **_SIMPLE_RESPONSE_DICT,
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "content": json_content},
+                        "finish_reason": "stop",
+                        "index": 0,
+                    }
+                ],
+            }
+        )
+        structured = model.with_structured_output(
+            GenerateUsername, method="json_schema", strict=True
+        )
+        structured.invoke([HumanMessage(content="Generate a username")])
+
+        call_kwargs = model.client.chat.send.call_args[1]
+        assert call_kwargs["response_format"]["json_schema"]["strict"] is True
+
 
 # ===========================================================================
 # Message conversion tests


### PR DESCRIPTION

  - When with_structured_output(method="json_schema", strict=True) was called,
  convert_to_json_schema was invoked without the strict argument, so
  "additionalProperties": false was never added to the schema. The OpenRouter API
  (and OpenAI-compatible structured output in general) requires this field for schema
   enforcement to take effect — without it the model treats the schema as a hint
  rather than a constraint, which is why field names were ignored.
  - Fix: forward strict to convert_to_json_schema(schema, strict=strict) on line 862.
   This is a single-character change that makes the schema sent to the API match what
   the provider enforces.
  - Updated test_with_structured_output_strict_json_schema and
  test_with_structured_output_json_schema_strict_reaches_sdk to assert
  additionalProperties: false is present in the schema inside response_format when
  strict=True.

  Fixes #36067.

  Changes

  - langchain_openrouter/chat_models.py: convert_to_json_schema(schema) →
  convert_to_json_schema(schema, strict=strict)
  - tests/unit_tests/test_chat_models.py: add additionalProperties: false assertion
  to strict-mode tests

  Test plan

  - uv run --group test pytest tests/unit_tests/test_chat_models.py — 201 passed
  - strict=True now produces {"additionalProperties": false, ...} in the schema field
  - strict=None (default) is unchanged — no additionalProperties injected, consistent
   with optional enforcement