### PR TITLE
fix(openai): preserve namespace field in streamed function_call content blocks

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4723,16 +4723,19 @@ def _convert_responses_chunk_to_generation_chunk(
                 "index": current_index,
             }
         )
-        content.append(
-            {
-                "type": "function_call",
-                "name": chunk.item.name,
-                "arguments": chunk.item.arguments,
-                "call_id": chunk.item.call_id,
-                "id": chunk.item.id,
-                "index": current_index,
-            }
-        )
+        fc_block: dict = {
+            "type": "function_call",
+            "name": chunk.item.name,
+            "arguments": chunk.item.arguments,
+            "call_id": chunk.item.call_id,
+            "id": chunk.item.id,
+            "index": current_index,
+        }
+        # Preserve namespace for deferred function_call items (e.g. tool_search
+        # results). Without it the next-turn round-trip raises "Missing namespace".
+        if namespace := getattr(chunk.item, "namespace", None):
+            fc_block["namespace"] = namespace
+        content.append(fc_block)
     elif chunk.type == "response.output_item.done" and chunk.item.type in (
         "compaction",
         "web_search_call",


### PR DESCRIPTION
## Description

When the OpenAI Responses API streams a `function_call` output item that contains a `namespace` field (e.g. tools created with `defer_loading=True` via `tool_search`), the streaming handler builds the content block manually and omits the `namespace` field. As a result, the field is silently dropped from the accumulated `AIMessage.content`.

On the next conversation turn, when the `AIMessage` is serialized and sent back to OpenAI, the `function_call` block is missing `namespace`, causing a `400 Bad Request: Missing namespace for function_call`.

## Root Cause

In `_convert_responses_chunk_to_generation_chunk`, the `response.output_item.added` handler for `function_call` items builds a dict with explicit keys but does not include `namespace`:

```python
# Before fix
content.append(
    {
        "type": "function_call",
        "name": chunk.item.name,
        "arguments": chunk.item.arguments,
        "call_id": chunk.item.call_id,
        "id": chunk.item.id,
        "index": current_index,
        # ← "namespace" never copied!
    }
)
```

## Fix

```python
# After fix
fc_block = {
    "type": "function_call",
    "name": chunk.item.name,
    "arguments": chunk.item.arguments,
    "call_id": chunk.item.call_id,
    "id": chunk.item.id,
    "index": current_index,
}
if namespace := getattr(chunk.item, "namespace", None):
    fc_block["namespace"] = namespace
content.append(fc_block)
```

## Changes

- `libs/partners/openai/langchain_openai/chat_models/base.py`: Copy `namespace` from the streaming chunk item into the `function_call` content block when present

Closes #36096
