### PR TITLE
fix(core): pass child_config instead of config in RunnableWithFallbacks.invoke()

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -193,7 +193,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     output = context.run(
                         runnable.invoke,
                         input,
-                        config,
+                        child_config,
                         **kwargs,
                     )
             except self.exceptions_to_handle as e:


### PR DESCRIPTION
In `RunnableWithFallbacks.invoke()`, `child_config` is created with the correct child callbacks via `patch_config(config, callbacks=run_manager.get_child())`, but then `config` (the parent) is passed to `runnable.invoke` instead of `child_config`.

This causes child callback events (`on_chat_model_start`, `on_llm_error`, `on_llm_end`) to receive `parent_run_id=None` instead of the fallback chain run_id, breaking tracing/observability tools that rely on `parent_run_id` to build span trees.

Fix: change `config` to `child_config` in the `context.run()` call.

Closes #36072