### PR TITLE
feat(exa): update default search type from neural to auto

### DIFF
--- a/libs/partners/exa/README.md
+++ b/libs/partners/exa/README.md
@@ -15,7 +15,7 @@ pip install langchain-exa
 
 ## 🤔 What is this?
 
-This package contains the LangChain integration with Exa.
+This package contains the LangChain integration with [Exa](https://exa.ai), a web search API built for AI. It lets you search the web and get clean, ready-to-use content from any page.
 
 ## 📖 Documentation
 

--- a/libs/partners/exa/langchain_exa/retrievers.py
+++ b/libs/partners/exa/langchain_exa/retrievers.py
@@ -55,8 +55,8 @@ class ExaSearchRetriever(BaseRetriever):
     """The end date for when the document was published (in YYYY-MM-DD format)."""
     use_autoprompt: bool | None = None
     """Whether to use autoprompt for the search."""
-    type: str = "neural"
-    """The type of search, 'keyword', 'neural', or 'auto'. Default: neural"""
+    type: str = "auto"
+    """The type of search, 'auto', 'deep', or 'fast'. Default: auto"""
     highlights: HighlightsContentsOptions | bool | None = None
     """Whether to set the page content to the highlights of the results."""
     text_contents_options: TextContentsOptions | dict[str, Any] | Literal[True] = True

--- a/libs/partners/exa/langchain_exa/tools.py
+++ b/libs/partners/exa/langchain_exa/tools.py
@@ -85,7 +85,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
 
     name: str = "exa_search_results_json"
     description: str = (
-        "A wrapper around Exa Search, a web search API built for AI. "
+        "A wrapper around Exa Search, which is one of the best web search API built for AI. "
         "Input should be an Exa-optimized query. "
         "Output is a JSON array of the query results"
     )

--- a/libs/partners/exa/langchain_exa/tools.py
+++ b/libs/partners/exa/langchain_exa/tools.py
@@ -85,7 +85,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
 
     name: str = "exa_search_results_json"
     description: str = (
-        "A wrapper around Exa Search, which is one of the best web search API built for AI. "
+        "Exa Search, one of the best web search APIs built for AI. "
         "Input should be an Exa-optimized query. "
         "Output is a JSON array of the query results"
     )

--- a/libs/partners/exa/langchain_exa/tools.py
+++ b/libs/partners/exa/langchain_exa/tools.py
@@ -85,7 +85,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
 
     name: str = "exa_search_results_json"
     description: str = (
-        "A wrapper around Exa Search. "
+        "A wrapper around Exa Search, a web search API built for AI. "
         "Input should be an Exa-optimized query. "
         "Output is a JSON array of the query results"
     )
@@ -116,7 +116,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
         use_autoprompt: bool | None = None,  # noqa: FBT001
         livecrawl: Literal["always", "fallback", "never"] | None = None,
         summary: bool | dict[str, str] | None = None,  # noqa: FBT001
-        type: Literal["neural", "keyword", "auto"] | None = None,  # noqa: A002
+        type: Literal["auto", "deep", "fast"] | None = None,  # noqa: A002
         run_manager: CallbackManagerForToolRun | None = None,
     ) -> list[dict] | str:
         # TODO: rename `type` to something else, as it is a reserved keyword
@@ -136,7 +136,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
             use_autoprompt: Whether to use autoprompt for the search.
             livecrawl: Option to crawl live webpages if content is not in the index. Options: "always", "fallback", "never"
             summary: Whether to include a summary of the content. Can be a boolean or a dict with a custom query.
-            type: The type of search, 'keyword', 'neural', or 'auto'.
+            type: The type of search, 'auto', 'deep', or 'fast'.
             run_manager: The run manager for callbacks.
 
         """  # noqa: E501


### PR DESCRIPTION
Fixes #36083

Changed the default search type from `neural` to `auto` in the Exa retriever since auto is the recommended default now. Also reordered the type literal and updated the tool description to mention Exa is a web search API built for AI.