### PR TITLE
fix(openai): downgrade tool_choice='required' to 'auto' for reasoning models

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2034,6 +2034,14 @@ class BaseChatOpenAI(BaseChatModel):
                     f"Received: {tool_choice}"
                 )
                 raise ValueError(msg)
+            # Reasoning models do not support tool_choice='required'.
+            # Downgrade to 'auto' to avoid API errors.
+            if tool_choice == "required" and (
+                (self.profile is not None and self.profile.get("reasoning_output"))
+                or self.reasoning_effort is not None
+                or self.reasoning is not None
+            ):
+                tool_choice = "auto"
             kwargs["tool_choice"] = tool_choice
 
         if response_format:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2034,13 +2034,26 @@ class BaseChatOpenAI(BaseChatModel):
                     f"Received: {tool_choice}"
                 )
                 raise ValueError(msg)
-            # Reasoning models do not support tool_choice='required'.
-            # Downgrade to 'auto' to avoid API errors.
+            # Reasoning models (o-series, gpt-5, and custom models with
+            # reasoning params) do not support tool_choice='required'.
+            # Downgrade to 'auto' to avoid API errors. Models with reasoning
+            # explicitly disabled (effort='none') are treated as non-reasoning.
             if tool_choice == "required" and (
                 (self.profile is not None and self.profile.get("reasoning_output"))
-                or self.reasoning_effort is not None
-                or self.reasoning is not None
+                or (
+                    self.reasoning_effort is not None
+                    and self.reasoning_effort != "none"
+                )
+                or (
+                    self.reasoning is not None
+                    and (self.reasoning or {}).get("effort") != "none"
+                )
             ):
+                warnings.warn(
+                    f"tool_choice='required' is not supported for reasoning model "
+                    f"'{self.model_name}'. Downgrading to tool_choice='auto'. "
+                    f"Pass tool_choice='auto' explicitly to suppress this warning."
+                )
                 tool_choice = "auto"
             kwargs["tool_choice"] = tool_choice
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -918,6 +918,63 @@ def test_bind_tools_tool_choice(tool_choice: Any, strict: bool | None) -> None:
 
 
 @pytest.mark.parametrize(
+    ("tool_choice_input", "reasoning_kwargs", "expected_tool_choice"),
+    [
+        # Reasoning model via profile: 'any' -> 'auto' (not 'required')
+        (
+            "any",
+            {"profile": {"reasoning_output": True}},
+            "auto",
+        ),
+        # Reasoning model via reasoning_effort: 'required' -> 'auto'
+        (
+            "required",
+            {"reasoning_effort": "medium"},
+            "auto",
+        ),
+        # Reasoning model via reasoning: True -> 'auto'
+        (
+            True,
+            {"reasoning": {"effort": "medium"}},
+            "auto",
+        ),
+        # Non-reasoning model: 'any' -> 'required' (unchanged behavior)
+        (
+            "any",
+            {},
+            "required",
+        ),
+        # Reasoning model with 'auto' stays 'auto'
+        (
+            "auto",
+            {"profile": {"reasoning_output": True}},
+            "auto",
+        ),
+        # Reasoning model with 'none' stays 'none'
+        (
+            "none",
+            {"profile": {"reasoning_output": True}},
+            "none",
+        ),
+    ],
+)
+def test_bind_tools_tool_choice_reasoning_models(
+    tool_choice_input: Any,
+    reasoning_kwargs: dict,
+    expected_tool_choice: str,
+) -> None:
+    """Test that reasoning models downgrade tool_choice='required' to 'auto'."""
+    llm = ChatOpenAI(
+        model="test-model",
+        temperature=0,
+        api_key=SecretStr("test"),
+        **reasoning_kwargs,
+    )
+    bound = llm.bind_tools(tools=[GenerateUsername], tool_choice=tool_choice_input)
+    assert bound.kwargs["tool_choice"] == expected_tool_choice  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
     "schema", [GenerateUsername, GenerateUsername.model_json_schema()]
 )
 @pytest.mark.parametrize("method", ["json_schema", "function_calling", "json_mode"])

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -956,6 +956,18 @@ def test_bind_tools_tool_choice(tool_choice: Any, strict: bool | None) -> None:
             {"profile": {"reasoning_output": True}},
             "none",
         ),
+        # reasoning_effort='none' should NOT trigger downgrade
+        (
+            "any",
+            {"reasoning_effort": "none"},
+            "required",
+        ),
+        # reasoning={'effort': 'none'} should NOT trigger downgrade
+        (
+            "any",
+            {"reasoning": {"effort": "none"}},
+            "required",
+        ),
     ],
 )
 def test_bind_tools_tool_choice_reasoning_models(
@@ -972,6 +984,23 @@ def test_bind_tools_tool_choice_reasoning_models(
     )
     bound = llm.bind_tools(tools=[GenerateUsername], tool_choice=tool_choice_input)
     assert bound.kwargs["tool_choice"] == expected_tool_choice  # type: ignore[attr-defined]
+
+
+def test_bind_tools_tool_choice_reasoning_model_warning() -> None:
+    """Test that a warning is emitted when downgrading tool_choice for reasoning."""
+    llm = ChatOpenAI(
+        model="o3",
+        temperature=0,
+        api_key=SecretStr("test"),
+        reasoning_effort="medium",
+    )
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        bound = llm.bind_tools(tools=[GenerateUsername], tool_choice="any")
+        assert bound.kwargs["tool_choice"] == "auto"  # type: ignore[attr-defined]
+        assert len(w) == 1
+        assert "tool_choice='required' is not supported" in str(w[0].message)
+        assert "o3" in str(w[0].message)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #36120

## Problem

When using reasoning/thinking models (o1, o3, gpt-5, qwen3.5-plus, etc.) with LangChain agents, the agent factory auto-sets `tool_choice='any'` which gets normalized to `tool_choice='required'` in `ChatOpenAI.bind_tools()`. Reasoning models reject `tool_choice='required'` with HTTP 400 errors.

## Changes

In `ChatOpenAI.bind_tools()`, after the tool_choice normalization block converts `'any'` → `'required'` and `True` → `'required'`, added a check: if the resulting tool_choice is `'required'` AND the model is a reasoning model, downgrade to `'auto'` with a warning.

A reasoning model is detected by:
1. `self.profile` has `reasoning_output=True`, OR
2. `self.reasoning_effort` is set, OR
3. `self.reasoning` is set

## Test plan

- Added unit tests verifying reasoning models get `'auto'` instead of `'required'`
- Added regression tests verifying non-reasoning models still get `'required'`
- Added tests verifying explicit `tool_choice='auto'`/`'none'` are unaffected
- All 324 existing tests pass

## Disclaimer

This PR was developed with AI agent assistance.