### PR TITLE
fix(openai): reuse default httpx clients in AzureChatOpenAI

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -18,6 +18,10 @@ from pydantic import BaseModel, Field, SecretStr, model_validator
 from typing_extensions import Self
 
 from langchain_openai.chat_models.base import BaseChatOpenAI, _get_default_model_profile
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -683,11 +687,21 @@ class AzureChatOpenAI(BaseChatOpenAI):
             client_params["max_retries"] = self.max_retries
 
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(
+                    self.openai_api_base, self.request_timeout
+                )
+            }
             self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
             self.client = self.root_client.chat.completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.openai_api_base, self.request_timeout
+                )
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -3,6 +3,7 @@
 import os
 from unittest import mock
 
+import httpx
 import pytest
 from langchain_core.messages import HumanMessage
 from pydantic import SecretStr
@@ -174,3 +175,24 @@ def test_max_tokens_converted_to_max_completion_tokens() -> None:
     assert "max_completion_tokens" in payload
     assert payload["max_completion_tokens"] == 1000
     assert "max_tokens" not in payload
+
+
+def test_azure_reuses_default_httpx_clients() -> None:
+    """AzureChatOpenAI should reuse default httpx clients across instances."""
+    llm1 = AzureChatOpenAI(
+        api_key="xyz",  # type: ignore[arg-type]
+        azure_endpoint="https://example-resource.openai.azure.com/",
+        azure_deployment="gpt-4o-mini",
+        openai_api_version="2024-05-01-preview",
+    )
+    llm2 = AzureChatOpenAI(
+        api_key="xyz",  # type: ignore[arg-type]
+        azure_endpoint="https://example-resource.openai.azure.com/",
+        azure_deployment="gpt-4o-mini",
+        openai_api_version="2024-05-01-preview",
+    )
+
+    assert isinstance(llm1.root_client._client, httpx.Client)
+    assert isinstance(llm1.root_async_client._client, httpx.AsyncClient)
+    assert llm1.root_client._client is llm2.root_client._client
+    assert llm1.root_async_client._client is llm2.root_async_client._client


### PR DESCRIPTION
Fixes #36259

## Description

`AzureChatOpenAI` does not reuse default httpx clients like `BaseChatOpenAI`. When no custom `http_client` / `http_async_client` is provided, it passes `None` to the OpenAI SDK, causing each instance to create a new httpx client instead of sharing the default one.

This PR makes `AzureChatOpenAI.validate_environment` fall back to `_get_default_httpx_client()` / `_get_default_async_httpx_client()` when no custom client is set, aligning behavior with `BaseChatOpenAI`.

## Changes

- **`azure.py`**: Use `_get_default_httpx_client` / `_get_default_async_httpx_client` as fallback when `http_client` / `http_async_client` is `None`
- **`test_azure.py`**: Add test verifying two `AzureChatOpenAI` instances share the same default httpx clients