### PR TITLE
fix(core): pass child_config instead of config to fallback runnables in RunnableWithFallbacks

### DIFF
--- a/docs/docs/integrations/chat/gigachat.ipynb
+++ b/docs/docs/integrations/chat/gigachat.ipynb
@@ -1,0 +1,136 @@
+{
+ "cells": [
+  {
+   "metadata": {},
+   "cell_type": "raw",
+   "source": [
+    "---\n",
+    "sidebar_label: GigaChat\n",
+    "---"
+   ],
+   "id": "b4154fbe"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "# GigaChat\n",
+    "\n",
+    "This notebook goes over how to use Langchain with [GigaChat](https://giga.chat/) chat model.\n",
+    "\n",
+    "## Overview\n",
+    "### Integration details\n",
+    "\n",
+    "| Class    | Package                | Local | Serializable | JS support |                                         Package downloads                                          |                                         Package latest                                          |\n",
+    "|:---------|:-----------------------| :---: | :---: |:----------:|:--------------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|\n",
+    "| GigaChat | [langchain-gigachat](https://github.com/ai-forever/langchain-gigachat) | ❌ | beta | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-gigachat?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-gigachat?style=flat-square&label=%20) |\n",
+    "\n",
+    "### Model features\n",
+    "| [Tool calling](../../how_to/tool_calling.ipynb) | [Structured output](../../how_to/structured_output.ipynb) | JSON mode | [Image input](../../how_to/multimodal_inputs.ipynb) | Audio input | Video input | [Token-level streaming](../../how_to/chat_streaming.ipynb) | Native async | [Token usage](../../how_to/chat_token_usage_tracking.ipynb) | [Logprobs](../../how_to/logprobs.ipynb) |\n",
+    "| :---: | :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |\n",
+    "| ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "To access GigaChat models you'll need to [create a GigaChat account](https://developers.sber.ru/docs/ru/gigachat/quickstart/main), get an API key, and install the `langchain-gigachat` integration package."
+   ],
+   "id": "af63c9db-e4bd-4d3b-a4d7-7927f5541734"
+  },
+  {
+   "cell_type": "code",
+   "id": "f3a8f9cb-ff03-4fb8-8185-ff19f2b8fc89",
+   "metadata": {},
+   "source": "%pip install --upgrade --quiet  langchain-gigachat",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### Initialization\n",
+    "\n",
+    "To initialize chat model:"
+   ],
+   "id": "7242c121c9e2f2fe"
+  },
+  {
+   "cell_type": "code",
+   "id": "eba2d63b-f871-4f61-b55f-f6092bdc297a",
+   "metadata": {},
+   "source": [
+    "from langchain_gigachat.chat_models import GigaChat\n",
+    "\n",
+    "giga = GigaChat(credentials=\"YOUR_AUTHORIZATION_KEY\", model='GigaChat-2-Max', verify_ssl_certs=False)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "To initialize embeddings:",
+   "id": "5a532bcab6f30906"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "from langchain_gigachat.embeddings import GigaChatEmbeddings\n",
+    "\n",
+    "embedding = GigaChatEmbeddings(\n",
+    "    credentials=\"YOUR_AUTHORIZATION_KEY\",\n",
+    "    verify_ssl_certs=False\n",
+    ")"
+   ],
+   "id": "c1488db53c9739bc",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "You can check a list of available models [here](https://developers.sber.ru/docs/ru/gigachat/models).",
+   "id": "96155ba830362bc6"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "### Usage\n",
+    "\n",
+    "Use the GigaChat object to generate responses:"
+   ],
+   "id": "3d631f52046a0fb5"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": "print(giga.invoke(\"Hello, world!\"))",
+   "id": "2f1ce423f77fc411",
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/docs/integrations/chat/gigachat.ipynb
+++ b/docs/docs/integrations/chat/gigachat.ipynb
@@ -1,18 +1,19 @@
 {
  "cells": [
   {
-   "metadata": {},
    "cell_type": "raw",
+   "id": "b4154fbe",
+   "metadata": {},
    "source": [
     "---\n",
     "sidebar_label: GigaChat\n",
     "---"
-   ],
-   "id": "b4154fbe"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "af63c9db-e4bd-4d3b-a4d7-7927f5541734",
+   "metadata": {},
    "source": [
     "# GigaChat\n",
     "\n",
@@ -33,83 +34,87 @@
     "## Setup\n",
     "\n",
     "To access GigaChat models you'll need to [create a GigaChat account](https://developers.sber.ru/docs/ru/gigachat/quickstart/main), get an API key, and install the `langchain-gigachat` integration package."
-   ],
-   "id": "af63c9db-e4bd-4d3b-a4d7-7927f5541734"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "f3a8f9cb-ff03-4fb8-8185-ff19f2b8fc89",
    "metadata": {},
-   "source": "%pip install --upgrade --quiet  langchain-gigachat",
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "%pip install --upgrade --quiet  langchain-gigachat"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "7242c121c9e2f2fe",
+   "metadata": {},
    "source": [
     "### Initialization\n",
     "\n",
     "To initialize chat model:"
-   ],
-   "id": "7242c121c9e2f2fe"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
    "id": "eba2d63b-f871-4f61-b55f-f6092bdc297a",
    "metadata": {},
+   "outputs": [],
    "source": [
     "from langchain_gigachat.chat_models import GigaChat\n",
     "\n",
-    "giga = GigaChat(credentials=\"YOUR_AUTHORIZATION_KEY\", model='GigaChat-2-Max', verify_ssl_certs=False)"
-   ],
-   "outputs": [],
-   "execution_count": null
+    "giga = GigaChat(\n",
+    "    credentials=\"YOUR_AUTHORIZATION_KEY\", model=\"GigaChat-2-Max\", verify_ssl_certs=False\n",
+    ")"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "To initialize embeddings:",
-   "id": "5a532bcab6f30906"
+   "id": "5a532bcab6f30906",
+   "metadata": {},
+   "source": "To initialize embeddings:"
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "c1488db53c9739bc",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from langchain_gigachat.embeddings import GigaChatEmbeddings\n",
     "\n",
     "embedding = GigaChatEmbeddings(\n",
-    "    credentials=\"YOUR_AUTHORIZATION_KEY\",\n",
-    "    verify_ssl_certs=False\n",
+    "    credentials=\"YOUR_AUTHORIZATION_KEY\", verify_ssl_certs=False\n",
     ")"
-   ],
-   "id": "c1488db53c9739bc",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "You can check a list of available models [here](https://developers.sber.ru/docs/ru/gigachat/models).",
-   "id": "96155ba830362bc6"
+   "id": "96155ba830362bc6",
+   "metadata": {},
+   "source": "You can check a list of available models [here](https://developers.sber.ru/docs/ru/gigachat/models)."
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "3d631f52046a0fb5",
+   "metadata": {},
    "source": [
     "### Usage\n",
     "\n",
     "Use the GigaChat object to generate responses:"
-   ],
-   "id": "3d631f52046a0fb5"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
-   "source": "print(giga.invoke(\"Hello, world!\"))",
+   "execution_count": null,
    "id": "2f1ce423f77fc411",
+   "metadata": {},
    "outputs": [],
-   "execution_count": null
+   "source": [
+    "print(giga.invoke(\"Hello, world!\"))"
+   ]
   }
  ],
  "metadata": {

--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -188,7 +188,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     output = context.run(
                         runnable.invoke,
                         input,
-                        config,
+                        child_config,
                         **kwargs,
                     )
             except self.exceptions_to_handle as e:
@@ -239,7 +239,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     input[self.exception_key] = last_error  # type: ignore[index]
                 child_config = patch_config(config, callbacks=run_manager.get_child())
                 with set_config_context(child_config) as context:
-                    coro = context.run(runnable.ainvoke, input, config, **kwargs)
+                    coro = context.run(runnable.ainvoke, input, child_config, **kwargs)
                     output = await coro_with_context(coro, context)
             except self.exceptions_to_handle as e:
                 if first_error is None:

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -494,7 +494,7 @@ _SUPPORTED_PROVIDERS = {
     "ibm",
     "xai",
     "perplexity",
-    "gigachat"
+    "gigachat",
 }
 
 

--- a/libs/langchain/langchain/chat_models/base.py
+++ b/libs/langchain/langchain/chat_models/base.py
@@ -120,6 +120,7 @@ def init_chat_model(
             - 'nvidia'              -> langchain-nvidia-ai-endpoints
             - 'xai'                 -> langchain-xai
             - 'perplexity'          -> langchain-perplexity
+            - 'gigachat'            -> langchain-gigachat
 
             Will attempt to infer model_provider from model if not specified. The
             following providers will be inferred based on these model prefixes:
@@ -134,6 +135,7 @@ def init_chat_model(
             - 'deepseek...'                     -> 'deepseek'
             - 'grok...'                         -> 'xai'
             - 'sonar...'                        -> 'perplexity'
+            - 'GigaChat...'                     -> 'gigachat'
         configurable_fields: Which model parameters are
             configurable:
 
@@ -459,6 +461,11 @@ def _init_chat_model_helper(
         from langchain_perplexity import ChatPerplexity
 
         return ChatPerplexity(model=model, **kwargs)
+    if model_provider == "gigachat":
+        _check_pkg("langchain_gigachat")
+        from langchain_gigachat import GigaChat
+
+        return GigaChat(model=model, **kwargs)
     supported = ", ".join(_SUPPORTED_PROVIDERS)
     msg = (
         f"Unsupported {model_provider=}.\n\nSupported model providers are: {supported}"
@@ -487,6 +494,7 @@ _SUPPORTED_PROVIDERS = {
     "ibm",
     "xai",
     "perplexity",
+    "gigachat"
 }
 
 
@@ -511,6 +519,8 @@ def _attempt_infer_model_provider(model_name: str) -> Optional[str]:
         return "xai"
     if model_name.startswith("sonar"):
         return "perplexity"
+    if model_name.startswith("GigaChat"):
+        return "gigachat"
     return None
 
 

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -39,6 +39,7 @@ aws = ["langchain-aws"]
 deepseek = ["langchain-deepseek"]
 xai = ["langchain-xai"]
 perplexity = ["langchain-perplexity"]
+gigachat = ["langchain-gigachat"]
 
 [project.urls]
 "Source Code" = "https://github.com/langchain-ai/langchain/tree/master/libs/langchain"


### PR DESCRIPTION
## Problem

Fixes #36072

In `RunnableWithFallbacks.invoke()` and `ainvoke()`, the fallback runnable is called with the **parent** `config` instead of `child_config`:

```python
# invoke() line ~189
child_config = patch_config(config, callbacks=run_manager.get_child())
with set_config_context(child_config) as context:
    output = context.run(
        runnable.invoke,
        input,
        config,        # ← Bug: should be child_config
        **kwargs,
    )
```

Because the fallback runnable receives `config` (parent) rather than `child_config`, it never sees:
- The `parent_run_id` set by `run_manager.get_child()`
- The callback chain attached to the child run

All callback events emitted by the fallback runnable appear as **top-level, parentless runs**, breaking tracing, LangSmith, streaming, and any handler that relies on the run hierarchy.

## Root Cause

Regression introduced by #25550 (which fixed #25337). That PR added `set_config_context(child_config)` to fix callbacks but kept the original `config` argument when calling `runnable.invoke`, negating part of the benefit.

## Fix

Pass `child_config` (not `config`) to both `runnable.invoke()` and `runnable.ainvoke()` inside the fallback loop:

```python
output = context.run(runnable.invoke, input, child_config, **kwargs)  # sync
coro   = context.run(runnable.ainvoke, input, child_config, **kwargs)  # async
```

## Testing

```python
from langchain_core.callbacks.base import BaseCallbackHandler
from langchain_core.runnables import RunnableLambda

parent_run_ids = []

class TrackParent(BaseCallbackHandler):
    def on_chain_start(self, *args, parent_run_id=None, **kwargs):
        parent_run_ids.append(parent_run_id)

error = RunnableLambda(lambda _: (_ for _ in ()).throw(ValueError("fail")))
fallback = RunnableLambda(lambda _: "ok")
chain = error.with_fallbacks([fallback])
chain.invoke("test", config={"callbacks": [TrackParent()]})

assert parent_run_ids[1] is not None  # fallback run now has a parent
```