### PR TITLE
docs: add Returns and Example to LLMMathChain.from_llm docstring

### DIFF
--- a/libs/langchain/langchain_classic/chains/llm_math/base.py
+++ b/libs/langchain/langchain_classic/chains/llm_math/base.py
@@ -310,6 +310,19 @@ class LLMMathChain(Chain):
             llm: a language model
             prompt: a prompt template
             **kwargs: additional arguments
+
+        Returns:
+            An ``LLMMathChain`` instance configured with the provided language model.
+
+        Example:
+            .. code-block:: python
+
+                from langchain_openai import ChatOpenAI
+                from langchain_classic.chains.llm_math.base import LLMMathChain
+
+                chain = LLMMathChain.from_llm(ChatOpenAI(model="gpt-4o-mini"))
+                result = chain.invoke({"question": "What is 37593 * 67?"})
+                print(result["answer"])
         """
         llm_chain = LLMChain(llm=llm, prompt=prompt)
         return cls(llm_chain=llm_chain, **kwargs)


### PR DESCRIPTION
## Summary
- add a `Returns` section to `LLMMathChain.from_llm`
- add a minimal usage example showing how to construct and invoke the chain

Closes #35749
