### PR TITLE
fix(core): allow StructuredTool payloads with self key

### DIFF
--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -73,6 +73,7 @@ class StructuredTool(BaseTool):
 
     def _run(
         self,
+        /,
         *args: Any,
         config: RunnableConfig,
         run_manager: CallbackManagerForToolRun | None = None,
@@ -100,6 +101,7 @@ class StructuredTool(BaseTool):
 
     async def _arun(
         self,
+        /,
         *args: Any,
         config: RunnableConfig,
         run_manager: AsyncCallbackManagerForToolRun | None = None,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2672,6 +2672,20 @@ def test_structured_tool_args_schema_dict(caplog: pytest.LogCaptureFixture) -> N
     assert "Failed to get args_schema annotations for filtering" not in caplog.text
 
 
+def test_structured_tool_allows_self_key_in_kwargs() -> None:
+    def func(**kwargs: Any) -> dict[str, Any]:
+        return kwargs
+
+    tool = StructuredTool(
+        name="test_tool",
+        description="test tool",
+        args_schema={"type": "object", "properties": {}},
+        func=func,
+    )
+
+    assert tool.invoke({"self": 2, "other": 3}) == {"self": 2, "other": 3}
+
+
 def test_simple_tool_args_schema_dict() -> None:
     args_schema = {
         "properties": {
@@ -2903,6 +2917,25 @@ async def test_tool_ainvoke_does_not_mutate_inputs() -> None:
         "id": "call_0_82c17db8-95df-452f-a4c2-03f809022134",
         "type": "tool_call",
     }
+
+
+async def test_structured_tool_ainvoke_allows_self_in_kwargs() -> None:
+    async def echo_kwargs(**kwargs: Any) -> dict[str, Any]:
+        return kwargs
+
+    tool = StructuredTool(
+        name="echo_kwargs",
+        description="Return all kwargs untouched.",
+        coroutine=echo_kwargs,
+        args_schema={
+            "type": "object",
+            "properties": {},
+        },
+    )
+
+    payload = {"self": 2, "other": 3}
+
+    assert await tool.ainvoke(payload) == payload
 
 
 def test_tool_invoke_does_not_mutate_inputs() -> None:


### PR DESCRIPTION
## Summary
- make `StructuredTool._run()` and `StructuredTool._arun()` receiver parameters positional-only
- allow payloads that include a `self` key to pass through to the wrapped function/coroutine
- add sync + async regression coverage for `StructuredTool.invoke()` / `ainvoke()` with `{"self": ...}` payloads

Fixes #34900.

## Testing
- `PYTHONPATH=libs/core pytest libs/core/tests/unit_tests/test_tools.py::test_structured_tool_allows_self_key_in_kwargs libs/core/tests/unit_tests/test_tools.py::test_structured_tool_ainvoke_allows_self_in_kwargs libs/core/tests/unit_tests/test_tools.py::test_structured_tool_args_schema_dict`
- `python3 -m ruff check libs/core/langchain_core/tools/structured.py libs/core/tests/unit_tests/test_tools.py`
- `python3 -m ruff format --check libs/core/langchain_core/tools/structured.py libs/core/tests/unit_tests/test_tools.py`