### PR TITLE
fix(core): pass child_config in RunnableWithFallbacks invoke/ainvoke/stream

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -193,7 +193,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     output = context.run(
                         runnable.invoke,
                         input,
-                        config,
+                        child_config,
                         **kwargs,
                     )
             except self.exceptions_to_handle as e:
@@ -244,7 +244,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     input[self.exception_key] = last_error  # type: ignore[index]
                 child_config = patch_config(config, callbacks=run_manager.get_child())
                 with set_config_context(child_config) as context:
-                    coro = context.run(runnable.ainvoke, input, config, **kwargs)
+                    coro = context.run(runnable.ainvoke, input, child_config, **kwargs)
                     output = await coro_with_context(coro, context)
             except self.exceptions_to_handle as e:
                 if first_error is None:
@@ -496,6 +496,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     stream = context.run(
                         runnable.stream,
                         input,
+                        child_config,
                         **kwargs,
                     )
                     chunk: Output = context.run(next, stream)

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -1,3 +1,4 @@
+import uuid
 from collections.abc import AsyncIterator, Callable, Iterator, Sequence
 from typing import (
     Any,
@@ -8,7 +9,7 @@ from pydantic import BaseModel
 from syrupy.assertion import SnapshotAssertion
 from typing_extensions import override
 
-from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.callbacks import BaseCallbackHandler, CallbackManagerForLLMRun
 from langchain_core.language_models import (
     BaseChatModel,
     FakeListLLM,
@@ -400,3 +401,103 @@ def test_fallbacks_getattr_runnable_output() -> None:
         for fallback in llm_with_fallbacks_with_tools.fallbacks
     )
     assert llm_with_fallbacks_with_tools.runnable.kwargs["tools"] == []
+
+
+class _RunTracker(BaseCallbackHandler):
+    """Records (event_name, run_id, parent_run_id) for every callback event."""
+
+    def __init__(self) -> None:
+        self.events: list[tuple[str, uuid.UUID, uuid.UUID | None]] = []
+
+    def on_chain_start(
+        self,
+        serialized: dict[str, Any],
+        inputs: dict[str, Any],
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: uuid.UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.events.append(("chain_start", run_id, parent_run_id))
+
+    def on_chain_end(
+        self,
+        outputs: dict[str, Any],
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: uuid.UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.events.append(("chain_end", run_id, parent_run_id))
+
+    def on_chain_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: uuid.UUID,
+        parent_run_id: uuid.UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.events.append(("chain_error", run_id, parent_run_id))
+
+
+def _make_error_then_ok_fallback() -> RunnableWithFallbacks:
+    """Return a RunnableWithFallbacks whose first runnable always raises."""
+    primary = RunnableLambda(lambda _: (_ for _ in ()).throw(ValueError("primary")))
+    fallback = RunnableLambda(lambda _: "ok")
+    return primary.with_fallbacks([fallback])
+
+
+def _assert_child_runs_nested(tracker: _RunTracker) -> None:
+    """Assert that all child runs have the root run as their parent.
+
+    The root run is the one whose parent_run_id is None.  All other runs
+    must have that root run_id as their parent_run_id.
+    """
+    root_run_ids = {rid for _, rid, pid in tracker.events if pid is None}
+    assert len(root_run_ids) == 1, (
+        f"Expected exactly one root run_id, got {root_run_ids}"
+    )
+    root_run_id = next(iter(root_run_ids))
+
+    child_events = [(name, pid) for name, rid, pid in tracker.events if pid is not None]
+    assert len(child_events) >= 1, "Expected at least one child run"
+    for name, parent_run_id in child_events:
+        assert parent_run_id == root_run_id, (
+            f"{name}: expected parent_run_id={root_run_id}, got {parent_run_id}"
+        )
+
+
+def test_fallbacks_invoke_preserves_parent_run_id() -> None:
+    """invoke() must pass child_config so child runs are nested under the fallback run.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/36072.
+    Before the fix, child runnables received ``config`` instead of ``child_config``,
+    so their parent_run_id was None (orphaned spans).
+    """
+    tracker = _RunTracker()
+    runnable = _make_error_then_ok_fallback()
+    runnable.invoke("hello", config={"callbacks": [tracker]})
+    _assert_child_runs_nested(tracker)
+
+
+async def test_fallbacks_ainvoke_preserves_parent_run_id() -> None:
+    """ainvoke() must pass child_config so child runs are nested under the fallback run.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/36072.
+    """
+    tracker = _RunTracker()
+    runnable = _make_error_then_ok_fallback()
+    await runnable.ainvoke("hello", config={"callbacks": [tracker]})
+    _assert_child_runs_nested(tracker)
+
+
+def test_fallbacks_stream_preserves_parent_run_id() -> None:
+    """stream() must pass child_config so child runs are nested under the fallback run.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/36072.
+    """
+    tracker = _RunTracker()
+    runnable = _make_error_then_ok_fallback()
+    list(runnable.stream("hello", config={"callbacks": [tracker]}))
+    _assert_child_runs_nested(tracker)


### PR DESCRIPTION
## Description

Fixes the regression introduced by #25550 where `RunnableWithFallbacks` passes the parent `config` to child runnables instead of the already-prepared `child_config`. This causes all child callback events to receive `parent_run_id=None`, breaking tracing/observability tools that rely on the parent → child run-id relationship to build span trees.

**Root cause:** Three methods pass the wrong config:

| Method | Bug |
|--------|-----|
| `invoke()` | Passes `config` instead of `child_config` (line 196) |
| `ainvoke()` | Passes `config` instead of `child_config` (line 247) |
| `stream()` | Passes no config to `runnable.stream` (line 496-499) |

`astream` already passes `child_config` correctly; `batch`/`abatch` also construct and pass child configs correctly.

## Issue

Fixes #36072

## Changes

- `libs/core/langchain_core/runnables/fallbacks.py`: 3 one-line fixes (config → child_config)
- `libs/core/tests/unit_tests/runnables/test_fallbacks.py`: regression tests for invoke, ainvoke, stream

## Test plan

Added 3 regression tests that verify child runs carry the correct `parent_run_id` after a fallback fires:

```
tests/unit_tests/runnables/test_fallbacks.py::test_fallbacks_invoke_preserves_parent_run_id  PASSED
tests/unit_tests/runnables/test_fallbacks.py::test_fallbacks_ainvoke_preserves_parent_run_id PASSED
tests/unit_tests/runnables/test_fallbacks.py::test_fallbacks_stream_preserves_parent_run_id  PASSED
```

All 19 existing fallback tests still pass.