### PR TITLE
fix(core): filter InjectedToolArgs when filter_args is provided

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -344,7 +344,7 @@ def create_schema_from_function(
     inferred_model = validated.model
 
     if filter_args:
-        filter_args_ = filter_args
+        filter_args_ = list(filter_args)
     else:
         # Handle classmethods and instance methods
         existing_params: list[str] = list(sig.parameters.keys())
@@ -353,8 +353,9 @@ def create_schema_from_function(
         else:
             filter_args_ = list(FILTERED_ARGS)
 
-        for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
+    if not include_injected:
+        for existing_param in sig.parameters:
+            if existing_param not in filter_args_ and _is_injected_arg_type(
                 sig.parameters[existing_param].annotation
             ):
                 filter_args_.append(existing_param)


### PR DESCRIPTION
Fixes #35831

## Problem

When `create_schema_from_function` is called with both `filter_args` and `include_injected=False`, injected arguments (annotated with `InjectedToolArg`) are silently leaked into the generated JSON schema.

**Root cause:** The injected-arg filtering loop was nested inside the `else` branch of `if filter_args:`, so it only ran when `filter_args` was NOT provided.

**Impact:** Sensitive parameters (API keys, sessions, internal context) designed to be hidden from the LLM via `InjectedToolArg` would be exposed in the schema, defeating the purpose of the annotation.

## Fix

1. Moved the injected-arg filtering outside the `if/else` block so it runs regardless of whether `filter_args` is provided
2. Added an `existing_param not in filter_args_` guard to avoid double-filtering
3. Copy `filter_args` to avoid mutating the caller's list

## Verification

```python
from typing import Annotated
from langchain_core.tools import InjectedToolArg
from langchain_core.tools.base import create_schema_from_function

def my_tool(query: str, secret: Annotated[str, InjectedToolArg]):
    pass

schema = create_schema_from_function(
    "MyTool", my_tool, filter_args=["query"], include_injected=False
)
# Before: ["secret"] leaked
# After:  [] (correctly filtered)
```

All 156 existing unit tests in `test_tools.py` pass.
