### PR TITLE
fix: fix UnboundLocalError in _consolidate_calls for unrecognized tools

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/_compat.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_compat.py
@@ -309,7 +309,7 @@ def _consolidate_calls(items: Iterable[dict[str, Any]]) -> Iterator[dict[str, An
                     pass
                 collapsed["type"] = "web_search_call"
 
-            if current.get("name") == "file_search":
+            elif current.get("name") == "file_search":
                 collapsed = {"id": current["id"]}
                 if "args" in current and "queries" in current["args"]:
                     collapsed["queries"] = current["args"]["queries"]
@@ -390,7 +390,10 @@ def _consolidate_calls(items: Iterable[dict[str, Any]]) -> Iterator[dict[str, An
                     if k not in ("server_label", "error"):
                         collapsed[k] = v
             else:
-                pass
+                # Unrecognized server tool — pass items through unchanged
+                yield current
+                yield nxt
+                continue  # skip `yield collapsed` below
 
             yield collapsed
 


### PR DESCRIPTION
## Problem
`_consolidate_calls` in `_compat.py` matches pairs of `server_tool_call` and 
`server_tool_result` items and collapses them into the Responses API format.

It handles `web_search`, `file_search`, `code_interpreter`, `remote_mcp`, 
and `mcp_list_tools` by name. However, if the tool name doesn't match any of 
these (e.g., `computer`, `image_generation`, or any future server tool), the 
`collapsed` variable is never assigned, causing `UnboundLocalError` when 
`yield collapsed` is reached.

Also, line 314 uses `if` instead of `elif` for `file_search`, which means 
for every `web_search` call, the code unnecessarily evaluates the `file_search` 
condition and the entire elif chain that follows.

## Changes
1. Fix `if` → `elif` for `file_search` branch (line 314)
2. Add fallback `else` branch for unrecognized tool names that emits both 
   items unchanged (matching the existing "not a matching pair" behavior)

## Testing
- Unrecognized server tools now pass through unchanged instead of crashing
- No change to behavior for known tool types

Fixes #36140