### PR TITLE
core: remove stale BlockBuster allowlist entry for deleted context.py

### DIFF
--- a/libs/core/tests/unit_tests/conftest.py
+++ b/libs/core/tests/unit_tests/conftest.py
@@ -17,9 +17,6 @@ def blockbuster() -> Iterator[BlockBuster]:
                 bb.functions[func]
                 .can_block_in("langchain_core/_api/internal.py", "is_caller_internal")
                 .can_block_in("langchain_core/runnables/base.py", "__repr__")
-                .can_block_in(
-                    "langchain_core/beta/runnables/context.py", "aconfig_with_context"
-                )
             )
 
         for func in ["os.stat", "io.TextIOWrapper.read"]:


### PR DESCRIPTION
## Description

Removes a stale entry from the BlockBuster allowlist in `libs/core/tests/unit_tests/conftest.py`.

The `aconfig_with_context` function and the entire `beta/runnables/context.py` module were removed by @eyurtsev in commit `fded6c6b1` (Sep 2025), but the BlockBuster allowlist entry still referenced the deleted file.

## Issue

Closes #29530 — the blocking call chain described in the issue no longer exists since the function was removed.

## Dependencies

None.