### PR TITLE
chore(core): remove stale blockbuster allowlist for deleted context module

### DIFF
--- a/libs/core/tests/unit_tests/conftest.py
+++ b/libs/core/tests/unit_tests/conftest.py
@@ -17,9 +17,6 @@ def blockbuster() -> Iterator[BlockBuster]:
                 bb.functions[func]
                 .can_block_in("langchain_core/_api/internal.py", "is_caller_internal")
                 .can_block_in("langchain_core/runnables/base.py", "__repr__")
-                .can_block_in(
-                    "langchain_core/beta/runnables/context.py", "aconfig_with_context"
-                )
             )
 
         for func in ["os.stat", "io.TextIOWrapper.read"]:


### PR DESCRIPTION
Closes #29530

---

Remove a stale BlockBuster allowlist entry in `conftest.py` referencing `aconfig_with_context` — the function and its containing module (`langchain_core/beta/runnables/context.py`) were deleted in `fded6c6b1` (Sep 2025, #32850). Spotted by @antonio-mello-ai in #29530.