### PR TITLE
fix(core): add float support to _dict_int_op in usage.py

### DIFF
--- a/libs/core/langchain_core/utils/usage.py
+++ b/libs/core/langchain_core/utils/usage.py
@@ -12,17 +12,17 @@ def _dict_int_op(
     depth: int = 0,
     max_depth: int = 100,
 ) -> dict:
-    """Apply an integer operation to corresponding values in two dictionaries.
+    """Apply a numeric operation to corresponding values in two dictionaries.
 
-    Recursively combines two dictionaries by applying the given operation to integer
-    values at matching keys.
+    Recursively combines two dictionaries by applying the given operation to numeric
+    (int or float) values at matching keys.
 
     Supports nested dictionaries.
 
     Args:
         left: First dictionary to combine.
         right: Second dictionary to combine.
-        op: Binary operation function to apply to integer values.
+        op: Binary operation function to apply to numeric values.
         default: Default value to use when a key is missing from a dictionary.
         depth: Current recursion depth (used internally).
         max_depth: Maximum recursion depth (to prevent infinite loops).
@@ -38,8 +38,8 @@ def _dict_int_op(
         raise ValueError(msg)
     combined: dict = {}
     for k in set(left).union(right):
-        if isinstance(left.get(k, default), int) and isinstance(
-            right.get(k, default), int
+        if isinstance(left.get(k, default), (int, float)) and isinstance(
+            right.get(k, default), (int, float)
         ):
             combined[k] = op(left.get(k, default), right.get(k, default))
         elif isinstance(left.get(k, {}), dict) and isinstance(right.get(k, {}), dict):
@@ -54,7 +54,8 @@ def _dict_int_op(
         else:
             types = [type(d[k]) for d in (left, right) if k in d]
             msg = (
-                f"Unknown value types: {types}. Only dict and int values are supported."
+                f"Unknown value types: {types}. "
+                "Only dict, int, and float values are supported."
             )
             raise ValueError(msg)  # noqa: TRY004
     return combined

--- a/libs/core/tests/unit_tests/utils/test_usage.py
+++ b/libs/core/tests/unit_tests/utils/test_usage.py
@@ -35,11 +35,32 @@ def test_dict_int_op_max_depth_exceeded() -> None:
         _dict_int_op(left, right, operator.add, max_depth=2)
 
 
+def test_dict_int_op_float_values() -> None:
+    left = {"tokens": 10, "cost": 0.05}
+    right = {"tokens": 20, "cost": 0.03}
+    result = _dict_int_op(left, right, operator.add)
+    assert result == {"tokens": 30, "cost": pytest.approx(0.08)}
+
+
+def test_dict_int_op_float_only_one_side() -> None:
+    left = {"tokens": 100, "cost": 0.005}
+    right = {"tokens": 200}
+    result = _dict_int_op(left, right, operator.add)
+    assert result == {"tokens": 300, "cost": pytest.approx(0.005)}
+
+
+def test_dict_int_op_mixed_int_float() -> None:
+    left = {"tokens": 100, "cost": 0}
+    right = {"tokens": 200, "cost": 0.01}
+    result = _dict_int_op(left, right, operator.add)
+    assert result == {"tokens": 300, "cost": pytest.approx(0.01)}
+
+
 def test_dict_int_op_invalid_types() -> None:
     left = {"a": 1, "b": "string"}
     right = {"a": 2, "b": 3}
     with pytest.raises(
         ValueError,
-        match="Only dict and int values are supported",
+        match="Only dict, int, and float values are supported",
     ):
         _dict_int_op(left, right, operator.add)


### PR DESCRIPTION
## Summary

`_dict_int_op()` in `libs/core/langchain_core/utils/usage.py` only handled `int` and `dict` types. When `UsageMetadata` contains `float` fields (e.g. `total_cost` from LLM providers that include pricing), the function raised `ValueError` during streaming chunk aggregation via `add_usage()`.

Fixes #36015

## Changes

- Widen type check from `isinstance(..., int)` to `isinstance(..., (int, float))` in `_dict_int_op()`
- Update docstring (`"integer values"` → `"numeric (int or float) values"`)
- Update error message to say `"Only dict, int, and float values are supported"`
- Add 3 regression tests: pure float values, float on one side only, mixed int/float

## Tests

```python
# All of these now work instead of raising ValueError:
_dict_int_op({"tokens": 10, "cost": 0.05}, {"tokens": 20, "cost": 0.03}, operator.add)
# → {"tokens": 30, "cost": 0.08}

_dict_int_op({"tokens": 100, "cost": 0.005}, {"tokens": 200}, operator.add)
# → {"tokens": 300, "cost": 0.005}

_dict_int_op({"tokens": 100, "cost": 0}, {"tokens": 200, "cost": 0.01}, operator.add)
# → {"tokens": 300, "cost": 0.01}
```