### PR TITLE
fix(core): preserve parent_run_id in fallback invoke paths

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -193,7 +193,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     output = context.run(
                         runnable.invoke,
                         input,
-                        config,
+                        child_config,
                         **kwargs,
                     )
             except self.exceptions_to_handle as e:
@@ -244,7 +244,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     input[self.exception_key] = last_error  # type: ignore[index]
                 child_config = patch_config(config, callbacks=run_manager.get_child())
                 with set_config_context(child_config) as context:
-                    coro = context.run(runnable.ainvoke, input, config, **kwargs)
+                    coro = context.run(runnable.ainvoke, input, child_config, **kwargs)
                     output = await coro_with_context(coro, context)
             except self.exceptions_to_handle as e:
                 if first_error is None:

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -2,13 +2,14 @@ from collections.abc import AsyncIterator, Callable, Iterator, Sequence
 from typing import (
     Any,
 )
+from uuid import UUID
 
 import pytest
 from pydantic import BaseModel
 from syrupy.assertion import SnapshotAssertion
 from typing_extensions import override
 
-from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.callbacks import BaseCallbackHandler, CallbackManagerForLLMRun
 from langchain_core.language_models import (
     BaseChatModel,
     FakeListLLM,
@@ -68,6 +69,72 @@ def _dont_raise_error(inputs: dict[str, Any]) -> str:
     raise ValueError
 
 
+class _FallbackRunTracker(BaseCallbackHandler):
+    def __init__(self) -> None:
+        self.events: list[tuple[str, UUID, UUID | None]] = []
+
+    @override
+    def on_chain_start(
+        self,
+        serialized: dict[str, Any] | None,
+        inputs: Any,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.events.append(("chain_start", run_id, parent_run_id))
+
+    @override
+    def on_chain_end(
+        self,
+        outputs: dict[str, Any] | Any,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.events.append(("chain_end", run_id, parent_run_id))
+
+    @override
+    def on_chain_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.events.append(("chain_error", run_id, parent_run_id))
+
+
+def _raise_string_error(_: str) -> str:
+    msg = "boom"
+    raise ValueError(msg)
+
+
+def _uppercase(value: str) -> str:
+    return value.upper()
+
+
+def _assert_fallback_child_run_parents(
+    events: list[tuple[str, UUID, UUID | None]],
+) -> None:
+    root_run_id = events[0][1]
+    child_starts = [event for event in events if event[0] == "chain_start"][1:]
+
+    assert len(child_starts) == 2
+    assert {event[2] for event in child_starts} == {root_run_id}
+
+    child_error = next(event for event in events if event[0] == "chain_error")
+    assert child_error[2] == root_run_id
+
+    child_end = next(
+        event for event in events if event[0] == "chain_end" and event[1] != root_run_id
+    )
+    assert child_end[2] == root_run_id
+
+
 @pytest.fixture
 def chain_pass_exceptions() -> Runnable[Any, str]:
     fallback = RunnableLambda(_dont_raise_error)
@@ -99,6 +166,26 @@ async def test_fallbacks_async(runnable_name: str, request: Any) -> None:
     assert await runnable.ainvoke("hello") == "bar"
     assert await runnable.abatch(["hi", "hey", "bye"]) == ["bar"] * 3
     assert list(await runnable.ainvoke("hello")) == list("bar")
+
+
+def test_invoke_propagates_parent_run_id_to_fallback_children() -> None:
+    tracker = _FallbackRunTracker()
+    runnable = RunnableLambda(_raise_string_error).with_fallbacks(
+        [RunnableLambda(_uppercase)]
+    )
+
+    assert runnable.invoke("hello", config={"callbacks": [tracker]}) == "HELLO"
+    _assert_fallback_child_run_parents(tracker.events)
+
+
+async def test_ainvoke_propagates_parent_run_id_to_fallback_children() -> None:
+    tracker = _FallbackRunTracker()
+    runnable = RunnableLambda(_raise_string_error).with_fallbacks(
+        [RunnableLambda(_uppercase)]
+    )
+
+    assert await runnable.ainvoke("hello", config={"callbacks": [tracker]}) == "HELLO"
+    _assert_fallback_child_run_parents(tracker.events)
 
 
 def _runnable(inputs: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- pass `child_config` into fallback `invoke()` and `ainvoke()` child runnables
- add focused fallback callback regression tests for both sync and async invocation paths

## Why
`RunnableWithFallbacks` already builds a patched `child_config` with `callbacks=run_manager.get_child()`, but `invoke()` and `ainvoke()` were still calling child runnables with the original `config`. That drops `parent_run_id` on fallback child callback events, which makes tracing/observability trees lose the child span relationship.

`batch`, `abatch`, and `astream` already use patched child configs correctly. This change brings the sync and async invoke paths back in line with the existing callback contract.

## Validation
- `uv run ruff format --check langchain_core/runnables/fallbacks.py tests/unit_tests/runnables/test_fallbacks.py`
- `uv run ruff check langchain_core/runnables/fallbacks.py tests/unit_tests/runnables/test_fallbacks.py`
- `uv run pytest tests/unit_tests/runnables/test_fallbacks.py -q`
- repeated the same focused gate a second time
- direct runtime repro now shows fallback child `chain_start` / `chain_error` / `chain_end` events carrying the root `parent_run_id`

Fixes #36072.
