### PR TITLE
chore(partners): bump `langchain-core` min to `1.2.21`

### DIFF
--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2206,7 +2206,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.20"
+version = "1.2.21"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2389,7 +2389,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.11"
+version = "1.1.12"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/model-profiles/uv.lock
+++ b/libs/model-profiles/uv.lock
@@ -528,7 +528,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.20"
+version = "1.2.21"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -656,7 +656,7 @@ typing = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.11"
+version = "1.1.12"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.4.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "anthropic>=0.85.0,<1.0.0",
-    "langchain-core>=1.2.19,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 

--- a/libs/partners/chroma/pyproject.toml
+++ b/libs/partners/chroma/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.1.3,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "numpy>=1.26.0; python_version < '3.13'",
     "numpy>=2.1.0; python_version >= '3.13'",
     "chromadb>=1.3.5,<2.0.0",

--- a/libs/partners/deepseek/pyproject.toml
+++ b/libs/partners/deepseek/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.1.0,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "langchain-openai>=1.1.0,<2.0.0",
 ]
 

--- a/libs/partners/exa/pyproject.toml
+++ b/libs/partners/exa/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.0.0,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "exa-py>=1.0.8,<2.0.0"
 ]
 

--- a/libs/partners/fireworks/pyproject.toml
+++ b/libs/partners/fireworks/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.1.0,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "fireworks-ai>=0.13.0,<1.0.0",
     "openai>=2.0.0,<3.0.0",
     "requests>=2.0.0,<3.0.0",

--- a/libs/partners/groq/pyproject.toml
+++ b/libs/partners/groq/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.2.8,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "groq>=0.30.0,<1.0.0"
 ]
 

--- a/libs/partners/huggingface/pyproject.toml
+++ b/libs/partners/huggingface/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.2.1"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.2.11,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "tokenizers>=0.19.1,<1.0.0",
     "huggingface-hub>=0.33.4,<2.0.0",
 ]

--- a/libs/partners/mistralai/pyproject.toml
+++ b/libs/partners/mistralai/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.2.19,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "tokenizers>=0.15.1,<1.0.0",
     "httpx>=0.25.2,<1.0.0",
     "httpx-sse>=0.3.1,<1.0.0",

--- a/libs/partners/nomic/pyproject.toml
+++ b/libs/partners/nomic/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.0.0,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "nomic>=3.5.3,<4.0.0",
     "pillow>=12.1.1,<13.0.0",
 ]

--- a/libs/partners/ollama/pyproject.toml
+++ b/libs/partners/ollama/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.0.1"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "ollama>=0.6.0,<1.0.0",
-    "langchain-core>=1.0.0,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
 ]
 
 [project.urls]

--- a/libs/partners/openrouter/pyproject.toml
+++ b/libs/partners/openrouter/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "0.1.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.2.13,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "openrouter>=0.6.0,<1.0.0",
 ]
 

--- a/libs/partners/perplexity/pyproject.toml
+++ b/libs/partners/perplexity/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.1.0,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "perplexityai>=0.22.0",
 ]
 

--- a/libs/partners/qdrant/pyproject.toml
+++ b/libs/partners/qdrant/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "qdrant-client>=1.15.1,<2.0.0",
     "pydantic>=2.7.4,<3.0.0",
-    "langchain-core>=1.0.0,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
 ]
 
 [project.urls]

--- a/libs/partners/xai/pyproject.toml
+++ b/libs/partners/xai/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.2.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-openai>=1.1.7,<2.0.0",
-    "langchain-core>=1.2.7,<2.0.0",
+    "langchain-core>=1.2.21,<2.0.0",
     "requests>=2.0.0,<3.0.0",
     "aiohttp>=3.9.1,<4.0.0",
 ]

--- a/libs/text-splitters/uv.lock
+++ b/libs/text-splitters/uv.lock
@@ -1184,7 +1184,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.20"
+version = "1.2.21"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Bump the minimum `langchain-core` dependency to `>=1.2.21` across all 14 partner packages in the monorepo. Aligns partner lower bounds with the latest core release so consumers pick up recent fixes (notably the `ModelProfile` schema drift fix from core 1.2.21).