### PR TITLE
fix(text-splitters): preserve content from unclosed markdown code blocks

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -446,7 +446,9 @@ class ExperimentalMarkdownSyntaxTextSplitter:
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk
-        return ""
+        # If code block is never closed, return accumulated content instead
+        # of silently discarding it.
+        return chunk
 
     def _complete_chunk_doc(self) -> None:
         chunk_content = self.current_chunk.page_content


### PR DESCRIPTION
In `ExperimentalMarkdownSyntaxTextSplitter._resolve_code_chunk()`, when a markdown code block is never closed (missing closing fence), the method returned an empty string `""`, silently discarding all accumulated content from the unclosed block. This fix returns the accumulated chunk content instead, ensuring no content is silently lost when processing malformed markdown.

Fixes #36186