### PR TITLE
fix: BaseTool cannot handle functions with 'self' parameter (#34900)

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -775,7 +775,7 @@ class ChildTool(BaseTool):
         return tool_input
 
     @abstractmethod
-    def _run(self, *args: Any, **kwargs: Any) -> Any:
+    def _run(self, /, *args: Any, **kwargs: Any) -> Any:
         """Use the tool.
 
         Add `run_manager: CallbackManagerForToolRun | None = None` to child
@@ -785,7 +785,7 @@ class ChildTool(BaseTool):
             The result of the tool execution.
         """
 
-    async def _arun(self, *args: Any, **kwargs: Any) -> Any:
+    async def _arun(self, /, *args: Any, **kwargs: Any) -> Any:
         """Use the tool asynchronously.
 
         Add `run_manager: AsyncCallbackManagerForToolRun | None = None` to child

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -73,6 +73,7 @@ class StructuredTool(BaseTool):
 
     def _run(
         self,
+        /,
         *args: Any,
         config: RunnableConfig,
         run_manager: CallbackManagerForToolRun | None = None,
@@ -100,6 +101,7 @@ class StructuredTool(BaseTool):
 
     async def _arun(
         self,
+        /,
         *args: Any,
         config: RunnableConfig,
         run_manager: AsyncCallbackManagerForToolRun | None = None,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3636,3 +3636,58 @@ def test_tool_args_schema_falsy_defaults() -> None:
     # Invoke with only required argument - falsy defaults should be applied
     result = config_tool.invoke({"name": "test"})
     assert result == "name=test, enabled=False, count=0, prefix=''"
+
+
+def test_structured_tool_with_self_in_input() -> None:
+    """Regression test for #34900.
+
+    A StructuredTool whose payload contains a key named 'self' must not
+    raise ``TypeError: got multiple values for argument 'self'``.  This can
+    happen when an unbound **kwargs function is wrapped as a tool and the
+    caller passes a dict that includes the key "self".
+    """
+
+    def func(**kwargs: object) -> str:
+        """Accept any keyword arguments."""
+        return str(kwargs)
+
+    tool_obj = StructuredTool(
+        name="test_tool",
+        func=func,
+        description="A tool that accepts any kwargs.",
+        args_schema={
+            "type": "object",
+            "properties": {},
+        },
+    )
+
+    tool_input = {"self": 2, "other": 3}
+
+    # Calling the plain function directly must work
+    assert func(**tool_input) == str(tool_input)
+
+    # Invoking through StructuredTool must produce the same result
+    result = tool_obj.invoke(tool_input)
+    assert result == str(tool_input)
+
+
+async def test_structured_tool_with_self_in_input_async() -> None:
+    """Async regression test for #34900 — same as sync variant but via ainvoke."""
+
+    async def afunc(**kwargs: object) -> str:
+        """Accept any keyword arguments."""
+        return str(kwargs)
+
+    tool_obj = StructuredTool(
+        name="test_tool_async",
+        coroutine=afunc,
+        description="An async tool that accepts any kwargs.",
+        args_schema={
+            "type": "object",
+            "properties": {},
+        },
+    )
+
+    tool_input = {"self": 2, "other": 3}
+    result = await tool_obj.ainvoke(tool_input)
+    assert result == str(tool_input)


### PR DESCRIPTION
## Summary
- When a tool's input schema has a field named `self`, `StructuredTool.invoke({"self": 2})` raises `TypeError: got multiple values for argument 'self'`
- Fix: add positional-only marker `/` after `self` in `_run` and `_arun` signatures in `BaseTool` and `StructuredTool`, so `self` is invisible to keyword-argument resolution

## Test plan
- Added sync and async regression tests with a tool that accepts a `self` parameter
- 162 passed, 1 skipped, zero regressions

Fixes #34900