### PR TITLE
fix: handle NotRequired InjectedState fields without KeyError

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -21,7 +21,8 @@ from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.constants import END, START
 from langgraph.graph.state import StateGraph
-from langgraph.prebuilt.tool_node import ToolCallWithContext, ToolNode
+from langgraph.prebuilt.tool_node import ToolCallWithContext
+from langchain.tools.tool_node import ToolNode
 from langgraph.types import Command, Send
 from langsmith import traceable
 from typing_extensions import NotRequired, Required, TypedDict

--- a/libs/langchain_v1/langchain/tools/tool_node.py
+++ b/libs/langchain_v1/langchain/tools/tool_node.py
@@ -1,14 +1,27 @@
-"""Utils file included for backwards compat imports."""
+"""ToolNode with graceful handling for NotRequired state fields.
 
+This module re-exports InjectedState-related types from langgraph and provides
+a ToolNode subclass that fixes KeyError when InjectedState references a
+NotRequired field that is absent from the agent state.
+
+See: https://github.com/langchain-ai/langchain/issues/35585
+"""
+
+from __future__ import annotations
+
+import inspect
+from copy import copy
+from typing import Any
+
+from langchain_core.tools import BaseTool
 from langgraph.prebuilt import InjectedState, InjectedStore, ToolRuntime
 from langgraph.prebuilt.tool_node import (
     ToolCallRequest,
     ToolCallWithContext,
     ToolCallWrapper,
+    ToolNode as _ToolNode,
 )
-from langgraph.prebuilt.tool_node import (
-    ToolNode as _ToolNode,  # noqa: F401
-)
+from langgraph.prebuilt.tool_node import ToolCall
 
 __all__ = [
     "InjectedState",
@@ -16,5 +29,134 @@ __all__ = [
     "ToolCallRequest",
     "ToolCallWithContext",
     "ToolCallWrapper",
+    "ToolNode",
     "ToolRuntime",
 ]
+
+_SENTINEL = object()
+
+
+def _tool_param_has_default(tool: BaseTool, param_name: str) -> bool:
+    """Return True if the tool's underlying function has a default for *param_name*."""
+    func = getattr(tool, "func", None) or getattr(tool, "coroutine", None)
+    if func is None:
+        return False
+    try:
+        sig = inspect.signature(func)
+        p = sig.parameters.get(param_name)
+        return p is not None and p.default is not inspect.Parameter.empty
+    except (ValueError, TypeError):
+        return False
+
+
+class ToolNode(_ToolNode):
+    """ToolNode that gracefully handles NotRequired InjectedState fields.
+
+    When a tool parameter is annotated with ``InjectedState("field")`` and the
+    referenced field is declared as ``NotRequired`` in the custom state schema,
+    langgraph's base ``ToolNode`` raises a ``KeyError`` if that field is absent
+    from the state dict.
+
+    This subclass overrides ``_inject_tool_args`` so that, when a specific state
+    field is absent from the state dict:
+
+    * If the tool parameter **has a default value**, the injection is skipped and
+      the default is used instead — this is the common ``NotRequired`` case.
+    * If the tool parameter has **no default**, the original ``KeyError`` is
+      re-raised with a clearer message so the user is aware of the missing field.
+
+    This matches the behaviour described in
+    https://github.com/langchain-ai/langchain/issues/35585.
+    """
+
+    def _inject_tool_args(
+        self,
+        tool_call: ToolCall,
+        tool_runtime: ToolRuntime,
+        tool: BaseTool | None = None,
+    ) -> ToolCall:
+        injected = self._injected_args.get(tool_call["name"])
+        if not injected and tool is not None:
+            from langgraph.prebuilt.tool_node import _get_all_injected_args
+
+            injected = _get_all_injected_args(tool)
+        if not injected:
+            return tool_call
+
+        # If there are no state injections we can delegate entirely to the parent.
+        if not injected.state:
+            return super()._inject_tool_args(tool_call, tool_runtime, tool)
+
+        state = tool_runtime.state
+
+        # For dict state, check whether each requested field actually exists before
+        # delegating to the parent.  Fields that are missing but have a default on
+        # the tool function are simply skipped; fields that are missing and have no
+        # default trigger a clear KeyError.
+        if isinstance(state, dict):
+            tool_obj = (
+                tool
+                if tool is not None
+                else self._tools_by_name.get(tool_call["name"])
+            )
+
+            missing_no_default: list[str] = []
+            missing_with_default: set[str] = set()
+
+            for tool_arg, state_field in injected.state.items():
+                if state_field is None:
+                    # Injecting the full state object — always present.
+                    continue
+                if state_field not in state:
+                    if tool_obj is not None and _tool_param_has_default(
+                        tool_obj, tool_arg
+                    ):
+                        missing_with_default.add(tool_arg)
+                    else:
+                        missing_no_default.append(state_field)
+
+            if missing_no_default:
+                raise KeyError(
+                    f"State field(s) {missing_no_default!r} are required by tool "
+                    f"'{tool_call['name']}' via InjectedState but are absent from the "
+                    "current state. Declare the field as NotRequired in your state "
+                    "schema and give the tool parameter a default value, or ensure "
+                    "the field is always populated before the tool is called."
+                )
+
+            if missing_with_default:
+                # Build a patched tool_runtime whose state only contains the fields
+                # that are actually present, then delegate to the parent.  The parent
+                # will iterate over injected.state and read each field — for the ones
+                # in missing_with_default the field won't be in the state dict, but
+                # we need to make the parent skip them rather than KeyError.
+                #
+                # The simplest safe approach: inject all present fields ourselves and
+                # return, mirroring what the parent does but skipping absent ones.
+                tool_call_copy: ToolCall = copy(tool_call)
+                injected_args: dict[str, Any] = {}
+
+                for tool_arg, state_field in injected.state.items():
+                    if tool_arg in missing_with_default:
+                        # Field absent but has a default — skip injection.
+                        continue
+                    injected_args[tool_arg] = state[state_field] if state_field else state
+
+                # Inject store if needed
+                if injected.store:
+                    if tool_runtime.store is None:
+                        raise ValueError(
+                            "Cannot inject store into tools with InjectedStore "
+                            "annotations - please compile your graph with a store."
+                        )
+                    injected_args[injected.store] = tool_runtime.store
+
+                # Inject runtime if needed
+                if injected.runtime:
+                    injected_args[injected.runtime] = tool_runtime
+
+                tool_call_copy["args"] = {**tool_call_copy["args"], **injected_args}
+                return tool_call_copy
+
+        # No missing fields (or non-dict state) — delegate to parent for all other cases.
+        return super()._inject_tool_args(tool_call, tool_runtime, tool)

--- a/libs/langchain_v1/tests/unit_tests/agents/test_create_agent_tool_validation.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_create_agent_tool_validation.py
@@ -2,10 +2,11 @@ import sys
 from typing import Annotated, Any
 
 import pytest
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, ToolMessage
 from langgraph.prebuilt import InjectedStore, ToolRuntime
 from langgraph.store.base import BaseStore
 from langgraph.store.memory import InMemoryStore
+from typing_extensions import NotRequired
 
 from langchain.agents import AgentState, create_agent
 from langchain.tools import InjectedState
@@ -376,3 +377,136 @@ def test_create_agent_error_only_model_controllable_params() -> None:
     assert "super_secret_password" not in content, (
         "Error should NOT contain password value (from system-injected state)"
     )
+
+
+# ---------------------------------------------------------------------------
+# Tests for InjectedState + NotRequired fields (issue #35585)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14"
+)
+def test_injected_state_not_required_field_absent_with_default() -> None:
+    """InjectedState("field") on a NotRequired field that is absent from state.
+
+    When the tool parameter has a default value the ToolNode should not raise a
+    KeyError.  Instead it should skip injection and let the default be used.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/35585
+    """
+
+    class CustomAgentState(AgentState[Any]):
+        city: NotRequired[str]
+
+    @dec_tool
+    def get_weather(
+        city: Annotated[str | None, InjectedState("city")] = None,
+    ) -> str:
+        """Get weather for a given city."""
+        return f"Weather in {city}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"args": {}, "id": "call_1", "name": "get_weather"}],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        state_schema=CustomAgentState,
+    )
+
+    # 'city' is absent from state — should use the tool default (None)
+    result = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "Weather in None"
+    assert tool_messages[0].status != "error"
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14"
+)
+def test_injected_state_not_required_field_present() -> None:
+    """InjectedState("field") on a NotRequired field that IS present in state.
+
+    When the NotRequired field is populated, InjectedState should inject the
+    actual value, not the default.
+    """
+
+    class CustomAgentState(AgentState[Any]):
+        city: NotRequired[str]
+
+    @dec_tool
+    def get_weather(
+        city: Annotated[str | None, InjectedState("city")] = None,
+    ) -> str:
+        """Get weather for a given city."""
+        return f"Weather in {city}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"args": {}, "id": "call_1", "name": "get_weather"}],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        state_schema=CustomAgentState,
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [HumanMessage("What's the weather?")],
+            "city": "Philadelphia",
+        }
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "Weather in Philadelphia"
+    assert tool_messages[0].status != "error"
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14), reason="Pydantic model rebuild issue in Python 3.14"
+)
+def test_injected_state_required_field_absent_raises() -> None:
+    """InjectedState("field") on a Required field that is absent should still raise.
+
+    Only NotRequired fields (with a default on the tool param) should be skipped.
+    A required state field that is genuinely absent should produce a clear error.
+    """
+
+    class CustomAgentState(AgentState[Any]):
+        city: str  # Required — always expected to be present
+
+    @dec_tool
+    def get_weather(
+        city: Annotated[str, InjectedState("city")],
+    ) -> str:
+        """Get weather for a given city."""
+        return f"Weather in {city}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"args": {}, "id": "call_1", "name": "get_weather"}],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        state_schema=CustomAgentState,
+    )
+
+    # 'city' required but absent — expect a KeyError (with a clear message)
+    with pytest.raises(KeyError, match="city"):
+        agent.invoke({"messages": [HumanMessage("What's the weather?")]})


### PR DESCRIPTION
## Summary

Fixes #35585.

`InjectedState("field")` on a `NotRequired` state field raises an unhandled `KeyError` when the field is absent from the state dict, because langgraph's `ToolNode._inject_tool_args` does a direct `state[state_field]` lookup.

This PR fixes the issue on the langchain side by introducing a `ToolNode` subclass in `langchain/tools/tool_node.py` that overrides `_inject_tool_args`:

- **Absent field + tool param has a default** → skip injection, let the default apply naturally. This is the correct behaviour for `NotRequired` fields.
- **Absent field + tool param has no default** → re-raise a `KeyError` with a clear message directing the user to either add a default or ensure the field is always populated.
- **All other cases** → delegate to the langgraph base implementation unchanged.

`langchain.agents.factory.create_agent` now uses this subclass instead of importing `ToolNode` directly from langgraph.

## What changed

- `libs/langchain_v1/langchain/tools/tool_node.py` — new `ToolNode` subclass with `_inject_tool_args` override and a `_tool_param_has_default` helper.
- `libs/langchain_v1/langchain/agents/factory.py` — import `ToolNode` from `langchain.tools.tool_node` instead of `langgraph.prebuilt.tool_node`.
- `libs/langchain_v1/tests/unit_tests/agents/test_create_agent_tool_validation.py` — three new regression tests.

## Test plan

- [x] `test_injected_state_not_required_field_absent_with_default` — absent `NotRequired` field, tool default (`None`) is used, no error.
- [x] `test_injected_state_not_required_field_present` — present `NotRequired` field is injected correctly.
- [x] `test_injected_state_required_field_absent_raises` — absent required field (no default) still raises `KeyError`.
- [x] All 726 existing agent unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)