### PR TITLE
fix(anthropic): redact mcp_servers authorization_token from invocation params

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -929,6 +929,33 @@ class ChatAnthropic(BaseChatModel):
             "thinking": self.thinking,
         }
 
+    def _get_invocation_params(
+        self,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        """Get the parameters used to invoke the model.
+
+        Redacts ``authorization_token`` from any ``mcp_servers`` entries so that
+        secrets are not leaked into LangSmith traces.
+        """
+        params = super()._get_invocation_params(stop=stop, **kwargs)
+        # Redact authorization_token from MCP server configs to avoid leaking
+        # credentials into traces (mirrors the analogous redaction in ChatOpenAI
+        # for MCP tool ``headers``).
+        if (mcp_servers := params.get("mcp_servers")) and isinstance(
+            mcp_servers, list
+        ):
+            params["mcp_servers"] = [
+                (
+                    {**server, "authorization_token": "**REDACTED**"}
+                    if isinstance(server, dict) and "authorization_token" in server
+                    else server
+                )
+                for server in mcp_servers
+            ]
+        return params
+
     def _get_ls_params(
         self,
         stop: list[str] | None = None,

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1697,13 +1697,32 @@ def test_mcp_tracing() -> None:
     with patch.object(llm, "_client", mock_client):
         _ = llm.invoke([input_message], config={"callbacks": [tracer]})
 
-    # Test headers are not traced
+    # Test authorization_token is not traced
     assert len(tracer.chat_model_start_inputs) == 1
     assert "PLACEHOLDER" not in str(tracer.chat_model_start_inputs)
 
-    # Test headers are correctly propagated to request
+    # Verify _get_invocation_params redacts authorization_token (model attribute case)
+    invocation_params = tracer.chat_model_start_inputs[0]["kwargs"]["invocation_params"]
+    if invocation_params.get("mcp_servers"):
+        for server in invocation_params["mcp_servers"]:
+            if "authorization_token" in server:
+                assert server["authorization_token"] == "**REDACTED**"  # noqa: S105
+
+    # Test authorization_token is correctly propagated to the actual API request
     payload = llm._get_request_payload([input_message])
     assert payload["mcp_servers"][0]["authorization_token"] == "PLACEHOLDER"  # noqa: S105
+
+    # Test that authorization_token is redacted when mcp_servers is passed via kwargs
+    llm_no_mcp = ChatAnthropic(model=MODEL_NAME)
+    invocation_params_kwargs = llm_no_mcp._get_invocation_params(
+        mcp_servers=mcp_servers
+    )
+    assert (
+        invocation_params_kwargs["mcp_servers"][0]["authorization_token"]
+        == "**REDACTED**"  # noqa: S105
+    )
+    # Verify the original mcp_servers list is not mutated
+    assert mcp_servers[0]["authorization_token"] == "PLACEHOLDER"  # noqa: S105
 
 
 def test_cache_control_kwarg() -> None:


### PR DESCRIPTION
## Summary

Closes #35574

When `mcp_servers` entries containing an `authorization_token` are passed via kwargs at invoke/bind time (rather than as a model attribute), the token was forwarded verbatim into LangSmith tracing through `_get_invocation_params`. This leaks credentials into traces.

- Override `_get_invocation_params` in `ChatAnthropic` to replace `authorization_token` with `"**REDACTED**"` in tracing params
- Mirrors the analogous redaction already in `ChatOpenAI` for MCP tool `headers`
- The actual API payload built by `_get_request_payload` is **not** affected — credentials continue to be forwarded correctly to the Anthropic API
- Creates a shallow copy of each server dict so the original list is never mutated

## Test plan

- Existing `test_mcp_tracing` extended with assertions that `authorization_token` is redacted in `invocation_params` and that the original list is not mutated

```bash
cd libs/partners/anthropic
pip install -e .
pytest tests/unit_tests/test_chat_models.py::test_mcp_tracing -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)