### PR TITLE
fix(core): ignore empty reasoning_content in message extraction 

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,10 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if (
+        isinstance(reasoning_content, str)
+        and reasoning_content.strip() != ""
+    ):
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -30,7 +30,9 @@ from langchain_core.messages.utils import (
     trim_messages,
 )
 from langchain_core.tools import BaseTool, tool
-
+from langchain_core.messages.base import (
+    _extract_reasoning_from_additional_kwargs,
+)
 
 @pytest.mark.parametrize("msg_cls", [HumanMessage, AIMessage, SystemMessage])
 def test_merge_message_runs_str(msg_cls: type[BaseMessage]) -> None:
@@ -2958,3 +2960,39 @@ def test_count_tokens_approximately_with_tools() -> None:
     # Test with empty tools list should equal base count
     count_empty_tools = count_tokens_approximately(messages, tools=[])
     assert count_empty_tools == base_count
+
+def test_extract_reasoning_ignores_empty_string():
+    msg = AIMessage(
+        content="Hello",
+        additional_kwargs={"reasoning_content": ""}
+    )
+
+    result = _extract_reasoning_from_additional_kwargs(msg)
+
+    assert result is None
+
+
+def test_extract_reasoning_ignores_whitespace():
+    msg = AIMessage(
+        content="Hello",
+        additional_kwargs={"reasoning_content": "   "}
+    )
+
+    result = _extract_reasoning_from_additional_kwargs(msg)
+
+    assert result is None
+
+
+def test_extract_reasoning_valid_string():
+    msg = AIMessage(
+        content="Hello",
+        additional_kwargs={"reasoning_content": "thinking..."}
+    )
+
+    result = _extract_reasoning_from_additional_kwargs(msg)
+
+    assert result == {
+        "type": "reasoning",
+        "reasoning": "thinking..."
+    }
+


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchain/issues/36194

Treat empty or whitespace-only reasoning_content as None to prevent empty reasoning blocks in output.