### PR TITLE
core[patch]: ignore empty/whitespace reasoning_content in _extract_reasoning_from_additional_kwargs

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if isinstance(reasoning_content, str) and reasoning_content.strip():
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/block_translators/test_groq.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_groq.py
@@ -27,6 +27,41 @@ def test_extract_reasoning_from_additional_kwargs_exists() -> None:
     assert callable(_extract_reasoning_from_additional_kwargs)
 
 
+def test_extract_reasoning_ignores_empty_string() -> None:
+    """Test that empty reasoning_content strings are ignored (not returned as blocks)."""
+    from langchain_core.messages.base import _extract_reasoning_from_additional_kwargs
+
+    # Empty string should return None
+    message = AIMessage(
+        content="answer",
+        additional_kwargs={"reasoning_content": ""},
+    )
+    assert _extract_reasoning_from_additional_kwargs(message) is None
+
+    # Whitespace-only string should also return None
+    message_ws = AIMessage(
+        content="answer",
+        additional_kwargs={"reasoning_content": "   "},
+    )
+    assert _extract_reasoning_from_additional_kwargs(message_ws) is None
+
+    # None value should return None
+    message_none = AIMessage(
+        content="answer",
+        additional_kwargs={"reasoning_content": None},
+    )
+    assert _extract_reasoning_from_additional_kwargs(message_none) is None
+
+    # Non-empty string should still work
+    message_valid = AIMessage(
+        content="answer",
+        additional_kwargs={"reasoning_content": "some reasoning"},
+    )
+    result = _extract_reasoning_from_additional_kwargs(message_valid)
+    assert result is not None
+    assert result["reasoning"] == "some reasoning"
+
+
 def test_groq_translate_content_basic() -> None:
     """Test basic groq content translation."""
     # Test with simple text message


### PR DESCRIPTION
**Fixes**: #36194

## Problem

Some providers (e.g. ChatTongyi) attach an empty `reasoning_content` string even after the reasoning stage is finished. With `LC_OUTPUT_VERSION=v1`, this creates alternating empty reasoning blocks and content blocks in the output.

## Fix

Changed the guard from:
```python
if reasoning_content is not None and isinstance(reasoning_content, str):
```
to:
```python
if isinstance(reasoning_content, str) and reasoning_content.strip():
```

This treats empty (`""`) and whitespace-only (`"   "`) strings as no reasoning content, matching the expected behavior that empty reasoning blocks should not be emitted.

## Testing

- Added unit test `test_extract_reasoning_ignores_empty_string` covering:
  - Empty string → returns None
  - Whitespace-only string → returns None
  - None value → returns None
  - Valid non-empty string → returns ReasoningContentBlock
- Verified all cases pass locally

## Changes

- `libs/core/langchain_core/messages/base.py`: one-line condition change
- `libs/core/tests/unit_tests/messages/block_translators/test_groq.py`: new test function
