### PR TITLE
fix(core): ignore empty strings in _extract_reasoning_from_additional_kwargs

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content and isinstance(reasoning_content, str):
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -502,3 +502,11 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+    # Test no reasoning extraction when reasoning content is empty string
+    message = AIMessage(
+        content="The answer is 42.", additional_kwargs={"reasoning_content": ""}
+    )
+    content_blocks = message.content_blocks
+    assert len(content_blocks) == 1
+    assert content_blocks[0]["type"] == "text"


### PR DESCRIPTION
Fixes #36194

Change `if reasoning_content is not None` to `if reasoning_content` in `_extract_reasoning_from_additional_kwargs` so that empty strings are treated the same as `None` — no empty `ReasoningContentBlock` is created.

Added a unit test that verifies `AIMessage(content="hi", additional_kwargs={"reasoning_content": ""})` produces no reasoning block.

**How I verified:** `make test` in `libs/core` — all tests pass.

- [x] make format
- [x] make lint
- [x] make test

Twitter: @
LinkedIn: https://linkedin.com/in/