### PR TITLE
docs(langchain-classic): add llmmathchain from_llm docstring details

### DIFF
--- a/libs/langchain/langchain_classic/chains/llm_math/base.py
+++ b/libs/langchain/langchain_classic/chains/llm_math/base.py
@@ -310,6 +310,17 @@ class LLMMathChain(Chain):
             llm: a language model
             prompt: a prompt template
             **kwargs: additional arguments
+
+        Returns:
+            An `LLMMathChain` instance initialized with the provided language model.
+
+        Example:
+            ```python
+            from langchain_classic.chains import LLMMathChain
+            from langchain_openai import OpenAI
+
+            llm_math = LLMMathChain.from_llm(OpenAI())
+            ```
         """
         llm_chain = LLMChain(llm=llm, prompt=prompt)
         return cls(llm_chain=llm_chain, **kwargs)


### PR DESCRIPTION
Fixes #35749

## Summary

- add a missing `Returns` section to `LLMMathChain.from_llm`
- add a usage example to the `LLMMathChain.from_llm` docstring

## Testing

- not run; docstring-only change

## AI involvement

- AI-assisted change, reviewed against the current issue scope before submission
