### PR TITLE
docs(core): fix grammatical error in development guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ This monorepo uses `uv` for dependency management. Local development uses editab
 
 Each package in `libs/` has its own `pyproject.toml` and `uv.lock`.
 
-Before running your tests, setup all packages by running:
+Before running your tests, set up all packages by running:
 
 ```bash
 # For all groups


### PR DESCRIPTION
Corrected "setup" (noun) to "set up" (verb) in the environment installation instructions for grammatical accuracy.

Fixes langchain-ai/docs#3299 