### PR TITLE
docs: add snowloader ServiceNow document loader integration

### DIFF
--- a/docs/docs/integrations/document_loaders/snowloader.ipynb
+++ b/docs/docs/integrations/document_loaders/snowloader.ipynb
@@ -1,0 +1,262 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# snowloader\n",
+    "\n",
+    ">[snowloader](https://github.com/ronidas39/snowloader) is a comprehensive ServiceNow data loader for AI/LLM pipelines. It pulls data from six core ServiceNow tables — Incidents, Knowledge Base, CMDB, Changes, Problems, and Service Catalog — and converts them into LangChain Documents.\n",
+    ">\n",
+    ">Built for production use with 4 authentication modes, retry logic with exponential backoff, rate limiting, delta sync, CMDB relationship traversal, and memory-efficient streaming.\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "I built snowloader because I needed a reliable way to pull structured ServiceNow data into RAG pipelines. Existing tools either covered a single table, ignored relationships between configuration items, or required too much boilerplate.\n",
+    "\n",
+    "### Features\n",
+    "\n",
+    "| Feature | Description |\n",
+    "|---------|-------------|\n",
+    "| **6 loaders** | Incidents, KB articles, CMDB CIs, Changes, Problems, Catalog items |\n",
+    "| **CMDB relationships** | Concurrent graph traversal of CI dependencies |\n",
+    "| **Delta sync** | Only fetch records updated since your last sync |\n",
+    "| **HTML cleaning** | Built-in KB article HTML stripping, no extra dependencies |\n",
+    "| **Journal support** | Optionally include work notes and comments |\n",
+    "| **4 auth modes** | Basic, OAuth Password, OAuth Client Credentials, Bearer Token |\n",
+    "| **Production-grade** | Retry with backoff, rate limiting, thread safety, proxy support |\n",
+    "\n",
+    "### Integration details\n",
+    "\n",
+    "| Class | Package | Serializable | JS support |\n",
+    "|-------|---------|:---:|:---:|\n",
+    "| ServiceNowIncidentLoader | snowloader | beta | ❌ |\n",
+    "| ServiceNowKBLoader | snowloader | beta | ❌ |\n",
+    "| ServiceNowCMDBLoader | snowloader | beta | ❌ |\n",
+    "| ServiceNowChangeLoader | snowloader | beta | ❌ |\n",
+    "| ServiceNowProblemLoader | snowloader | beta | ❌ |\n",
+    "| ServiceNowCatalogLoader | snowloader | beta | ❌ |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Install the package with the LangChain extra:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU snowloader[langchain]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You need a ServiceNow instance with REST API access and a user account with appropriate roles (e.g., `itil` for incidents, `knowledge` for KB articles)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialization\n",
+    "\n",
+    "Create a connection to your ServiceNow instance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from snowloader import SnowConnection\n",
+    "from snowloader.adapters.langchain import ServiceNowIncidentLoader\n",
+    "\n",
+    "conn = SnowConnection(\n",
+    "    instance_url=\"https://mycompany.service-now.com\",\n",
+    "    username=\"admin\",\n",
+    "    password=\"password\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For production, use OAuth Client Credentials (no user password needed):\n",
+    "\n",
+    "```python\n",
+    "conn = SnowConnection(\n",
+    "    instance_url=\"https://mycompany.service-now.com\",\n",
+    "    client_id=\"your_client_id\",\n",
+    "    client_secret=\"your_client_secret\",\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load incidents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loader = ServiceNowIncidentLoader(connection=conn, query=\"active=true^priority<=2\")\n",
+    "docs = loader.load()\n",
+    "\n",
+    "print(f\"Loaded {len(docs)} incidents\")\n",
+    "print(docs[0].page_content[:300])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(docs[0].metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lazy loading (streaming)\n",
+    "\n",
+    "For large tables, use `lazy_load()` to stream documents one at a time without holding everything in memory:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for doc in loader.lazy_load():\n",
+    "    print(f\"[{doc.metadata['number']}] {doc.page_content[:100]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## All available loaders\n",
+    "\n",
+    "```python\n",
+    "from snowloader.adapters.langchain import (\n",
+    "    ServiceNowIncidentLoader,    # IT incidents\n",
+    "    ServiceNowKBLoader,          # Knowledge Base articles (HTML auto-cleaned)\n",
+    "    ServiceNowCMDBLoader,        # CMDB Configuration Items + relationships\n",
+    "    ServiceNowChangeLoader,      # Change requests\n",
+    "    ServiceNowProblemLoader,     # Problem records\n",
+    "    ServiceNowCatalogLoader,     # Service catalog items\n",
+    ")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CMDB with relationship traversal\n",
+    "\n",
+    "The CMDB loader can map out how configuration items relate to each other:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from snowloader.adapters.langchain import ServiceNowCMDBLoader\n",
+    "\n",
+    "cmdb_loader = ServiceNowCMDBLoader(\n",
+    "    connection=conn,\n",
+    "    ci_class=\"cmdb_ci_server\",\n",
+    "    include_relationships=True,\n",
+    ")\n",
+    "\n",
+    "server_docs = cmdb_loader.load()\n",
+    "print(server_docs[0].page_content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delta sync\n",
+    "\n",
+    "Only fetch records updated since your last sync:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timezone\n",
+    "\n",
+    "# Only get incidents updated in the last 24 hours\n",
+    "since = datetime(2024, 6, 1, tzinfo=timezone.utc)\n",
+    "updated_docs = loader.load_since(since)\n",
+    "print(f\"{len(updated_docs)} incidents updated since {since}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use with a vector store\n",
+    "\n",
+    "```python\n",
+    "from langchain_community.vectorstores import FAISS\n",
+    "from langchain_openai import OpenAIEmbeddings\n",
+    "\n",
+    "docs = ServiceNowIncidentLoader(connection=conn, query=\"active=true\").load()\n",
+    "vectorstore = FAISS.from_documents(docs, OpenAIEmbeddings())\n",
+    "retriever = vectorstore.as_retriever(search_kwargs={\"k\": 5})\n",
+    "results = retriever.invoke(\"network outage incidents\")\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API reference\n",
+    "\n",
+    "For a full list of parameters and configuration options, see the [snowloader documentation](https://snowloader.readthedocs.io)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Description

Adds documentation for [snowloader](https://pypi.org/project/snowloader/), a ServiceNow data loader that works with LangChain out of the box.

snowloader covers six ServiceNow tables — Incidents, Knowledge Base, CMDB, Changes, Problems, and Service Catalog — with production-grade features including retry logic, delta sync, CMDB relationship traversal, and HTML cleaning.

The package is already published on PyPI (`pip install snowloader[langchain]`) and implements `langchain_core.document_loaders.BaseLoader` for all six loaders.

## Changes

- Added `docs/docs/integrations/document_loaders/snowloader.ipynb` — integration documentation notebook

The notebook covers:
- Setup and installation
- Loading incidents with query filtering
- Lazy loading for memory efficiency
- CMDB relationship traversal
- Delta sync for incremental updates
- All 6 available loader classes
- Vector store integration example (FAISS)

## Links

- PyPI: https://pypi.org/project/snowloader/
- GitHub: https://github.com/ronidas39/snowloader
- Documentation: https://snowloader.readthedocs.io