### PR TITLE
fix(core): add "computer" to _WellKnownOpenAITools

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -500,6 +500,7 @@ def convert_to_openai_function(
 _WellKnownOpenAITools = (
     "function",
     "file_search",
+    "computer",
     "computer_use_preview",
     "code_interpreter",
     "mcp",

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -32,6 +32,7 @@ from langchain_core.utils.function_calling import (
     _convert_typed_dict_to_openai_function,
     convert_to_json_schema,
     convert_to_openai_function,
+    convert_to_openai_tool,
     tool_example_to_messages,
 )
 
@@ -1242,3 +1243,15 @@ def test_convert_to_openai_function_json_schema_missing_title_includes_schema() 
     }
     with pytest.raises(ValueError, match="my_field"):
         convert_to_openai_function(schema_without_title)
+
+
+def test_convert_to_openai_tool_computer_passthrough() -> None:
+    """Test that the 'computer' tool type is passed through unchanged."""
+    computer_tool = {
+        "type": "computer",
+        "display_width": 1024,
+        "display_height": 768,
+        "environment": "browser",
+    }
+    result = convert_to_openai_tool(computer_tool)
+    assert result == computer_tool


### PR DESCRIPTION
## Description

Closes #36209.

Adds `"computer"` to the `_WellKnownOpenAITools` tuple in `langchain_core/utils/function_calling.py` so that OpenAI's `computer` tool type (used in the Responses API for computer use) is passed through `convert_to_openai_tool` unchanged, just like `computer_use_preview` and other well-known tool types.

## Changes

- Added `"computer"` to `_WellKnownOpenAITools` in `libs/core/langchain_core/utils/function_calling.py`
- Added a regression test verifying that a `{"type": "computer", ...}` dict passes through `convert_to_openai_tool` without modification

## AI Disclosure

This contribution was made with the assistance of an AI coding agent (Claude Code).