### PR TITLE
fix(openai): auto-route file URL content to Responses API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1526,7 +1526,10 @@ class BaseChatOpenAI(BaseChatModel):
 
         payload = {**self._default_params, **kwargs}
 
-        if self._use_responses_api(payload):
+        use_responses_api = self._use_responses_api(payload) or (
+            self.use_responses_api is None and _messages_require_responses_api(messages)
+        )
+        if use_responses_api:
             if self.use_previous_response_id:
                 last_messages, previous_response_id = _get_last_messages(messages)
                 payload_to_use = last_messages if previous_response_id else messages
@@ -3939,6 +3942,25 @@ def _use_responses_api(payload: dict) -> bool:
         "truncation",
     }
     return bool(uses_builtin_tools or responses_only_args.intersection(payload))
+
+
+def _messages_require_responses_api(messages: Sequence[BaseMessage]) -> bool:
+    """Return whether message content requires the OpenAI Responses API.
+
+    This currently detects file URL blocks, which are unsupported by Chat
+    Completions but supported by the Responses API.
+    """
+    for message in messages:
+        if not isinstance(message.content, list):
+            continue
+        for block in message.content:
+            if (
+                isinstance(block, dict)
+                and block.get("type") == "file"
+                and isinstance(block.get("url"), str)
+            ):
+                return True
+    return False
 
 
 def _get_last_messages(

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1347,6 +1347,53 @@ def test_output_version_compat() -> None:
     assert llm._use_responses_api({}) is True
 
 
+def test_file_url_content_auto_uses_responses_api() -> None:
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key="test")
+    messages = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "Summarize this file"},
+                {
+                    "type": "file",
+                    "source_type": "url",
+                    "url": "https://example.com/test.pdf",
+                },
+            ]
+        )
+    ]
+    payload = llm._get_request_payload(messages, stop=None)
+
+    assert "input" in payload
+    assert "messages" not in payload
+    assert payload["input"][0]["content"][1] == {
+        "type": "input_file",
+        "file_url": "https://example.com/test.pdf",
+    }
+
+
+def test_file_url_content_does_not_override_explicit_chat_completions() -> None:
+    llm = ChatOpenAI(
+        model="gpt-4o-mini", use_responses_api=False, api_key="test"
+    )
+    messages = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "Summarize this file"},
+                {
+                    "type": "file",
+                    "source_type": "url",
+                    "url": "https://example.com/test.pdf",
+                },
+            ]
+        )
+    ]
+
+    with pytest.raises(
+        ValueError, match=r"OpenAI Chat Completions does not support file URLs\."
+    ):
+        llm._get_request_payload(messages, stop=None)
+
+
 def test_verbosity_parameter_payload() -> None:
     """Test verbosity parameter is included in request payload for Responses API."""
     llm = ChatOpenAI(model="gpt-5", verbosity="high", use_responses_api=True)


### PR DESCRIPTION
Resolves #31505

## Summary
Fixes OpenAI request routing when user messages include file URL content blocks (`{"type":"file","url":...}`).

When `use_responses_api` is not explicitly set, `ChatOpenAI` now auto-routes to the Responses API for this content type, since Chat Completions does not support file URLs.


## Why
Chat Completions rejects file URL blocks, which can surface as request-shape errors in multimodal flows (for example, missing/invalid file parameters).
This change makes routing behavior align with content capabilities and avoids avoidable runtime failures.

## Changes
- Added `_messages_require_responses_api(...)` in OpenAI chat model base implementation to detect file URL blocks in message content.
- Updated payload construction in `_get_request_payload(...)`:
  - If `use_responses_api` is explicitly set, behavior is unchanged.
  - If `use_responses_api=None` (auto mode), file URL content triggers Responses API routing.
- Kept explicit opt-out behavior intact:
  - `use_responses_api=False` still uses Chat Completions and raises the same unsupported file URL error.

## Tests
Added unit tests in `libs/partners/openai/tests/unit_tests/chat_models/test_base.py`:
- `test_file_url_content_auto_uses_responses_api`
- `test_file_url_content_does_not_override_explicit_chat_completions`

Both pass locally with targeted pytest run.

## Reviewer Focus
- Routing precedence and backward compatibility:
  - explicit config > auto-detection
- Correctness of file URL detection scope (only `type="file"` with `url`).