### PR TITLE
fix(core): ignore empty reasoning_content strings

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if isinstance(reasoning_content, str) and reasoning_content != "":
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -502,3 +502,11 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+    # Test no reasoning extraction when reasoning content is an empty string
+    message = AIMessage(
+        content="The answer is 42.", additional_kwargs={"reasoning_content": ""}
+    )
+    content_blocks = message.content_blocks
+    assert len(content_blocks) == 1
+    assert content_blocks[0]["type"] == "text"


### PR DESCRIPTION
## Summary

Ignores empty-string `reasoning_content` values when extracting reasoning blocks from `additional_kwargs` in `langchain-core`.

Without this guard, providers that emit `reasoning_content=""` can produce empty reasoning blocks in `content_blocks`, which matches the behavior reported in #36194.

## Why this change

The existing helper treats any string, including `""`, as valid reasoning content. That creates a spurious `{"type": "reasoning", "reasoning": ""}` block even though there is no actual reasoning payload to preserve.

This patch keeps the existing behavior for non-empty strings and only skips the empty-string edge case.

## Tests

- Added a regression assertion in `libs/core/tests/unit_tests/messages/test_ai.py` covering `additional_kwargs={"reasoning_content": ""}`.
- Ran:
  - `python -m uv sync --group test`
  - `python -m uv run --group test pytest tests/unit_tests/messages/test_ai.py -k reasoning_extraction`
  - `python -m uv run --group lint ruff check langchain_core/messages/base.py tests/unit_tests/messages/test_ai.py`

## Review notes

- The behavior change is intentionally narrow: empty strings are ignored, but whitespace-only strings are still preserved as provided.

## AI assistance disclosure

This PR was prepared with AI agent assistance, then manually validated by running the targeted LangChain core test and lint commands listed above.

Closes #36194.