### PR TITLE
fix(core): support float usage aggregation

### DIFF
--- a/libs/core/langchain_core/utils/usage.py
+++ b/libs/core/langchain_core/utils/usage.py
@@ -2,19 +2,21 @@
 
 from collections.abc import Callable
 
+Number = int | float
+
 
 def _dict_int_op(
     left: dict,
     right: dict,
-    op: Callable[[int, int], int],
+    op: Callable[[Number, Number], Number],
     *,
-    default: int = 0,
+    default: Number = 0,
     depth: int = 0,
     max_depth: int = 100,
 ) -> dict:
-    """Apply an integer operation to corresponding values in two dictionaries.
+    """Apply a numeric operation to corresponding values in two dictionaries.
 
-    Recursively combines two dictionaries by applying the given operation to integer
+    Recursively combines two dictionaries by applying the given operation to numeric
     values at matching keys.
 
     Supports nested dictionaries.
@@ -22,7 +24,7 @@ def _dict_int_op(
     Args:
         left: First dictionary to combine.
         right: Second dictionary to combine.
-        op: Binary operation function to apply to integer values.
+        op: Binary operation function to apply to numeric values.
         default: Default value to use when a key is missing from a dictionary.
         depth: Current recursion depth (used internally).
         max_depth: Maximum recursion depth (to prevent infinite loops).
@@ -38,8 +40,8 @@ def _dict_int_op(
         raise ValueError(msg)
     combined: dict = {}
     for k in set(left).union(right):
-        if isinstance(left.get(k, default), int) and isinstance(
-            right.get(k, default), int
+        if isinstance(left.get(k, default), (int, float)) and isinstance(
+            right.get(k, default), (int, float)
         ):
             combined[k] = op(left.get(k, default), right.get(k, default))
         elif isinstance(left.get(k, {}), dict) and isinstance(right.get(k, {}), dict):
@@ -54,7 +56,8 @@ def _dict_int_op(
         else:
             types = [type(d[k]) for d in (left, right) if k in d]
             msg = (
-                f"Unknown value types: {types}. Only dict and int values are supported."
+                f"Unknown value types: {types}. "
+                "Only dict and numeric values are supported."
             )
             raise ValueError(msg)  # noqa: TRY004
     return combined

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -143,6 +143,20 @@ def test_add_usage_with_details() -> None:
     assert result["output_token_details"]["reasoning"] == 15
 
 
+def test_add_usage_with_float_total_cost() -> None:
+    usage1 = UsageMetadata(input_tokens=10, output_tokens=20, total_tokens=30)
+    usage1["total_cost"] = 0.005  # type: ignore[typeddict-item]
+    usage2 = UsageMetadata(input_tokens=5, output_tokens=10, total_tokens=15)
+    usage2["total_cost"] = 0.01  # type: ignore[typeddict-item]
+
+    result = add_usage(usage1, usage2)
+
+    assert result["input_tokens"] == 15
+    assert result["output_tokens"] == 30
+    assert result["total_tokens"] == 45
+    assert abs(result["total_cost"] - 0.015) < 1e-12  # type: ignore[typeddict-item]
+
+
 def test_subtract_usage_both_none() -> None:
     result = subtract_usage(None, None)
     assert result == UsageMetadata(input_tokens=0, output_tokens=0, total_tokens=0)

--- a/libs/core/tests/unit_tests/utils/test_usage.py
+++ b/libs/core/tests/unit_tests/utils/test_usage.py
@@ -26,6 +26,22 @@ def test_dict_int_op_nested() -> None:
     assert result == {"a": 3, "b": {"c": 3, "d": 3, "e": 4}}
 
 
+def test_dict_int_op_add_with_floats() -> None:
+    left = {"tokens": 10, "cost": 0.05}
+    right = {"tokens": 20, "cost": 0.03}
+    result = _dict_int_op(left, right, operator.add)
+    assert result["tokens"] == 30
+    assert result["cost"] == pytest.approx(0.08)
+
+
+def test_dict_int_op_add_float_with_missing_key() -> None:
+    left = {"tokens": 10, "cost": 0.05}
+    right = {"tokens": 20}
+    result = _dict_int_op(left, right, operator.add)
+    assert result["tokens"] == 30
+    assert result["cost"] == pytest.approx(0.05)
+
+
 def test_dict_int_op_max_depth_exceeded() -> None:
     left = {"a": {"b": {"c": 1}}}
     right = {"a": {"b": {"c": 2}}}
@@ -40,6 +56,6 @@ def test_dict_int_op_invalid_types() -> None:
     right = {"a": 2, "b": 3}
     with pytest.raises(
         ValueError,
-        match="Only dict and int values are supported",
+        match="Only dict and numeric values are supported",
     ):
         _dict_int_op(left, right, operator.add)


### PR DESCRIPTION
## Summary

Adds float support to `_dict_int_op()` so usage aggregation no longer crashes when `UsageMetadata` includes float-valued fields such as `total_cost`.

## Why this change

The helper currently treats only `int` values as numeric, which means streaming aggregation fails as soon as a provider attaches a float metric. That shows up through `add_usage()` and breaks otherwise valid usage metadata merges.

This patch keeps the existing recursive structure intact and only broadens the supported scalar type from `int` to numeric (`int | float`).

## Tests

- Added direct regression coverage in `libs/core/tests/unit_tests/utils/test_usage.py` for:
  - float + float aggregation
  - float + missing-key aggregation
- Added `UsageMetadata.total_cost` regression coverage in `libs/core/tests/unit_tests/messages/test_ai.py`.
- Ran:
  - `python -m uv sync --group test`
  - `python -m uv run --group test pytest tests/unit_tests/utils/test_usage.py tests/unit_tests/messages/test_ai.py -k "usage or dict_int_op"`
  - `python -m uv run --group lint ruff check langchain_core/utils/usage.py tests/unit_tests/utils/test_usage.py tests/unit_tests/messages/test_ai.py`

## Review notes

- `_dict_int_op()` remains private and keeps the same call shape; this only expands accepted scalar values and updates the wording from `int` to `numeric`.
- The subtraction path also benefits from the same fix because it uses the same helper.

## AI assistance disclosure

This PR was prepared with AI agent assistance, then manually validated with the targeted LangChain core test and lint commands listed above.

Closes #36015.