### PR TITLE
fix(openai): preserve reasoning_content in chat completions

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -12,6 +12,7 @@ from langchain_core.language_models._utils import (
 )
 from langchain_core.messages import AIMessageChunk
 from langchain_core.messages import content as types
+from langchain_core.messages.base import _extract_reasoning_from_additional_kwargs
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -1050,9 +1051,17 @@ def translate_content(message: AIMessage) -> list[types.ContentBlock]:
         The derived content blocks.
     """
     if isinstance(message.content, str):
-        return _convert_to_v1_from_chat_completions(message)
-    message = _convert_from_v03_ai_message(message)
-    return _convert_to_v1_from_responses(message)
+        blocks = _convert_to_v1_from_chat_completions(message)
+    else:
+        message = _convert_from_v03_ai_message(message)
+        blocks = _convert_to_v1_from_responses(message)
+
+    if not any(block.get("type") == "reasoning" for block in blocks) and (
+        reasoning_block := _extract_reasoning_from_additional_kwargs(message)
+    ):
+        blocks.insert(0, reasoning_block)
+
+    return blocks
 
 
 def translate_content_chunk(message: AIMessageChunk) -> list[types.ContentBlock]:
@@ -1065,9 +1074,17 @@ def translate_content_chunk(message: AIMessageChunk) -> list[types.ContentBlock]
         The derived content blocks.
     """
     if isinstance(message.content, str):
-        return _convert_to_v1_from_chat_completions_chunk(message)
-    message = _convert_from_v03_ai_message(message)  # type: ignore[assignment]
-    return _convert_to_v1_from_responses(message)
+        blocks = _convert_to_v1_from_chat_completions_chunk(message)
+    else:
+        message = _convert_from_v03_ai_message(message)  # type: ignore[assignment]
+        blocks = _convert_to_v1_from_responses(message)
+
+    if not any(block.get("type") == "reasoning" for block in blocks) and (
+        reasoning_block := _extract_reasoning_from_additional_kwargs(message)
+    ):
+        blocks.insert(0, reasoning_block)
+
+    return blocks
 
 
 def _register_openai_translator() -> None:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4,9 +4,10 @@
 
         `ChatOpenAI` targets
         [official OpenAI API specifications](https://github.com/openai/openai-openapi)
-        only. Non-standard response fields added by third-party providers (e.g.,
-        `reasoning_content`, `reasoning_details`) are **not** extracted or
-        preserved. If you are pointing `base_url` at a provider such as
+        only. Non-standard response fields added by third-party providers are not
+        standardized by this integration. Some raw compatibility fields, such as
+        `reasoning_content`, may still be preserved in `additional_kwargs`, but if
+        you are pointing `base_url` at a provider such as
         OpenRouter, vLLM, or DeepSeek, use the corresponding provider-specific
         LangChain package instead (e.g., `ChatDeepSeek`, `ChatOpenRouter`).
 """
@@ -189,6 +190,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # Also OpenAI returns None for tool invocations
         content = _dict.get("content", "") or ""
         additional_kwargs: dict = {}
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = reasoning_content
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
         tool_calls = []
@@ -408,6 +411,8 @@ def _convert_delta_to_message_chunk(
     role = cast(str, _dict.get("role"))
     content = cast(str, _dict.get("content") or "")
     additional_kwargs: dict = {}
+    if reasoning_content := _dict.get("reasoning_content"):
+        additional_kwargs["reasoning_content"] = reasoning_content
     if _dict.get("function_call"):
         function_call = dict(_dict["function_call"])
         if "name" in function_call and function_call["name"] is None:
@@ -556,9 +561,10 @@ class BaseChatOpenAI(BaseChatModel):
 
     This base class targets
     [official OpenAI API specifications](https://github.com/openai/openai-openapi)
-    only. Non-standard response fields added by third-party providers (e.g.,
-    `reasoning_content`) are not extracted. Use a provider-specific subclass for
-    full provider support.
+    only. Non-standard response fields added by third-party providers are not
+    standardized. Some raw compatibility fields, such as `reasoning_content`, may be
+    preserved in `additional_kwargs`, but provider-specific subclasses still offer the
+    best support.
     """
 
     client: Any = Field(default=None, exclude=True)
@@ -2355,9 +2361,10 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
 
         `ChatOpenAI` targets
         [official OpenAI API specifications](https://github.com/openai/openai-openapi)
-        only. Non-standard response fields added by third-party providers (e.g.,
-        `reasoning_content`, `reasoning_details`) are **not** extracted or
-        preserved. If you are pointing `base_url` at a provider such as
+        only. Non-standard response fields added by third-party providers are not
+        standardized by this integration. Some raw compatibility fields, such as
+        `reasoning_content`, may still be preserved in `additional_kwargs`, but if
+        you are pointing `base_url` at a provider such as
         OpenRouter, vLLM, or DeepSeek, use the corresponding provider-specific
         LangChain package instead (e.g., `ChatDeepSeek`, `ChatOpenRouter`).
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -197,6 +197,19 @@ def test__convert_dict_to_message_ai() -> None:
     assert _convert_message_to_dict(expected_output) == message
 
 
+def test__convert_dict_to_message_ai_with_reasoning_content() -> None:
+    message = {
+        "role": "assistant",
+        "content": "</think>final answer",
+        "reasoning_content": "<think>step by step",
+    }
+    result = _convert_dict_to_message(message)
+    assert result == AIMessage(
+        content="</think>final answer",
+        additional_kwargs={"reasoning_content": "<think>step by step"},
+    )
+
+
 def test__convert_dict_to_message_ai_with_name() -> None:
     message = {"role": "assistant", "content": "foo", "name": "test"}
     result = _convert_dict_to_message(message)
@@ -314,6 +327,65 @@ def test__convert_dict_to_message_tool_call() -> None:
         reverted_message_dict["tool_calls"], key=lambda x: x["id"]
     )
     assert reverted_message_dict == message
+
+
+def test_convert_chunk_to_generation_chunk_preserves_reasoning_content() -> None:
+    llm = ChatOpenAI(model="gpt-4.1-mini", api_key="test")
+
+    first = llm._convert_chunk_to_generation_chunk(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "role": "assistant",
+                        "reasoning_content": "<think>step ",
+                    }
+                }
+            ]
+        },
+        AIMessageChunk,
+        None,
+    )
+    second = llm._convert_chunk_to_generation_chunk(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "reasoning_content": "by step",
+                    }
+                }
+            ]
+        },
+        AIMessageChunk,
+        None,
+    )
+    third = llm._convert_chunk_to_generation_chunk(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "content": "</think>final answer",
+                    }
+                }
+            ]
+        },
+        AIMessageChunk,
+        None,
+    )
+
+    assert first is not None
+    assert second is not None
+    assert third is not None
+
+    full = first.message + second.message + third.message
+
+    assert isinstance(full, AIMessageChunk)
+    assert full.additional_kwargs["reasoning_content"] == "<think>step by step"
+    assert full.content == "</think>final answer"
+    assert full.content_blocks == [
+        {"type": "reasoning", "reasoning": "<think>step by step"},
+        {"type": "text", "text": "</think>final answer"},
+    ]
 
 
 class MockAsyncContextManager:


### PR DESCRIPTION
## Summary
- preserve raw easoning_content on assistant messages parsed from chat-completions responses
- preserve streamed easoning_content deltas on chat-completions chunks
- surface preserved reasoning in the OpenAI content-block translator when no structured reasoning block is already present

## Why
Some OpenAI-compatible backends stream reasoning separately via easoning_content. ChatOpenAI currently drops those chat-completions deltas, so observing stream_mode=["messages"] can lose the opening <think> portion during chunk accumulation even when the backend's non-streamed response keeps it intact.

This keeps the compatibility behavior narrow: the raw field is still not standardized, but if a backend returns it we no longer discard it during parsing or content-block translation.

## Testing
- OPENAI_API_KEY=test python -m uv run --group test pytest tests/unit_tests/chat_models/test_base.py
- python -m uv run --group test ruff check langchain_openai/chat_models/base.py tests/unit_tests/chat_models/test_base.py ../../core/langchain_core/messages/block_translators/openai.py

## Areas for review
- the added translator fallback only inserts a reasoning block when one is not already present
- the new preservation path is limited to raw easoning_content passthrough, not broader third-party field normalization

## AI assistance
- This PR was prepared with AI assistance. I reviewed the generated changes, validated the touched tests locally, and verified the touched lint checks locally.

Closes #36214