### PR TITLE
fix(openai): reuse cached httpx clients in azure classes

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -17,6 +17,10 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 from langchain_openai.chat_models.base import BaseChatOpenAI, _get_default_model_profile
 
 if TYPE_CHECKING:
@@ -686,11 +690,21 @@ class AzureChatOpenAI(BaseChatOpenAI):
             client_params["max_retries"] = self.max_retries
 
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                ),
+            }
             self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
             self.client = self.root_client.chat.completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                ),
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -10,6 +10,10 @@ from langchain_core.utils import from_env, secret_from_env
 from pydantic import Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 from langchain_openai.embeddings.base import OpenAIEmbeddings
 
 
@@ -206,13 +210,23 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):  # type: ignore[override]
             "default_query": self.default_query,
         }
         if not self.client:
-            sync_specific: dict = {"http_client": self.http_client}
+            sync_specific: dict = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                ),
+            }
             self.client = openai.AzureOpenAI(
                 **client_params,  # type: ignore[arg-type]
                 **sync_specific,
             ).embeddings
         if not self.async_client:
-            async_specific: dict = {"http_client": self.http_async_client}
+            async_specific: dict = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                ),
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (

--- a/libs/partners/openai/langchain_openai/llms/azure.py
+++ b/libs/partners/openai/langchain_openai/llms/azure.py
@@ -12,6 +12,10 @@ from langchain_core.utils import from_env, secret_from_env
 from pydantic import Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 from langchain_openai.llms.base import BaseOpenAI
 
 logger = logging.getLogger(__name__)
@@ -175,13 +179,23 @@ class AzureOpenAI(BaseOpenAI):
             "default_query": self.default_query,
         }
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                ),
+            }
             self.client = openai.AzureOpenAI(
                 **client_params,
                 **sync_specific,  # type: ignore[arg-type]
             ).completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                ),
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (


### PR DESCRIPTION
azure chat, llm and embedding classes create a new httpx client on every instantiation because they pass self.http_client directly (which defaults to None) instead of falling back to the cached client helpers. the base openai classes already do this correctly via _get_default_httpx_client/_get_default_async_httpx_client

added the same fallback pattern to all three azure classes

fixes #32489