### PR TITLE
fix: skip empty reasoning_content strings

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,8 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    # Check for non-empty string to avoid creating empty reasoning blocks
+    if reasoning_content and isinstance(reasoning_content, str):
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None


### PR DESCRIPTION
## Description
Fixes #36194

Empty `reasoning_content` strings were creating empty `ReasoningContentBlock` objects, causing unnecessary empty reasoning blocks in message content.

## Changes
- Modified `_extract_reasoning_from_additional_kwargs` to check for non-empty string (`if reasoning_content and isinstance(...)`) instead of just checking for not None
- This prevents empty strings from being converted to reasoning blocks

## Test
Before fix:
```python
message.additional_kwargs = {"reasoning_content": ""}
# Would create: {"type": "reasoning", "reasoning": ""}
```

After fix:
```python
message.additional_kwargs = {"reasoning_content": ""}
# Returns None, no empty block created
```

## Checklist
- [x] I confirm that this pull request is my own work and that I have the right to submit it under the project's license