### PR TITLE
fix: pass child_config instead of config in RunnableWithFallbacks.invoke

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -193,7 +193,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     output = context.run(
                         runnable.invoke,
                         input,
-                        config,
+                        child_config,
                         **kwargs,
                     )
             except self.exceptions_to_handle as e:


### PR DESCRIPTION
Fixes #36072

`RunnableWithFallbacks.invoke()` was passing `config` instead of `child_config` to child runnables, causing child callback events to receive `parent_run_id=None`. This breaks tracing tools that rely on `parent_run_id` to build span trees.

Verified by running the reproduction script from the issue: AssertionError before the fix, clean run after.