### PR TITLE
fix(core): apply injected arg filtering when filter_args is provided

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -344,7 +344,7 @@ def create_schema_from_function(
     inferred_model = validated.model
 
     if filter_args:
-        filter_args_ = filter_args
+        filter_args_ = list(filter_args)
     else:
         # Handle classmethods and instance methods
         existing_params: list[str] = list(sig.parameters.keys())
@@ -353,11 +353,12 @@ def create_schema_from_function(
         else:
             filter_args_ = list(FILTERED_ARGS)
 
-        for existing_param in existing_params:
-            if not include_injected and _is_injected_arg_type(
-                sig.parameters[existing_param].annotation
-            ):
-                filter_args_.append(existing_param)
+    if not include_injected:
+        for param_name in sig.parameters:
+            if _is_injected_arg_type(
+                sig.parameters[param_name].annotation
+            ) and param_name not in filter_args_:
+                filter_args_.append(param_name)
 
     description, arg_descriptions = _infer_arg_descriptions(
         func,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -60,6 +60,7 @@ from langchain_core.tools.base import (
     _DirectlyInjectedToolArg,
     _is_message_content_block,
     _is_message_content_type,
+    create_schema_from_function,
     get_all_basemodel_annotations,
 )
 from langchain_core.utils.function_calling import (
@@ -3653,3 +3654,93 @@ def test_tool_default_factory_not_required() -> None:
     schema = convert_to_openai_tool(some_func)
     params = schema["function"]["parameters"]
     assert "names" not in params.get("required", [])
+
+
+class TestCreateSchemaFromFunctionInjectedFiltering:
+    """Regression tests for issue #35831.
+
+    Verifies that create_schema_from_function correctly excludes
+    injected args when both filter_args and include_injected=False
+    are provided.
+    """
+
+    @staticmethod
+    def _sample_fn(
+        query: str,
+        secret: Annotated[str, InjectedToolArg],
+    ) -> str:
+        """A test tool with an injected argument."""
+        return query
+
+    def test_filter_args_with_include_injected_false(self) -> None:
+        """Injected args should be excluded even when filter_args is provided."""
+        schema = create_schema_from_function(
+            "MyTool",
+            self._sample_fn,
+            filter_args=["query"],
+            include_injected=False,
+        )
+        schema_props = schema.model_json_schema().get("properties", {})
+        assert "secret" not in schema_props, (
+            "Injected arg 'secret' should be excluded when "
+            "include_injected=False and filter_args is provided"
+        )
+
+    def test_include_injected_false_without_filter_args(self) -> None:
+        """Injected args should be excluded when no filter_args is given."""
+        schema = create_schema_from_function(
+            "MyTool",
+            self._sample_fn,
+            include_injected=False,
+        )
+        schema_props = schema.model_json_schema().get("properties", {})
+        assert "secret" not in schema_props
+        assert "query" in schema_props
+
+    def test_include_injected_true_preserves_injected_args(self) -> None:
+        """With include_injected=True (default), injected args remain."""
+        schema = create_schema_from_function(
+            "MyTool",
+            self._sample_fn,
+            include_injected=True,
+        )
+        schema_props = schema.model_json_schema().get("properties", {})
+        assert "secret" in schema_props
+        assert "query" in schema_props
+
+    def test_filter_args_list_not_mutated(self) -> None:
+        """Caller's filter_args list must not be modified."""
+        original_filter = ["query"]
+        filter_copy = list(original_filter)
+        create_schema_from_function(
+            "MyTool",
+            self._sample_fn,
+            filter_args=original_filter,
+            include_injected=False,
+        )
+        assert original_filter == filter_copy, (
+            "The caller's filter_args list was mutated"
+        )
+
+    def test_filter_args_with_include_injected_false_multiple_injected(
+        self,
+    ) -> None:
+        """Multiple injected args should all be excluded."""
+
+        def multi_injected_fn(
+            query: str,
+            secret: Annotated[str, InjectedToolArg],
+            token: Annotated[str, InjectedToolArg],
+        ) -> str:
+            """Tool with two injected args."""
+            return query
+
+        schema = create_schema_from_function(
+            "MyTool",
+            multi_injected_fn,
+            filter_args=["query"],
+            include_injected=False,
+        )
+        schema_props = schema.model_json_schema().get("properties", {})
+        assert "secret" not in schema_props
+        assert "token" not in schema_props


### PR DESCRIPTION
## Summary
- Fixes `create_schema_from_function` ignoring `include_injected=False` when `filter_args` is also provided, which caused injected args (API keys, sessions) to leak into the LLM-facing schema
- Moves the injected-arg filtering loop outside the `if filter_args:` / `else` block so it always runs when `include_injected=False`
- Copies `filter_args` with `list()` to avoid mutating the caller's sequence
- Adds 5 regression tests covering the bug scenario, existing behavior, caller mutation, and multiple injected args

Fixes #35831

## Details

The injected-arg filtering logic (checking `include_injected` and `_is_injected_arg_type`) was nested inside the `else` branch of `if filter_args:`, so it was skipped entirely when `filter_args` was provided. This meant `InjectedToolArg`-annotated parameters (designed to hide sensitive args like API keys from the LLM) would leak into the generated schema.

**Areas requiring careful review:**
- The moved filtering loop at lines 356-361 — verify the `param_name not in filter_args_` dedup check is correct
- The `list(filter_args)` copy on line 347 — necessary to prevent `append()` from mutating the caller's sequence

## Test plan
- [x] `test_filter_args_with_include_injected_false` — the exact bug scenario from #35831
- [x] `test_include_injected_false_without_filter_args` — regression guard for existing behavior
- [x] `test_include_injected_true_preserves_injected_args` — ensures default behavior unchanged
- [x] `test_filter_args_list_not_mutated` — verifies caller's list isn't modified
- [x] `test_filter_args_with_include_injected_false_multiple_injected` — multiple injected args all excluded
- [x] Full test suite (161 tests) passes with 0 failures

> **Disclaimer:** This contribution was developed with the assistance of AI agents (Claude Code) for implementation, testing, and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)