### PR TITLE
fix(core): forward detail field in convert_to_openai_image_block

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
-    """Convert `ImageContentBlock` to format expected by OpenAI Chat Completions.
+    """Convert `ImageContentBlock` and `Base64ContentBlock` to OpenAI Chat Completions.
 
     Args:
         block: The image content block to convert.
@@ -32,25 +32,27 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
     Returns:
         The formatted image content block.
     """
-    if "url" in block:
-        return {
-            "type": "image_url",
-            "image_url": {
-                "url": block["url"],
-            },
-        }
+    image_url: dict[str, Any] = {}
+
+    # Extract detail from the block
+    if detail := block.get("detail"):
+        image_url["detail"] = detail
+    elif ((extras := block.get("extras")) and ("detail" in extras)) or (
+        (extras := block.get("metadata")) and ("detail" in extras)
+    ):
+        image_url["detail"] = extras["detail"]
+
+    if "url" in block:  # Intentionally do not check for source_type="url"
+        image_url["url"] = block["url"]
+        return {"type": "image_url", "image_url": image_url}
     if "base64" in block or block.get("source_type") == "base64":
         if "mime_type" not in block:
             error_message = "mime_type key is required for base64 data."
             raise ValueError(error_message)
         mime_type = block["mime_type"]
         base64_data = block["data"] if "data" in block else block["base64"]
-        return {
-            "type": "image_url",
-            "image_url": {
-                "url": f"data:{mime_type};base64,{base64_data}",
-            },
-        }
+        image_url["url"] = f"data:{mime_type};base64,{base64_data}"
+        return {"type": "image_url", "image_url": image_url}
     error_message = "Unsupported source type. Only 'url' and 'base64' are supported."
     raise ValueError(error_message)
 
@@ -82,10 +84,8 @@ def convert_to_openai_data_block(
                 "type": "input_image",
                 "image_url": chat_completions_block["image_url"]["url"],
             }
-            if chat_completions_block["image_url"].get("detail"):
-                formatted_block["detail"] = chat_completions_block["image_url"][
-                    "detail"
-                ]
+            if detail := chat_completions_block["image_url"].get("detail"):
+                formatted_block["detail"] = detail
         else:
             formatted_block = chat_completions_block
 

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -479,29 +479,102 @@ def test_compat_responses_v03() -> None:
 def test_convert_to_openai_data_block() -> None:
     # Chat completions
     # Image / url
-    block = {
-        "type": "image",
-        "url": "https://example.com/test.png",
-    }
-    expected = {
-        "type": "image_url",
-        "image_url": {"url": "https://example.com/test.png"},
-    }
-    result = convert_to_openai_data_block(block)
-    assert result == expected
+    input_blocks: list[dict] = [
+        {
+            "type": "image",
+            "url": "https://example.com/test.png",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "url": "https://example.com/test.png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "url": "https://example.com/test.png",
+            "metadata": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://example.com/test.png",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://example.com/test.png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://example.com/test.png",
+            "metadata": {"detail": "high"},
+        },
+    ]
+
+    for input_block in input_blocks:
+        expected = {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/test.png", "detail": "high"},
+        }
+        result = convert_to_openai_data_block(input_block)
+        assert result == expected
 
     # Image / base64
-    block = {
-        "type": "image",
-        "base64": "<base64 string>",
-        "mime_type": "image/png",
-    }
-    expected = {
-        "type": "image_url",
-        "image_url": {"url": "data:image/png;base64,<base64 string>"},
-    }
-    result = convert_to_openai_data_block(block)
-    assert result == expected
+    input_blocks = [
+        {
+            "type": "image",
+            "base64": "<base64 string>",
+            "mime_type": "image/png",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "base64": "<base64 string>",
+            "mime_type": "image/png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "base64": "<base64 string>",
+            "mime_type": "image/png",
+            "metadata": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "image/png",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "image/png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "image/png",
+            "metadata": {"detail": "high"},
+        },
+    ]
+    for input_block in input_blocks:
+        expected = {
+            "type": "image_url",
+            "image_url": {
+                "url": "data:image/png;base64,<base64 string>",
+                "detail": "high",
+            },
+        }
+        result = convert_to_openai_data_block(input_block)
+        assert result == expected
 
     # File / url
     block = {
@@ -512,30 +585,77 @@ def test_convert_to_openai_data_block() -> None:
         result = convert_to_openai_data_block(block)
 
     # File / base64
-    block = {
-        "type": "file",
-        "base64": "<base64 string>",
-        "mime_type": "application/pdf",
-        "filename": "test.pdf",
-    }
-    expected = {
-        "type": "file",
-        "file": {
-            "file_data": "data:application/pdf;base64,<base64 string>",
+    input_blocks = [
+        {
+            "type": "file",
+            "base64": "<base64 string>",
+            "mime_type": "application/pdf",
             "filename": "test.pdf",
         },
-    }
-    result = convert_to_openai_data_block(block)
-    assert result == expected
+        {
+            "type": "file",
+            "base64": "<base64 string>",
+            "mime_type": "application/pdf",
+            "extras": {"filename": "test.pdf"},
+        },
+        {
+            "type": "file",
+            "base64": "<base64 string>",
+            "mime_type": "application/pdf",
+            "metadata": {"filename": "test.pdf"},
+        },
+        {
+            "type": "file",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "application/pdf",
+            "filename": "test.pdf",
+        },
+        {
+            "type": "file",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "application/pdf",
+            "extras": {"filename": "test.pdf"},
+        },
+        {
+            "type": "file",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "application/pdf",
+            "metadata": {"filename": "test.pdf"},
+        },
+    ]
+    for input_block in input_blocks:
+        expected = {
+            "type": "file",
+            "file": {
+                "file_data": "data:application/pdf;base64,<base64 string>",
+                "filename": "test.pdf",
+            },
+        }
+        result = convert_to_openai_data_block(input_block)
+        assert result == expected
 
     # File / file ID
-    block = {
-        "type": "file",
-        "file_id": "file-abc123",
-    }
-    expected = {"type": "file", "file": {"file_id": "file-abc123"}}
-    result = convert_to_openai_data_block(block)
-    assert result == expected
+    input_blocks = [
+        {
+            "type": "file",
+            "file_id": "file-abc123",
+        },
+        {
+            "type": "file",
+            "source_type": "id",
+            "id": "file-abc123",
+        },
+    ]
+    for input_block in input_blocks:
+        expected = {
+            "type": "file",
+            "file": {"file_id": "file-abc123"},
+        }
+        result = convert_to_openai_data_block(input_block)
+        assert result == expected
 
     # Audio / base64
     block = {
@@ -552,54 +672,177 @@ def test_convert_to_openai_data_block() -> None:
 
     # Responses
     # Image / url
-    block = {
-        "type": "image",
-        "url": "https://example.com/test.png",
-    }
-    expected = {"type": "input_image", "image_url": "https://example.com/test.png"}
-    result = convert_to_openai_data_block(block, api="responses")
-    assert result == expected
+    input_blocks = [
+        {
+            "type": "image",
+            "url": "https://example.com/test.png",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "url": "https://example.com/test.png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "url": "https://example.com/test.png",
+            "metadata": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://example.com/test.png",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://example.com/test.png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://example.com/test.png",
+            "metadata": {"detail": "high"},
+        },
+    ]
+    for input_block in input_blocks:
+        expected = {
+            "type": "input_image",
+            "image_url": "https://example.com/test.png",
+            "detail": "high",
+        }
+        result = convert_to_openai_data_block(input_block, api="responses")
+        assert result == expected
 
     # Image / base64
-    block = {
-        "type": "image",
-        "base64": "<base64 string>",
-        "mime_type": "image/png",
-    }
-    expected = {
-        "type": "input_image",
-        "image_url": "data:image/png;base64,<base64 string>",
-    }
-    result = convert_to_openai_data_block(block, api="responses")
-    assert result == expected
+    input_blocks = [
+        {
+            "type": "image",
+            "base64": "<base64 string>",
+            "mime_type": "image/png",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "base64": "<base64 string>",
+            "mime_type": "image/png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "base64": "<base64 string>",
+            "mime_type": "image/png",
+            "metadata": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "image/png",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "image/png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "image/png",
+            "metadata": {"detail": "high"},
+        },
+    ]
+    for input_block in input_blocks:
+        expected = {
+            "type": "input_image",
+            "image_url": "data:image/png;base64,<base64 string>",
+            "detail": "high",
+        }
+        result = convert_to_openai_data_block(input_block, api="responses")
+        assert result == expected
 
     # File / url
-    block = {
+    input_block = {
         "type": "file",
         "url": "https://example.com/test.pdf",
     }
     expected = {"type": "input_file", "file_url": "https://example.com/test.pdf"}
+    result = convert_to_openai_data_block(input_block, api="responses")
+    assert result == expected
 
     # File / base64
-    block = {
-        "type": "file",
-        "base64": "<base64 string>",
-        "mime_type": "application/pdf",
-        "filename": "test.pdf",
-    }
-    expected = {
-        "type": "input_file",
-        "file_data": "data:application/pdf;base64,<base64 string>",
-        "filename": "test.pdf",
-    }
-    result = convert_to_openai_data_block(block, api="responses")
-    assert result == expected
+    input_blocks = [
+        {
+            "type": "file",
+            "base64": "<base64 string>",
+            "mime_type": "application/pdf",
+            "filename": "test.pdf",
+        },
+        {
+            "type": "file",
+            "base64": "<base64 string>",
+            "mime_type": "application/pdf",
+            "extras": {"filename": "test.pdf"},
+        },
+        {
+            "type": "file",
+            "base64": "<base64 string>",
+            "mime_type": "application/pdf",
+            "metadata": {"filename": "test.pdf"},
+        },
+        {
+            "type": "file",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "application/pdf",
+            "filename": "test.pdf",
+        },
+        {
+            "type": "file",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "application/pdf",
+            "extras": {"filename": "test.pdf"},
+        },
+        {
+            "type": "file",
+            "source_type": "base64",
+            "data": "<base64 string>",
+            "mime_type": "application/pdf",
+            "metadata": {"filename": "test.pdf"},
+        },
+    ]
+    for input_block in input_blocks:
+        expected = {
+            "type": "input_file",
+            "file_data": "data:application/pdf;base64,<base64 string>",
+            "filename": "test.pdf",
+        }
+        result = convert_to_openai_data_block(input_block, api="responses")
+        assert result == expected
 
     # File / file ID
-    block = {
-        "type": "file",
-        "file_id": "file-abc123",
-    }
-    expected = {"type": "input_file", "file_id": "file-abc123"}
-    result = convert_to_openai_data_block(block, api="responses")
-    assert result == expected
+    input_blocks = [
+        {
+            "type": "file",
+            "file_id": "file-abc123",
+        },
+        {
+            "type": "file",
+            "source_type": "id",
+            "id": "file-abc123",
+        },
+    ]
+    for input_block in input_blocks:
+        expected = {
+            "type": "input_file",
+            "file_id": "file-abc123",
+        }
+        result = convert_to_openai_data_block(input_block, api="responses")
+        assert result == expected

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1284,17 +1284,45 @@ def test_convert_to_openai_image_block() -> None:
             "type": "image",
             "url": "https://...",
             "cache_control": {"type": "ephemeral"},
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "url": "https://...",
+            "cache_control": {"type": "ephemeral"},
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "url": "https://...",
+            "cache_control": {"type": "ephemeral"},
+            "metadata": {"detail": "high"},
         },
         {
             "type": "image",
             "source_type": "url",
             "url": "https://...",
             "cache_control": {"type": "ephemeral"},
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://...",
+            "cache_control": {"type": "ephemeral"},
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://...",
+            "cache_control": {"type": "ephemeral"},
+            "metadata": {"detail": "high"},
         },
     ]:
         expected = {
             "type": "image_url",
-            "image_url": {"url": "https://..."},
+            "image_url": {"url": "https://...", "detail": "high"},
         }
         result = convert_to_openai_image_block(input_block)
         assert result == expected
@@ -1305,6 +1333,21 @@ def test_convert_to_openai_image_block() -> None:
             "base64": "<base64 data>",
             "mime_type": "image/jpeg",
             "cache_control": {"type": "ephemeral"},
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "base64": "<base64 data>",
+            "mime_type": "image/jpeg",
+            "cache_control": {"type": "ephemeral"},
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "base64": "<base64 data>",
+            "mime_type": "image/jpeg",
+            "cache_control": {"type": "ephemeral"},
+            "metadata": {"detail": "high"},
         },
         {
             "type": "image",
@@ -1312,12 +1355,30 @@ def test_convert_to_openai_image_block() -> None:
             "data": "<base64 data>",
             "mime_type": "image/jpeg",
             "cache_control": {"type": "ephemeral"},
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<base64 data>",
+            "mime_type": "image/jpeg",
+            "cache_control": {"type": "ephemeral"},
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<base64 data>",
+            "mime_type": "image/jpeg",
+            "cache_control": {"type": "ephemeral"},
+            "metadata": {"detail": "high"},
         },
     ]:
         expected = {
             "type": "image_url",
             "image_url": {
                 "url": "data:image/jpeg;base64,<base64 data>",
+                "detail": "high",
             },
         }
         result = convert_to_openai_image_block(input_block)


### PR DESCRIPTION
`convert_to_openai_image_block` constructs the `image_url` dict with only the `url` key, ignoring any `detail` field in the input block.

This also breaks `convert_to_openai_data_block` for the Responses API, which checks `chat_completions_block["image_url"].get("detail")` — a condition that can never be true since the upstream function never includes `detail`.

Extract `detail` from the block (top-level, `extras`, or `metadata`) and include it in the output when present. Fix the tests covering both functions and both APIs.

Fixes #36297

## Social handles
Twitter: @insilications