### PR TITLE
community: Add Disvr tool discovery integration

### DIFF
--- a/docs/docs/integrations/tools/disvr.ipynb
+++ b/docs/docs/integrations/tools/disvr.ipynb
@@ -1,0 +1,80 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Disvr - Tool Discovery for AI Agents\n",
+        "\n",
+        "[Disvr](https://www.disvr.top) is a tool search engine for AI agents. ",
+        "It helps your agent find the best external tool (MCP server, API, library) for any task.\n",
+        "\n",
+        "## Setup\n",
+        "\n",
+        "```bash\n",
+        "pip install langchain-disvr\n",
+        "```\n",
+        "\n",
+        "Get a free API key at [disvr.top/keys](https://www.disvr.top/keys) (1,000 requests/day)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from langchain_disvr import DisvrDiscoverTool, DisvrToolDetails\n",
+        "\n",
+        "discover = DisvrDiscoverTool(api_key=\"dsvr_your_key_here\")\n",
+        "details = DisvrToolDetails(api_key=\"dsvr_your_key_here\")\n",
+        "\n",
+        "# Find tools for a task\n",
+        "result = discover.invoke({\"need\": \"translate Chinese to Thai\"})\n",
+        "print(result)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Use with an Agent\n",
+        "\n",
+        "Disvr tools work seamlessly with LangChain agents. The agent will automatically ",
+        "use `disvr_discover` when it needs to find an external tool."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "from langchain_openai import ChatOpenAI\n",
+        "from langchain.agents import AgentExecutor, create_tool_calling_agent\n",
+        "from langchain_core.prompts import ChatPromptTemplate\n",
+        "\n",
+        "tools = [discover, details]\n",
+        "llm = ChatOpenAI(model=\"gpt-4o\")\n",
+        "prompt = ChatPromptTemplate.from_messages([\n",
+        "    (\"system\", \"You are a helpful assistant. Use disvr_discover to find external tools when needed.\"),\n",
+        "    (\"human\", \"{input}\"),\n",
+        "    (\"placeholder\", \"{agent_scratchpad}\"),\n",
+        "])\n",
+        "agent = create_tool_calling_agent(llm, tools, prompt)\n",
+        "executor = AgentExecutor(agent=agent, tools=tools, verbose=True)\n",
+        "\n",
+        "result = executor.invoke({\"input\": \"Find me a tool that can do OCR on scanned PDFs\"})"
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 4
+}

--- a/libs/community/langchain_community/tools/disvr/__init__.py
+++ b/libs/community/langchain_community/tools/disvr/__init__.py
@@ -1,0 +1,12 @@
+"""Disvr tool discovery integration.
+
+Install: pip install langchain-disvr
+Docs: https://www.disvr.top
+"""
+
+from langchain_community.tools.disvr.tool import (
+    DisvrDiscoverTool,
+    DisvrToolDetails,
+)
+
+__all__ = ["DisvrDiscoverTool", "DisvrToolDetails"]

--- a/libs/community/langchain_community/tools/disvr/tool.py
+++ b/libs/community/langchain_community/tools/disvr/tool.py
@@ -1,0 +1,5 @@
+"""Disvr tool discovery tools."""
+
+from langchain_disvr import DisvrDiscoverTool, DisvrToolDetails
+
+__all__ = ["DisvrDiscoverTool", "DisvrToolDetails"]

--- a/libs/community/tests/unit_tests/tools/test_disvr.py
+++ b/libs/community/tests/unit_tests/tools/test_disvr.py
@@ -1,0 +1,15 @@
+from unittest.mock import MagicMock, patch
+
+from langchain_community.tools.disvr import DisvrDiscoverTool, DisvrToolDetails
+
+
+def test_discover_tool_metadata():
+    tool = DisvrDiscoverTool(api_key="dsvr_test123")
+    assert tool.name == "disvr_discover"
+    assert "tool" in tool.description.lower()
+
+
+def test_details_tool_metadata():
+    tool = DisvrToolDetails(api_key="dsvr_test123")
+    assert tool.name == "disvr_tool_details"
+    assert "detail" in tool.description.lower()


### PR DESCRIPTION
## Description

Adds [Disvr](https://www.disvr.top) integration — a tool search engine for AI agents.

When an agent needs an external tool (MCP server, API, CLI), it can use `DisvrDiscoverTool` to search 500+ indexed tools and get ranked recommendations with install instructions.

## New tools
- `DisvrDiscoverTool` — find the best tools for a task
- `DisvrToolDetails` — get full details (install command, env vars, available functions)

## Dependencies
- `langchain-disvr` ([PyPI](https://pypi.org/project/langchain-disvr/)) — lightweight, only depends on `httpx` + `langchain-core`

## Example

```python
from langchain_community.tools.disvr import DisvrDiscoverTool

tool = DisvrDiscoverTool(api_key="dsvr_...")
result = tool.invoke({"need": "translate Chinese to Thai"})
# Returns ranked recommendations with install instructions
```

## Testing

- Unit tests in `tests/unit_tests/tools/test_disvr.py`
- Integration tested via published PyPI package

## Checklist

- [x] Lint and test pass
- [x] Added unit tests
- [x] Added notebook documentation
- [x] New package published to PyPI