### PR TITLE
chore(langchain): remove unnecessary description for toods list as a group

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -7,7 +7,7 @@ from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
 from langchain_core.tools import InjectedToolCallId, StructuredTool, tool
 from langgraph.runtime import Runtime
 from langgraph.types import Command
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from typing_extensions import NotRequired, TypedDict, override
 
 from langchain.agents.middleware.types import (

--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -46,7 +46,7 @@ class PlanningState(AgentState[ResponseT]):
 class WriteTodosInput(BaseModel):
     """Input schema for the `write_todos` tool."""
 
-    todos: list[Todo] = Field(description="Updated todo items for the current work session.")
+    todos: list[Todo]
 
 
 WRITE_TODOS_TOOL_DESCRIPTION = """Use this tool to create and manage a structured task list for your current work session. This helps you track progress, organize complex tasks, and demonstrate thoroughness to the user.


### PR DESCRIPTION
This was introduced this the refactor. The description at the list[Todos] level didn't exist, instead we only had a description at a single todo level.