### PR TITLE
AttributeError: 'ImportErrorProfileModel' object has no attribute 'profile #36312

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -390,7 +390,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         path. A plain method override does not prevent the base validator from
         running.
         """
-        if self.profile is None:
+        if getattr(self, "profile", None) is None:
             # Suppress errors from partner overrides (e.g., missing profile
             # files, broken imports) so model construction never fails over an
             # optional field.
@@ -405,8 +405,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         """Warn on unrecognized profile keys."""
         # isinstance guard: ModelProfile is a TypedDict (always a dict), but
         # protects against unexpected types from partner overrides.
-        if self.profile and isinstance(self.profile, dict):
-            _warn_unknown_profile_keys(self.profile)
+        # getattr guards against subclasses that raise AttributeError for
+        # 'profile' via __getattribute__ overrides.
+        profile = getattr(self, "profile", None)
+        if profile and isinstance(profile, dict):
+            _warn_unknown_profile_keys(profile)
         return self
 
     @cached_property

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -398,6 +398,46 @@ def test_summarization_middleware_missing_profile() -> None:
         )
 
 
+def test_summarization_middleware_missing_profile_attribute_error() -> None:
+    """Ensure automatic profile inference falls back when profiles are unavailable.
+
+    Regression test for a bug where model construction crashed with AttributeError
+    instead of letting SummarizationMiddleware raise the expected ValueError.
+    The crash occurred in _set_model_profile when accessing self.profile on a
+    subclass that raises AttributeError via __getattribute__.
+    """
+
+    class ImportErrorProfileModel(BaseChatModel):
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            raise NotImplementedError
+
+        @property
+        def _llm_type(self) -> str:
+            return "mock"
+
+        # NOTE: Using __getattribute__ because @property cannot override Pydantic fields.
+        def __getattribute__(self, name: str) -> Any:
+            if name == "profile":
+                msg = "Profile not available"
+                raise AttributeError(msg)
+            return super().__getattribute__(name)
+
+    with pytest.raises(
+        ValueError,
+        match="Model profile information is required to use fractional token limits",
+    ):
+        _ = SummarizationMiddleware(
+            model=ImportErrorProfileModel(), trigger=("fraction", 0.5), keep=("messages", 1)
+        )
+
+
 def test_summarization_middleware_full_workflow() -> None:
     """Test SummarizationMiddleware complete summarization workflow."""
     with pytest.warns(DeprecationWarning, match="messages_to_keep is deprecated"):


### PR DESCRIPTION
  Fixes #36312
                                                                               
  _set_model_profile and _check_profile_keys in BaseChatModel accessed
  self.profile directly, causing model construction to crash with
  AttributeError when a subclass overrides __getattribute__ to raise it for    
  'profile'. Replaced with getattr(self, "profile", None) which safely catches 
  AttributeError from both __getattr__ and __getattribute__ overrides.

  Verification: Added regression test
  test_summarization_middleware_missing_profile_attribute_error reproducing the
   exact failing scenario from the bug report. Both new and existing profile   
  tests pass. All 74 core chat_models/ unit tests pass.

  ▎ AI assistance was used in diagnosing and implementing this fix.


  LinkedIn: https://www.linkedin.com/in/rino-a-12769910a/