### PR TITLE
fix(langchain): recognize ChatAnthropicVertex in _get_approximate_token_counter

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -141,7 +141,7 @@ Example:
 
 def _get_approximate_token_counter(model: BaseChatModel) -> TokenCounter:
     """Tune parameters of approximate token counter based on model type."""
-    if model._llm_type == "anthropic-chat":  # noqa: SLF001
+    if model._llm_type.startswith("anthropic-chat"):  # noqa: SLF001
         # 3.3 was estimated in an offline experiment, comparing with Claude's token-counting
         # API: https://platform.claude.com/docs/en/build-with-claude/token-counting
         return partial(


### PR DESCRIPTION
## Summary

`_get_approximate_token_counter` uses `model._llm_type == "anthropic-chat"` to detect Anthropic models and apply `chars_per_token=3.3`. But `ChatAnthropicVertex` (Claude via Vertex AI) returns `_llm_type = "anthropic-chat-vertexai"`, so the check fails and the default `4.0 chars/token` is used.

This underestimates token count by ~16%. When used with `SummarizationMiddleware`, the trigger threshold (e.g. 85% of 200K = 170K) is never reached according to the estimate, but the actual prompt is already past 200K. The API rejects it with `prompt is too long`.

## Change

`== "anthropic-chat"` → `.startswith("anthropic-chat")`

This covers both `ChatAnthropic` (`"anthropic-chat"`) and `ChatAnthropicVertex` (`"anthropic-chat-vertexai"`).

## Reproduction

Full standalone script with API calls: https://gist.github.com/Jordanh1996/af56156da6cfab82917215dd340f76ac

Fixes #36318

---

This contribution was made with AI assistance (Claude).