### PR TITLE
fix(core): ignore empty strings in _extract_reasoning_from_additional_kwargs

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content is not None and isinstance(reasoning_content, str) and reasoning_content.strip():
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/block_translators/test_groq.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_groq.py
@@ -27,6 +27,35 @@ def test_extract_reasoning_from_additional_kwargs_exists() -> None:
     assert callable(_extract_reasoning_from_additional_kwargs)
 
 
+def test_extract_reasoning_from_additional_kwargs_empty_string() -> None:
+    """Test that empty reasoning_content strings are ignored."""
+    # Test with empty string - should return None
+    message = AIMessage(
+        content="Final answer",
+        additional_kwargs={"reasoning_content": ""},
+    )
+    result = _extract_reasoning_from_additional_kwargs(message)
+    assert result is None
+
+    # Test with whitespace-only string - should return None
+    message = AIMessage(
+        content="Final answer",
+        additional_kwargs={"reasoning_content": "   "},
+    )
+    result = _extract_reasoning_from_additional_kwargs(message)
+    assert result is None
+
+    # Test with valid reasoning - should return the block
+    message = AIMessage(
+        content="Final answer",
+        additional_kwargs={"reasoning_content": "Let me think..."},
+    )
+    result = _extract_reasoning_from_additional_kwargs(message)
+    assert result is not None
+    assert result["type"] == "reasoning"
+    assert result["reasoning"] == "Let me think..."
+
+
 def test_groq_translate_content_basic() -> None:
     """Test basic groq content translation."""
     # Test with simple text message


### PR DESCRIPTION
## Summary

The function `_extract_reasoning_from_additional_kwargs` was returning a `ReasoningContentBlock` even when `reasoning_content` was an empty string, causing issues with reasoning models (e.g., ChatTongyi) that attach empty `reasoning_content=""` after the reasoning stage completes.

## Problem

When using `LC_OUTPUT_VERSION=v1`, the content_blocks would contain alternating empty reasoning blocks and content blocks, creating a messy output.

## Fix

Add `.strip()` check to ignore empty/whitespace-only strings.

## Testing

Added unit tests covering:
- Empty string returns `None`
- Whitespace-only string returns `None`
- Valid reasoning returns the expected block

Fixes #36194