### PR TITLE
core: Fix convert_to_openai_image_block dropping detail field

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -19,6 +19,21 @@ if TYPE_CHECKING:
     from langchain_core.messages import AIMessage
 
 
+def _resolve_detail(block: dict[str, Any]) -> str | None:
+    """Extract the ``detail`` field from an image content block.
+
+    Checks the top-level dict first, then ``extras``, then ``metadata``
+    (for backwards compatibility).
+    """
+    if "detail" in block:
+        return block["detail"]
+    if (extras := block.get("extras")) and "detail" in extras:
+        return extras["detail"]
+    if (meta := block.get("metadata")) and "detail" in meta:
+        return meta["detail"]
+    return None
+
+
 def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
     """Convert `ImageContentBlock` to format expected by OpenAI Chat Completions.
 
@@ -32,12 +47,15 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
     Returns:
         The formatted image content block.
     """
+    detail = _resolve_detail(block)
+
     if "url" in block:
+        image_url: dict[str, Any] = {"url": block["url"]}
+        if detail:
+            image_url["detail"] = detail
         return {
             "type": "image_url",
-            "image_url": {
-                "url": block["url"],
-            },
+            "image_url": image_url,
         }
     if "base64" in block or block.get("source_type") == "base64":
         if "mime_type" not in block:
@@ -45,11 +63,12 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
             raise ValueError(error_message)
         mime_type = block["mime_type"]
         base64_data = block["data"] if "data" in block else block["base64"]
+        image_url = {"url": f"data:{mime_type};base64,{base64_data}"}
+        if detail:
+            image_url["detail"] = detail
         return {
             "type": "image_url",
-            "image_url": {
-                "url": f"data:{mime_type};base64,{base64_data}",
-            },
+            "image_url": image_url,
         }
     error_message = "Unsupported source type. Only 'url' and 'base64' are supported."
     raise ValueError(error_message)

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -4,6 +4,7 @@ from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
 from langchain_core.messages import content as types
 from langchain_core.messages.block_translators.openai import (
     convert_to_openai_data_block,
+    convert_to_openai_image_block,
 )
 from tests.unit_tests.language_models.chat_models.test_base import (
     _content_blocks_equal_ignore_id,
@@ -603,3 +604,91 @@ def test_convert_to_openai_data_block() -> None:
     expected = {"type": "input_file", "file_id": "file-abc123"}
     result = convert_to_openai_data_block(block, api="responses")
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "input_block, expected",
+    [
+        # detail at top level — url
+        (
+            {"type": "image", "url": "https://img.png", "detail": "high"},
+            {"type": "image_url", "image_url": {"url": "https://img.png", "detail": "high"}},
+        ),
+        # detail in extras — url
+        (
+            {"type": "image", "url": "https://img.png", "extras": {"detail": "low"}},
+            {"type": "image_url", "image_url": {"url": "https://img.png", "detail": "low"}},
+        ),
+        # detail in metadata — url
+        (
+            {"type": "image", "url": "https://img.png", "metadata": {"detail": "auto"}},
+            {"type": "image_url", "image_url": {"url": "https://img.png", "detail": "auto"}},
+        ),
+        # detail at top level — base64
+        (
+            {"type": "image", "base64": "abc", "mime_type": "image/png", "detail": "high"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc", "detail": "high"}},
+        ),
+        # detail in extras — base64
+        (
+            {"type": "image", "base64": "abc", "mime_type": "image/png", "extras": {"detail": "low"}},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc", "detail": "low"}},
+        ),
+        # no detail — url (should remain unchanged)
+        (
+            {"type": "image", "url": "https://img.png"},
+            {"type": "image_url", "image_url": {"url": "https://img.png"}},
+        ),
+        # no detail — base64 (should remain unchanged)
+        (
+            {"type": "image", "base64": "abc", "mime_type": "image/png"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+        ),
+    ],
+)
+def test_convert_to_openai_image_block_detail(
+    input_block: dict, expected: dict
+) -> None:
+    assert convert_to_openai_image_block(input_block) == expected
+
+
+@pytest.mark.parametrize(
+    "input_block, expected_chat, expected_responses",
+    [
+        # detail at top level
+        (
+            {"type": "image", "url": "https://img.png", "detail": "high"},
+            {"type": "image_url", "image_url": {"url": "https://img.png", "detail": "high"}},
+            {"type": "input_image", "image_url": "https://img.png", "detail": "high"},
+        ),
+        # detail in extras
+        (
+            {"type": "image", "url": "https://img.png", "extras": {"detail": "low"}},
+            {"type": "image_url", "image_url": {"url": "https://img.png", "detail": "low"}},
+            {"type": "input_image", "image_url": "https://img.png", "detail": "low"},
+        ),
+        # detail in metadata
+        (
+            {"type": "image", "url": "https://img.png", "metadata": {"detail": "auto"}},
+            {"type": "image_url", "image_url": {"url": "https://img.png", "detail": "auto"}},
+            {"type": "input_image", "image_url": "https://img.png", "detail": "auto"},
+        ),
+        # base64 with detail
+        (
+            {"type": "image", "base64": "abc", "mime_type": "image/png", "detail": "high"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc", "detail": "high"}},
+            {"type": "input_image", "image_url": "data:image/png;base64,abc", "detail": "high"},
+        ),
+        # no detail — stays unchanged
+        (
+            {"type": "image", "url": "https://img.png"},
+            {"type": "image_url", "image_url": {"url": "https://img.png"}},
+            {"type": "input_image", "image_url": "https://img.png"},
+        ),
+    ],
+)
+def test_convert_to_openai_data_block_detail(
+    input_block: dict, expected_chat: dict, expected_responses: dict
+) -> None:
+    assert convert_to_openai_data_block(input_block) == expected_chat
+    assert convert_to_openai_data_block(input_block, api="responses") == expected_responses


### PR DESCRIPTION
Fixes #36297

`convert_to_openai_image_block` constructs the `image_url` dict with only the `url` key, silently dropping the `detail` field that controls image resolution. This affects both Chat Completions and Responses API paths.

The fix extracts `detail` from the input block (checking direct attributes, `extras`, and `metadata` for backwards compatibility) and includes it in the output dict when present. Added tests covering all lookup paths for both `convert_to_openai_image_block` and `convert_to_openai_data_block`, plus no-detail cases to prevent regression.