### PR TITLE
fix(core): ignore empty strings in _extract_reasoning_from_additional_kwargs

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,11 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if (
+        reasoning_content is not None
+        and isinstance(reasoning_content, str)
+        and reasoning_content.strip()
+    ):
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/block_translators/test_groq.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_groq.py
@@ -138,3 +138,38 @@ def test_parse_code_json() -> None:
     # Test invalid format raises ValueError
     with pytest.raises(ValueError, match="Could not extract Python code"):
         _parse_code_json('{"invalid": "format"}')
+
+
+def test_extract_reasoning_ignores_empty_string() -> None:
+    """Test that _extract_reasoning_from_additional_kwargs ignores empty strings."""
+    # Empty string should return None
+    message = AIMessage(
+        content="Final answer",
+        additional_kwargs={"reasoning_content": ""},
+    )
+    result = _extract_reasoning_from_additional_kwargs(message)
+    assert result is None
+
+
+def test_extract_reasoning_ignores_whitespace_only() -> None:
+    """Test that _extract_reasoning_from_additional_kwargs ignores whitespace."""
+    # Whitespace-only string should return None
+    message = AIMessage(
+        content="Final answer",
+        additional_kwargs={"reasoning_content": "   \n\t  "},
+    )
+    result = _extract_reasoning_from_additional_kwargs(message)
+    assert result is None
+
+
+def test_extract_reasoning_preserves_valid_content() -> None:
+    """Test that _extract_reasoning_from_additional_kwargs preserves content."""
+    # Valid reasoning content should be preserved
+    message = AIMessage(
+        content="Final answer",
+        additional_kwargs={"reasoning_content": "Let me think about this..."},
+    )
+    result = _extract_reasoning_from_additional_kwargs(message)
+    assert result is not None
+    assert result["type"] == "reasoning"
+    assert result["reasoning"] == "Let me think about this..."


### PR DESCRIPTION
## Summary

- Fix a bug in `_extract_reasoning_from_additional_kwargs` that returned a `ReasoningContentBlock` even when `reasoning_content` was an empty string
- Add `.strip()` check to ignore empty/whitespace-only `reasoning_content` strings
- Add unit tests for empty string, whitespace-only, and valid content cases

## Problem

The function was returning a `ReasoningContentBlock` even when `reasoning_content` was an empty string, causing issues with reasoning models (e.g., ChatTongyi) that attach `reasoning_content=""` after the reasoning stage completes.

When using `LC_OUTPUT_VERSION=v1`, this led to messy `content_blocks` with alternating empty reasoning blocks and content blocks.

## Fix

```python
# Before
if reasoning_content is not None and isinstance(reasoning_content, str):
    return {"type": "reasoning", "reasoning": reasoning_content}

# After
if (
    reasoning_content is not None
    and isinstance(reasoning_content, str)
    and reasoning_content.strip()
):
    return {"type": "reasoning", "reasoning": reasoning_content}
```

## Test Plan

- [x] Added `test_extract_reasoning_ignores_empty_string()` - verifies empty string returns None
- [x] Added `test_extract_reasoning_ignores_whitespace_only()` - verifies whitespace-only returns None
- [x] Added `test_extract_reasoning_preserves_valid_content()` - verifies valid content is preserved
- [x] `make lint` passed
- [x] All tests pass locally

Fixes #36194