### PR TITLE
fix(core): ignore empty string reasoning_content in additional_kwargs

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content and isinstance(reasoning_content, str):
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2958,3 +2958,19 @@ def test_count_tokens_approximately_with_tools() -> None:
     # Test with empty tools list should equal base count
     count_empty_tools = count_tokens_approximately(messages, tools=[])
     assert count_empty_tools == base_count
+
+
+def test_convert_to_openai_messages_empty_reasoning_content_ignored() -> None:
+    """Empty string reasoning_content should not produce a reasoning block.
+
+    Intermediate stream chunks from models like DeepSeek/Tongyi may send
+    reasoning_content="" before the actual reasoning arrives. These must not
+    be surfaced as a ReasoningContentBlock.
+    """
+    msg = AIMessage(
+        content="hello",
+        additional_kwargs={"reasoning_content": ""},
+    )
+    result = convert_to_openai_messages(msg)
+    # No reasoning block should appear in the output
+    assert result == {"role": "assistant", "content": "hello"}


### PR DESCRIPTION
Fixes #36194.

## Problem

Models like DeepSeek and Tongyi emit `reasoning_content=""` on intermediate
stream chunks before the actual reasoning text arrives. The existing guard:

```python
if reasoning_content is not None and isinstance(reasoning_content, str):
```

treats an empty string as valid, producing a `ReasoningContentBlock` with
`reasoning=""`. Downstream consumers receive spurious empty reasoning blocks
on every partial chunk.

## Fix

Tighten the check to a plain truthiness test:

```python
if reasoning_content and isinstance(reasoning_content, str):
```

Empty strings are now filtered out. `None` and non-string values are
unaffected. Non-empty strings continue to produce a `ReasoningContentBlock`
as before.

## Testing

Added `test_convert_to_openai_messages_empty_reasoning_content_ignored` to
`tests/unit_tests/messages/test_utils.py` asserting that a message carrying
`additional_kwargs={"reasoning_content": ""}` produces no reasoning block in
the converted output.
