### PR TITLE
fix(text-splitters): preserve content from unclosed code blocks in ExperimentalMarkdownSyntaxTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -446,7 +446,7 @@ class ExperimentalMarkdownSyntaxTextSplitter:
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk
-        return ""
+        return chunk
 
     def _complete_chunk_doc(self) -> None:
         chunk_content = self.current_chunk.page_content

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -4122,3 +4122,19 @@ def test_character_text_splitter_chunk_size_effect(
         keep_separator=False,
     )
     assert splitter.split_text(text) == expected
+
+
+def test_experimental_markdown_syntax_text_splitter_unclosed_code_block() -> None:
+    """Content inside an unclosed code block must not be silently discarded."""
+    markdown = """\
+# Section
+
+```python
+def hello():
+    pass
+"""
+    splitter = ExperimentalMarkdownSyntaxTextSplitter()
+    docs = splitter.split_text(markdown)
+    full_text = "".join(doc.page_content for doc in docs)
+    assert "def hello():" in full_text
+    assert "pass" in full_text


### PR DESCRIPTION
Fixes #36186.

## Problem

`ExperimentalMarkdownSyntaxTextSplitter._resolve_code_chunk()` scans forward
for a closing fence. If the input ends without one, it returns `""`,
silently discarding all content accumulated since the opening fence:

```python
def _resolve_code_chunk(self, current_line: str, raw_lines: list[str]) -> str:
    chunk = current_line
    while raw_lines:
        raw_line = raw_lines.pop(0)
        chunk += raw_line
        if self._match_code(raw_line):
            return chunk
    return ""   # ← all content lost here
```

Any Markdown document that ends inside a code block (unterminated fence,
common in READMEs and LLM-generated text) will have that entire section
dropped from the split output.

## Fix

Return the accumulated `chunk` instead of `""`. If the opening fence was
the last line, `chunk` is empty anyway, so there is no behaviour change for
the empty case. For non-empty unclosed blocks, content is now preserved.

## Testing

Added `test_experimental_markdown_syntax_text_splitter_unclosed_code_block`
to `tests/unit_tests/test_text_splitters.py`. It splits a Markdown document
whose code block has no closing fence and asserts the code body appears in
the output.
