### PR TITLE
fix(anthropic): read args['path'] in _handle_rename instead of args['old_path']

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -530,7 +530,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1032,7 +1032,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -268,7 +268,7 @@ class TestFileOperations:
 
         args = {
             "command": "rename",
-            "old_path": "/memories/old.txt",
+            "path": "/memories/old.txt",
             "new_path": "/memories/new.txt",
         }
         result = middleware._handle_rename(args, state, "test_id")
@@ -449,3 +449,50 @@ class TestSystemMessageHandling:
         assert captured_request.system_message is not None
         assert "Existing instructions." in captured_request.system_message.text
         assert custom_prompt in captured_request.system_message.text
+
+
+class TestRenameUsesPathKey:
+    """_handle_rename must read args['path'], matching the dispatch dict built
+    in the tool function body, not args['old_path'] which was never set there."""
+
+    def test_state_middleware_rename_uses_path_key(self) -> None:
+        """StateClaudeMemoryMiddleware._handle_rename reads args['path']."""
+        from langchain_anthropic.middleware.anthropic_tools import (
+            StateClaudeMemoryMiddleware,
+        )
+
+        middleware = StateClaudeMemoryMiddleware()
+        state: AnthropicToolsState = {
+            "messages": [],
+            "memory_files": {
+                "/memories/old.txt": {
+                    "content": ["line1"],
+                    "created_at": "2025-01-01T00:00:00",
+                    "modified_at": "2025-01-01T00:00:00",
+                }
+            },
+        }
+        args = {"path": "/memories/old.txt", "new_path": "/memories/new.txt"}
+        result = middleware._handle_rename(args, state, "test_id")
+
+        assert isinstance(result, Command)
+        files = result.update.get("memory_files", {})
+        assert files.get("/memories/old.txt") is None
+        assert files.get("/memories/new.txt") is not None
+
+    def test_state_middleware_rename_raises_keyerror_with_old_path_key(
+        self,
+    ) -> None:
+        """Confirm old_path key is not accepted (documents the breaking change)."""
+        from langchain_anthropic.middleware.anthropic_tools import (
+            StateClaudeMemoryMiddleware,
+        )
+
+        middleware = StateClaudeMemoryMiddleware()
+        state: AnthropicToolsState = {
+            "messages": [],
+            "memory_files": {"/memories/old.txt": {"content": [], "created_at": "", "modified_at": ""}},
+        }
+        args = {"old_path": "/memories/old.txt", "new_path": "/memories/new.txt"}
+        with pytest.raises(KeyError):
+            middleware._handle_rename(args, state, "test_id")


### PR DESCRIPTION
Fixes #35852.

## Problem

Both `_StateClaudeFileToolMiddleware._handle_rename` and
`_FilesystemClaudeFileToolMiddleware._handle_rename` read the source path
from `args["old_path"]`:

```python
old_path = args["old_path"]  # KeyError — this key is never set
```

The tool function body that dispatches all commands builds the args dict as:

```python
args: dict[str, Any] = {"path": path}
```

The key `"old_path"` is never populated. Every rename command therefore
raises `KeyError: "old_path"` before any filesystem or state operation is
attempted.

## Fix

Change both reads from `args["old_path"]` to `args["path"]` to match the
dispatch contract. Update the existing `test_rename_operation` test to
pass `"path"` (the real dispatch key) and add `TestRenameUsesPathKey` with
a positive test and a negative test that documents `"old_path"` is not a
valid key.

## Testing

- `TestRenameUsesPathKey::test_state_middleware_rename_uses_path_key` — rename
  succeeds with `args["path"]`
- `TestRenameUsesPathKey::test_state_middleware_rename_raises_keyerror_with_old_path_key`
  — confirms `args["old_path"]` is rejected (negative/regression test)
- `TestFileOperations::test_rename_operation` (existing, updated) — still passes
