### PR TITLE
fix(infra): correct lint_diff relative paths in package makefiles

### DIFF
--- a/libs/langchain_v1/Makefile
+++ b/libs/langchain_v1/Makefile
@@ -81,7 +81,7 @@ check_version:
 PYTHON_FILES=.
 MYPY_CACHE=.mypy_cache
 lint format: PYTHON_FILES=.
-lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/langchain --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
+lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/langchain_v1 --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain
 lint_tests: PYTHON_FILES=tests
 lint_tests: MYPY_CACHE=.mypy_cache_test

--- a/libs/partners/mistralai/Makefile
+++ b/libs/partners/mistralai/Makefile
@@ -32,7 +32,7 @@ integration_test integration_tests:
 PYTHON_FILES=.
 MYPY_CACHE=.mypy_cache
 lint format: PYTHON_FILES=.
-lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/mistral --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
+lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/partners/mistralai --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain_mistralai
 lint_tests: PYTHON_FILES=tests
 lint_tests: MYPY_CACHE=.mypy_cache_test

--- a/libs/text-splitters/Makefile
+++ b/libs/text-splitters/Makefile
@@ -37,7 +37,7 @@ extended_tests:
 PYTHON_FILES=.
 MYPY_CACHE=.mypy_cache
 lint format: PYTHON_FILES=.
-lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/core --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
+lint_diff format_diff: PYTHON_FILES=$(shell git diff --relative=libs/text-splitters --name-only --diff-filter=d master | grep -E '\.py$$|\.ipynb$$')
 lint_package: PYTHON_FILES=langchain_text_splitters
 lint_tests: PYTHON_FILES=tests/unit_tests
 lint_tests: MYPY_CACHE=.mypy_cache_test


### PR DESCRIPTION
Fixes #36332

Corrected lint_diff/format_diff relative path settings in three package Makefiles so changed-file linting runs against the correct package scope. This is an infra-only fix and does not change runtime behavior.

How did you verify your code works?
- make -n -C libs/langchain_v1 lint_diff
- make -n -C libs/text-splitters lint_diff
- make -n -C libs/partners/mistralai lint_diff
- Confirmed only the three Makefiles are changed, with no uv.lock or pyproject.toml updates.

AI assistance disclaimer: I used AI assistance to draft and review this contribution.
