### PR TITLE
fix(openai): stringify responses function_call_output tool blocks

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4118,7 +4118,7 @@ def _convert_chat_completions_blocks_to_responses(
     return block
 
 
-def _ensure_valid_tool_message_content(tool_output: Any) -> str | list[dict]:
+def _ensure_valid_tool_message_content(tool_output: Any) -> str:
     if isinstance(tool_output, str):
         return tool_output
     if isinstance(tool_output, list) and all(
@@ -4134,10 +4134,11 @@ def _ensure_valid_tool_message_content(tool_output: Any) -> str | list[dict]:
         )
         for block in tool_output
     ):
-        return [
+        converted_blocks = [
             _convert_chat_completions_blocks_to_responses(block)
             for block in tool_output
         ]
+        return _stringify(converted_blocks)
     return _stringify(tool_output)
 
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2418,6 +2418,32 @@ def test__construct_responses_api_input_tool_message_conversion() -> None:
     assert result[0]["call_id"] == "call_123"
 
 
+def test__construct_responses_api_input_tool_message_content_blocks_are_stringified() -> (
+    None
+):
+    """Tool message block content must be serialized to string for function tools."""
+    messages = [
+        ToolMessage(
+            content=[
+                {"type": "text", "text": "Temperature is 72F"},
+                {"type": "text", "text": "Condition is sunny"},
+            ],
+            tool_call_id="call_123",
+        )
+    ]
+
+    result = _construct_responses_api_input(messages)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "function_call_output"
+    assert isinstance(result[0]["output"], str)
+    assert json.loads(result[0]["output"]) == [
+        {"type": "input_text", "text": "Temperature is 72F"},
+        {"type": "input_text", "text": "Condition is sunny"},
+    ]
+    assert result[0]["call_id"] == "call_123"
+
+
 def test__construct_responses_api_input_multiple_message_types() -> None:
     """Test conversion of a conversation with multiple message types."""
     messages = [


### PR DESCRIPTION
Fixes #36321

This fixes Responses API tool-output serialization for OpenAI-compatible backends by ensuring function tool outputs are always sent as strings, including MCP-style ToolMessage block content. It also adds a regression test to lock in this behavior.

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

How did you verify your code works?
- Added regression test in libs/partners/openai/tests/unit_tests/chat_models/test_base.py covering ToolMessage list-block serialization for function_call_output.
- Ran focused tests:
  - OPENAI_API_KEY=test .venv/bin/python -m pytest -c /dev/null libs/partners/openai/tests/unit_tests/chat_models/test_base.py::test__construct_responses_api_input_tool_message_conversion -q
  - OPENAI_API_KEY=test .venv/bin/python -m pytest -c /dev/null libs/partners/openai/tests/unit_tests/chat_models/test_base.py::test__construct_responses_api_input_tool_message_content_blocks_are_stringified -q
  - OPENAI_API_KEY=test .venv/bin/python -m pytest -c /dev/null libs/partners/openai/tests/unit_tests/chat_models/test_base.py::test__construct_responses_api_input_multiple_message_types -q
- Ran broader subset:
  - OPENAI_API_KEY=test .venv/bin/python -m pytest -c /dev/null --asyncio-mode=auto libs/partners/openai/tests/unit_tests/chat_models -q
  - Result: 233 passed, 1 xpassed.

Breaking changes
- None.

AI assistance disclosure
- This change was implemented with AI coding assistance; I manually reviewed, refined, and validated the final patch and tests.

Areas for careful review
- libs/partners/openai/langchain_openai/chat_models/base.py around _ensure_valid_tool_message_content to confirm stringification is correct for all function_call_output paths.
