### PR TITLE
fix(openai): stringify Responses function_call_output tool blocks

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4118,21 +4118,27 @@ def _convert_chat_completions_blocks_to_responses(
     return block
 
 
+def _is_valid_tool_content_block(block: Any) -> bool:
+    if not isinstance(block, dict):
+        return False
+    block_type = block.get("type")
+    if block_type in ("input_text", "input_image", "input_file"):
+        return True
+    if block_type == "text":
+        return "text" in block
+    if block_type == "image_url":
+        image_url = block.get("image_url")
+        return isinstance(image_url, dict) and "url" in image_url
+    if block_type == "file":
+        return isinstance(block.get("file"), dict)
+    return False
+
+
 def _ensure_valid_tool_message_content(tool_output: Any) -> str:
     if isinstance(tool_output, str):
         return tool_output
     if isinstance(tool_output, list) and all(
-        isinstance(block, dict)
-        and block.get("type")
-        in (
-            "input_text",
-            "input_image",
-            "input_file",
-            "text",
-            "image_url",
-            "file",
-        )
-        for block in tool_output
+        _is_valid_tool_content_block(block) for block in tool_output
     ):
         converted_blocks = [
             _convert_chat_completions_blocks_to_responses(block)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4118,7 +4118,7 @@ def _convert_chat_completions_blocks_to_responses(
     return block
 
 
-def _ensure_valid_tool_message_content(tool_output: Any) -> str | list[dict]:
+def _ensure_valid_tool_message_content(tool_output: Any) -> str:
     if isinstance(tool_output, str):
         return tool_output
     if isinstance(tool_output, list) and all(
@@ -4134,10 +4134,11 @@ def _ensure_valid_tool_message_content(tool_output: Any) -> str | list[dict]:
         )
         for block in tool_output
     ):
-        return [
+        converted_blocks = [
             _convert_chat_completions_blocks_to_responses(block)
             for block in tool_output
         ]
+        return _stringify(converted_blocks)
     return _stringify(tool_output)
 
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2418,6 +2418,32 @@ def test__construct_responses_api_input_tool_message_conversion() -> None:
     assert result[0]["call_id"] == "call_123"
 
 
+def test__construct_responses_api_input_tool_message_content_blocks_are_stringified() -> (
+    None
+):
+    """Tool message block content must be serialized to string for function tools."""
+    messages = [
+        ToolMessage(
+            content=[
+                {"type": "text", "text": "Temperature is 72F"},
+                {"type": "text", "text": "Condition is sunny"},
+            ],
+            tool_call_id="call_123",
+        )
+    ]
+
+    result = _construct_responses_api_input(messages)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "function_call_output"
+    assert isinstance(result[0]["output"], str)
+    assert json.loads(result[0]["output"]) == [
+        {"type": "input_text", "text": "Temperature is 72F"},
+        {"type": "input_text", "text": "Condition is sunny"},
+    ]
+    assert result[0]["call_id"] == "call_123"
+
+
 def test__construct_responses_api_input_multiple_message_types() -> None:
     """Test conversion of a conversation with multiple message types."""
     messages = [

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2418,9 +2418,7 @@ def test__construct_responses_api_input_tool_message_conversion() -> None:
     assert result[0]["call_id"] == "call_123"
 
 
-def test__construct_responses_api_input_tool_message_content_blocks_are_stringified() -> (
-    None
-):
+def test__construct_responses_api_input_tool_message_content_blocks_are_stringified() -> None:
     """Tool message block content must be serialized to string for function tools."""
     messages = [
         ToolMessage(
@@ -2441,6 +2439,26 @@ def test__construct_responses_api_input_tool_message_content_blocks_are_stringif
         {"type": "input_text", "text": "Temperature is 72F"},
         {"type": "input_text", "text": "Condition is sunny"},
     ]
+    assert result[0]["call_id"] == "call_123"
+
+
+def test__construct_responses_api_input_tool_message_malformed_blocks_stringified() -> None:
+    """Malformed tool blocks should be stringified without conversion errors."""
+    messages = [
+        ToolMessage(
+            content=[
+                {"type": "text"},
+            ],
+            tool_call_id="call_123",
+        )
+    ]
+
+    result = _construct_responses_api_input(messages)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "function_call_output"
+    assert isinstance(result[0]["output"], str)
+    assert json.loads(result[0]["output"]) == [{"type": "text"}]
     assert result[0]["call_id"] == "call_123"
 
 


### PR DESCRIPTION
Fixes #36321

Serialize Responses function tool outputs as strings when ToolMessage content is provided as blocks, and guard conversion so malformed blocks cannot raise KeyError during payload construction. Add regression coverage for both valid block serialization and malformed-block fallback behavior.

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

## How did you verify your code works?
- `OPENAI_API_KEY=test .venv/bin/python -m pytest -c /dev/null --asyncio-mode=auto libs/partners/openai/tests/unit_tests/chat_models -q`
- `OPENAI_API_KEY=test .venv/bin/python -m pytest -c /dev/null libs/partners/openai/tests/unit_tests/chat_models/test_base.py::test__construct_responses_api_input_tool_message_conversion libs/partners/openai/tests/unit_tests/chat_models/test_base.py::test__construct_responses_api_input_tool_message_content_blocks_are_stringified libs/partners/openai/tests/unit_tests/chat_models/test_base.py::test__construct_responses_api_input_tool_message_malformed_blocks_stringified -q`

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/
