### PR TITLE
fix(openrouter): handle renamed SDK params for x_title and categories

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -329,11 +329,15 @@ class ChatOpenRouter(BaseChatModel):
         Returns:
             An `openrouter.OpenRouter` SDK client instance.
         """
+        import inspect  # noqa: PLC0415
+
         import openrouter  # noqa: PLC0415
         from openrouter.utils import (  # noqa: PLC0415
             BackoffStrategy,
             RetryConfig,
         )
+
+        sdk_params = set(inspect.signature(openrouter.OpenRouter.__init__).parameters)
 
         client_kwargs: dict[str, Any] = {
             "api_key": self.openrouter_api_key.get_secret_value(),  # type: ignore[union-attr]
@@ -343,24 +347,32 @@ class ChatOpenRouter(BaseChatModel):
         if self.app_url:
             client_kwargs["http_referer"] = self.app_url
         if self.app_title:
-            client_kwargs["x_title"] = self.app_title
+            # >=0.8.0 renamed x_title to x_open_router_title
+            title_key = (
+                "x_open_router_title"
+                if "x_open_router_title" in sdk_params
+                else "x_title"
+            )
+            client_kwargs[title_key] = self.app_title
         if self.app_categories:
-            # The SDK lacks a native constructor param for X-OpenRouter-Categories,
-            # so inject the header via custom httpx clients. The SDK sets its own
-            # headers (Authorization, HTTP-Referer, X-Title) per-request, and httpx
-            # merges client-default headers with per-request headers, so nothing is
-            # lost.
-            import httpx  # noqa: PLC0415
+            if "x_open_router_categories" in sdk_params:
+                # >=0.8.0 supports categories natively
+                client_kwargs["x_open_router_categories"] = ",".join(
+                    self.app_categories
+                )
+            else:
+                # Older SDK: inject the header via custom httpx clients.
+                import httpx  # noqa: PLC0415
 
-            extra_headers = {
-                "X-OpenRouter-Categories": ",".join(self.app_categories),
-            }
-            client_kwargs["client"] = httpx.Client(
-                headers=extra_headers, follow_redirects=True
-            )
-            client_kwargs["async_client"] = httpx.AsyncClient(
-                headers=extra_headers, follow_redirects=True
-            )
+                extra_headers = {
+                    "X-OpenRouter-Categories": ",".join(self.app_categories),
+                }
+                client_kwargs["client"] = httpx.Client(
+                    headers=extra_headers, follow_redirects=True
+                )
+                client_kwargs["async_client"] = httpx.AsyncClient(
+                    headers=extra_headers, follow_redirects=True
+                )
         if self.request_timeout is not None:
             client_kwargs["timeout_ms"] = self.request_timeout
         if self.max_retries > 0:

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -300,7 +300,7 @@ class TestChatOpenRouterInstantiation:
             assert call_kwargs["http_referer"] == "https://myapp.com"
 
     def test_app_title_passed_to_client(self) -> None:
-        """Test that app_title is passed as x_title to the SDK client."""
+        """Test that app_title is passed to the SDK client."""
         with patch("openrouter.OpenRouter") as mock_cls:
             mock_cls.return_value = MagicMock()
             ChatOpenRouter(
@@ -309,7 +309,12 @@ class TestChatOpenRouterInstantiation:
                 app_title="My App",
             )
             call_kwargs = mock_cls.call_args[1]
-            assert call_kwargs["x_title"] == "My App"
+            title_key = (
+                "x_open_router_title"
+                if "x_open_router_title" in call_kwargs
+                else "x_title"
+            )
+            assert call_kwargs[title_key] == "My App"
 
     def test_default_attribution_headers(self) -> None:
         """Test that default attribution headers are sent when not overridden."""
@@ -321,7 +326,12 @@ class TestChatOpenRouterInstantiation:
             )
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["http_referer"] == ("https://docs.langchain.com")
-            assert call_kwargs["x_title"] == "LangChain"
+            title_key = (
+                "x_open_router_title"
+                if "x_open_router_title" in call_kwargs
+                else "x_title"
+            )
+            assert call_kwargs[title_key] == "LangChain"
 
     def test_user_attribution_overrides_defaults(self) -> None:
         """Test that user-supplied attribution overrides the defaults."""
@@ -335,7 +345,12 @@ class TestChatOpenRouterInstantiation:
             )
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["http_referer"] == "https://my-custom-app.com"
-            assert call_kwargs["x_title"] == "My Custom App"
+            title_key = (
+                "x_open_router_title"
+                if "x_open_router_title" in call_kwargs
+                else "x_title"
+            )
+            assert call_kwargs[title_key] == "My Custom App"
 
     def test_app_categories_passed_to_client(self) -> None:
         """Test that app_categories injects custom httpx clients with header."""
@@ -398,10 +413,19 @@ class TestChatOpenRouterInstantiation:
             )
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["http_referer"] == "https://myapp.com"
-            assert call_kwargs["x_title"] == "My App"
-            assert "client" in call_kwargs
-            sync_headers = call_kwargs["client"].headers
-            assert sync_headers["X-OpenRouter-Categories"] == "cli-agent"
+            title_key = (
+                "x_open_router_title"
+                if "x_open_router_title" in call_kwargs
+                else "x_title"
+            )
+            assert call_kwargs[title_key] == "My App"
+            # Categories passed via httpx headers (old SDK) or native param
+            if "x_open_router_categories" in call_kwargs:
+                assert call_kwargs["x_open_router_categories"] == "cli-agent"
+            else:
+                assert "client" in call_kwargs
+                sync_headers = call_kwargs["client"].headers
+                assert sync_headers["X-OpenRouter-Categories"] == "cli-agent"
 
     def test_reasoning_in_params(self) -> None:
         """Test that `reasoning` is included in default params."""

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -300,7 +300,7 @@ class TestChatOpenRouterInstantiation:
             assert call_kwargs["http_referer"] == "https://myapp.com"
 
     def test_app_title_passed_to_client(self) -> None:
-        """Test that app_title is passed to the SDK client."""
+        """Test that app_title is passed as x_title to the SDK client."""
         with patch("openrouter.OpenRouter") as mock_cls:
             mock_cls.return_value = MagicMock()
             ChatOpenRouter(
@@ -309,12 +309,7 @@ class TestChatOpenRouterInstantiation:
                 app_title="My App",
             )
             call_kwargs = mock_cls.call_args[1]
-            title_key = (
-                "x_open_router_title"
-                if "x_open_router_title" in call_kwargs
-                else "x_title"
-            )
-            assert call_kwargs[title_key] == "My App"
+            assert call_kwargs["x_title"] == "My App"
 
     def test_default_attribution_headers(self) -> None:
         """Test that default attribution headers are sent when not overridden."""
@@ -326,12 +321,7 @@ class TestChatOpenRouterInstantiation:
             )
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["http_referer"] == ("https://docs.langchain.com")
-            title_key = (
-                "x_open_router_title"
-                if "x_open_router_title" in call_kwargs
-                else "x_title"
-            )
-            assert call_kwargs[title_key] == "LangChain"
+            assert call_kwargs["x_title"] == "LangChain"
 
     def test_user_attribution_overrides_defaults(self) -> None:
         """Test that user-supplied attribution overrides the defaults."""
@@ -345,12 +335,7 @@ class TestChatOpenRouterInstantiation:
             )
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["http_referer"] == "https://my-custom-app.com"
-            title_key = (
-                "x_open_router_title"
-                if "x_open_router_title" in call_kwargs
-                else "x_title"
-            )
-            assert call_kwargs[title_key] == "My Custom App"
+            assert call_kwargs["x_title"] == "My Custom App"
 
     def test_app_categories_passed_to_client(self) -> None:
         """Test that app_categories injects custom httpx clients with header."""
@@ -413,19 +398,80 @@ class TestChatOpenRouterInstantiation:
             )
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["http_referer"] == "https://myapp.com"
-            title_key = (
-                "x_open_router_title"
-                if "x_open_router_title" in call_kwargs
-                else "x_title"
+            assert call_kwargs["x_title"] == "My App"
+            assert "client" in call_kwargs
+            sync_headers = call_kwargs["client"].headers
+            assert sync_headers["X-OpenRouter-Categories"] == "cli-agent"
+
+    def test_build_client_new_sdk_uses_x_open_router_title(self) -> None:
+        """Test that x_open_router_title is used when the SDK has that param."""
+        captured: dict[str, Any] = {}
+
+        class _FakeNewSDK:
+            def __init__(
+                self, *, api_key: str = "", x_open_router_title: str = "", **kw: Any
+            ) -> None:
+                captured.update(
+                    api_key=api_key, x_open_router_title=x_open_router_title, **kw
+                )
+
+        with patch("openrouter.OpenRouter", _FakeNewSDK):
+            ChatOpenRouter(
+                model=MODEL_NAME,
+                api_key=SecretStr("test-key"),
+                app_title="My App",
             )
-            assert call_kwargs[title_key] == "My App"
-            # Categories passed via httpx headers (old SDK) or native param
-            if "x_open_router_categories" in call_kwargs:
-                assert call_kwargs["x_open_router_categories"] == "cli-agent"
-            else:
-                assert "client" in call_kwargs
-                sync_headers = call_kwargs["client"].headers
-                assert sync_headers["X-OpenRouter-Categories"] == "cli-agent"
+            assert captured["x_open_router_title"] == "My App"
+            assert "x_title" not in captured
+
+    def test_build_client_new_sdk_uses_x_open_router_categories(self) -> None:
+        """Test that categories are passed as a kwarg when SDK supports it."""
+        captured: dict[str, Any] = {}
+
+        class _FakeNewSDK:
+            def __init__(
+                self,
+                *,
+                api_key: str = "",
+                x_open_router_title: str = "",
+                x_open_router_categories: str = "",
+                **kw: Any,
+            ) -> None:
+                captured.update(
+                    api_key=api_key,
+                    x_open_router_title=x_open_router_title,
+                    x_open_router_categories=x_open_router_categories,
+                    **kw,
+                )
+
+        with patch("openrouter.OpenRouter", _FakeNewSDK):
+            ChatOpenRouter(
+                model=MODEL_NAME,
+                api_key=SecretStr("test-key"),
+                app_categories=["cli-agent", "programming-app"],
+            )
+            assert captured["x_open_router_categories"] == ("cli-agent,programming-app")
+            assert "client" not in captured
+            assert "async_client" not in captured
+
+    def test_build_client_old_sdk_uses_x_title(self) -> None:
+        """Test that x_title is used when the SDK lacks x_open_router_title."""
+        captured: dict[str, Any] = {}
+
+        class _FakeOldSDK:
+            def __init__(
+                self, *, api_key: str = "", x_title: str = "", **kw: Any
+            ) -> None:
+                captured.update(api_key=api_key, x_title=x_title, **kw)
+
+        with patch("openrouter.OpenRouter", _FakeOldSDK):
+            ChatOpenRouter(
+                model=MODEL_NAME,
+                api_key=SecretStr("test-key"),
+                app_title="My App",
+            )
+            assert captured["x_title"] == "My App"
+            assert "x_open_router_title" not in captured
 
     def test_reasoning_in_params(self) -> None:
         """Test that `reasoning` is included in default params."""


### PR DESCRIPTION
Fixes #36339

OpenRouter SDK >=0.8.0 renamed `x_title` to `x_open_router_title` and added a native `x_open_router_categories` param. The old `x_title` kwarg now throws `TypeError: OpenRouter.__init__() got an unexpected keyword argument 'x_title'`.

This uses `inspect.signature` to check which params the installed SDK version accepts, then picks the right kwarg name at runtime. Both old (<0.8.0) and new (>=0.8.0) SDKs work without pinning a specific version.

Three new unit tests cover both paths using fake SDK classes patched via `unittest.mock.patch`.

**How I verified:** `make test` from `libs/partners/openrouter` — 217 passed.

**Note:** This PR was developed with AI assistance.

- [x] I've read and followed the [contributing guidelines](https://docs.langchain.com/oss/python/contributing/overview)
- [x] `make format`, `make lint` and `make test` pass
- [x] This PR links to an approved issue
- [x] This PR touches only one package
- [x] `uv.lock` is not modified