### PR TITLE
fix(openai): ensure tool output is string for Responses API function_call_output

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4261,6 +4261,10 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                 input_.append(custom_tool_output)
             else:
                 tool_output = _ensure_valid_tool_message_content(tool_output)
+                # Ensure output is always a string for function_call_output
+                # The Responses API requires output to be a string, not a list
+                if isinstance(tool_output, list):
+                    tool_output = _stringify(tool_output)
                 function_call_output = {
                     "type": "function_call_output",
                     "output": tool_output,

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2418,6 +2418,29 @@ def test__construct_responses_api_input_tool_message_conversion() -> None:
     assert result[0]["call_id"] == "call_123"
 
 
+def test__construct_responses_api_input_tool_message_with_list_content() -> None:
+    """Test that tool messages with list content are properly converted to function_call_output with string output.
+
+    This is a regression test for https://github.com/langchain-ai/langchain/issues/36321
+    where MCP tools return list content that needs to be stringified for the Responses API.
+    """
+    messages = [
+        ToolMessage(
+            content=[{"type": "text", "text": '{"temperature": 72}'}],
+            tool_call_id="call_123",
+        )
+    ]
+
+    result = _construct_responses_api_input(messages)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "function_call_output"
+    # The output should be a string, not a list
+    assert isinstance(result[0]["output"], str)
+    assert "72" in result[0]["output"]
+    assert result[0]["call_id"] == "call_123"
+
+
 def test__construct_responses_api_input_multiple_message_types() -> None:
     """Test conversion of a conversation with multiple message types."""
     messages = [


### PR DESCRIPTION
## Description

When using ChatOpenAI with reasoning configuration and MCP tools, the tool output can be a list of content blocks. The OpenAI Responses API requires the 'output' field in 'function_call_output' to be a string, not a list.

This fix ensures that when the tool output is a list, it gets stringified before being passed to the Responses API.

Fixes #36321

## Issue

The error message was:


This happened because:
1. When using ChatOpenAI with reasoning configuration, the Responses API is used
2. MCP tools return tool output as a list of content blocks
3. The  function returns this list as-is
4. The Responses API expects the  field in  to be a string

## Fix

Added a check in  to stringify the tool output if it's a list before passing it to the .

## Testing

Added a new test  that verifies tool messages with list content are properly converted to function_call_output with string output.

All existing tests continue to pass.