### PR TITLE
fix(openrouter): update x_title to x_open_router_title for SDK 0.8.0 compatibility

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -333,7 +333,7 @@ class ChatOpenRouter(BaseChatModel):
             if self.app_url:
                 client_kwargs["http_referer"] = self.app_url
             if self.app_title:
-                client_kwargs["x_title"] = self.app_title
+                client_kwargs["x_open_router_title"] = self.app_title
             if self.request_timeout is not None:
                 client_kwargs["timeout_ms"] = self.request_timeout
             if self.max_retries > 0:

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -300,7 +300,7 @@ class TestChatOpenRouterInstantiation:
             assert call_kwargs["http_referer"] == "https://myapp.com"
 
     def test_app_title_passed_to_client(self) -> None:
-        """Test that app_title is passed as x_title to the SDK client."""
+        """Test that app_title is passed as x_open_router_title to the SDK client."""
         with patch("openrouter.OpenRouter") as mock_cls:
             mock_cls.return_value = MagicMock()
             ChatOpenRouter(
@@ -309,7 +309,7 @@ class TestChatOpenRouterInstantiation:
                 app_title="My App",
             )
             call_kwargs = mock_cls.call_args[1]
-            assert call_kwargs["x_title"] == "My App"
+            assert call_kwargs["x_open_router_title"] == "My App"
 
     def test_default_attribution_headers(self) -> None:
         """Test that default attribution headers are sent when not overridden."""
@@ -321,7 +321,7 @@ class TestChatOpenRouterInstantiation:
             )
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["http_referer"] == ("https://docs.langchain.com/oss")
-            assert call_kwargs["x_title"] == "langchain"
+            assert call_kwargs["x_open_router_title"] == "langchain"
 
     def test_user_attribution_overrides_defaults(self) -> None:
         """Test that user-supplied attribution overrides the defaults."""
@@ -335,7 +335,7 @@ class TestChatOpenRouterInstantiation:
             )
             call_kwargs = mock_cls.call_args[1]
             assert call_kwargs["http_referer"] == "https://my-custom-app.com"
-            assert call_kwargs["x_title"] == "My Custom App"
+            assert call_kwargs["x_open_router_title"] == "My Custom App"
 
     def test_reasoning_in_params(self) -> None:
         """Test that `reasoning` is included in default params."""


### PR DESCRIPTION
Fixes #36339. The openrouter Python SDK changed the parameter name from x_title to x_open_router_title in version 0.8.0. This PR updates the ChatOpenRouter class to use the new parameter name.