### PR TITLE
fix(openai): reuse default httpx clients in AzureChatOpenAI

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -17,7 +17,12 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from typing_extensions import Self
 
-from langchain_openai.chat_models.base import BaseChatOpenAI, _get_default_model_profile
+from langchain_openai.chat_models.base import (
+    BaseChatOpenAI,
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+    _get_default_model_profile,
+)
 
 if TYPE_CHECKING:
     from langchain_core.language_models import ModelProfile
@@ -686,11 +691,21 @@ class AzureChatOpenAI(BaseChatOpenAI):
             client_params["max_retries"] = self.max_retries
 
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(
+                    self.openai_api_base, self.request_timeout
+                ),
+            }
             self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
             self.client = self.root_client.chat.completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.openai_api_base, self.request_timeout
+                ),
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -174,3 +174,35 @@ def test_max_tokens_converted_to_max_completion_tokens() -> None:
     assert "max_completion_tokens" in payload
     assert payload["max_completion_tokens"] == 1000
     assert "max_tokens" not in payload
+
+
+def test_azure_client_caching() -> None:
+    """AzureChatOpenAI instances with identical settings should share the same
+    underlying httpx client, enabling connection pooling."""
+    llm1 = AzureChatOpenAI(  # type: ignore[call-arg]
+        api_key="xyz",  # type: ignore[arg-type]
+        azure_endpoint="https://example.openai.azure.com/",
+        azure_deployment="gpt-4o-mini",
+        openai_api_version="2024-05-01-preview",
+    )
+    llm2 = AzureChatOpenAI(  # type: ignore[call-arg]
+        api_key="xyz",  # type: ignore[arg-type]
+        azure_endpoint="https://example.openai.azure.com/",
+        azure_deployment="gpt-4o-mini",
+        openai_api_version="2024-05-01-preview",
+    )
+    assert llm1.root_client._client is llm2.root_client._client
+
+    # A custom http_client must not be shared with the default cached client.
+    import httpx
+
+    custom_client = httpx.Client()
+    llm3 = AzureChatOpenAI(  # type: ignore[call-arg]
+        api_key="xyz",  # type: ignore[arg-type]
+        azure_endpoint="https://example.openai.azure.com/",
+        azure_deployment="gpt-4o-mini",
+        openai_api_version="2024-05-01-preview",
+        http_client=custom_client,
+    )
+    assert llm3.root_client._client is custom_client
+    assert llm3.root_client._client is not llm1.root_client._client


### PR DESCRIPTION
## Why

`AzureChatOpenAI.validate_environment` passed `self.http_client` / `self.http_async_client` directly to `openai.AzureOpenAI` without the shared-client fallback. When no custom client is provided, each instance created a brand-new httpx client — no connection pooling across identically configured instances.

`BaseChatOpenAI` already solves this via `_get_default_httpx_client` / `_get_default_async_httpx_client`. This PR applies the same pattern to `AzureChatOpenAI`.

Fixes #36259

## Changes

- `azure.py`: import `_get_default_httpx_client` and `_get_default_async_httpx_client` from `base`; use them as fallbacks in `sync_specific` / `async_specific` when no custom client is supplied.
- `test_azure.py`: add `test_azure_client_caching` that verifies two default-configured instances share the same underlying httpx client, and that a custom client is used as-is.

## Review notes

The only code change is in `validate_environment` — no public API surface is affected. The logic mirrors the existing `BaseChatOpenAI` pattern exactly.

Tests run: `pytest tests/unit_tests/chat_models/test_azure.py::test_azure_client_caching` — 1 passed.

---

> **AI assistance disclosure**: This contribution was developed with AI assistance (Claude). The fix, test, and rationale were reviewed and validated before submission.