### PR TITLE
fix(agents): raise NoStructuredOutputError when model forgets to make tool calls

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -44,6 +44,7 @@ from langchain.agents.middleware.types import (
 from langchain.agents.structured_output import (
     AutoStrategy,
     MultipleStructuredOutputsError,
+    NoStructuredOutputError,
     OutputToolBinding,
     ProviderStrategy,
     ProviderStrategyBinding,
@@ -1053,78 +1054,95 @@ def create_agent(
             return {"messages": [output]}
 
         # Handle structured output with tool strategy
-        if (
-            isinstance(effective_response_format, ToolStrategy)
-            and isinstance(output, AIMessage)
-            and output.tool_calls
-        ):
-            structured_tool_calls = [
-                tc for tc in output.tool_calls if tc["name"] in structured_output_tools
-            ]
+        if isinstance(effective_response_format, ToolStrategy) and isinstance(output, AIMessage):
+            if output.tool_calls:
+                structured_tool_calls = [
+                    tc for tc in output.tool_calls if tc["name"] in structured_output_tools
+                ]
 
-            if structured_tool_calls:
-                exception: StructuredOutputError | None = None
-                if len(structured_tool_calls) > 1:
-                    # Handle multiple structured outputs error
-                    tool_names = [tc["name"] for tc in structured_tool_calls]
-                    exception = MultipleStructuredOutputsError(tool_names, output)
-                    should_retry, error_message = _handle_structured_output_error(
-                        exception, effective_response_format
-                    )
-                    if not should_retry:
-                        raise exception
-
-                    # Add error messages and retry
-                    tool_messages = [
-                        ToolMessage(
-                            content=error_message,
-                            tool_call_id=tc["id"],
-                            name=tc["name"],
+                if structured_tool_calls:
+                    exception: StructuredOutputError | None = None
+                    if len(structured_tool_calls) > 1:
+                        # Handle multiple structured outputs error
+                        tool_names = [tc["name"] for tc in structured_tool_calls]
+                        exception = MultipleStructuredOutputsError(tool_names, output)
+                        should_retry, error_message = _handle_structured_output_error(
+                            exception, effective_response_format
                         )
-                        for tc in structured_tool_calls
-                    ]
-                    return {"messages": [output, *tool_messages]}
+                        if not should_retry:
+                            raise exception
 
-                # Handle single structured output
-                tool_call = structured_tool_calls[0]
-                try:
-                    structured_tool_binding = structured_output_tools[tool_call["name"]]
-                    structured_response = structured_tool_binding.parse(tool_call["args"])
-
-                    tool_message_content = (
-                        effective_response_format.tool_message_content
-                        or f"Returning structured response: {structured_response}"
-                    )
-
-                    return {
-                        "messages": [
-                            output,
-                            ToolMessage(
-                                content=tool_message_content,
-                                tool_call_id=tool_call["id"],
-                                name=tool_call["name"],
-                            ),
-                        ],
-                        "structured_response": structured_response,
-                    }
-                except Exception as exc:
-                    exception = StructuredOutputValidationError(tool_call["name"], exc, output)
-                    should_retry, error_message = _handle_structured_output_error(
-                        exception, effective_response_format
-                    )
-                    if not should_retry:
-                        raise exception from exc
-
-                    return {
-                        "messages": [
-                            output,
+                        # Add error messages and retry
+                        tool_messages = [
                             ToolMessage(
                                 content=error_message,
-                                tool_call_id=tool_call["id"],
-                                name=tool_call["name"],
-                            ),
-                        ],
-                    }
+                                tool_call_id=tc["id"],
+                                name=tc["name"],
+                            )
+                            for tc in structured_tool_calls
+                        ]
+                        return {"messages": [output, *tool_messages]}
+
+                    # Handle single structured output
+                    tool_call = structured_tool_calls[0]
+                    try:
+                        structured_tool_binding = structured_output_tools[tool_call["name"]]
+                        structured_response = structured_tool_binding.parse(tool_call["args"])
+
+                        tool_message_content = (
+                            effective_response_format.tool_message_content
+                            or f"Returning structured response: {structured_response}"
+                        )
+
+                        return {
+                            "messages": [
+                                output,
+                                ToolMessage(
+                                    content=tool_message_content,
+                                    tool_call_id=tool_call["id"],
+                                    name=tool_call["name"],
+                                ),
+                            ],
+                            "structured_response": structured_response,
+                        }
+                    except Exception as exc:
+                        exception = StructuredOutputValidationError(tool_call["name"], exc, output)
+                        should_retry, error_message = _handle_structured_output_error(
+                            exception, effective_response_format
+                        )
+                        if not should_retry:
+                            raise exception from exc
+
+                        return {
+                            "messages": [
+                                output,
+                                ToolMessage(
+                                    content=error_message,
+                                    tool_call_id=tool_call["id"],
+                                    name=tool_call["name"],
+                                ),
+                            ],
+                        }
+
+            # No structured output tool calls were made when one was expected
+            if structured_output_tools:
+                exception = NoStructuredOutputError(output)
+                should_retry, error_message = _handle_structured_output_error(
+                    exception, effective_response_format
+                )
+                if not should_retry:
+                    raise exception
+
+                return {
+                    "messages": [
+                        output,
+                        ToolMessage(
+                            content=error_message,
+                            tool_call_id="no_call",
+                            name="no_structured_output",
+                        ),
+                    ],
+                }
 
         return {"messages": [output]}
 
@@ -1708,7 +1726,13 @@ def _make_model_to_tools_edge(
 
         # 3. If the model hasn't called any tools, exit the loop
         # this is the classic exit condition for an agent loop
+        # However, if there are structured output tools expected and there are
+        # tool messages after the AI message (indicating error feedback for missing
+        # structured output), we should loop back to the model for retry.
         if len(last_ai_message.tool_calls) == 0:
+            if structured_output_tools and tool_messages:
+                # Error feedback was added for missing structured output, retry
+                return model_destination
             return end_destination
 
         pending_tool_calls = [

--- a/libs/langchain_v1/langchain/agents/structured_output.py
+++ b/libs/langchain_v1/langchain/agents/structured_output.py
@@ -74,6 +74,19 @@ class StructuredOutputValidationError(StructuredOutputError):
         super().__init__(f"Failed to parse structured output for tool '{tool_name}': {source}.")
 
 
+class NoStructuredOutputError(StructuredOutputError):
+    """Raised when no structured output tool is called when one was expected."""
+
+    def __init__(self, ai_message: AIMessage) -> None:
+        """Initialize `NoStructuredOutputError`.
+
+        Args:
+            ai_message: The AI message that did not contain a structured output tool call.
+        """
+        self.ai_message = ai_message
+        super().__init__("No structured output tool called.")
+
+
 def _parse_with_schema(
     schema: type[SchemaT] | dict[str, Any], schema_kind: SchemaKind, data: dict[str, Any]
 ) -> Any:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_no_structured_output.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_no_structured_output.py
@@ -1,0 +1,256 @@
+"""Tests for NoStructuredOutputError functionality (issue #36349)."""
+
+from collections.abc import Callable
+
+import pytest
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from pydantic import BaseModel
+
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+from langchain.agents.structured_output import (
+    NoStructuredOutputError,
+    StructuredOutputError,
+    ToolStrategy,
+)
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+class WeatherReport(BaseModel):
+    """Weather report schema for testing."""
+
+    temperature: float
+    conditions: str
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get the weather for a given city.
+
+    Args:
+        city: The city to get weather for.
+
+    Returns:
+        Weather information for the city.
+    """
+    return f"The weather in {city} is sunny and 72 degrees."
+
+
+def test_no_structured_output_error_raised() -> None:
+    """Test that NoStructuredOutputError is raised when model makes no tool calls."""
+    # Model returns no tool calls at all
+    tool_calls = [
+        [],  # No tool calls
+    ]
+
+    model = FakeToolCallingModel(tool_calls=tool_calls)
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        response_format=ToolStrategy(schema=WeatherReport, handle_errors=False),
+    )
+
+    # Should raise NoStructuredOutputError when no tool calls are made
+    with pytest.raises(NoStructuredOutputError):
+        agent.invoke(
+            {"messages": [HumanMessage("What's the weather in Tokyo?")]},
+        )
+
+    # Verify the model was called once
+    assert model.index == 1
+
+
+def test_no_structured_output_error_message() -> None:
+    """Test that NoStructuredOutputError contains the AI message."""
+    tool_calls = [
+        [],  # No tool calls
+    ]
+
+    model = FakeToolCallingModel(tool_calls=tool_calls)
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        response_format=ToolStrategy(schema=WeatherReport, handle_errors=False),
+    )
+
+    try:
+        agent.invoke(
+            {"messages": [HumanMessage("What's the weather in Tokyo?")]},
+        )
+        pytest.fail("Expected NoStructuredOutputError to be raised")
+    except NoStructuredOutputError as e:
+        # Verify the error message
+        assert "No structured output tool called" in str(e)
+        # Verify the AI message is accessible
+        assert e.ai_message is not None
+
+
+def test_no_structured_output_with_retry() -> None:
+    """Test that no structured output error triggers retry when handle_errors=True."""
+    # First attempt: no tool calls, second attempt: valid structured output
+    tool_calls = [
+        [],  # No tool calls on first attempt
+        [
+            {
+                "name": "WeatherReport",
+                "id": "1",
+                "args": {"temperature": 72.5, "conditions": "sunny"},
+            }
+        ],  # Valid on second attempt
+    ]
+
+    model = FakeToolCallingModel(tool_calls=tool_calls)
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        response_format=ToolStrategy(schema=WeatherReport, handle_errors=True),
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("What's the weather in Tokyo?")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    # Verify we got a structured response after retry
+    assert "structured_response" in result
+    structured = result["structured_response"]
+    assert isinstance(structured, WeatherReport)
+    assert structured.temperature == 72.5
+    assert structured.conditions == "sunny"
+
+    # Verify the model was called twice (initial + 1 retry)
+    assert model.index == 2
+
+
+def test_no_structured_output_is_structured_output_error() -> None:
+    """Test that NoStructuredOutputError is a subclass of StructuredOutputError."""
+    assert issubclass(NoStructuredOutputError, StructuredOutputError)
+
+
+class StructuredOutputRetryMiddleware(AgentMiddleware):
+    """Retries model calls when structured output parsing fails."""
+
+    def __init__(self, max_retries: int) -> None:
+        """Initialize the structured output retry middleware.
+
+        Args:
+            max_retries: Maximum number of retry attempts.
+        """
+        self.max_retries = max_retries
+
+    def wrap_model_call(
+        self, request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]
+    ) -> ModelResponse:
+        """Intercept and control model execution via handler callback.
+
+        Args:
+            request: The model request containing messages and configuration.
+            handler: The function to call the model.
+
+        Returns:
+            The model response.
+
+        Raises:
+            StructuredOutputError: If max retries exceeded without success.
+        """
+        for attempt in range(self.max_retries + 1):
+            try:
+                return handler(request)
+            except StructuredOutputError as exc:
+                if attempt == self.max_retries:
+                    raise
+
+                # Include both the AI message and error in a single human message
+                # to maintain valid chat history alternation
+                ai_content = exc.ai_message.content
+                error_message = (
+                    f"Your previous response was:\\n{ai_content}\\n\\n"
+                    f"Error: {exc}. Please try again with a valid response."
+                )
+                request.messages.append(HumanMessage(content=error_message))
+
+        # This should never be reached, but satisfies type checker
+        return handler(request)
+
+
+def test_no_structured_output_retry_with_middleware() -> None:
+    """Test retry middleware catches NoStructuredOutputError."""
+    # First two attempts: no tool calls, third attempt: valid
+    tool_calls = [
+        [],  # No tool calls on first attempt
+        [],  # No tool calls on second attempt
+        [
+            {
+                "name": "WeatherReport",
+                "id": "1",
+                "args": {"temperature": 75.0, "conditions": "cloudy"},
+            }
+        ],  # Valid on third attempt
+    ]
+
+    model = FakeToolCallingModel(tool_calls=tool_calls)
+    retry_middleware = StructuredOutputRetryMiddleware(max_retries=2)
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        middleware=[retry_middleware],
+        response_format=ToolStrategy(schema=WeatherReport, handle_errors=False),
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("What's the weather in London?")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    # Verify we got a structured response after retries
+    assert "structured_response" in result
+    structured = result["structured_response"]
+    assert isinstance(structured, WeatherReport)
+    assert structured.temperature == 75.0
+    assert structured.conditions == "cloudy"
+
+    # Verify the model was called 3 times (initial + 2 retries)
+    assert model.index == 3
+
+
+def test_no_structured_output_retry_exceeds_max() -> None:
+    """Test that retry middleware raises error when max retries exceeded."""
+    # All attempts: no tool calls
+    tool_calls = [
+        [],
+        [],
+        [],
+    ]
+
+    model = FakeToolCallingModel(tool_calls=tool_calls)
+    retry_middleware = StructuredOutputRetryMiddleware(max_retries=2)
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        middleware=[retry_middleware],
+        response_format=ToolStrategy(schema=WeatherReport, handle_errors=False),
+        checkpointer=InMemorySaver(),
+    )
+
+    # Should raise NoStructuredOutputError after exhausting retries
+    with pytest.raises(NoStructuredOutputError):
+        agent.invoke(
+            {"messages": [HumanMessage("What's the weather in Paris?")]},
+            {"configurable": {"thread_id": "test"}},
+        )
+
+    # Verify the model was called 3 times (initial + 2 retries)
+    assert model.index == 3


### PR DESCRIPTION
When using ToolStrategy for structured output, if the model fails to make any tool calls at all, the agent now raises NoStructuredOutputError instead of silently failing without a structured_response key.

## Changes
- Added NoStructuredOutputError exception class in structured_output.py
- Modified _handle_model_output in factory.py to detect missing tool calls
- Updated _make_model_to_tools_edge to loop back to model for retry when handle_errors=True and error feedback was added
- Added comprehensive tests for the new functionality

## Testing
All existing tests pass, plus new tests verify:
1. NoStructuredOutputError is raised when no tool calls are made (handle_errors=False)
2. Error message contains the AI message
3. Retry works when handle_errors=True
4. NoStructuredOutputError is a subclass of StructuredOutputError
5. Retry middleware can catch and handle NoStructuredOutputError

Fixes #36349