### PR TITLE
fix(langchain): raise NoToolCallError when ToolStrategy model returns no tool calls

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -44,6 +44,7 @@ from langchain.agents.middleware.types import (
 from langchain.agents.structured_output import (
     AutoStrategy,
     MultipleStructuredOutputsError,
+    NoToolCallError,
     OutputToolBinding,
     ProviderStrategy,
     ProviderStrategyBinding,
@@ -1125,6 +1126,25 @@ def create_agent(
                             ),
                         ],
                     }
+
+        elif (
+            isinstance(effective_response_format, ToolStrategy)
+            and isinstance(output, AIMessage)
+            and not output.tool_calls
+        ):
+            exception = NoToolCallError(output)
+            should_retry, error_message = _handle_structured_output_error(
+                exception, effective_response_format
+            )
+            if not should_retry:
+                raise exception
+
+            return {
+                "messages": [
+                    output,
+                    SystemMessage(content=error_message),
+                ],
+            }
 
         return {"messages": [output]}
 

--- a/libs/langchain_v1/langchain/agents/structured_output.py
+++ b/libs/langchain_v1/langchain/agents/structured_output.py
@@ -57,6 +57,19 @@ class MultipleStructuredOutputsError(StructuredOutputError):
         )
 
 
+class NoToolCallError(StructuredOutputError):
+    """Raised when a ToolStrategy response format is set but the model returns no tool calls."""
+
+    def __init__(self, ai_message: AIMessage) -> None:
+        """Initialize `NoToolCallError`.
+
+        Args:
+            ai_message: The AI message that contained no tool calls.
+        """
+        self.ai_message = ai_message
+        super().__init__("Model did not make a structured output tool call.")
+
+
 class StructuredOutputValidationError(StructuredOutputError):
     """Raised when structured output tool call arguments fail to parse according to the schema."""
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -25,6 +25,7 @@ from langchain.agents.middleware.types import (
 )
 from langchain.agents.structured_output import (
     MultipleStructuredOutputsError,
+    NoToolCallError,
     ProviderStrategy,
     StructuredOutputValidationError,
     ToolStrategy,
@@ -683,6 +684,57 @@ class TestResponseFormatAsToolStrategy:
             match=r".*WeatherBaseModel.*",
         ):
             agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+
+class TestNoToolCallError:
+    def test_no_tool_call_raises_when_handle_errors_false(self) -> None:
+        """Test that NoToolCallError is raised when model returns no tool calls.
+
+        When ToolStrategy is set and the model returns an AIMessage with no tool calls,
+        NoToolCallError should be raised if handle_errors=False.
+        """
+        model = FakeToolCallingModel(tool_calls=[[]])
+
+        agent = create_agent(
+            model,
+            [],
+            response_format=ToolStrategy(
+                WeatherBaseModel,
+                handle_errors=False,
+            ),
+        )
+
+        with pytest.raises(NoToolCallError):
+            agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+    def test_no_tool_call_retries_when_handle_errors_true(self) -> None:
+        """Test that agent retries when model initially returns no tool calls.
+
+        When ToolStrategy is set and the model returns no tool calls on the first
+        attempt, the agent should send an error message and retry. On the second
+        attempt the model returns the correct tool call.
+        """
+        tool_calls = [
+            [],  # First response: no tool calls
+            [{"name": "WeatherBaseModel", "id": "2", "args": WEATHER_DATA}],
+        ]
+
+        model = FakeToolCallingModel(tool_calls=tool_calls)
+
+        agent = create_agent(
+            model,
+            [],
+            response_format=ToolStrategy(
+                WeatherBaseModel,
+                handle_errors=True,
+            ),
+        )
+
+        response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        # HumanMessage, AIMessage (no tool call), SystemMessage (error), AIMessage, ToolMessage
+        assert len(response["messages"]) == 5
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
 
 
 class TestResponseFormatAsProviderStrategy:


### PR DESCRIPTION
## Why

When `ToolStrategy` is set as the `response_format` for `create_agent`, the agent silently returns a response without a `structured_response` key if the model forgets to make a tool call altogether. The existing `if` block in `factory.py` only handles cases where `output.tool_calls` is non-empty, so a plain `AIMessage` with no tool calls falls through to `return {"messages": [output]}` with no error raised and no `structured_response` populated.

This is a silent failure that can disrupt entire agentic workflows without any indication of what went wrong.

Fixes #36349

## Changes

- `structured_output.py`: add `NoToolCallError` exception (subclass of `StructuredOutputError`) raised when `ToolStrategy` is active but the model returns no tool calls.
- `factory.py`: add `elif` branch after the existing `ToolStrategy` handler to catch the no-tool-call case, route it through `_handle_structured_output_error`, and either raise the exception or return a `SystemMessage` prompt for retry — consistent with how `MultipleStructuredOutputsError` and `StructuredOutputValidationError` are handled.
- `test_response_format.py`: add `TestNoToolCallError` with two tests — raise on `handle_errors=False`, retry and succeed on `handle_errors=True`.

## Review notes

The change adds one new `elif` branch and mirrors the existing error-handling pattern exactly. No public API surfaces are changed beyond the addition of `NoToolCallError` to `structured_output.py`.