### PR TITLE
fix: raise when structured output tool call is missing

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -44,6 +44,7 @@ from langchain.agents.middleware.types import (
 from langchain.agents.structured_output import (
     AutoStrategy,
     MultipleStructuredOutputsError,
+    NoStructuredOutputError,
     OutputToolBinding,
     ProviderStrategy,
     ProviderStrategyBinding,
@@ -1053,14 +1054,19 @@ def create_agent(
             return {"messages": [output]}
 
         # Handle structured output with tool strategy
-        if (
-            isinstance(effective_response_format, ToolStrategy)
-            and isinstance(output, AIMessage)
-            and output.tool_calls
-        ):
+        if isinstance(effective_response_format, ToolStrategy) and isinstance(output, AIMessage):
             structured_tool_calls = [
                 tc for tc in output.tool_calls if tc["name"] in structured_output_tools
             ]
+
+            if not structured_tool_calls and not output.tool_calls:
+                exception = NoStructuredOutputError(output)
+                should_retry, _ = _handle_structured_output_error(
+                    exception, effective_response_format
+                )
+                if not should_retry:
+                    raise exception
+                return {"messages": [output]}
 
             if structured_tool_calls:
                 exception: StructuredOutputError | None = None

--- a/libs/langchain_v1/langchain/agents/structured_output.py
+++ b/libs/langchain_v1/langchain/agents/structured_output.py
@@ -74,6 +74,21 @@ class StructuredOutputValidationError(StructuredOutputError):
         super().__init__(f"Failed to parse structured output for tool '{tool_name}': {source}.")
 
 
+class NoStructuredOutputError(StructuredOutputError):
+    """Raised when a tool strategy response omits the structured output tool call."""
+
+    def __init__(self, ai_message: AIMessage) -> None:
+        """Initialize `NoStructuredOutputError`.
+
+        Args:
+            ai_message: The AI message that omitted the structured output tool call.
+        """
+        self.ai_message = ai_message
+        super().__init__(
+            "Model did not call the structured output tool when one was required."
+        )
+
+
 def _parse_with_schema(
     schema: type[SchemaT] | dict[str, Any], schema_kind: SchemaKind, data: dict[str, Any]
 ) -> Any:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py
@@ -1,10 +1,14 @@
 """Tests for StructuredOutputRetryMiddleware functionality."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import pytest
-from langchain_core.messages import HumanMessage
-from langchain_core.tools import tool
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.prompt_values import PromptValue
+from langchain_core.runnables import Runnable
+from langchain_core.tools import BaseTool, tool
 from langgraph.checkpoint.memory import InMemorySaver
 from pydantic import BaseModel
 
@@ -69,6 +73,22 @@ class WeatherReport(BaseModel):
 
     temperature: float
     conditions: str
+
+
+class FakeWithStructuredOutput(GenericFakeChatModel):
+    """Fake chat model that supports bind_tools for structured output tests."""
+
+    def bind_tools(
+        self,
+        tools: Sequence[dict[str, Any] | type | Callable[..., Any] | BaseTool],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable[
+        PromptValue | str | Sequence[BaseMessage | list[str] | tuple[str, str] | str | dict[str, Any]],
+        AIMessage,
+    ]:
+        return self.bind(tools=tools, tool_choice=tool_choice, **kwargs)
 
 
 @tool
@@ -367,3 +387,56 @@ def test_structured_output_retry_preserves_messages() -> None:
     retry_message = human_messages[-1]
     assert "Error:" in retry_message.content
     assert "Please try again" in retry_message.content
+
+
+def test_structured_output_missing_tool_call_raises_without_retries() -> None:
+    """Missing structured output tool calls should raise when retries are disabled."""
+    model = FakeWithStructuredOutput(messages=iter([AIMessage(content="just text")]))
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        response_format=ToolStrategy(schema=WeatherReport, handle_errors=False),
+    )
+
+    with pytest.raises(StructuredOutputError, match="did not call the structured output tool"):
+        agent.invoke({"messages": [HumanMessage("What's the weather in Tokyo?")]})
+
+
+def test_structured_output_missing_tool_call_can_be_retried_by_middleware() -> None:
+    """Middleware retries should also handle missing structured output tool calls."""
+    model = FakeWithStructuredOutput(
+        messages=iter(
+            [
+                AIMessage(content="just text"),
+                AIMessage(
+                    content="tool call",
+                    tool_calls=[
+                        {
+                            "name": "WeatherReport",
+                            "id": "1",
+                            "args": {"temperature": 72.5, "conditions": "sunny"},
+                        }
+                    ],
+                ),
+            ]
+        )
+    )
+    retry_middleware = StructuredOutputRetryMiddleware(max_retries=1)
+
+    agent = create_agent(
+        model=model,
+        tools=[get_weather],
+        middleware=[retry_middleware],
+        response_format=ToolStrategy(schema=WeatherReport, handle_errors=False),
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("What's the weather in Tokyo?")]},
+        {"configurable": {"thread_id": "test-missing-tool-call"}},
+    )
+
+    assert isinstance(result["structured_response"], WeatherReport)
+    assert result["structured_response"].temperature == 72.5
+    assert result["structured_response"].conditions == "sunny"


### PR DESCRIPTION
## Summary

Raise a structured-output error when a `ToolStrategy` response forgets to call the structured output tool, instead of silently returning an unstructured AI message.

## Changes

- add `NoStructuredOutputError` for missing structured output tool calls
- raise that error when `ToolStrategy(..., handle_errors=False)` receives an AI message with no tool calls
- add regression tests for both direct failure and middleware-driven retry recovery

## Testing

- `uv run --project libs/langchain_v1 --group test pytest libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py -q`

Fixes langchain-ai/langchain#36349