### PR TITLE
fix: ShellToolMiddleware may kill caller process group when create_process_group=False

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -143,6 +143,8 @@ class ShellSession:
         self._stdout_thread: threading.Thread | None = None
         self._stderr_thread: threading.Thread | None = None
         self._terminated = False
+        # Determine if process groups should be used for termination
+        self._use_process_group = getattr(policy, "create_process_group", True)
 
     def start(self) -> None:
         """Start the shell subprocess and reader threads.
@@ -402,7 +404,7 @@ class ShellSession:
         if not self._process:
             return
 
-        if hasattr(os, "killpg"):
+        if self._use_process_group and hasattr(os, "killpg"):
             with contextlib.suppress(ProcessLookupError):
                 os.killpg(os.getpgid(self._process.pid), signal.SIGKILL)
         else:  # pragma: no cover


### PR DESCRIPTION
## Summary

When `HostExecutionPolicy(create_process_group=False)` is used, the child process shares the caller's process group. The `_kill_process` method was unconditionally using `os.killpg()` which kills the entire process group, potentially killing the caller and sibling processes.

## Changes

- Store the `create_process_group` setting from the policy in `ShellSession`
- Use `os.kill()` (single process kill) when `create_process_group=False`
- Use `os.killpg()` (process group kill) when `create_process_group=True`

## Related Issue

Fixes #36358

## Testing

The fix was verified with a simple test script that confirms:
- When `create_process_group=True`: uses `os.killpg` (process group kill)
- When `create_process_group=False`: uses `process.kill()` (single process kill)

This prevents killing the caller's process group when `create_process_group=False`.