### PR TITLE
fix(langchain): prevent killpg from terminating caller when child sha…

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -403,11 +403,18 @@ class ShellSession:
             return
 
         if hasattr(os, "killpg"):
-            with contextlib.suppress(ProcessLookupError):
-                os.killpg(os.getpgid(self._process.pid), signal.SIGKILL)
-        else:  # pragma: no cover
-            with contextlib.suppress(ProcessLookupError):
-                self._process.kill()
+            try:
+                child_pgid = os.getpgid(self._process.pid)
+                # Only group-kill when the child has its own process group.
+                # If it shares ours, killpg would terminate the caller too.
+                if child_pgid != os.getpgrp():
+                    os.killpg(child_pgid, signal.SIGKILL)
+                    return
+            except ProcessLookupError:
+                return
+
+        with contextlib.suppress(ProcessLookupError):
+            self._process.kill()
 
     def _enqueue_stream(self, stream: Any, label: str) -> None:
         for line in iter(stream.readline, ""):

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import gc
+import signal
+import os
 import tempfile
 import time
 from pathlib import Path
 from typing import cast
+from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_core.messages import ToolMessage
@@ -14,6 +17,7 @@ from langgraph.runtime import Runtime
 from langchain.agents.middleware.shell_tool import (
     HostExecutionPolicy,
     RedactionRule,
+    ShellSession,
     ShellToolMiddleware,
     ShellToolState,
     _SessionResources,
@@ -546,3 +550,55 @@ def test_get_or_create_resources_reuses_existing(tmp_path: Path) -> None:
 
     # Clean up
     resources1.finalizer()
+
+
+def _make_session_with_mock_process(tmp_path: Path, pid: int) -> ShellSession:
+    """Create a ShellSession with a mock process (no real subprocess started)."""
+    session = ShellSession(
+        workspace=tmp_path,
+        policy=HostExecutionPolicy(),
+        command=("/bin/sh",),
+        environment={},
+    )
+    mock_process = MagicMock()
+    mock_process.pid = pid
+    session._process = mock_process
+    return session
+
+
+def test_kill_process_shared_group_uses_single_kill(tmp_path: Path) -> None:
+    """When child shares parent's process group, os.killpg must NOT be called.
+
+    Reproduces the bug from https://github.com/langchain-ai/langchain/issues/36358
+    where create_process_group=False causes the child to share the caller's PGID,
+    but the previous implementation would killpg the shared group (killing the caller).
+    """
+    current_pgid = os.getpgrp()
+    session = _make_session_with_mock_process(tmp_path, pid=current_pgid)
+
+    with (
+        patch("langchain.agents.middleware.shell_tool.os.getpgid", return_value=current_pgid),
+        patch("langchain.agents.middleware.shell_tool.os.getpgrp", return_value=current_pgid),
+        patch("langchain.agents.middleware.shell_tool.os.killpg") as mock_killpg,
+    ):
+        session._kill_process()
+
+    mock_killpg.assert_not_called()
+    session._process.kill.assert_called_once()
+
+
+def test_kill_process_dedicated_group_uses_killpg(tmp_path: Path) -> None:
+    """When child has a dedicated process group, os.killpg must be called with the child's PGID."""
+    current_pgid = os.getpgrp()
+    child_pgid = current_pgid + 1  # different group — child has its own session
+    session = _make_session_with_mock_process(tmp_path, pid=child_pgid)
+
+    with (
+        patch("langchain.agents.middleware.shell_tool.os.getpgid", return_value=child_pgid),
+        patch("langchain.agents.middleware.shell_tool.os.getpgrp", return_value=current_pgid),
+        patch("langchain.agents.middleware.shell_tool.os.killpg") as mock_killpg,
+    ):
+        session._kill_process()
+
+    mock_killpg.assert_called_once_with(child_pgid, signal.SIGKILL)
+    session._process.kill.assert_not_called()


### PR DESCRIPTION
…res process group

When create_process_group=False, the child shell inherits the caller's process group. The previous _kill_process implementation unconditionally called os.killpg(), which would kill the entire shared group — including the parent process and siblings.

Now we compare the child's PGID against the current process's PGID via os.getpgrp(). Group kill is only used when the child has its own dedicated process group; otherwise we fall back to killing the child process directly.

Fixes #36358

Fixes #

<!-- Replace everything above this line with a 1-2 sentence description of your change. Keep the "Fixes #xx" keyword and update the issue number. -->

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangChain! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

  - Examples:
    - fix(anthropic): resolve flag parsing error
    - feat(core): add multi-tenant support
    - test(openai): update API usage tests
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langchain/blob/master/.github/workflows/pr_lint.yml#L15-L33

2. PR description:

  - Write 1-2 sentences summarizing the change.
  - The `Fixes #xx` line at the top is **required** for external contributions — update the issue number and keep the keyword. This links your PR to the approved issue and auto-closes it on merge.
  - If there are any breaking changes, please clearly describe them.
  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

4. How did you verify your code works?

Additional guidelines:

  - All external PRs must link to an issue or discussion where a solution has been approved by a maintainer, and you must be assigned to that issue. PRs without prior approval will be closed.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/
