### PR TITLE
fix(core): improve message pretty_repr and cleanup output parser

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -336,10 +336,47 @@ class BaseMessage(Serializable):
             ```
         """  # noqa: E501
         title = get_msg_title_repr(self.type.title() + " Message", bold=html)
-        # TODO: handle non-string content.
         if self.name is not None:
             title += f"\nName: {self.name}"
-        return f"{title}\n\n{self.content}"
+
+        content = self.content
+        if isinstance(content, list):
+            formatted_content = []
+            for item in content:
+                if isinstance(item, str):
+                    formatted_content.append(item)
+                elif isinstance(item, dict):
+                    item_type = item.get("type")
+                    if item_type == "text":
+                        formatted_content.append(item.get("text", ""))
+                    elif item_type == "image_url":
+                        url = item.get("image_url", {}).get("url")
+                        formatted_content.append(f"Image: {url}")
+                    elif item_type == "image":
+                        url = item.get("url")
+                        if url:
+                            formatted_content.append(f"Image: {url}")
+                        else:
+                            formatted_content.append("Image (base64 data)")
+                    elif item_type == "video":
+                        url = item.get("url")
+                        formatted_content.append(f"Video: {url if url else 'base64 data'}")
+                    elif item_type == "audio":
+                        url = item.get("url")
+                        formatted_content.append(f"Audio: {url if url else 'base64 data'}")
+                    elif item_type == "file":
+                        url = item.get("url")
+                        formatted_content.append(f"File: {url if url else 'base64 data'}")
+                    elif item_type == "reasoning":
+                        reasoning = item.get("reasoning", "")
+                        formatted_content.append(f"Reasoning: {reasoning}")
+                    else:
+                        formatted_content.append(f"[{item_type}] content block")
+                else:
+                    formatted_content.append(str(item))
+            content = "\n".join(formatted_content)
+
+        return f"{title}\n\n{content}"
 
     def pretty_print(self) -> None:
         """Print a pretty representation of the message.

--- a/libs/core/langchain_core/output_parsers/base.py
+++ b/libs/core/langchain_core/output_parsers/base.py
@@ -307,10 +307,9 @@ class BaseOutputParser(
         """
         return await run_in_executor(None, self.parse, text)
 
-    # TODO: rename 'completion' -> 'text'.
     def parse_with_prompt(
         self,
-        completion: str,
+        text: str,
         prompt: PromptValue,  # noqa: ARG002
     ) -> Any:
         """Parse the output of an LLM call with the input prompt for context.
@@ -319,13 +318,13 @@ class BaseOutputParser(
         fix the output in some way, and needs information from the prompt to do so.
 
         Args:
-            completion: String output of a language model.
+            text: String output of a language model.
             prompt: Input `PromptValue`.
 
         Returns:
             Structured output.
         """
-        return self.parse(completion)
+        return self.parse(text)
 
     def get_format_instructions(self) -> str:
         """Instructions on how the LLM output should be formatted."""


### PR DESCRIPTION
Resolves #36365

### Description
This PR addresses two "Developer Experience" (DX) improvements in `langchain-core`:

1. **Multimodal `pretty_repr`**: Previously, the `pretty_repr` method used by `pretty_print()` printed multimodal content (images, audio, video, reasoning) as raw Python dictionaries. I've updated it to iterate through `content` blocks and format them into a human-readable representation.
2. **Standardization**: Renamed the parameter `completion` to `text` in `OutputParser.parse_with_prompt`, resolving a long-standing legacy `TODO`.

### Tagging & Labels
#core #fix #dx #new-contributor

### Verification
Manually verified `HumanMessage.pretty_print()` with a list of multimodal content blocks (images and reasoning). The output is now formatted cleanly instead of showing raw dictionaries.
