### PR TITLE
fix(core): improve BaseMessage.pretty_repr for multimodal content

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -336,10 +336,63 @@ class BaseMessage(Serializable):
             ```
         """  # noqa: E501
         title = get_msg_title_repr(self.type.title() + " Message", bold=html)
-        # TODO: handle non-string content.
         if self.name is not None:
             title += f"\nName: {self.name}"
-        return f"{title}\n\n{self.content}"
+
+        prints: list[str] = []
+        content = self.content
+        if isinstance(content, str):
+            prints.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, str):
+                    prints.append(block)
+                elif isinstance(block, dict):
+                    block_type = block.get("type")
+                    if block_type == "text" and "text" in block:
+                        prints.append(block["text"])
+                    elif block_type == "image_url":
+                        img_url = block.get("image_url", {})
+                        if isinstance(img_url, dict) and "url" in img_url:
+                            u = img_url["url"]
+                            u_str = u if isinstance(u, str) else "..."
+                            prints.append(f"[image: {u_str}]")
+                        elif isinstance(img_url, str):
+                            prints.append(f"[image: {img_url}]")
+                        else:
+                            prints.append(str(block))
+                    elif block_type == "image":
+                        if "url" in block:
+                            prints.append(f"[image: {block['url']}]")
+                        elif "base64" in block:
+                            prints.append("[image: base64 data]")
+                        else:
+                            prints.append("[image]")
+                    elif block_type == "video":
+                        if "url" in block:
+                            prints.append(f"[video: {block['url']}]")
+                        elif "base64" in block:
+                            prints.append("[video: base64 data]")
+                        else:
+                            prints.append("[video]")
+                    elif block_type == "audio":
+                        if "url" in block:
+                            prints.append(f"[audio: {block['url']}]")
+                        elif "base64" in block:
+                            prints.append("[audio: base64 data]")
+                        else:
+                            prints.append("[audio]")
+                    elif block_type == "reasoning" and "reasoning" in block:
+                        prints.append(block["reasoning"])
+                    else:
+                        prints.append(str(block))
+                else:
+                    prints.append(str(block))
+        else:
+            prints.append(str(self.content))
+
+        body = "\n".join(prints)
+        return f"{title}\n\n{body}"
 
     def pretty_print(self) -> None:
         """Print a pretty representation of the message.

--- a/libs/core/tests/unit_tests/messages/test_base.py
+++ b/libs/core/tests/unit_tests/messages/test_base.py
@@ -1,0 +1,46 @@
+from langchain_core.messages import AIMessage, HumanMessage
+
+
+def test_pretty_repr_string_content() -> None:
+    msg = HumanMessage(content="What is the capital of France?")
+    repr_str = msg.pretty_repr()
+    assert "Human Message" in repr_str
+    assert "What is the capital of France?" in repr_str
+
+
+def test_pretty_repr_multimodal_content() -> None:
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "What is in this image?"},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.png"},
+            },
+        ]
+    )
+    repr_str = msg.pretty_repr()
+    assert "Human Message" in repr_str
+    assert "What is in this image?" in repr_str
+    assert "[image: https://example.com/image.png]" in repr_str
+    assert "'type': 'text'" not in repr_str  # Ensure raw dict is not printed
+
+
+def test_pretty_repr_all_blocks() -> None:
+    msg = AIMessage(
+        content=[
+            {"type": "text", "text": "Look at these:"},
+            {"type": "image", "url": "https://foo.com/bar.jpg"},
+            {"type": "image", "base64": "ZXhhbXBsZQ=="},
+            {"type": "video", "url": "https://foo.com/video.mp4"},
+            {"type": "audio", "base64": "XYZ="},
+            {"type": "reasoning", "reasoning": "This is a thought process."},
+        ]
+    )
+    repr_str = msg.pretty_repr()
+    assert "Ai Message" in repr_str
+    assert "Look at these:" in repr_str
+    assert "[image: https://foo.com/bar.jpg]" in repr_str
+    assert "[image: base64 data]" in repr_str
+    assert "[video: https://foo.com/video.mp4]" in repr_str
+    assert "[audio: base64 data]" in repr_str
+    assert "This is a thought process." in repr_str


### PR DESCRIPTION
# Description
Fixes #36365

Currently, `BaseMessage.pretty_repr` only handles string content elegantly. When a message contains a list of multimodal content blocks, it defaults to printing the raw python dict payloads, which is difficult for developers to parse during debugging/logging.

This PR iterates through the dicts and cleanly formats textual representations for `text`, `reasoning`, `image`, `image_url`, `video`, and `audio` block types instead.

### Testing
Added three test groups under `tests/unit_tests/messages/test_base.py` to ensure `pretty_repr` accurately handles combinations of `list[str | dict]` layouts without regressions to standard string payloads.

---
*Disclaimer: This contribution was developed with assistance from an AI coding agent.*
