### PR TITLE
fix(core): filter _DirectlyInjectedToolArg params from inferred tool schema (fixes #35931)

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -708,7 +708,16 @@ class ChildTool(BaseTool):
                             )
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
-                result = input_args.model_validate(tool_input)
+                # Strip _DirectlyInjectedToolArg instances (e.g., ToolRuntime) from
+                # the input before Pydantic validation. These are not included in the
+                # schema (filtered by _filter_schema_args) and would cause validation
+                # errors. They are re-added via _injected_args_keys after validation.
+                tool_input_for_validation = {
+                    k: v
+                    for k, v in tool_input.items()
+                    if not isinstance(v, _DirectlyInjectedToolArg)
+                }
+                result = input_args.model_validate(tool_input_for_validation)
                 result_dict = result.model_dump()
             elif issubclass(input_args, BaseModelV1):
                 # Check args_schema for InjectedToolCallId

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -28,6 +28,7 @@ from langchain_core.tools.base import (
     ArgsSchema,
     BaseTool,
     _get_runnable_config_param,
+    _is_directly_injected_arg_type,
     _is_injected_arg_type,
     create_schema_from_function,
 )
@@ -267,5 +268,10 @@ def _filter_schema_args(func: Callable) -> list[str]:
     filter_args = list(FILTERED_ARGS)
     if config_param := _get_runnable_config_param(func):
         filter_args.append(config_param)
-    # filter_args.extend(_get_non_model_params(type_hints))
+    # Filter _DirectlyInjectedToolArg parameters (e.g., ToolRuntime).
+    # These are injected by the framework at runtime and should not be
+    # part of the tool's Pydantic schema or validated by Pydantic.
+    for param_name, param in signature(func).parameters.items():
+        if _is_directly_injected_arg_type(param.annotation):
+            filter_args.append(param_name)
     return filter_args

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3316,6 +3316,62 @@ def test_filter_injected_args_not_in_schema(
     assert "runtime" not in captured
 
 
+@dataclass
+class _DataclassRuntime(_DirectlyInjectedToolArg):
+    """Dataclass runtime injected at tool call time (mirrors ToolRuntime pattern)."""
+
+    data: dict[str, Any]
+
+
+def test_directly_injected_dataclass_arg_with_inferred_schema() -> None:
+    """Regression test: _DirectlyInjectedToolArg dataclasses should not cause
+    Pydantic validation errors when the schema is inferred via @tool.
+
+    The auto-generated schema uses extra='forbid'. Previously, passing a
+    _DirectlyInjectedToolArg instance would fail Pydantic validation because
+    the field appeared in the schema but Pydantic could not validate the
+    dataclass instance (type=dataclass_type error). This test verifies both:
+    1. The arg is filtered from the inferred schema.
+    2. The tool still receives the injected value correctly.
+    """
+
+    @tool
+    def tool_with_dataclass_runtime(
+        query: str, limit: int, runtime: _DataclassRuntime
+    ) -> str:
+        """Tool with a dataclass _DirectlyInjectedToolArg parameter.
+
+        Args:
+            query: The search query.
+            limit: Max results.
+            runtime: Dataclass runtime (directly injected).
+        """
+        assert runtime.data == {"key": "value"}
+        return f"Query: {query}, Limit: {limit}"
+
+    # The inferred schema should not include the directly injected arg
+    schema_fields = tool_with_dataclass_runtime.get_input_schema().model_fields
+    assert "runtime" not in schema_fields
+    assert "query" in schema_fields
+    assert "limit" in schema_fields
+
+    handler = CallbackHandlerWithInputCapture(captured_inputs=[])
+
+    result = tool_with_dataclass_runtime.invoke(
+        {
+            "query": "test",
+            "limit": 5,
+            "runtime": _DataclassRuntime(data={"key": "value"}),
+        },
+        config={"callbacks": [handler]},
+    )
+
+    assert result == "Query: test, Limit: 5"
+    captured = handler.captured_inputs[0]
+    assert captured == {"query": "test", "limit": 5}
+    assert "runtime" not in captured
+
+
 class CallbackHandlerWithToolCallIdCapture(FakeCallbackHandler):
     """Callback handler that captures `tool_call_id` passed to `on_tool_start`.
 


### PR DESCRIPTION
## Summary

Fixes #35931.

When a tool function has a `runtime: ToolRuntime` (or any `_DirectlyInjectedToolArg` subclass) parameter and the schema is **inferred** via `@tool` / `StructuredTool.from_function()`, `ToolNode.invoke()` raises a `pydantic_core.ValidationError`:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for get_current_time
runtime
  Input should be a dictionary or an instance of ToolRuntime [type=dataclass_type, ...]
```

---

## Root Cause

In `structured.py`, `_filter_schema_args` only removes `FILTERED_ARGS` (callback manager args) and `RunnableConfig` params. It does **not** call `_is_directly_injected_arg_type`, so `runtime: ToolRuntime` is included in the generated Pydantic schema as a required field (with `extra="forbid"` from `_SchemaConfig`).

At validation time, `_parse_input` calls `input_args.model_validate(tool_input)` where `tool_input` contains the `ToolRuntime` stdlib `@dataclass` instance. Pydantic v2 raises `ValidationError` because it cannot validate the dataclass value against the `ToolRuntime` field type.

---

## Solution

Two-part fix:

1. **`_filter_schema_args` (`structured.py`)**: iterate the function signature and append any parameter whose annotation satisfies `_is_directly_injected_arg_type` to `filter_args`. This removes `runtime: ToolRuntime` from the inferred schema so it is neither a required field nor validated by Pydantic.

2. **`_parse_input` (`base.py`)**: build `tool_input_for_validation` by filtering out any value that is an instance of `_DirectlyInjectedToolArg` before calling `model_validate`. This prevents the `extra="forbid"` schema from rejecting the runtime value. The existing `_injected_args_keys` loop already re-injects these values after validation.

---

## Testing

- Added `test_directly_injected_dataclass_arg_with_inferred_schema` — uses a `@dataclass _DataclassRuntime(_DirectlyInjectedToolArg)` with the `@tool` decorator (no custom schema, `extra="forbid"` applies), directly reproducing the issue #35931 / langgraph#6431 failure pattern. Does **not** require LangGraph to be installed.
- All 21 related inject/runtime tests pass (sync + async).

---

## Checklist

- [x] Fixes the root cause (not just the symptom)
- [x] New test covers the exact failing scenario from the issue
- [x] All existing related tests pass
- [x] No unrelated changes
- [x] Code style matches project conventions