### PR TITLE
test(langchain): cover runtime recursion limit override in create_agent

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
@@ -284,6 +284,17 @@ def test_tool_runtime_config_access() -> None:
     assert isinstance(tool_message, ToolMessage)
     assert tool_message.content == "Config accessed for 5"
 
+    result = agent.invoke(
+        {"messages": [HumanMessage("Test config again")]},
+        config={"recursion_limit": 7},
+    )
+
+    assert config_data["recursion_limit"] == 7
+
+    tool_message = result["messages"][2]
+    assert isinstance(tool_message, ToolMessage)
+    assert tool_message.content == "Config accessed for 5"
+
 
 def test_tool_runtime_with_custom_state() -> None:
     """Test ToolRuntime works with custom state schemas."""

--- a/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_injected_runtime_create_agent.py
@@ -254,9 +254,10 @@ def test_tool_runtime_config_access() -> None:
         config_data["has_configurable"] = (
             "configurable" in runtime.config if runtime.config else False
         )
-        # Config may have run_id or other fields depending on execution context
         if runtime.config:
             config_data["config_keys"] = list(runtime.config.keys())
+            config_data["recursion_limit"] = runtime.config.get("recursion_limit")
+            config_data["metadata"] = runtime.config.get("metadata")
         return f"Config accessed for {x}"
 
     agent = create_agent(
@@ -270,13 +271,15 @@ def test_tool_runtime_config_access() -> None:
         system_prompt="You are a helpful assistant.",
     )
 
-    result = agent.invoke({"messages": [HumanMessage("Test config")]})
+    result = agent.invoke(
+        {"messages": [HumanMessage("Test config")]},
+    )
 
-    # Verify config was accessible
     assert config_data["config_exists"] is True
     assert "config_keys" in config_data
+    assert config_data["recursion_limit"] == 9999
+    assert config_data["metadata"]["ls_integration"] == "langchain_create_agent"
 
-    # Verify tool executed
     tool_message = result["messages"][2]
     assert isinstance(tool_message, ToolMessage)
     assert tool_message.content == "Config accessed for 5"


### PR DESCRIPTION
Extends the existing  unit test for  to verify that a per-invoke  override is visible inside the tool runtime config. This keeps the coverage in the existing fake-model end-to-end test and exercises both the default config path and the override path in one place.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview) using gpt-5.4 (provider: openai).