### PR TITLE
fix(openai): handle unknown tool names in _consolidate_calls

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/_compat.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_compat.py
@@ -311,7 +311,7 @@ def _consolidate_calls(items: Iterable[dict[str, Any]]) -> Iterator[dict[str, An
                     pass
                 collapsed["type"] = "web_search_call"
 
-            if current.get("name") == "file_search":
+            elif current.get("name") == "file_search":
                 collapsed = {"id": current["id"]}
                 if "args" in current and "queries" in current["args"]:
                     collapsed["queries"] = current["args"]["queries"]
@@ -392,7 +392,7 @@ def _consolidate_calls(items: Iterable[dict[str, Any]]) -> Iterator[dict[str, An
                     if k not in ("server_label", "error"):
                         collapsed[k] = v
             else:
-                pass
+                continue
 
             yield collapsed
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_compat_consolidate_calls.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_compat_consolidate_calls.py
@@ -1,0 +1,44 @@
+from langchain_openai.chat_models._compat import _consolidate_calls
+
+
+def _call(tool_name: str, call_id: str = "call_1") -> dict:
+    return {
+        "type": "server_tool_call",
+        "id": call_id,
+        "name": tool_name,
+        "args": {},
+    }
+
+
+def _result(call_id: str = "call_1", status: str = "success", output=None) -> dict:
+    return {
+        "type": "server_tool_result",
+        "tool_call_id": call_id,
+        "status": status,
+        "output": output or [],
+        "extras": {},
+    }
+
+
+def test_consolidate_calls_unknown_tool_does_not_crash() -> None:
+    chunks = [_call("unknown_tool"), _result()]
+    assert list(_consolidate_calls(chunks)) == []
+
+
+def test_consolidate_calls_web_search_still_yields_result() -> None:
+    chunks = [_call("web_search"), _result()]
+    consolidated = list(_consolidate_calls(chunks))
+    assert len(consolidated) == 1
+    assert consolidated[0]["type"] == "web_search_call"
+
+
+def test_consolidate_calls_known_and_unknown_tools_is_deterministic() -> None:
+    chunks = [
+        _call("unknown_tool", "call_unknown"),
+        _result("call_unknown"),
+        _call("web_search", "call_web"),
+        _result("call_web"),
+    ]
+    consolidated = list(_consolidate_calls(chunks))
+    assert len(consolidated) == 1
+    assert consolidated[0]["type"] == "web_search_call"


### PR DESCRIPTION
## Summary
- fix the broken if/elif dispatch in `_consolidate_calls` by making `file_search` part of the same chain
- skip unknown tool names instead of falling through to `yield collapsed`
- add regression tests for unknown tool names, web_search, and mixed known/unknown tool sequences

## Testing
- uv run --group test pytest tests/unit_tests/chat_models/test_compat_consolidate_calls.py -q

Fixes #35694