### PR TITLE
fix(core): suppress AttributeError from self.profile read in _set_model_profile

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -390,11 +390,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         path. A plain method override does not prevent the base validator from
         running.
         """
-        if self.profile is None:
-            # Suppress errors from partner overrides (e.g., missing profile
-            # files, broken imports) so model construction never fails over an
-            # optional field.
-            with contextlib.suppress(Exception):
+        # Suppress errors from partner overrides (e.g., missing profile
+        # files, broken imports, or custom __getattribute__ raising AttributeError)
+        # so model construction never fails over an optional field.
+        with contextlib.suppress(Exception):
+            if self.profile is None:
                 self.profile = self._resolve_model_profile()
         return self
 


### PR DESCRIPTION
## Problem

`_set_model_profile` crashes when a subclass overrides `__getattribute__` to raise `AttributeError` for the `profile` attribute (or when any property/descriptor raises on access).

The current code places `contextlib.suppress(Exception)` only around the `_resolve_model_profile()` call, but the triggering line `if self.profile is None` is **outside** the suppress block:

```python
# current — crashes before entering suppress
if self.profile is None:
    with contextlib.suppress(Exception):
        self.profile = self._resolve_model_profile()
```

This causes `test_summarization_middleware_missing_profile` to fail with:

```
AttributeError: 'ImportErrorProfileModel' object has no attribute 'profile'
```

because `ImportErrorProfileModel.__getattribute__` raises `AttributeError` for `profile`, which is never caught.

## Fix

Move the guard inside the `suppress` block so errors from both reading and resolving the profile are suppressed:

```python
with contextlib.suppress(Exception):
    if self.profile is None:
        self.profile = self._resolve_model_profile()
```

This does not change any behaviour for the normal case — `self.profile` is a Pydantic field with a plain `None` default, so reading it never throws under normal conditions.

Fixes #36312

## Test plan

- [ ] `test_summarization_middleware_missing_profile` in `tests/unit_tests/agents/middleware/implementations/test_summarization.py` should now pass
- [ ] Existing model profile tests should be unaffected