### PR TITLE
fix(core): preserve `detail` field in convert_to_openai_image_block

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -32,25 +32,22 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
     Returns:
         The formatted image content block.
     """
+    detail = block.get("detail") or block.get("extras", {}).get("detail") or block.get("metadata", {}).get("detail")
     if "url" in block:
-        return {
-            "type": "image_url",
-            "image_url": {
-                "url": block["url"],
-            },
-        }
+        image_url: dict[str, Any] = {"url": block["url"]}
+        if detail:
+            image_url["detail"] = detail
+        return {"type": "image_url", "image_url": image_url}
     if "base64" in block or block.get("source_type") == "base64":
         if "mime_type" not in block:
             error_message = "mime_type key is required for base64 data."
             raise ValueError(error_message)
         mime_type = block["mime_type"]
         base64_data = block["data"] if "data" in block else block["base64"]
-        return {
-            "type": "image_url",
-            "image_url": {
-                "url": f"data:{mime_type};base64,{base64_data}",
-            },
-        }
+        image_url = {"url": f"data:{mime_type};base64,{base64_data}"}
+        if detail:
+            image_url["detail"] = detail
+        return {"type": "image_url", "image_url": image_url}
     error_message = "Unsupported source type. Only 'url' and 'base64' are supported."
     raise ValueError(error_message)
 

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -4,6 +4,7 @@ from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
 from langchain_core.messages import content as types
 from langchain_core.messages.block_translators.openai import (
     convert_to_openai_data_block,
+    convert_to_openai_image_block,
 )
 from tests.unit_tests.language_models.chat_models.test_base import (
     _content_blocks_equal_ignore_id,
@@ -603,3 +604,55 @@ def test_convert_to_openai_data_block() -> None:
     expected = {"type": "input_file", "file_id": "file-abc123"}
     result = convert_to_openai_data_block(block, api="responses")
     assert result == expected
+
+
+def test_convert_to_openai_image_block_preserves_detail() -> None:
+    """detail field must survive the url and base64 conversion paths (GH #36297)."""
+    # URL image with detail at top level
+    block = {"url": "https://example.com/test.png", "detail": "high"}
+    result = convert_to_openai_image_block(block)
+    assert result == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/test.png", "detail": "high"},
+    }
+
+    # base64 image with detail at top level
+    block = {
+        "base64": "abc123==",
+        "mime_type": "image/jpeg",
+        "detail": "low",
+    }
+    result = convert_to_openai_image_block(block)
+    assert result == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/jpeg;base64,abc123==", "detail": "low"},
+    }
+
+    # detail nested under extras
+    block = {"url": "https://example.com/test.png", "extras": {"detail": "auto"}}
+    result = convert_to_openai_image_block(block)
+    assert result["image_url"]["detail"] == "auto"
+
+    # No detail → key must be absent (not None)
+    block = {"url": "https://example.com/test.png"}
+    result = convert_to_openai_image_block(block)
+    assert "detail" not in result["image_url"]
+
+
+def test_convert_to_openai_data_block_image_preserves_detail() -> None:
+    """detail must flow through convert_to_openai_data_block for both APIs (GH #36297)."""
+    # Chat Completions API
+    block = {"type": "image", "url": "https://example.com/test.png", "detail": "high"}
+    result = convert_to_openai_data_block(block)
+    assert result == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/test.png", "detail": "high"},
+    }
+
+    # Responses API — detail is top-level on the input_image dict
+    result_responses = convert_to_openai_data_block(block, api="responses")
+    assert result_responses == {
+        "type": "input_image",
+        "image_url": "https://example.com/test.png",
+        "detail": "high",
+    }


### PR DESCRIPTION
## Summary

Fixes #36297 — `convert_to_openai_image_block` silently drops the `detail` field (`"low"`, `"high"`, `"auto"`) from image content blocks.

**Root cause:** Both the `url` and `base64` branches built `image_url` with only `{"url": ...}`, never forwarding `detail`. The downstream `convert_to_openai_data_block` Responses API path then conditionally copies `detail` from the already-built Chat Completions block — so the field was lost for both API targets.

**Fix:** Extract `detail` from the input block (top-level key → `extras` → `metadata` fallback chain) and conditionally include it in the `image_url` dict.

```python
# Before
return {"type": "image_url", "image_url": {"url": block["url"]}}

# After
detail = block.get("detail") or block.get("extras", {}).get("detail") or block.get("metadata", {}).get("detail")
image_url: dict[str, Any] = {"url": block["url"]}
if detail:
    image_url["detail"] = detail
return {"type": "image_url", "image_url": image_url}
```

The same fix applies to the `base64` branch.

## Test plan

- [x] `test_convert_to_openai_image_block_preserves_detail` — url path, base64 path, extras-nested detail, absent detail
- [x] `test_convert_to_openai_data_block_image_preserves_detail` — Chat Completions API and Responses API
- [ ] Run `pytest libs/core/tests/unit_tests/messages/block_translators/test_openai.py`