### PR TITLE
fix(core): fire on_retry callback in RunnableRetry

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -184,6 +184,8 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         **kwargs: Any,
     ) -> Output:
         for attempt in self._sync_retrying(reraise=True):
+            if attempt.retry_state.attempt_number > 1:
+                run_manager.on_retry(attempt.retry_state)
             with attempt:
                 result = super().invoke(
                     input_,
@@ -208,6 +210,8 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         **kwargs: Any,
     ) -> Output:
         async for attempt in self._async_retrying(reraise=True):
+            if attempt.retry_state.attempt_number > 1:
+                await run_manager.on_retry(attempt.retry_state)
             with attempt:
                 result = await super().ainvoke(
                     input_,
@@ -237,12 +241,15 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         result = not_set
         try:
             for attempt in self._sync_retrying():
+                # Determine which original indices remain.
+                remaining_indices = [
+                    i for i in range(len(inputs)) if i not in results_map
+                ]
+                if attempt.retry_state.attempt_number > 1:
+                    for i in remaining_indices:
+                        run_manager[i].on_retry(attempt.retry_state)
                 with attempt:
                     # Retry for inputs that have not yet succeeded
-                    # Determine which original indices remain.
-                    remaining_indices = [
-                        i for i in range(len(inputs)) if i not in results_map
-                    ]
                     if not remaining_indices:
                         break
                     pending_inputs = [inputs[i] for i in remaining_indices]
@@ -313,12 +320,15 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         result = not_set
         try:
             async for attempt in self._async_retrying():
+                # Determine which original indices remain.
+                remaining_indices = [
+                    i for i in range(len(inputs)) if i not in results_map
+                ]
+                if attempt.retry_state.attempt_number > 1:
+                    for i in remaining_indices:
+                        await run_manager[i].on_retry(attempt.retry_state)
                 with attempt:
                     # Retry for inputs that have not yet succeeded
-                    # Determine which original indices remain.
-                    remaining_indices = [
-                        i for i in range(len(inputs)) if i not in results_map
-                    ]
                     if not remaining_indices:
                         break
                     pending_inputs = [inputs[i] for i in remaining_indices]

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -4044,6 +4044,94 @@ async def test_async_retrying(mocker: MockerFixture) -> None:
     lambda_mock.reset_mock()
 
 
+def test_retry_on_retry_callback() -> None:
+    """Test that on_retry callback fires on each retry attempt."""
+    retry_attempts: list[int] = []
+
+    class RetryHandler(BaseCallbackHandler):
+        def on_retry(self, retry_state: Any, **kwargs: Any) -> Any:  # noqa: ARG002
+            retry_attempts.append(retry_state.attempt_number)
+
+    count = 0
+
+    def flaky(x: int) -> int:
+        nonlocal count
+        count += 1
+        if count < 3:
+            msg = "transient"
+            raise ValueError(msg)
+        return x
+
+    handler = RetryHandler()
+    runnable = RunnableLambda(flaky).with_retry(
+        retry_if_exception_type=(ValueError,),
+        stop_after_attempt=5,
+        wait_exponential_jitter=False,
+    )
+    result = runnable.invoke(1, config={"callbacks": [handler]})
+    assert result == 1
+    # on_retry should fire for attempt 2 and attempt 3
+    assert retry_attempts == [2, 3]
+
+
+async def test_async_retry_on_retry_callback() -> None:
+    """Test that on_retry callback fires on each retry attempt (async)."""
+    retry_attempts: list[int] = []
+
+    class RetryHandler(BaseCallbackHandler):
+        async def on_retry(self, retry_state: Any, **kwargs: Any) -> Any:  # noqa: ARG002
+            retry_attempts.append(retry_state.attempt_number)
+
+    count = 0
+
+    def flaky(x: int) -> int:
+        nonlocal count
+        count += 1
+        if count < 3:
+            msg = "transient"
+            raise ValueError(msg)
+        return x
+
+    handler = RetryHandler()
+    runnable = RunnableLambda(flaky).with_retry(
+        retry_if_exception_type=(ValueError,),
+        stop_after_attempt=5,
+        wait_exponential_jitter=False,
+    )
+    result = await runnable.ainvoke(1, config={"callbacks": [handler]})
+    assert result == 1
+    assert retry_attempts == [2, 3]
+
+
+def test_retry_batch_on_retry_callback() -> None:
+    """Test that on_retry callback fires during batch retries."""
+    retry_attempts: list[int] = []
+
+    class RetryHandler(BaseCallbackHandler):
+        def on_retry(self, retry_state: Any, **kwargs: Any) -> Any:  # noqa: ARG002
+            retry_attempts.append(retry_state.attempt_number)
+
+    first_fail: set[int] = {1}
+
+    def sometimes_fail(x: int) -> int:
+        if x in first_fail:
+            first_fail.remove(x)
+            msg = "fail once"
+            raise ValueError(msg)
+        return x
+
+    handler = RetryHandler()
+    runnable = RunnableLambda(sometimes_fail).with_retry(
+        retry_if_exception_type=(ValueError,),
+        stop_after_attempt=3,
+        wait_exponential_jitter=False,
+    )
+    results = runnable.batch([0, 1, 2], config={"callbacks": [handler]})
+    assert results == [0, 1, 2]
+    # on_retry should fire for the failed input on attempt 2
+    assert retry_attempts == [2]
+
+
 def test_runnable_lambda_stream() -> None:
     """Test that stream works for both normal functions & those returning Runnable."""
     # Normal output should work


### PR DESCRIPTION
Fixes [#36382](https://github.com/langchain-ai/langchain/issues/36382)

This updates `RunnableRetry` to fire the `on_retry` callback for retry attempts in sync,
async, and batch execution paths. It also adds unit tests covering those callback flows so
retry handlers receive the expected attempt metadata.

AI assistance disclaimer: AI tooling was used to help draft and validate this change, and
the final code and PR content were reviewed by the author.

- Added unit tests covering sync `invoke`, async `ainvoke`, and `batch` retry callback
behavior.
- Attempted to run targeted pytest coverage for the new retry callback tests locally, but
the current environment is missing the `blockbuster` test dependency, so I could not complete
the test run in this checkout.

## Important Notes

- This is not a breaking change; it restores expected callback behavior for retries.
- The change is scoped to core, which matches the modified files.
- There is a local modification to libs/core/uv.lock in the working tree that is not part
  of the branch diff against origin/master; do not include it in the PR on purpose.

## Verification Notes

If you want the verification section to claim passing checks instead of the blocked local
run, first install the core test dependencies and rerun the targeted tests from libs/core.