### PR TITLE
fix(langchain): trace create_agent model node callbacks

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1362,7 +1362,7 @@ def create_agent(
         return _build_commands(result.model_response, result.commands)
 
     # Use sync or async based on model capabilities
-    graph.add_node("model", RunnableCallable(model_node, amodel_node, trace=False))
+    graph.add_node("model", RunnableCallable(model_node, amodel_node))
 
     # Only add tools node if we have tools
     if tool_node is not None:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_model_call.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_model_call.py
@@ -12,6 +12,7 @@ from typing import Any
 import pytest
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
+    BaseCallbackHandler,
     CallbackManagerForLLMRun,
 )
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -1461,6 +1462,92 @@ class TestAsyncWrapModelCall:
 
         assert call_log == ["before", "after"]
         assert result["messages"][1].content == "Async response"
+
+
+class TestModelNodeTracing:
+    """Test callback hierarchy for the agent model node."""
+
+    def test_sync_model_callbacks_are_children_of_model_node(self) -> None:
+        """Test sync model callbacks are nested under `model_node` tracing."""
+
+        class TrackingHandler(BaseCallbackHandler):
+            def __init__(self) -> None:
+                self.chain_run_ids: dict[str, str] = {}
+                self.chat_parent_run_ids: list[str | None] = []
+
+            def on_chain_start(
+                self,
+                serialized: dict[str, Any] | None,
+                inputs: dict[str, Any],
+                *,
+                run_id: Any,
+                parent_run_id: Any | None = None,
+                **kwargs: Any,
+            ) -> None:
+                name = kwargs.get("name")
+                if isinstance(name, str):
+                    self.chain_run_ids[name] = str(run_id)
+
+            def on_chat_model_start(
+                self,
+                serialized: dict[str, Any],
+                messages: list[list[BaseMessage]],
+                *,
+                run_id: Any,
+                parent_run_id: Any | None = None,
+                **kwargs: Any,
+            ) -> None:
+                self.chat_parent_run_ids.append(str(parent_run_id) if parent_run_id else None)
+
+        handler = TrackingHandler()
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="Response")]))
+        agent = create_agent(model=model)
+
+        agent.invoke({"messages": [HumanMessage("Test")]}, config={"callbacks": [handler]})
+
+        assert "model_node" in handler.chain_run_ids
+        assert handler.chat_parent_run_ids == [handler.chain_run_ids["model_node"]]
+
+    async def test_async_model_callbacks_are_children_of_model_node(self) -> None:
+        """Test async model callbacks are nested under `model_node` tracing."""
+
+        class TrackingHandler(BaseCallbackHandler):
+            def __init__(self) -> None:
+                self.chain_run_ids: dict[str, str] = {}
+                self.chat_parent_run_ids: list[str | None] = []
+
+            def on_chain_start(
+                self,
+                serialized: dict[str, Any] | None,
+                inputs: dict[str, Any],
+                *,
+                run_id: Any,
+                parent_run_id: Any | None = None,
+                **kwargs: Any,
+            ) -> None:
+                name = kwargs.get("name")
+                if isinstance(name, str):
+                    self.chain_run_ids[name] = str(run_id)
+
+            def on_chat_model_start(
+                self,
+                serialized: dict[str, Any],
+                messages: list[list[BaseMessage]],
+                *,
+                run_id: Any,
+                parent_run_id: Any | None = None,
+                **kwargs: Any,
+            ) -> None:
+                self.chat_parent_run_ids.append(str(parent_run_id) if parent_run_id else None)
+
+        handler = TrackingHandler()
+        model = GenericFakeChatModel(messages=iter([AIMessage(content="Response")]))
+        agent = create_agent(model=model)
+
+        await agent.ainvoke({"messages": [HumanMessage("Test")]}, config={"callbacks": [handler]})
+
+        assert "model_node" in handler.chain_run_ids
+        assert handler.chat_parent_run_ids == [handler.chain_run_ids["model_node"]]
 
 
 class TestSyncAsyncInterop:


### PR DESCRIPTION
Fixes #36395

Enable tracing on the `create_agent` model node by removing `trace=False` so callback hierarchy includes `model_node`. Add sync and async regression tests that verify chat model callbacks are parented under `model_node`.

No breaking changes.

How did you verify your code works?
- `cd libs/langchain_v1 && uv run --group test pytest tests/unit_tests/agents/middleware/core/test_wrap_model_call.py -q`
- `cd libs/langchain_v1 && make test_fast`
- `cd libs/langchain_v1 && make lint`

This PR was prepared with assistance from an AI coding agent; the final diff and validations were reviewed before submission.
