### PR TITLE
ci: tighten top-level release permissions to `contents: read`

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -37,7 +37,7 @@ env:
   UV_NO_SYNC: "true"
 
 permissions:
-  contents: write # Required for creating GitHub releases
+  contents: read # Job-level overrides grant write only where needed (mark-release)
 
 jobs:
   # Build the distribution package and extract version info


### PR DESCRIPTION
Tighten the top-level `permissions` default in the release workflow from `contents: write` to `contents: read`. All 8 jobs already declare their own `permissions` blocks, so this has zero functional impact — but it prevents any future job added without explicit permissions from silently inheriting write access.