### PR TITLE
ci: minimize stale enforcement comments on pr reopen

### DIFF
--- a/.github/workflows/reopen_on_assignment.yml
+++ b/.github/workflows/reopen_on_assignment.yml
@@ -135,4 +135,27 @@ jobs:
               } catch (e) {
                 if (e.status !== 404) throw e;
               }
+
+              // Minimize stale enforcement comment (best-effort;
+              // sync w/ require_issue_link.yml minimize blocks)
+              try {
+                const marker = '<!-- require-issue-link -->';
+                const comments = await github.paginate(
+                  github.rest.issues.listComments,
+                  { owner, repo, issue_number: prNumber, per_page: 100 },
+                );
+                const stale = comments.find(c => c.body && c.body.includes(marker));
+                if (stale) {
+                  await github.graphql(`
+                    mutation($id: ID!) {
+                      minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                        minimizedComment { isMinimized }
+                      }
+                    }
+                  `, { id: stale.node_id });
+                  console.log(`Minimized stale enforcement comment ${stale.id} as outdated`);
+                }
+              } catch (e) {
+                core.warning(`Could not minimize stale comment on PR #${prNumber}: ${e.message}`);
+              }
             }

--- a/.github/workflows/require_issue_link.yml
+++ b/.github/workflows/require_issue_link.yml
@@ -144,6 +144,29 @@ jobs:
               // Add bypass-issue-check so future triggers skip enforcement
               await ensureAndAddLabel('bypass-issue-check', '0e8a16');
 
+              // Minimize stale enforcement comment (best-effort; must not
+              // abort bypass — sync w/ reopen_on_assignment.yml & step below)
+              try {
+                const marker = '<!-- require-issue-link -->';
+                const comments = await github.paginate(
+                  github.rest.issues.listComments,
+                  { owner, repo, issue_number: prNumber, per_page: 100 },
+                );
+                const stale = comments.find(c => c.body && c.body.includes(marker));
+                if (stale) {
+                  await github.graphql(`
+                    mutation($id: ID!) {
+                      minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                        minimizedComment { isMinimized }
+                      }
+                    }
+                  `, { id: stale.node_id });
+                  console.log(`Minimized stale enforcement comment ${stale.id} as outdated`);
+                }
+              } catch (e) {
+                core.warning(`Could not minimize stale comment on PR #${prNumber}: ${e.message}`);
+              }
+
               core.setOutput('has-link', 'true');
               core.setOutput('is-assigned', 'true');
             }
@@ -314,6 +337,29 @@ jobs:
                 state: 'open',
               });
               console.log(`Reopened PR #${prNumber}`);
+            }
+
+            // Minimize stale enforcement comment (best-effort;
+            // sync w/ applyMaintainerBypass above & reopen_on_assignment.yml)
+            try {
+              const marker = '<!-- require-issue-link -->';
+              const comments = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: prNumber, per_page: 100 },
+              );
+              const stale = comments.find(c => c.body && c.body.includes(marker));
+              if (stale) {
+                await github.graphql(`
+                  mutation($id: ID!) {
+                    minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+                      minimizedComment { isMinimized }
+                    }
+                  }
+                `, { id: stale.node_id });
+                console.log(`Minimized stale enforcement comment ${stale.id} as outdated`);
+              }
+            } catch (e) {
+              core.warning(`Could not minimize stale comment on PR #${prNumber}: ${e.message}`);
             }
 
       - name: Post comment, close PR, and fail


### PR DESCRIPTION
When the `require_issue_link` workflow closes a PR and posts an enforcement comment, that comment was never cleaned up after the situation resolved — leaving a stale "automatically closed" message visible on reopened PRs. Now all three resolution paths (maintainer bypass, author fixing the issue link, and contributor assignment) minimize the enforcement comment as outdated via GraphQL. The cleanup is best-effort: failures log a warning but never block the primary workflow logic (label removal, bypass, reopen).