### PR TITLE
fix(langchain): route back to model when return_direct tool call fails

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1794,7 +1794,7 @@ def _make_tools_to_model_edge(
         if last_ai_message is None:
             return model_destination
 
-        # 2. Exit condition: All executed tools have return_direct=True
+        # 2. Exit condition: All executed tools have return_direct=True and succeeded
         # Filter to only client-side tools (provider tools are not in tool_node)
         client_side_tool_calls = [
             c for c in last_ai_message.tool_calls if c["name"] in tool_node.tools_by_name
@@ -1802,7 +1802,21 @@ def _make_tools_to_model_edge(
         if client_side_tool_calls and all(
             tool_node.tools_by_name[c["name"]].return_direct for c in client_side_tool_calls
         ):
-            return end_destination
+            # Build a lookup from tool_call_id to its ToolMessage status so we can
+            # check whether every return_direct call actually succeeded.
+            client_side_ids = {c["id"] for c in client_side_tool_calls}
+            tool_message_status = {
+                m.tool_call_id: m.status
+                for m in tool_messages
+                if m.tool_call_id in client_side_ids
+            }
+            # Only exit when every return_direct tool call succeeded; route back to
+            # the model on any error so it can retry or handle the failure.
+            if all(
+                c["id"] is not None and tool_message_status.get(c["id"]) == "success"
+                for c in client_side_tool_calls
+            ):
+                return end_destination
 
         # 3. Exit condition: A structured output tool was executed
         if any(t.name in structured_output_tools for t in tool_messages):

--- a/libs/langchain_v1/tests/unit_tests/agents/test_return_direct_graph.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_return_direct_graph.py
@@ -1,6 +1,7 @@
-"""Tests for return_direct tool graph structure."""
+"""Tests for return_direct tool graph structure and routing behavior."""
 
-from langchain_core.tools import tool
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import StructuredTool, ToolException, tool
 from syrupy.assertion import SnapshotAssertion
 
 from langchain.agents.factory import create_agent
@@ -70,3 +71,69 @@ def test_agent_graph_with_mixed_tools(snapshot: SnapshotAssertion) -> None:
     # because at least one tool has return_direct=True
     mermaid_diagram = agent.get_graph().draw_mermaid()
     assert mermaid_diagram == snapshot
+
+
+def test_return_direct_tool_success_terminates() -> None:
+    """When a return_direct=True tool succeeds, the agent should exit immediately."""
+
+    @tool(return_direct=True)
+    def my_tool(x: str) -> str:
+        """Return input directly."""
+        return f"ok: {x}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"name": "my_tool", "args": {"x": "hello"}, "id": "c1", "type": "tool_call"}],
+        ]
+    )
+    agent = create_agent(model, tools=[my_tool], system_prompt="You are a helpful assistant.")
+    result = agent.invoke({"messages": [HumanMessage("run it")]})
+
+    # The last message must be the ToolMessage (agent exited after tool success)
+    assert isinstance(result["messages"][-1], ToolMessage)
+    assert result["messages"][-1].status == "success"
+    # Model was only invoked once (no retry loop)
+    assert model.index == 1
+
+
+def test_return_direct_tool_error_routes_to_model() -> None:
+    """When a return_direct=True tool fails, the agent should route back to the model.
+
+    The error ToolMessage should be passed to the model so it can retry or
+    handle the failure, instead of the agent terminating silently with an error.
+    """
+
+    def _failing_impl(x: str) -> str:
+        msg = "something went wrong"
+        raise ToolException(msg)
+
+    failing_tool = StructuredTool.from_function(
+        func=_failing_impl,
+        name="failing_tool",
+        description="A tool that always fails.",
+        return_direct=True,
+        handle_tool_error=True,
+    )
+
+    # Round 1: model calls the tool; round 2: model produces a final text reply
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"name": "failing_tool", "args": {"x": "hi"}, "id": "c1", "type": "tool_call"}],
+            [],
+        ]
+    )
+    agent = create_agent(
+        model, tools=[failing_tool], system_prompt="You are a helpful assistant."
+    )
+    result = agent.invoke({"messages": [HumanMessage("run it")]})
+
+    # The final message must be an AIMessage, not the error ToolMessage
+    assert isinstance(result["messages"][-1], AIMessage)
+
+    # The error ToolMessage should be present in the history with status="error"
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].status == "error"
+
+    # Model was invoked twice: once to call the tool, once after the error
+    assert model.index == 2


### PR DESCRIPTION
## Summary

- `_make_tools_to_model_edge` in `libs/langchain_v1/langchain/agents/factory.py` decides whether to exit the agent loop after tool execution.
- The `return_direct` exit condition (checking `tool.return_direct` on the tool definition) ignored whether the tool call actually *succeeded*, causing the agent to terminate silently when a `return_direct=True` tool produced a `ToolMessage` with `status="error"`.
- This PR adds a status check: the agent only exits when **all** `return_direct` tool calls produced `status="success"` ToolMessages; on any error it routes back to the model.

## Why this fix is correct

`ToolMessage.status` (`Literal["success", "error"]`) is already populated by `langchain-core`'s `BaseTool.run` / `arun` on failure and by `ToolNode`'s error handler. No new fields or changes outside `factory.py` are required.

## Changes

| File | Change |
|------|--------|
| `libs/langchain_v1/langchain/agents/factory.py` | Added status check inside the `return_direct` exit condition in `_make_tools_to_model_edge` |
| `libs/langchain_v1/tests/unit_tests/agents/test_return_direct_graph.py` | Added `test_return_direct_tool_success_terminates` and `test_return_direct_tool_error_routes_to_model` unit tests |

## Areas requiring careful review

- The `c["id"] is not None` guard: tool call IDs should always be set in practice, but the type system allows `None`; the guard ensures we never accidentally treat a missing ID as a match.
- The `tool_message_status` lookup is built only from ToolMessages whose `tool_call_id` is in `client_side_ids`, so provider-side tool results are not considered (consistent with how the surrounding code filters on `tool_node.tools_by_name`).

Closes #36411

---
> This PR was authored with AI assistance (Claude Code). The logic, tests, and review decisions were made by the contributor.