### PR TITLE
fix(core): fire on_retry callback in RunnableRetry for all execution paths

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -192,6 +192,8 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                 )
             if attempt.retry_state.outcome and not attempt.retry_state.outcome.failed:
                 attempt.retry_state.set_result(result)
+            elif attempt.retry_state.outcome and attempt.retry_state.outcome.failed:
+                run_manager.on_retry(attempt.retry_state)
         return result
 
     @override
@@ -216,6 +218,8 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                 )
             if attempt.retry_state.outcome and not attempt.retry_state.outcome.failed:
                 attempt.retry_state.set_result(result)
+            elif attempt.retry_state.outcome and attempt.retry_state.outcome.failed:
+                await run_manager.on_retry(attempt.retry_state)
         return result
 
     @override
@@ -275,6 +279,9 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     and not attempt.retry_state.outcome.failed
                 ):
                     attempt.retry_state.set_result(result)
+                elif attempt.retry_state.outcome and attempt.retry_state.outcome.failed:
+                    for rm in run_manager:
+                        rm.on_retry(attempt.retry_state)
         except RetryError as e:
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))
@@ -350,6 +357,9 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     and not attempt.retry_state.outcome.failed
                 ):
                     attempt.retry_state.set_result(result)
+                elif attempt.retry_state.outcome and attempt.retry_state.outcome.failed:
+                    for rm in run_manager:
+                        await rm.on_retry(attempt.retry_state)
         except RetryError as e:
             if result is not_set:
                 result = cast("list[Output]", [e] * len(inputs))

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -4044,6 +4044,144 @@ async def test_async_retrying(mocker: MockerFixture) -> None:
     lambda_mock.reset_mock()
 
 
+def test_retry_fires_on_retry_callback() -> None:
+    """on_retry callback should fire for every failed retry attempt (sync)."""
+    from tenacity import RetryCallState
+
+    retry_attempt_numbers: list[int] = []
+
+    class RetryLogger(BaseCallbackHandler):
+        def on_retry(
+            self, retry_state: RetryCallState, **kwargs: Any
+        ) -> None:
+            retry_attempt_numbers.append(retry_state.attempt_number)
+
+    count = 0
+
+    def flaky(x: int) -> int:
+        nonlocal count
+        count += 1
+        if count < 3:
+            msg = "transient"
+            raise ValueError(msg)
+        return x
+
+    runnable = RunnableLambda(flaky).with_retry(
+        retry_if_exception_type=(ValueError,),
+        stop_after_attempt=5,
+        wait_exponential_jitter=False,
+    )
+
+    result = runnable.invoke(1, config={"callbacks": [RetryLogger()]})
+    assert result == 1
+    # 2 failures before success → 2 on_retry calls
+    assert len(retry_attempt_numbers) == 2
+    assert retry_attempt_numbers[0] == 1
+    assert retry_attempt_numbers[1] == 2
+
+
+async def test_async_retry_fires_on_retry_callback() -> None:
+    """on_retry callback should fire for every failed retry attempt (async)."""
+    from tenacity import RetryCallState
+
+    retry_attempt_numbers: list[int] = []
+
+    class RetryLogger(BaseCallbackHandler):
+        async def on_retry(
+            self, retry_state: RetryCallState, **kwargs: Any
+        ) -> None:
+            retry_attempt_numbers.append(retry_state.attempt_number)
+
+    count = 0
+
+    def flaky(x: int) -> int:
+        nonlocal count
+        count += 1
+        if count < 3:
+            msg = "transient"
+            raise ValueError(msg)
+        return x
+
+    runnable = RunnableLambda(flaky).with_retry(
+        retry_if_exception_type=(ValueError,),
+        stop_after_attempt=5,
+        wait_exponential_jitter=False,
+    )
+
+    result = await runnable.ainvoke(1, config={"callbacks": [RetryLogger()]})
+    assert result == 1
+    assert len(retry_attempt_numbers) == 2
+    assert retry_attempt_numbers[0] == 1
+    assert retry_attempt_numbers[1] == 2
+
+
+def test_retry_batch_fires_on_retry_callback() -> None:
+    """on_retry callback should fire during batch retries (sync)."""
+    from tenacity import RetryCallState
+
+    retry_states: list[RetryCallState] = []
+
+    class RetryLogger(BaseCallbackHandler):
+        def on_retry(
+            self, retry_state: RetryCallState, **kwargs: Any
+        ) -> None:
+            retry_states.append(retry_state)
+
+    fail_once: set[int] = {1}
+
+    def sometimes_fail(x: int) -> int:
+        if x in fail_once:
+            fail_once.remove(x)
+            msg = "fail once"
+            raise ValueError(msg)
+        return x
+
+    runnable = RunnableLambda(sometimes_fail).with_retry(
+        retry_if_exception_type=(ValueError,),
+        stop_after_attempt=3,
+        wait_exponential_jitter=False,
+    )
+
+    results = runnable.batch([0, 1, 2], config={"callbacks": [RetryLogger()]})
+    assert results == [0, 1, 2]
+    # At least one on_retry should have fired for the failed attempt
+    assert len(retry_states) >= 1
+
+
+async def test_async_retry_batch_fires_on_retry_callback() -> None:
+    """on_retry callback should fire during batch retries (async)."""
+    from tenacity import RetryCallState
+
+    retry_states: list[RetryCallState] = []
+
+    class RetryLogger(BaseCallbackHandler):
+        async def on_retry(
+            self, retry_state: RetryCallState, **kwargs: Any
+        ) -> None:
+            retry_states.append(retry_state)
+
+    fail_once: set[int] = {1}
+
+    def sometimes_fail(x: int) -> int:
+        if x in fail_once:
+            fail_once.remove(x)
+            msg = "fail once"
+            raise ValueError(msg)
+        return x
+
+    runnable = RunnableLambda(sometimes_fail).with_retry(
+        retry_if_exception_type=(ValueError,),
+        stop_after_attempt=3,
+        wait_exponential_jitter=False,
+    )
+
+    results = await runnable.abatch(
+        [0, 1, 2], config={"callbacks": [RetryLogger()]}
+    )
+    assert results == [0, 1, 2]
+    assert len(retry_states) >= 1
+
+
 def test_runnable_lambda_stream() -> None:
     """Test that stream works for both normal functions & those returning Runnable."""
     # Normal output should work


### PR DESCRIPTION
## Why

RunnableRetry wraps tenacity's retry loop but never calls un_manager.on_retry() after a failed attempt. This means any BaseCallbackHandler that implements on_retry receives no signal, making it impossible to observe or log individual retry attempts via the standard callback interface.

Fixes #36382

## What changed

libs/core/langchain_core/runnables/retry.py — after each failed tenacity attempt (detected via ttempt.retry_state.outcome.failed), the appropriate on_retry method is called on the run manager in all four execution paths:

| Method | Change |
|---|---|
| _invoke | calls un_manager.on_retry(retry_state) |
| _ainvoke | calls wait run_manager.on_retry(retry_state) |
| _batch | calls m.on_retry(retry_state) for each run manager |
| _abatch | calls wait rm.on_retry(retry_state) for each run manager |

No public API changes. No new parameters. Fully backward compatible.

## Tests

Four new unit tests added to 	est_runnable.py:
- 	est_retry_fires_on_retry_callback — sync invoke, 2 failures then success, verifies 2 on_retry calls with correct attempt numbers
- 	est_async_retry_fires_on_retry_callback — async invoke, same scenario
- 	est_retry_batch_fires_on_retry_callback — sync batch with one failing element, verifies on_retry fires
- 	est_async_retry_batch_fires_on_retry_callback — async batch, same scenario

All 8 relevant tests (4 new + 4 existing retry tests) pass.

## Areas requiring careful review

- The outcome.failed check runs outside the with attempt: block. After a successful attempt, tenacity sets outcome to a non-failed result before we check — so the elif branch will not fire on success. This is correct, but worth confirming against tenacity's internal state machine.

## AI disclosure

This PR was developed with AI assistance. I have reviewed every line of the fix and the tests, understand the root cause, and verified all tests pass locally.