### PR TITLE
fix(core): forward detail field in convert_to_openai_image_block

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -32,12 +32,20 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
     Returns:
         The formatted image content block.
     """
+    # Resolve optional detail field: top-level wins, then extras, then metadata.
+    detail = (
+        block.get("detail")
+        or (block.get("extras") or {}).get("detail")
+        or (block.get("metadata") or {}).get("detail")
+    )
+
     if "url" in block:
+        image_url: dict[str, Any] = {"url": block["url"]}
+        if detail:
+            image_url["detail"] = detail
         return {
             "type": "image_url",
-            "image_url": {
-                "url": block["url"],
-            },
+            "image_url": image_url,
         }
     if "base64" in block or block.get("source_type") == "base64":
         if "mime_type" not in block:
@@ -45,11 +53,12 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
             raise ValueError(error_message)
         mime_type = block["mime_type"]
         base64_data = block["data"] if "data" in block else block["base64"]
+        image_url = {"url": f"data:{mime_type};base64,{base64_data}"}
+        if detail:
+            image_url["detail"] = detail
         return {
             "type": "image_url",
-            "image_url": {
-                "url": f"data:{mime_type};base64,{base64_data}",
-            },
+            "image_url": image_url,
         }
     error_message = "Unsupported source type. Only 'url' and 'base64' are supported."
     raise ValueError(error_message)

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -603,3 +603,182 @@ def test_convert_to_openai_data_block() -> None:
     expected = {"type": "input_file", "file_id": "file-abc123"}
     result = convert_to_openai_data_block(block, api="responses")
     assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Tests for detail field forwarding (regression for #36297)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"type": "image", "url": "https://example.com/img.png", "detail": "high"},
+        {
+            "type": "image",
+            "url": "https://example.com/img.png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "url": "https://example.com/img.png",
+            "metadata": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://example.com/img.png",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://example.com/img.png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "url",
+            "url": "https://example.com/img.png",
+            "metadata": {"detail": "high"},
+        },
+    ],
+)
+def test_convert_to_openai_image_block_url_preserves_detail(block: dict) -> None:
+    """convert_to_openai_image_block must forward detail for URL-based images."""
+    from langchain_core.messages.block_translators.openai import (
+        convert_to_openai_image_block,
+    )
+
+    result = convert_to_openai_image_block(block)
+    assert result == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/img.png", "detail": "high"},
+    }
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {
+            "type": "image",
+            "base64": "<b64>",
+            "mime_type": "image/jpeg",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "base64": "<b64>",
+            "mime_type": "image/jpeg",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "base64": "<b64>",
+            "mime_type": "image/jpeg",
+            "metadata": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<b64>",
+            "mime_type": "image/jpeg",
+            "detail": "high",
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<b64>",
+            "mime_type": "image/jpeg",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "source_type": "base64",
+            "data": "<b64>",
+            "mime_type": "image/jpeg",
+            "metadata": {"detail": "high"},
+        },
+    ],
+)
+def test_convert_to_openai_image_block_base64_preserves_detail(block: dict) -> None:
+    """convert_to_openai_image_block must forward detail for base64 images."""
+    from langchain_core.messages.block_translators.openai import (
+        convert_to_openai_image_block,
+    )
+
+    result = convert_to_openai_image_block(block)
+    assert result == {
+        "type": "image_url",
+        "image_url": {
+            "url": "data:image/jpeg;base64,<b64>",
+            "detail": "high",
+        },
+    }
+
+
+def test_convert_to_openai_image_block_no_detail_omitted() -> None:
+    """When no detail is supplied, the detail key must not appear in output."""
+    from langchain_core.messages.block_translators.openai import (
+        convert_to_openai_image_block,
+    )
+
+    result = convert_to_openai_image_block(
+        {"type": "image", "url": "https://example.com/img.png"}
+    )
+    assert "detail" not in result["image_url"]
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"type": "image", "url": "https://example.com/img.png", "detail": "high"},
+        {
+            "type": "image",
+            "url": "https://example.com/img.png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "url": "https://example.com/img.png",
+            "metadata": {"detail": "high"},
+        },
+    ],
+)
+def test_convert_to_openai_data_block_chat_completions_preserves_detail(
+    block: dict,
+) -> None:
+    """convert_to_openai_data_block (Chat Completions) must include detail."""
+    result = convert_to_openai_data_block(block)
+    assert result == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/img.png", "detail": "high"},
+    }
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        {"type": "image", "url": "https://example.com/img.png", "detail": "high"},
+        {
+            "type": "image",
+            "url": "https://example.com/img.png",
+            "extras": {"detail": "high"},
+        },
+        {
+            "type": "image",
+            "url": "https://example.com/img.png",
+            "metadata": {"detail": "high"},
+        },
+    ],
+)
+def test_convert_to_openai_data_block_responses_preserves_detail(
+    block: dict,
+) -> None:
+    """convert_to_openai_data_block (Responses API) must include detail."""
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == {
+        "type": "input_image",
+        "image_url": "https://example.com/img.png",
+        "detail": "high",
+    }


### PR DESCRIPTION
## Why

convert_to_openai_image_block constructs the image_url dict with only the url key, silently dropping any detail field present in the input block. Since convert_to_openai_data_block delegates to convert_to_openai_image_block and checks chat_completions_block['image_url'].get('detail') to forward detail to the Responses API format, the detail field was lost for **both** the Chat Completions API and the Responses API.

The detail parameter controls image analysis resolution ('low', 'high', 'auto') and is documented by OpenAI. Silently dropping it causes models to silently fall back to their default behavior, which may result in lower-quality or more expensive image analysis than the caller intended.

Fixes #36297

## What changed

**libs/core/langchain_core/messages/block_translators/openai.py**

In convert_to_openai_image_block: resolve detail from the input block (top-level → extras → metadata for backwards compat, following the existing pattern used throughout the file for ilename) and include it in the constructed image_url dict when present. No change needed in convert_to_openai_data_block — it already forwards detail from the inner dict.

No public API changes. Fully backward compatible.

## Tests

19 new parametrized unit tests in 	est_openai.py:

| Test | Coverage |
|---|---|
| 	est_convert_to_openai_image_block_url_preserves_detail | 6 cases: URL source × {top-level, extras, metadata} × {with/without source_type} |
| 	est_convert_to_openai_image_block_base64_preserves_detail | 6 cases: base64 source × {top-level, extras, metadata} × {legacy ase64 key, source_type=base64} |
| 	est_convert_to_openai_image_block_no_detail_omitted | detail key absent when not supplied |
| 	est_convert_to_openai_data_block_chat_completions_preserves_detail | 3 cases: Chat Completions API end-to-end |
| 	est_convert_to_openai_data_block_responses_preserves_detail | 3 cases: Responses API end-to-end |

All 19 pass. All pre-existing tests in the file continue to pass.

## Areas requiring review

- The detail resolution chain uses or short-circuit: lock.get('detail') or (block.get('extras') or {}).get('detail') or (block.get('metadata') or {}).get('detail'). This matches the existing pattern for ilename lookup in convert_to_openai_data_block for file blocks. If detail could ever be a falsy value (it can't per OpenAI spec — valid values are 'low', 'high', 'auto'), an explicit is not None check would be safer, but this mirrors existing style.

## AI disclosure

This PR was developed with AI assistance. I have reviewed every line of the fix and the tests, understand the root cause, and verified all tests pass locally.