### PR TITLE
fix(agents): propagate config to model_.ainvoke in agent model nodes

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1327,7 +1327,7 @@ def create_agent(
         if request.system_message:
             messages = [request.system_message, *messages]
 
-        output = await model_.ainvoke(messages)
+        output = await model_.ainvoke(messages, config=request.config)
         if name:
             output.name = name
 
@@ -1352,6 +1352,7 @@ def create_agent(
             tool_choice=None,
             state=state,
             runtime=runtime,
+            config = runtime.config,
         )
 
         if awrap_model_call_handler is None:

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -101,6 +101,7 @@ class ModelRequest(Generic[ContextT]):
     response_format: ResponseFormat[Any] | None
     state: AgentState[Any]
     runtime: Runtime[ContextT]
+    config: Optional[RunnableConfig] = None
     model_settings: dict[str, Any] = field(default_factory=dict)
 
     def __init__(


### PR DESCRIPTION
Fixes #36393

Propagate `RunnableConfig` to `model_.ainvoke()` in agent model nodes so callbacks are not dropped during execution. This ensures tracing and callback handlers work correctly for agent-based and nested LangGraph workflows.

## How did you verify your code works?

- Added a temporary `CallbackHandler` and confirmed `on_llm_start` / `on_llm_end` are triggered for agent LLM calls  
- Verified that `request.config` is populated from `runtime.config`  
- Tested with nested agents (subgraphs) to ensure callback propagation works end-to-end  
- Confirmed no regression in existing agent execution paths  