### PR TITLE
fix(langchain): clarify Y/N verdict semantics in criteria evaluation prompts

### DIFF
--- a/libs/langchain/langchain_classic/evaluation/criteria/prompt.py
+++ b/libs/langchain/langchain_classic/evaluation/criteria/prompt.py
@@ -12,7 +12,7 @@ template = """You are assessing a submitted answer on a given task or input base
 [Criteria]: {criteria}
 ***
 [END DATA]
-Does the submission meet the Criteria? First, write out in a step by step manner your reasoning about each criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line corresponding to the correct answer of whether the submission meets all criteria. At the end, repeat just the letter again by itself on a new line."""  # noqa: E501
+Does the submission meet the Criteria? First, write out in a step by step manner your reasoning about each criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line as your verdict: print "Y" if and only if the submission meets all criteria, print "N" if the submission does not meet all criteria. Your verdict must be consistent with your reasoning. At the end, repeat just the letter again by itself on a new line."""  # noqa: E501
 
 PROMPT = PromptTemplate(
     input_variables=["input", "output", "criteria"], template=template
@@ -30,7 +30,7 @@ template = """You are assessing a submitted answer on a given task or input base
 [Reference]: {reference}
 ***
 [END DATA]
-Does the submission meet the Criteria? First, write out in a step by step manner your reasoning about each criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line corresponding to the correct answer of whether the submission meets all criteria. At the end, repeat just the letter again by itself on a new line."""  # noqa: E501
+Does the submission meet the Criteria? First, write out in a step by step manner your reasoning about each criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line as your verdict: print "Y" if and only if the submission meets all criteria, print "N" if the submission does not meet all criteria. Your verdict must be consistent with your reasoning. At the end, repeat just the letter again by itself on a new line."""  # noqa: E501
 
 PROMPT_WITH_REFERENCES = PromptTemplate(
     input_variables=["input", "output", "criteria", "reference"], template=template

--- a/libs/langchain/tests/unit_tests/evaluation/criteria/test_eval_chain.py
+++ b/libs/langchain/tests/unit_tests/evaluation/criteria/test_eval_chain.py
@@ -97,5 +97,41 @@ def test_criteria_eval_chain_missing_reference() -> None:
         chain.evaluate_strings(prediction="my prediction", input="my input")
 
 
+def test_labeled_criteria_eval_chain() -> None:
+    """Test that LabeledCriteriaEvalChain correctly parses Y/N verdicts."""
+    chain = LabeledCriteriaEvalChain.from_llm(
+        llm=FakeLLM(
+            queries={"text": "The submission does not meet the criteria.\nN"},
+            sequential_responses=True,
+        ),
+        criteria={"correctness": "Is the submission correct?"},
+    )
+    result = chain.evaluate_strings(
+        prediction="my prediction",
+        reference="my reference",
+        input="my input",
+    )
+    assert result["value"] == "N"
+    assert result["score"] == 0
+
+
+def test_labeled_criteria_eval_chain_passing() -> None:
+    """Test that LabeledCriteriaEvalChain scores Y as 1."""
+    chain = LabeledCriteriaEvalChain.from_llm(
+        llm=FakeLLM(
+            queries={"text": "The submission meets the criteria.\nY"},
+            sequential_responses=True,
+        ),
+        criteria={"correctness": "Is the submission correct?"},
+    )
+    result = chain.evaluate_strings(
+        prediction="my prediction",
+        reference="my reference",
+        input="my input",
+    )
+    assert result["value"] == "Y"
+    assert result["score"] == 1
+
+
 def test_implements_string_protocol() -> None:
     assert issubclass(CriteriaEvalChain, StringEvaluator)


### PR DESCRIPTION
Fixes #31870

The criteria evaluation prompts (`PROMPT` and `PROMPT_WITH_REFERENCES`) were ambiguous about what Y and N mean as verdict characters. This caused some LLMs to output a verdict inconsistent with their own reasoning — for example, the reasoning would conclude the submission does not meet the criteria, but the LLM would still output "Y" (score: 1).

Updated both prompt templates to explicitly state:
- "Y" means the submission **meets** all criteria
- "N" means it **does not** meet all criteria
- The verdict **must be consistent** with the reasoning

Also added unit tests for `LabeledCriteriaEvalChain` covering both passing and failing evaluation scenarios.

Verified by running `make test` in `libs/langchain` — all 23 criteria evaluation tests pass.