### PR TITLE
fix(core): improve validation error messages with tool name and field details

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -985,7 +985,9 @@ class ChildTool(BaseTool):
             if not self.handle_validation_error:
                 error_to_raise = e
             else:
-                content = _handle_validation_error(e, flag=self.handle_validation_error)
+                content = _handle_validation_error(
+                    e, flag=self.handle_validation_error, tool_name=self.name,
+                )
                 status = "error"
         except ToolException as e:
             if not self.handle_tool_error:
@@ -1115,7 +1117,9 @@ class ChildTool(BaseTool):
             if not self.handle_validation_error:
                 error_to_raise = e
             else:
-                content = _handle_validation_error(e, flag=self.handle_validation_error)
+                content = _handle_validation_error(
+                    e, flag=self.handle_validation_error, tool_name=self.name,
+                )
                 status = "error"
         except ToolException as e:
             if not self.handle_tool_error:
@@ -1147,16 +1151,38 @@ def _is_tool_call(x: Any) -> bool:
     return isinstance(x, dict) and x.get("type") == "tool_call"
 
 
+def _format_validation_errors(
+    e: ValidationError | ValidationErrorV1,
+) -> str:
+    """Build a human-readable summary of individual validation errors.
+
+    Args:
+        e: The validation error to format.
+
+    Returns:
+        A multi-line string describing each validation error.
+    """
+    if isinstance(e, ValidationError):
+        parts: list[str] = []
+        for err in e.errors():
+            loc = " -> ".join(str(l) for l in err["loc"]) if err["loc"] else "<root>"
+            parts.append(f"  Field: {loc}, Error: {err['msg']}")
+        return "\n".join(parts)
+    return str(e)
+
+
 def _handle_validation_error(
     e: ValidationError | ValidationErrorV1,
     *,
     flag: Literal[True] | str | Callable[[ValidationError | ValidationErrorV1], str],
+    tool_name: str | None = None,
 ) -> str:
     """Handle validation errors based on the configured flag.
 
     Args:
         e: The validation error that occurred.
         flag: How to handle the error (`bool`, `str`, or `Callable`).
+        tool_name: The name of the tool that raised the error.
 
     Returns:
         The error message to return.
@@ -1165,7 +1191,12 @@ def _handle_validation_error(
         ValueError: If the flag type is unexpected.
     """
     if isinstance(flag, bool):
-        content = "Tool input validation error"
+        prefix = (
+            f"Validation error in tool '{tool_name}'" if tool_name
+            else "Tool input validation error"
+        )
+        details = _format_validation_errors(e)
+        content = f"{prefix}:\n{details}"
     elif isinstance(flag, str):
         content = flag
     elif callable(flag):

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -882,10 +882,10 @@ def test_structured_tool_from_function() -> None:
 
 def test_validation_error_handling_bool() -> None:
     """Test that validation errors are handled correctly."""
-    expected = "Tool input validation error"
     tool_ = _MockStructuredTool(handle_validation_error=True)
     actual = tool_.run({})
-    assert expected == actual
+    assert "Validation error in tool 'structured_api'" in actual
+    assert "Field:" in actual
 
 
 def test_validation_error_handling_str() -> None:
@@ -948,10 +948,10 @@ def test_validation_error_handling_non_validation_error(
 
 async def test_async_validation_error_handling_bool() -> None:
     """Test that validation errors are handled correctly."""
-    expected = "Tool input validation error"
     tool_ = _MockStructuredTool(handle_validation_error=True)
     actual = await tool_.arun({})
-    assert expected == actual
+    assert "Validation error in tool 'structured_api'" in actual
+    assert "Field:" in actual
 
 
 async def test_async_validation_error_handling_str() -> None:
@@ -3653,3 +3653,87 @@ def test_tool_default_factory_not_required() -> None:
     schema = convert_to_openai_tool(some_func)
     params = schema["function"]["parameters"]
     assert "names" not in params.get("required", [])
+
+
+class TestValidationErrorMessages:
+    """Tests that validation error messages are detailed and actionable."""
+
+    def _make_tool(self) -> BaseTool:
+        class _StrictSchema(BaseModel):
+            name: str
+            age: int = Field(gt=0, le=150)
+
+        class _StrictTool(BaseTool):
+            name: str = "strict_tool"
+            description: str = "A tool with strict validation"
+            args_schema: type[BaseModel] = _StrictSchema
+
+            @override
+            def _run(self, *, name: str, age: int) -> str:
+                return f"{name} is {age}"
+
+        return _StrictTool(handle_validation_error=True)
+
+    @pytest.mark.parametrize(
+        ("tool_input", "expected_fragment"),
+        [
+            pytest.param(
+                {"age": 25},
+                "name",
+                id="missing_required_field",
+            ),
+            pytest.param(
+                {"name": "Alice", "age": "not_a_number"},
+                "age",
+                id="wrong_type",
+            ),
+            pytest.param(
+                {"name": "Alice", "age": -1},
+                "age",
+                id="constraint_violation",
+            ),
+        ],
+    )
+    def test_validation_error_message_content(
+        self,
+        tool_input: dict,
+        expected_fragment: str,
+    ) -> None:
+        """Validation error messages must name the tool and the failing field."""
+        tool_ = self._make_tool()
+        result = tool_.run(tool_input)
+        assert "Validation error in tool 'strict_tool'" in result
+        assert f"Field:" in result
+        assert expected_fragment in result
+
+    @pytest.mark.parametrize(
+        ("tool_input", "expected_fragment"),
+        [
+            pytest.param(
+                {"age": 25},
+                "name",
+                id="missing_required_field",
+            ),
+            pytest.param(
+                {"name": "Alice", "age": "not_a_number"},
+                "age",
+                id="wrong_type",
+            ),
+            pytest.param(
+                {"name": "Alice", "age": -1},
+                "age",
+                id="constraint_violation",
+            ),
+        ],
+    )
+    async def test_async_validation_error_message_content(
+        self,
+        tool_input: dict,
+        expected_fragment: str,
+    ) -> None:
+        """Async path should produce the same detailed messages."""
+        tool_ = self._make_tool()
+        result = await tool_.arun(tool_input)
+        assert "Validation error in tool 'strict_tool'" in result
+        assert f"Field:" in result
+        assert expected_fragment in result


### PR DESCRIPTION
## Summary
- Replaces the generic `"Tool input validation error"` message with structured output that includes the tool name and per-field error details (field location + error description).
- Adds `_format_validation_errors()` helper to extract human-readable info from pydantic `ValidationError`.
- Passes `tool_name` through to `_handle_validation_error()` in both sync (`run`) and async (`arun`) code paths.
- Adds `TestValidationErrorMessages` with parametrized tests covering three failure modes: missing required field, wrong type, and constraint violation (both sync and async).

Closes #892

## Test plan
- [x] `TestValidationErrorMessages::test_validation_error_message_content[missing_required_field]`
- [x] `TestValidationErrorMessages::test_validation_error_message_content[wrong_type]`
- [x] `TestValidationErrorMessages::test_validation_error_message_content[constraint_violation]`
- [x] Async variants of all three cases pass
- [x] Existing `test_validation_error_handling_*` tests updated and passing (18/18)

> This contribution was developed with AI assistance.