### PR TITLE
fix(agents): enable tracing for model node to support callbacks

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1362,7 +1362,7 @@ def create_agent(
         return _build_commands(result.model_response, result.commands)
 
     # Use sync or async based on model capabilities
-    graph.add_node("model", RunnableCallable(model_node, amodel_node, trace=False))
+    graph.add_node("model", RunnableCallable(model_node, amodel_node, trace=True))
 
     # Only add tools node if we have tools
     if tool_node is not None:


### PR DESCRIPTION
Fixes #36395

The agent model node was using trace=False, which prevented callback handlers from being properly set up in RunnableCallable.ainvoke().

This caused on_llm_start and other callbacks to be skipped entirely, breaking observability tools like:
- Langfuse
- LangSmith
- OpenTelemetry
- Custom callback handlers

Changed trace=False to trace=True to allow proper callback propagation to LLM calls within agent workflows.

## Verification
- [x] Syntax valid (Python compiles)
- [x] 1-line change only
- [x] No breaking changes (trace=True is the default)
- [x] Fixes real production issue (callbacks broken in agents)