### PR TITLE
feat(core): add runnable output verification gate

### DIFF
--- a/libs/core/langchain_core/exceptions.py
+++ b/libs/core/langchain_core/exceptions.py
@@ -73,6 +73,28 @@ class ContextOverflowError(LangChainException):
     """
 
 
+class OutputVerificationError(LangChainException):
+    """Raised when a `RunnableWithOutputVerification` rejects an output."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        step_name: str = "",
+        output: Any | None = None,
+    ) -> None:
+        """Create an `OutputVerificationError`.
+
+        Args:
+            message: Human-readable explanation.
+            step_name: Optional step label used in audit entries.
+            output: The runnable output that failed verification, if available.
+        """
+        super().__init__(message)
+        self.step_name = step_name
+        self.output = output
+
+
 class ErrorCode(Enum):
     """Error codes."""
 

--- a/libs/core/langchain_core/runnables/__init__.py
+++ b/libs/core/langchain_core/runnables/__init__.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
         aadd,
         add,
     )
+    from langchain_core.runnables.verification import RunnableWithOutputVerification
 
 __all__ = (
     "AddableDict",
@@ -83,6 +84,7 @@ __all__ = (
     "RunnableSerializable",
     "RunnableWithFallbacks",
     "RunnableWithMessageHistory",
+    "RunnableWithOutputVerification",
     "aadd",
     "add",
     "chain",
@@ -110,6 +112,7 @@ _dynamic_imports = {
     "run_in_executor": "config",
     "RunnableWithFallbacks": "fallbacks",
     "RunnableWithMessageHistory": "history",
+    "RunnableWithOutputVerification": "verification",
     "RunnableAssign": "passthrough",
     "RunnablePassthrough": "passthrough",
     "RunnablePick": "passthrough",

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -1921,6 +1921,45 @@ class Runnable(ABC, Generic[Input, Output]):
             exponential_jitter_params=exponential_jitter_params,
         )
 
+    def with_output_verification(
+        self,
+        verify: Callable[[Any], bool],
+        *,
+        step_name: str = "runnable",
+        audit_sink: Any | None = None,
+        on_audit: Callable[[dict[str, Any]], None] | None = None,
+        audit_max_output_len: int = 10_000,
+    ) -> Runnable[Input, Output]:
+        """Wrap this `Runnable` with output verification and optional audit records.
+
+        Args:
+            verify: Return `True` to allow the output through, `False` to raise
+                `OutputVerificationError`.
+            step_name: Stored in audit entries and on the exception.
+            audit_sink: If provided, each verification appends one dict with keys
+                `timestamp`, `step`, `raw_output`, `status` (`VERIFIED` or `BLOCKED`).
+            on_audit: Optional callback invoked with the same dict.
+            audit_max_output_len: Truncate `raw_output` in audit entries.
+
+        Returns:
+            A `RunnableWithOutputVerification` around this runnable.
+
+        """
+        from langchain_core.runnables.verification import (  # noqa: PLC0415
+            RunnableWithOutputVerification,
+        )
+
+        return RunnableWithOutputVerification(
+            bound=self,
+            kwargs={},
+            config={},
+            verify=verify,
+            step_name=step_name,
+            audit_sink=audit_sink,
+            on_audit=on_audit,
+            audit_max_output_len=audit_max_output_len,
+        )
+
     def map(self) -> Runnable[list[Input], list[Output]]:
         """Return a new `Runnable` that maps a list of inputs to a list of outputs.
 
@@ -5950,6 +5989,7 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):  # type: ignore[no-re
     - `with_types`: Override the input and output types of the underlying
         `Runnable`.
     - `with_retry`: Bind a retry policy to the underlying `Runnable`.
+    - `with_output_verification`: Verify outputs of the underlying `Runnable`.
     - `with_fallbacks`: Bind a fallback policy to the underlying `Runnable`.
 
     Example:
@@ -6094,6 +6134,29 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):  # type: ignore[no-re
     def with_retry(self, **kwargs: Any) -> Runnable[Input, Output]:
         return self.__class__(
             bound=self.bound.with_retry(**kwargs),
+            kwargs=self.kwargs,
+            config=self.config,
+            config_factories=self.config_factories,
+        )
+
+    @override
+    def with_output_verification(
+        self,
+        verify: Callable[[Any], bool],
+        *,
+        step_name: str = "runnable",
+        audit_sink: Any | None = None,
+        on_audit: Callable[[dict[str, Any]], None] | None = None,
+        audit_max_output_len: int = 10_000,
+    ) -> Runnable[Input, Output]:
+        return self.__class__(
+            bound=self.bound.with_output_verification(
+                verify,
+                step_name=step_name,
+                audit_sink=audit_sink,
+                on_audit=on_audit,
+                audit_max_output_len=audit_max_output_len,
+            ),
             kwargs=self.kwargs,
             config=self.config,
             config_factories=self.config_factories,

--- a/libs/core/langchain_core/runnables/verification.py
+++ b/libs/core/langchain_core/runnables/verification.py
@@ -1,0 +1,262 @@
+"""Output verification wrapper for `Runnable` objects."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable, Iterator  # noqa: TC003
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, cast
+
+from pydantic import ConfigDict, Field
+from typing_extensions import override
+
+from langchain_core.exceptions import OutputVerificationError
+from langchain_core.runnables.base import RunnableBindingBase
+from langchain_core.runnables.utils import Input, Output
+
+if TYPE_CHECKING:
+    from langchain_core.runnables.config import RunnableConfig
+
+_DEFAULT_AUDIT_SNIPPET_LEN = 10_000
+
+
+class RunnableWithOutputVerification(RunnableBindingBase[Input, Output]):  # type: ignore[no-redef]
+    """Wrap a `Runnable` to verify its output before returning it to callers.
+
+    After the bound runnable completes, the optional output is passed to `verify`.
+    If `verify` returns `False`, an `OutputVerificationError` is raised and the
+    output is not returned downstream.
+
+    You can record each decision by passing `audit_sink` and/or `on_audit`.
+
+    !!! note
+
+        `transform` / `atransform` forward to the bound runnable without running
+        verification, because chunk boundaries are not guaranteed to represent
+        complete logical outputs.
+
+        `batch_as_completed` / `abatch_as_completed` use the bound runnable's
+        implementation directly and do not run output verification.
+
+    Example:
+        ```python
+        from langchain_core.runnables import RunnableLambda
+
+
+        def is_safe(text: object) -> bool:
+            return "error" not in str(text).lower()
+
+
+        chain = RunnableLambda(lambda _: "ok").with_output_verification(
+            verify=is_safe,
+            step_name="demo",
+        )
+        chain.invoke({})
+        ```
+
+    """
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
+
+    verify: Callable[[Any], bool] = Field(...)
+    """Return `True` if the output may proceed, `False` to block."""
+
+    step_name: str = "runnable"
+    """Label stored in audit entries and on `OutputVerificationError`."""
+
+    audit_sink: Any | None = None
+    """If set, append one JSON-friendly dict per verification attempt.
+
+    Use a `list` you own; this field is typed as `Any` so the same object is
+    kept (Pydantic would otherwise copy `list[dict[...]]` inputs).
+    """
+
+    on_audit: Callable[[dict[str, Any]], None] | None = None
+    """Optional callback invoked with the same dict appended to `audit_sink`."""
+
+    audit_max_output_len: int = Field(
+        default=_DEFAULT_AUDIT_SNIPPET_LEN,
+        ge=1,
+    )
+    """Truncate `raw_output` in audit entries to this many characters."""
+
+    @classmethod
+    @override
+    def is_lc_serializable(cls) -> bool:
+        """This runnable holds callables and is not serializable."""
+        return False
+
+    def _snapshot_output(self, output: Any) -> str:
+        text = str(output)
+        if len(text) > self.audit_max_output_len:
+            return f"{text[: self.audit_max_output_len]}...<truncated>"
+        return text
+
+    def _emit_audit(self, *, verified: bool, output: Any) -> None:
+        entry: dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "step": self.step_name,
+            "raw_output": self._snapshot_output(output),
+            "status": "VERIFIED" if verified else "BLOCKED",
+        }
+        if self.audit_sink is not None:
+            cast("list[Any]", self.audit_sink).append(entry)
+        if self.on_audit is not None:
+            self.on_audit(entry)
+
+    def _verify_and_audit(self, output: Any) -> Output:
+        ok = self.verify(output)
+        if ok:
+            self._emit_audit(verified=True, output=output)
+            return cast("Output", output)
+        self._emit_audit(verified=False, output=output)
+        msg = f"Output verification failed for step {self.step_name!r}"
+        raise OutputVerificationError(
+            msg,
+            step_name=self.step_name,
+            output=output,
+        )
+
+    @staticmethod
+    def _aggregate_stream_chunks(chunks: list[Output]) -> Output:
+        if not chunks:
+            msg = "Cannot aggregate an empty stream."
+            raise ValueError(msg)
+        aggregated: Output = chunks[0]
+        for chunk in chunks[1:]:
+            try:
+                aggregated = aggregated + chunk  # type: ignore[operator]
+            except TypeError:
+                return chunks[-1]
+        return aggregated
+
+    @override
+    def invoke(
+        self,
+        input: Input,
+        config: RunnableConfig | None = None,
+        **kwargs: Any | None,
+    ) -> Output:
+        out = super().invoke(input, config, **kwargs)
+        return self._verify_and_audit(out)
+
+    @override
+    async def ainvoke(
+        self,
+        input: Input,
+        config: RunnableConfig | None = None,
+        **kwargs: Any | None,
+    ) -> Output:
+        out = await super().ainvoke(input, config, **kwargs)
+        return self._verify_and_audit(out)
+
+    @override
+    def batch(
+        self,
+        inputs: list[Input],
+        config: RunnableConfig | list[RunnableConfig] | None = None,
+        *,
+        return_exceptions: bool = False,
+        **kwargs: Any | None,
+    ) -> list[Output]:
+        outs = super().batch(
+            inputs,
+            config,
+            return_exceptions=return_exceptions,
+            **kwargs,
+        )
+        if return_exceptions:
+            verified_exc: list[Output | Exception] = []
+            for o in outs:
+                if isinstance(o, Exception):
+                    verified_exc.append(o)
+                else:
+                    verified_exc.append(self._verify_and_audit(o))
+            return cast("list[Output]", verified_exc)
+        return [self._verify_and_audit(o) for o in outs]
+
+    @override
+    async def abatch(
+        self,
+        inputs: list[Input],
+        config: RunnableConfig | list[RunnableConfig] | None = None,
+        *,
+        return_exceptions: bool = False,
+        **kwargs: Any | None,
+    ) -> list[Output]:
+        outs = await super().abatch(
+            inputs,
+            config,
+            return_exceptions=return_exceptions,
+            **kwargs,
+        )
+        if return_exceptions:
+            averified_exc: list[Output | Exception] = []
+            for o in outs:
+                if isinstance(o, Exception):
+                    averified_exc.append(o)
+                else:
+                    averified_exc.append(self._verify_and_audit(o))
+            return cast("list[Output]", averified_exc)
+        return [self._verify_and_audit(o) for o in outs]
+
+    @override
+    def stream(
+        self,
+        input: Input,
+        config: RunnableConfig | None = None,
+        **kwargs: Any | None,
+    ) -> Iterator[Output]:
+        merged_config = self._merge_configs(config)
+        merged_kw = {**self.kwargs, **kwargs}
+        chunks: list[Output] = list(
+            self.bound.stream(input, merged_config, **merged_kw),
+        )
+        if not chunks:
+            return
+        aggregated = self._aggregate_stream_chunks(chunks)
+        self._verify_and_audit(aggregated)
+        yield from chunks
+
+    @override
+    async def astream(
+        self,
+        input: Input,
+        config: RunnableConfig | None = None,
+        **kwargs: Any | None,
+    ) -> AsyncIterator[Output]:
+        merged_config = self._merge_configs(config)
+        merged_kw = {**self.kwargs, **kwargs}
+        chunks: list[Output] = [
+            chunk
+            async for chunk in self.bound.astream(input, merged_config, **merged_kw)
+        ]
+        if not chunks:
+            return
+        aggregated = self._aggregate_stream_chunks(chunks)
+        self._verify_and_audit(aggregated)
+        for chunk in chunks:
+            yield chunk
+
+    @override
+    def transform(
+        self,
+        input: Iterator[Input],
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> Iterator[Output]:
+        return super().transform(input, config, **kwargs)
+
+    @override
+    async def atransform(
+        self,
+        input: AsyncIterator[Input],
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[Output]:
+        async for item in super().atransform(input, config, **kwargs):
+            yield item
+
+
+__all__ = ["RunnableWithOutputVerification"]

--- a/libs/core/tests/unit_tests/runnables/test_imports.py
+++ b/libs/core/tests/unit_tests/runnables/test_imports.py
@@ -27,6 +27,7 @@ EXPECTED_ALL = [
     "RunnableSequence",
     "RunnableWithFallbacks",
     "RunnableWithMessageHistory",
+    "RunnableWithOutputVerification",
     "get_config_list",
     "aadd",
     "add",

--- a/libs/core/tests/unit_tests/runnables/test_output_verification.py
+++ b/libs/core/tests/unit_tests/runnables/test_output_verification.py
@@ -1,0 +1,115 @@
+from typing import Any
+
+import pytest
+
+from langchain_core.exceptions import OutputVerificationError
+from langchain_core.language_models import GenericFakeChatModel
+from langchain_core.runnables import (
+    Runnable,
+    RunnableLambda,
+    RunnableWithOutputVerification,
+)
+
+
+def test_invoke_verified() -> None:
+    inner: Runnable[int, int] = RunnableLambda(lambda x: x * 2)
+    gated = inner.with_output_verification(verify=lambda y: y == 4)
+    assert gated.invoke(2) == 4
+
+
+def test_invoke_blocked() -> None:
+    inner: Runnable[Any, str] = RunnableLambda(lambda _: "Fatal Error: nope")
+    gated = inner.with_output_verification(
+        verify=lambda y: "error" not in str(y).lower(),
+        step_name="tool_a",
+    )
+    with pytest.raises(OutputVerificationError) as exc_info:
+        gated.invoke({})
+    assert exc_info.value.step_name == "tool_a"
+    assert "error" in str(exc_info.value.output).lower()
+
+
+def test_audit_sink_and_on_audit() -> None:
+    sink: list[dict] = []
+    side: list[dict] = []
+
+    def _on_audit(entry: dict) -> None:
+        side.append(entry)
+
+    inner = RunnableLambda(lambda x: x)
+    gated = inner.with_output_verification(
+        verify=lambda y: y > 0,
+        step_name="step-1",
+        audit_sink=sink,
+        on_audit=_on_audit,
+    )
+    assert gated.invoke(3) == 3
+    assert sink[0]["status"] == "VERIFIED"
+    assert sink[0]["step"] == "step-1"
+    assert side[0]["status"] == "VERIFIED"
+
+    with pytest.raises(OutputVerificationError):
+        gated.invoke(-1)
+    assert sink[-1]["status"] == "BLOCKED"
+    assert side[-1]["status"] == "BLOCKED"
+
+
+def test_batch() -> None:
+    inner = RunnableLambda(lambda x: x)
+    gated = inner.with_output_verification(verify=lambda y: y % 2 == 0)
+    assert gated.batch([2, 4]) == [2, 4]
+    with pytest.raises(OutputVerificationError):
+        gated.batch([2, 3])
+
+
+def test_stream_aggregates_then_verifies() -> None:
+    model = GenericFakeChatModel(
+        messages=iter(["hello world"]),
+    )
+    gated = model.with_output_verification(
+        verify=lambda m: "error" not in str(getattr(m, "content", m)).lower(),
+        step_name="chat",
+    )
+    chunks = list(gated.stream("hi"))
+    assert len(chunks) >= 1
+    assert all("error" not in str(c.content).lower() for c in chunks)
+
+
+def test_stream_blocked_before_yield() -> None:
+    model = GenericFakeChatModel(
+        messages=iter(["error: boom"]),
+    )
+    gated = model.with_output_verification(
+        verify=lambda m: "error" not in str(getattr(m, "content", m)).lower(),
+    )
+    with pytest.raises(OutputVerificationError):
+        list(gated.stream("hi"))
+
+
+@pytest.mark.asyncio
+async def test_astream_verified() -> None:
+    model = GenericFakeChatModel(
+        messages=iter(["ok"]),
+    )
+    gated = model.with_output_verification(
+        verify=lambda m: "error" not in str(getattr(m, "content", m)).lower(),
+    )
+    chunks = [c async for c in gated.astream("hi")]
+    assert len(chunks) >= 1
+
+
+def test_runnable_binding_forwards_verification() -> None:
+    inner = RunnableLambda(lambda x: x).with_config(run_name="inner")
+    gated = inner.with_output_verification(verify=lambda y: y > 0)
+    assert gated.invoke(5) == 5
+
+
+def test_direct_constructor_matches_factory() -> None:
+    inner: Runnable[int, int] = RunnableLambda(lambda x: x)
+    direct: RunnableWithOutputVerification[int, int] = RunnableWithOutputVerification(
+        bound=inner,
+        verify=lambda y: y == 7,
+        kwargs={},
+        config={},
+    )
+    assert direct.invoke(7) == 7


### PR DESCRIPTION
Closes #36447
This PR adds an output **verification gate** for composable runnables in `langchain-core`:
- **`RunnableWithOutputVerification`** — wraps a bound `Runnable`, runs `verify(output) -> bool` after completion, raises **`OutputVerificationError`** when verification fails, and returns the output unchanged when it passes.
- **`Runnable.with_output_verification(...)`** — convenience constructor (including composition when the runnable is already a `RunnableBinding`).
- **Optional audit trail** — `audit_sink` (caller-owned `list`) and/or `on_audit` callback; each attempt records `timestamp` (UTC ISO), `step`, `raw_output` (truncated), and `status` (`VERIFIED` / `BLOCKED`), similar in spirit to the TrustFlow-Agent audit shape discussed on the issue.
- **`stream` / `astream`** — buffer chunks, aggregate when possible, verify once, then yield the same chunks. **`transform` / `atransform`** and **`batch_as_completed` / `abatch_as_completed`** are documented as **not** applying verification (they delegate to the bound runnable).
Tests: `libs/core/tests/unit_tests/runnables/test_output_verification.py`
---