### PR TITLE
fix(core): correct parameter names in filter_messages docstring example

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -874,9 +874,9 @@ def filter_messages(
 
         filter_messages(
             messages,
-            incl_names=("example_user", "example_assistant"),
-            incl_types=("system",),
-            excl_ids=("bar",),
+            include_names=("example_user", "example_assistant"),
+            include_types=("system",),
+            exclude_ids=("bar",),
         )
         ```
 


### PR DESCRIPTION
## Why

The docstring example in `filter_messages` uses abbreviated kwarg names (`incl_names`, `incl_types`, `excl_ids`) that don't exist on the function signature. The real parameter names are `include_names`, `include_types`, and `exclude_ids`. Anyone copying the example from the docs gets a `TypeError` with no obvious explanation.

Fixes #36463

## What changed

Renamed the three wrong kwarg names in the docstring example to match the actual function signature. No logic touched.

## Review notes

Docstring-only change, safe to merge without additional test changes.