### PR TITLE
fix(langchain): route back to model when return_direct tool fails

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1783,7 +1783,7 @@ def _make_tools_to_model_edge(
         if last_ai_message is None:
             return model_destination
 
-        # 2. Exit condition: All executed tools have return_direct=True
+        # 2. Exit condition: All executed tools have return_direct=True and all succeeded
         # Filter to only client-side tools (provider tools are not in tool_node)
         client_side_tool_calls = [
             c for c in last_ai_message.tool_calls if c["name"] in tool_node.tools_by_name
@@ -1791,7 +1791,14 @@ def _make_tools_to_model_edge(
         if client_side_tool_calls and all(
             tool_node.tools_by_name[c["name"]].return_direct for c in client_side_tool_calls
         ):
-            return end_destination
+            client_side_call_ids = {c["id"] for c in client_side_tool_calls}
+            any_failed = any(
+                m.status == "error"
+                for m in tool_messages
+                if m.tool_call_id in client_side_call_ids
+            )
+            if not any_failed:
+                return end_destination
 
         # 3. Exit condition: A structured output tool was executed
         if any(t.name in structured_output_tools for t in tool_messages):

--- a/libs/langchain_v1/tests/unit_tests/agents/test_return_direct_graph.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_return_direct_graph.py
@@ -1,6 +1,8 @@
 """Tests for return_direct tool graph structure."""
 
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.tools import tool
+from langchain_core.tools.base import ToolException
 from syrupy.assertion import SnapshotAssertion
 
 from langchain.agents.factory import create_agent
@@ -70,3 +72,69 @@ def test_agent_graph_with_mixed_tools(snapshot: SnapshotAssertion) -> None:
     # because at least one tool has return_direct=True
     mermaid_diagram = agent.get_graph().draw_mermaid()
     assert mermaid_diagram == snapshot
+
+
+def test_return_direct_tool_error_routes_back_to_model() -> None:
+    """Test that a failed return_direct tool routes back to the model instead of exiting.
+
+    When a return_direct=True tool raises an exception, ToolNode produces a
+    ToolMessage with status="error". The agent should route back to the model
+    so it can handle the error, rather than terminating immediately.
+    """
+
+    @tool(return_direct=True)
+    def failing_tool(x: str) -> str:
+        """A tool that always fails."""
+        msg = "tool error"
+        raise ToolException(msg)
+
+    failing_tool.handle_tool_error = True
+
+    tool_call = {"name": "failing_tool", "args": {"x": "hi"}, "id": "c1", "type": "tool_call"}
+    model = FakeToolCallingModel(tool_calls=[[tool_call], []])
+    agent = create_agent(
+        model=model,
+        tools=[failing_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("run the tool")]})
+
+    # The agent must NOT terminate after the error ToolMessage.
+    # It should route back to the model, which then produces a final AIMessage.
+    last_message = result["messages"][-1]
+    assert isinstance(last_message, AIMessage), (
+        f"Expected final AIMessage after tool error, got {type(last_message).__name__}"
+    )
+
+    # Confirm the error ToolMessage is present in history
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].status == "error"
+
+
+def test_return_direct_tool_success_exits_loop() -> None:
+    """Test that a successful return_direct tool exits the agent loop normally."""
+
+    @tool(return_direct=True)
+    def succeeding_tool(x: str) -> str:
+        """A tool that always succeeds."""
+        return f"result: {x}"
+
+    tool_call = {"name": "succeeding_tool", "args": {"x": "hi"}, "id": "c2", "type": "tool_call"}
+    model = FakeToolCallingModel(tool_calls=[[tool_call]])
+    agent = create_agent(
+        model=model,
+        tools=[succeeding_tool],
+        system_prompt="You are a helpful assistant.",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("run the tool")]})
+
+    # Successful return_direct tool should exit immediately — last message is ToolMessage
+    last_message = result["messages"][-1]
+    assert isinstance(last_message, ToolMessage), (
+        f"Expected ToolMessage as final message for successful return_direct, "
+        f"got {type(last_message).__name__}"
+    )
+    assert last_message.status == "success"


### PR DESCRIPTION
## Summary

Fixes #36411.

When a `return_direct=True` tool raises and produces a `ToolMessage(status="error")`, the agent was terminating immediately instead of routing back to the model. The routing condition in `_make_tools_to_model_edge` only checked whether all called tools had `return_direct=True` — it never checked whether those calls actually succeeded.

- **Root cause:** `tools_to_model` exits to `end_destination` solely based on the `return_direct` flag, ignoring `ToolMessage.status`
- **Fix:** Before exiting, also verify that none of the corresponding `ToolMessage`s have `status="error"`. If any failed, route back to the model so it can handle the error or retry

The `ToolMessage.status` field already exists in `langchain-core` — no new fields or schema changes needed.

## Changes

- [`libs/langchain_v1/langchain/agents/factory.py`](https://github.com/langchain-ai/langchain/blob/fix/langchain-return-direct-tool-error-routing/libs/langchain_v1/langchain/agents/factory.py): add error-status check to the `return_direct` exit condition in `_make_tools_to_model_edge`
- [`libs/langchain_v1/tests/unit_tests/agents/test_return_direct_graph.py`](https://github.com/langchain-ai/langchain/blob/fix/langchain-return-direct-tool-error-routing/libs/langchain_v1/tests/unit_tests/agents/test_return_direct_graph.py): two new tests — one that fails before the fix (error must route back), one that confirms successful `return_direct` still exits normally

## Test plan

- [ ] `test_return_direct_tool_error_routes_back_to_model` — agent with a failing `return_direct` tool must produce a final `AIMessage`, not terminate at the error `ToolMessage`
- [ ] `test_return_direct_tool_success_exits_loop` — successful `return_direct` tool still exits the loop (no regression)
- [ ] Full agents unit suite: `uv run --group test pytest tests/unit_tests/agents/ -q` → 725 passed

> **AI disclosure:** This fix was implemented with assistance from Claude Code (Anthropic). The root cause analysis, code change, and tests were reviewed and verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)