### PR TITLE
fix(core): forward detail field in convert_to_openai_image_block

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -32,12 +32,20 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
     Returns:
         The formatted image content block.
     """
+    # Extract detail field from block (can be at top level, in extras, or in metadata)
+    detail = block.get("detail")
+    if detail is None and (extras := block.get("extras")):
+        detail = extras.get("detail")
+    if detail is None and (metadata := block.get("metadata")):
+        detail = metadata.get("detail")
+    
     if "url" in block:
+        image_url: dict[str, Any] = {"url": block["url"]}
+        if detail is not None:
+            image_url["detail"] = detail
         return {
             "type": "image_url",
-            "image_url": {
-                "url": block["url"],
-            },
+            "image_url": image_url,
         }
     if "base64" in block or block.get("source_type") == "base64":
         if "mime_type" not in block:
@@ -45,11 +53,12 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
             raise ValueError(error_message)
         mime_type = block["mime_type"]
         base64_data = block["data"] if "data" in block else block["base64"]
+        image_url_data: dict[str, Any] = {"url": f"data:{mime_type};base64,{base64_data}"}
+        if detail is not None:
+            image_url_data["detail"] = detail
         return {
             "type": "image_url",
-            "image_url": {
-                "url": f"data:{mime_type};base64,{base64_data}",
-            },
+            "image_url": image_url_data,
         }
     error_message = "Unsupported source type. Only 'url' and 'base64' are supported."
     raise ValueError(error_message)


### PR DESCRIPTION
## Summary

Fixes #36297

The `detail` field controls image analysis resolution (`low`, `high`, `auto`) in OpenAI API. Previously, this field was silently dropped when converting image blocks via `convert_to_openai_image_block`.

## Changes

- Extract `detail` from top-level, `extras`, or `metadata` fields
- Forward the `detail` field to the output `image_url` dict

## Testing

Tested manually with all combinations:
- URL with detail at top level ✅
- URL with detail in extras ✅  
- URL with detail in metadata ✅
- Base64 with detail ✅
- No detail (backward compat) ✅
- `convert_to_openai_data_block` for chat/completions API ✅
- `convert_to_openai_data_block` for responses API ✅

## Example

Before:
```python
block = {'type': 'image', 'url': 'https://...', 'detail': 'high'}
convert_to_openai_image_block(block)
# {'type': 'image_url', 'image_url': {'url': 'https://...'}}  # detail lost!
```

After:
```python
block = {'type': 'image', 'url': 'https://...', 'detail': 'high'}
convert_to_openai_image_block(block)
# {'type': 'image_url', 'image_url': {'url': 'https://...', 'detail': 'high'}}  # detail preserved!
```
