### PR TITLE
Fix(agents): Avoid forcing tool_choice='any' when Anthropic thinking, #36418

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1248,7 +1248,15 @@ def create_agent(
                     raise ValueError(msg)
 
             # Force tool use if we have structured output tools
-            tool_choice = "any" if structured_output_tools else request.tool_choice
+            is_thinking_enabled = (
+                hasattr(request.model, "thinking")
+                and request.model.thinking is not None
+                and request.model.thinking.get("type") in ("enabled", "adaptive")
+            )
+            if structured_output_tools and not is_thinking_enabled:
+                tool_choice = "any"
+            else:
+                tool_choice = request.tool_choice
             return (
                 request.model.bind_tools(
                     final_tools, tool_choice=tool_choice, **request.model_settings


### PR DESCRIPTION
Fixes #36418

## Fix

Avoid forcing `tool_choice="any"` when using Anthropic models with thinking enabled, as this causes API error with structured output.

## How did you verify your code works?
Ran relevant unit tests locally to ensure no regressions in agent behavior.

---
This change preserves existing behavior when thinking is disabled.