### PR TITLE
feat(core): add RunnableFactChecker for post-generation verification

### DIFF
--- a/libs/core/langchain_core/runnables/__init__.py
+++ b/libs/core/langchain_core/runnables/__init__.py
@@ -19,7 +19,6 @@ primitives.
 """
 
 from typing import TYPE_CHECKING
-
 from langchain_core._import_utils import import_attr
 
 if TYPE_CHECKING:
@@ -73,6 +72,7 @@ __all__ = (
     "RunnableBinding",
     "RunnableBranch",
     "RunnableConfig",
+    "RunnableFactChecker",
     "RunnableGenerator",
     "RunnableLambda",
     "RunnableMap",
@@ -126,6 +126,10 @@ _dynamic_imports = {
 
 
 def __getattr__(attr_name: str) -> object:
+    if attr_name == "RunnableFactChecker":
+        from langchain_core.runnables.fact_checker import RunnableFactChecker
+        return RunnableFactChecker
+
     module_name = _dynamic_imports.get(attr_name)
     result = import_attr(attr_name, module_name, __spec__.parent)
     globals()[attr_name] = result

--- a/libs/core/langchain_core/runnables/fact_checker.py
+++ b/libs/core/langchain_core/runnables/fact_checker.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, List
+import re
+
+from langchain_core.messages import AIMessage
+from langchain_core.runnables.base import Runnable
+
+
+class RunnableFactChecker(Runnable[Dict[str, Any], AIMessage]):
+    """Runnable that verifies LLM outputs against context."""
+
+    def __init__(self, llm, strict_mode: bool = False):
+        self.llm = llm
+        self.strict_mode = strict_mode
+
+    def invoke(self, input: Dict[str, Any], config: Any = None) -> AIMessage:
+        context_docs = input.get("context", [])
+        answer = input.get("answer") or input.get("content")
+
+        if not answer:
+            return AIMessage(content="", response_metadata={"confidence_score": 0.0})
+
+        sentences = self._split_sentences(answer)
+
+        context_text = "\n\n".join(
+            getattr(doc, "page_content", str(doc)) for doc in context_docs
+        )
+
+        supported = []
+
+        for sentence in sentences:
+            verdict = self._verify(sentence, context_text)
+            if verdict.strip().upper() == "TRUE":
+                supported.append(sentence)
+
+        score = len(supported) / len(sentences) if sentences else 0.0
+
+        final_text = (
+            " ".join(supported) if self.strict_mode else " ".join(sentences)
+        )
+
+        return AIMessage(
+            content=final_text,
+            response_metadata={"confidence_score": score},
+        )
+
+    async def ainvoke(self, input: Dict[str, Any], config: Any = None) -> AIMessage:
+        return self.invoke(input, config)
+
+    def _verify(self, sentence: str, context: str) -> str:
+        prompt = f"""Context:
+{context}
+
+Statement:
+{sentence}
+
+Is this supported? Answer TRUE or FALSE."""
+        response = self.llm.invoke(prompt)
+        return getattr(response, "content", str(response))
+
+    def _split_sentences(self, text: str) -> List[str]:
+        return re.split(r"(?<=[.!?])\s+", text.strip())

--- a/libs/core/tests/unit_tests/runnables/test_fact_checker.py
+++ b/libs/core/tests/unit_tests/runnables/test_fact_checker.py
@@ -1,0 +1,52 @@
+from langchain_core.runnables.fact_checker import RunnableFactChecker
+
+
+class DummyLLM:
+    def __init__(self, responses):
+        self.responses = responses
+        self.index = 0
+
+    def invoke(self, prompt):
+        class Response:
+            def __init__(self, content):
+                self.content = content
+
+        result = self.responses[self.index]
+        self.index += 1
+        return Response(result)
+
+
+def test_fact_checker_all_true():
+    llm = DummyLLM(["TRUE", "TRUE"])
+    checker = RunnableFactChecker(llm=llm)
+
+    result = checker.invoke({
+        "context": [],
+        "answer": "Sky is blue. Grass is green."
+    })
+
+    assert result.response_metadata["confidence_score"] == 1.0
+
+
+def test_fact_checker_mixed():
+    llm = DummyLLM(["TRUE", "FALSE"])
+    checker = RunnableFactChecker(llm=llm)
+
+    result = checker.invoke({
+        "context": [],
+        "answer": "Sky is blue. Sky is red."
+    })
+
+    assert result.response_metadata["confidence_score"] == 0.5
+
+
+def test_fact_checker_strict():
+    llm = DummyLLM(["TRUE", "FALSE"])
+    checker = RunnableFactChecker(llm=llm, strict_mode=True)
+
+    result = checker.invoke({
+        "context": [],
+        "answer": "Sky is blue. Sky is red."
+    })
+
+    assert "Sky is red." not in result.content


### PR DESCRIPTION
Closes #36481

## Summary
Adds `RunnableFactChecker` to verify LLM outputs against context in RAG pipelines.

## Features
- Sentence-level verification using LLM
- Confidence score computation
- Optional strict mode to filter unsupported statements
- Async support via `ainvoke`
- Lazy import integration to avoid circular dependencies

## Example
```python
fact_checker = RunnableFactChecker(llm=verifier_llm, strict_mode=True)

result = fact_checker.invoke({
    "context": docs,
    "answer": generated_text
})


---

## 🔹 3. Check Files (VERY IMPORTANT)

Make sure ONLY these are in PR:

```text
✅ fact_checker.py
✅ test_fact_checker.py
✅ __init__.py (lazy import)