### PR TITLE
fix(text-splitters): use deque to avoid O(n²) in ExperimentalMarkdownSyntaxTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import deque
 from typing import Any, TypedDict
 
 from langchain_core.documents import Document
@@ -389,10 +390,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
         self.current_chunk = Document(page_content="")
         self.current_header_stack.clear()
 
-        raw_lines = text.splitlines(keepends=True)
+        raw_lines = deque(text.splitlines(keepends=True))
 
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             header_match = self._match_header(raw_line)
             code_match = self._match_code(raw_line)
             horz_match = self._match_horz(raw_line)
@@ -439,10 +440,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
                 break
         self.current_header_stack.append((header_depth, header_text))
 
-    def _resolve_code_chunk(self, current_line: str, raw_lines: list[str]) -> str:
+    def _resolve_code_chunk(self, current_line: str, raw_lines: deque[str]) -> str:
         chunk = current_line
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk


### PR DESCRIPTION
## Summary

- Replace `list.pop(0)` with `collections.deque.popleft()` in `ExperimentalMarkdownSyntaxTextSplitter.split_text()` and `_resolve_code_chunk()`
- `list.pop(0)` is O(n) per call (shifts all remaining elements), making the while loop O(n²) overall
- `deque.popleft()` is O(1), bringing total complexity to O(n)

The `raw_lines` variable is only used with truthiness checks, `.pop(0)`/`.popleft()`, and passed to the private `_resolve_code_chunk()` method — no indexing or slicing — so `deque` is a safe drop-in replacement.

Fixes #36488

## AI Disclosure

This contribution was developed with assistance from AI agents (Claude Code and Codex) for bug discovery, fix verification, and review. The fix itself is a straightforward data structure substitution.

## Test plan

- [x] All 127 existing unit tests pass (`pytest tests/unit_tests/test_text_splitters.py` — 127 passed, 4 skipped)
- [ ] Verify performance improvement on large markdown files (50k+ lines)