### PR TITLE
fix(core): filter OpenAI function_call blocks with excluded tools

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -922,8 +922,17 @@ def filter_messages(
                         for content_block in msg.content
                         if (
                             not isinstance(content_block, dict)
-                            or content_block.get("type") != "tool_use"
-                            or content_block.get("id") not in exclude_tool_calls
+                            or (
+                                content_block.get("type") == "tool_use"
+                                and content_block.get("id") not in exclude_tool_calls
+                            )
+                            or (
+                                content_block.get("type") == "function_call"
+                                and content_block.get("call_id")
+                                not in exclude_tool_calls
+                            )
+                            or content_block.get("type")
+                            not in {"tool_use", "function_call"}
                         )
                     ]
 

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -269,6 +269,60 @@ def test_filter_message_exclude_tool_calls_content_blocks() -> None:
     assert messages == messages_model_copy
 
 
+def test_filter_message_exclude_tool_calls_openai_function_call_blocks() -> None:
+    tool_calls = [
+        {"name": "foo", "id": "1", "args": {}, "type": "tool_call"},
+        {"name": "bar", "id": "2", "args": {}, "type": "tool_call"},
+    ]
+    messages = [
+        HumanMessage("foo", name="blah", id="1"),
+        AIMessage(
+            [
+                {"text": "bar-response", "type": "text"},
+                {
+                    "type": "function_call",
+                    "call_id": "1",
+                    "name": "foo",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "2",
+                    "name": "bar",
+                    "arguments": "{}",
+                },
+            ],
+            tool_calls=tool_calls,
+            id="2",
+        ),
+        ToolMessage("baz", tool_call_id="1", id="3"),
+        ToolMessage("qux", tool_call_id="2", id="4"),
+    ]
+    messages_model_copy = [m.model_copy(deep=True) for m in messages]
+
+    expected = messages[:2] + messages[-1:]
+    expected[1] = expected[1].model_copy(
+        update={
+            "tool_calls": [tool_calls[1]],
+            "content": [
+                {"text": "bar-response", "type": "text"},
+                {
+                    "type": "function_call",
+                    "call_id": "2",
+                    "name": "bar",
+                    "arguments": "{}",
+                },
+            ],
+        }
+    )
+
+    actual = filter_messages(messages, exclude_tool_calls=["1"])
+    assert expected == actual
+
+    # assert that we didn't mutate the original messages
+    assert messages == messages_model_copy
+
+
 _MESSAGES_TO_TRIM = [
     SystemMessage("This is a 4 token text."),
     HumanMessage("This is a 4 token text.", id="first"),


### PR DESCRIPTION
Fixes #36492

This keeps `AIMessage.content` in sync with `tool_calls` when `filter_messages(..., exclude_tool_calls=...)` is used on OpenAI Responses-style `function_call` blocks. I verified it with focused unit tests in `tests/unit_tests/messages/test_utils.py`.

AI assistance: I used AI assistance to help inspect the code and draft the initial patch, then reviewed the final changes and test coverage myself.
