### PR TITLE
fix(core): handle pydantic v1 async tool validation

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1111,7 +1111,7 @@ class ChildTool(BaseTool):
                         error_to_raise = ValueError(msg)
             else:
                 content = response
-        except ValidationError as e:
+        except (ValidationError, ValidationErrorV1) as e:
             if not self.handle_validation_error:
                 error_to_raise = e
             else:

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -974,6 +974,32 @@ async def test_async_validation_error_handling_callable() -> None:
     assert expected == actual
 
 
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14),
+    reason="pydantic.v1 namespace not supported with Python 3.14+",
+)
+async def test_async_validation_error_handling_pydantic_v1_schema() -> None:
+    """Test async validation handling for tools with Pydantic v1 schemas."""
+
+    class _MockSchemaV1(BaseModelV1):
+        arg1: int
+        arg2: bool
+
+    def foo(arg1: int, arg2: bool) -> str:
+        """Return the arguments directly."""
+        return f"{arg1} {arg2}"
+
+    tool_ = StructuredTool.from_function(
+        foo,
+        args_schema=cast("ArgsSchema", _MockSchemaV1),
+        handle_validation_error=True,
+    )
+
+    expected = "Tool input validation error"
+    assert tool_.run({}) == expected
+    assert await tool_.arun({}) == expected
+
+
 @pytest.mark.parametrize(
     "handler",
     [


### PR DESCRIPTION
Fixes #36491

This makes `BaseTool.arun()` handle Pydantic v1 validation errors the same way as `BaseTool.run()` when `handle_validation_error` is enabled. I verified it with focused unit tests in `tests/unit_tests/test_tools.py`.

AI assistance: I used AI assistance to help inspect the code and draft the initial patch, then reviewed the final changes and test coverage myself.
