### PR TITLE
fix(core): preserve TypedDict optional fields in OpenAI schemas

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -62,6 +62,17 @@ _ORIGIN_MAP: dict[type, Any] = {
 if hasattr(types, "UnionType"):
     _ORIGIN_MAP[types.UnionType] = Union
 
+_TYPED_DICT_REQUIREDNESS_MARKERS = {
+    marker
+    for marker in (
+        getattr(typing, "Required", None),
+        getattr(typing, "NotRequired", None),
+        getattr(typing_extensions, "Required", None),
+        getattr(typing_extensions, "NotRequired", None),
+    )
+    if marker is not None
+}
+
 
 class FunctionDescription(TypedDict):
     """Representation of a callable function to send to an LLM."""
@@ -265,6 +276,13 @@ def _convert_any_typed_dicts_to_pydantic(
         return visited[type_]
     if depth >= _MAX_TYPED_DICT_RECURSION:
         return type_
+    if (origin := get_origin(type_)) in _TYPED_DICT_REQUIREDNESS_MARKERS:
+        type_args = get_args(type_)
+        if len(type_args) != 1:
+            return type_
+        return _convert_any_typed_dicts_to_pydantic(
+            type_args[0], depth=depth + 1, visited=visited
+        )
     if is_typeddict(type_):
         typed_dict = type_
         docstring = inspect.getdoc(typed_dict)
@@ -279,8 +297,15 @@ def _convert_any_typed_dicts_to_pydantic(
         description, arg_descriptions = _parse_google_docstring(
             docstring, list(annotations_)
         )
+        required_keys = getattr(typed_dict, "__required_keys__", frozenset())
+        optional_keys = getattr(typed_dict, "__optional_keys__", frozenset())
         fields: dict = {}
         for arg, arg_type in annotations_.items():
+            is_required = arg in required_keys or (
+                arg not in required_keys
+                and arg not in optional_keys
+                and getattr(typed_dict, "__total__", True)
+            )
             if get_origin(arg_type) in {Annotated, typing_extensions.Annotated}:
                 annotated_args = get_args(arg_type)
                 new_arg_type = _convert_any_typed_dicts_to_pydantic(
@@ -289,6 +314,8 @@ def _convert_any_typed_dicts_to_pydantic(
                 field_kwargs = dict(
                     zip(("default", "description"), annotated_args[1:], strict=False)
                 )
+                if not is_required and "default" not in field_kwargs:
+                    field_kwargs["default"] = None
                 if (field_desc := field_kwargs.get("description")) and not isinstance(
                     field_desc, str
                 ):
@@ -305,7 +332,7 @@ def _convert_any_typed_dicts_to_pydantic(
                 new_arg_type = _convert_any_typed_dicts_to_pydantic(
                     arg_type, depth=depth + 1, visited=visited
                 )
-                field_kwargs = {"default": ...}
+                field_kwargs = {"default": ... if is_required else None}
                 if arg_desc := arg_descriptions.get(arg):
                     field_kwargs["description"] = arg_desc
                 fields[arg] = (new_arg_type, Field_v1(**field_kwargs))

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -11,7 +11,11 @@ from typing import TypedDict as TypingTypedDict
 import pytest
 from pydantic import BaseModel as BaseModelV2Maybe  # pydantic: ignore
 from pydantic import Field as FieldV2Maybe  # pydantic: ignore
-from typing_extensions import TypedDict as ExtensionsTypedDict
+from typing_extensions import (
+    NotRequired,
+    Required,
+    TypedDict as ExtensionsTypedDict,
+)
 
 try:
     from typing import Annotated as TypingAnnotated
@@ -1045,6 +1049,38 @@ def test__convert_typed_dict_to_openai_function_fail(typed_dict: type) -> None:
     # Error should be raised since we're using v1 code path here
     with pytest.raises(TypeError):
         _convert_typed_dict_to_openai_function(Tool)
+
+
+@pytest.mark.parametrize(
+    "typed_dict",
+    [ExtensionsTypedDict, TypingTypedDict],
+    ids=["typing_extensions.TypedDict", "typing.TypedDict"],
+)
+def test__convert_typed_dict_to_openai_function_optional_fields(
+    typed_dict: type,
+) -> None:
+    class Tool(typed_dict, total=False):  # type: ignore[misc]
+        """Tool docstring."""
+
+        required_arg: Required[int]
+        optional_arg: str
+        explicit_optional_arg: NotRequired[bool]
+
+    actual = _convert_typed_dict_to_openai_function(Tool)
+
+    assert actual == {
+        "name": "Tool",
+        "description": "Tool docstring.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "required_arg": {"type": "integer"},
+                "optional_arg": {"type": "string"},
+                "explicit_optional_arg": {"type": "boolean"},
+            },
+            "required": ["required_arg"],
+        },
+    }
 
 
 def test_convert_union_type() -> None:


### PR DESCRIPTION
Fixes #36490

This preserves `TypedDict` optionality in OpenAI function schemas by unwrapping `Required` and `NotRequired` markers and honoring `TypedDict` required vs optional keys. I verified it with focused unit tests in `tests/unit_tests/utils/test_function_calling.py`.

AI assistance: I used AI assistance to help inspect the code and draft the initial patch, then reviewed the final changes and test coverage myself.
