### PR TITLE
fix(text-splitters): preserve content from unclosed markdown code blocks

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -446,7 +446,7 @@ class ExperimentalMarkdownSyntaxTextSplitter:
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk
-        return ""
+        return chunk
 
     def _complete_chunk_doc(self) -> None:
         chunk_content = self.current_chunk.page_content

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1954,6 +1954,39 @@ def test_experimental_markdown_syntax_text_splitter_split_lines() -> None:
     assert output == expected_output
 
 
+def test_experimental_markdown_syntax_text_splitter_unclosed_code_block() -> None:
+    """Unclosed code blocks should preserve accumulated content, not silently drop it.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/36186.
+    """
+    splitter = ExperimentalMarkdownSyntaxTextSplitter()
+
+    # Code block without a closing fence
+    text = (
+        "# Header\n"
+        "\n"
+        "Some text before code.\n"
+        "\n"
+        "```python\n"
+        "def hello():\n"
+        '    print("world")\n'
+        "\n"
+        "More text after the unclosed code block.\n"
+    )
+    chunks = splitter.split_text(text)
+
+    # Content inside the unclosed code block must be preserved
+    assert len(chunks) == 2
+    assert chunks[0].page_content == "Some text before code.\n\n"
+    assert "```python\n" in chunks[1].page_content
+    assert 'print("world")' in chunks[1].page_content
+
+    # Verify nothing is silently discarded
+    full_text = "".join(c.page_content for c in chunks)
+    assert "def hello():" in full_text
+    assert 'print("world")' in full_text
+
+
 EXPERIMENTAL_MARKDOWN_DOCUMENTS = [
     (
         "# My Header 1 From Document 1\n"


### PR DESCRIPTION
## Summary

- Fixes a silent data loss bug in `ExperimentalMarkdownSyntaxTextSplitter`
- When a markdown code block has no closing fence (` ``` `), `_resolve_code_chunk()` was returning `""`, discarding all accumulated content
- Fix: return `chunk` instead of `""` when the loop exhausts without finding a closing fence

**Root cause** (`libs/text-splitters/langchain_text_splitters/markdown.py` line 449):
```python
# Before (buggy)
return ""

# After (fixed)
return chunk
```

Malformed/unclosed code blocks are common in real-world data (e.g., AI-generated markdown), making silent content loss difficult to debug.

## Test plan

- [x] Added `test_experimental_markdown_syntax_text_splitter_unclosed_code_block` — verifies content from an unclosed code block is preserved, not silently dropped
- [x] Existing `ExperimentalMarkdownSyntaxTextSplitter` tests cover the happy path (closed blocks still work correctly)

## Notes

> This PR was developed with AI assistance (Claude Code). The fix and tests were reviewed and validated manually.

Fixes #36186