### PR TITLE
fix(core): skip empty reasoning_content strings in _extract_reasoning_from_additional_kwargs

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content is not None and isinstance(reasoning_content, str) and reasoning_content:
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -495,6 +495,16 @@ def test_content_blocks_reasoning_extraction() -> None:
     assert content_blocks[1]["type"] == "text"
     assert content_blocks[1]["text"] == "The answer is 42."
 
+
+    # Test no reasoning extraction when reasoning_content is empty string
+    # Some providers (e.g. ChatTongyi) set reasoning_content="" after reasoning stage
+    message = AIMessage(
+        content="The answer is 42.",
+        additional_kwargs={"reasoning_content": ""},
+    )
+    content_blocks = message.content_blocks
+    assert len(content_blocks) == 1
+    assert content_blocks[0]["type"] == "text"
     # Test no reasoning extraction when no reasoning content
     message = AIMessage(
         content="The answer is 42.", additional_kwargs={"other_field": "some value"}


### PR DESCRIPTION
## Summary

- Fix `_extract_reasoning_from_additional_kwargs` in `libs/core/langchain_core/messages/base.py` to ignore empty strings for `reasoning_content`
- Some model providers (e.g. ChatTongyi) attach `reasoning_content=""` to `additional_kwargs` even after the reasoning stage is finished, causing alternating empty `ReasoningContentBlock` and content blocks
- Added a truthiness check (`and reasoning_content`) so empty strings are treated the same as `None`
- Added test case for the empty string scenario

Closes #36194

## Test plan

- [x] Added unit test in `libs/core/tests/unit_tests/messages/test_ai.py` verifying that `reasoning_content=""` does not produce a reasoning content block
- [ ] Existing tests continue to pass (reasoning extraction with non-empty strings still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)