### PR TITLE
fix(core): forward detail field in convert_to_openai_image_block

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -19,6 +19,20 @@ if TYPE_CHECKING:
     from langchain_core.messages import AIMessage
 
 
+def _get_detail(block: dict[str, Any]) -> str | None:
+    """Extract the ``detail`` field from an image content block.
+
+    The value may live at the top level of the block, inside an ``extras``
+    dict, or inside a ``metadata`` dict.  Return ``None`` when absent.
+    """
+    detail = block.get("detail")
+    if detail is None:
+        detail = block.get("extras", {}).get("detail")
+    if detail is None:
+        detail = block.get("metadata", {}).get("detail")
+    return detail
+
+
 def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
     """Convert `ImageContentBlock` to format expected by OpenAI Chat Completions.
 
@@ -32,12 +46,15 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
     Returns:
         The formatted image content block.
     """
+    detail = _get_detail(block)
+
     if "url" in block:
+        image_url: dict[str, Any] = {"url": block["url"]}
+        if detail is not None:
+            image_url["detail"] = detail
         return {
             "type": "image_url",
-            "image_url": {
-                "url": block["url"],
-            },
+            "image_url": image_url,
         }
     if "base64" in block or block.get("source_type") == "base64":
         if "mime_type" not in block:
@@ -45,11 +62,12 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
             raise ValueError(error_message)
         mime_type = block["mime_type"]
         base64_data = block["data"] if "data" in block else block["base64"]
+        image_url = {"url": f"data:{mime_type};base64,{base64_data}"}
+        if detail is not None:
+            image_url["detail"] = detail
         return {
             "type": "image_url",
-            "image_url": {
-                "url": f"data:{mime_type};base64,{base64_data}",
-            },
+            "image_url": image_url,
         }
     error_message = "Unsupported source type. Only 'url' and 'base64' are supported."
     raise ValueError(error_message)

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -603,3 +603,97 @@ def test_convert_to_openai_data_block() -> None:
     expected = {"type": "input_file", "file_id": "file-abc123"}
     result = convert_to_openai_data_block(block, api="responses")
     assert result == expected
+
+
+def test_convert_to_openai_data_block_detail_field() -> None:
+    """detail field should be forwarded from image blocks to OpenAI output."""
+
+    # --- Chat Completions API ---
+
+    # detail at top level (url)
+    block: dict = {
+        "type": "image",
+        "url": "https://example.com/img.png",
+        "detail": "high",
+    }
+    result = convert_to_openai_data_block(block)
+    assert result == {
+        "type": "image_url",
+        "image_url": {"url": "https://example.com/img.png", "detail": "high"},
+    }
+
+    # detail at top level (base64)
+    block = {
+        "type": "image",
+        "base64": "<b64>",
+        "mime_type": "image/png",
+        "detail": "low",
+    }
+    result = convert_to_openai_data_block(block)
+    assert result == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,<b64>", "detail": "low"},
+    }
+
+    # detail in extras
+    block = {
+        "type": "image",
+        "url": "https://example.com/img.png",
+        "extras": {"detail": "auto"},
+    }
+    result = convert_to_openai_data_block(block)
+    assert result["image_url"]["detail"] == "auto"
+
+    # detail in metadata
+    block = {
+        "type": "image",
+        "url": "https://example.com/img.png",
+        "metadata": {"detail": "high"},
+    }
+    result = convert_to_openai_data_block(block)
+    assert result["image_url"]["detail"] == "high"
+
+    # no detail => key absent
+    block = {
+        "type": "image",
+        "url": "https://example.com/img.png",
+    }
+    result = convert_to_openai_data_block(block)
+    assert "detail" not in result["image_url"]
+
+    # --- Responses API ---
+
+    # detail at top level (url)
+    block = {
+        "type": "image",
+        "url": "https://example.com/img.png",
+        "detail": "high",
+    }
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == {
+        "type": "input_image",
+        "image_url": "https://example.com/img.png",
+        "detail": "high",
+    }
+
+    # detail at top level (base64, responses)
+    block = {
+        "type": "image",
+        "base64": "<b64>",
+        "mime_type": "image/png",
+        "detail": "low",
+    }
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == {
+        "type": "input_image",
+        "image_url": "data:image/png;base64,<b64>",
+        "detail": "low",
+    }
+
+    # no detail => key absent (responses)
+    block = {
+        "type": "image",
+        "url": "https://example.com/img.png",
+    }
+    result = convert_to_openai_data_block(block, api="responses")
+    assert "detail" not in result


### PR DESCRIPTION
## Summary

- `convert_to_openai_image_block` was silently dropping the `detail` field when constructing the `image_url` dict for OpenAI. The `detail` parameter controls image analysis resolution (`"low"`, `"high"`, `"auto"`) and is important for controlling token usage and analysis quality.
- Added a `_get_detail()` helper that extracts `detail` from the block's top-level, `extras`, or `metadata` dicts.
- The fix applies to both the Chat Completions API path (`{"type": "image_url", "image_url": {"url": "...", "detail": "high"}}`) and the Responses API path (`{"type": "input_image", "image_url": "...", "detail": "high"}`). The Responses API path in `convert_to_openai_data_block` already had code to forward `detail` from the intermediate chat completions block, but it was always empty before this fix.
- Added comprehensive tests covering `detail` from all three source locations, both API paths, and the absence case.

Closes #36297

## Test plan

- [x] Added `test_convert_to_openai_data_block_detail_field` covering:
  - Chat Completions: `detail` at top level (url and base64), in `extras`, in `metadata`, and absent
  - Responses API: `detail` at top level (url and base64), and absent
- [x] AST validation passes on both modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)