### PR TITLE
fix(openai): preserve non-strict tool default when converting to Responses API payload

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3997,8 +3997,15 @@ def _construct_responses_api_payload(
             # chat api: {"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}, "strict": ...}}  # noqa: E501
             # responses api: {"type": "function", "name": "...", "description": "...", "parameters": {...}, "strict": ...}  # noqa: E501
             if tool["type"] == "function" and "function" in tool:
+                func = tool["function"]
+                # In Chat Completions API, omitting `strict` means non-strict.
+                # In Responses API, omitting `strict` defaults to True.
+                # Explicitly set strict=False to preserve Chat Completions
+                # semantics.
+                if "strict" not in func:
+                    func = {**func, "strict": False}
                 extra = {k: v for k, v in tool.items() if k not in ("type", "function")}
-                new_tools.append({"type": "function", **tool["function"], **extra})
+                new_tools.append({"type": "function", **func, **extra})
             else:
                 if tool["type"] == "image_generation":
                     # Handle partial images (not yet supported)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3708,3 +3708,65 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test_responses_api_tool_strict_default_preserved() -> None:
+    """Test that tools without explicit strict get strict=False in Responses API.
+
+    In Chat Completions API, omitting `strict` means non-strict mode.
+    In Responses API, omitting `strict` defaults to strict=True.
+    The conversion must explicitly set strict=False to preserve semantics.
+    See: https://github.com/langchain-ai/langchain/issues/35837
+    """
+    from langchain_openai.chat_models.base import _construct_responses_api_payload
+
+    messages: list = []
+    payload = {
+        "model": "gpt-4o",
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "no_strict",
+                    "description": "Tool without strict set.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"x": {"type": "string"}},
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "explicit_strict_true",
+                    "description": "Tool with strict=True.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"x": {"type": "string"}},
+                    },
+                    "strict": True,
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "explicit_strict_false",
+                    "description": "Tool with strict=False.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"x": {"type": "string"}},
+                    },
+                    "strict": False,
+                },
+            },
+        ],
+    }
+    result = _construct_responses_api_payload(messages, payload)
+    tools_by_name = {t["name"]: t for t in result["tools"]}
+
+    # Tool without strict should get strict=False (not omitted)
+    assert tools_by_name["no_strict"]["strict"] is False
+    # Tool with explicit strict=True should keep it
+    assert tools_by_name["explicit_strict_true"]["strict"] is True
+    # Tool with explicit strict=False should keep it
+    assert tools_by_name["explicit_strict_false"]["strict"] is False


### PR DESCRIPTION
## Summary

- When `_construct_responses_api_payload` converts Chat Completions function tools to Responses API format, the `strict` parameter's default semantics differ between the two APIs: Chat Completions treats omitted `strict` as non-strict (`false`), while Responses API defaults to `strict: true`. This caused tools that were intended to be non-strict to silently become strict when reasoning parameters triggered the Responses API path.
- This fix explicitly sets `"strict": False` on any function tool that does not already have a `strict` value, preserving the original Chat Completions behavior.
- Added a unit test covering the three cases: no `strict` set (should default to `False`), explicit `strict: true`, and explicit `strict: false`.

Closes #35837

## Test plan

- [x] New unit test `test_responses_api_tool_strict_default_preserved` verifies that tools without `strict` get `strict=False`, and tools with explicit `strict` values are preserved unchanged.
- [ ] Existing unit tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)