### PR TITLE
feat(core): add `ChatBaseten` to serializable mapping

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -283,6 +283,11 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "chat_models",
         "ChatXAI",
     ),
+    ("langchain_baseten", "chat_models", "ChatBaseten"): (
+        "langchain_baseten",
+        "chat_models",
+        "ChatBaseten",
+    ),
     ("langchain", "chat_models", "fireworks", "ChatFireworks"): (
         "langchain_fireworks",
         "chat_models",


### PR DESCRIPTION
Register `ChatBaseten` from `langchain_baseten` in the core serialization mapping so it can round-trip through `loads`/`dumps`. Without this entry, serialized `ChatBaseten` objects fail to deserialize.