### PR TITLE
fix(core): ignore empty reasoning_content in additional_kwargs extraction

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content is not None and isinstance(reasoning_content, str) and reasoning_content:
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -502,3 +502,14 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+    # Test no reasoning extraction when reasoning_content is an empty string.
+    # Some providers (e.g. ChatTongyi) attach reasoning_content="" after the
+    # reasoning stage finishes, which should not produce empty reasoning blocks.
+    message = AIMessage(
+        content="The answer is 42.",
+        additional_kwargs={"reasoning_content": ""},
+    )
+    content_blocks = message.content_blocks
+    assert len(content_blocks) == 1
+    assert content_blocks[0]["type"] == "text"


### PR DESCRIPTION
## Summary

- Adds a truthiness check for `reasoning_content` in `_extract_reasoning_from_additional_kwargs` so empty strings (`""`) are treated the same as absent values
- Prevents empty `ReasoningContentBlock` entries from cluttering `content_blocks`

## Motivation

Some model providers (e.g. ChatTongyi, and potentially others) attach `reasoning_content=""` to `additional_kwargs` after the reasoning stage finishes. The current check `reasoning_content is not None and isinstance(reasoning_content, str)` passes for empty strings, producing empty reasoning blocks.

With `LC_OUTPUT_VERSION=v1`, this causes alternating empty reasoning and text blocks:

```
[{"type": "reasoning", "reasoning": ""}, {"type": "text", ...}, {"type": "reasoning", "reasoning": ""}, ...]
```

## Changes

- **`libs/core/langchain_core/messages/base.py`**: Added `and reasoning_content` truthiness check to the existing condition (1 character change)
- **`libs/core/tests/unit_tests/messages/test_ai.py`**: Added test case for empty `reasoning_content` string in `test_content_blocks_reasoning_extraction`

## Testing

- Added a test case that verifies `AIMessage` with `reasoning_content=""` in `additional_kwargs` produces only a text block (no empty reasoning block)
- Existing test for non-empty `reasoning_content` continues to pass

## Disclaimer

AI agents (Claude Code) assisted with this contribution — investigating the issue, tracing the code path, and drafting the fix.

Fixes #36194