### PR TITLE
fix(text-splitters): use deque to fix O(n²) in ExperimentalMarkdownSyntaxTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import deque
 from typing import Any, TypedDict
 
 from langchain_core.documents import Document
@@ -389,10 +390,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
         self.current_chunk = Document(page_content="")
         self.current_header_stack.clear()
 
-        raw_lines = text.splitlines(keepends=True)
+        raw_lines = deque(text.splitlines(keepends=True))
 
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             header_match = self._match_header(raw_line)
             code_match = self._match_code(raw_line)
             horz_match = self._match_horz(raw_line)
@@ -439,10 +440,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
                 break
         self.current_header_stack.append((header_depth, header_text))
 
-    def _resolve_code_chunk(self, current_line: str, raw_lines: list[str]) -> str:
+    def _resolve_code_chunk(self, current_line: str, raw_lines: deque[str]) -> str:
         chunk = current_line
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk


### PR DESCRIPTION
## Summary

- Replaces `list.pop(0)` with `collections.deque.popleft()` in `ExperimentalMarkdownSyntaxTextSplitter.split_text()` and `_resolve_code_chunk()`
- Reduces time complexity from O(n²) to O(n) for large markdown documents

## Motivation

`list.pop(0)` is O(n) because it shifts all remaining elements left. Called in a `while` loop over every line, this makes the overall algorithm O(n²). For a 50,000-line markdown document, that's ~1.25 billion element shifts instead of 50,000 iterations.

`collections.deque.popleft()` is O(1), making the fix a drop-in replacement with no behavioral change.

## Changes

- **`markdown.py`**: Import `deque` from `collections`, convert `raw_lines` from `list` to `deque`, replace `.pop(0)` with `.popleft()` in both `split_text()` and `_resolve_code_chunk()`
- Updated `_resolve_code_chunk` type hint from `list[str]` to `deque[str]`

## Why `deque` is safe here

`raw_lines` is only used with:
- `while raw_lines:` — truthiness check (works with deque)
- `.pop(0)` → `.popleft()` — the fix
- Passed to `_resolve_code_chunk()` — private method, single call site

No indexing, slicing, or other list-specific operations are used.

## Testing

Existing unit tests cover all splitter behavior (basic split, code blocks, headers, strip_headers, return_each_line, multi-file). The deque change is purely a performance improvement with identical output.

## Disclaimer

AI agents (Claude Code) assisted with this contribution.

Fixes #36488