### PR TITLE
fix(huggingface): support pydantic structured output for function calling

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,7 +47,7 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticToolsParser
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
     make_invalid_tool_call,
@@ -1168,11 +1168,13 @@ class ChatHuggingFace(BaseChatModel):
                 },
             )
             if is_pydantic_schema:
-                msg = "Pydantic schema is not supported for function calling"
-                raise NotImplementedError(msg)
-            output_parser: JsonOutputKeyToolsParser | JsonOutputParser = (
-                JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
-            )
+                output_parser = PydanticToolsParser(
+                    tools=[cast("type[BaseModel]", schema)], first_tool_only=True
+                )
+            else:
+                output_parser = JsonOutputKeyToolsParser(
+                    key_name=tool_name, first_tool_only=True
+                )
         elif method == "json_schema":
             if schema is None:
                 msg = (

--- a/libs/partners/huggingface/tests/integration_tests/test_standard.py
+++ b/libs/partners/huggingface/tests/integration_tests/test_standard.py
@@ -29,10 +29,7 @@ class TestHuggingFaceEndpoint(ChatModelIntegrationTests):
     def model(self, request: Any) -> BaseChatModel:
         return self.chat_model_class(**self.chat_model_params)  # type: ignore[call-arg]
 
-    @pytest.mark.xfail(
-        reason=("Overrding, testing only typed dict and json schema structured output")
-    )
-    @pytest.mark.parametrize("schema_type", ["typeddict", "json_schema"])
+    @pytest.mark.parametrize("schema_type", ["pydantic", "typeddict", "json_schema"])
     def test_structured_output(
         self,
         model: BaseChatModel,
@@ -40,10 +37,7 @@ class TestHuggingFaceEndpoint(ChatModelIntegrationTests):
     ) -> None:
         super().test_structured_output(model, schema_type)
 
-    @pytest.mark.xfail(
-        reason=("Overrding, testing only typed dict and json schema structured output")
-    )
-    @pytest.mark.parametrize("schema_type", ["typeddict", "json_schema"])
+    @pytest.mark.parametrize("schema_type", ["pydantic", "typeddict", "json_schema"])
     async def test_structured_output_async(
         self,
         model: BaseChatModel,
@@ -51,11 +45,9 @@ class TestHuggingFaceEndpoint(ChatModelIntegrationTests):
     ) -> None:
         super().test_structured_output(model, schema_type)
 
-    @pytest.mark.xfail(reason=("Pydantic structured output is not supported"))
     def test_structured_output_pydantic_2_v1(self, model: BaseChatModel) -> None:
         super().test_structured_output_pydantic_2_v1(model)
 
-    @pytest.mark.xfail(reason=("Pydantic structured output is not supported"))
     def test_structured_output_optional_param(self, model: BaseChatModel) -> None:
         super().test_structured_output_optional_param(model)
 

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -10,7 +10,9 @@ from langchain_core.messages import (
     SystemMessage,
 )
 from langchain_core.outputs import ChatResult
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
@@ -220,6 +222,82 @@ def test_bind_tools(chat_hugging_face: Any) -> None:
         _, kwargs = mock_super_bind.call_args
         assert kwargs["tools"] == tools
         assert kwargs["tool_choice"] == "auto"
+
+
+def test_with_structured_output_pydantic_function_calling(
+    chat_hugging_face: Any,
+) -> None:
+    class Joke(BaseModel):
+        """Joke response schema."""
+
+        setup: str
+        punchline: str
+
+    fake_llm = RunnableLambda(
+        lambda _: AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_joke",
+                    "name": "Joke",
+                    "args": {
+                        "setup": "Why did the model cross the road?",
+                        "punchline": "To reach the token on the other side.",
+                    },
+                }
+            ],
+        )
+    )
+
+    with patch.object(
+        ChatHuggingFace, "bind_tools", return_value=fake_llm
+    ) as mock_bind_tools:
+        structured_llm = chat_hugging_face.with_structured_output(Joke)
+        result = structured_llm.invoke("Tell me a joke")
+
+    mock_bind_tools.assert_called_once()
+    assert isinstance(result, Joke)
+    assert result.setup == "Why did the model cross the road?"
+    assert result.punchline == "To reach the token on the other side."
+
+
+def test_with_structured_output_pydantic_function_calling_include_raw(
+    chat_hugging_face: Any,
+) -> None:
+    class Joke(BaseModel):
+        """Joke response schema."""
+
+        setup: str
+        punchline: str
+
+    raw_message = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "id": "call_joke",
+                "name": "Joke",
+                "args": {
+                    "setup": "Why did the model cross the road?",
+                    "punchline": "To reach the token on the other side.",
+                },
+            }
+        ],
+    )
+    fake_llm = RunnableLambda(lambda _: raw_message)
+
+    with patch.object(
+        ChatHuggingFace, "bind_tools", return_value=fake_llm
+    ) as mock_bind_tools:
+        structured_llm = chat_hugging_face.with_structured_output(
+            Joke, include_raw=True
+        )
+        result = structured_llm.invoke("Tell me a joke")
+
+    mock_bind_tools.assert_called_once()
+    assert result["raw"] == raw_message
+    assert isinstance(result["parsed"], Joke)
+    assert result["parsed"].setup == "Why did the model cross the road?"
+    assert result["parsing_error"] is None
 
 
 def test_property_inheritance_integration(chat_hugging_face: Any) -> None:


### PR DESCRIPTION
Fixes #36441

Enable Pydantic schemas in `ChatHuggingFace.with_structured_output(..., method="function_calling")` by using `PydanticToolsParser` instead of raising `NotImplementedError`. Add unit coverage for parsed and `include_raw=True` behavior and remove outdated xfails for Pydantic structured output.

## How did you verify your code works?

I verified the change with:
`uv run pytest tests/unit_tests/test_chat_models.py -k 'structured_output_pydantic_function_calling' -q`

## AI Disclosure

This contribution was developed with assistance from an AI coding agent and reviewed manually.
