### PR TITLE
feat: add state_schema parameter to @wrap_tool_call decorator

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -1902,6 +1902,7 @@ def wrap_tool_call(
 def wrap_tool_call(
     func: None = None,
     *,
+    state_schema: type[StateT] | None = None,
     tools: list[BaseTool] | None = None,
     name: str | None = None,
 ) -> Callable[
@@ -1913,6 +1914,7 @@ def wrap_tool_call(
 def wrap_tool_call(
     func: _CallableReturningToolResponse | None = None,
     *,
+    state_schema: type[StateT] | None = None,
     tools: list[BaseTool] | None = None,
     name: str | None = None,
 ) -> (
@@ -1935,6 +1937,9 @@ def wrap_tool_call(
             `Command`.
 
             Can be sync or async.
+        state_schema: Optional custom state schema type.
+
+            If not provided, uses the default `AgentState` schema.
         tools: Additional tools to register with this middleware.
         name: Middleware class name.
 
@@ -2022,7 +2027,7 @@ def wrap_tool_call(
                 middleware_name,
                 (AgentMiddleware,),
                 {
-                    "state_schema": AgentState,
+                    "state_schema": state_schema or AgentState,
                     "tools": tools or [],
                     "awrap_tool_call": async_wrapped,
                 },
@@ -2041,7 +2046,7 @@ def wrap_tool_call(
             middleware_name,
             (AgentMiddleware,),
             {
-                "state_schema": AgentState,
+                "state_schema": state_schema or AgentState,
                 "tools": tools or [],
                 "wrap_tool_call": wrapped,
             },

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py
@@ -14,7 +14,7 @@ from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.types import Command
 
 from langchain.agents.factory import create_agent
-from langchain.agents.middleware.types import ToolCallRequest, wrap_tool_call
+from langchain.agents.middleware.types import AgentState, ToolCallRequest, wrap_tool_call
 from tests.unit_tests.agents.model import FakeToolCallingModel
 
 
@@ -865,3 +865,19 @@ def test_wrap_tool_call_monitoring_pattern() -> None:
     assert metrics[0]["success"] is True
     assert isinstance(metrics[0]["execution_time"], float)
     assert metrics[0]["execution_time"] >= 0
+
+def test_wrap_tool_call_with_state_schema() -> None:
+    """Test wrap_tool_call decorator with state_schema parameter."""
+
+    class CustomState(AgentState):
+        """Custom state with additional field."""
+        custom_field: str
+
+    @wrap_tool_call(state_schema=CustomState)
+    def wrapper_with_state(
+        request: ToolCallRequest, handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]]
+    ) -> ToolMessage | Command[Any]:
+        return handler(request)
+
+    # Verify state schema was applied
+    assert wrapper_with_state.state_schema == CustomState


### PR DESCRIPTION
# Allow defining `state_schema` through the `@wrap_tool_call` decorator

## Description
This PR adds the `state_schema` parameter to the `@wrap_tool_call` decorator, making it consistent with other middleware decorators like `@before_model`, `@after_model`, and `@wrap_model_call`.

## Changes
- Added `state_schema` parameter to `wrap_tool_call` function signature and overloads
- Updated decorator implementation to apply custom state schema to generated middleware
- Added docstring documentation for the new parameter
- Added test case `test_wrap_tool_call_with_state_schema` to verify functionality

## Fixes
Closes #36409

## How did you verify your code works?
✅ All 20 tests pass in `test_wrap_tool_call.py`
✅ No breaking changes to existing functionality