### PR TITLE
fix(langchain-huggingface): Support Pydantic schema for structured output

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,9 +47,10 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
+    PydanticToolsParser,
     make_invalid_tool_call,
     parse_tool_call,
 )
@@ -1168,11 +1169,13 @@ class ChatHuggingFace(BaseChatModel):
                 },
             )
             if is_pydantic_schema:
-                msg = "Pydantic schema is not supported for function calling"
-                raise NotImplementedError(msg)
-            output_parser: JsonOutputKeyToolsParser | JsonOutputParser = (
-                JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
-            )
+                output_parser: Any = PydanticToolsParser(
+                    tools=[schema], first_tool_only=True
+                )
+            else:
+                output_parser = JsonOutputKeyToolsParser(
+                    key_name=tool_name, first_tool_only=True
+                )
         elif method == "json_schema":
             if schema is None:
                 msg = (
@@ -1188,7 +1191,10 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(pydantic_object=schema)
+            else:
+                output_parser = JsonOutputParser()  # type: ignore[arg-type]
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1197,7 +1203,10 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(pydantic_object=schema)
+            else:
+                output_parser = JsonOutputParser()  # type: ignore[arg-type]
         else:
             msg = (
                 f"Unrecognized method argument. Expected one of 'function_calling' or "

--- a/libs/partners/huggingface/tests/unit_tests/test_structured_output.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_structured_output.py
@@ -1,0 +1,62 @@
+from typing import Any
+from unittest.mock import Mock, patch
+import pytest
+
+from pydantic import BaseModel, Field
+
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from langchain_huggingface.chat_models import ChatHuggingFace
+from langchain_huggingface.llms.huggingface_endpoint import HuggingFaceEndpoint
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
+from langchain_core.output_parsers.openai_tools import (
+    JsonOutputKeyToolsParser,
+    PydanticToolsParser,
+)
+
+class PersonInfo(BaseModel):
+    name: str = Field(description="Name of the person")
+    age: int = Field(description="Age of the person")
+
+@pytest.fixture
+def mock_llm() -> Mock:
+    llm = Mock(spec=HuggingFaceEndpoint)
+    llm.repo_id = "test/model"
+    llm.model = "test/model"
+    return llm
+
+@pytest.fixture
+@patch("langchain_huggingface.chat_models.huggingface.ChatHuggingFace._resolve_model_id")
+def chat_hugging_face(mock_resolve_id: Any, mock_llm: Any) -> ChatHuggingFace:
+    return ChatHuggingFace(llm=mock_llm)
+
+def test_structured_output_function_calling_pydantic(chat_hugging_face: ChatHuggingFace) -> None:
+    """Test with_structured_output returns PydanticToolsParser when schema is a Pydantic model and method is function_calling."""
+    chain = chat_hugging_face.with_structured_output(schema=PersonInfo, method="function_calling")
+    
+    output_parser = chain.last  # Getting the output parser from the pipeline
+    assert isinstance(output_parser, PydanticToolsParser)
+
+def test_structured_output_json_schema_pydantic(chat_hugging_face: ChatHuggingFace) -> None:
+    """Test with_structured_output returns PydanticOutputParser when schema is a Pydantic model and method is json_schema."""
+    chain = chat_hugging_face.with_structured_output(schema=PersonInfo, method="json_schema")
+    
+    output_parser = chain.last
+    assert isinstance(output_parser, PydanticOutputParser)
+    assert output_parser.pydantic_object == PersonInfo
+
+def test_structured_output_json_mode_pydantic(chat_hugging_face: ChatHuggingFace) -> None:
+    """Test with_structured_output returns PydanticOutputParser when schema is a Pydantic model and method is json_mode."""
+    chain = chat_hugging_face.with_structured_output(schema=PersonInfo, method="json_mode")
+    
+    output_parser = chain.last
+    assert isinstance(output_parser, PydanticOutputParser)
+    assert output_parser.pydantic_object == PersonInfo
+
+def test_structured_output_function_calling_dict(chat_hugging_face: ChatHuggingFace) -> None:
+    """Test with_structured_output returns JsonOutputKeyToolsParser when schema is a dict."""
+    schema_dict = convert_to_openai_tool(PersonInfo)
+    
+    chain = chat_hugging_face.with_structured_output(schema=schema_dict, method="function_calling")
+    
+    output_parser = chain.last
+    assert isinstance(output_parser, JsonOutputKeyToolsParser)


### PR DESCRIPTION
Resolves #32197. This PR ensures Pydantic output parsers are utilized when a Pydantic BaseModel is provided to ChatHuggingFace \with_structured_output\. Tests have been introduced to verify logic in \unction_calling\, \json_schema\, and \json_mode\.