### PR TITLE
feat(huggingface): add chat_template_kwargs to ChatHuggingFace

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -526,6 +526,9 @@ class ChatHuggingFace(BaseChatModel):
     """Maximum number of tokens to generate."""
     model_kwargs: dict[str, Any] = Field(default_factory=dict)
     """Holds any model parameters valid for `create` call not explicitly specified."""
+    chat_template_kwargs: dict[str, Any] = Field(default_factory=dict)
+    """Additional keyword arguments to pass to the tokenizer's
+    ``apply_chat_template`` method (e.g. ``{"enable_thinking": True}``)."""
 
     def __init__(self, **kwargs: Any):
         super().__init__(**kwargs)
@@ -958,7 +961,10 @@ class ChatHuggingFace(BaseChatModel):
         messages_dicts = [self._to_chatml_format(m) for m in messages]
 
         return self.tokenizer.apply_chat_template(
-            messages_dicts, tokenize=False, add_generation_prompt=True
+            messages_dicts,
+            tokenize=False,
+            add_generation_prompt=True,
+            **self.chat_template_kwargs,
         )
 
     def _to_chatml_format(self, message: BaseMessage) -> dict:

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -327,6 +327,46 @@ def test_inheritance_with_empty_llm() -> None:
         assert chat.temperature is None
 
 
+def test_to_chat_prompt_with_chat_template_kwargs(mock_llm: Any) -> None:
+    """Test that chat_template_kwargs are forwarded to apply_chat_template."""
+    with patch(
+        "langchain_huggingface.chat_models.huggingface.ChatHuggingFace._resolve_model_id"
+    ):
+        tokenizer = MagicMock()
+        tokenizer.apply_chat_template.return_value = "Generated chat prompt"
+
+        chat = ChatHuggingFace(
+            llm=mock_llm,
+            tokenizer=tokenizer,
+            chat_template_kwargs={"enable_thinking": True},
+        )
+
+        messages = [HumanMessage(content="Hello")]
+        result = chat._to_chat_prompt(messages)
+
+        assert result == "Generated chat prompt"
+        tokenizer.apply_chat_template.assert_called_once_with(
+            [{"role": "user", "content": "Hello"}],
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=True,
+        )
+
+
+def test_to_chat_prompt_empty_chat_template_kwargs(chat_hugging_face: Any) -> None:
+    """Test that empty chat_template_kwargs does not change behavior."""
+    chat_hugging_face.tokenizer.apply_chat_template.return_value = "prompt"
+
+    messages = [HumanMessage(content="Hi")]
+    chat_hugging_face._to_chat_prompt(messages)
+
+    chat_hugging_face.tokenizer.apply_chat_template.assert_called_once_with(
+        [{"role": "user", "content": "Hi"}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+
 def test_profile() -> None:
     empty_llm = Mock(spec=HuggingFaceEndpoint)
     empty_llm.repo_id = "test/model"


### PR DESCRIPTION
Fixes #36535

## Description

`ChatHuggingFace._to_chat_prompt` currently calls `tokenizer.apply_chat_template` with hardcoded arguments only (`tokenize=False, add_generation_prompt=True`). This makes it impossible to pass model-specific template options — most notably `enable_thinking` for reasoning models like QwQ, DeepSeek-R1, etc. — without subclassing.

This PR adds a `chat_template_kwargs` field (default `{}`) that gets unpacked into `apply_chat_template`, so users can pass any extra kwargs the tokenizer supports:

```python
chat = ChatHuggingFace(
    llm=pipeline,
    chat_template_kwargs={"enable_thinking": True},
)
```

## Changes

- Added `chat_template_kwargs: dict[str, Any]` field to `ChatHuggingFace`
- Unpacked it in `_to_chat_prompt` via `**self.chat_template_kwargs`
- Added unit tests for both the new kwarg forwarding and the default (empty) case

## Backward compatibility

Default value is `{}`, so `**{}` adds nothing — existing behavior is unchanged.