### PR TITLE
fix(text-splitters): replace list.pop(0) with deque.popleft() in markdown splitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import deque
 from typing import Any, TypedDict
 
 from langchain_core.documents import Document
@@ -389,10 +390,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
         self.current_chunk = Document(page_content="")
         self.current_header_stack.clear()
 
-        raw_lines = text.splitlines(keepends=True)
+        raw_lines = deque(text.splitlines(keepends=True))
 
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             header_match = self._match_header(raw_line)
             code_match = self._match_code(raw_line)
             horz_match = self._match_horz(raw_line)
@@ -439,10 +440,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
                 break
         self.current_header_stack.append((header_depth, header_text))
 
-    def _resolve_code_chunk(self, current_line: str, raw_lines: list[str]) -> str:
+    def _resolve_code_chunk(self, current_line: str, raw_lines: deque[str]) -> str:
         chunk = current_line
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk


### PR DESCRIPTION
## Summary

- Replaces `list.pop(0)` with `collections.deque.popleft()` in `ExperimentalMarkdownSyntaxTextSplitter`
- Fixes O(n^2) performance — `list.pop(0)` is O(n) per call due to element shifting, making the main loop O(n^2) for large documents
- `deque.popleft()` is O(1), bringing overall complexity to O(n)

As reported in #36488, this gives ~100x speedup on documents with 50k+ lines.

Closes #36488

## Changes

- `text.splitlines()` result is now wrapped in `collections.deque()` 
- Both `.pop(0)` call sites replaced with `.popleft()`
- `_resolve_code_chunk` type hint updated from `list[str]` to `deque[str]`

> This PR was created with AI agent assistance.

## Test plan

- [x] No behavioral change — only performance improvement
- [x] All existing markdown splitter tests pass unchanged
- [x] Verified `deque` supports the same iteration/truthiness checks used in the `while raw_lines:` loops