### PR TITLE
fix(core): fire `on_retry` callback in `RunnableRetry`

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -1,5 +1,4 @@
 """`Runnable` that retries a `Runnable` if it fails."""
-
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -176,6 +175,25 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
             for c, rm in zip(config, run_manager, strict=False)
         ]
 
+    @staticmethod
+    def _copy_retry_state(
+        retry_state: RetryCallState,
+        exc: BaseException,
+    ) -> RetryCallState:
+        copied = RetryCallState(
+            retry_object=retry_state.retry_object,
+            fn=retry_state.fn,
+            args=retry_state.args,
+            kwargs=retry_state.kwargs,
+        )
+        copied.start_time = retry_state.start_time
+        copied.attempt_number = retry_state.attempt_number
+        copied.idle_for = retry_state.idle_for
+        copied.next_action = retry_state.next_action
+        copied.upcoming_sleep = retry_state.upcoming_sleep
+        copied.set_exception((type(exc), exc, exc.__traceback__))
+        return copied
+
     def _invoke(
         self,
         input_: Input,
@@ -244,14 +262,14 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         **kwargs: Any,
     ) -> list[Output | Exception]:
         results_map: dict[int, Output] = {}
-        retry_run_managers: list["CallbackManagerForChainRun"] = []
+        retry_failures: list[tuple["CallbackManagerForChainRun", BaseException]] = []
 
         not_set: list[Output] = []
         result = not_set
         try:
             def _before_sleep(retry_state: RetryCallState) -> None:
-                for manager in retry_run_managers:
-                    manager.on_retry(retry_state)
+                for manager, exc in retry_failures:
+                    manager.on_retry(self._copy_retry_state(retry_state, exc))
 
             for attempt in self._sync_retrying(before_sleep=_before_sleep):
                 with attempt:
@@ -277,12 +295,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     # Register the results of the inputs that have succeeded, mapping
                     # back to their original indices.
                     first_exception = None
-                    retry_run_managers = []
+                    retry_failures = []
                     for offset, r in enumerate(result):
                         if isinstance(r, Exception):
                             if not first_exception:
                                 first_exception = r
-                            retry_run_managers.append(pending_run_managers[offset])
+                            retry_failures.append((pending_run_managers[offset], r))
                             continue
                         orig_idx = remaining_indices[offset]
                         results_map[orig_idx] = r
@@ -327,14 +345,14 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         **kwargs: Any,
     ) -> list[Output | Exception]:
         results_map: dict[int, Output] = {}
-        retry_run_managers: list["AsyncCallbackManagerForChainRun"] = []
+        retry_failures: list[tuple["AsyncCallbackManagerForChainRun", BaseException]] = []
 
         not_set: list[Output] = []
         result = not_set
         try:
             async def _before_sleep(retry_state: RetryCallState) -> None:
-                for manager in retry_run_managers:
-                    await manager.on_retry(retry_state)
+                for manager, exc in retry_failures:
+                    await manager.on_retry(self._copy_retry_state(retry_state, exc))
 
             async for attempt in self._async_retrying(before_sleep=_before_sleep):
                 with attempt:
@@ -359,12 +377,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     # Register the results of the inputs that have succeeded, mapping
                     # back to their original indices.
                     first_exception = None
-                    retry_run_managers = []
+                    retry_failures = []
                     for offset, r in enumerate(result):
                         if isinstance(r, Exception):
                             if not first_exception:
                                 first_exception = r
-                            retry_run_managers.append(pending_run_managers[offset])
+                            retry_failures.append((pending_run_managers[offset], r))
                             continue
                         orig_idx = remaining_indices[offset]
                         results_map[orig_idx] = r

--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -183,7 +183,13 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         config: RunnableConfig,
         **kwargs: Any,
     ) -> Output:
-        for attempt in self._sync_retrying(reraise=True):
+        def _before_sleep(retry_state: RetryCallState) -> None:
+            run_manager.on_retry(retry_state)
+
+        for attempt in self._sync_retrying(
+            reraise=True,
+            before_sleep=_before_sleep,
+        ):
             with attempt:
                 result = super().invoke(
                     input_,
@@ -207,7 +213,13 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         config: RunnableConfig,
         **kwargs: Any,
     ) -> Output:
-        async for attempt in self._async_retrying(reraise=True):
+        async def _before_sleep(retry_state: RetryCallState) -> None:
+            await run_manager.on_retry(retry_state)
+
+        async for attempt in self._async_retrying(
+            reraise=True,
+            before_sleep=_before_sleep,
+        ):
             with attempt:
                 result = await super().ainvoke(
                     input_,
@@ -232,11 +244,16 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         **kwargs: Any,
     ) -> list[Output | Exception]:
         results_map: dict[int, Output] = {}
+        retry_run_managers: list["CallbackManagerForChainRun"] = []
 
         not_set: list[Output] = []
         result = not_set
         try:
-            for attempt in self._sync_retrying():
+            def _before_sleep(retry_state: RetryCallState) -> None:
+                for manager in retry_run_managers:
+                    manager.on_retry(retry_state)
+
+            for attempt in self._sync_retrying(before_sleep=_before_sleep):
                 with attempt:
                     # Retry for inputs that have not yet succeeded
                     # Determine which original indices remain.
@@ -260,10 +277,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     # Register the results of the inputs that have succeeded, mapping
                     # back to their original indices.
                     first_exception = None
+                    retry_run_managers = []
                     for offset, r in enumerate(result):
                         if isinstance(r, Exception):
                             if not first_exception:
                                 first_exception = r
+                            retry_run_managers.append(pending_run_managers[offset])
                             continue
                         orig_idx = remaining_indices[offset]
                         results_map[orig_idx] = r
@@ -308,11 +327,16 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
         **kwargs: Any,
     ) -> list[Output | Exception]:
         results_map: dict[int, Output] = {}
+        retry_run_managers: list["AsyncCallbackManagerForChainRun"] = []
 
         not_set: list[Output] = []
         result = not_set
         try:
-            async for attempt in self._async_retrying():
+            async def _before_sleep(retry_state: RetryCallState) -> None:
+                for manager in retry_run_managers:
+                    await manager.on_retry(retry_state)
+
+            async for attempt in self._async_retrying(before_sleep=_before_sleep):
                 with attempt:
                     # Retry for inputs that have not yet succeeded
                     # Determine which original indices remain.
@@ -335,10 +359,12 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     # Register the results of the inputs that have succeeded, mapping
                     # back to their original indices.
                     first_exception = None
+                    retry_run_managers = []
                     for offset, r in enumerate(result):
                         if isinstance(r, Exception):
                             if not first_exception:
                                 first_exception = r
+                            retry_run_managers.append(pending_run_managers[offset])
                             continue
                         orig_idx = remaining_indices[offset]
                         results_map[orig_idx] = r

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -4050,6 +4050,7 @@ class RetryCallbackHandler(BaseCallbackHandler):
 
     def __init__(self) -> None:
         self.attempt_numbers: list[int] = []
+        self.exceptions: list[BaseException] = []
 
     @override
     def on_retry(
@@ -4061,6 +4062,10 @@ class RetryCallbackHandler(BaseCallbackHandler):
         **kwargs: Any,
     ) -> None:
         self.attempt_numbers.append(retry_state.attempt_number)
+        if retry_state.outcome is not None and retry_state.outcome.failed:
+            exc = retry_state.outcome.exception()
+            if exc is not None:
+                self.exceptions.append(exc)
 
 
 def test_retry_invoke_fires_on_retry_callback() -> None:
@@ -4155,6 +4160,56 @@ async def test_retry_abatch_fires_on_retry_callback_for_failed_inputs_only() -> 
         retry_if_exception_type=(ValueError,),
     ).abatch([0, 1, 2], config=configs) == [0, 1, 2]
     assert [handler.attempt_numbers for handler in handlers] == [[], [1], []]
+
+
+def test_retry_batch_reports_each_failure_exception_to_matching_callback() -> None:
+    failures = {
+        0: ValueError("value-error"),
+        1: RuntimeError("runtime-error"),
+    }
+
+    def flaky(value: int) -> int:
+        if value in failures:
+            raise failures.pop(value)
+        return value
+
+    handlers = [RetryCallbackHandler() for _ in range(3)]
+    configs = [{"callbacks": [handler]} for handler in handlers]
+    runnable = RunnableLambda(flaky)
+
+    assert runnable.with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError, RuntimeError),
+    ).batch([0, 1, 2], config=configs) == [0, 1, 2]
+    assert [type(exc) for exc in handlers[0].exceptions] == [ValueError]
+    assert [type(exc) for exc in handlers[1].exceptions] == [RuntimeError]
+    assert handlers[2].exceptions == []
+
+
+async def test_retry_abatch_reports_each_failure_exception_to_matching_callback() -> None:
+    failures = {
+        0: ValueError("value-error"),
+        1: RuntimeError("runtime-error"),
+    }
+
+    def flaky(value: int) -> int:
+        if value in failures:
+            raise failures.pop(value)
+        return value
+
+    handlers = [RetryCallbackHandler() for _ in range(3)]
+    configs = [{"callbacks": [handler]} for handler in handlers]
+    runnable = RunnableLambda(flaky)
+
+    assert await runnable.with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError, RuntimeError),
+    ).abatch([0, 1, 2], config=configs) == [0, 1, 2]
+    assert [type(exc) for exc in handlers[0].exceptions] == [ValueError]
+    assert [type(exc) for exc in handlers[1].exceptions] == [RuntimeError]
+    assert handlers[2].exceptions == []
 
 
 def test_runnable_lambda_stream() -> None:

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -22,6 +22,7 @@ from packaging import version
 from pydantic import BaseModel, Field
 from pytest_mock import MockerFixture
 from syrupy.assertion import SnapshotAssertion
+from tenacity import RetryCallState
 from typing_extensions import TypedDict, override
 
 from langchain_core.callbacks import BaseCallbackHandler
@@ -4042,6 +4043,118 @@ async def test_async_retrying(mocker: MockerFixture) -> None:
     assert isinstance(output[1], RuntimeError)
     assert output[2] == 0
     lambda_mock.reset_mock()
+
+
+class RetryCallbackHandler(BaseCallbackHandler):
+    """Capture retry attempt numbers observed through callbacks."""
+
+    def __init__(self) -> None:
+        self.attempt_numbers: list[int] = []
+
+    @override
+    def on_retry(
+        self,
+        retry_state: RetryCallState,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.attempt_numbers.append(retry_state.attempt_number)
+
+
+def test_retry_invoke_fires_on_retry_callback() -> None:
+    attempts = 0
+
+    def flaky(value: int) -> int:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            msg = "transient"
+            raise ValueError(msg)
+        return value
+
+    handler = RetryCallbackHandler()
+    runnable = RunnableLambda(flaky)
+
+    assert (
+        runnable.with_retry(
+            stop_after_attempt=3,
+            wait_exponential_jitter=False,
+            retry_if_exception_type=(ValueError,),
+        ).invoke(1, config={"callbacks": [handler]})
+        == 1
+    )
+    assert handler.attempt_numbers == [1, 2]
+
+
+async def test_retry_ainvoke_fires_on_retry_callback() -> None:
+    attempts = 0
+
+    def flaky(value: int) -> int:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            msg = "transient"
+            raise ValueError(msg)
+        return value
+
+    handler = RetryCallbackHandler()
+    runnable = RunnableLambda(flaky)
+
+    assert (
+        await runnable.with_retry(
+            stop_after_attempt=3,
+            wait_exponential_jitter=False,
+            retry_if_exception_type=(ValueError,),
+        ).ainvoke(1, config={"callbacks": [handler]})
+        == 1
+    )
+    assert handler.attempt_numbers == [1, 2]
+
+
+def test_retry_batch_fires_on_retry_callback_for_failed_inputs_only() -> None:
+    failed_once: set[int] = {1}
+
+    def flaky(value: int) -> int:
+        if value in failed_once:
+            failed_once.remove(value)
+            msg = "transient"
+            raise ValueError(msg)
+        return value
+
+    handlers = [RetryCallbackHandler() for _ in range(3)]
+    configs = [{"callbacks": [handler]} for handler in handlers]
+    runnable = RunnableLambda(flaky)
+
+    assert runnable.with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError,),
+    ).batch([0, 1, 2], config=configs) == [0, 1, 2]
+    assert [handler.attempt_numbers for handler in handlers] == [[], [1], []]
+
+
+async def test_retry_abatch_fires_on_retry_callback_for_failed_inputs_only() -> None:
+    failed_once: set[int] = {1}
+
+    def flaky(value: int) -> int:
+        if value in failed_once:
+            failed_once.remove(value)
+            msg = "transient"
+            raise ValueError(msg)
+        return value
+
+    handlers = [RetryCallbackHandler() for _ in range(3)]
+    configs = [{"callbacks": [handler]} for handler in handlers]
+    runnable = RunnableLambda(flaky)
+
+    assert await runnable.with_retry(
+        stop_after_attempt=2,
+        wait_exponential_jitter=False,
+        retry_if_exception_type=(ValueError,),
+    ).abatch([0, 1, 2], config=configs) == [0, 1, 2]
+    assert [handler.attempt_numbers for handler in handlers] == [[], [1], []]
 
 
 def test_runnable_lambda_stream() -> None:


### PR DESCRIPTION
## Description

`RunnableRetry` does not fire `on_retry` callbacks, making it impossible to observe retry attempts through LangChain's callback system.

This PR wires tenacity's `before_sleep` hook to `run_manager.on_retry()` across all four execution paths: `_invoke`, `_ainvoke`, `_batch`, and `_abatch`.

Fixes #36382

## Changes

### Production (`langchain_core/runnables/retry.py`)

- **`_invoke` / `_ainvoke`**: Added a `_before_sleep` closure that calls `run_manager.on_retry(retry_state)` before each retry sleep. Passed to `self._sync_retrying()` / `self._async_retrying()` via the `before_sleep` kwarg.
- **`_batch` / `_abatch`**: Same pattern, but the closure iterates only over `retry_run_managers` — the subset of run managers whose inputs failed in the current attempt. Successful inputs never receive `on_retry`.

### Tests (`tests/unit_tests/runnables/test_runnable.py`)

Added 4 regression tests with a `RetryCallbackHandler` that records `attempt_number` from each `on_retry` call:

| Test | Path | Validates |
|---|---|---|
| `test_retry_invoke_fires_on_retry_callback` | sync invoke | `on_retry` fires on attempts 1, 2 |
| `test_retry_ainvoke_fires_on_retry_callback` | async invoke | same, async path |
| `test_retry_batch_fires_on_retry_callback_for_failed_inputs_only` | sync batch | only failed input's handler fires |
| `test_retry_abatch_fires_on_retry_callback_for_failed_inputs_only` | async batch | same, async path |

## Notes

- No new dependencies introduced (`RetryCallState` was already imported).
- The batch path shares a single `retry_state` across all failed inputs in a given attempt (inherent to tenacity's single-exception-raise model). This is consistent with the existing batch retry architecture and can be refined in a future PR if per-input retry state is needed.