### PR TITLE
fix(core): handle pydantic v1 validation errors in BaseTool.arun

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1111,7 +1111,7 @@ class ChildTool(BaseTool):
                         error_to_raise = ValueError(msg)
             else:
                 content = response
-        except ValidationError as e:
+        except (ValidationError, ValidationErrorV1) as e:
             if not self.handle_validation_error:
                 error_to_raise = e
             else:


### PR DESCRIPTION
## Description
`BaseTool.arun()` was only catching pydantic v2 `ValidationError`, while
`BaseTool.run()` catches both `ValidationError` and `ValidationErrorV1`.

This caused `handle_validation_error=True` to work correctly in sync
execution but raise an unhandled exception in async execution when using
a pydantic v1 `args_schema`.

## Fix
Added `ValidationErrorV1` to the `except` clause in `arun()` to match
the existing behavior in `run()`.

## Testing
Verified locally with the reproduction script from the issue — both
`tool.run()` and `tool.arun()` now return `"Tool input validation error"`
for invalid input.

Fixes #36491