### PR TITLE
chore(langchain): drop gpt-3.5-turbo from docstring examples

### DIFF
--- a/libs/langchain/langchain_classic/chains/combine_documents/stuff.py
+++ b/libs/langchain/langchain_classic/chains/combine_documents/stuff.py
@@ -68,7 +68,7 @@ def create_stuff_documents_chain(
         prompt = ChatPromptTemplate.from_messages(
             [("system", "What are everyone's favorite colors:\n\n{context}")]
         )
-        model = ChatOpenAI(model="gpt-3.5-turbo")
+        model = ChatOpenAI(model="gpt-5.4-mini")
         chain = create_stuff_documents_chain(model, prompt)
 
         docs = [

--- a/libs/langchain/langchain_classic/chains/conversation/base.py
+++ b/libs/langchain/langchain_classic/chains/conversation/base.py
@@ -47,7 +47,7 @@ class ConversationChain(LLMChain):
             return store[session_id]
 
 
-        model = ChatOpenAI(model="gpt-3.5-turbo-0125")
+        model = ChatOpenAI(model="gpt-5.4-mini")
 
         chain = RunnableWithMessageHistory(model, get_session_history)
         chain.invoke(
@@ -85,7 +85,7 @@ class ConversationChain(LLMChain):
             return store[session_id]
 
 
-        model = ChatOpenAI(model="gpt-3.5-turbo-0125")
+        model = ChatOpenAI(model="gpt-5.4-mini")
 
         chain = RunnableWithMessageHistory(model, get_session_history)
         chain.invoke(

--- a/libs/langchain/langchain_classic/chains/openai_functions/base.py
+++ b/libs/langchain/langchain_classic/chains/openai_functions/base.py
@@ -191,7 +191,7 @@ def create_structured_output_chain(
             color: str = Field(..., description="The dog's color")
             fav_food: str | None = Field(None, description="The dog's favorite food")
 
-        model = ChatOpenAI(model="gpt-3.5-turbo-0613", temperature=0)
+        model = ChatOpenAI(model="gpt-5.4-mini")
         prompt = ChatPromptTemplate.from_messages(
             [
                 ("system", "You are a world class algorithm for extracting information in structured formats."),

--- a/libs/langchain/langchain_classic/chains/openai_functions/openapi.py
+++ b/libs/langchain/langchain_classic/chains/openai_functions/openapi.py
@@ -351,7 +351,7 @@ def get_openapi_chain(
     Args:
         spec: OpenAPISpec or url/file/text string corresponding to one.
         llm: language model, should be an OpenAI function-calling model, e.g.
-            `ChatOpenAI(model="gpt-3.5-turbo-0613")`.
+            `ChatOpenAI(model="gpt-5.4-mini")`.
         prompt: Main prompt template to use.
         request_chain: Chain for taking the functions output and executing the request.
         params: Request parameters.

--- a/libs/langchain/langchain_classic/chains/sql_database/query.py
+++ b/libs/langchain/langchain_classic/chains/sql_database/query.py
@@ -75,7 +75,7 @@ def create_sql_query_chain(
         from langchain_community.utilities import SQLDatabase
 
         db = SQLDatabase.from_uri("sqlite:///Chinook.db")
-        model = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
+        model = ChatOpenAI(model="gpt-5.4-mini")
         chain = create_sql_query_chain(model, db)
         response = chain.invoke({"question": "How many employees are there"})
         ```

--- a/libs/langchain/langchain_classic/chains/structured_output/base.py
+++ b/libs/langchain/langchain_classic/chains/structured_output/base.py
@@ -250,7 +250,7 @@ def create_structured_output_runnable(
             color: str = Field(..., description="The dog's color")
             fav_food: str | None = Field(None, description="The dog's favorite food")
 
-        model = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0)
+        model = ChatOpenAI(model="gpt-5.4-mini")
         prompt = ChatPromptTemplate.from_messages(
             [
                 ("system", "You are an extraction algorithm. Please extract every possible instance"),
@@ -303,7 +303,7 @@ def create_structured_output_runnable(
         }
 
 
-        model = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0)
+        model = ChatOpenAI(model="gpt-5.4-mini")
         structured_model = create_structured_output_runnable(
             dog_schema,
             model,
@@ -330,7 +330,7 @@ def create_structured_output_runnable(
             color: str = Field(..., description="The dog's color")
             fav_food: str | None = Field(None, description="The dog's favorite food")
 
-        model = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0)
+        model = ChatOpenAI(model="gpt-5.4-mini")
         structured_model = create_structured_output_runnable(Dog, model, mode="openai-functions")
         structured_model.invoke("Harry was a chubby brown beagle who loved chicken")
         # -> Dog(name="Harry", color="brown", fav_food="chicken")
@@ -352,7 +352,7 @@ def create_structured_output_runnable(
             color: str = Field(..., description="The dog's color")
             fav_food: str | None = Field(None, description="The dog's favorite food")
 
-        model = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0)
+        model = ChatOpenAI(model="gpt-5.4-mini")
         structured_model = create_structured_output_runnable(Dog, model, mode="openai-functions")
         system = '''Extract information about any dogs mentioned in the user input.'''
         prompt = ChatPromptTemplate.from_messages(
@@ -379,7 +379,7 @@ def create_structured_output_runnable(
             color: str = Field(..., description="The dog's color")
             fav_food: str | None = Field(None, description="The dog's favorite food")
 
-        model = ChatOpenAI(model="gpt-3.5-turbo-0125", temperature=0)
+        model = ChatOpenAI(model="gpt-5.4-mini")
         structured_model = create_structured_output_runnable(Dog, model, mode="openai-json")
         system = '''You are a world class assistant for extracting information in structured JSON formats. \
 

--- a/libs/langchain/langchain_classic/evaluation/agents/trajectory_eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/agents/trajectory_eval_chain.py
@@ -113,7 +113,7 @@ class TrajectoryEvalChain(AgentTrajectoryEvaluator, LLMEvalChain):
         \"\"\"Very helpful answers to geography questions.\"\"\"
         return f"{country}? IDK - We may never know {question}."
 
-    model = ChatOpenAI(model="gpt-3.5-turbo", temperature=0)
+    model = ChatOpenAI(model="gpt-5.4-mini")
     agent = initialize_agent(
         tools=[geography_answers],
         llm=model,

--- a/libs/langchain/langchain_classic/retrievers/document_compressors/listwise_rerank.py
+++ b/libs/langchain/langchain_classic/retrievers/document_compressors/listwise_rerank.py
@@ -65,7 +65,7 @@ class LLMListwiseRerank(BaseDocumentCompressor):
         ]
 
         reranker = LLMListwiseRerank.from_llm(
-            llm=ChatOpenAI(model="gpt-3.5-turbo"), top_n=3
+            llm=ChatOpenAI(model="gpt-5.4-mini"), top_n=3
         )
         compressed_docs = reranker.compress_documents(documents, "Who is steve")
         assert len(compressed_docs) == 3


### PR DESCRIPTION
## Description
Updated outdated `gpt-3.5-turbo` model references in docstring examples
across `langchain-classic` to use `gpt-5.4-mini`, consistent with the
recent cleanup done in `langchain-core` (#36497).

## Files changed
- chains/combine_documents/stuff.py
- chains/conversation/base.py
- chains/sql_database/query.py
- chains/openai_functions/base.py
- chains/openai_functions/openapi.py
- chains/structured_output/base.py
- evaluation/agents/trajectory_eval_chain.py
- retrievers/document_compressors/listwise_rerank.py

No functional changes — docstring examples only.