### PR TITLE
docs(langchain): add missing baseten and litellm to `init_chat_model`

### DIFF
--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -285,6 +285,8 @@ def init_chat_model(
             - `openrouter`              -> [`langchain-openrouter`](https://docs.langchain.com/oss/python/integrations/providers/openrouter)
             - `perplexity`              -> [`langchain-perplexity`](https://docs.langchain.com/oss/python/integrations/providers/perplexity)
             - `upstage`                 -> [`langchain-upstage`](https://docs.langchain.com/oss/python/integrations/providers/upstage)
+            - `baseten`                 -> [`langchain-baseten`](https://docs.langchain.com/oss/python/integrations/providers/baseten)
+            - `litellm`                 -> [`langchain-litellm`](https://docs.langchain.com/oss/python/integrations/providers/litellm)
 
         configurable_fields: Which model parameters are configurable at runtime:
 


### PR DESCRIPTION
The `init_chat_model` docstring lists supported `model_provider` values, but `baseten` and `litellm` were missing despite both being present in `_BUILTIN_PROVIDERS` since they were added. This adds the two missing entries to keep the docstring in sync with the registry.