### PR TITLE
fix(core): filter OpenAI function_call content blocks in filter_messages

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -915,15 +915,21 @@ def filter_messages(
                     continue
 
                 content = msg.content
-                # handle Anthropic content blocks
+                # handle Anthropic and OpenAI content blocks
                 if isinstance(msg.content, list):
                     content = [
                         content_block
                         for content_block in msg.content
                         if (
                             not isinstance(content_block, dict)
-                            or content_block.get("type") != "tool_use"
-                            or content_block.get("id") not in exclude_tool_calls
+                            or (
+                                content_block.get("type") != "tool_use"
+                                or content_block.get("id") not in exclude_tool_calls
+                            )
+                            and (
+                                content_block.get("type") != "function_call"
+                                or content_block.get("call_id") not in exclude_tool_calls
+                            )
                         )
                     ]
 


### PR DESCRIPTION
Fixes #36492

## Problem
`filter_messages()` with `exclude_tool_calls` was only removing
Anthropic-style `tool_use` content blocks (matched by `id`).
OpenAI Responses-style `function_call` blocks (matched by `call_id`)
were left behind, making `AIMessage.content` inconsistent with
`AIMessage.tool_calls`.

## Fix
Also filter `function_call` content blocks whose `call_id` matches
the excluded tool call IDs, consistent with how `tool_use` blocks
are already handled.

## Testing
Verified locally with the reproduction script from the issue —
both `tool_calls` and `content` are now consistent after filtering.