### PR TITLE
fix(ollama): prevent `_convert_messages_to_ollama_messages` from mutating caller list

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -820,6 +820,7 @@ class ChatOllama(BaseChatModel):
         Returns:
             List of messages in Ollama format.
         """
+        messages = list(messages)  # shallow copy to avoid mutating caller's list
         for idx, message in enumerate(messages):
             # Handle message content written in v1 format
             if (


### PR DESCRIPTION
Fixes #36564

The method modifies messages[idx] in-place when converting v1 format content. Add messages = list(messages) to create a shallow copy before any mutations.

1 line change in libs/partners/ollama/langchain_ollama/chat_models.py