### PR TITLE
ci: match both `h2` and `h3` area headings in auto-labeler

### DIFF
--- a/.github/workflows/auto-label-by-package.yml
+++ b/.github/workflows/auto-label-by-package.yml
@@ -20,9 +20,15 @@ jobs:
           script: |
             const body = context.payload.issue.body || "";
 
-            // Extract text under "### Package" (handles " (Required)" suffix and being last section)
-            const match = body.match(/### Package[^\n]*\n([\s\S]*?)(?:\n###|$)/i);
-            if (!match) return;
+            // Extract text under "## Package" or "### Package" (handles " (Required)" suffix and being last section)
+            const match = body.match(/#{2,3} Package[^\n]*\n([\s\S]*?)(?:\n#{2,3} |$)/i);
+            if (!match) {
+              core.setFailed(
+                `Could not find "## Package" section in issue #${context.issue.number} body. ` +
+                `The issue template may have changed — update the regex in this workflow.`
+              );
+              return;
+            }
 
             const packageSection = match[1].trim();
 


### PR DESCRIPTION
GitHub issue forms render the "Area (Required)" field label at inconsistent heading levels — some issues get `### Area` (h3), others get `## Area` (h2). The `auto-label-by-package` workflow's regex was hardcoded to `### Area`, silently skipping issues with `## Area` headings and never applying package labels (e.g. [#2471](https://github.com/langchain-ai/deepagents/issues/2471)).