### PR TITLE
fix(core): handle Pydantic-incompatible types in injected tool args

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -33,6 +33,7 @@ from pydantic import (
     ValidationError,
     validate_arguments,
 )
+from pydantic.errors import PydanticInvalidForJsonSchema
 from pydantic.fields import FieldInfo
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import ValidationError as ValidationErrorV1
@@ -378,13 +379,38 @@ def create_schema_from_function(
         if field not in filter_args_:
             valid_properties.append(field)
 
-    return _create_subset_model(
+    subset = _create_subset_model(
         model_name,
         inferred_model,
         list(valid_properties),
         descriptions=arg_descriptions,
         fn_description=description,
     )
+
+    # Verify the model can produce a JSON schema. Injected args with
+    # Pydantic-incompatible types (e.g., Protocol types) will cause
+    # model_json_schema() to fail. Replace those annotations with Any
+    # and rebuild. See: https://github.com/langchain-ai/langchain/issues/32067
+    if include_injected:
+        try:
+            subset.model_json_schema()
+        except PydanticInvalidForJsonSchema:
+            for prop in valid_properties:
+                if prop in sig.parameters and _is_injected_arg_type(
+                    sig.parameters[prop].annotation
+                ):
+                    field = inferred_model.model_fields.get(prop)
+                    if field is not None:
+                        field.annotation = Any
+            subset = _create_subset_model(
+                model_name,
+                inferred_model,
+                list(valid_properties),
+                descriptions=arg_descriptions,
+                fn_description=description,
+            )
+
+    return subset
 
 
 class ToolException(Exception):  # noqa: N818

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -16,9 +16,11 @@ from typing import (
     Any,
     Generic,
     Literal,
+    Protocol,
     TypeVar,
     cast,
     get_type_hints,
+    runtime_checkable,
 )
 
 import pytest
@@ -1823,6 +1825,49 @@ def test_tool_injected_arg() -> None:
             "required": ["x"],
         },
     }
+
+
+def test_tool_injected_arg_with_pydantic_incompatible_type() -> None:
+    """Regression test for https://github.com/langchain-ai/langchain/issues/32067."""
+
+    @runtime_checkable
+    class StateLike(Protocol):
+        pass
+
+    class InjectedState(InjectedToolArg):
+        pass
+
+    @tool("test_tool", description="test")
+    def handoff_to_agent(
+        state: Annotated[StateLike, InjectedState],
+        x: int,
+    ) -> str:
+        """Handoff.
+
+        Args:
+            state: The state.
+            x: An integer.
+        """
+        return "hello"
+
+    assert _schema(handoff_to_agent.get_input_schema()) == {
+        "title": "test_tool",
+        "description": "Handoff.\n\nArgs:\n    state: The state.\n    x: An integer.",
+        "type": "object",
+        "properties": {
+            "state": {"title": "State"},
+            "x": {"title": "X", "type": "integer"},
+        },
+        "required": ["state", "x"],
+    }
+    assert _schema(handoff_to_agent.tool_call_schema) == {
+        "title": "test_tool",
+        "description": "test",
+        "type": "object",
+        "properties": {"x": {"title": "X", "type": "integer"}},
+        "required": ["x"],
+    }
+    assert handoff_to_agent.invoke({"x": 5, "state": {}}) == "hello"
 
 
 def test_tool_inherited_injected_arg() -> None:


### PR DESCRIPTION
## Summary

- Fixes `PydanticInvalidForJsonSchema` crash when calling `get_input_schema().model_json_schema()` on tools with injected args typed as Pydantic-incompatible types (e.g., `Annotated[StateLike, InjectedState]` where `StateLike` is a Protocol)
- After building the schema model, attempts `model_json_schema()` — if it fails, replaces injected arg annotations with `Any` and rebuilds
- Compatible types (`str`, `dict`, etc.) are never modified

Fixes #32067

## Why this approach

Injected args are only used at runtime injection — they're excluded from `tool_call_schema` (what the LLM sees) and don't need JSON-serializable types. The fix is minimal: it only triggers when `model_json_schema()` actually fails, so the happy path has no behavior change.

## Test plan

- [x] Added regression test `test_tool_injected_arg_with_pydantic_incompatible_type` reproducing #32067
- [x] All 157 tool unit tests pass (156 existing + 1 new)
- [x] Full langchain-core suite passes (1740 passed)
- [x] langchain_v1 injected arg tests pass (15 passed)
- [x] Verified compatible injected types (`str`, `dict`, `Any`) are not modified
- [x] Lint (ruff + mypy) passes cleanly

This contribution was developed with AI assistance for code exploration and implementation.