### PR TITLE
fix(langchain): enforce middleware-narrowed ToolStrategy in tool binding

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1216,8 +1216,17 @@ def create_agent(
         # and dicts (built-ins)
         final_tools = list(request.tools)
         if isinstance(effective_response_format, ToolStrategy):
-            # Add structured output tools to final tools list
-            structured_tools = [info.tool for info in structured_output_tools.values()]
+            # Add structured output tools to final tools list.
+            # Middleware (e.g. wrap_model_call) may have narrowed the response format
+            # to a subset of the originally declared structured output tools. Only bind
+            # the structured output tools that are present in the effective (possibly
+            # narrowed) response format, so the model never sees the dropped variants.
+            narrowed_tool_names = {tc.name for tc in effective_response_format.schema_specs}
+            structured_tools = [
+                info.tool
+                for name, info in structured_output_tools.items()
+                if name in narrowed_tool_names
+            ]
             final_tools.extend(structured_tools)
 
         # Bind model based on effective response format

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -13,7 +13,7 @@ from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import HumanMessage
 from langchain_core.runnables import Runnable
 from pydantic import BaseModel, Field
-from typing_extensions import TypedDict
+from typing_extensions import TypedDict, override
 
 from langchain.agents import create_agent
 from langchain.agents.factory import _supports_provider_strategy
@@ -870,6 +870,138 @@ class TestDynamicModelWithResponseFormat:
         # ProviderStrategy doesn't use tool calls - it parses content directly
         assert ai_message.tool_calls == []
         assert ai_message.content == json.dumps(WEATHER_DATA)
+
+    def test_middleware_narrows_tool_strategy_filters_bound_tools(self) -> None:
+        """Middleware-narrowed `ToolStrategy` should only bind the narrowed structured tools.
+
+        Regression test for the bug where `wrap_model_call` middleware overriding
+        `response_format` to a subset `ToolStrategy` was validated against the original
+        spec but never enforced -- the model was still bound with all structured output
+        tools from the original union and could freely choose any of them.
+        """
+
+        bound_tool_names: list[set[str]] = []
+
+        class RecordingModel(FakeToolCallingModel):
+            @override
+            def bind_tools(
+                self,
+                tools: Sequence[dict[str, Any] | type | Callable[..., Any] | BaseTool],
+                *,
+                tool_choice: str | None = None,
+                **kwargs: Any,
+            ) -> Runnable[LanguageModelInput, AIMessage]:
+                names: set[str] = set()
+                for t in tools:
+                    if isinstance(t, BaseTool):
+                        names.add(t.name)
+                    elif isinstance(t, dict):
+                        # FakeToolCallingModel returns simplified dict tool specs
+                        if "function" in t and isinstance(t["function"], dict):
+                            name = t["function"].get("name")
+                        else:
+                            name = t.get("name")
+                        if isinstance(name, str):
+                            names.add(name)
+                bound_tool_names.append(names)
+                return super().bind_tools(tools, tool_choice=tool_choice, **kwargs)
+
+        # The model returns a WeatherBaseModel call -- the only tool the middleware
+        # leaves available after narrowing.
+        tool_calls = [
+            [
+                {
+                    "name": "WeatherBaseModel",
+                    "id": "1",
+                    "args": WEATHER_DATA,
+                }
+            ],
+        ]
+        model = RecordingModel(tool_calls=tool_calls)
+
+        class NarrowResponseFormatMiddleware(AgentMiddleware):
+            def wrap_model_call(
+                self,
+                request: ModelRequest,
+                handler: Callable[[ModelRequest], ModelResponse],
+            ) -> ModelCallResult:
+                # Narrow the response format from the union to a single variant.
+                narrowed = request.override(
+                    response_format=ToolStrategy(WeatherBaseModel),
+                )
+                return handler(narrowed)
+
+        agent = create_agent(
+            model=model,
+            tools=[],
+            response_format=ToolStrategy(WeatherBaseModel | LocationResponse),
+            middleware=[NarrowResponseFormatMiddleware()],
+        )
+        response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        # The model should have been bound exactly once, with only the narrowed
+        # structured output tool. The dropped variant must NOT be bound.
+        assert len(bound_tool_names) == 1
+        assert "WeatherBaseModel" in bound_tool_names[0]
+        assert "LocationResponse" not in bound_tool_names[0]
+
+        # End-to-end behaviour: the narrowed tool's response is parsed correctly.
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+
+    def test_no_middleware_narrowing_keeps_full_tool_strategy_binding(self) -> None:
+        """Without narrowing, every structured output tool from the union must be bound.
+
+        Regression guard: the narrowing fix must not accidentally drop variants when
+        no middleware override is in play.
+        """
+
+        bound_tool_names: list[set[str]] = []
+
+        class RecordingModel(FakeToolCallingModel):
+            @override
+            def bind_tools(
+                self,
+                tools: Sequence[dict[str, Any] | type | Callable[..., Any] | BaseTool],
+                *,
+                tool_choice: str | None = None,
+                **kwargs: Any,
+            ) -> Runnable[LanguageModelInput, AIMessage]:
+                names: set[str] = set()
+                for t in tools:
+                    if isinstance(t, BaseTool):
+                        names.add(t.name)
+                    elif isinstance(t, dict):
+                        if "function" in t and isinstance(t["function"], dict):
+                            name = t["function"].get("name")
+                        else:
+                            name = t.get("name")
+                        if isinstance(name, str):
+                            names.add(name)
+                bound_tool_names.append(names)
+                return super().bind_tools(tools, tool_choice=tool_choice, **kwargs)
+
+        tool_calls = [
+            [
+                {
+                    "name": "WeatherBaseModel",
+                    "id": "1",
+                    "args": WEATHER_DATA,
+                }
+            ],
+        ]
+        model = RecordingModel(tool_calls=tool_calls)
+
+        agent = create_agent(
+            model=model,
+            tools=[],
+            response_format=ToolStrategy(WeatherBaseModel | LocationResponse),
+        )
+        agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        assert len(bound_tool_names) == 1
+        # Both variants from the original union should be bound when nothing narrows them.
+        assert "WeatherBaseModel" in bound_tool_names[0]
+        assert "LocationResponse" in bound_tool_names[0]
 
 
 def test_union_of_types() -> None:


### PR DESCRIPTION
## Summary

Fixes #36568 — when `wrap_model_call` middleware narrows `response_format` from a union `ToolStrategy` to a single-type subset via `request.override(response_format=ToolStrategy(SubsetType))`, the narrowing was validated against the original spec but never enforced. The model was still bound with all structured output tools from the original union and could freely choose any of them, contradicting the intended behavior documented at `factory.py:1234-1239`.

## Root cause

In `_get_bound_model()`, `structured_tools` was built from the closure-captured `structured_output_tools` (the full set from `initial_response_format`), not from the runtime `effective_response_format` that middleware may have narrowed:

```python
structured_tools = [info.tool for info in structured_output_tools.values()]
```

This meant every variant of the original union was bound to the model regardless of any middleware narrowing.

## Fix

Filter `structured_output_tools` by the names actually present in `effective_response_format.schema_specs` before building the final tools list. Because `schema_specs` is what middleware can narrow at runtime, the model now only sees the variants the effective format permits.

```python
narrowed_tool_names = {tc.name for tc in effective_response_format.schema_specs}
structured_tools = [
    info.tool
    for name, info in structured_output_tools.items()
    if name in narrowed_tool_names
]
```

The existing validation at `factory.py:1241-1248` already guarantees every name in `effective_response_format.schema_specs` exists in `structured_output_tools`, so this filter is always a non-empty subset (or equal to the original set when nothing was narrowed).

## Tests

Two new regression tests in `TestDynamicModelWithResponseFormat`:

1. `test_middleware_narrows_tool_strategy_filters_bound_tools` — middleware narrows `ToolStrategy(WeatherBaseModel | LocationResponse)` to `ToolStrategy(WeatherBaseModel)` via `wrap_model_call` → asserts the model is bound with only `WeatherBaseModel` and not `LocationResponse`, and that the end-to-end structured response is parsed correctly.

2. `test_no_middleware_narrowing_keeps_full_tool_strategy_binding` — regression guard ensuring that when no middleware override is in play, both variants of the union are still bound (the fix must not accidentally drop variants in the default case).

Both tests use a `RecordingModel` subclass of `FakeToolCallingModel` that captures the names of tools passed to `bind_tools`, mirroring the existing `CustomModel` pattern in `test_middleware_model_swap_provider_to_tool_strategy`.

## Pre-Submission checklist

- [x] Added regression tests in `libs/langchain_v1/tests/unit_tests/agents/test_response_format.py`
- [x] PR scope is isolated to a single problem
- [x] Fix preserves existing behavior when no middleware narrowing is involved
- [x] No changes to `_handle_model_output` or edge functions: with the model bound to only the narrowed tools, well-behaved providers physically cannot emit dropped variants, so the existing closure-captured `structured_output_tools` references in those locations remain correct.

## AI assistance disclosure

This contribution was prepared with assistance from an AI coding agent. I reviewed, validated, and finalized the proposed changes and test coverage before submission.