### PR TITLE
fix(core): handle unresolvable forward refs in RunnableWithFallbacks.__getattr__

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -649,7 +649,25 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
 def _returns_runnable(attr: Any) -> bool:
     if not callable(attr):
         return False
-    return_type = typing.get_type_hints(attr).get("return")
+    try:
+        return_type = typing.get_type_hints(attr).get("return")
+    except (NameError, TypeError, AttributeError):
+        # ``typing.get_type_hints`` evaluates string forward references against
+        # the function's ``__globals__``. If a method's return annotation
+        # references a name that isn't importable from that scope (e.g. a
+        # ``Runnable[...]`` forward ref defined further up an inheritance chain
+        # in a module that doesn't import ``Runnable`` directly), the call
+        # raises ``NameError``. ``get_type_hints`` can also raise ``TypeError``
+        # for unsupported callables (some bound methods, classmethods, partial
+        # objects) and ``AttributeError`` if ``__annotations__`` is missing.
+        #
+        # When we can't determine the return type, default to ``False`` — the
+        # attribute will be returned unwrapped instead of being treated as a
+        # ``Runnable``-returning method. This is the safe choice: it preserves
+        # access to the attribute (callers can still invoke it) and just
+        # disables the automatic fallback re-wrapping. Methods that genuinely
+        # return ``Runnable`` and have resolvable annotations are unaffected.
+        return False
     return bool(return_type and _is_runnable_type(return_type))
 
 

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -400,3 +400,71 @@ def test_fallbacks_getattr_runnable_output() -> None:
         for fallback in llm_with_fallbacks_with_tools.fallbacks
     )
     assert llm_with_fallbacks_with_tools.runnable.kwargs["tools"] == []
+
+
+class FakeModelWithUnresolvableAnnotation(BaseChatModel):
+    """Model with a method whose return annotation can't be resolved.
+
+    Reproduces the bug where ``_returns_runnable`` crashes with ``NameError``
+    when introspecting a method whose return annotation is a string forward
+    reference that ``typing.get_type_hints`` can't resolve in the function's
+    ``__globals__``.
+
+    Real-world trigger: a ``ChatModel`` (e.g. ``ChatXAI``) inherits a method
+    like ``with_structured_output`` from a base class whose module doesn't
+    have all of the annotation's forward refs in scope. Calling
+    ``with_fallbacks(...).with_structured_output(...)`` then crashes inside
+    ``RunnableWithFallbacks.__getattr__`` → ``_returns_runnable``.
+    """
+
+    foo: int
+
+    @override
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        return ChatResult(generations=[])
+
+    def some_method_with_unresolvable_annotation(
+        self,
+        schema: Any,  # noqa: ARG002
+    ) -> "ThisClassDoesNotExistAnywhere":  # type: ignore[name-defined]  # noqa: F821
+        # The string annotation above is the bug trigger: ``typing.get_type_hints``
+        # tries to ``eval()`` it against this method's ``__globals__`` and raises
+        # ``NameError`` because the name isn't importable from anywhere.
+        return None
+
+    @property
+    def _llm_type(self) -> str:
+        return "fake_unresolvable"
+
+
+def test_fallbacks_getattr_unresolvable_annotation() -> None:
+    """Regression: ``_returns_runnable`` must not crash on unresolvable annotations.
+
+    Before the fix, ``RunnableWithFallbacks.__getattr__`` →
+    ``_returns_runnable`` → ``typing.get_type_hints(attr)`` raised::
+
+        NameError: name 'ThisClassDoesNotExistAnywhere' is not defined
+
+    After the fix, ``_returns_runnable`` catches NameError/TypeError/
+    AttributeError from ``get_type_hints`` and returns ``False``, so the
+    attribute is returned unwrapped. Callers can still invoke it; the only
+    behavior loss is that the method is not automatically re-wrapped to
+    propagate fallbacks (which is the right safe default when we can't
+    determine the return type).
+    """
+    model_with_fallbacks = FakeModelWithUnresolvableAnnotation(foo=3).with_fallbacks(
+        [FakeModel(bar=4)]
+    )
+
+    # Accessing the attribute should not raise NameError. Before the fix it did.
+    method = model_with_fallbacks.some_method_with_unresolvable_annotation
+    assert callable(method)
+    # And calling it should work — it just returns None, since
+    # ``_returns_runnable`` returned False so we got the bare method back.
+    assert method({}) is None


### PR DESCRIPTION
Fixes #36579

`RunnableWithFallbacks.__getattr__` calls `_returns_runnable(attr)` which calls `typing.get_type_hints(attr)` to decide whether the attribute should be re-wrapped to propagate fallbacks. When the introspected method's return annotation is a string forward reference that can't be resolved against the function's `__globals__`, `get_type_hints` raises `NameError` and the entire `__getattr__` lookup crashes.

This makes `chain.with_fallbacks([fallback]).with_structured_output(schema)` unusable for any chat model whose `with_structured_output` is inherited from a base class whose module doesn't have all of the annotation's forward refs in scope (hit in production with `langchain-xai`'s ChatXAI).

## Fix

Catch `NameError`, `TypeError`, and `AttributeError` from `typing.get_type_hints` in `_returns_runnable` and default to `False`. The attribute is then returned bare instead of being treated as a `Runnable`-returning method. Methods that genuinely return `Runnable` and have resolvable annotations are unaffected — the only behavioral loss is automatic fallback re-wrapping for methods we can't introspect, which is the right safe default when we can't determine the return type.

## Test

Adds `test_fallbacks_getattr_unresolvable_annotation` which constructs a fake chat model whose method has a string forward reference to a name that can't be resolved (`"ThisClassDoesNotExistAnywhere"`), wraps it with fallbacks, and asserts that `__getattr__` returns the bare method instead of raising.

Verified to fail before the fix with the same `NameError` pattern as the production crash, and pass after.

## How verified

From `libs/core`:

- `make format` — clean
- `make lint` (ruff + mypy) — clean
- `make test` on `tests/unit_tests/runnables/test_fallbacks.py` — 17/17 passing (16 existing + 1 new regression test)