### PR TITLE
docs: fix inline code snippets and grammar across multiple readmes

### DIFF
--- a/libs/partners/nomic/README.md
+++ b/libs/partners/nomic/README.md
@@ -15,7 +15,7 @@ pip install langchain-nomic
 
 ## 🤔 What is this?
 
-This package contains the LangChain integration with Nomic
+This package contains the LangChain integration with Nomic.
 
 ## 📖 Documentation
 

--- a/libs/partners/ollama/README.md
+++ b/libs/partners/ollama/README.md
@@ -15,7 +15,7 @@ pip install langchain-ollama
 
 ## 🤔 What is this?
 
-This package contains the LangChain integration with Ollama
+This package contains the LangChain integration with Ollama.
 
 ## 📖 Documentation
 

--- a/libs/standard-tests/README.md
+++ b/libs/standard-tests/README.md
@@ -89,5 +89,5 @@ as required is optional.
 
 - `chat_model_class` (required): The class of the chat model to be tested
 - `chat_model_params`: The keyword arguments to pass to the chat model constructor
-- `chat_model_has_tool_calling`: Whether the chat model can call tools. By default, this is set to `hasattr(chat_model_class, 'bind_tools)`
-- `chat_model_has_structured_output`: Whether the chat model can structured output. By default, this is set to `hasattr(chat_model_class, 'with_structured_output')`
+- `chat_model_has_tool_calling`: Whether the chat model can call tools. By default, this is set to `hasattr(chat_model_class, "bind_tools")`
+- `chat_model_has_structured_output`: Whether the chat model can produce structured output. By default, this is set to `hasattr(chat_model_class, "with_structured_output")`

--- a/libs/text-splitters/README.md
+++ b/libs/text-splitters/README.md
@@ -25,10 +25,6 @@ For full documentation, see the [API reference](https://reference.langchain.com/
 
 See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Versioning](https://docs.langchain.com/oss/python/versioning) policies.
 
-We encourage pinning your version to a specific version in order to avoid breaking your CI when we publish new tests. We recommend upgrading to the latest version periodically to make sure you have the latest tests.
-
-Not pinning your version will ensure you always have the latest tests, but it may also break your CI if we introduce tests that your integration doesn't pass.
-
 ## 💁 Contributing
 
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.


### PR DESCRIPTION
Fixes #3481

## Description
This PR addresses several minor documentation issues across the monorepo:
- **libs/standard-tests**: Fixed a broken inline code snippet and improved grammatical clarity.
- **libs/text-splitters**: Removed out-of-scope testing documentation.
- **libs/partners/ollama & nomic**: Added missing periods for consistency.

## Why
Improves the professional standard and technical accuracy of the documentation.

## AI Disclosure
This contribution was prepared with the assistance of AI (Gemini/Cursor). All changes were manually verified.