### PR TITLE
fix(middleware): normalise provider-specific content blocks in ModelFallbackMiddleware fallback path

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, Any
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
     ContextT,
+    ExtendedModelResponse,
     ModelRequest,
     ModelResponse,
     ResponseT,
@@ -18,7 +20,86 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from langchain_core.language_models.chat_models import BaseChatModel
-    from langchain_core.messages import AIMessage
+    from langchain_core.messages import AIMessage, BaseMessage
+
+
+def _normalise_ai_message(message: AIMessage) -> AIMessage:
+    """Convert provider-specific content blocks to LangChain standard types.
+
+    Converts OpenAI `function_call` content blocks to standard `tool_use` blocks.
+    This ensures messages produced by a fallback model (e.g. an OpenAI model)
+    are safe to pass back as history to the primary model (e.g. ChatBedrockConverse),
+    which only understands LangChain-standard content block types.
+    """
+    if isinstance(message.content, str) or not message.content:
+        return message
+
+    normalised: list[Any] = []
+    changed = False
+    for block in message.content:
+        if isinstance(block, dict) and block.get("type") == "function_call":
+            raw_args = block.get("arguments", "{}")
+            if isinstance(raw_args, str):
+                try:
+                    tool_input: dict[str, Any] = json.loads(raw_args) if raw_args else {}
+                except json.JSONDecodeError:
+                    tool_input = {}
+            elif isinstance(raw_args, dict):
+                tool_input = raw_args
+            else:
+                tool_input = {}
+            tool_use_id = (
+                block.get("id") or block.get("callId") or block.get("call_id") or ""
+            )
+            normalised.append(
+                {
+                    "type": "tool_use",
+                    "id": tool_use_id,
+                    "name": block["name"],
+                    "input": tool_input,
+                }
+            )
+            changed = True
+        else:
+            normalised.append(block)
+
+    if not changed:
+        return message
+    return message.model_copy(update={"content": normalised})
+
+
+def _normalise_fallback_response(
+    response: ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT],
+) -> ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]:
+    """Normalise provider-specific content blocks in a fallback model response.
+
+    Applied after a fallback model succeeds so that the returned message history
+    only contains LangChain-standard content block types before being passed
+    back to the primary model.
+    """
+    from dataclasses import replace
+
+    from langchain_core.messages import AIMessage as _AIMessage
+
+    if isinstance(response, _AIMessage):
+        return _normalise_ai_message(response)
+
+    if isinstance(response, ExtendedModelResponse):
+        normalised_result = [
+            _normalise_ai_message(msg) if isinstance(msg, _AIMessage) else msg
+            for msg in response.model_response.result
+        ]
+        return replace(
+            response,
+            model_response=replace(response.model_response, result=normalised_result),
+        )
+
+    # ModelResponse
+    normalised_result = [
+        _normalise_ai_message(msg) if isinstance(msg, _AIMessage) else msg
+        for msg in response.result
+    ]
+    return replace(response, result=normalised_result)
 
 
 class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
@@ -26,6 +107,11 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
 
     Retries failed model calls with alternative models in sequence until
     success or all models exhausted. Primary model specified in `create_agent`.
+
+    After a successful fallback, any provider-specific content blocks in the
+    response (e.g. OpenAI `function_call` blocks) are normalised to LangChain
+    standard types before the message is added to history. This ensures the
+    primary model only ever sees content block types it is designed to handle.
 
     Example:
         ```python
@@ -60,7 +146,6 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         """
         super().__init__()
 
-        # Initialize all fallback models
         all_models = (first_model, *additional_models)
         self.models: list[BaseChatModel] = []
         for model in all_models:
@@ -73,7 +158,7 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         self,
         request: ModelRequest[ContextT],
         handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
-    ) -> ModelResponse[ResponseT] | AIMessage:
+    ) -> ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]:
         """Try fallback models in sequence on errors.
 
         Args:
@@ -81,22 +166,22 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             handler: Callback to execute the model.
 
         Returns:
-            AIMessage from successful model call.
+            Response from successful model call, normalised to LangChain standard
+            content block types when a fallback model was used.
 
         Raises:
             Exception: If all models fail, re-raises last exception.
         """
-        # Try primary model first
         last_exception: Exception
         try:
             return handler(request)
         except Exception as e:
             last_exception = e
 
-        # Try fallback models
         for fallback_model in self.models:
             try:
-                return handler(request.override(model=fallback_model))
+                response = handler(request.override(model=fallback_model))
+                return _normalise_fallback_response(response)
             except Exception as e:
                 last_exception = e
                 continue
@@ -107,7 +192,7 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         self,
         request: ModelRequest[ContextT],
         handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
-    ) -> ModelResponse[ResponseT] | AIMessage:
+    ) -> ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]:
         """Try fallback models in sequence on errors (async version).
 
         Args:
@@ -115,22 +200,22 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             handler: Async callback to execute the model.
 
         Returns:
-            AIMessage from successful model call.
+            Response from successful model call, normalised to LangChain standard
+            content block types when a fallback model was used.
 
         Raises:
             Exception: If all models fail, re-raises last exception.
         """
-        # Try primary model first
         last_exception: Exception
         try:
             return await handler(request)
         except Exception as e:
             last_exception = e
 
-        # Try fallback models
         for fallback_model in self.models:
             try:
-                return await handler(request.override(model=fallback_model))
+                response = await handler(request.override(model=fallback_model))
+                return _normalise_fallback_response(response)
             except Exception as e:
                 last_exception = e
                 continue

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_model_fallback_normalise.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_model_fallback_normalise.py
@@ -1,0 +1,246 @@
+"""Tests for ModelFallbackMiddleware response normalisation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from langchain.agents.middleware.model_fallback import (
+    _normalise_ai_message,
+    _normalise_fallback_response,
+)
+from langchain.agents.middleware.types import ModelResponse
+
+
+# ---------------------------------------------------------------------------
+# _normalise_ai_message
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_ai_message_string_content_unchanged() -> None:
+    """String content is returned as-is."""
+    msg = AIMessage(content="hello")
+    assert _normalise_ai_message(msg) is msg
+
+
+def test_normalise_ai_message_empty_content_unchanged() -> None:
+    """Empty list content is returned as-is."""
+    msg = AIMessage(content=[])
+    assert _normalise_ai_message(msg) is msg
+
+
+def test_normalise_ai_message_no_function_call_unchanged() -> None:
+    """Content with no function_call blocks is returned as-is."""
+    msg = AIMessage(content=[{"type": "text", "text": "hi"}])
+    assert _normalise_ai_message(msg) is msg
+
+
+def test_normalise_ai_message_function_call_converted() -> None:
+    """function_call block is converted to tool_use."""
+    msg = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "id": "call_abc",
+                "name": "get_weather",
+                "arguments": '{"city": "Paris"}',
+            }
+        ]
+    )
+    result = _normalise_ai_message(msg)
+    assert result is not msg
+    assert result.content == [
+        {
+            "type": "tool_use",
+            "id": "call_abc",
+            "name": "get_weather",
+            "input": {"city": "Paris"},
+        }
+    ]
+
+
+def test_normalise_ai_message_function_call_call_id() -> None:
+    """call_id is used as fallback for toolUseId."""
+    msg = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "call_id": "c_xyz",
+                "name": "search",
+                "arguments": "{}",
+            }
+        ]
+    )
+    result = _normalise_ai_message(msg)
+    assert result.content[0]["id"] == "c_xyz"
+
+
+def test_normalise_ai_message_function_call_callId() -> None:
+    """callId (camelCase) is used as fallback for toolUseId."""
+    msg = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "callId": "c_camel",
+                "name": "noop",
+                "arguments": "{}",
+            }
+        ]
+    )
+    result = _normalise_ai_message(msg)
+    assert result.content[0]["id"] == "c_camel"
+
+
+def test_normalise_ai_message_function_call_dict_arguments() -> None:
+    """arguments already a dict is preserved."""
+    msg = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "id": "c1",
+                "name": "noop",
+                "arguments": {"x": 1},
+            }
+        ]
+    )
+    result = _normalise_ai_message(msg)
+    assert result.content[0]["input"] == {"x": 1}
+
+
+def test_normalise_ai_message_mixed_blocks() -> None:
+    """text block is preserved alongside converted function_call block."""
+    msg = AIMessage(
+        content=[
+            {"type": "text", "text": "Sure."},
+            {
+                "type": "function_call",
+                "id": "call_m",
+                "name": "get_weather",
+                "arguments": '{"city": "London"}',
+            },
+        ]
+    )
+    result = _normalise_ai_message(msg)
+    assert result.content == [
+        {"type": "text", "text": "Sure."},
+        {
+            "type": "tool_use",
+            "id": "call_m",
+            "name": "get_weather",
+            "input": {"city": "London"},
+        },
+    ]
+
+
+def test_normalise_ai_message_invalid_json_arguments() -> None:
+    """Malformed JSON in arguments produces empty dict input without raising."""
+    msg = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "id": "c1",
+                "name": "bad",
+                "arguments": "{not valid json",
+            }
+        ]
+    )
+    result = _normalise_ai_message(msg)
+    assert result.content[0]["input"] == {}
+
+
+# ---------------------------------------------------------------------------
+# _normalise_fallback_response
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_fallback_response_ai_message() -> None:
+    """AIMessage response is normalised directly."""
+    msg = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "id": "c1",
+                "name": "fn",
+                "arguments": "{}",
+            }
+        ]
+    )
+    result = _normalise_fallback_response(msg)
+    assert isinstance(result, AIMessage)
+    assert result.content[0]["type"] == "tool_use"
+
+
+def test_normalise_fallback_response_model_response() -> None:
+    """ModelResponse result messages are normalised."""
+    ai_msg = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "id": "c2",
+                "name": "fn",
+                "arguments": '{"k": "v"}',
+            }
+        ]
+    )
+    response = ModelResponse(result=[ai_msg])
+    result = _normalise_fallback_response(response)
+    assert isinstance(result, ModelResponse)
+    assert result.result[0].content[0]["type"] == "tool_use"
+    assert result.result[0].content[0]["input"] == {"k": "v"}
+
+
+def test_normalise_fallback_response_no_function_call_unchanged() -> None:
+    """ModelResponse with no function_call blocks passes through unchanged content."""
+    ai_msg = AIMessage(content="plain text")
+    response = ModelResponse(result=[ai_msg])
+    result = _normalise_fallback_response(response)
+    assert isinstance(result, ModelResponse)
+    assert result.result[0].content == "plain text"
+
+
+def test_normalise_fallback_response_primary_not_normalised() -> None:
+    """Primary model responses are NOT normalised (normalisation only in fallback path)."""
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
+    from langchain.agents.middleware.types import AgentState, ModelRequest, ModelResponse
+
+    from typing import cast
+    from langgraph.runtime import Runtime
+
+    primary_msg = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "id": "c_primary",
+                "name": "fn",
+                "arguments": "{}",
+            }
+        ]
+    )
+    primary_model = GenericFakeChatModel(messages=iter([primary_msg]))
+    fallback_model = GenericFakeChatModel(messages=iter([AIMessage(content="fallback")]))
+
+    middleware = ModelFallbackMiddleware(fallback_model)
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        result = req.model.invoke([])
+        return ModelResponse(result=[result])
+
+    request = ModelRequest(
+        model=primary_model,
+        system_prompt=None,
+        messages=[],
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+        state=AgentState(messages=[]),
+        runtime=cast("Runtime", object()),
+        model_settings={},
+    )
+
+    response = middleware.wrap_model_call(request, mock_handler)
+    assert isinstance(response, ModelResponse)
+    # Primary response is NOT normalised
+    assert response.result[0].content[0]["type"] == "function_call"


### PR DESCRIPTION
Fixes #36599

## Problem

When `ModelFallbackMiddleware` falls back to an OpenAI-based model, the response can contain `function_call` content blocks (OpenAI's internal format). If that response is added back into message history and forwarded to a primary model that only understands LangChain-standard `tool_use` blocks (e.g. `ChatBedrockConverse`), the primary model raises an error on the unrecognised block type.

This was surfaced in [langchain-ai/langchain-aws#978](https://github.com/langchain-ai/langchain-aws/pull/978), where a reviewer ([@michaelnchin](https://github.com/michaelnchin)) identified the correct fix location as `ModelFallbackMiddleware` in this repo.

## Fix

Add two normalisation helpers to `libs/langchain_v1/langchain/agents/middleware/model_fallback.py`:

- `_normalise_ai_message(message)`: converts any `function_call` block in an `AIMessage` to the standard `tool_use` format (handles string and dict `arguments`, and all id aliases: `id`, `callId`, `call_id`).
- `_normalise_fallback_response(response)`: applies `_normalise_ai_message` across all result messages in a `ModelResponse` or `ExtendedModelResponse`, and passes through raw `AIMessage` responses.

Both `wrap_model_call` and `awrap_model_call` call `_normalise_fallback_response` after a fallback model succeeds. The primary model path is unchanged.

## Tests

`tests/unit_tests/agents/middleware/test_model_fallback_normalise.py` covers:
- string and empty content passes through unchanged
- non-function-call blocks are not modified
- `function_call` converted to `tool_use` (string args parsed, dict args preserved)
- id alias resolution (`id`, `call_id`, `callId`)
- invalid JSON in arguments produces empty dict without raising
- mixed text + function_call blocks
- `ModelResponse` and `ExtendedModelResponse` normalised correctly
- primary model path NOT normalised

cc @Vishwaspatel2401 for review (context: langchain-ai/langchain-aws#978)