### PR TITLE
fix(langchain): prefer metadata `ls_provider` in SummarizationMiddleware token check

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -378,7 +378,12 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             and last_ai_message.usage_metadata is not None
             and (reported_tokens := last_ai_message.usage_metadata.get("total_tokens", -1))
             and reported_tokens >= threshold
-            and (message_provider := last_ai_message.response_metadata.get("model_provider"))
+            and (
+                message_provider := last_ai_message.response_metadata.get(
+                    "ls_provider",
+                    last_ai_message.response_metadata.get("model_provider"),
+                )
+            )
             and message_provider == self.model._get_ls_params().get("ls_provider")  # noqa: SLF001
         ):
             return True

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -1219,6 +1219,56 @@ def test_usage_metadata_trigger() -> None:
     assert not middleware._should_summarize(messages, 0)
 
 
+def test_usage_metadata_trigger_ls_provider() -> None:
+    """ls_provider in response_metadata takes precedence over model_provider."""
+
+    class BedrockMockModel(MockChatModel):
+        def _get_ls_params(self, **kwargs: Any) -> dict[str, Any]:
+            return {"ls_provider": "amazon_bedrock"}
+
+    model = BedrockMockModel()
+    middleware = SummarizationMiddleware(
+        model=model,
+        trigger=("tokens", 10_000),
+        keep=("messages", 4),
+    )
+    # ls_provider matches even though model_provider doesn't
+    messages: list[AnyMessage] = [
+        HumanMessage(content="msg1"),
+        AIMessage(
+            content="msg2",
+            response_metadata={
+                "model_provider": "bedrock_converse",
+                "ls_provider": "amazon_bedrock",
+            },
+            usage_metadata={
+                "input_tokens": 7500,
+                "output_tokens": 2501,
+                "total_tokens": 10_001,
+            },
+        ),
+    ]
+    assert middleware._should_summarize(messages, 0)
+
+    # ls_provider doesn't match — should not trigger
+    messages_mismatch: list[AnyMessage] = [
+        HumanMessage(content="msg1"),
+        AIMessage(
+            content="msg2",
+            response_metadata={
+                "model_provider": "amazon_bedrock",
+                "ls_provider": "not-amazon_bedrock",
+            },
+            usage_metadata={
+                "input_tokens": 7500,
+                "output_tokens": 2501,
+                "total_tokens": 10_001,
+            },
+        ),
+    ]
+    assert not middleware._should_summarize(messages_mismatch, 0)
+
+
 class ConfigCapturingModel(BaseChatModel):
     """Mock model that captures the config passed to invoke/ainvoke."""
 


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/langchain-aws/issues/946

Part 2 of the proposed fix noted in https://github.com/langchain-ai/langchain-aws/issues/946#issuecomment-4203871366. The [first PR](https://github.com/langchain-ai/langchain-aws/pull/981) in `langchain-aws` adds `response_metadata["ls_provider"] = "amazon_bedrock"` to messages generated by ChatBedrock and ChatBedrockConverse.

This follow-up PR will update `SummarizationMiddleware`'s `_should_summarize_based_on_reported_tokens` method to prefer `response_metadata["ls_provider"]` over `model_provider` when checking if a message came from the current provider.

This is specifically unblocks optimal use with Bedrock chat models, where Converse API and Invoke API requests require unique `model_provider` values (`bedrock`/`bedrock_converse`), but share the same tracing `ls_provider` (`amazon_bedrock`) for token pricing. For messages from other providers that don't set `ls_provider` in metadata, `model_provider` will still be used as the fallback.