### PR TITLE
fix(core): handle Pydantic-incompatible types in injected tool args

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -34,6 +34,7 @@ from pydantic import (
     validate_arguments,
 )
 from pydantic.fields import FieldInfo
+from pydantic.errors import PydanticInvalidForJsonSchema
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import ValidationError as ValidationErrorV1
 from pydantic.v1 import validate_arguments as validate_arguments_v1
@@ -378,13 +379,38 @@ def create_schema_from_function(
         if field not in filter_args_:
             valid_properties.append(field)
 
-    return _create_subset_model(
+    subset = _create_subset_model(
         model_name,
         inferred_model,
         list(valid_properties),
         descriptions=arg_descriptions,
         fn_description=description,
     )
+
+    # Verify the model can produce a JSON schema. Injected args with
+    # Pydantic-incompatible types (e.g., Protocol types) will cause
+    # model_json_schema() to fail. Replace those annotations with Any
+    # and rebuild. See: https://github.com/langchain-ai/langchain/issues/32067
+    if include_injected:
+        try:
+            subset.model_json_schema()
+        except PydanticInvalidForJsonSchema:
+            for prop in valid_properties:
+                if prop in sig.parameters and _is_injected_arg_type(
+                    sig.parameters[prop].annotation
+                ):
+                    field = inferred_model.model_fields.get(prop)
+                    if field is not None:
+                        field.annotation = Any
+            subset = _create_subset_model(
+                model_name,
+                inferred_model,
+                list(valid_properties),
+                descriptions=arg_descriptions,
+                fn_description=description,
+            )
+
+    return subset
 
 
 class ToolException(Exception):  # noqa: N818


### PR DESCRIPTION
## Summary

- Fixes PydanticInvalidForJsonSchema crash when calling `get_input_schema().model_json_schema()` on tools with injected args typed as Pydantic-incompatible types (e.g., `Annotated[StateLike, InjectedState]` where `StateLike` is a Protocol)
- After building the schema model, attempts `model_json_schema()` — if it fails, replaces injected arg annotations with `Any` and rebuilds
- Compatible types (`str`, `dict`, etc.) are never modified

Fixes #32067

## Why this approach

Injected args are only used at runtime injection — they're excluded from `tool_call_schema` (what the LLM sees) and don't need JSON-serializable types. The fix is minimal: it only triggers when `model_json_schema()` actually fails, so the happy path has no behavior change.

## Test plan

- [ ] Add regression test reproducing #32067
- [ ] All tool unit tests pass
- [ ] Full langchain-core suite passes