### PR TITLE
fix(anthropic): strip trailing AIMessage for models without prefill support

### DIFF
--- a/libs/core/langchain_core/language_models/model_profile.py
+++ b/libs/core/langchain_core/language_models/model_profile.py
@@ -120,6 +120,15 @@ class ModelProfile(TypedDict, total=False):
     temperature: bool
     """Whether the model supports a temperature parameter."""
 
+    assistant_prefill: bool
+    """Whether the model supports assistant message prefill (trailing assistant
+    message in the conversation).  When ``False``, the chat model implementation
+    should strip any trailing assistant message before sending the request to
+    avoid a 400 error from the provider."""
+    # Anthropic note: older models (e.g. claude-opus-3, claude-sonnet-3.*) accept
+    # prefill, but newer models in the claude-opus-4.x / claude-sonnet-4.x family
+    # (starting around claude-opus-4-6) do not.
+
 
 ModelProfileRegistry = dict[str, ModelProfile]
 """Registry mapping model identifiers or names to their ModelProfile."""

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1059,6 +1059,19 @@ class ChatAnthropic(BaseChatModel):
                     }
                 )
 
+        # Some newer models do not support assistant message prefill.  If the
+        # model profile explicitly marks `assistant_prefill` as False and the
+        # last message is an AIMessage, strip it before formatting to avoid a
+        # 400 from the provider.
+        profile = self._resolve_model_profile()
+        if (
+            profile is not None
+            and profile.get("assistant_prefill") is False
+            and messages
+            and isinstance(messages[-1], AIMessage)
+        ):
+            messages = list(messages[:-1])
+
         system, formatted_messages = _format_messages(messages)
 
         payload = {

--- a/libs/partners/anthropic/langchain_anthropic/data/_profiles.py
+++ b/libs/partners/anthropic/langchain_anthropic/data/_profiles.py
@@ -465,6 +465,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_tool_message": True,
         "image_tool_message": True,
         "structured_output": False,
+        "assistant_prefill": False,
     },
     "claude-sonnet-4-0": {
         "name": "Claude Sonnet 4 (latest)",
@@ -590,5 +591,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "pdf_tool_message": True,
         "image_tool_message": True,
         "structured_output": False,
+        "assistant_prefill": False,
     },
 }

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2764,3 +2764,47 @@ def test_thinking_in_params_recognizes_adaptive() -> None:
     assert not _thinking_in_params({"thinking": {"type": "disabled"}})
     assert not _thinking_in_params({"thinking": {}})
     assert not _thinking_in_params({})
+
+
+def test_trailing_ai_message_stripped_for_no_prefill_models() -> None:
+    """Models with assistant_prefill=False in their profile should not receive
+    a trailing AIMessage in the request payload."""
+    chat_model = ChatAnthropic(
+        model="claude-opus-4-6",
+        anthropic_api_key="secret-api-key",
+    )
+
+    messages = [
+        HumanMessage(content="hello"),
+        AIMessage(content="hi there"),
+    ]
+    payload = chat_model._get_request_payload(messages)
+    formatted = payload["messages"]
+
+    # The trailing AIMessage must have been stripped
+    assert all(m["role"] != "assistant" for m in formatted), (
+        "Expected trailing assistant message to be stripped for claude-opus-4-6, "
+        f"got: {formatted}"
+    )
+
+
+def test_trailing_ai_message_kept_for_prefill_models() -> None:
+    """Models that support prefill should retain a trailing AIMessage."""
+    chat_model = ChatAnthropic(
+        model="claude-sonnet-4-20250514",
+        anthropic_api_key="secret-api-key",
+    )
+
+    messages = [
+        HumanMessage(content="hello"),
+        AIMessage(content="hi there"),
+    ]
+    payload = chat_model._get_request_payload(messages)
+    formatted = payload["messages"]
+
+    # The assistant message must be present
+    roles = [m["role"] for m in formatted]
+    assert "assistant" in roles, (
+        "Expected trailing assistant message to be kept for claude-sonnet-4-20250514, "
+        f"got: {formatted}"
+    )


### PR DESCRIPTION
Closes #36597

## Problem

Newer Anthropic models (`claude-opus-4-6`, `claude-sonnet-4-6`) do not support assistant message prefill. When a conversation ends with an `AIMessage` and that's passed to `ChatAnthropic`, the SDK raises:

```
anthropic.BadRequestError: 400 - This model does not support assistant message prefill.
The conversation must end with a user message.
```

## Root cause

`ChatAnthropic._get_request_payload` always passes the full message list (including a trailing `AIMessage`) to `_format_messages`, which forwards it to the Anthropic API verbatim. Models that accept prefill work fine; models that don't explode.

## Solution

Three-part fix:

1. **`langchain-core` `ModelProfile`** – add an `assistant_prefill: bool` field so providers can declare this capability.

2. **Anthropic partner profiles** – mark `claude-opus-4-6` and `claude-sonnet-4-6` (the models confirmed to reject prefill) with `"assistant_prefill": False`.

3. **`ChatAnthropic._get_request_payload`** – when the active model's profile has `assistant_prefill=False`, silently drop the trailing `AIMessage` before building the payload. No other code paths are touched; models without a profile entry (or with `assistant_prefill=True`) behave exactly as before.

## Tests

Added two unit tests in `tests/unit_tests/test_chat_models.py`:
- `test_trailing_ai_message_stripped_for_no_prefill_models` – verifies the message is dropped for `claude-opus-4-6`
- `test_trailing_ai_message_kept_for_prefill_models` – verifies the message is kept for older models