### PR TITLE
fix(core): normalize same-index tool call chunks before parsing

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -35,6 +35,31 @@ from langchain_core.utils.utils import LC_AUTO_PREFIX, LC_ID_PREFIX
 logger = logging.getLogger(__name__)
 
 
+def _normalize_tool_call_chunks(
+    tool_call_chunks: list[ToolCallChunk],
+) -> list[ToolCallChunk]:
+    """Normalize tool call continuations that share a stream index.
+
+    Some providers can emit multiple fragments for the same tool call in a single
+    delta. Those fragments need to be merged before best-effort JSON parsing,
+    otherwise continuations can be split across `tool_calls` and
+    `invalid_tool_calls`.
+    """
+    normalized: list[dict[str, Any]] | None = None
+    for chunk in tool_call_chunks:
+        normalized = merge_lists(normalized, [chunk])
+
+    return [
+        create_tool_call_chunk(
+            name=chunk.get("name"),
+            args=chunk.get("args"),
+            id=chunk.get("id"),
+            index=chunk.get("index"),
+        )
+        for chunk in normalized or []
+    ]
+
+
 class InputTokenDetails(TypedDict, total=False):
     """Breakdown of input token counts.
 
@@ -525,6 +550,8 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = tool_call_chunks
 
             return self
+        self.tool_call_chunks = _normalize_tool_call_chunks(self.tool_call_chunks)
+
         tool_calls = []
         invalid_tool_calls = []
 

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -985,6 +985,35 @@ def test_merge_tool_calls_parallel_same_index() -> None:
     assert [m["id"] for m in merged] == ["id_a", "id_b", "id_c"]
 
 
+def test_ai_message_chunk_merges_same_index_tool_call_continuations_in_delta() -> None:
+    first = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(name="search", args="", id="id1", index=0),
+            create_tool_call_chunk(name=None, args="{", id=None, index=0),
+        ],
+    )
+
+    merged = first + AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name=None, args='"query": "bar"}', id=None, index=0
+            )
+        ],
+    )
+
+    assert merged.tool_call_chunks == [
+        create_tool_call_chunk(
+            name="search", args='{"query": "bar"}', id="id1", index=0
+        )
+    ]
+    assert merged.tool_calls == [
+        create_tool_call(name="search", args={"query": "bar"}, id="id1")
+    ]
+    assert merged.invalid_tool_calls == []
+
+
 def test_tool_message_serdes() -> None:
     message = ToolMessage(
         "foo", artifact={"bar": {"baz": 123}}, tool_call_id="1", status="error"


### PR DESCRIPTION
## Summary

- normalize `tool_call_chunks` inside `AIMessageChunk.init_tool_calls()` before best-effort JSON parsing
- add a regression test for chat.completions-style streaming where one logical tool call is split into multiple same-index fragments inside a single delta

## Why

Some OpenAI-compatible providers emit multiple same-index tool-call fragments in the same streamed delta, for example one fragment with `name`/`id` and empty `arguments`, plus another fragment with just `"{"`.

Without pre-normalizing those fragments, later continuations merge into the first entry while the dangling same-index fragment remains in the list. After parsing, that produces:

- a blank `tool_call`
- a real call in `invalid_tool_calls`

This is the root cause behind the minimal core repro in #36627. It is distinct from #32562 / #32580, which are about Responses API index advancement.

## Testing

- `/opt/anaconda3/envs/langchain/bin/python -m pytest -c /dev/null libs/core/tests/unit_tests/test_messages.py -k "merge_tool_calls or ai_message_chunk_merges_same_index_tool_call_continuations_in_delta"`

Closes #36627
