### PR TITLE
fix(partners): structured output for AzureChatOpenAI

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1004,7 +1004,6 @@ class BaseChatOpenAI(BaseChatModel):
                     "http_async_client",
                 )
             )
-            and "OPENAI_BASE_URL" not in os.environ
         ):
             self.stream_usage = True
 


### PR DESCRIPTION
Fixes #36606

Updated the conditions for enabling stream_usage in order to fix PydanticSerializationUnexpectedValue warning when using structured output for AzureChatOpenAI.

