### PR TITLE
fix(core): skip empty string in _extract_reasoning_from_additional_kwargs

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content and isinstance(reasoning_content, str):
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -502,3 +502,14 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+    # Empty string reasoning_content should not produce a reasoning block (#36194)
+    message = AIMessage(
+        content="The answer is 42.",
+        additional_kwargs={"reasoning_content": ""},
+    )
+    content_blocks = message.content_blocks
+    assert len(content_blocks) == 1, (
+        "Empty reasoning_content should be ignored, not produce a reasoning block"
+    )
+    assert content_blocks[0]["type"] == "text"


### PR DESCRIPTION
## Description

Fixes #36194

When a model returns `additional_kwargs["reasoning_content"] = ""` (empty string) — which Ollama and some OpenAI-compatible providers do when not actively reasoning — `_extract_reasoning_from_additional_kwargs` was creating a spurious `ReasoningContentBlock` with `reasoning=''`. This block would be prepended to `content_blocks`, creating noise in downstream processing and causing tools that expect non-empty reasoning to behave unexpectedly.

**Root cause:** the guard condition was `if reasoning_content is not None`, which allows empty strings through.

**Fix:** change to a truthiness check (`if reasoning_content`), which is falsy for both `None` and `'''`. This is the same pattern used throughout the codebase for optional string fields.

## Changes

- : 1-character fix in 
- : added a regression test for the empty-string case inside the existing  test function

## Testing



All existing tests pass; new test case explicitly asserts that `reasoning_content=''` does not produce a reasoning block.