### PR TITLE
fix(core): validate batch_size > 0 in _batch and _abatch

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -90,6 +90,9 @@ def _hash_nested_dict(
 
 def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError("Batch size must be a positive integer.")
+
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))
@@ -100,6 +103,9 @@ def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
 
 async def _abatch(size: int, iterable: AsyncIterable[T]) -> AsyncIterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError("Batch size must be a positive integer.")
+
     batch: list[T] = []
     async for element in iterable:
         if len(batch) < size:

--- a/libs/core/tests/unit_tests/indexing/test_public_api.py
+++ b/libs/core/tests/unit_tests/indexing/test_public_api.py
@@ -1,4 +1,8 @@
 from langchain_core.indexing import __all__
+import pytest
+from typing import List, AsyncIterable
+
+from langchain_core.indexing.api import _batch, _abatch
 
 
 def test_all() -> None:
@@ -14,3 +18,55 @@ def test_all() -> None:
         "RecordManager",
         "UpsertResponse",
     }
+
+async def async_iter_from_list(data: List):
+    for item in data:
+        yield item
+
+
+def test_batch_size_zero_raises_error() -> None:
+    """Test that _batch raises ValueError when size <= 0."""
+    with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        list(_batch(0, [1, 2, 3]))
+
+    with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        list(_batch(-1, [1, 2, 3]))
+
+
+def test_batch_normal_behavior() -> None:
+    """Test that _batch works correctly for valid sizes."""
+    assert list(_batch(2, [1, 2, 3, 4, 5])) == [[1, 2], [3, 4], [5]]
+    assert list(_batch(10, [1, 2, 3])) == [[1, 2, 3]]
+    assert list(_batch(2, [])) == []
+
+
+@pytest.mark.asyncio
+async def test_abatch_size_zero_raises_error() -> None:
+    """Test that _abatch raises ValueError when size <= 0."""
+    with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        async for _ in _abatch(0, async_iter_from_list([1, 2, 3])):
+            pass
+
+    with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        async for _ in _abatch(-5, async_iter_from_list([1, 2, 3])):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_abatch_normal_behavior() -> None:
+    """Test that _abatch works correctly for valid sizes."""
+    data = [1, 2, 3, 4, 5]
+    batches = []
+    async for b in _abatch(2, async_iter_from_list(data)):
+        batches.append(b)
+    assert batches == [[1, 2], [3, 4], [5]]
+
+    batches = []
+    async for b in _abatch(10, async_iter_from_list(data)):
+        batches.append(b)
+    assert batches == [[1, 2, 3, 4, 5]]
+
+    batches = []
+    async for b in _abatch(2, async_iter_from_list([])):
+        batches.append(b)
+    assert batches == []


### PR DESCRIPTION
Fixes #36647

Add input validation to `_batch` and `_abatch` to raise `ValueError` when `size <= 0`, preventing infinite loop in synchronous indexing and empty-batch spam in async indexing.

## Verification
- Added unit tests `test_batch_size_zero_raises_error` and `test_abatch_size_zero_raises_error`.
- Verified locally with manual test script and confirmed existing tests pass.