### PR TITLE
fix(openai): guard service_tier token arithmetic against None values

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3864,12 +3864,17 @@ def _create_usage_metadata(
     }
     if service_tier is not None:
         # Avoid counting cache and reasoning tokens towards the service tier token
-        # counts, since service tier tokens are already priced differently
-        input_token_details[service_tier] = input_tokens - input_token_details.get(
-            f"{service_tier_prefix}cache_read", 0
+        # counts, since service tier tokens are already priced differently.
+        # Use ``or 0`` instead of ``.get(key, 0)`` because the key *exists* in
+        # the dict with a value of ``None`` when the upstream API omits the
+        # corresponding ``*_tokens`` field.  ``.get(key, 0)`` only returns the
+        # default when the key is *absent*; when it is present-but-None the
+        # default is ignored and a ``TypeError: int - NoneType`` results.
+        input_token_details[service_tier] = input_tokens - (
+            input_token_details.get(f"{service_tier_prefix}cache_read") or 0
         )
-        output_token_details[service_tier] = output_tokens - output_token_details.get(
-            f"{service_tier_prefix}reasoning", 0
+        output_token_details[service_tier] = output_tokens - (
+            output_token_details.get(f"{service_tier_prefix}reasoning") or 0
         )
     return UsageMetadata(
         input_tokens=input_tokens,
@@ -3904,13 +3909,12 @@ def _create_usage_metadata_responses(
         ).get("cached_tokens")
     }
     if service_tier is not None:
-        # Avoid counting cache and reasoning tokens towards the service tier token
-        # counts, since service tier tokens are already priced differently
-        output_token_details[service_tier] = output_tokens - output_token_details.get(
-            f"{service_tier_prefix}reasoning", 0
+        # Same ``or 0`` guard as _create_usage_metadata — see comment there.
+        output_token_details[service_tier] = output_tokens - (
+            output_token_details.get(f"{service_tier_prefix}reasoning") or 0
         )
-        input_token_details[service_tier] = input_tokens - input_token_details.get(
-            f"{service_tier_prefix}cache_read", 0
+        input_token_details[service_tier] = input_tokens - (
+            input_token_details.get(f"{service_tier_prefix}cache_read") or 0
         )
     return UsageMetadata(
         input_tokens=input_tokens,


### PR DESCRIPTION
## Bug

`_create_usage_metadata` and `_create_usage_metadata_responses` crash with:

```
TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
```

when `service_tier` is `"priority"` or `"flex"` and the OpenAI API response omits `cached_tokens` or `reasoning_tokens` from the token usage details.

## Root Cause

The `input_token_details` dict is built with:

```python
f"{service_tier_prefix}cache_read": (
    oai_token_usage.get("prompt_tokens_details") or {}
).get("cached_tokens"),  # ← None when key absent
```

This stores `None` as the value. The subsequent subtraction uses:

```python
input_tokens - input_token_details.get(f"..._cache_read", 0)
```

`dict.get(key, default)` only returns the default when the key is **missing**. When the key **exists** with value `None`, the default is ignored and `None` is returned. `int - None` → `TypeError`.

## Reproduction

```python
details = {"priority_cache_read": None}  # key exists, value None
100 - details.get("priority_cache_read", 0)
# TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
```

This triggers when a user has a priority/flex service tier and the API response's `prompt_tokens_details` does not include `cached_tokens` (or `completion_tokens_details` does not include `reasoning_tokens`).

## Fix

Replace `.get(key, 0)` with `.get(key) or 0` in all 4 affected sites (2 per function). `or 0` coalesces both missing-key and present-but-None into 0.

```python
# Before (crashes on None)
input_tokens - input_token_details.get(f"..._cache_read", 0)

# After (safe)
input_tokens - (input_token_details.get(f"..._cache_read") or 0)
```

## Scope

- `_create_usage_metadata`: 2 sites (cache_read + reasoning)
- `_create_usage_metadata_responses`: 2 sites (same pattern)
- 1 file changed, +15 -11

Related to #36500 which fixed a similar is-not-None pattern in other token extraction paths but did not cover the service_tier arithmetic.

Fixes #36657.