### PR TITLE
fix(openai): handle malformed tool calls per-item instead of per-batch

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -413,20 +413,20 @@ def _convert_delta_to_message_chunk(
         if "name" in function_call and function_call["name"] is None:
             function_call["name"] = ""
         additional_kwargs["function_call"] = function_call
-    tool_call_chunks = []
+    tool_call_chunks: list = []
     if raw_tool_calls := _dict.get("tool_calls"):
-        try:
-            tool_call_chunks = [
-                tool_call_chunk(
-                    name=rtc["function"].get("name"),
-                    args=rtc["function"].get("arguments"),
-                    id=rtc.get("id"),
-                    index=rtc["index"],
+        for rtc in raw_tool_calls:
+            try:
+                tool_call_chunks.append(
+                    tool_call_chunk(
+                        name=rtc["function"].get("name"),
+                        args=rtc["function"].get("arguments"),
+                        id=rtc.get("id"),
+                        index=rtc["index"],
+                    )
                 )
-                for rtc in raw_tool_calls
-            ]
-        except KeyError:
-            pass
+            except KeyError:
+                pass
 
     if role == "user" or default_class == HumanMessageChunk:
         return HumanMessageChunk(content=content, id=id_)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -69,6 +69,7 @@ from langchain_openai.chat_models.base import (
     OpenAIRefusalError,
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
+    _convert_delta_to_message_chunk,
     _convert_dict_to_message,
     _convert_message_to_dict,
     _convert_to_openai_response_format,
@@ -3708,3 +3709,32 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test_convert_delta_to_message_chunk_mixed_tool_calls() -> None:
+    """Test that a KeyError in one tool call chunk doesn't drop valid ones."""
+    delta = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "index": 0,
+                "id": "call_valid",
+                "function": {"name": "my_tool", "arguments": '{"x": 1}'},
+            },
+            # Invalid entry: missing "function" key entirely
+            {"index": 1, "id": "call_invalid"},
+            {
+                "index": 2,
+                "id": "call_also_valid",
+                "function": {"name": "other_tool", "arguments": '{"y": 2}'},
+            },
+        ],
+    }
+    result = _convert_delta_to_message_chunk(delta, AIMessageChunk)
+    assert isinstance(result, AIMessageChunk)
+    assert len(result.tool_call_chunks) == 2
+    assert result.tool_call_chunks[0]["name"] == "my_tool"
+    assert result.tool_call_chunks[0]["id"] == "call_valid"
+    assert result.tool_call_chunks[1]["name"] == "other_tool"
+    assert result.tool_call_chunks[1]["id"] == "call_also_valid"

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -591,6 +591,7 @@ test = [
     { name = "langchain-tests", editable = "../../standard-tests" },
     { name = "pytest", specifier = ">=8.0.0,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.2,<2.0.0" },
+    { name = "pytest-benchmark", specifier = ">=5.1.0,<6.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0,<8.0.0" },
     { name = "pytest-mock" },
     { name = "pytest-socket", specifier = ">=0.6.0,<1.0.0" },
@@ -614,7 +615,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.2.25"
+version = "1.3.0a1"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -761,7 +762,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.5"
+version = "1.1.6"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Fixes #35782

- The `_convert_delta_to_message_chunk` function wrapped an entire list comprehension in a single `try/except KeyError: pass` block. If **any** tool call chunk in a streaming batch was malformed (e.g., missing `"function"` key), **all** tool call chunks — including valid ones — were silently dropped.
- This PR restructures the loop so each tool call chunk is processed independently: a `KeyError` in one item skips only that item, preserving all valid tool calls in the batch.
- Added a unit test (`test_convert_delta_to_message_chunk_mixed_tool_calls`) that verifies mixed valid/invalid tool call entries are handled correctly.

## Areas requiring careful review

- The change is in `libs/partners/openai/langchain_openai/chat_models/base.py` around line 417. The logic is intentionally kept minimal — only the `try/except` scope was narrowed.

## Test plan

- [x] New unit test passes with mixed valid/invalid tool call chunks
- [x] Full test suite passes (318 tests)
- [x] Lint and mypy pass

> This PR was developed with the assistance of an AI coding agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)