### PR TITLE
fix(text-splitters): preserve content from unclosed markdown code blocks

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -446,7 +446,7 @@ class ExperimentalMarkdownSyntaxTextSplitter:
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk
-        return ""
+        return chunk
 
     def _complete_chunk_doc(self) -> None:
         chunk_content = self.current_chunk.page_content

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -4226,3 +4226,16 @@ def test_character_text_splitter_chunk_size_effect(
         keep_separator=False,
     )
     assert splitter.split_text(text) == expected
+
+
+def test_experimental_markdown_syntax_text_splitter_unclosed_code_block() -> None:
+    """Test that unclosed code blocks preserve content instead of discarding it."""
+    markdown_splitter = ExperimentalMarkdownSyntaxTextSplitter()
+    markdown_text = "# Header\n```python\nprint('hello')\nx = 42\n"
+    output = markdown_splitter.split_text(markdown_text)
+
+    # The unclosed code block content should be preserved, not silently dropped.
+    code_docs = [doc for doc in output if "Code" in doc.metadata]
+    assert len(code_docs) == 1
+    assert "print('hello')" in code_docs[0].page_content
+    assert "x = 42" in code_docs[0].page_content


### PR DESCRIPTION
## Summary
- `_resolve_code_chunk()` returned empty string when a code block was never closed, silently discarding all content within it
- Changed `return ""` to `return chunk` so nothing is lost

Fixes #36186

## Test plan
- [x] Added `test_experimental_markdown_syntax_text_splitter_unclosed_code_block`
- [x] Existing markdown splitter tests still pass

AI assistance (Claude Code) was used. All changes reviewed and validated by the submitting human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)