### PR TITLE
fix(core): ignore empty reasoning_content in content block extraction

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content and isinstance(reasoning_content, str):
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -495,6 +495,15 @@ def test_content_blocks_reasoning_extraction() -> None:
     assert content_blocks[1]["type"] == "text"
     assert content_blocks[1]["text"] == "The answer is 42."
 
+    # Test empty string reasoning content is ignored (not treated as real reasoning)
+    message = AIMessage(
+        content="The answer is 42.",
+        additional_kwargs={"reasoning_content": ""},
+    )
+    content_blocks = message.content_blocks
+    assert len(content_blocks) == 1
+    assert content_blocks[0]["type"] == "text"
+
     # Test no reasoning extraction when no reasoning content
     message = AIMessage(
         content="The answer is 42.", additional_kwargs={"other_field": "some value"}


### PR DESCRIPTION
## Summary
- When a provider sends `reasoning_content: ""`, skip it instead of creating a `ReasoningContentBlock` with empty reasoning
- One-line condition change: `is not None` → truthiness check

Fixes #36194

## Test plan
- [x] Added test case for empty string `reasoning_content` in `test_content_blocks_reasoning_extraction`
- [x] Existing reasoning extraction tests still pass

AI assistance (Claude Code) was used. All changes reviewed and validated by the submitting human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)