### PR TITLE
fix(core): support string data in Blob.as_bytes_io()

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,10 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
+
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f

--- a/libs/core/tests/unit_tests/documents/test_document.py
+++ b/libs/core/tests/unit_tests/documents/test_document.py
@@ -10,3 +10,11 @@ def test_init() -> None:
         Document(page_content="foo", id=1),
     ]:
         assert isinstance(doc, Document)
+
+def test_blob_as_bytes_io_with_string_data() -> None:
+    """Test that as_bytes_io() works correctly with string data."""
+    from langchain_core.documents.base import Blob
+
+    blob = Blob.from_data("hello")
+    with blob.as_bytes_io() as f:
+        assert f.read() == b"hello"


### PR DESCRIPTION
Fixes #36667

## Summary
`Blob.as_bytes_io()` currently raises `NotImplementedError` when the blob's `data` is a string, even though `as_string()` and `as_bytes()` handle string data correctly. This PR adds a branch to encode the string to bytes and return a `BytesIO` stream, making the API consistent.

## Changes
- Added `elif isinstance(self.data, str):` branch in `as_bytes_io()` to yield `BytesIO(self.data.encode(self.encoding))`.
- Added unit test `test_blob_as_bytes_io_with_string_data` to verify the fix.

## Verification
- [x] Manually tested locally with `Blob.from_data("hello")`.
- [x] Unit test passes.