### PR TITLE
fix(core): use >= when enforcing InMemoryCache maxsize

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -226,7 +226,7 @@ class InMemoryCache(BaseCache):
 
                 The value is a list of `Generation` (or subclasses).
         """
-        if self._maxsize is not None and len(self._cache) == self._maxsize:
+        if self._maxsize is not None and len(self._cache) >= self._maxsize:
             del self._cache[next(iter(self._cache))]
         self._cache[prompt, llm_string] = return_val
 


### PR DESCRIPTION
## Summary

Changes the `InMemoryCache.update` guard from `len(self._cache) == self._maxsize` to `>=` so eviction still runs if the cache ever exceeds the configured limit (defensive consistency).

## Review

- Small one-line behavior change in `libs/core/langchain_core/caches.py`.

---

This contribution was prepared with assistance from an AI coding agent.