### PR TITLE
fix(core): normalize same-index tool_call_chunks packed in a single streamed delta

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -525,6 +525,21 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = tool_call_chunks
 
             return self
+        # Normalize same-index continuation fragments that a provider may pack
+        # in a single streamed delta.  A provider may emit multiple same-index
+        # tool_call fragments (e.g. one with name+id, another with the first
+        # bytes of arguments) inside one delta.  Without normalization each
+        # fragment is parsed separately: the continuation becomes a blank
+        # tool_call while the original ends up in invalid_tool_calls.
+        # We fold them here using the same merge_lists() semantics used by
+        # __add__ so that downstream accumulation via + also works correctly.
+        chunks_to_parse: list = []
+        for chunk in self.tool_call_chunks:
+            chunks_to_parse = merge_lists(chunks_to_parse, [chunk]) or []
+        if len(chunks_to_parse) != len(self.tool_call_chunks):
+            # Update tool_call_chunks so that subsequent __add__ calls see the
+            # already-normalized list rather than the raw per-delta fragments.
+            self.tool_call_chunks = chunks_to_parse
         tool_calls = []
         invalid_tool_calls = []
 
@@ -538,7 +553,7 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 )
             )
 
-        for chunk in self.tool_call_chunks:
+        for chunk in chunks_to_parse:
             try:
                 args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}
                 if isinstance(args_, dict):


### PR DESCRIPTION
## Summary

Fixes #36627.

Some providers (e.g. Bocha) emit multiple `ToolCallChunk` fragments **for the same logical tool call** within a **single** streamed delta — for example one fragment carries the function name and `id`, and a second carries the opening `{` of the arguments JSON.

Before this change `AIMessageChunk.init_tool_calls()` parsed each fragment independently:
- The name-carrying fragment accumulated args from later deltas and ended up in `invalid_tool_calls` (incomplete JSON fragment).
- The dangling continuation fragment (just `{`) became a blank `tool_call` with an empty name.

### Root cause

`merge_lists()` (used by `__add__`) merges same-index chunks **across two different messages**. But when two same-index chunks already exist **inside a single delta** (i.e. in `self.tool_call_chunks` at construction time), nothing merges them before `init_tool_calls()` parses them.

### Fix

At the start of `init_tool_calls()`, fold same-index continuation fragments using `merge_lists()` — the same semantics already used by `__add__`:

```python
chunks_to_parse: list = []
for chunk in self.tool_call_chunks:
    chunks_to_parse = merge_lists(chunks_to_parse, [chunk]) or []
if len(chunks_to_parse) != len(self.tool_call_chunks):
    self.tool_call_chunks = chunks_to_parse
```

Writing the result back to `self.tool_call_chunks` ensures subsequent `__add__` calls concatenate new deltas onto the correct merged fragment.

Same-index chunks with **distinct non-empty ids** are intentionally left separate (they represent genuinely parallel tool calls).

## Test plan

- [x] Reproduction case from the issue passes (`tool_calls` contains one valid entry, `invalid_tool_calls` is empty)
- [x] Normal single-fragment streaming (docstring example) still works
- [x] Multiple tool calls with different indices still works
- [x] Invalid args still route to `invalid_tool_calls`
- [x] Same-index chunks with different ids are kept separate (not merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)