### PR TITLE
fix(core): validate batch_size > 0 in _batch and _abatch to prevent infinite loop

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -90,6 +90,8 @@ def _hash_nested_dict(
 
 def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError(f"batch_size must be positive, got {size}")
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))
@@ -100,6 +102,8 @@ def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
 
 async def _abatch(size: int, iterable: AsyncIterable[T]) -> AsyncIterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError(f"batch_size must be positive, got {size}")
     batch: list[T] = []
     async for element in iterable:
         if len(batch) < size:


### PR DESCRIPTION
`_batch(0, items)` and `_abatch(0, items)` hang forever — zero batch size means no progress per iteration. Added a `ValueError` guard at the top of both generators. Fixes #36647