### PR TITLE
core: handle string data in Blob.as_bytes_io()

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f

--- a/libs/core/tests/unit_tests/document_loaders/test_base.py
+++ b/libs/core/tests/unit_tests/document_loaders/test_base.py
@@ -56,6 +56,27 @@ def test_lazy_load_not_implemented() -> None:
         loader.lazy_load()
 
 
+def test_blob_as_bytes_io_with_string_data() -> None:
+    """Blob.as_bytes_io() should handle string data the same way as_bytes() does."""
+    blob = Blob.from_data("hello")
+    with blob.as_bytes_io() as f:
+        assert f.read() == b"hello"
+
+
+def test_blob_as_bytes_io_with_bytes_data() -> None:
+    """Blob.as_bytes_io() should handle bytes data."""
+    blob = Blob.from_data(b"hello")
+    with blob.as_bytes_io() as f:
+        assert f.read() == b"hello"
+
+
+def test_blob_as_bytes_io_with_encoding() -> None:
+    """Blob.as_bytes_io() should respect the encoding parameter for string data."""
+    blob = Blob(data="café", encoding="utf-8")
+    with blob.as_bytes_io() as f:
+        assert f.read() == "café".encode("utf-8")
+
+
 async def test_default_aload() -> None:
     class FakeLoader(BaseLoader):
         @override


### PR DESCRIPTION
## Summary

Fixes #36667 — `Blob.as_bytes_io()` raises `NotImplementedError` when the blob contains string data, even though `as_bytes()` and `as_string()` both handle strings fine.

## Root Cause

`as_bytes_io()` only had branches for `bytes` data and file path. The `str` case was missing, falling through to the `else` which raises `NotImplementedError`.

## Fix

Added the missing `isinstance(self.data, str)` branch that encodes the string using `self.encoding`, matching the existing pattern in `as_bytes()`.

```python
# Before: only bytes and path handled
if isinstance(self.data, bytes):
    yield BytesIO(self.data)
elif self.data is None and self.path:
    ...

# After: string data encoded to bytes
if isinstance(self.data, bytes):
    yield BytesIO(self.data)
elif isinstance(self.data, str):
    yield BytesIO(self.data.encode(self.encoding))
elif self.data is None and self.path:
    ...
```

## Tests

Added 3 test cases:
- String data → returns encoded bytes
- Bytes data → works as before
- Custom encoding → respects `self.encoding`

cc @baskaryan @ccurme