### PR TITLE
fix(core): validate batch_size > 0 in _batch and _abatch

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -90,6 +90,8 @@ def _hash_nested_dict(
 
 def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError("Batch size must be a positive integer.")
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))
@@ -100,6 +102,8 @@ def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
 
 async def _abatch(size: int, iterable: AsyncIterable[T]) -> AsyncIterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError("Batch size must be a positive integer.")
     batch: list[T] = []
     async for element in iterable:
         if len(batch) < size:


### PR DESCRIPTION
Fixes #36647

Add input validation to `_batch` and `_abatch` in `langchain_core.indexing.api` to raise `ValueError` when `size <= 0`, preventing the infinite loop in `_batch` and the empty-batch flood in `_abatch` described in the issue.