### PR TITLE
core: handle malformed function dicts in tool call parsers

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -362,20 +362,31 @@ def default_tool_parser(
     for raw_tool_call in raw_tool_calls:
         if "function" not in raw_tool_call:
             continue
-        function_name = raw_tool_call["function"]["name"]
+        function = raw_tool_call["function"]
+        if not isinstance(function, dict):
+            invalid_tool_calls.append(
+                invalid_tool_call(
+                    name=None,
+                    args=str(function),
+                    id=raw_tool_call.get("id"),
+                    error=f"Malformed `function` field: {function!r}",
+                )
+            )
+            continue
+        function_name = function.get("name")
         try:
-            function_args = json.loads(raw_tool_call["function"]["arguments"])
+            function_args = json.loads(function.get("arguments") or "")
             parsed = tool_call(
                 name=function_name or "",
                 args=function_args or {},
                 id=raw_tool_call.get("id"),
             )
             tool_calls.append(parsed)
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, TypeError):
             invalid_tool_calls.append(
                 invalid_tool_call(
                     name=function_name,
-                    args=raw_tool_call["function"]["arguments"],
+                    args=function.get("arguments", ""),
                     id=raw_tool_call.get("id"),
                     error=None,
                 )
@@ -398,8 +409,13 @@ def default_tool_chunk_parser(raw_tool_calls: list[dict]) -> list[ToolCallChunk]
             function_args = None
             function_name = None
         else:
-            function_args = tool_call["function"]["arguments"]
-            function_name = tool_call["function"]["name"]
+            function = tool_call["function"]
+            if isinstance(function, dict):
+                function_args = function.get("arguments")
+                function_name = function.get("name")
+            else:
+                function_args = None
+                function_name = None
         parsed = tool_call_chunk(
             name=function_name,
             args=function_args,

--- a/libs/core/tests/unit_tests/messages/test_tool_parsers.py
+++ b/libs/core/tests/unit_tests/messages/test_tool_parsers.py
@@ -1,0 +1,161 @@
+"""Tests for default_tool_parser and default_tool_chunk_parser."""
+
+from langchain_core.messages.tool import (
+    default_tool_chunk_parser,
+    default_tool_parser,
+)
+
+
+class TestDefaultToolParser:
+    def test_valid_tool_call(self) -> None:
+        raw = [
+            {
+                "function": {"name": "get_weather", "arguments": '{"city": "Cairo"}'},
+                "id": "call_1",
+            }
+        ]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "get_weather"
+        assert tool_calls[0]["args"] == {"city": "Cairo"}
+        assert tool_calls[0]["id"] == "call_1"
+        assert len(invalid_tool_calls) == 0
+
+    def test_invalid_json_arguments(self) -> None:
+        raw = [
+            {
+                "function": {"name": "get_weather", "arguments": "not json"},
+                "id": "call_1",
+            }
+        ]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 1
+        assert invalid_tool_calls[0]["name"] == "get_weather"
+        assert invalid_tool_calls[0]["args"] == "not json"
+
+    def test_missing_function_key_skipped(self) -> None:
+        raw = [{"id": "call_1"}]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 0
+
+    def test_function_is_none(self) -> None:
+        """function key present but value is None should not crash."""
+        raw = [{"function": None, "id": "call_1"}]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 1
+        assert invalid_tool_calls[0]["id"] == "call_1"
+
+    def test_function_missing_name_key(self) -> None:
+        """function dict without 'name' should not crash."""
+        raw = [{"function": {"arguments": '{"x": 1}'}, "id": "call_1"}]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == ""
+        assert tool_calls[0]["args"] == {"x": 1}
+
+    def test_function_missing_arguments_key(self) -> None:
+        """function dict without 'arguments' should not crash."""
+        raw = [{"function": {"name": "my_tool"}, "id": "call_1"}]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        # Missing arguments → empty string → JSONDecodeError → invalid
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 1
+        assert invalid_tool_calls[0]["name"] == "my_tool"
+
+    def test_function_empty_dict(self) -> None:
+        """Empty function dict should not crash."""
+        raw = [{"function": {}, "id": "call_1"}]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 1
+
+    def test_function_is_string(self) -> None:
+        """function key with string value should not crash."""
+        raw = [{"function": "some_string", "id": "call_1"}]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 1
+
+    def test_mixed_valid_and_malformed(self) -> None:
+        """Valid tool calls should still be parsed even if others are malformed."""
+        raw = [
+            {"function": None, "id": "bad_1"},
+            {
+                "function": {"name": "good_tool", "arguments": '{"a": 1}'},
+                "id": "good_1",
+            },
+            {"function": {"name": "bad_json", "arguments": "{bad"}, "id": "bad_2"},
+        ]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "good_tool"
+        assert len(invalid_tool_calls) == 2
+
+    def test_function_arguments_is_none(self) -> None:
+        """arguments key present but None should not crash."""
+        raw = [
+            {"function": {"name": "my_tool", "arguments": None}, "id": "call_1"}
+        ]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        # None arguments → or "" → JSONDecodeError → invalid
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 1
+
+
+class TestDefaultToolChunkParser:
+    def test_valid_chunk(self) -> None:
+        raw = [
+            {
+                "function": {"name": "get_weather", "arguments": '{"city":'},
+                "id": "call_1",
+                "index": 0,
+            }
+        ]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] == "get_weather"
+        assert chunks[0]["args"] == '{"city":'
+        assert chunks[0]["id"] == "call_1"
+        assert chunks[0]["index"] == 0
+
+    def test_missing_function_key(self) -> None:
+        raw = [{"id": "call_1", "index": 0}]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] is None
+        assert chunks[0]["args"] is None
+
+    def test_function_is_none(self) -> None:
+        """function key present but None should not crash."""
+        raw = [{"function": None, "id": "call_1", "index": 0}]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] is None
+        assert chunks[0]["args"] is None
+
+    def test_function_missing_keys(self) -> None:
+        """function dict with missing name/arguments should not crash."""
+        raw = [{"function": {}, "id": "call_1", "index": 0}]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] is None
+        assert chunks[0]["args"] is None
+
+    def test_function_partial_keys(self) -> None:
+        """function dict with only arguments should not crash."""
+        raw = [{"function": {"arguments": '{"x":'}, "id": "call_1", "index": 0}]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] is None
+        assert chunks[0]["args"] == '{"x":'
+
+    def test_function_is_string(self) -> None:
+        """function key with non-dict value should not crash."""
+        raw = [{"function": "bad", "id": "call_1", "index": 0}]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] is None
+        assert chunks[0]["args"] is None


### PR DESCRIPTION
## Description

Fixes #36679

`default_tool_parser` and `default_tool_chunk_parser` crash with unhandled `KeyError`/`TypeError` when a raw tool call has a malformed `function` field (None, non-dict, or missing name/arguments keys).

**The real problem:** One malformed tool call kills the entire parsing loop, and the broad `except Exception` in `ai.py` silently drops ALL tool calls including valid ones. A function documented as "Best-effort parsing" should not be all-or-nothing.

## Changes

### `default_tool_parser`
- Validate `function` is a dict before accessing keys
- Use `.get()` for `name` and `arguments` instead of direct indexing
- Route non-dict `function` values to `invalid_tool_calls` with a descriptive error
- Catch `TypeError` alongside `JSONDecodeError` (handles `arguments: null`)

### `default_tool_chunk_parser`
- Validate `function` is a dict before accessing keys
- Use `.get()` for `name` and `arguments`
- Treat non-dict `function` values same as missing function (args=None, name=None)

### Tests
- Added 16 unit tests in `test_tool_parsers.py` covering:
  - Valid tool calls (baseline)
  - `function: null`
  - `function: {}` (empty dict)
  - `function: "string"` (wrong type)
  - Missing `name` key
  - Missing `arguments` key
  - `arguments: null`
  - Mixed valid + malformed in same list (key test)

## Reproduction

```python
from langchain_core.messages.tool import default_tool_parser

# Before fix: crashes, drops ALL tool calls
default_tool_parser([{"function": None, "id": "1"}])  # TypeError
default_tool_parser([{"function": {}, "id": "1"}])    # KeyError

# After fix: gracefully routes to invalid_tool_calls
tool_calls, invalid = default_tool_parser([{"function": None, "id": "1"}])
assert len(tool_calls) == 0
assert len(invalid) == 1
```