### PR TITLE
fix(core): handle malformed function dicts in default tool parsers

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -362,9 +362,20 @@ def default_tool_parser(
     for raw_tool_call in raw_tool_calls:
         if "function" not in raw_tool_call:
             continue
-        function_name = raw_tool_call["function"]["name"]
+        function = raw_tool_call["function"]
+        if not isinstance(function, dict):
+            invalid_tool_calls.append(
+                invalid_tool_call(
+                    name=None,
+                    args=None,
+                    id=raw_tool_call.get("id"),
+                    error=f"Expected 'function' to be a dict, got {type(function)}",
+                )
+            )
+            continue
+        function_name = function.get("name")
         try:
-            function_args = json.loads(raw_tool_call["function"]["arguments"])
+            function_args = json.loads(function.get("arguments", ""))
             parsed = tool_call(
                 name=function_name or "",
                 args=function_args or {},
@@ -375,7 +386,7 @@ def default_tool_parser(
             invalid_tool_calls.append(
                 invalid_tool_call(
                     name=function_name,
-                    args=raw_tool_call["function"]["arguments"],
+                    args=function.get("arguments"),
                     id=raw_tool_call.get("id"),
                     error=None,
                 )
@@ -398,8 +409,13 @@ def default_tool_chunk_parser(raw_tool_calls: list[dict]) -> list[ToolCallChunk]
             function_args = None
             function_name = None
         else:
-            function_args = tool_call["function"]["arguments"]
-            function_name = tool_call["function"]["name"]
+            function = tool_call["function"]
+            if isinstance(function, dict):
+                function_args = function.get("arguments")
+                function_name = function.get("name")
+            else:
+                function_args = None
+                function_name = None
         parsed = tool_call_chunk(
             name=function_name,
             args=function_args,

--- a/libs/core/tests/unit_tests/messages/test_tool.py
+++ b/libs/core/tests/unit_tests/messages/test_tool.py
@@ -1,0 +1,126 @@
+"""Tests for default_tool_parser and default_tool_chunk_parser."""
+
+from langchain_core.messages.tool import (
+    default_tool_chunk_parser,
+    default_tool_parser,
+)
+
+
+class TestDefaultToolParser:
+    def test_valid_tool_call(self) -> None:
+        raw = [
+            {
+                "function": {"name": "my_tool", "arguments": '{"a": 1}'},
+                "id": "call_1",
+            }
+        ]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "my_tool"
+        assert tool_calls[0]["args"] == {"a": 1}
+        assert tool_calls[0]["id"] == "call_1"
+        assert len(invalid_tool_calls) == 0
+
+    def test_invalid_json_arguments(self) -> None:
+        raw = [
+            {
+                "function": {"name": "my_tool", "arguments": "not json"},
+                "id": "call_1",
+            }
+        ]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 1
+        assert invalid_tool_calls[0]["name"] == "my_tool"
+        assert invalid_tool_calls[0]["args"] == "not json"
+
+    def test_missing_function_key_skipped(self) -> None:
+        raw = [{"id": "call_1"}]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 0
+
+    def test_function_value_none(self) -> None:
+        """When function value is None, the call should be marked invalid."""
+        raw = [{"function": None, "id": "call_1"}]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 1
+        assert invalid_tool_calls[0]["id"] == "call_1"
+
+    def test_function_dict_missing_keys(self) -> None:
+        """When function dict is empty, the call should be marked invalid."""
+        raw = [{"function": {}, "id": "call_1"}]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 0
+        assert len(invalid_tool_calls) == 1
+
+    def test_malformed_does_not_drop_valid_calls(self) -> None:
+        """A malformed call should not prevent valid calls from being parsed."""
+        raw = [
+            {"function": None, "id": "bad"},
+            {
+                "function": {"name": "good_tool", "arguments": '{"a": 1}'},
+                "id": "good",
+            },
+        ]
+        tool_calls, invalid_tool_calls = default_tool_parser(raw)
+        assert len(tool_calls) == 1
+        assert tool_calls[0]["name"] == "good_tool"
+        assert tool_calls[0]["id"] == "good"
+        assert len(invalid_tool_calls) == 1
+        assert invalid_tool_calls[0]["id"] == "bad"
+
+
+class TestDefaultToolChunkParser:
+    def test_valid_chunk(self) -> None:
+        raw = [
+            {
+                "function": {"name": "my_tool", "arguments": '{"a": 1}'},
+                "id": "call_1",
+                "index": 0,
+            }
+        ]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] == "my_tool"
+        assert chunks[0]["args"] == '{"a": 1}'
+        assert chunks[0]["id"] == "call_1"
+        assert chunks[0]["index"] == 0
+
+    def test_missing_function_key(self) -> None:
+        raw = [{"id": "call_1", "index": 0}]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] is None
+        assert chunks[0]["args"] is None
+
+    def test_function_value_none(self) -> None:
+        """When function value is None, should not crash."""
+        raw = [{"function": None, "id": "call_1", "index": 0}]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] is None
+        assert chunks[0]["args"] is None
+
+    def test_function_dict_missing_keys(self) -> None:
+        """When function dict has missing keys, should use None defaults."""
+        raw = [{"function": {}, "id": "call_1", "index": 0}]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 1
+        assert chunks[0]["name"] is None
+        assert chunks[0]["args"] is None
+
+    def test_malformed_does_not_drop_valid_chunks(self) -> None:
+        """A malformed chunk should not prevent valid chunks from being parsed."""
+        raw = [
+            {"function": None, "id": "bad", "index": 0},
+            {
+                "function": {"name": "good_tool", "arguments": '{"a": 1}'},
+                "id": "good",
+                "index": 1,
+            },
+        ]
+        chunks = default_tool_chunk_parser(raw)
+        assert len(chunks) == 2
+        assert chunks[1]["name"] == "good_tool"


### PR DESCRIPTION
## Summary
- `default_tool_parser` and `default_tool_chunk_parser` crash with `TypeError`/`KeyError` when a raw tool call has `function` set to `None` or a dict missing expected keys (`name`, `arguments`)
- This kills the entire parsing loop, causing all valid sibling tool calls to be silently dropped — despite the function being documented as "best-effort"
- Added `isinstance` and `.get()` guards so malformed entries are routed to `invalid_tool_calls` (or yield `None` in chunks) instead of crashing

## Test plan
- [x] Added 11 unit tests in `tests/unit_tests/messages/test_tool.py`
- [x] Valid tool calls still parse identically (no behavioral change for well-formed input)
- [x] `function: None` → routed to `invalid_tool_calls`
- [x] `function: {}` (missing keys) → routed to `invalid_tool_calls`
- [x] Malformed entry no longer drops valid sibling calls

> This PR was developed with assistance from an AI agent (Claude).


