### PR TITLE
fix(chroma): reject async chroma clients with a clear error

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -6,6 +6,7 @@ It contains the Chroma class which is a vector store for handling various tasks.
 from __future__ import annotations
 
 import base64
+import inspect
 import logging
 import uuid
 from collections.abc import Callable, Iterable, Sequence
@@ -150,6 +151,19 @@ def maximal_marginal_relevance(
         idxs.append(idx_to_add)
         selected = np.append(selected, [embedding_list[idx_to_add]], axis=0)
     return idxs
+
+
+def _validate_client(client: chromadb.ClientAPI | Any) -> None:
+    """Reject async clients with an actionable error message."""
+    if inspect.isawaitable(client):
+        msg = (
+            "`langchain_chroma.Chroma` requires a synchronous Chroma client. "
+            "Received an awaitable client, which usually means "
+            "`chromadb.AsyncHttpClient(...)` was passed in. Use "
+            "`chromadb.HttpClient(...)` or another synchronous `chromadb.ClientAPI` "
+            "instance instead."
+        )
+        raise TypeError(msg)
 
 
 class Chroma(VectorStore):
@@ -367,6 +381,7 @@ class Chroma(VectorStore):
             raise ValueError(msg)
 
         if client is not None:
+            _validate_client(client)
             self._client = client
 
         # PersistentClient

--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -153,19 +153,6 @@ def maximal_marginal_relevance(
     return idxs
 
 
-def _validate_client(client: chromadb.ClientAPI | Any) -> None:
-    """Reject async clients with an actionable error message."""
-    if inspect.isawaitable(client):
-        msg = (
-            "`langchain_chroma.Chroma` requires a synchronous Chroma client. "
-            "Received an awaitable client, which usually means "
-            "`chromadb.AsyncHttpClient(...)` was passed in. Use "
-            "`chromadb.HttpClient(...)` or another synchronous `chromadb.ClientAPI` "
-            "instance instead."
-        )
-        raise TypeError(msg)
-
-
 class Chroma(VectorStore):
     """Chroma vector store integration.
 
@@ -381,7 +368,15 @@ class Chroma(VectorStore):
             raise ValueError(msg)
 
         if client is not None:
-            _validate_client(client)
+            if inspect.isawaitable(client):
+                msg = (
+                    "`client` must be a synchronous Chroma client implementing "
+                    "`chromadb.ClientAPI`. Got an awaitable instead, which usually "
+                    "means `chromadb.AsyncHttpClient(...)` was passed in. Use "
+                    "`chromadb.HttpClient(...)` or another synchronous client "
+                    "instance instead."
+                )
+                raise TypeError(msg)
             self._client = client
 
         # PersistentClient

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -1,3 +1,5 @@
+import chromadb
+import pytest
 from langchain_core.embeddings.fake import (
     FakeEmbeddings,
 )
@@ -28,3 +30,13 @@ def test_similarity_search() -> None:
     output = docsearch.similarity_search("foo", k=1)
     docsearch.delete_collection()
     assert len(output) == 1
+
+
+def test_async_http_client_rejected() -> None:
+    """Chroma should fail fast when given an async Chroma client."""
+    client = chromadb.AsyncHttpClient(host="localhost", port=8000)
+
+    with pytest.raises(TypeError, match="requires a synchronous Chroma client"):
+        Chroma(client=client)
+
+    client.close()

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -36,7 +36,7 @@ def test_async_http_client_rejected() -> None:
     """Chroma should fail fast when given an async Chroma client."""
     client = chromadb.AsyncHttpClient(host="localhost", port=8000)
 
-    with pytest.raises(TypeError, match="requires a synchronous Chroma client"):
+    with pytest.raises(TypeError, match="must be a synchronous Chroma client"):
         Chroma(client=client)
 
     client.close()


### PR DESCRIPTION
Fixes #30704

## Summary

Reject awaitable Chroma clients passed to `langchain_chroma.Chroma` with a clear `TypeError` instead of failing later with an `AttributeError`.

## Why

Passing `chromadb.AsyncHttpClient(...)` currently produces an awaitable, and `Chroma` later crashes during collection setup with `'coroutine' object has no attribute 'get_or_create_collection'`. This change fails fast with an actionable message that points users to a synchronous client.

## Changes

- validate `client` during `Chroma` initialization
- raise a clear `TypeError` when an awaitable client is provided
- add a regression test for `chromadb.AsyncHttpClient(...)`

## Testing

- `pytest tests/unit_tests/test_vectorstores.py -q`

## AI Disclosure

This PR was prepared with assistance from an AI coding agent, then reviewed and submitted by me.