### PR TITLE
Add Muninn memory integration (99.1% LOCOMO accuracy)

### DIFF
--- a/libs/partners/muninn/LICENSE
+++ b/libs/partners/muninn/LICENSE
@@ -1,0 +1,2 @@
+# License
+MIT

--- a/libs/partners/muninn/README.md
+++ b/libs/partners/muninn/README.md
@@ -1,0 +1,65 @@
+# langchain-muninn
+
+An integration package connecting Muninn memory and LangChain.
+
+## Installation
+
+```bash
+pip install langchain-muninn
+```
+
+## Features
+
+- **MuninnMemory**: Conversational memory backed by Muninn's semantic search
+- **MuninnEntityMemory**: Entity-focused memory for tracking facts about people, organizations, and concepts
+- **99.1% LOCOMO Accuracy**: Highest publicly reported score on the LOCOMO benchmark
+
+## Quick Start
+
+```python
+from langchain_muninn import MuninnMemory
+from langchain.agents import initialize_agent
+from langchain_openai import ChatOpenAI
+
+# Initialize Muninn memory
+memory = MuninnMemory(
+    api_key="muninn_xxx",
+    organization_id="my-agent"
+)
+
+# Use with an agent
+llm = ChatOpenAI(temperature=0)
+agent = initialize_agent(
+    tools=tools,
+    llm=llm,
+    memory=memory,
+    agent="zero-shot-react-description"
+)
+```
+
+## MuninnEntityMemory
+
+For agents that need to remember specific facts:
+
+```python
+from langchain_muninn import MuninnEntityMemory
+
+memory = MuninnEntityMemory(
+    api_key="muninn_xxx",
+    organization_id="my-agent"
+)
+
+# Automatically extracts and stores entity facts
+# Example: "James works at TechCorp" -> {James: {works_at: TechCorp}}
+```
+
+## Links
+
+- [Muninn Documentation](https://muninn.au)
+- [LOCOMO Benchmark Results](https://muninn.au/benchmark)
+- [GitHub](https://github.com/Phillipneho/muninn)
+- [PyPI](https://pypi.org/project/muninn-sdk/)
+
+## License
+
+MIT

--- a/libs/partners/muninn/langchain_muninn/__init__.py
+++ b/libs/partners/muninn/langchain_muninn/__init__.py
@@ -1,0 +1,168 @@
+"""Muninn memory integration for LangChain."""
+
+from typing import Any, Dict, List, Optional
+
+from langchain_core.memory import BaseMemory
+from langchain_core.messages import HumanMessage, AIMessage
+from muninn import MuninnClient
+
+
+class MuninnMemory(BaseMemory):
+    """
+    LangChain memory backed by Muninn semantic search.
+    
+    Provides persistent, searchable memory for LangChain agents.
+    99.1% accuracy on LOCOMO benchmark.
+    
+    Example:
+        from langchain_muninn import MuninnMemory
+        from langchain.agents import initialize_agent
+        
+        memory = MuninnMemory(api_key="muninn_xxx")
+        agent = initialize_agent(tools=tools, llm=llm, memory=memory)
+    
+    Args:
+        api_key: Muninn API key
+        organization_id: Organization ID for multi-tenant isolation
+        base_url: Muninn API base URL (default: https://api.muninn.au)
+        memory_type: Memory type for stored memories (default: conversational)
+    """
+    
+    api_key: str
+    organization_id: str = "default"
+    base_url: str = "https://api.muninn.au"
+    memory_type: str = "conversational"
+    
+    _client: Optional[MuninnClient] = None
+    
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._client = MuninnClient(
+            api_key=self.api_key,
+            organization_id=self.organization_id,
+            base_url=self.base_url
+        )
+    
+    @property
+    def memory_variables(self) -> List[str]:
+        """Return memory variables."""
+        return ["history"]
+    
+    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Load memory from Muninn using semantic search."""
+        query = str(inputs)
+        
+        memories = self._client.search(
+            query=query,
+            limit=10,
+            search_type="hybrid"
+        )
+        
+        # Format as conversation history
+        history = []
+        for memory in memories:
+            content = memory.get("content", "")
+            metadata = memory.get("metadata", {})
+            role = metadata.get("role", "user")
+            
+            if role == "assistant":
+                history.append(AIMessage(content=content))
+            else:
+                history.append(HumanMessage(content=content))
+        
+        return {"history": history}
+    
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        """Save conversation turn to Muninn."""
+        user_input = str(inputs)
+        if user_input:
+            self._client.store(
+                content=user_input,
+                memory_type=self.memory_type,
+                metadata={"role": "user", "source": "langchain"}
+            )
+        
+        ai_output = outputs.get("output", str(outputs))
+        if ai_output:
+            self._client.store(
+                content=ai_output,
+                memory_type=self.memory_type,
+                metadata={"role": "assistant", "source": "langchain"}
+            )
+    
+    def clear(self) -> None:
+        """Clear memory (no-op for safety)."""
+        pass
+
+
+class MuninnEntityMemory(BaseMemory):
+    """
+    Entity-focused memory for LangChain agents.
+    
+    Stores and retrieves facts about entities mentioned in conversation.
+    Best for agents that need to remember specific information about
+    people, organizations, or concepts.
+    
+    Example:
+        from langchain_muninn import MuninnEntityMemory
+        
+        memory = MuninnEntityMemory(api_key="muninn_xxx")
+        # Automatically extracts: "James works at TechCorp"
+        # into entity facts: {James: {works_at: TechCorp}}
+    """
+    
+    api_key: str
+    organization_id: str = "default"
+    base_url: str = "https://api.muninn.au"
+    
+    _client: Optional[MuninnClient] = None
+    
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._client = MuninnClient(
+            api_key=self.api_key,
+            organization_id=self.organization_id,
+            base_url=self.base_url
+        )
+    
+    @property
+    def memory_variables(self) -> List[str]:
+        return ["entity_facts"]
+    
+    def load_memory_variables(self, inputs: Dict[str, Any]) -> Dict[str, Any]:
+        """Load facts about entities mentioned in inputs."""
+        query = str(inputs)
+        
+        facts = self._client.search(
+            query=query,
+            limit=20,
+            search_type="hybrid"
+        )
+        
+        # Group by entity
+        entity_facts = {}
+        for fact in facts:
+            content = fact.get("content", "")
+            entities = fact.get("entities", [])
+            
+            for entity in entities:
+                if entity not in entity_facts:
+                    entity_facts[entity] = []
+                entity_facts[entity].append(content)
+        
+        return {"entity_facts": entity_facts}
+    
+    def save_context(self, inputs: Dict[str, Any], outputs: Dict[str, str]) -> None:
+        """Store conversation turn (Muninn handles entity extraction)."""
+        combined = f"User: {inputs}\nAssistant: {outputs}"
+        self._client.store(
+            content=combined,
+            memory_type="conversational",
+            metadata={"source": "langchain_entity"}
+        )
+    
+    def clear(self) -> None:
+        pass
+
+
+__all__ = ["MuninnMemory", "MuninnEntityMemory"]

--- a/libs/partners/muninn/pyproject.toml
+++ b/libs/partners/muninn/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langchain-muninn"
+description = "An integration package connecting Muninn memory and LangChain"
+license = { text = "MIT" }
+readme = "README.md"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+version = "2.0.0"
+requires-python = ">=3.10.0,<4.0.0"
+dependencies = [
+    "langchain-core>=1.2.21,<2.0.0",
+    "muninn-sdk>=2.0.0,<3.0.0",
+]
+
+[project.urls]
+Homepage = "https://muninn.au"
+Documentation = "https://muninn.au/docs"
+Repository = "https://github.com/langchain-ai/langchain"
+Issues = "https://github.com/langchain-ai/langchain/issues"
+Changelog = "https://github.com/Phillipneho/muninn/releases"
+
+[dependency-groups]
+test = [
+    "pytest>=7.3.0,<8.0.0",
+    "pytest-mock>=3.10.0,<4.0.0",
+    "pytest-asyncio>=0.21.1,<1.0.0",
+]
+
+[tool.hatch.build]
+include = ["langchain_muninn"]
+
+[tool.mypy]
+disallow_untyped_defs = true

--- a/libs/partners/muninn/tests/unit_tests/test_memory.py
+++ b/libs/partners/muninn/tests/unit_tests/test_memory.py
@@ -1,0 +1,18 @@
+"""Tests for langchain-muninn integration."""
+
+from langchain_muninn import MuninnMemory, MuninnEntityMemory
+
+
+def test_import():
+    """Test that the package can be imported."""
+    assert MuninnMemory is not None
+    assert MuninnEntityMemory is not None
+
+
+def test_memory_variables():
+    """Test that memory variables are defined."""
+    memory = MuninnMemory(api_key="test_key")
+    assert memory.memory_variables == ["history"]
+    
+    entity_memory = MuninnEntityMemory(api_key="test_key")
+    assert entity_memory.memory_variables == ["entity_facts"]


### PR DESCRIPTION
## Summary

This PR adds a LangChain integration for [Muninn](https://muninn.au), a semantic memory system for AI agents.

### Key Features

- **MuninnMemory**: Conversational memory backed by Muninn's semantic search
- **MuninnEntityMemory**: Entity-focused memory for tracking facts about people, organizations, and concepts
- **99.1% LOCOMO Accuracy**: Highest publicly reported score on the LOCOMO benchmark

### Installation

```bash
pip install langchain-muninn
```

### Usage

```python
from langchain_muninn import MuninnMemory
from langchain.agents import initialize_agent
from langchain_openai import ChatOpenAI

memory = MuninnMemory(api_key="muninn_xxx", organization_id="my-agent")
llm = ChatOpenAI(temperature=0)
agent = initialize_agent(tools=tools, llm=llm, memory=memory)
```

### Why Muninn?

- **Semantic Search**: Find relevant memories by meaning, not keywords
- **Temporal Reasoning**: Facts with valid_from/valid_until timestamps
- **Knowledge Graph**: Entity relationships with confidence scores
- **Edge-Native**: Runs on Cloudflare Workers, <100ms latency
- **Open Source**: Full source available at github.com/Phillipneho/muninn

### Links

- [Muninn Documentation](https://muninn.au)
- [LOCOMO Benchmark Results](https://dev.to/phillip_neho/we-hit-991-on-the-locomo-benchmark-heres-how-18di)
- [PyPI: muninn-sdk](https://pypi.org/project/muninn-sdk/)

### Testing

```bash
cd libs/partners/muninn
pip install -e .
pytest tests/
```

---

@hwchase17 @jerryjliu0 - would love feedback on the integration approach!