### PR TITLE
docs: add Superlinked (SIE) embeddings integration

### DIFF
--- a/docs/docs/integrations/text_embedding/superlinked.ipynb
+++ b/docs/docs/integrations/text_embedding/superlinked.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "sidebar_label: Superlinked\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SIEEmbeddings\n",
+    "\n",
+    ">[Superlinked](https://superlinked.com) is a self-hosted inference engine (SIE) for embedding, reranking, and extraction. The `sie-langchain` package provides LangChain components backed by a single SIE endpoint, giving you access to 85+ embedding models (dense, sparse, ColBERT/multivector).\n",
+    "\n",
+    "This notebook shows how to get started with `SIEEmbeddings`. For reranking, use `SIEReranker` (a `BaseDocumentCompressor`), also included in the `sie-langchain` package."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "To use `SIEEmbeddings`, you need a running SIE instance and the `sie-langchain` package. See the [Superlinked quickstart](https://superlinked.com/docs) for deployment options (Docker, GPU, etc.)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade --quiet sie-langchain"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This installs `sie-sdk` and `langchain-core` as dependencies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Start the SIE server\n",
+    "\n",
+    "Run SIE locally with Docker:\n",
+    "\n",
+    "```bash\n",
+    "docker run -p 8080:8080 ghcr.io/superlinked/sie-server:default\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Usage\n",
+    "\n",
+    "`SIEEmbeddings` implements LangChain's `Embeddings` interface, so it drops into any vector store or retriever."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sie_langchain import SIEEmbeddings\n",
+    "\n",
+    "embeddings = SIEEmbeddings(\n",
+    "    base_url=\"http://localhost:8080\",\n",
+    "    model=\"BAAI/bge-m3\",\n",
+    ")\n",
+    "\n",
+    "# Embed documents\n",
+    "vectors = embeddings.embed_documents(\n",
+    "    [\n",
+    "        \"Machine learning uses algorithms to learn from data.\",\n",
+    "        \"The weather is sunny today.\",\n",
+    "    ]\n",
+    ")\n",
+    "print(len(vectors))\n",
+    "\n",
+    "# Embed a query\n",
+    "query_vector = embeddings.embed_query(\"What is machine learning?\")\n",
+    "print(len(query_vector))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Any of SIE's 85+ supported models works. Common picks:\n",
+    "\n",
+    "| Model | Dims | Notes |\n",
+    "|---|---|---|\n",
+    "| `BAAI/bge-m3` | 1024 | Strong all-round, supports dense + sparse |\n",
+    "| `NovaSearch/stella_en_400M_v5` | 1024 | High retrieval quality |\n",
+    "| `nomic-ai/nomic-embed-text-v2-moe` | 768 | MoE, multilingual |\n",
+    "| `intfloat/e5-large-v2` | 1024 | Instruction-tuned, SIE handles query vs document encoding automatically |\n",
+    "\n",
+    "See the [Model Catalog](https://superlinked.com/models) for all supported models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### With a vector store\n",
+    "\n",
+    "Use `SIEEmbeddings` as a drop-in embedding for any LangChain-supported vector store."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_chroma import Chroma\n",
+    "from sie_langchain import SIEEmbeddings\n",
+    "\n",
+    "embeddings = SIEEmbeddings(model=\"BAAI/bge-m3\")\n",
+    "\n",
+    "vectorstore = Chroma.from_texts(\n",
+    "    texts=[\n",
+    "        \"Machine learning is a branch of artificial intelligence.\",\n",
+    "        \"Neural networks are inspired by biological neurons.\",\n",
+    "        \"Deep learning uses multiple layers of neural networks.\",\n",
+    "    ],\n",
+    "    embedding=embeddings,\n",
+    ")\n",
+    "\n",
+    "results = vectorstore.similarity_search(\"What is deep learning?\", k=2)\n",
+    "for doc in results:\n",
+    "    print(doc.page_content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Async\n",
+    "\n",
+    "Both sync and async methods are available:\n",
+    "\n",
+    "```python\n",
+    "vectors = await embeddings.aembed_documents(texts)\n",
+    "query_vec = await embeddings.aembed_query(text)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reranking\n",
+    "\n",
+    "The `sie-langchain` package also ships `SIEReranker`, which implements `BaseDocumentCompressor` and works with both cross-encoder models (e.g. `jinaai/jina-reranker-v2-base-multilingual`) and ColBERT / late-interaction models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.retrievers import ContextualCompressionRetriever\n",
+    "from sie_langchain import SIEReranker\n",
+    "\n",
+    "reranker = SIEReranker(\n",
+    "    base_url=\"http://localhost:8080\",\n",
+    "    model=\"jinaai/jina-reranker-v2-base-multilingual\",\n",
+    "    top_k=5,\n",
+    ")\n",
+    "\n",
+    "compression_retriever = ContextualCompressionRetriever(\n",
+    "    base_compressor=reranker,\n",
+    "    base_retriever=vectorstore.as_retriever(search_kwargs={\"k\": 20}),\n",
+    ")\n",
+    "\n",
+    "# Retrieves 20 docs, reranks with SIE, returns top 5\n",
+    "results = compression_retriever.invoke(\"What is machine learning?\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## API reference\n",
+    "\n",
+    "- [`sie-langchain` on PyPI](https://pypi.org/project/sie-langchain/)\n",
+    "- [Superlinked on GitHub](https://github.com/superlinked/sie)\n",
+    "- [Superlinked docs](https://superlinked.com/docs)\n",
+    "- [Model Catalog](https://superlinked.com/models)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Description

Adds a docs notebook at `docs/docs/integrations/text_embedding/superlinked.ipynb` for [Superlinked](https://superlinked.com) (SIE), a self-hosted inference engine that exposes 85+ embedding models (dense, sparse, ColBERT / multivector) and cross-encoder rerankers through a single endpoint.

The `sie-langchain` package (on PyPI) provides:

- `SIEEmbeddings` - implements LangChain's `Embeddings` interface (sync + async)
- `SIEReranker` - implements `BaseDocumentCompressor`, works with cross-encoder and ColBERT / late-interaction reranker models
- `SIESparseEncoder` - sparse encoder for hybrid-search integrations (e.g. Pinecone)

The notebook follows the same structure as the existing `voyageai.ipynb` / `jina.ipynb` / `cohere.ipynb` pages in the same directory.

## Issue

N/A - new provider integration docs.

## Dependencies

None. The `sie-langchain` package is published on PyPI and depends on `sie-sdk` and `langchain-core`.

## Links

- Package: https://pypi.org/project/sie-langchain/
- Source: https://github.com/superlinked/sie
- Superlinked docs: https://superlinked.com/docs

Targeting \`v0.3\` since docs live on that branch.