### PR TITLE
fix(core): correct typo in Visitor._validate_func error message

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
Fixes #36701

## Changes

Changed "comparators" to "operators" in the error message for the operator validation branch of  in .

When an invalid operator was passed, the error message incorrectly said:
> Received disallowed operator Operator.OR. Allowed **comparators** are (Operator.AND,)

It should say:
> Received disallowed operator Operator.OR. Allowed **operators** are (Operator.AND,)

This is a one-word fix for a copy-paste typo.

---

*This contribution was made with AI agent assistance.*