### PR TITLE
feat(openai): add native OpenAI Batch API support

### DIFF
--- a/libs/partners/openai/langchain_openai/__init__.py
+++ b/libs/partners/openai/langchain_openai/__init__.py
@@ -1,6 +1,7 @@
 """Module for OpenAI integrations."""
 
 from langchain_openai.chat_models import AzureChatOpenAI, ChatOpenAI
+from langchain_openai.chat_models._batch_api import BatchRequest, BatchResult
 from langchain_openai.embeddings import AzureOpenAIEmbeddings, OpenAIEmbeddings
 from langchain_openai.llms import AzureOpenAI, OpenAI
 from langchain_openai.tools import custom_tool
@@ -9,6 +10,8 @@ __all__ = [
     "AzureChatOpenAI",
     "AzureOpenAI",
     "AzureOpenAIEmbeddings",
+    "BatchRequest",
+    "BatchResult",
     "ChatOpenAI",
     "OpenAI",
     "OpenAIEmbeddings",

--- a/libs/partners/openai/langchain_openai/chat_models/_batch_api.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_batch_api.py
@@ -13,8 +13,9 @@ import io
 import json
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any
 
 
 @dataclass

--- a/libs/partners/openai/langchain_openai/chat_models/_batch_api.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_batch_api.py
@@ -1,0 +1,418 @@
+"""Utilities for OpenAI Batch API integration.
+
+Handles the lifecycle of OpenAI Batch API requests: JSONL creation,
+file upload, batch submission, polling, and result retrieval.
+
+See https://platform.openai.com/docs/guides/batch for API details.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass
+class BatchRequest:
+    """A single request within a batch submission."""
+
+    custom_id: str
+    body: dict[str, Any]
+    endpoint: str = "/v1/chat/completions"
+    method: str = "POST"
+
+    def to_jsonl_line(self) -> str:
+        """Serialize to a single JSONL line."""
+        return json.dumps(
+            {
+                "custom_id": self.custom_id,
+                "method": self.method,
+                "url": self.endpoint,
+                "body": self.body,
+            }
+        )
+
+
+@dataclass
+class BatchResult:
+    """Result of a batch API operation."""
+
+    batch_id: str
+    status: str
+    results: dict[str, Any] | None = None
+    errors: dict[str, Any] | None = None
+    request_counts: dict[str, int] = field(default_factory=dict)
+
+
+def create_batch_jsonl(requests: list[BatchRequest]) -> str:
+    """Convert BatchRequest objects to JSONL string for upload.
+
+    Args:
+        requests: List of batch requests to serialize.
+
+    Returns:
+        JSONL-formatted string with one request per line.
+    """
+    return "\n".join(req.to_jsonl_line() for req in requests)
+
+
+def build_batch_requests(
+    payloads: list[dict[str, Any]],
+    *,
+    batch_prefix: str | None = None,
+) -> list[BatchRequest]:
+    """Build BatchRequest objects from LangChain request payloads.
+
+    Args:
+        payloads: List of request payloads from ``_get_request_payload()``.
+        batch_prefix: Optional prefix for custom_ids. Defaults to a random UUID
+            segment to group requests from the same batch call.
+
+    Returns:
+        List of BatchRequest objects ready for JSONL serialization.
+    """
+    prefix = batch_prefix or f"lc-{uuid.uuid4().hex[:8]}"
+    requests = []
+    for i, payload in enumerate(payloads):
+        body = {k: v for k, v in payload.items() if k != "stream"}
+        requests.append(
+            BatchRequest(
+                custom_id=f"{prefix}-{i}",
+                body=body,
+            )
+        )
+    return requests
+
+
+def upload_and_submit_batch(
+    client: Any,
+    jsonl_content: str,
+    *,
+    endpoint: str = "/v1/chat/completions",
+    completion_window: str = "24h",
+    metadata: dict[str, str] | None = None,
+) -> str:
+    """Upload JSONL file and create a batch job.
+
+    Args:
+        client: An ``openai.OpenAI`` root client instance.
+        jsonl_content: JSONL-formatted string of batch requests.
+        endpoint: The API endpoint for batch processing.
+        completion_window: Time window for batch completion.
+        metadata: Optional metadata key-value pairs for the batch.
+
+    Returns:
+        The batch ID string.
+    """
+    file_obj = io.BytesIO(jsonl_content.encode("utf-8"))
+    file_obj.name = "batch_requests.jsonl"
+    batch_file = client.files.create(file=file_obj, purpose="batch")
+
+    create_kwargs: dict[str, Any] = {
+        "input_file_id": batch_file.id,
+        "endpoint": endpoint,
+        "completion_window": completion_window,
+    }
+    if metadata:
+        create_kwargs["metadata"] = metadata
+
+    batch = client.batches.create(**create_kwargs)
+    return batch.id
+
+
+async def async_upload_and_submit_batch(
+    client: Any,
+    jsonl_content: str,
+    *,
+    endpoint: str = "/v1/chat/completions",
+    completion_window: str = "24h",
+    metadata: dict[str, str] | None = None,
+) -> str:
+    """Async version: upload JSONL file and create a batch job.
+
+    Args:
+        client: An ``openai.AsyncOpenAI`` root client instance.
+        jsonl_content: JSONL-formatted string of batch requests.
+        endpoint: The API endpoint for batch processing.
+        completion_window: Time window for batch completion.
+        metadata: Optional metadata key-value pairs for the batch.
+
+    Returns:
+        The batch ID string.
+    """
+    file_obj = io.BytesIO(jsonl_content.encode("utf-8"))
+    file_obj.name = "batch_requests.jsonl"
+    batch_file = await client.files.create(file=file_obj, purpose="batch")
+
+    create_kwargs: dict[str, Any] = {
+        "input_file_id": batch_file.id,
+        "endpoint": endpoint,
+        "completion_window": completion_window,
+    }
+    if metadata:
+        create_kwargs["metadata"] = metadata
+
+    batch = await client.batches.create(**create_kwargs)
+    return batch.id
+
+
+_TERMINAL_STATUSES = frozenset(
+    {"completed", "failed", "expired", "cancelled", "canceled"}
+)
+_MAX_POLL_INTERVAL = 120.0
+
+
+def _parse_batch_to_result(batch: Any) -> BatchResult:
+    """Convert an OpenAI Batch object to a BatchResult."""
+    counts = {}
+    if hasattr(batch, "request_counts") and batch.request_counts:
+        rc = batch.request_counts
+        counts = {
+            "total": getattr(rc, "total", 0),
+            "completed": getattr(rc, "completed", 0),
+            "failed": getattr(rc, "failed", 0),
+        }
+    return BatchResult(
+        batch_id=batch.id,
+        status=batch.status,
+        request_counts=counts,
+    )
+
+
+def poll_batch_status(
+    client: Any,
+    batch_id: str,
+    *,
+    poll_interval: float = 10.0,
+    max_wait: float | None = None,
+    on_poll: Callable[[BatchResult], None] | None = None,
+) -> BatchResult:
+    """Poll a batch until it reaches a terminal status.
+
+    Uses adaptive backoff: interval doubles each poll, capped at 120s.
+
+    Args:
+        client: An ``openai.OpenAI`` root client instance.
+        batch_id: The batch ID to monitor.
+        poll_interval: Initial polling interval in seconds.
+        max_wait: Maximum total wait time in seconds. ``None`` waits indefinitely.
+        on_poll: Optional callback invoked with current status on each poll.
+
+    Returns:
+        Final BatchResult once the batch reaches a terminal status.
+
+    Raises:
+        TimeoutError: If ``max_wait`` is exceeded before batch completes.
+    """
+    interval = poll_interval
+    elapsed = 0.0
+    while True:
+        batch = client.batches.retrieve(batch_id)
+        result = _parse_batch_to_result(batch)
+        if on_poll:
+            on_poll(result)
+        if result.status in _TERMINAL_STATUSES:
+            return result
+        if max_wait is not None and elapsed >= max_wait:
+            msg = (
+                f"Batch {batch_id} did not complete within {max_wait}s "
+                f"(status: {result.status}). Retrieve results later with "
+                f"batch_api_retrieve('{batch_id}')."
+            )
+            raise TimeoutError(msg)
+        time.sleep(interval)
+        elapsed += interval
+        interval = min(interval * 2, _MAX_POLL_INTERVAL)
+
+
+async def async_poll_batch_status(
+    client: Any,
+    batch_id: str,
+    *,
+    poll_interval: float = 10.0,
+    max_wait: float | None = None,
+    on_poll: Callable[[BatchResult], None] | None = None,
+) -> BatchResult:
+    """Async poll a batch until it reaches a terminal status.
+
+    Args:
+        client: An ``openai.AsyncOpenAI`` root client instance.
+        batch_id: The batch ID to monitor.
+        poll_interval: Initial polling interval in seconds.
+        max_wait: Maximum total wait time in seconds. ``None`` waits indefinitely.
+        on_poll: Optional callback invoked with current status on each poll.
+
+    Returns:
+        Final BatchResult once the batch reaches a terminal status.
+
+    Raises:
+        TimeoutError: If ``max_wait`` is exceeded before batch completes.
+    """
+    interval = poll_interval
+    elapsed = 0.0
+    while True:
+        batch = await client.batches.retrieve(batch_id)
+        result = _parse_batch_to_result(batch)
+        if on_poll:
+            on_poll(result)
+        if result.status in _TERMINAL_STATUSES:
+            return result
+        if max_wait is not None and elapsed >= max_wait:
+            msg = (
+                f"Batch {batch_id} did not complete within {max_wait}s "
+                f"(status: {result.status}). Retrieve results later with "
+                f"abatch_api_retrieve('{batch_id}')."
+            )
+            raise TimeoutError(msg)
+        await asyncio.sleep(interval)
+        elapsed += interval
+        interval = min(interval * 2, _MAX_POLL_INTERVAL)
+
+
+def _parse_output_file(content: str) -> dict[str, Any]:
+    """Parse a batch output JSONL file into a dict keyed by custom_id.
+
+    Args:
+        content: Raw text content of the output file.
+
+    Returns:
+        Dict mapping custom_id to the response body.
+    """
+    results: dict[str, Any] = {}
+    for line in content.strip().split("\n"):
+        if not line:
+            continue
+        entry = json.loads(line)
+        custom_id = entry["custom_id"]
+        result_body = entry.get("result", {})
+        if result_body.get("status_code") == 200:
+            results[custom_id] = result_body.get("body")
+        else:
+            results[custom_id] = result_body
+    return results
+
+
+def _parse_error_file(content: str) -> dict[str, Any]:
+    """Parse a batch error JSONL file into a dict keyed by custom_id.
+
+    Args:
+        content: Raw text content of the error file.
+
+    Returns:
+        Dict mapping custom_id to the error body.
+    """
+    errors: dict[str, Any] = {}
+    for line in content.strip().split("\n"):
+        if not line:
+            continue
+        entry = json.loads(line)
+        custom_id = entry["custom_id"]
+        errors[custom_id] = entry.get("result", {}).get("body", {}).get("error", {})
+    return errors
+
+
+def retrieve_batch_results(
+    client: Any,
+    batch_id: str,
+) -> BatchResult:
+    """Retrieve and parse results for a completed batch.
+
+    Args:
+        client: An ``openai.OpenAI`` root client instance.
+        batch_id: The batch ID to retrieve results for.
+
+    Returns:
+        BatchResult with parsed results and errors.
+
+    Raises:
+        ValueError: If the batch has not completed successfully.
+    """
+    batch = client.batches.retrieve(batch_id)
+    result = _parse_batch_to_result(batch)
+
+    if batch.status == "failed":
+        msg = f"Batch {batch_id} failed."
+        raise ValueError(msg)
+
+    if batch.status not in _TERMINAL_STATUSES:
+        msg = (
+            f"Batch {batch_id} is not complete (status: {batch.status}). "
+            f"Poll with batch_api_status() first."
+        )
+        raise ValueError(msg)
+
+    if batch.output_file_id:
+        output_content = client.files.content(batch.output_file_id)
+        result.results = _parse_output_file(output_content.text)
+
+    if batch.error_file_id:
+        error_content = client.files.content(batch.error_file_id)
+        result.errors = _parse_error_file(error_content.text)
+
+    return result
+
+
+async def async_retrieve_batch_results(
+    client: Any,
+    batch_id: str,
+) -> BatchResult:
+    """Async retrieve and parse results for a completed batch.
+
+    Args:
+        client: An ``openai.AsyncOpenAI`` root client instance.
+        batch_id: The batch ID to retrieve results for.
+
+    Returns:
+        BatchResult with parsed results and errors.
+
+    Raises:
+        ValueError: If the batch has not completed successfully.
+    """
+    batch = await client.batches.retrieve(batch_id)
+    result = _parse_batch_to_result(batch)
+
+    if batch.status == "failed":
+        msg = f"Batch {batch_id} failed."
+        raise ValueError(msg)
+
+    if batch.status not in _TERMINAL_STATUSES:
+        msg = (
+            f"Batch {batch_id} is not complete (status: {batch.status}). "
+            f"Poll with batch_api_status() first."
+        )
+        raise ValueError(msg)
+
+    if batch.output_file_id:
+        output_content = await client.files.content(batch.output_file_id)
+        result.results = _parse_output_file(output_content.text)
+
+    if batch.error_file_id:
+        error_content = await client.files.content(batch.error_file_id)
+        result.errors = _parse_error_file(error_content.text)
+
+    return result
+
+
+def cancel_batch(client: Any, batch_id: str) -> None:
+    """Cancel an in-progress batch.
+
+    Args:
+        client: An ``openai.OpenAI`` root client instance.
+        batch_id: The batch ID to cancel.
+    """
+    client.batches.cancel(batch_id)
+
+
+async def async_cancel_batch(client: Any, batch_id: str) -> None:
+    """Async cancel an in-progress batch.
+
+    Args:
+        client: An ``openai.AsyncOpenAI`` root client instance.
+        batch_id: The batch ID to cancel.
+    """
+    await client.batches.cancel(batch_id)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -903,6 +903,26 @@ class BaseChatOpenAI(BaseChatModel):
     !!! version-added "Added in `langchain-openai` 0.3.9"
     """
 
+    use_batch_api: bool = False
+    """If ``True``, :meth:`batch` and :meth:`abatch` will use OpenAI's Batch API
+    (``/v1/batches``) instead of making parallel individual requests. This provides
+    a **50% cost discount** but has up to a 24-hour completion window.
+
+    Only supported with the Chat Completions endpoint — not compatible with the
+    Responses API (``use_responses_api=True``).
+
+    When enabled, :meth:`batch` becomes a blocking call that polls until the
+    batch completes or the configured timeout is reached. For non-blocking usage,
+    use :meth:`batch_api_submit` and :meth:`batch_api_retrieve` directly.
+
+    Polling behavior can be configured via the ``configurable`` dict::
+
+        model.batch(inputs, config={"configurable": {
+            "batch_poll_interval": 10,   # initial poll interval in seconds
+            "batch_max_wait": 3600,      # max wait time in seconds
+        }})
+    """
+
     output_version: str | None = Field(
         default_factory=from_env("LC_OUTPUT_VERSION", default=None)
     )
@@ -2346,6 +2366,418 @@ class BaseChatOpenAI(BaseChatModel):
         return ChatGenerationChunk(
             message=message, generation_info=chat_result.llm_output
         )
+
+    # ------------------------------------------------------------------
+    # OpenAI Batch API integration
+    # ------------------------------------------------------------------
+
+    def _validate_batch_api_compatible(self) -> None:
+        """Raise if the current config is incompatible with the Batch API."""
+        if self.use_responses_api:
+            msg = (
+                "Batch API does not support the Responses API. "
+                "Set use_responses_api=False or use_batch_api=False."
+            )
+            raise ValueError(msg)
+
+    def _build_batch_payloads(
+        self,
+        inputs: list[LanguageModelInput],
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Build request payloads for each input, suitable for batch submission."""
+        self._ensure_sync_client_available()
+        payloads = []
+        for inp in inputs:
+            messages = self._convert_input(inp).to_messages()
+            payload = self._get_request_payload(messages, **kwargs)
+            payload.pop("stream", None)
+            payloads.append(payload)
+        return payloads
+
+    def batch(
+        self,
+        inputs: list[LanguageModelInput],
+        config: Any | None = None,
+        *,
+        return_exceptions: bool = False,
+        **kwargs: Any,
+    ) -> list[Any]:
+        """Run the model on a list of inputs.
+
+        When ``use_batch_api=True``, submits all inputs as a single OpenAI Batch
+        API request for 50% cost savings. This blocks until the batch completes.
+
+        Polling can be configured via ``config["configurable"]``::
+
+            model.batch(inputs, config={"configurable": {
+                "batch_poll_interval": 10,
+                "batch_max_wait": 3600,
+            }})
+
+        Args:
+            inputs: List of model inputs (strings, message lists, or PromptValues).
+            config: Optional RunnableConfig or list of configs.
+            return_exceptions: If True, return exceptions instead of raising.
+            **kwargs: Additional keyword arguments passed to the model.
+
+        Returns:
+            List of model outputs, one per input.
+        """
+        if not self.use_batch_api:
+            return super().batch(
+                inputs,
+                config,
+                return_exceptions=return_exceptions,
+                **kwargs,
+            )
+
+        self._validate_batch_api_compatible()
+
+        from langchain_openai.chat_models._batch_api import (
+            BatchResult,
+            build_batch_requests,
+            create_batch_jsonl,
+            poll_batch_status,
+            retrieve_batch_results,
+            upload_and_submit_batch,
+        )
+
+        configurable = {}
+        if isinstance(config, dict):
+            configurable = config.get("configurable", {})
+        elif isinstance(config, list) and config:
+            configurable = (config[0] or {}).get("configurable", {})
+
+        poll_interval = configurable.get("batch_poll_interval", 10.0)
+        max_wait = configurable.get("batch_max_wait", None)
+
+        payloads = self._build_batch_payloads(inputs, **kwargs)
+        requests = build_batch_requests(payloads)
+        jsonl = create_batch_jsonl(requests)
+
+        batch_id = upload_and_submit_batch(self.root_client, jsonl)
+
+        poll_batch_status(
+            self.root_client,
+            batch_id,
+            poll_interval=poll_interval,
+            max_wait=max_wait,
+        )
+
+        result = retrieve_batch_results(self.root_client, batch_id)
+        return self._batch_result_to_outputs(
+            result, requests, return_exceptions=return_exceptions
+        )
+
+    async def abatch(
+        self,
+        inputs: list[LanguageModelInput],
+        config: Any | None = None,
+        *,
+        return_exceptions: bool = False,
+        **kwargs: Any,
+    ) -> list[Any]:
+        """Async run the model on a list of inputs.
+
+        When ``use_batch_api=True``, submits all inputs as a single OpenAI Batch
+        API request for 50% cost savings.
+
+        Args:
+            inputs: List of model inputs.
+            config: Optional RunnableConfig or list of configs.
+            return_exceptions: If True, return exceptions instead of raising.
+            **kwargs: Additional keyword arguments passed to the model.
+
+        Returns:
+            List of model outputs, one per input.
+        """
+        if not self.use_batch_api:
+            return await super().abatch(
+                inputs,
+                config,
+                return_exceptions=return_exceptions,
+                **kwargs,
+            )
+
+        self._validate_batch_api_compatible()
+
+        from langchain_openai.chat_models._batch_api import (
+            BatchResult,
+            async_poll_batch_status,
+            async_retrieve_batch_results,
+            async_upload_and_submit_batch,
+            build_batch_requests,
+            create_batch_jsonl,
+        )
+
+        configurable = {}
+        if isinstance(config, dict):
+            configurable = config.get("configurable", {})
+        elif isinstance(config, list) and config:
+            configurable = (config[0] or {}).get("configurable", {})
+
+        poll_interval = configurable.get("batch_poll_interval", 10.0)
+        max_wait = configurable.get("batch_max_wait", None)
+
+        payloads = self._build_batch_payloads(inputs, **kwargs)
+        requests = build_batch_requests(payloads)
+        jsonl = create_batch_jsonl(requests)
+
+        batch_id = await async_upload_and_submit_batch(
+            self.root_async_client, jsonl
+        )
+
+        await async_poll_batch_status(
+            self.root_async_client,
+            batch_id,
+            poll_interval=poll_interval,
+            max_wait=max_wait,
+        )
+
+        result = await async_retrieve_batch_results(
+            self.root_async_client, batch_id
+        )
+        return self._batch_result_to_outputs(
+            result, requests, return_exceptions=return_exceptions
+        )
+
+    def _batch_result_to_outputs(
+        self,
+        result: Any,
+        requests: list[Any],
+        *,
+        return_exceptions: bool = False,
+    ) -> list[Any]:
+        """Map batch results back to outputs in input order."""
+        outputs: list[Any] = []
+        for req in requests:
+            cid = req.custom_id
+            if result.results and cid in result.results:
+                response_body = result.results[cid]
+                if isinstance(response_body, dict) and "choices" in response_body:
+                    try:
+                        chat_result = self._create_chat_result(response_body)
+                        outputs.append(chat_result.generations[0].message)
+                    except Exception as e:
+                        if return_exceptions:
+                            outputs.append(e)
+                        else:
+                            raise
+                elif isinstance(response_body, dict) and "error" in response_body:
+                    err = ValueError(
+                        f"Batch request {cid} failed: "
+                        f"{response_body['error']}"
+                    )
+                    if return_exceptions:
+                        outputs.append(err)
+                    else:
+                        raise err
+                else:
+                    err = ValueError(
+                        f"Unexpected response for {cid}: {response_body}"
+                    )
+                    if return_exceptions:
+                        outputs.append(err)
+                    else:
+                        raise err
+            elif result.errors and cid in result.errors:
+                err = ValueError(
+                    f"Batch request {cid} errored: {result.errors[cid]}"
+                )
+                if return_exceptions:
+                    outputs.append(err)
+                else:
+                    raise err
+            else:
+                err = ValueError(
+                    f"No result found for batch request {cid}"
+                )
+                if return_exceptions:
+                    outputs.append(err)
+                else:
+                    raise err
+        return outputs
+
+    def batch_api_submit(
+        self,
+        inputs: list[LanguageModelInput],
+        *,
+        metadata: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> str:
+        """Submit inputs to OpenAI Batch API without waiting for completion.
+
+        Use this for fire-and-forget workflows. Pair with
+        :meth:`batch_api_status` and :meth:`batch_api_retrieve` to get results
+        later.
+
+        Example::
+
+            model = ChatOpenAI(model="gpt-4o-mini")
+            batch_id = model.batch_api_submit([
+                [HumanMessage("Question 1")],
+                [HumanMessage("Question 2")],
+            ])
+            # ... later ...
+            status = model.batch_api_status(batch_id)
+            if status.status == "completed":
+                results = model.batch_api_retrieve(batch_id)
+
+        Args:
+            inputs: List of model inputs (strings, message lists, or PromptValues).
+            metadata: Optional metadata key-value pairs attached to the batch.
+            **kwargs: Additional keyword arguments passed to payload construction.
+
+        Returns:
+            The batch ID string for later retrieval.
+        """
+        self._validate_batch_api_compatible()
+
+        from langchain_openai.chat_models._batch_api import (
+            build_batch_requests,
+            create_batch_jsonl,
+            upload_and_submit_batch,
+        )
+
+        payloads = self._build_batch_payloads(inputs, **kwargs)
+        requests = build_batch_requests(payloads)
+        jsonl = create_batch_jsonl(requests)
+        return upload_and_submit_batch(
+            self.root_client, jsonl, metadata=metadata
+        )
+
+    async def abatch_api_submit(
+        self,
+        inputs: list[LanguageModelInput],
+        *,
+        metadata: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> str:
+        """Async submit inputs to OpenAI Batch API without waiting.
+
+        Args:
+            inputs: List of model inputs.
+            metadata: Optional metadata key-value pairs attached to the batch.
+            **kwargs: Additional keyword arguments passed to payload construction.
+
+        Returns:
+            The batch ID string for later retrieval.
+        """
+        self._validate_batch_api_compatible()
+
+        from langchain_openai.chat_models._batch_api import (
+            async_upload_and_submit_batch,
+            build_batch_requests,
+            create_batch_jsonl,
+        )
+
+        payloads = self._build_batch_payloads(inputs, **kwargs)
+        requests = build_batch_requests(payloads)
+        jsonl = create_batch_jsonl(requests)
+        return await async_upload_and_submit_batch(
+            self.root_async_client, jsonl, metadata=metadata
+        )
+
+    def batch_api_status(self, batch_id: str) -> Any:
+        """Check the status of a submitted batch.
+
+        Args:
+            batch_id: The batch ID returned by :meth:`batch_api_submit`.
+
+        Returns:
+            A :class:`~langchain_openai.chat_models._batch_api.BatchResult`
+            with current status and progress counts.
+        """
+        self._ensure_sync_client_available()
+        from langchain_openai.chat_models._batch_api import _parse_batch_to_result
+
+        batch = self.root_client.batches.retrieve(batch_id)
+        return _parse_batch_to_result(batch)
+
+    def batch_api_retrieve(self, batch_id: str) -> list[Any]:
+        """Retrieve results for a completed batch.
+
+        Args:
+            batch_id: The batch ID returned by :meth:`batch_api_submit`.
+
+        Returns:
+            List of ``AIMessage`` outputs in submission order.
+
+        Raises:
+            ValueError: If the batch has not completed or failed.
+        """
+        self._ensure_sync_client_available()
+        from langchain_openai.chat_models._batch_api import retrieve_batch_results
+
+        result = retrieve_batch_results(self.root_client, batch_id)
+
+        if not result.results:
+            return []
+
+        outputs = []
+        for cid in sorted(result.results.keys()):
+            response_body = result.results[cid]
+            if isinstance(response_body, dict) and "choices" in response_body:
+                chat_result = self._create_chat_result(response_body)
+                outputs.append(chat_result.generations[0].message)
+            else:
+                outputs.append(response_body)
+        return outputs
+
+    async def abatch_api_retrieve(self, batch_id: str) -> list[Any]:
+        """Async retrieve results for a completed batch.
+
+        Args:
+            batch_id: The batch ID returned by :meth:`abatch_api_submit`.
+
+        Returns:
+            List of ``AIMessage`` outputs in submission order.
+
+        Raises:
+            ValueError: If the batch has not completed or failed.
+        """
+        from langchain_openai.chat_models._batch_api import (
+            async_retrieve_batch_results,
+        )
+
+        result = await async_retrieve_batch_results(
+            self.root_async_client, batch_id
+        )
+
+        if not result.results:
+            return []
+
+        outputs = []
+        for cid in sorted(result.results.keys()):
+            response_body = result.results[cid]
+            if isinstance(response_body, dict) and "choices" in response_body:
+                chat_result = self._create_chat_result(response_body)
+                outputs.append(chat_result.generations[0].message)
+            else:
+                outputs.append(response_body)
+        return outputs
+
+    def batch_api_cancel(self, batch_id: str) -> None:
+        """Cancel an in-progress batch.
+
+        Args:
+            batch_id: The batch ID to cancel.
+        """
+        self._ensure_sync_client_available()
+        from langchain_openai.chat_models._batch_api import cancel_batch
+
+        cancel_batch(self.root_client, batch_id)
+
+    async def abatch_api_cancel(self, batch_id: str) -> None:
+        """Async cancel an in-progress batch.
+
+        Args:
+            batch_id: The batch ID to cancel.
+        """
+        from langchain_openai.chat_models._batch_api import async_cancel_batch
+
+        await async_cancel_batch(self.root_async_client, batch_id)
 
 
 class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2410,10 +2410,15 @@ class BaseChatOpenAI(BaseChatModel):
 
         Polling can be configured via ``config["configurable"]``::
 
-            model.batch(inputs, config={"configurable": {
-                "batch_poll_interval": 10,
-                "batch_max_wait": 3600,
-            }})
+            model.batch(
+                inputs,
+                config={
+                    "configurable": {
+                        "batch_poll_interval": 10,
+                        "batch_max_wait": 3600,
+                    }
+                },
+            )
 
         Args:
             inputs: List of model inputs (strings, message lists, or PromptValues).
@@ -2435,7 +2440,6 @@ class BaseChatOpenAI(BaseChatModel):
         self._validate_batch_api_compatible()
 
         from langchain_openai.chat_models._batch_api import (
-            BatchResult,
             build_batch_requests,
             create_batch_jsonl,
             poll_batch_status,
@@ -2503,7 +2507,6 @@ class BaseChatOpenAI(BaseChatModel):
         self._validate_batch_api_compatible()
 
         from langchain_openai.chat_models._batch_api import (
-            BatchResult,
             async_poll_batch_status,
             async_retrieve_batch_results,
             async_upload_and_submit_batch,
@@ -2524,9 +2527,7 @@ class BaseChatOpenAI(BaseChatModel):
         requests = build_batch_requests(payloads)
         jsonl = create_batch_jsonl(requests)
 
-        batch_id = await async_upload_and_submit_batch(
-            self.root_async_client, jsonl
-        )
+        batch_id = await async_upload_and_submit_batch(self.root_async_client, jsonl)
 
         await async_poll_batch_status(
             self.root_async_client,
@@ -2535,9 +2536,7 @@ class BaseChatOpenAI(BaseChatModel):
             max_wait=max_wait,
         )
 
-        result = await async_retrieve_batch_results(
-            self.root_async_client, batch_id
-        )
+        result = await async_retrieve_batch_results(self.root_async_client, batch_id)
         return self._batch_result_to_outputs(
             result, requests, return_exceptions=return_exceptions
         )
@@ -2566,33 +2565,26 @@ class BaseChatOpenAI(BaseChatModel):
                             raise
                 elif isinstance(response_body, dict) and "error" in response_body:
                     err = ValueError(
-                        f"Batch request {cid} failed: "
-                        f"{response_body['error']}"
+                        f"Batch request {cid} failed: {response_body['error']}"
                     )
                     if return_exceptions:
                         outputs.append(err)
                     else:
                         raise err
                 else:
-                    err = ValueError(
-                        f"Unexpected response for {cid}: {response_body}"
-                    )
+                    err = ValueError(f"Unexpected response for {cid}: {response_body}")
                     if return_exceptions:
                         outputs.append(err)
                     else:
                         raise err
             elif result.errors and cid in result.errors:
-                err = ValueError(
-                    f"Batch request {cid} errored: {result.errors[cid]}"
-                )
+                err = ValueError(f"Batch request {cid} errored: {result.errors[cid]}")
                 if return_exceptions:
                     outputs.append(err)
                 else:
                     raise err
             else:
-                err = ValueError(
-                    f"No result found for batch request {cid}"
-                )
+                err = ValueError(f"No result found for batch request {cid}")
                 if return_exceptions:
                     outputs.append(err)
                 else:
@@ -2615,10 +2607,12 @@ class BaseChatOpenAI(BaseChatModel):
         Example::
 
             model = ChatOpenAI(model="gpt-4o-mini")
-            batch_id = model.batch_api_submit([
-                [HumanMessage("Question 1")],
-                [HumanMessage("Question 2")],
-            ])
+            batch_id = model.batch_api_submit(
+                [
+                    [HumanMessage("Question 1")],
+                    [HumanMessage("Question 2")],
+                ]
+            )
             # ... later ...
             status = model.batch_api_status(batch_id)
             if status.status == "completed":
@@ -2643,9 +2637,7 @@ class BaseChatOpenAI(BaseChatModel):
         payloads = self._build_batch_payloads(inputs, **kwargs)
         requests = build_batch_requests(payloads)
         jsonl = create_batch_jsonl(requests)
-        return upload_and_submit_batch(
-            self.root_client, jsonl, metadata=metadata
-        )
+        return upload_and_submit_batch(self.root_client, jsonl, metadata=metadata)
 
     async def abatch_api_submit(
         self,
@@ -2695,6 +2687,21 @@ class BaseChatOpenAI(BaseChatModel):
         batch = self.root_client.batches.retrieve(batch_id)
         return _parse_batch_to_result(batch)
 
+    async def abatch_api_status(self, batch_id: str) -> Any:
+        """Async check the status of a submitted batch.
+
+        Args:
+            batch_id: The batch ID returned by :meth:`abatch_api_submit`.
+
+        Returns:
+            A :class:`~langchain_openai.chat_models._batch_api.BatchResult`
+            with current status and progress counts.
+        """
+        from langchain_openai.chat_models._batch_api import _parse_batch_to_result
+
+        batch = await self.root_async_client.batches.retrieve(batch_id)
+        return _parse_batch_to_result(batch)
+
     def batch_api_retrieve(self, batch_id: str) -> list[Any]:
         """Retrieve results for a completed batch.
 
@@ -2715,8 +2722,12 @@ class BaseChatOpenAI(BaseChatModel):
         if not result.results:
             return []
 
+        def _sort_key(cid: str) -> int:
+            """Extract numeric index from custom_id for correct ordering."""
+            return int(cid.rsplit("-", 1)[-1])
+
         outputs = []
-        for cid in sorted(result.results.keys()):
+        for cid in sorted(result.results.keys(), key=_sort_key):
             response_body = result.results[cid]
             if isinstance(response_body, dict) and "choices" in response_body:
                 chat_result = self._create_chat_result(response_body)
@@ -2741,15 +2752,17 @@ class BaseChatOpenAI(BaseChatModel):
             async_retrieve_batch_results,
         )
 
-        result = await async_retrieve_batch_results(
-            self.root_async_client, batch_id
-        )
+        result = await async_retrieve_batch_results(self.root_async_client, batch_id)
 
         if not result.results:
             return []
 
+        def _sort_key(cid: str) -> int:
+            """Extract numeric index from custom_id for correct ordering."""
+            return int(cid.rsplit("-", 1)[-1])
+
         outputs = []
-        for cid in sorted(result.results.keys()):
+        for cid in sorted(result.results.keys(), key=_sort_key):
             response_body = result.results[cid]
             if isinstance(response_body, dict) and "choices" in response_body:
                 chat_result = self._create_chat_result(response_body)

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_batch_api.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_batch_api.py
@@ -77,9 +77,7 @@ class TestBatchApiLifecycle:
 
     def test_cancel(self, model_no_batch: ChatOpenAI) -> None:
         """Test batch cancellation."""
-        batch_id = model_no_batch.batch_api_submit(
-            [f"Question {i}" for i in range(10)]
-        )
+        batch_id = model_no_batch.batch_api_submit([f"Question {i}" for i in range(10)])
         # Cancel immediately
         model_no_batch.batch_api_cancel(batch_id)
 
@@ -100,9 +98,7 @@ class TestBatchApiAsync:
         assert hasattr(results[0], "content")
 
     @pytest.mark.asyncio
-    async def test_abatch_submit_and_retrieve(
-        self, model_no_batch: ChatOpenAI
-    ) -> None:
+    async def test_abatch_submit_and_retrieve(self, model_no_batch: ChatOpenAI) -> None:
         """Async fire-and-forget lifecycle."""
         batch_id = await model_no_batch.abatch_api_submit(
             ["Say 'async lifecycle' and nothing else."]

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_batch_api.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_batch_api.py
@@ -1,0 +1,110 @@
+"""Integration tests for OpenAI Batch API.
+
+These tests require an ``OPENAI_API_KEY`` environment variable and will
+make real API calls. The Batch API has a 24-hour completion window, so
+these tests may take a while to complete (typically minutes, not hours,
+for small batches).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from langchain_openai import ChatOpenAI
+from langchain_openai.chat_models._batch_api import BatchResult
+
+_SKIP_REASON = "Set OPENAI_API_KEY to run Batch API integration tests"
+
+
+@pytest.fixture
+def model() -> ChatOpenAI:
+    return ChatOpenAI(model="gpt-4o-mini", use_batch_api=True)
+
+
+@pytest.fixture
+def model_no_batch() -> ChatOpenAI:
+    return ChatOpenAI(model="gpt-4o-mini")
+
+
+@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason=_SKIP_REASON)
+class TestBatchApiEndToEnd:
+    def test_batch_simple(self, model: ChatOpenAI) -> None:
+        """Submit a small batch and verify results come back."""
+        results = model.batch(
+            [
+                "Say 'hello' and nothing else.",
+                "Say 'world' and nothing else.",
+            ],
+            config={"configurable": {"batch_poll_interval": 5}},
+        )
+        assert len(results) == 2
+        for r in results:
+            assert hasattr(r, "content")
+            assert len(r.content) > 0
+
+    def test_batch_with_return_exceptions(self, model: ChatOpenAI) -> None:
+        """Verify return_exceptions works with batch API."""
+        results = model.batch(
+            ["Say 'test' and nothing else."],
+            return_exceptions=True,
+        )
+        assert len(results) == 1
+        # Should be a successful message, not an exception
+        assert hasattr(results[0], "content")
+
+
+@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason=_SKIP_REASON)
+class TestBatchApiLifecycle:
+    def test_submit_status_retrieve(self, model_no_batch: ChatOpenAI) -> None:
+        """Test the fire-and-forget lifecycle."""
+        batch_id = model_no_batch.batch_api_submit(
+            ["Say 'lifecycle test' and nothing else."]
+        )
+        assert isinstance(batch_id, str)
+        assert len(batch_id) > 0
+
+        status = model_no_batch.batch_api_status(batch_id)
+        assert isinstance(status, BatchResult)
+        assert status.batch_id == batch_id
+        assert status.status in {
+            "validating",
+            "in_progress",
+            "finalizing",
+            "completed",
+        }
+
+    def test_cancel(self, model_no_batch: ChatOpenAI) -> None:
+        """Test batch cancellation."""
+        batch_id = model_no_batch.batch_api_submit(
+            [f"Question {i}" for i in range(10)]
+        )
+        # Cancel immediately
+        model_no_batch.batch_api_cancel(batch_id)
+
+        status = model_no_batch.batch_api_status(batch_id)
+        assert status.status in {"cancelling", "cancelled", "canceled"}
+
+
+@pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), reason=_SKIP_REASON)
+class TestBatchApiAsync:
+    @pytest.mark.asyncio
+    async def test_abatch_simple(self, model: ChatOpenAI) -> None:
+        """Async batch submission and retrieval."""
+        results = await model.abatch(
+            ["Say 'async hello' and nothing else."],
+            config={"configurable": {"batch_poll_interval": 5}},
+        )
+        assert len(results) == 1
+        assert hasattr(results[0], "content")
+
+    @pytest.mark.asyncio
+    async def test_abatch_submit_and_retrieve(
+        self, model_no_batch: ChatOpenAI
+    ) -> None:
+        """Async fire-and-forget lifecycle."""
+        batch_id = await model_no_batch.abatch_api_submit(
+            ["Say 'async lifecycle' and nothing else."]
+        )
+        assert isinstance(batch_id, str)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_batch_api.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_batch_api.py
@@ -1,0 +1,502 @@
+"""Unit tests for OpenAI Batch API integration."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from langchain_openai.chat_models._batch_api import (
+    BatchRequest,
+    BatchResult,
+    _parse_error_file,
+    _parse_output_file,
+    build_batch_requests,
+    cancel_batch,
+    create_batch_jsonl,
+    poll_batch_status,
+    retrieve_batch_results,
+    upload_and_submit_batch,
+)
+
+
+class TestBatchRequest:
+    def test_to_jsonl_line(self) -> None:
+        req = BatchRequest(
+            custom_id="req-0",
+            body={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        line = req.to_jsonl_line()
+        parsed = json.loads(line)
+        assert parsed["custom_id"] == "req-0"
+        assert parsed["method"] == "POST"
+        assert parsed["url"] == "/v1/chat/completions"
+        assert parsed["body"]["model"] == "gpt-4o-mini"
+        assert parsed["body"]["messages"][0]["content"] == "hi"
+
+    def test_to_jsonl_line_custom_endpoint(self) -> None:
+        req = BatchRequest(
+            custom_id="req-0",
+            body={"model": "gpt-4o-mini"},
+            endpoint="/v1/embeddings",
+        )
+        parsed = json.loads(req.to_jsonl_line())
+        assert parsed["url"] == "/v1/embeddings"
+
+
+class TestCreateBatchJsonl:
+    def test_single_request(self) -> None:
+        requests = [
+            BatchRequest(custom_id="r-0", body={"model": "gpt-4o-mini", "messages": []}),
+        ]
+        jsonl = create_batch_jsonl(requests)
+        lines = jsonl.strip().split("\n")
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["custom_id"] == "r-0"
+
+    def test_multiple_requests(self) -> None:
+        requests = [
+            BatchRequest(custom_id=f"r-{i}", body={"model": "gpt-4o-mini", "messages": []})
+            for i in range(5)
+        ]
+        jsonl = create_batch_jsonl(requests)
+        lines = jsonl.strip().split("\n")
+        assert len(lines) == 5
+        for i, line in enumerate(lines):
+            parsed = json.loads(line)
+            assert parsed["custom_id"] == f"r-{i}"
+
+
+class TestBuildBatchRequests:
+    def test_basic_payloads(self) -> None:
+        payloads = [
+            {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "q1"}], "stream": True},
+            {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "q2"}], "stream": True},
+        ]
+        requests = build_batch_requests(payloads, batch_prefix="test")
+        assert len(requests) == 2
+        assert requests[0].custom_id == "test-0"
+        assert requests[1].custom_id == "test-1"
+        # stream should be stripped
+        assert "stream" not in requests[0].body
+        assert "stream" not in requests[1].body
+        # messages preserved
+        assert requests[0].body["messages"][0]["content"] == "q1"
+
+    def test_auto_prefix(self) -> None:
+        payloads = [{"model": "gpt-4o-mini", "messages": []}]
+        requests = build_batch_requests(payloads)
+        assert requests[0].custom_id.startswith("lc-")
+        # format: lc-<8hex>-0
+        parts = requests[0].custom_id.split("-")
+        assert len(parts) == 3
+        assert parts[2] == "0"
+
+    def test_with_tools_in_payload(self) -> None:
+        payloads = [
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "use tool"}],
+                "tools": [{"type": "function", "function": {"name": "get_weather"}}],
+                "stream": False,
+            },
+        ]
+        requests = build_batch_requests(payloads, batch_prefix="t")
+        assert "tools" in requests[0].body
+        assert requests[0].body["tools"][0]["function"]["name"] == "get_weather"
+
+    def test_with_response_format(self) -> None:
+        payloads = [
+            {
+                "model": "gpt-4o-mini",
+                "messages": [],
+                "response_format": {"type": "json_object"},
+            },
+        ]
+        requests = build_batch_requests(payloads, batch_prefix="t")
+        assert "response_format" in requests[0].body
+
+
+class TestParseOutputFile:
+    def test_successful_responses(self) -> None:
+        lines = [
+            json.dumps({
+                "custom_id": "r-0",
+                "result": {
+                    "status_code": 200,
+                    "body": {
+                        "id": "chatcmpl-1",
+                        "choices": [{"message": {"role": "assistant", "content": "hello"}}],
+                        "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+                    },
+                },
+            }),
+            json.dumps({
+                "custom_id": "r-1",
+                "result": {
+                    "status_code": 200,
+                    "body": {
+                        "id": "chatcmpl-2",
+                        "choices": [{"message": {"role": "assistant", "content": "world"}}],
+                        "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+                    },
+                },
+            }),
+        ]
+        content = "\n".join(lines)
+        results = _parse_output_file(content)
+        assert len(results) == 2
+        assert results["r-0"]["choices"][0]["message"]["content"] == "hello"
+        assert results["r-1"]["choices"][0]["message"]["content"] == "world"
+
+    def test_failed_response(self) -> None:
+        lines = [
+            json.dumps({
+                "custom_id": "r-0",
+                "result": {
+                    "status_code": 400,
+                    "body": {"error": {"message": "bad request", "type": "invalid_request_error"}},
+                },
+            }),
+        ]
+        content = "\n".join(lines)
+        results = _parse_output_file(content)
+        # Non-200 status codes are still returned (not as body)
+        assert "r-0" in results
+        assert results["r-0"]["status_code"] == 400
+
+    def test_empty_content(self) -> None:
+        results = _parse_output_file("")
+        assert results == {}
+
+    def test_out_of_order_results(self) -> None:
+        """Results are NOT guaranteed to be in input order."""
+        lines = [
+            json.dumps({
+                "custom_id": "r-2",
+                "result": {"status_code": 200, "body": {"id": "c2", "choices": []}},
+            }),
+            json.dumps({
+                "custom_id": "r-0",
+                "result": {"status_code": 200, "body": {"id": "c0", "choices": []}},
+            }),
+            json.dumps({
+                "custom_id": "r-1",
+                "result": {"status_code": 200, "body": {"id": "c1", "choices": []}},
+            }),
+        ]
+        results = _parse_output_file("\n".join(lines))
+        assert results["r-0"]["id"] == "c0"
+        assert results["r-1"]["id"] == "c1"
+        assert results["r-2"]["id"] == "c2"
+
+
+class TestParseErrorFile:
+    def test_parse_errors(self) -> None:
+        lines = [
+            json.dumps({
+                "custom_id": "r-0",
+                "result": {
+                    "body": {
+                        "error": {"message": "rate limit", "type": "rate_limit_error"},
+                    },
+                },
+            }),
+        ]
+        errors = _parse_error_file("\n".join(lines))
+        assert "r-0" in errors
+        assert errors["r-0"]["message"] == "rate limit"
+
+
+class TestUploadAndSubmitBatch:
+    def test_upload_and_submit(self) -> None:
+        mock_client = MagicMock()
+        mock_client.files.create.return_value = MagicMock(id="file-abc123")
+        mock_client.batches.create.return_value = MagicMock(id="batch-xyz789")
+
+        batch_id = upload_and_submit_batch(
+            mock_client,
+            '{"custom_id":"r-0","method":"POST","url":"/v1/chat/completions","body":{}}',
+        )
+
+        assert batch_id == "batch-xyz789"
+        mock_client.files.create.assert_called_once()
+        call_kwargs = mock_client.files.create.call_args
+        assert call_kwargs.kwargs["purpose"] == "batch"
+
+        mock_client.batches.create.assert_called_once()
+        create_kwargs = mock_client.batches.create.call_args.kwargs
+        assert create_kwargs["input_file_id"] == "file-abc123"
+        assert create_kwargs["endpoint"] == "/v1/chat/completions"
+        assert create_kwargs["completion_window"] == "24h"
+
+    def test_upload_with_metadata(self) -> None:
+        mock_client = MagicMock()
+        mock_client.files.create.return_value = MagicMock(id="file-abc")
+        mock_client.batches.create.return_value = MagicMock(id="batch-xyz")
+
+        upload_and_submit_batch(
+            mock_client,
+            "{}",
+            metadata={"project": "test"},
+        )
+
+        create_kwargs = mock_client.batches.create.call_args.kwargs
+        assert create_kwargs["metadata"] == {"project": "test"}
+
+
+class TestPollBatchStatus:
+    def test_immediate_completion(self) -> None:
+        mock_client = MagicMock()
+        mock_batch = MagicMock()
+        mock_batch.id = "batch-1"
+        mock_batch.status = "completed"
+        mock_batch.request_counts = MagicMock(total=5, completed=5, failed=0)
+        mock_client.batches.retrieve.return_value = mock_batch
+
+        result = poll_batch_status(mock_client, "batch-1")
+        assert result.status == "completed"
+        assert result.batch_id == "batch-1"
+        assert result.request_counts["completed"] == 5
+        mock_client.batches.retrieve.assert_called_once_with("batch-1")
+
+    def test_polls_until_complete(self) -> None:
+        mock_client = MagicMock()
+
+        in_progress = MagicMock()
+        in_progress.id = "batch-1"
+        in_progress.status = "in_progress"
+        in_progress.request_counts = MagicMock(total=5, completed=2, failed=0)
+
+        completed = MagicMock()
+        completed.id = "batch-1"
+        completed.status = "completed"
+        completed.request_counts = MagicMock(total=5, completed=5, failed=0)
+
+        mock_client.batches.retrieve.side_effect = [in_progress, completed]
+
+        with patch("langchain_openai.chat_models._batch_api.time.sleep"):
+            result = poll_batch_status(mock_client, "batch-1", poll_interval=1.0)
+
+        assert result.status == "completed"
+        assert mock_client.batches.retrieve.call_count == 2
+
+    def test_timeout(self) -> None:
+        mock_client = MagicMock()
+        in_progress = MagicMock()
+        in_progress.id = "batch-1"
+        in_progress.status = "in_progress"
+        in_progress.request_counts = MagicMock(total=5, completed=0, failed=0)
+        mock_client.batches.retrieve.return_value = in_progress
+
+        with patch("langchain_openai.chat_models._batch_api.time.sleep"):
+            with pytest.raises(TimeoutError, match="did not complete"):
+                poll_batch_status(
+                    mock_client,
+                    "batch-1",
+                    poll_interval=1.0,
+                    max_wait=0.5,
+                )
+
+    def test_on_poll_callback(self) -> None:
+        mock_client = MagicMock()
+        completed = MagicMock()
+        completed.id = "batch-1"
+        completed.status = "completed"
+        completed.request_counts = MagicMock(total=1, completed=1, failed=0)
+        mock_client.batches.retrieve.return_value = completed
+
+        callback_results: list[BatchResult] = []
+        poll_batch_status(
+            mock_client,
+            "batch-1",
+            on_poll=lambda r: callback_results.append(r),
+        )
+        assert len(callback_results) == 1
+        assert callback_results[0].status == "completed"
+
+    def test_handles_failed_status(self) -> None:
+        mock_client = MagicMock()
+        failed = MagicMock()
+        failed.id = "batch-1"
+        failed.status = "failed"
+        failed.request_counts = MagicMock(total=5, completed=0, failed=5)
+        mock_client.batches.retrieve.return_value = failed
+
+        result = poll_batch_status(mock_client, "batch-1")
+        assert result.status == "failed"
+
+
+class TestRetrieveBatchResults:
+    def _make_output_content(self, results: list[dict]) -> MagicMock:
+        lines = []
+        for r in results:
+            lines.append(json.dumps(r))
+        mock = MagicMock()
+        mock.text = "\n".join(lines)
+        return mock
+
+    def test_retrieve_completed(self) -> None:
+        mock_client = MagicMock()
+        mock_batch = MagicMock()
+        mock_batch.id = "batch-1"
+        mock_batch.status = "completed"
+        mock_batch.output_file_id = "file-out"
+        mock_batch.error_file_id = None
+        mock_batch.request_counts = MagicMock(total=2, completed=2, failed=0)
+        mock_client.batches.retrieve.return_value = mock_batch
+
+        output_content = self._make_output_content([
+            {
+                "custom_id": "r-0",
+                "result": {
+                    "status_code": 200,
+                    "body": {
+                        "id": "chatcmpl-1",
+                        "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+                    },
+                },
+            },
+            {
+                "custom_id": "r-1",
+                "result": {
+                    "status_code": 200,
+                    "body": {
+                        "id": "chatcmpl-2",
+                        "choices": [{"message": {"role": "assistant", "content": "bye"}}],
+                    },
+                },
+            },
+        ])
+        mock_client.files.content.return_value = output_content
+
+        result = retrieve_batch_results(mock_client, "batch-1")
+        assert result.status == "completed"
+        assert result.results is not None
+        assert len(result.results) == 2
+        assert result.results["r-0"]["choices"][0]["message"]["content"] == "hi"
+
+    def test_retrieve_failed_raises(self) -> None:
+        mock_client = MagicMock()
+        mock_batch = MagicMock()
+        mock_batch.id = "batch-1"
+        mock_batch.status = "failed"
+        mock_batch.request_counts = MagicMock(total=1, completed=0, failed=1)
+        mock_client.batches.retrieve.return_value = mock_batch
+
+        with pytest.raises(ValueError, match="failed"):
+            retrieve_batch_results(mock_client, "batch-1")
+
+    def test_retrieve_in_progress_raises(self) -> None:
+        mock_client = MagicMock()
+        mock_batch = MagicMock()
+        mock_batch.id = "batch-1"
+        mock_batch.status = "in_progress"
+        mock_batch.request_counts = MagicMock(total=5, completed=2, failed=0)
+        mock_client.batches.retrieve.return_value = mock_batch
+
+        with pytest.raises(ValueError, match="not complete"):
+            retrieve_batch_results(mock_client, "batch-1")
+
+
+class TestCancelBatch:
+    def test_cancel(self) -> None:
+        mock_client = MagicMock()
+        cancel_batch(mock_client, "batch-1")
+        mock_client.batches.cancel.assert_called_once_with("batch-1")
+
+
+class TestAdaptiveBackoff:
+    """Verify polling interval doubles and caps at 120s."""
+
+    def test_backoff_behavior(self) -> None:
+        mock_client = MagicMock()
+        call_count = 0
+
+        def side_effect(batch_id: str) -> MagicMock:
+            nonlocal call_count
+            call_count += 1
+            mock = MagicMock()
+            mock.id = batch_id
+            mock.request_counts = MagicMock(total=1, completed=0, failed=0)
+            # Complete on 5th call
+            mock.status = "completed" if call_count >= 5 else "in_progress"
+            return mock
+
+        mock_client.batches.retrieve.side_effect = side_effect
+
+        sleep_durations: list[float] = []
+        original_sleep = __import__("time").sleep
+
+        with patch(
+            "langchain_openai.chat_models._batch_api.time.sleep",
+            side_effect=lambda d: sleep_durations.append(d),
+        ):
+            poll_batch_status(mock_client, "batch-1", poll_interval=5.0)
+
+        # 4 sleeps before completion on 5th poll
+        assert len(sleep_durations) == 4
+        assert sleep_durations[0] == 5.0
+        assert sleep_durations[1] == 10.0
+        assert sleep_durations[2] == 20.0
+        assert sleep_durations[3] == 40.0
+
+
+class TestChatOpenAIBatchIntegration:
+    """Test the batch methods on BaseChatOpenAI without hitting the network."""
+
+    def test_batch_api_disabled_by_default(self) -> None:
+        """batch() should use default behavior when use_batch_api=False."""
+        from langchain_openai import ChatOpenAI
+
+        model = ChatOpenAI(model="gpt-4o-mini", api_key="fake")
+        assert model.use_batch_api is False
+
+    def test_batch_api_responses_api_conflict(self) -> None:
+        """Should raise if both use_batch_api and use_responses_api are True."""
+        from langchain_openai import ChatOpenAI
+
+        model = ChatOpenAI(
+            model="gpt-4o-mini",
+            api_key="fake",
+            use_batch_api=True,
+            use_responses_api=True,
+        )
+        with pytest.raises(ValueError, match="Responses API"):
+            model.batch(["test"])
+
+    def test_batch_api_submit_builds_correct_jsonl(self) -> None:
+        """Verify that batch_api_submit constructs correct JSONL payloads."""
+        from langchain_openai import ChatOpenAI
+
+        model = ChatOpenAI(model="gpt-4o-mini", api_key="fake")
+
+        submitted_jsonl: list[str] = []
+
+        def mock_upload(client: Any, jsonl: str, **kwargs: Any) -> str:
+            submitted_jsonl.append(jsonl)
+            return "batch-test-123"
+
+        with patch(
+            "langchain_openai.chat_models._batch_api.upload_and_submit_batch",
+            side_effect=mock_upload,
+        ):
+            batch_id = model.batch_api_submit(["Hello", "World"])
+
+        assert batch_id == "batch-test-123"
+        assert len(submitted_jsonl) == 1
+
+        lines = submitted_jsonl[0].strip().split("\n")
+        assert len(lines) == 2
+
+        for line in lines:
+            parsed = json.loads(line)
+            assert parsed["method"] == "POST"
+            assert parsed["url"] == "/v1/chat/completions"
+            assert "model" in parsed["body"]
+            assert "messages" in parsed["body"]
+            assert "stream" not in parsed["body"]

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_batch_api.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_batch_api.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import SecretStr
 
 from langchain_openai.chat_models._batch_api import (
     BatchRequest,
@@ -27,7 +27,10 @@ class TestBatchRequest:
     def test_to_jsonl_line(self) -> None:
         req = BatchRequest(
             custom_id="req-0",
-            body={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+            body={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
         )
         line = req.to_jsonl_line()
         parsed = json.loads(line)
@@ -50,7 +53,10 @@ class TestBatchRequest:
 class TestCreateBatchJsonl:
     def test_single_request(self) -> None:
         requests = [
-            BatchRequest(custom_id="r-0", body={"model": "gpt-4o-mini", "messages": []}),
+            BatchRequest(
+                custom_id="r-0",
+                body={"model": "gpt-4o-mini", "messages": []},
+            ),
         ]
         jsonl = create_batch_jsonl(requests)
         lines = jsonl.strip().split("\n")
@@ -60,7 +66,10 @@ class TestCreateBatchJsonl:
 
     def test_multiple_requests(self) -> None:
         requests = [
-            BatchRequest(custom_id=f"r-{i}", body={"model": "gpt-4o-mini", "messages": []})
+            BatchRequest(
+                custom_id=f"r-{i}",
+                body={"model": "gpt-4o-mini", "messages": []},
+            )
             for i in range(5)
         ]
         jsonl = create_batch_jsonl(requests)
@@ -74,8 +83,16 @@ class TestCreateBatchJsonl:
 class TestBuildBatchRequests:
     def test_basic_payloads(self) -> None:
         payloads = [
-            {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "q1"}], "stream": True},
-            {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "q2"}], "stream": True},
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "q1"}],
+                "stream": True,
+            },
+            {
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "q2"}],
+                "stream": True,
+            },
         ]
         requests = build_batch_requests(payloads, batch_prefix="test")
         assert len(requests) == 2
@@ -124,28 +141,36 @@ class TestBuildBatchRequests:
 class TestParseOutputFile:
     def test_successful_responses(self) -> None:
         lines = [
-            json.dumps({
-                "custom_id": "r-0",
-                "result": {
-                    "status_code": 200,
-                    "body": {
-                        "id": "chatcmpl-1",
-                        "choices": [{"message": {"role": "assistant", "content": "hello"}}],
-                        "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+            json.dumps(
+                {
+                    "custom_id": "r-0",
+                    "result": {
+                        "status_code": 200,
+                        "body": {
+                            "id": "chatcmpl-1",
+                            "choices": [
+                                {"message": {"role": "assistant", "content": "hello"}}
+                            ],
+                            "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+                        },
                     },
-                },
-            }),
-            json.dumps({
-                "custom_id": "r-1",
-                "result": {
-                    "status_code": 200,
-                    "body": {
-                        "id": "chatcmpl-2",
-                        "choices": [{"message": {"role": "assistant", "content": "world"}}],
-                        "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+                }
+            ),
+            json.dumps(
+                {
+                    "custom_id": "r-1",
+                    "result": {
+                        "status_code": 200,
+                        "body": {
+                            "id": "chatcmpl-2",
+                            "choices": [
+                                {"message": {"role": "assistant", "content": "world"}}
+                            ],
+                            "usage": {"prompt_tokens": 5, "completion_tokens": 3},
+                        },
                     },
-                },
-            }),
+                }
+            ),
         ]
         content = "\n".join(lines)
         results = _parse_output_file(content)
@@ -155,13 +180,20 @@ class TestParseOutputFile:
 
     def test_failed_response(self) -> None:
         lines = [
-            json.dumps({
-                "custom_id": "r-0",
-                "result": {
-                    "status_code": 400,
-                    "body": {"error": {"message": "bad request", "type": "invalid_request_error"}},
-                },
-            }),
+            json.dumps(
+                {
+                    "custom_id": "r-0",
+                    "result": {
+                        "status_code": 400,
+                        "body": {
+                            "error": {
+                                "message": "bad request",
+                                "type": "invalid_request_error",
+                            }
+                        },
+                    },
+                }
+            ),
         ]
         content = "\n".join(lines)
         results = _parse_output_file(content)
@@ -176,18 +208,24 @@ class TestParseOutputFile:
     def test_out_of_order_results(self) -> None:
         """Results are NOT guaranteed to be in input order."""
         lines = [
-            json.dumps({
-                "custom_id": "r-2",
-                "result": {"status_code": 200, "body": {"id": "c2", "choices": []}},
-            }),
-            json.dumps({
-                "custom_id": "r-0",
-                "result": {"status_code": 200, "body": {"id": "c0", "choices": []}},
-            }),
-            json.dumps({
-                "custom_id": "r-1",
-                "result": {"status_code": 200, "body": {"id": "c1", "choices": []}},
-            }),
+            json.dumps(
+                {
+                    "custom_id": "r-2",
+                    "result": {"status_code": 200, "body": {"id": "c2", "choices": []}},
+                }
+            ),
+            json.dumps(
+                {
+                    "custom_id": "r-0",
+                    "result": {"status_code": 200, "body": {"id": "c0", "choices": []}},
+                }
+            ),
+            json.dumps(
+                {
+                    "custom_id": "r-1",
+                    "result": {"status_code": 200, "body": {"id": "c1", "choices": []}},
+                }
+            ),
         ]
         results = _parse_output_file("\n".join(lines))
         assert results["r-0"]["id"] == "c0"
@@ -198,14 +236,19 @@ class TestParseOutputFile:
 class TestParseErrorFile:
     def test_parse_errors(self) -> None:
         lines = [
-            json.dumps({
-                "custom_id": "r-0",
-                "result": {
-                    "body": {
-                        "error": {"message": "rate limit", "type": "rate_limit_error"},
+            json.dumps(
+                {
+                    "custom_id": "r-0",
+                    "result": {
+                        "body": {
+                            "error": {
+                                "message": "rate limit",
+                                "type": "rate_limit_error",
+                            },
+                        },
                     },
-                },
-            }),
+                }
+            ),
         ]
         errors = _parse_error_file("\n".join(lines))
         assert "r-0" in errors
@@ -293,14 +336,16 @@ class TestPollBatchStatus:
         in_progress.request_counts = MagicMock(total=5, completed=0, failed=0)
         mock_client.batches.retrieve.return_value = in_progress
 
-        with patch("langchain_openai.chat_models._batch_api.time.sleep"):
-            with pytest.raises(TimeoutError, match="did not complete"):
-                poll_batch_status(
-                    mock_client,
-                    "batch-1",
-                    poll_interval=1.0,
-                    max_wait=0.5,
-                )
+        with (
+            patch("langchain_openai.chat_models._batch_api.time.sleep"),
+            pytest.raises(TimeoutError, match="did not complete"),
+        ):
+            poll_batch_status(
+                mock_client,
+                "batch-1",
+                poll_interval=1.0,
+                max_wait=0.5,
+            )
 
     def test_on_poll_callback(self) -> None:
         mock_client = MagicMock()
@@ -350,28 +395,34 @@ class TestRetrieveBatchResults:
         mock_batch.request_counts = MagicMock(total=2, completed=2, failed=0)
         mock_client.batches.retrieve.return_value = mock_batch
 
-        output_content = self._make_output_content([
-            {
-                "custom_id": "r-0",
-                "result": {
-                    "status_code": 200,
-                    "body": {
-                        "id": "chatcmpl-1",
-                        "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+        output_content = self._make_output_content(
+            [
+                {
+                    "custom_id": "r-0",
+                    "result": {
+                        "status_code": 200,
+                        "body": {
+                            "id": "chatcmpl-1",
+                            "choices": [
+                                {"message": {"role": "assistant", "content": "hi"}}
+                            ],
+                        },
                     },
                 },
-            },
-            {
-                "custom_id": "r-1",
-                "result": {
-                    "status_code": 200,
-                    "body": {
-                        "id": "chatcmpl-2",
-                        "choices": [{"message": {"role": "assistant", "content": "bye"}}],
+                {
+                    "custom_id": "r-1",
+                    "result": {
+                        "status_code": 200,
+                        "body": {
+                            "id": "chatcmpl-2",
+                            "choices": [
+                                {"message": {"role": "assistant", "content": "bye"}}
+                            ],
+                        },
                     },
                 },
-            },
-        ])
+            ]
+        )
         mock_client.files.content.return_value = output_content
 
         result = retrieve_batch_results(mock_client, "batch-1")
@@ -430,7 +481,6 @@ class TestAdaptiveBackoff:
         mock_client.batches.retrieve.side_effect = side_effect
 
         sleep_durations: list[float] = []
-        original_sleep = __import__("time").sleep
 
         with patch(
             "langchain_openai.chat_models._batch_api.time.sleep",
@@ -453,7 +503,7 @@ class TestChatOpenAIBatchIntegration:
         """batch() should use default behavior when use_batch_api=False."""
         from langchain_openai import ChatOpenAI
 
-        model = ChatOpenAI(model="gpt-4o-mini", api_key="fake")
+        model = ChatOpenAI(model="gpt-4o-mini", api_key=SecretStr("fake"))
         assert model.use_batch_api is False
 
     def test_batch_api_responses_api_conflict(self) -> None:
@@ -462,7 +512,7 @@ class TestChatOpenAIBatchIntegration:
 
         model = ChatOpenAI(
             model="gpt-4o-mini",
-            api_key="fake",
+            api_key=SecretStr("fake"),
             use_batch_api=True,
             use_responses_api=True,
         )
@@ -473,7 +523,7 @@ class TestChatOpenAIBatchIntegration:
         """Verify that batch_api_submit constructs correct JSONL payloads."""
         from langchain_openai import ChatOpenAI
 
-        model = ChatOpenAI(model="gpt-4o-mini", api_key="fake")
+        model = ChatOpenAI(model="gpt-4o-mini", api_key=SecretStr("fake"))
 
         submitted_jsonl: list[str] = []
 


### PR DESCRIPTION
## Summary

  Adds native [OpenAI Batch API](https://platform.openai.com/docs/guides/batch) support to `ChatOpenAI`, giving users **50% cost savings** on batch workloads. Resolves #28508 (most-upvoted open issue).

  Two usage modes:

  - **Drop-in**: `ChatOpenAI(use_batch_api=True).batch(inputs)` — transparently routes through the Batch API with adaptive-backoff polling
  - **Fire-and-forget**: `batch_api_submit()` / `batch_api_retrieve()` — for async workflows that don't want to block

  ### What's included

  - New `_batch_api.py` utility module handling the full lifecycle: JSONL creation, file upload via `io.BytesIO`, batch submission, adaptive polling (interval doubles, capped at 120s), and result parsing
  - `batch()` / `abatch()` overrides on `BaseChatOpenAI` — opt-in via `use_batch_api=True`, fully backwards-compatible (default behavior unchanged)
  - Explicit lifecycle methods: `batch_api_submit`, `batch_api_status`, `batch_api_retrieve`, `batch_api_cancel` (sync + async variants)
  - Reuses existing `_get_request_payload()` and `_create_chat_result()` internals — no duplication
  - Validates incompatibility with Responses API (`use_responses_api=True` + `use_batch_api=True` raises clear error)
  - Exports `BatchResult` and `BatchRequest` from `langchain_openai`
  - 28 unit tests + integration test suite

  ### Design decisions worth reviewing

  - **`use_batch_api` as a class field** rather than a `batch()` kwarg — makes it easy to toggle for an entire model instance, and plays well with `bind_tools()` / `with_structured_output()` chains
  - **`batch_api_retrieve()` sorts results by numeric index** extracted from `custom_id` (`lc-<uuid>-N`) to guarantee input-order output, even though OpenAI returns results unordered
  - **No new dependencies** — uses the existing `openai` SDK's batch support
  - **No temp files** — all JSONL handled via `io.BytesIO` in-memory

  ## Example usage

  ```python
  from langchain_openai import ChatOpenAI

  # Drop-in: 50% cheaper, blocks until batch completes
  llm = ChatOpenAI(model="gpt-4o-mini", use_batch_api=True)
  results = llm.batch(["Summarize: ...", "Translate: ...", "Extract: ..."])

  # Fire-and-forget: submit now, retrieve later
  llm = ChatOpenAI(model="gpt-4o-mini")
  batch_id = llm.batch_api_submit(["Question 1", "Question 2"])
  # ... hours later ...
  status = llm.batch_api_status(batch_id)
  if status.status == "completed":
      results = llm.batch_api_retrieve(batch_id)
  ```

  ## Test plan

  - [x] 28 unit tests covering JSONL creation, payload construction, polling backoff, result ordering, error handling, and ChatOpenAI integration (all mocked, no network)
  - [ ] Integration tests (require `OPENAI_API_KEY`) for end-to-end batch lifecycle
  - [x] `make lint` passes (ruff + mypy clean)
  - [x] Backwards compatibility: `batch()` unchanged when `use_batch_api=False` (default)

  ---

  > [!NOTE]
  > This PR was developed with AI assistance (Claude Code)