### PR TITLE
feat(langchain): add ToolArgValidationMiddleware for model-side validation

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -21,6 +21,7 @@ from langchain.agents.middleware.shell_tool import (
 )
 from langchain.agents.middleware.summarization import SummarizationMiddleware
 from langchain.agents.middleware.todo import TodoListMiddleware
+from langchain.agents.middleware.tool_arg_validation import ToolArgValidationMiddleware
 from langchain.agents.middleware.tool_call_limit import ToolCallLimitMiddleware
 from langchain.agents.middleware.tool_emulator import LLMToolEmulator
 from langchain.agents.middleware.tool_retry import ToolRetryMiddleware
@@ -70,6 +71,7 @@ __all__ = [
     "ShellToolMiddleware",
     "SummarizationMiddleware",
     "TodoListMiddleware",
+    "ToolArgValidationMiddleware",
     "ToolCallLimitMiddleware",
     "ToolCallRequest",
     "ToolRetryMiddleware",

--- a/libs/langchain_v1/langchain/agents/middleware/tool_arg_validation.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_arg_validation.py
@@ -1,0 +1,417 @@
+"""Tool argument validation middleware for agents."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+from langchain_core.messages import AIMessage, ToolMessage
+from pydantic import BaseModel, ValidationError
+from pydantic.v1 import BaseModel as BaseModelV1
+from pydantic.v1 import ValidationError as ValidationErrorV1
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    ModelRequest,
+    ModelResponse,
+    ResponseT,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Sequence
+
+    from langchain_core.tools import BaseTool
+
+_MIXED_BATCH_ERROR = (
+    "Tool call batch rejected because another tool call in the same assistant message "
+    "had invalid arguments. Regenerate the full set of tool calls from your previous "
+    "response."
+)
+
+ValidatorKind = Literal["json_schema", "pydantic_v1", "pydantic_v2"]
+
+
+@dataclass
+class _ToolValidatorSpec:
+    """Cached validation metadata for a tool."""
+
+    tool: BaseTool
+    kind: ValidatorKind
+    schema: type[BaseModel | BaseModelV1] | dict[str, Any]
+    field_names: frozenset[str] | None = None
+    json_schema_validator: Any | None = None
+
+
+@dataclass
+class _ValidatedToolCall:
+    """Validation result for a single tool call."""
+
+    tool_call: dict[str, Any]
+    error_message: str | None = None
+
+
+class ToolArgValidationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
+    """Validate LLM-generated tool arguments before tool execution."""
+
+    def __init__(
+        self,
+        *,
+        max_retries: int = 2,
+        strip_empty_values: bool = True,
+        json_schema_validator_class: type[Any] | None = None,
+    ) -> None:
+        """Initialize the tool argument validation middleware.
+
+        Args:
+            max_retries: Maximum number of validation retries after the initial model
+                response.
+            strip_empty_values: Whether to recursively remove empty dict keys with
+                `None`, `{}`, or `[]` values before validation.
+            json_schema_validator_class: Optional JSON Schema validator class for dict
+                schemas. Defaults to `jsonschema.Draft7Validator` when needed.
+
+        Raises:
+            TypeError: If `json_schema_validator_class` is not a class.
+            ValueError: If `max_retries` is negative.
+        """
+        super().__init__()
+        if max_retries < 0:
+            msg = "max_retries must be >= 0"
+            raise ValueError(msg)
+        if json_schema_validator_class is not None and not isinstance(
+            json_schema_validator_class, type
+        ):
+            msg = "json_schema_validator_class must be a class or None"
+            raise TypeError(msg)
+
+        self.max_retries = max_retries
+        self.strip_empty_values = strip_empty_values
+        self.json_schema_validator_class = json_schema_validator_class
+        self.tools = []
+        self._validator_cache: dict[str, _ToolValidatorSpec] = {}
+
+    def _get_json_schema_validator_class(self) -> type[Any]:
+        """Resolve the JSON Schema validator class lazily."""
+        if self.json_schema_validator_class is not None:
+            return self.json_schema_validator_class
+
+        try:
+            jsonschema = importlib.import_module("jsonschema")
+        except ImportError as exc:
+            msg = (
+                "ToolArgValidationMiddleware requires the jsonschema package to "
+                "validate tools with dict args_schema. Please install it with "
+                "`pip install jsonschema` or pass json_schema_validator_class."
+            )
+            raise ImportError(msg) from exc
+
+        return cast("type[Any]", jsonschema.Draft7Validator)
+
+    def _build_validator_spec(self, tool: BaseTool) -> _ToolValidatorSpec:
+        """Build a validator spec for a tool."""
+        schema = tool.tool_call_schema
+
+        if isinstance(schema, dict):
+            properties = schema.get("properties", {})
+            validator_class = self._get_json_schema_validator_class()
+            return _ToolValidatorSpec(
+                tool=tool,
+                kind="json_schema",
+                schema=schema,
+                field_names=(
+                    frozenset(properties.keys()) if isinstance(properties, dict) else None
+                ),
+                json_schema_validator=validator_class(schema),
+            )
+
+        if issubclass(schema, BaseModelV1):
+            return _ToolValidatorSpec(
+                tool=tool,
+                kind="pydantic_v1",
+                schema=schema,
+                field_names=frozenset(schema.__fields__),
+            )
+
+        if issubclass(schema, BaseModel):
+            return _ToolValidatorSpec(
+                tool=tool,
+                kind="pydantic_v2",
+                schema=schema,
+                field_names=frozenset(schema.model_fields),
+            )
+
+        msg = f"Unsupported tool_call_schema for tool '{tool.name}': {schema!r}"
+        raise TypeError(msg)
+
+    def _resolve_request_validators(
+        self, tools: Sequence[BaseTool | dict[str, Any]]
+    ) -> dict[str, _ToolValidatorSpec]:
+        """Resolve validators for the current request tools."""
+        resolved: dict[str, _ToolValidatorSpec] = {}
+
+        for tool in tools:
+            if isinstance(tool, dict):
+                continue
+
+            cached_spec = self._validator_cache.get(tool.name)
+            if cached_spec is None or cached_spec.tool is not tool:
+                cached_spec = self._build_validator_spec(tool)
+                self._validator_cache[tool.name] = cached_spec
+
+            resolved[tool.name] = cached_spec
+
+        return resolved
+
+    @staticmethod
+    def _format_path(path: Sequence[Any]) -> str:
+        """Format a nested error path."""
+        if not path:
+            return "<root>"
+        return ".".join(str(part) for part in path)
+
+    @staticmethod
+    def _build_error_message(
+        tool_name: str,
+        args: dict[str, Any] | Any,
+        details: list[str],
+    ) -> str:
+        """Build a validation error message for a tool call."""
+        rendered_args = repr(args)
+        joined_details = "\n".join(f"- {detail}" for detail in details) or "- Invalid input"
+        return (
+            f"Invalid arguments for tool '{tool_name}'. Regenerate the full set of tool "
+            f"calls from your previous response.\n"
+            f"Received args: {rendered_args}\n"
+            f"Validation errors:\n{joined_details}"
+        )
+
+    @staticmethod
+    def _filter_args_for_message(
+        args: dict[str, Any], field_names: frozenset[str] | None
+    ) -> dict[str, Any]:
+        """Filter rendered args to fields declared in the tool schema."""
+        if field_names is None:
+            return args
+        return {key: value for key, value in args.items() if key in field_names}
+
+    def _strip_empty_value(self, value: Any) -> Any:
+        """Recursively remove empty dict values while preserving list shape."""
+        if isinstance(value, dict):
+            cleaned: dict[str, Any] = {}
+            for key, child in value.items():
+                cleaned_child = self._strip_empty_value(child)
+                if cleaned_child is None:
+                    continue
+                if isinstance(cleaned_child, dict) and not cleaned_child:
+                    continue
+                if isinstance(cleaned_child, list) and not cleaned_child:
+                    continue
+                cleaned[key] = cleaned_child
+            return cleaned
+
+        if isinstance(value, list):
+            return [self._strip_empty_value(item) for item in value]
+
+        return value
+
+    def _sanitize_args(self, tool_args: dict[str, Any]) -> dict[str, Any]:
+        """Return sanitized tool arguments for validation."""
+        cleaned_args = cast("dict[str, Any]", self._strip_empty_value(tool_args))
+        return cleaned_args if self.strip_empty_values else tool_args.copy()
+
+    def _format_pydantic_error(
+        self,
+        validator_spec: _ToolValidatorSpec,
+        args: dict[str, Any],
+        exc: ValidationError | ValidationErrorV1,
+    ) -> str:
+        """Format a Pydantic validation error."""
+        details = [
+            f"{self._format_path(cast('Sequence[Any]', err.get('loc', ())))}: "
+            f"{err.get('msg', 'Invalid value')}"
+            for err in exc.errors()
+        ]
+        display_args = self._filter_args_for_message(args, validator_spec.field_names)
+        return self._build_error_message(validator_spec.tool.name, display_args, details)
+
+    def _format_json_schema_error(
+        self,
+        validator_spec: _ToolValidatorSpec,
+        args: dict[str, Any],
+        errors: list[Any],
+    ) -> str:
+        """Format JSON Schema validation errors."""
+        details = [f"{self._format_path(error.path)}: {error.message}" for error in errors]
+        display_args = self._filter_args_for_message(args, validator_spec.field_names)
+        return self._build_error_message(validator_spec.tool.name, display_args, details)
+
+    def _validate_known_tool_call(
+        self,
+        tool_call: dict[str, Any],
+        validator_spec: _ToolValidatorSpec,
+    ) -> _ValidatedToolCall:
+        """Validate a tool call against a resolved tool schema."""
+        raw_args = tool_call.get("args")
+        if not isinstance(raw_args, dict):
+            error_message = self._build_error_message(
+                validator_spec.tool.name,
+                raw_args,
+                [f"<root>: expected an object but received {type(raw_args).__name__}"],
+            )
+            return _ValidatedToolCall(tool_call=tool_call, error_message=error_message)
+
+        sanitized_args = self._sanitize_args(raw_args)
+        tool_call["args"] = sanitized_args
+
+        try:
+            if validator_spec.kind == "pydantic_v2":
+                cast("type[BaseModel]", validator_spec.schema).model_validate(sanitized_args)
+            elif validator_spec.kind == "pydantic_v1":
+                cast("type[BaseModelV1]", validator_spec.schema).parse_obj(sanitized_args)
+            else:
+                json_schema_validator = validator_spec.json_schema_validator
+                errors = sorted(
+                    json_schema_validator.iter_errors(sanitized_args),
+                    key=lambda error: list(error.path),
+                )
+                if errors:
+                    error_message = self._format_json_schema_error(
+                        validator_spec,
+                        sanitized_args,
+                        errors,
+                    )
+                    return _ValidatedToolCall(tool_call=tool_call, error_message=error_message)
+        except (ValidationError, ValidationErrorV1) as exc:
+            error_message = self._format_pydantic_error(validator_spec, sanitized_args, exc)
+            return _ValidatedToolCall(tool_call=tool_call, error_message=error_message)
+
+        return _ValidatedToolCall(tool_call=tool_call)
+
+    def _build_retry_messages(
+        self,
+        validated_tool_calls: list[_ValidatedToolCall],
+    ) -> list[ToolMessage]:
+        """Build synthetic tool messages for a rejected tool-call batch."""
+        has_invalid_tool_call = any(
+            result.error_message is not None for result in validated_tool_calls
+        )
+        if not has_invalid_tool_call:
+            return []
+
+        tool_messages: list[ToolMessage] = []
+        for result in validated_tool_calls:
+            tool_call = result.tool_call
+            content = result.error_message or _MIXED_BATCH_ERROR
+            tool_messages.append(
+                ToolMessage(
+                    content=content,
+                    name=tool_call["name"],
+                    tool_call_id=tool_call["id"] or "",
+                    status="error",
+                )
+            )
+
+        return tool_messages
+
+    def _validate_model_response(
+        self,
+        model_response: ModelResponse[ResponseT],
+        request: ModelRequest[ContextT],
+    ) -> tuple[ModelResponse[ResponseT], list[ToolMessage], bool]:
+        """Validate a model response and decide whether to retry."""
+        if len(model_response.result) != 1:
+            return model_response, [], True
+
+        message = model_response.result[0]
+        if not isinstance(message, AIMessage) or not message.tool_calls:
+            return model_response, [], True
+
+        validators_by_name = self._resolve_request_validators(request.tools)
+        if not validators_by_name:
+            return model_response, [], True
+
+        ai_message = message.model_copy(deep=True)
+        validated_tool_calls: list[_ValidatedToolCall] = []
+
+        for tool_call in ai_message.tool_calls:
+            validator_spec = validators_by_name.get(tool_call["name"])
+            if validator_spec is None:
+                validated_tool_calls.append(_ValidatedToolCall(tool_call=tool_call))
+                continue
+
+            validated_tool_calls.append(self._validate_known_tool_call(tool_call, validator_spec))
+
+        tool_messages = self._build_retry_messages(validated_tool_calls)
+        if tool_messages:
+            return (
+                ModelResponse(
+                    result=[ai_message],
+                    structured_response=model_response.structured_response,
+                ),
+                tool_messages,
+                False,
+            )
+
+        return (
+            ModelResponse(
+                result=[ai_message],
+                structured_response=model_response.structured_response,
+            ),
+            [],
+            True,
+        )
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
+    ) -> ModelResponse[ResponseT]:
+        """Validate tool arguments around synchronous model execution."""
+        current_request = request
+
+        for attempt in range(self.max_retries + 1):
+            model_response = handler(current_request)
+            validated_response, tool_messages, is_valid = self._validate_model_response(
+                model_response, current_request
+            )
+            if is_valid:
+                return validated_response
+            if attempt == self.max_retries:
+                return model_response
+
+            ai_message = cast("AIMessage", validated_response.result[0].model_copy(deep=True))
+            current_request = current_request.override(
+                messages=[*current_request.messages, ai_message, *tool_messages]
+            )
+
+        msg = "Unexpected: validation retry loop completed without returning"
+        raise RuntimeError(msg)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        """Validate tool arguments around asynchronous model execution."""
+        current_request = request
+
+        for attempt in range(self.max_retries + 1):
+            model_response = await handler(current_request)
+            validated_response, tool_messages, is_valid = self._validate_model_response(
+                model_response, current_request
+            )
+            if is_valid:
+                return validated_response
+            if attempt == self.max_retries:
+                return model_response
+
+            ai_message = cast("AIMessage", validated_response.result[0].model_copy(deep=True))
+            current_request = current_request.override(
+                messages=[*current_request.messages, ai_message, *tool_messages]
+            )
+
+        msg = "Unexpected: validation retry loop completed without returning"
+        raise RuntimeError(msg)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_arg_validation.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_arg_validation.py
@@ -1,0 +1,665 @@
+"""Tests for ToolArgValidationMiddleware."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import BaseTool, tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.runtime import Runtime
+from pydantic import BaseModel
+from pydantic.v1 import BaseModel as BaseModelV1
+
+from langchain.agents import create_agent
+from langchain.agents.middleware import ToolArgValidationMiddleware
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain.agents.structured_output import ToolStrategy
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+def _build_request(
+    *,
+    tools: list[BaseTool | dict[str, Any]] | None = None,
+    messages: list[Any] | None = None,
+) -> ModelRequest[None]:
+    """Create a model request for middleware unit tests."""
+    return ModelRequest(
+        model=FakeToolCallingModel(),
+        tools=tools or [],
+        messages=messages or [HumanMessage("Hello")],
+        runtime=Runtime(),
+    )
+
+
+def _build_response(
+    tool_calls: list[dict[str, Any]] | None = None,
+    *,
+    content: str = "assistant",
+    extra_messages: list[Any] | None = None,
+) -> ModelResponse[Any]:
+    """Create a model response with a single AI message by default."""
+    result: list[Any] = [AIMessage(content=content, tool_calls=tool_calls or [])]
+    if extra_messages:
+        result.extend(extra_messages)
+    return ModelResponse(result=result)
+
+
+def _build_sync_handler(
+    responses: list[ModelResponse[Any]],
+    captured_requests: list[ModelRequest[Any]],
+) -> Callable[[ModelRequest[Any]], ModelResponse[Any]]:
+    """Build a sequential synchronous handler."""
+
+    def handler(request: ModelRequest[Any]) -> ModelResponse[Any]:
+        captured_requests.append(request)
+        return responses[len(captured_requests) - 1]
+
+    return handler
+
+
+def _build_async_handler(
+    responses: list[ModelResponse[Any]],
+    captured_requests: list[ModelRequest[Any]],
+) -> Callable[[ModelRequest[Any]], Awaitable[ModelResponse[Any]]]:
+    """Build a sequential asynchronous handler."""
+
+    async def handler(request: ModelRequest[Any]) -> ModelResponse[Any]:
+        captured_requests.append(request)
+        return responses[len(captured_requests) - 1]
+
+    return handler
+
+
+class SearchArgs(BaseModel):
+    """Schema for search tool tests."""
+
+    query: str
+    limit: int
+    metadata: dict[str, Any] | None = None
+    items: list[Any] | None = None
+
+
+@tool(args_schema=SearchArgs)
+def search_tool(
+    query: str,
+    limit: int,
+    metadata: dict[str, Any] | None = None,
+    items: list[Any] | None = None,
+) -> str:
+    """Search for content."""
+    return f"{query}:{limit}:{metadata}:{items}"
+
+
+class LegacySearchArgs(BaseModelV1):
+    """Legacy schema for async validation tests."""
+
+    city: str
+    count: int
+
+
+@tool(args_schema=LegacySearchArgs)
+async def legacy_search_tool(city: str, count: int) -> str:
+    """Search using a legacy pydantic v1 schema."""
+    return f"{city}:{count}"
+
+
+JSON_SCHEMA_TOOL_ARGS = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string"},
+        "limit": {"type": "integer"},
+    },
+    "required": ["query", "limit"],
+    "additionalProperties": False,
+}
+
+
+@tool(args_schema=JSON_SCHEMA_TOOL_ARGS)
+def json_schema_tool(query: str, limit: int) -> str:
+    """Search with a dict schema."""
+    return f"{query}:{limit}"
+
+
+class CountingArgs(BaseModel):
+    """Schema for cache tests."""
+
+    value: str
+
+
+class CountingTool(BaseTool):
+    """Tool whose schema access can be counted."""
+
+    name: str = "counting_tool"
+    description: str = "A counting tool."
+    args_schema: type[BaseModel] = CountingArgs
+    schema_accesses: int = 0
+
+    @property
+    def tool_call_schema(self) -> type[BaseModel]:
+        """Count how many times the schema is resolved."""
+        self.schema_accesses += 1
+        return super().tool_call_schema
+
+    def _run(self, value: str) -> str:
+        """Run the counting tool."""
+        return value
+
+
+def test_tool_arg_validation_initialization() -> None:
+    """Test initialization defaults and validation."""
+    middleware = ToolArgValidationMiddleware()
+
+    assert middleware.max_retries == 2
+    assert middleware.strip_empty_values is True
+    assert middleware.json_schema_validator_class is None
+    assert middleware.tools == []
+
+    with pytest.raises(ValueError, match="max_retries must be >= 0"):
+        ToolArgValidationMiddleware(max_retries=-1)
+
+    with pytest.raises(TypeError, match="json_schema_validator_class must be a class or None"):
+        ToolArgValidationMiddleware(json_schema_validator_class=object())  # type: ignore[arg-type]
+
+
+def test_wrap_model_call_passes_through_without_tool_calls() -> None:
+    """Test sync pass-through when the model does not emit tool calls."""
+    middleware = ToolArgValidationMiddleware()
+    captured_requests: list[ModelRequest[Any]] = []
+    response = _build_response(content="No tools")
+
+    result = middleware.wrap_model_call(
+        _build_request(tools=[search_tool]),
+        _build_sync_handler([response], captured_requests),
+    )
+
+    assert result is response
+    assert len(captured_requests) == 1
+
+
+def test_wrap_model_call_retries_pydantic_v2_and_sanitizes_args() -> None:
+    """Test sync retries with Pydantic v2 validation and sanitized args."""
+    middleware = ToolArgValidationMiddleware()
+    captured_requests: list[ModelRequest[Any]] = []
+    responses = [
+        _build_response(
+            [
+                {
+                    "name": "search_tool",
+                    "id": "call_invalid",
+                    "args": {"query": "python", "limit": "oops"},
+                }
+            ],
+            content="invalid",
+        ),
+        _build_response(
+            [
+                {
+                    "name": "search_tool",
+                    "id": "call_valid",
+                    "args": {
+                        "query": "python",
+                        "limit": 3,
+                        "metadata": {"keep": "yes", "drop": None, "nested": {}},
+                    },
+                }
+            ],
+            content="valid",
+        ),
+    ]
+
+    result = middleware.wrap_model_call(
+        _build_request(tools=[search_tool]),
+        _build_sync_handler(responses, captured_requests),
+    )
+
+    assert len(captured_requests) == 2
+    retry_request = captured_requests[1]
+    assert isinstance(retry_request.messages[-2], AIMessage)
+    assert isinstance(retry_request.messages[-1], ToolMessage)
+    assert "Invalid arguments for tool 'search_tool'" in retry_request.messages[-1].content
+
+    final_message = result.result[0]
+    assert isinstance(final_message, AIMessage)
+    assert final_message.tool_calls[0]["args"] == {
+        "query": "python",
+        "limit": 3,
+        "metadata": {"keep": "yes"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_awrap_model_call_retries_pydantic_v1() -> None:
+    """Test async retries with a Pydantic v1 args schema."""
+    middleware = ToolArgValidationMiddleware()
+    captured_requests: list[ModelRequest[Any]] = []
+    responses = [
+        _build_response(
+            [
+                {
+                    "name": "legacy_search_tool",
+                    "id": "legacy_invalid",
+                    "args": {"city": "Tokyo", "count": "nope"},
+                }
+            ]
+        ),
+        _build_response(
+            [
+                {
+                    "name": "legacy_search_tool",
+                    "id": "legacy_valid",
+                    "args": {"city": "Tokyo", "count": 2},
+                }
+            ]
+        ),
+    ]
+
+    result = await middleware.awrap_model_call(
+        _build_request(tools=[legacy_search_tool]),
+        _build_async_handler(responses, captured_requests),
+    )
+
+    assert len(captured_requests) == 2
+    retry_request = captured_requests[1]
+    assert isinstance(retry_request.messages[-1], ToolMessage)
+    assert "legacy_search_tool" in retry_request.messages[-1].content
+
+    final_message = result.result[0]
+    assert isinstance(final_message, AIMessage)
+    assert final_message.tool_calls[0]["args"] == {"city": "Tokyo", "count": 2}
+
+
+def test_strip_empty_values_recursively_preserves_list_shape() -> None:
+    """Test recursive stripping and list-shape preservation."""
+    middleware = ToolArgValidationMiddleware()
+    response = _build_response(
+        [
+            {
+                "name": "search_tool",
+                "id": "call_sanitized",
+                "args": {
+                    "query": "python",
+                    "limit": 5,
+                    "metadata": {"drop": None, "nested": {}},
+                    "items": [{"keep": 1, "drop": None}, None, {}, []],
+                },
+            }
+        ]
+    )
+
+    result = middleware.wrap_model_call(
+        _build_request(tools=[search_tool]),
+        _build_sync_handler([response], []),
+    )
+
+    final_message = result.result[0]
+    assert isinstance(final_message, AIMessage)
+    assert final_message.tool_calls[0]["args"] == {
+        "query": "python",
+        "limit": 5,
+        "items": [{"keep": 1}, None, {}, []],
+    }
+
+
+def test_retry_exhaustion_returns_last_invalid_response_unchanged() -> None:
+    """Test fail-open behavior after validation retries are exhausted."""
+    middleware = ToolArgValidationMiddleware(max_retries=1)
+    captured_requests: list[ModelRequest[Any]] = []
+    responses = [
+        _build_response(
+            [
+                {
+                    "name": "search_tool",
+                    "id": "call_1",
+                    "args": {"query": "python", "limit": "bad"},
+                }
+            ]
+        ),
+        _build_response(
+            [
+                {
+                    "name": "search_tool",
+                    "id": "call_2",
+                    "args": {
+                        "query": "python",
+                        "limit": "still-bad",
+                        "metadata": {"empty": None},
+                    },
+                }
+            ]
+        ),
+    ]
+
+    result = middleware.wrap_model_call(
+        _build_request(tools=[search_tool]),
+        _build_sync_handler(responses, captured_requests),
+    )
+
+    assert len(captured_requests) == 2
+    assert result is responses[-1]
+    last_message = result.result[0]
+    assert isinstance(last_message, AIMessage)
+    assert last_message.tool_calls[0]["args"] == {
+        "query": "python",
+        "limit": "still-bad",
+        "metadata": {"empty": None},
+    }
+
+
+def test_unknown_tool_calls_pass_through_without_validation() -> None:
+    """Test that tool calls not present in the request are ignored."""
+    middleware = ToolArgValidationMiddleware()
+    captured_requests: list[ModelRequest[Any]] = []
+    response = _build_response(
+        [{"name": "unknown_tool", "id": "call_unknown", "args": {"bad": "value"}}]
+    )
+
+    result = middleware.wrap_model_call(
+        _build_request(tools=[search_tool]),
+        _build_sync_handler([response], captured_requests),
+    )
+
+    assert result is not response
+    final_message = result.result[0]
+    assert isinstance(final_message, AIMessage)
+    assert final_message.tool_calls[0]["name"] == "unknown_tool"
+    assert len(captured_requests) == 1
+
+
+def test_mixed_valid_invalid_batch_retries_all_tool_calls() -> None:
+    """Test retry-all behavior when a batch contains valid and invalid tool calls."""
+
+    @tool
+    def calculator_tool(expression: str) -> str:
+        """Evaluate an expression."""
+        return expression
+
+    middleware = ToolArgValidationMiddleware()
+    captured_requests: list[ModelRequest[Any]] = []
+    responses = [
+        _build_response(
+            [
+                {
+                    "name": "search_tool",
+                    "id": "invalid_search",
+                    "args": {"query": "python", "limit": "bad"},
+                },
+                {
+                    "name": "calculator_tool",
+                    "id": "valid_calc",
+                    "args": {"expression": "1 + 1"},
+                },
+            ]
+        ),
+        _build_response(
+            [
+                {
+                    "name": "search_tool",
+                    "id": "fixed_search",
+                    "args": {"query": "python", "limit": 2},
+                },
+                {
+                    "name": "calculator_tool",
+                    "id": "fixed_calc",
+                    "args": {"expression": "1 + 1"},
+                },
+            ]
+        ),
+    ]
+
+    result = middleware.wrap_model_call(
+        _build_request(tools=[search_tool, calculator_tool]),
+        _build_sync_handler(responses, captured_requests),
+    )
+
+    assert len(captured_requests) == 2
+    retry_messages = captured_requests[1].messages[-3:]
+    assert isinstance(retry_messages[0], AIMessage)
+    assert isinstance(retry_messages[1], ToolMessage)
+    assert isinstance(retry_messages[2], ToolMessage)
+    assert "Invalid arguments for tool 'search_tool'" in retry_messages[1].content
+    assert "batch rejected" in retry_messages[2].content
+
+    final_message = result.result[0]
+    assert isinstance(final_message, AIMessage)
+    assert [tool_call["id"] for tool_call in final_message.tool_calls] == [
+        "fixed_search",
+        "fixed_calc",
+    ]
+
+
+@pytest.mark.requires("jsonschema")
+def test_dict_schema_validation_retries_with_jsonschema() -> None:
+    """Test dict-schema validation and retry behavior."""
+    middleware = ToolArgValidationMiddleware()
+    captured_requests: list[ModelRequest[Any]] = []
+    responses = [
+        _build_response(
+            [
+                {
+                    "name": "json_schema_tool",
+                    "id": "json_invalid",
+                    "args": {"query": "python", "limit": 2, "extra": "boom"},
+                }
+            ]
+        ),
+        _build_response(
+            [
+                {
+                    "name": "json_schema_tool",
+                    "id": "json_valid",
+                    "args": {"query": "python", "limit": 2},
+                }
+            ]
+        ),
+    ]
+
+    result = middleware.wrap_model_call(
+        _build_request(tools=[json_schema_tool]),
+        _build_sync_handler(responses, captured_requests),
+    )
+
+    assert len(captured_requests) == 2
+    retry_message = captured_requests[1].messages[-1]
+    assert isinstance(retry_message, ToolMessage)
+    assert "extra" in retry_message.content
+
+    final_message = result.result[0]
+    assert isinstance(final_message, AIMessage)
+    assert final_message.tool_calls[0]["args"] == {"query": "python", "limit": 2}
+
+
+def test_missing_jsonschema_raises_clear_error() -> None:
+    """Test the ImportError path for dict-schema tools."""
+    middleware = ToolArgValidationMiddleware()
+    request = _build_request(tools=[json_schema_tool])
+    response = _build_response(
+        [{"name": "json_schema_tool", "id": "json_call", "args": {"query": "python"}}]
+    )
+
+    with (
+        patch(
+            "langchain.agents.middleware.tool_arg_validation.importlib.import_module",
+            side_effect=ImportError("missing jsonschema"),
+        ),
+        pytest.raises(ImportError, match="requires the jsonschema package"),
+    ):
+        middleware.wrap_model_call(request, _build_sync_handler([response], []))
+
+
+def test_validator_cache_reuses_tools_and_refreshes_when_tool_object_changes() -> None:
+    """Test validator caching across requests."""
+    middleware = ToolArgValidationMiddleware()
+    first_tool = CountingTool()
+    second_tool = CountingTool()
+
+    first_request = _build_request(tools=[first_tool])
+    second_request = _build_request(tools=[second_tool])
+
+    middleware.wrap_model_call(
+        first_request,
+        _build_sync_handler(
+            [
+                _build_response(
+                    [{"name": "counting_tool", "id": "call_1", "args": {"value": "first"}}]
+                )
+            ],
+            [],
+        ),
+    )
+    middleware.wrap_model_call(
+        first_request,
+        _build_sync_handler(
+            [
+                _build_response(
+                    [{"name": "counting_tool", "id": "call_2", "args": {"value": "again"}}]
+                )
+            ],
+            [],
+        ),
+    )
+    middleware.wrap_model_call(
+        second_request,
+        _build_sync_handler(
+            [
+                _build_response(
+                    [{"name": "counting_tool", "id": "call_3", "args": {"value": "fresh"}}]
+                )
+            ],
+            [],
+        ),
+    )
+
+    assert first_tool.schema_accesses == 1
+    assert second_tool.schema_accesses == 1
+    assert middleware._validator_cache["counting_tool"].tool is second_tool
+
+
+def test_create_agent_retries_inside_model_node_sync() -> None:
+    """Test end-to-end sync retry behavior with create_agent."""
+
+    @tool
+    def uppercase_tool(value: str) -> str:
+        """Uppercase a string."""
+        return value.upper()
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"name": "uppercase_tool", "id": "call_invalid", "args": {"wrong": "x"}}],
+            [{"name": "uppercase_tool", "id": "call_valid", "args": {"value": "hello"}}],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[uppercase_tool],
+        middleware=[ToolArgValidationMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Please uppercase hello")]},
+        {"configurable": {"thread_id": "tool-arg-validation-sync"}},
+    )
+
+    assert model.index == 3
+    assert len(result["messages"]) == 4
+    assert isinstance(result["messages"][1], AIMessage)
+    assert result["messages"][1].tool_calls[0]["id"] == "call_valid"
+
+    tool_messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "HELLO"
+    assert tool_messages[0].status == "success"
+
+
+@pytest.mark.asyncio
+async def test_create_agent_retries_inside_model_node_async() -> None:
+    """Test end-to-end async retry behavior with create_agent."""
+
+    @tool
+    async def async_uppercase_tool(value: str) -> str:
+        """Uppercase a string asynchronously."""
+        return value.upper()
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"name": "async_uppercase_tool", "id": "call_invalid", "args": {"oops": "x"}}],
+            [
+                {
+                    "name": "async_uppercase_tool",
+                    "id": "call_valid",
+                    "args": {"value": "hello"},
+                }
+            ],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[async_uppercase_tool],
+        middleware=[ToolArgValidationMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage("Please uppercase hello")]},
+        {"configurable": {"thread_id": "tool-arg-validation-async"}},
+    )
+
+    assert model.index == 3
+    assert len(result["messages"]) == 4
+    assert isinstance(result["messages"][1], AIMessage)
+    assert result["messages"][1].tool_calls[0]["id"] == "call_valid"
+
+    tool_messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "HELLO"
+    assert tool_messages[0].status == "success"
+
+
+def test_structured_output_flow_is_unchanged() -> None:
+    """Test that structured output retries are not intercepted."""
+
+    class WeatherReport(BaseModel):
+        """Structured weather response."""
+
+        temperature: float
+        conditions: str
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [{"name": "WeatherReport", "id": "sr_invalid", "args": {"temperature": "bad"}}],
+            [
+                {
+                    "name": "WeatherReport",
+                    "id": "sr_valid",
+                    "args": {"temperature": 72.0, "conditions": "sunny"},
+                }
+            ],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        middleware=[ToolArgValidationMiddleware()],
+        response_format=ToolStrategy(schema=WeatherReport),
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("What's the weather?")]},
+        {"configurable": {"thread_id": "tool-arg-structured-output"}},
+    )
+
+    assert model.index == 2
+    assert isinstance(result["structured_response"], WeatherReport)
+    assert result["structured_response"].temperature == 72.0
+    assert result["structured_response"].conditions == "sunny"


### PR DESCRIPTION
Fixes #36700

Adds `ToolArgValidationMiddleware` to validate LLM-generated tool-call arguments against Pydantic and JSON schemas at the model boundary. This enables the model to self-correct invalid arguments via an internal retry loop before execution, reducing runtime errors in tool nodes.

How I verified:
- Ran `make format`, `make lint`, and `make test` within `libs/langchain_v1`.
- All 14 tests in `test_tool_arg_validation.py` passed, covering Pydantic v1/v2, JSON Schema, and E2E `AgentExecutor` flows.