### PR TITLE
fix: typo in Visitor error msg, Blob.as_bytes_io string support, batch_size validation

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode("utf-8"))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f

--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -90,6 +90,8 @@ def _hash_nested_dict(
 
 def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError("batch_size must be a positive integer")
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))
@@ -100,6 +102,8 @@ def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
 
 async def _abatch(size: int, iterable: AsyncIterable[T]) -> AsyncIterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError("batch_size must be a positive integer")
     batch: list[T] = []
     async for element in iterable:
         if len(batch) < size:

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
## Summary

### Fix 1 — Typo in `Visitor._validate_func` error message (fixes #36701)
The error message for disallowed operators said 'Allowed **comparators** are...' instead of 'Allowed **operators** are...'. Fixed the incorrect word.

### Fix 2 — `Blob.as_bytes_io()` raises `NotImplementedError` for string data (fixes #36667)
When `blob.data` is a `str`, the method raised `NotImplementedError`. Now encodes the string to UTF-8 bytes and yields a `BytesIO` object, consistent with the `bytes` branch.

### Fix 3 — `_batch`/`_abatch` missing `batch_size` validation (fixes #36647)
When `batch_size <= 0` was passed, both functions would loop infinitely. Added a guard at the top of each:
```python
if size <= 0:
    raise ValueError("batch_size must be a positive integer")
```