### PR TITLE
fix(perplexity): expose num_search_queries in UsageMetadata and cost in response_metadata

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -36,6 +36,7 @@ from langchain_core.messages import (
     ToolMessageChunk,
 )
 from langchain_core.messages.ai import (
+    InputTokenDetails,
     OutputTokenDetails,
     UsageMetadata,
     subtract_usage,
@@ -87,6 +88,12 @@ def _create_usage_metadata(token_usage: dict) -> UsageMetadata:
     output_tokens = token_usage.get("completion_tokens", 0)
     total_tokens = token_usage.get("total_tokens", input_tokens + output_tokens)
 
+    # Build input_token_details for Perplexity-specific fields.
+    # num_search_queries drives per-query cost and is a provider-specific key.
+    input_token_details: InputTokenDetails = {}
+    if (num_search_queries := token_usage.get("num_search_queries")) is not None:
+        input_token_details["num_search_queries"] = num_search_queries  # type: ignore[typeddict-unknown-key]
+
     # Build output_token_details for Perplexity-specific fields
     output_token_details: OutputTokenDetails = {}
     if (reasoning := token_usage.get("reasoning_tokens")) is not None:
@@ -94,12 +101,15 @@ def _create_usage_metadata(token_usage: dict) -> UsageMetadata:
     if (citation_tokens := token_usage.get("citation_tokens")) is not None:
         output_token_details["citation_tokens"] = citation_tokens  # type: ignore[typeddict-unknown-key]
 
-    return UsageMetadata(
+    usage = UsageMetadata(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
         output_token_details=output_token_details,
     )
+    if input_token_details:
+        usage["input_token_details"] = input_token_details
+    return usage
 
 
 class ChatPerplexity(BaseChatModel):
@@ -630,6 +640,8 @@ class ChatPerplexity(BaseChatModel):
             response_metadata["num_search_queries"] = num_search_queries
         if search_context_size := usage_dict.get("search_context_size"):
             response_metadata["search_context_size"] = search_context_size
+        if cost := usage_dict.get("cost"):
+            response_metadata["cost"] = cost
 
         message = AIMessage(
             content=response.choices[0].message.content,
@@ -689,6 +701,8 @@ class ChatPerplexity(BaseChatModel):
             response_metadata["num_search_queries"] = num_search_queries
         if search_context_size := usage_dict.get("search_context_size"):
             response_metadata["search_context_size"] = search_context_size
+        if cost := usage_dict.get("cost"):
+            response_metadata["cost"] = cost
 
         message = AIMessage(
             content=response.choices[0].message.content,

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -161,6 +161,48 @@ def test_create_usage_metadata_basic() -> None:
     assert usage_metadata["total_tokens"] == 30
     assert usage_metadata["output_token_details"]["reasoning"] == 0
     assert usage_metadata["output_token_details"]["citation_tokens"] == 0  # type: ignore[typeddict-item]
+    assert "input_token_details" not in usage_metadata
+
+
+def test_create_usage_metadata_with_search_queries() -> None:
+    """Test _create_usage_metadata includes num_search_queries in input_token_details.
+
+    num_search_queries drives per-query billing and must be surfaced in
+    input_token_details so that LangSmith can compute accurate call costs.
+    """
+    token_usage = {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+        "num_search_queries": 3,
+        "reasoning_tokens": 5,
+        "citation_tokens": 15,
+    }
+
+    usage_metadata = _create_usage_metadata(token_usage)
+
+    assert usage_metadata["input_tokens"] == 10
+    assert usage_metadata["output_tokens"] == 20
+    assert usage_metadata["total_tokens"] == 30
+    # num_search_queries drives per-query billing and must be in input_token_details
+    assert usage_metadata["input_token_details"]["num_search_queries"] == 3  # type: ignore[typeddict-item]
+    assert usage_metadata["output_token_details"]["reasoning"] == 5
+    assert usage_metadata["output_token_details"]["citation_tokens"] == 15  # type: ignore[typeddict-item]
+
+
+def test_create_usage_metadata_zero_search_queries() -> None:
+    """Test _create_usage_metadata with num_search_queries=0."""
+    token_usage = {
+        "prompt_tokens": 5,
+        "completion_tokens": 10,
+        "total_tokens": 15,
+        "num_search_queries": 0,
+    }
+
+    usage_metadata = _create_usage_metadata(token_usage)
+
+    # Zero is a valid value — still included so callers can distinguish 0 from absent
+    assert usage_metadata["input_token_details"]["num_search_queries"] == 0  # type: ignore[typeddict-item]
 
 
 def test_perplexity_invoke_includes_num_search_queries(mocker: MockerFixture) -> None:
@@ -206,6 +248,126 @@ def test_perplexity_invoke_includes_num_search_queries(mocker: MockerFixture) ->
     assert result.response_metadata["search_context_size"] == "high"
     assert result.response_metadata["model_name"] == "test-model"
     patcher.assert_called_once()
+
+
+def test_num_search_queries_flows_into_usage_metadata(
+    mocker: MockerFixture,
+) -> None:
+    """Smoke test: num_search_queries from the API response reaches usage_metadata.
+
+    Verifies the full path: API response -> _create_usage_metadata ->
+    AIMessage.usage_metadata.input_token_details["num_search_queries"].
+    Previously num_search_queries was only stored in response_metadata, making
+    it invisible to LangSmith's cost calculator.
+    """
+    llm = ChatPerplexity(model="sonar-pro", timeout=30)
+
+    mock_usage = MagicMock()
+    mock_usage.model_dump.return_value = {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+        "num_search_queries": 3,
+        "citation_tokens": 20,
+        "reasoning_tokens": 0,
+        "cost": {
+            "input_tokens_cost": 0.0001,
+            "output_tokens_cost": 0.00005,
+            "total_cost": 0.03015,
+            "citation_tokens_cost": 0.00002,
+            "reasoning_tokens_cost": None,
+            "request_cost": None,
+            "search_queries_cost": 0.015,
+        },
+    }
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(content="Paris is the capital.", tool_calls=None),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.model = "sonar-pro"
+    mock_response.usage = mock_usage
+    mock_response.citations = None
+    mock_response.images = None
+    mock_response.related_questions = None
+    mock_response.search_results = None
+    mock_response.videos = None
+    mock_response.reasoning_steps = None
+
+    mocker.patch.object(
+        llm.client.chat.completions, "create", return_value=mock_response
+    )
+
+    result = llm.invoke("What is the capital of France?")
+
+    assert result.usage_metadata is not None
+    # num_search_queries must be in input_token_details for LangSmith cost tracking
+    assert "input_token_details" in result.usage_metadata
+    assert result.usage_metadata["input_token_details"]["num_search_queries"] == 3  # type: ignore[typeddict-item]
+    # citation_tokens and reasoning must still be in output_token_details
+    assert result.usage_metadata["output_token_details"]["citation_tokens"] == 20  # type: ignore[typeddict-item]
+    assert result.usage_metadata["output_token_details"]["reasoning"] == 0
+    # token counts correct
+    assert result.usage_metadata["input_tokens"] == 100
+    assert result.usage_metadata["output_tokens"] == 50
+    assert result.usage_metadata["total_tokens"] == 150
+    # The API-returned cost breakdown must be in response_metadata so callers
+    # can read the exact cost Perplexity charged (incl. search_queries_cost)
+    assert result.response_metadata["cost"]["total_cost"] == 0.03015
+    assert result.response_metadata["cost"]["search_queries_cost"] == 0.015
+
+
+def test_cost_absent_when_reasoning_mode_enabled(mocker: MockerFixture) -> None:
+    """Smoke test: missing cost field (e.g. reasoning mode) does not raise.
+
+    Some providers (e.g. OpenRouter) omit the cost object from the usage
+    payload when reasoning mode is enabled. The integration must degrade
+    gracefully — no KeyError, no crash — and simply omit 'cost' from
+    response_metadata.
+    """
+    llm = ChatPerplexity(model="sonar-reasoning-pro", timeout=30)
+
+    mock_usage = MagicMock()
+    mock_usage.model_dump.return_value = {
+        "prompt_tokens": 200,
+        "completion_tokens": 80,
+        "total_tokens": 280,
+        "reasoning_tokens": 60,
+        "num_search_queries": 2,
+        # cost is absent — simulates reasoning-mode responses from some providers
+    }
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(content="Reasoned answer.", tool_calls=None),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.model = "sonar-reasoning-pro"
+    mock_response.usage = mock_usage
+    mock_response.citations = None
+    mock_response.images = None
+    mock_response.related_questions = None
+    mock_response.search_results = None
+    mock_response.videos = None
+    mock_response.reasoning_steps = None
+
+    mocker.patch.object(
+        llm.client.chat.completions, "create", return_value=mock_response
+    )
+
+    result = llm.invoke("Explain quantum entanglement.")
+
+    # Must not raise — cost simply absent from response_metadata
+    assert "cost" not in result.response_metadata
+    # Other fields still correct
+    assert result.usage_metadata is not None
+    assert result.usage_metadata["input_token_details"]["num_search_queries"] == 2  # type: ignore[typeddict-item]
+    assert result.usage_metadata["output_token_details"]["reasoning"] == 60
 
 
 def test_profile() -> None:


### PR DESCRIPTION
## Description

Fixes inaccurate cost tracking for Perplexity API calls in LangSmith (fixes #31647).

Two gaps were causing costs to be off by up to an order of magnitude:

**1. `num_search_queries` missing from `UsageMetadata`**

Perplexity charges per search query (e.g. \$5/1000 for sonar-pro) in addition to per token. `num_search_queries` was only stored in `response_metadata`, making it invisible to cost calculators that read `UsageMetadata`. It is now added as a provider-specific key in `input_token_details`, following the same pattern as `citation_tokens` in `output_token_details`.

**2. Perplexity `Cost` object was silently discarded**

The Perplexity SDK returns a `Cost` object with a full breakdown (`input_tokens_cost`, `output_tokens_cost`, `search_queries_cost`, `reasoning_tokens_cost`, `total_cost`) that was being thrown away. It is now forwarded into `response_metadata["cost"]` for both `_generate` and `_agenerate`.

When the `cost` field is absent (e.g. OpenRouter proxying Perplexity with reasoning mode enabled) the code degrades gracefully — no crash, `cost` simply omitted from `response_metadata`.

## Changes

- `langchain_perplexity/chat_models.py` — import `InputTokenDetails`; add `num_search_queries` to `input_token_details` in `_create_usage_metadata`; forward `cost` dict into `response_metadata` in both `_generate` and `_agenerate`
- `tests/unit_tests/test_chat_models.py` — three new tests: `num_search_queries` in `input_token_details`, zero search queries, full end-to-end smoke test through `invoke()` including `cost` in `response_metadata`, and a defensive test for missing `cost` (reasoning mode / OpenRouter)

## Tests

```
make lint_package  ✅
make lint_tests    ✅
make test          ✅  56 passed, 1 skipped
```