### PR TITLE
fix(core): correct error message typo in Visitor._validate_func

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
## Description

Fixed a typo in the error message for disallowed operators in `Visitor._validate_func` (`langchain_core/structured_query.py:32`). Changed `"comparators"` to `"operators"` to match the actual variable `self.allowed_operators` being referenced.

**Before:**
```python
f"Received disallowed operator {func}. Allowed "
f"comparators are {self.allowed_operators}"
```

**After:**
```python
f"Received disallowed operator {func}. Allowed "
f"operators are {self.allowed_operators}"
```

## Why

The error message incorrectly says "Allowed comparators are" when validating operators, which is confusing since the variable is `self.allowed_operators`. This is a copy-paste typo from the similar comparator validation logic above.

## Testing

- Existing tests continue to pass
- The error message now correctly references "operators" instead of "comparators"

Fixes #36701

---

**AI assistance disclaimer:** AI assistance was used to help identify this issue and draft the initial fix. The final changes and test coverage were reviewed manually.