### PR TITLE
fix(core): improve BaseMessage.pretty_repr for multimodal content

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -21,6 +21,70 @@ if TYPE_CHECKING:
     from langchain_core.prompts.chat import ChatPromptTemplate
 
 
+def _format_content(
+    content: str | list[str | dict],
+) -> str:
+    """Format message content for pretty printing.
+
+    Handles both string content and multimodal content blocks (lists of dicts),
+    producing human-readable output for each block type.
+
+    Args:
+        content: The message content, either a string or a list of content blocks.
+
+    Returns:
+        A formatted string representation of the content.
+    """
+    if isinstance(content, str):
+        return content
+
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, str):
+            parts.append(block)
+        elif isinstance(block, dict):
+            block_type = block.get("type", "")
+            if block_type == "text":
+                text = block.get("text", "")
+                parts.append(text)
+            elif block_type in {"image", "image_url"}:
+                source = block.get("source", {})
+                url = block.get("url", "")
+                if isinstance(source, dict) and source.get("type") == "base64":
+                    media_type = source.get("media_type", "unknown")
+                    parts.append(f"[image: base64 {media_type}]")
+                elif url:
+                    url_str = url.get("url", str(url)) if isinstance(url, dict) else url
+                    parts.append(f"[image: {url_str}]")
+                else:
+                    parts.append("[image]")
+            elif block_type == "audio":
+                source = block.get("source", {})
+                if isinstance(source, dict) and source.get("type") == "base64":
+                    media_type = source.get("media_type", "unknown")
+                    parts.append(f"[audio: base64 {media_type}]")
+                else:
+                    parts.append("[audio]")
+            elif block_type == "video":
+                source = block.get("source", {})
+                if isinstance(source, dict) and source.get("type") == "base64":
+                    media_type = source.get("media_type", "unknown")
+                    parts.append(f"[video: base64 {media_type}]")
+                else:
+                    parts.append("[video]")
+            elif block_type == "reasoning":
+                reasoning_text = block.get("reasoning_text", "")
+                if reasoning_text:
+                    parts.append(f"[reasoning: {reasoning_text}]")
+                else:
+                    parts.append("[reasoning]")
+            else:
+                parts.append(str(block))
+        else:
+            parts.append(str(block))
+    return "\n".join(parts)
+
+
 def _extract_reasoning_from_additional_kwargs(
     message: BaseMessage,
 ) -> types.ReasoningContentBlock | None:
@@ -336,10 +400,10 @@ class BaseMessage(Serializable):
             ```
         """  # noqa: E501
         title = get_msg_title_repr(self.type.title() + " Message", bold=html)
-        # TODO: handle non-string content.
         if self.name is not None:
             title += f"\nName: {self.name}"
-        return f"{title}\n\n{self.content}"
+        content = _format_content(self.content)
+        return f"{title}\n\n{content}"
 
     def pretty_print(self) -> None:
         """Print a pretty representation of the message.

--- a/libs/core/tests/unit_tests/messages/test_pretty_repr.py
+++ b/libs/core/tests/unit_tests/messages/test_pretty_repr.py
@@ -1,0 +1,173 @@
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+
+def test_pretty_repr_string_content() -> None:
+    msg = HumanMessage(content="What is the capital of France?")
+    result = msg.pretty_repr()
+    assert "Human Message" in result
+    assert "What is the capital of France?" in result
+
+
+def test_pretty_repr_text_block() -> None:
+    msg = HumanMessage(content=[{"type": "text", "text": "Hello"}])
+    result = msg.pretty_repr()
+    assert "Hello" in result
+    assert "{'type': 'text'" not in result
+
+
+def test_pretty_repr_image_url_block() -> None:
+    msg = HumanMessage(
+        content=[
+            {"type": "text", "text": "Describe this image"},
+            {"type": "image_url", "url": "https://example.com/image.png"},
+        ]
+    )
+    result = msg.pretty_repr()
+    assert "Describe this image" in result
+    assert "[image: https://example.com/image.png]" in result
+    assert "{'type': 'image_url'" not in result
+
+
+def test_pretty_repr_image_url_dict_block() -> None:
+    msg = HumanMessage(
+        content=[
+            {
+                "type": "image_url",
+                "url": {"url": "https://example.com/image.png"},
+            }
+        ]
+    )
+    result = msg.pretty_repr()
+    assert "[image: https://example.com/image.png]" in result
+
+
+def test_pretty_repr_image_base64_block() -> None:
+    msg = HumanMessage(
+        content=[
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": "iVBOR...",
+                },
+            }
+        ]
+    )
+    result = msg.pretty_repr()
+    assert "[image: base64 image/png]" in result
+
+
+def test_pretty_repr_audio_base64_block() -> None:
+    msg = HumanMessage(
+        content=[
+            {
+                "type": "audio",
+                "source": {
+                    "type": "base64",
+                    "media_type": "audio/mp3",
+                    "data": "UklGRi...",
+                },
+            }
+        ]
+    )
+    result = msg.pretty_repr()
+    assert "[audio: base64 audio/mp3]" in result
+
+
+def test_pretty_repr_video_base64_block() -> None:
+    msg = HumanMessage(
+        content=[
+            {
+                "type": "video",
+                "source": {
+                    "type": "base64",
+                    "media_type": "video/mp4",
+                    "data": "AAAA...",
+                },
+            }
+        ]
+    )
+    result = msg.pretty_repr()
+    assert "[video: base64 video/mp4]" in result
+
+
+def test_pretty_repr_reasoning_block() -> None:
+    msg = AIMessage(
+        content=[
+            {"type": "reasoning", "reasoning_text": "Let me think about this..."},
+            {"type": "text", "text": "The answer is 42."},
+        ]
+    )
+    result = msg.pretty_repr()
+    assert "[reasoning: Let me think about this...]" in result
+    assert "The answer is 42." in result
+
+
+def test_pretty_repr_reasoning_block_empty() -> None:
+    msg = AIMessage(
+        content=[{"type": "reasoning", "reasoning_text": ""}]
+    )
+    result = msg.pretty_repr()
+    assert "[reasoning]" in result
+
+
+def test_pretty_repr_audio_no_source() -> None:
+    msg = HumanMessage(content=[{"type": "audio"}])
+    result = msg.pretty_repr()
+    assert "[audio]" in result
+
+
+def test_pretty_repr_video_no_source() -> None:
+    msg = HumanMessage(content=[{"type": "video"}])
+    result = msg.pretty_repr()
+    assert "[video]" in result
+
+
+def test_pretty_repr_image_no_url() -> None:
+    msg = HumanMessage(content=[{"type": "image"}])
+    result = msg.pretty_repr()
+    assert "[image]" in result
+
+
+def test_pretty_repr_mixed_string_and_blocks() -> None:
+    msg = HumanMessage(
+        content=["Hello", {"type": "text", "text": "World"}]
+    )
+    result = msg.pretty_repr()
+    assert "Hello" in result
+    assert "World" in result
+
+
+def test_pretty_repr_unknown_block_type() -> None:
+    msg = HumanMessage(content=[{"type": "custom", "data": "value"}])
+    result = msg.pretty_repr()
+    assert "custom" in result
+    assert "value" in result
+
+
+def test_pretty_repr_with_name() -> None:
+    msg = HumanMessage(content="Hello", name="Alice")
+    result = msg.pretty_repr()
+    assert "Name: Alice" in result
+    assert "Hello" in result
+
+
+def test_pretty_repr_system_message() -> None:
+    msg = SystemMessage(content="You are a helpful assistant.")
+    result = msg.pretty_repr()
+    assert "System Message" in result
+    assert "You are a helpful assistant." in result
+
+
+def test_pretty_repr_ai_message_multimodal() -> None:
+    msg = AIMessage(
+        content=[
+            {"type": "text", "text": "Here is the analysis"},
+            {"type": "reasoning", "reasoning_text": "I analyzed the data"},
+        ]
+    )
+    result = msg.pretty_repr()
+    assert "Ai Message" in result
+    assert "Here is the analysis" in result
+    assert "[reasoning: I analyzed the data]" in result


### PR DESCRIPTION
## Description

This PR improves `BaseMessage.pretty_repr()` to handle multimodal content blocks with human-readable output instead of falling back to raw Python dict representations.

**Before:**
```
================================ Human Message =================================

[{'type': 'image_url', 'url': 'https://example.com/image.png'}, {'type': 'text', 'text': 'Describe this image'}]
```

**After:**
```
================================ Human Message =================================

[image: https://example.com/image.png]
Describe this image
```

## Changes

- Added `_format_content()` helper function that handles different content block types:
  - `text` blocks: rendered as plain text
  - `image`/`image_url` blocks: rendered as `[image: url]` or `[image: base64 media_type]`
  - `audio` blocks: rendered as `[audio: base64 media_type]` or `[audio]`
  - `video` blocks: rendered as `[video: base64 media_type]` or `[video]`
  - `reasoning` blocks: rendered as `[reasoning: text]` or `[reasoning]`
  - Unknown block types: fall back to `str(block)`
- Updated `BaseMessage.pretty_repr()` to use `_format_content()` instead of directly printing `self.content`
- Removed the `# TODO: handle non-string content.` comment since this is now handled
- Added 17 unit tests covering all content block types

## Testing

- Added `tests/unit_tests/messages/test_pretty_repr.py` with 17 test cases
- All existing 215 message tests still pass
- `ruff check` passes with no errors

Fixes #36365

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)