### PR TITLE
fix: correct error message in Visitor._validate_func for operators

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
## Summary

Fixes a copy-paste typo in `Visitor._validate_func` where the error message for disallowed operators incorrectly says "Allowed comparators are" instead of "Allowed operators are".

## Changes

- `libs/core/langchain_core/structured_query.py`: Changed "comparators" to "operators" in the error message for operator validation (line 32).

## Testing

- Verified the change is a single-word fix in an error message string.
- No functional code changes; error message now correctly describes what is being validated.

Fixes #36701