### PR TITLE
fix(core): support string data in Blob.as_bytes_io()

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f

--- a/libs/core/tests/unit_tests/document_loaders/test_base.py
+++ b/libs/core/tests/unit_tests/document_loaders/test_base.py
@@ -70,3 +70,33 @@ async def test_default_aload() -> None:
     assert docs == [Document(page_content="foo"), Document(page_content="bar")]
     assert docs == [doc async for doc in loader.alazy_load()]
     assert docs == await loader.aload()
+
+
+def test_as_bytes_io_with_bytes_data() -> None:
+    """as_bytes_io works with bytes data — must not regress."""
+    blob = Blob.from_data(b"hello bytes")
+    with blob.as_bytes_io() as f:
+        assert f.read() == b"hello bytes"
+
+
+def test_as_bytes_io_with_string_data() -> None:
+    """as_bytes_io must encode string data to bytes using utf-8."""
+    blob = Blob.from_data("hello string")
+    with blob.as_bytes_io() as f:
+        assert f.read() == b"hello string"
+
+
+def test_as_bytes_io_with_string_data_custom_encoding() -> None:
+    """as_bytes_io must respect custom encoding when string data is used."""
+    blob = Blob(data="héllo", encoding="latin-1")
+    with blob.as_bytes_io() as f:
+        assert f.read() == "héllo".encode("latin-1")
+
+
+def test_as_bytes_io_string_consistent_with_as_bytes() -> None:
+    """as_bytes_io for string data must produce the same bytes as as_bytes()."""
+    text = "consistency check"
+    blob = Blob.from_data(text)
+    with blob.as_bytes_io() as f:
+        stream_bytes = f.read()
+    assert stream_bytes == blob.as_bytes()


### PR DESCRIPTION
Fixes #36667

`Blob.as_bytes_io()` raised `NotImplementedError` when the blob contained string data, even though `as_bytes()` and `as_string()` both handle it. This adds the missing `elif isinstance(self.data, str)` branch that encodes the string using `self.encoding` before wrapping it in a `BytesIO` — consistent with how `as_bytes()` already works.

**Change:** one `elif` branch added in `libs/core/langchain_core/documents/base.py`.

**Tests added** in `libs/core/tests/unit_tests/document_loaders/test_base.py`:
- `test_as_bytes_io_with_string_data` — basic string → bytes
- `test_as_bytes_io_with_string_data_custom_encoding` — respects `encoding` field
- `test_as_bytes_io_string_consistent_with_as_bytes` — output matches `as_bytes()`
- `test_as_bytes_io_with_bytes_data` — regression for existing bytes behaviour

## How I verified it works

Ran all 4 tests locally against the patched file. Confirmed the original `NotImplementedError` is no longer raised for string data, and all edge cases pass.