### PR TITLE
fix(langchain): detect done marker anywhere in stdout line to fix no-trailing-newline timeout

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -265,8 +265,15 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
-                _, _, status = data.partition(" ")
+            if source == "stdout" and marker in data:
+                # The marker may appear mid-line when the command's stdout lacks a
+                # trailing newline — the shell appends the printf done-marker to the
+                # same line (e.g. "hello__LC_SHELL_DONE__<id> 0").  Preserve any
+                # real output that precedes the marker on that line.
+                pre, _, rest = data.partition(marker)
+                if pre:
+                    collected.append(pre)
+                _, _, status = rest.partition(" ")
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.
                 # The stderr reader thread runs independently, so output might

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -546,3 +546,63 @@ def test_get_or_create_resources_reuses_existing(tmp_path: Path) -> None:
 
     # Clean up
     resources1.finalizer()
+
+
+def test_command_output_without_trailing_newline(tmp_path: Path) -> None:
+    """Regression: commands that print without a trailing newline must not time out.
+
+    printf 'text' writes bytes with no trailing newline.  The shell appends the
+    done marker on the same readline() chunk, so the old startswith() check
+    missed it and caused a timeout.  The fixed 'in' check must capture it and
+    return the output correctly.
+    """
+    policy = HostExecutionPolicy(command_timeout=3.0)
+    middleware = ShellToolMiddleware(
+        workspace_root=tmp_path / "workspace", execution_policy=policy
+    )
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+
+        result = middleware._run_shell_tool(
+            resources,
+            {"command": "printf 'hello without newline'"},
+            tool_call_id=None,
+        )
+
+        assert isinstance(result, str)
+        assert "hello without newline" in result
+        assert "timed out" not in result.lower()
+    finally:
+        middleware.after_agent(state, runtime)
+
+
+def test_command_output_without_trailing_newline_exit_code(tmp_path: Path) -> None:
+    """Regression: exit code must be captured correctly when no trailing newline."""
+    policy = HostExecutionPolicy(command_timeout=3.0)
+    middleware = ShellToolMiddleware(
+        workspace_root=tmp_path / "workspace", execution_policy=policy
+    )
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+
+        result = middleware._run_shell_tool(
+            resources,
+            {"command": "printf 'partial'; exit 0"},
+            tool_call_id="test-id",
+        )
+
+        assert isinstance(result, ToolMessage)
+        assert result.artifact["timed_out"] is False
+        assert result.artifact["exit_code"] == 0
+    finally:
+        middleware.after_agent(state, runtime)


### PR DESCRIPTION
Fixes #36696

`ShellSession._collect_output()` used `data.startswith(marker)` to detect command completion. When a command's stdout has no trailing newline, `readline()` returns the command output and the injected done-marker on the **same line** (e.g. `hello without newline__LC_SHELL_DONE__<id> 0`). `startswith()` misses the marker, and the command times out waiting for it.

**Fix:** use `marker in data` instead of `data.startswith(marker)`. When the marker is found mid-line, `str.partition(marker)` extracts any real stdout that precedes it before parsing the exit code from the suffix.

**Change:** one conditional in `_collect_output()` in `libs/langchain_v1/langchain/agents/middleware/shell_tool.py`.

**Tests added** in `libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py`:
- `test_command_output_without_trailing_newline` — `printf 'text'` returns output without timing out
- `test_command_output_without_trailing_newline_exit_code` — exit code is correctly parsed when marker is mid-line

## How I verified it works

Ran the logic against all four cases manually:
- Normal line with trailing newline + marker at start ✅
- Output + marker on same line (the bug case) ✅
- Non-zero exit code with mid-line marker ✅
- Confirmed old `startswith()` returns `False` for the bug case ✅