### PR TITLE
core: fix "comparators" -> "operators" in Visitor._validate_func error message

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
## Summary

`Visitor._validate_func` in `libs/core/langchain_core/structured_query.py` has two branches — one for `Operator`, one for `Comparator`. The error messages were originally copy-pasted and the operator branch still says *comparators*:

```python
msg = (
    f"Received disallowed operator {func}. Allowed "
    f"comparators are {self.allowed_operators}"   # wrong noun
)
```

So when a custom visitor restricts operators and an unsupported one is passed, the raised `ValueError` reads like this:

```
ValueError: Received disallowed operator Operator.OR. Allowed comparators are (Operator.AND,)
```

…which is self-contradictory (two different nouns for the same thing) and confusing to anyone implementing a custom `Visitor`.

One-word fix: `comparators` → `operators` on L32. The `Comparator` branch a few lines below is already correct.

Fixes #36701

## Test plan

- [x] Single-word edit, no behavior change
- [x] The `Comparator` branch (L41) unchanged — still says "comparators" as it should
- [ ] Existing tests in `libs/core/tests/unit_tests/` for `structured_query` continue to pass (CI will verify)

## Base branch

Targeting `master` — happy to retarget if maintainers prefer a different base.