### PR TITLE
fix(core): parse_partial_json escapes raw \r and \t inside strings (#36747)

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -84,9 +84,11 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
             if char == '"' and not escaped:
                 is_inside_string = False
             elif char == "\n" and not escaped:
-                new_char = (
-                    "\\n"  # Replace the newline character with the escape sequence.
-                )
+                new_char = "\\n"  # newline must be escaped inside JSON strings
+            elif char == "\r" and not escaped:
+                new_char = "\\r"  # carriage return must be escaped inside JSON strings
+            elif char == "\t" and not escaped:
+                new_char = "\\t"  # tab must be escaped inside JSON strings
             elif char == "\\":
                 escaped = not escaped
             else:

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -254,6 +254,14 @@ TEST_CASES_PARTIAL = [
     ('{"foo": "bar", "bar"', '{"foo": "bar"}'),
     ('{"foo": "bar", ', '{"foo": "bar"}'),
     ('{"foo":"bar\\', '{"foo": "bar"}'),
+    # Raw newline inside string value — already handled historically.
+    ('{"key": "line1\nline2"}', '{"key": "line1\\nline2"}'),
+    # Raw carriage return — regression guard for #36747.
+    ('{"key": "line1\rline2"}', '{"key": "line1\\rline2"}'),
+    # Raw tab — regression guard for #36747.
+    ('{"key": "col1\tcol2"}', '{"key": "col1\\tcol2"}'),
+    # Mixed raw control chars in a single string value.
+    ('{"k": "a\nb\rc\td"}', '{"k": "a\\nb\\rc\\td"}'),
 ]
 
 


### PR DESCRIPTION
## Why

Closes #36747.

`parse_partial_json` already escapes raw `\n` inside JSON string values (required by RFC 8259 — unescaped control chars are illegal in JSON strings). But `\r` and `\t` were not handled, so model outputs containing those raw control chars would crash the parser with `json.JSONDecodeError: Invalid control character`.

Repro from the issue:

```python
>>> parse_partial_json('{"key": "col1\tcol2"}')
# raises json.JSONDecodeError
```

## What

Two more elif branches in the inner character loop, mirroring the existing `\n` handler:

```python
elif char == "\r" and not escaped:
    new_char = "\\r"
elif char == "\t" and not escaped:
    new_char = "\\t"
```

The sibling helper `_replace_new_line` already handles all three in the non-streaming path (line 25-27), so this just brings the streaming parser up to the same behavior.

## Tests

4 new parametrized cases in `TEST_CASES_PARTIAL`:

```python
('{"key": "line1\nline2"}', '{"key": "line1\\nline2"}'),   # pre-existing behavior, now explicit
('{"key": "line1\rline2"}', '{"key": "line1\\rline2"}'),   # #36747 regression guard
('{"key": "col1\tcol2"}', '{"key": "col1\\tcol2"}'),       # #36747 regression guard
('{"k": "a\nb\rc\td"}', '{"k": "a\\nb\\rc\\td"}'),         # mixed
```

```
$ pytest libs/core/tests/unit_tests/output_parsers/test_json.py -k parse_partial -v
13 passed
```

## Scope

Minimal behavior change. No public API change. Doesn't affect any other JSON parsing path — only the character-by-character recovery loop inside `parse_partial_json`.

## Related

- Closes #36747
- Aligns with `_replace_new_line` helper (same file) which already handles all three control chars