### PR TITLE
Feature/Bug: Implement missing Language.PERL separators and fix InMemoryCache maxsize update bug

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -226,7 +226,11 @@ class InMemoryCache(BaseCache):
 
                 The value is a list of `Generation` (or subclasses).
         """
-        if self._maxsize is not None and len(self._cache) == self._maxsize:
+        if (
+            self._maxsize is not None
+            and len(self._cache) >= self._maxsize
+            and (prompt, llm_string) not in self._cache
+        ):
             del self._cache[next(iter(self._cache))]
         self._cache[prompt, llm_string] = return_val
 

--- a/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
+++ b/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
@@ -69,6 +69,36 @@ def test_update_with_maxsize() -> None:
     assert cache.lookup(prompt3, llm_string3) == generations3
 
 
+def test_update_existing_key_does_not_evict() -> None:
+    """Updating an existing key must not evict any other entry.
+
+    Regression test: the old implementation checked ``len == maxsize`` before
+    evicting, so re-writing an existing key that was *not* the insertion-order
+    first entry would incorrectly evict that first entry and leave the cache
+    one slot under capacity.
+    """
+    cache = InMemoryCache(maxsize=2)
+
+    prompt1, llm_string1, generations1 = cache_item(1)
+    prompt2, llm_string2, generations2 = cache_item(2)
+    cache.update(prompt1, llm_string1, generations1)
+    cache.update(prompt2, llm_string2, generations2)
+
+    # Both entries are present; cache is at capacity.
+    assert cache.lookup(prompt1, llm_string1) == generations1
+    assert cache.lookup(prompt2, llm_string2) == generations2
+
+    # Update the *second* (non-first) key. With the old code this would evict
+    # prompt1 (insertion-order first) even though it was not the key being
+    # replaced, leaving the cache with only 1 entry.
+    new_generations2 = [*generations2]
+    cache.update(prompt2, llm_string2, new_generations2)
+
+    # Both keys must still be present; no entry should have been evicted.
+    assert cache.lookup(prompt1, llm_string1) == generations1
+    assert cache.lookup(prompt2, llm_string2) == new_generations2
+
+
 def test_clear(cache: InMemoryCache) -> None:
     """Test the clear method of InMemoryCache."""
     prompt, llm_string, generations = cache_item(1)

--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -794,6 +794,32 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "",
             ]
 
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "\nsub ",
+                # Split along package declarations
+                "\npackage ",
+                # Split along use/require statements
+                "\nuse ",
+                "\nrequire ",
+                # Split along control flow statements
+                "\nif ",
+                "\nunless ",
+                "\nwhile ",
+                "\nuntil ",
+                "\nfor ",
+                "\nforeach ",
+                "\ndo ",
+                # Split along eval blocks
+                "\neval ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
+
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"
             raise ValueError(msg)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1173,6 +1173,36 @@ if (TRUE) {
     ]
 
 
+def test_perl_code_splitter() -> None:
+    splitter = RecursiveCharacterTextSplitter.from_language(
+        Language.PERL, chunk_size=CHUNK_SIZE, chunk_overlap=0
+    )
+    code = """
+package HelloWorld;
+
+use strict;
+use warnings;
+
+sub hello {
+    print "Hello, World!\\n";
+}
+
+hello();
+    """
+    chunks = splitter.split_text(code)
+    assert chunks == [
+        "package",
+        "HelloWorld;",
+        "use strict;",
+        "use warnings;",
+        "sub hello {",
+        'print "Hello,',
+        'World!\\n";',
+        "}",
+        "hello();",
+    ]
+
+
 def test_markdown_code_splitter() -> None:
     splitter = RecursiveCharacterTextSplitter.from_language(
         Language.MARKDOWN, chunk_size=CHUNK_SIZE, chunk_overlap=0


### PR DESCRIPTION
Fixes #36750

### Description
This PR addresses two separate issues:
1. **Missing `Language.PERL` implementation**: `Language.PERL` was defined in the `Language` enum but had no separators in `get_separators_for_language`, causing it to throw a `ValueError` when used. This PR adds the correct perl-specific separators (`sub`, `package`, `use`, `require`, `eval`, and control flow words) along with a unit test.
2. **`InMemoryCache.update` eviction bug**: When `InMemoryCache` reaches `maxsize` and you update an entry that *already exists* in the cache, the old code incorrectly evicted the first entry in the dictionary. It now specifically checks `(prompt, llm_string) not in self._cache` before triggering an eviction. We also added a regression test to prevent this bug in the future.
