### PR TITLE
Fix #30870: `llm.ainvoke` is traced differently than `llm.invoke` (...

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -251,6 +251,35 @@ def shielded(func: Func) -> Func:
     return cast("Func", wrapped)
 
 
+async def _wrap_chat_model_start_coro(
+    coro: Coroutine[Any, Any, Any],
+    handler: BaseCallbackHandler,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> None:
+    """Await *coro* and, on ``NotImplementedError``, fall back to ``on_llm_start``.
+
+    This mirrors the fallback logic in :func:`_ahandle_event_for_handler` so
+    that async callback handlers whose ``on_chat_model_start`` raises
+    ``NotImplementedError`` are correctly routed to ``on_llm_start`` even when
+    invoked from the **sync** :func:`handle_event` path (which collects
+    coroutines and runs them via :func:`_run_coros`).
+    """
+    try:
+        await coro
+    except NotImplementedError:
+        message_strings = [get_buffer_string(m) for m in args[1]]
+        await _ahandle_event_for_handler(
+            handler,
+            "on_llm_start",
+            "ignore_llm",
+            args[0],
+            message_strings,
+            *args[2:],
+            **kwargs,
+        )
+
+
 def handle_event(
     handlers: list[BaseCallbackHandler],
     event_name: str,
@@ -280,7 +309,18 @@ def handle_event(
                 ):
                     event = getattr(handler, event_name)(*args, **kwargs)
                     if asyncio.iscoroutine(event):
-                        coros.append(event)
+                        if event_name == "on_chat_model_start":
+                            # Wrap the coroutine so that NotImplementedError
+                            # raised *inside* the async handler falls back to
+                            # on_llm_start, mirroring the behaviour of
+                            # _ahandle_event_for_handler.
+                            coros.append(
+                                _wrap_chat_model_start_coro(
+                                    event, handler, args, kwargs
+                                )
+                            )
+                        else:
+                            coros.append(event)
             except NotImplementedError as e:
                 if event_name == "on_chat_model_start":
                     if message_strings is None:

--- a/libs/core/tests/unit_tests/callbacks/test_handle_event.py
+++ b/libs/core/tests/unit_tests/callbacks/test_handle_event.py
@@ -5,10 +5,11 @@ Handlers must declare `serialized` and `messages` as explicit positional args
 (not *args) — see on_chat_model_start docstring for details.
 
 See: https://github.com/langchain-ai/langchain/issues/31576
+See: https://github.com/langchain-ai/langchain/issues/30870
 """
 
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -132,3 +133,52 @@ async def test_ahandle_event_other_event_not_implemented_logs_warning() -> None:
         {"name": "test"},
         ["prompt"],
     )
+
+
+class _AsyncFallbackChatHandler(BaseCallbackHandler):
+    """Async handler whose on_chat_model_start raises NotImplementedError.
+
+    This simulates an AsyncBaseTracer-derived handler that does not override
+    on_chat_model_start.  When used with the *sync* handle_event path
+    (llm.invoke), the coroutine is collected and run later — the
+    NotImplementedError must still trigger the on_llm_start fallback.
+
+    See: https://github.com/langchain-ai/langchain/issues/30870
+    """
+
+    async def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        **kwargs: Any,
+    ) -> None:
+        raise NotImplementedError
+
+    async def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+def test_handle_event_async_handler_chat_model_start_fallback() -> None:
+    """Sync handle_event with async handler: on_chat_model_start raises
+    NotImplementedError inside the coroutine → falls back to on_llm_start.
+
+    This is the exact scenario from issue #30870 where llm.invoke (sync) with
+    an async callback handler would fail to trace because the
+    NotImplementedError was raised when the coroutine was awaited, not when it
+    was created, so the sync fallback logic never caught it.
+    """
+    handler = _AsyncFallbackChatHandler()
+    handler.on_llm_start = AsyncMock()  # type: ignore[method-assign]
+
+    serialized = {"name": "test"}
+    messages = [[HumanMessage(content="hello")]]
+
+    handle_event(
+        [handler],
+        "on_chat_model_start",
+        "ignore_chat_model",
+        serialized,
+        messages,
+    )
+
+    handler.on_llm_start.assert_called_once()


### PR DESCRIPTION
## Summary
When an async callback handler's `on_chat_model_start` raises `NotImplementedError`, the sync `handle_event` path (used by `llm.invoke`) collects the coroutine and runs it later — but the `NotImplementedError` is only raised at `await` time, so the existing sync-side `except NotImplementedError` block never catches it. This means async handlers that rely on the `on_llm_start` fallback (e.g. `AsyncBaseTracer` subclasses) silently fail to trace when called through the sync path.

## Changes
- Add `_wrap_chat_model_start_coro` in `manager.py` that wraps async `on_chat_model_start` coroutines with a `try/except NotImplementedError` and falls back to `on_llm_start` via `_ahandle_event_for_handler`, mirroring what the fully-async `ahandle_event` path already does
- In `handle_event`, apply this wrapper when collecting coroutines for the `on_chat_model_start` event
- Add a unit test with an async handler whose `on_chat_model_start` raises `NotImplementedError`, verifying the `on_llm_start` fallback is called when going through the sync `handle_event` path

## Testing
```bash
cd libs/core
uv sync --group test
uv run pytest tests/unit_tests/callbacks/test_handle_event.py -v
```

Existing tests continue to pass, confirming the sync handler fallback is unaffected.

Closes #30870