### PR TITLE
fix(mistralai): add retry handling and enforce concurrency limits for API calls

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -99,12 +99,33 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
     return default.copy()
 
 
+def _is_retryable_error(exception: BaseException) -> bool:
+    """Determine if an exception is transient and warrants a retry.
+
+    Retries on network-layer errors, rate-limit responses (429), and
+    server-side errors (5xx).  Permanent client errors (4xx other than
+    429) are not retried to avoid wasting quota.
+    """
+    if isinstance(exception, (httpx.RequestError, httpx.StreamError)):
+        # Network / connection / timeout failures — always transient.
+        if isinstance(exception, httpx.HTTPStatusError):
+            # RequestError can only be HTTPStatusError when the response has
+            # a status code, so gate on that.
+            status_code = exception.response.status_code
+            return status_code == 429 or status_code >= 500
+        return True
+    if isinstance(exception, httpx.HTTPStatusError):
+        status_code = exception.response.status_code
+        return status_code == 429 or status_code >= 500
+    return False
+
+
 def _create_retry_decorator(
     llm: ChatMistralAI,
     run_manager: AsyncCallbackManagerForLLMRun | CallbackManagerForLLMRun | None = None,
 ) -> Callable[[Any], Any]:
     """Return a tenacity retry decorator, preconfigured to handle exceptions."""
-    errors = [httpx.RequestError, httpx.StreamError]
+    errors = [httpx.RequestError, httpx.StreamError, httpx.HTTPStatusError]
     return create_base_retry_decorator(
         error_types=errors, max_retries=llm.max_retries, run_manager=run_manager
     )
@@ -605,13 +626,21 @@ class ChatMistralAI(BaseChatModel):
         else:
             api_key_str = self.mistral_api_key
 
-        # TODO: handle retries
         base_url_str = (
             self.endpoint
             or os.environ.get("MISTRAL_BASE_URL")
             or "https://api.mistral.ai/v1"
         )
         self.endpoint = base_url_str
+
+        # Bound the connection pool to max_concurrent_requests so that callers
+        # cannot inadvertently open an unbounded number of simultaneous TCP
+        # connections to the Mistral API.  Retries are handled at the call-site
+        # via completion_with_retry / acompletion_with_retry (tenacity).
+        limits = httpx.Limits(
+            max_connections=self.max_concurrent_requests,
+            max_keepalive_connections=self.max_concurrent_requests,
+        )
         if not self.client:
             self.client = httpx.Client(
                 base_url=base_url_str,
@@ -622,8 +651,8 @@ class ChatMistralAI(BaseChatModel):
                 },
                 timeout=self.timeout,
                 verify=global_ssl_context,
+                limits=limits,
             )
-        # TODO: handle retries and max_concurrency
         if not self.async_client:
             self.async_client = httpx.AsyncClient(
                 base_url=base_url_str,
@@ -634,6 +663,7 @@ class ChatMistralAI(BaseChatModel):
                 },
                 timeout=self.timeout,
                 verify=global_ssl_context,
+                limits=limits,
             )
 
         if self.temperature is not None and not 0 <= self.temperature <= 1:

--- a/libs/partners/mistralai/langchain_mistralai/embeddings.py
+++ b/libs/partners/mistralai/langchain_mistralai/embeddings.py
@@ -178,7 +178,15 @@ class MistralAIEmbeddings(BaseModel, Embeddings):
     def validate_environment(self) -> Self:
         """Validate configuration."""
         api_key_str = self.mistral_api_key.get_secret_value()
-        # TODO: handle retries
+
+        # Bound the connection pool to max_concurrent_requests so that callers
+        # cannot inadvertently open an unbounded number of simultaneous TCP
+        # connections to the Mistral API.  Retries are handled at the call-site
+        # via the _retry decorator (tenacity).
+        limits = httpx.Limits(
+            max_connections=self.max_concurrent_requests,
+            max_keepalive_connections=self.max_concurrent_requests,
+        )
         if not self.client:
             self.client = httpx.Client(
                 base_url=self.endpoint,
@@ -188,8 +196,8 @@ class MistralAIEmbeddings(BaseModel, Embeddings):
                     "Authorization": f"Bearer {api_key_str}",
                 },
                 timeout=self.timeout,
+                limits=limits,
             )
-        # TODO: handle retries and max_concurrency
         if not self.async_client:
             self.async_client = httpx.AsyncClient(
                 base_url=self.endpoint,
@@ -199,6 +207,7 @@ class MistralAIEmbeddings(BaseModel, Embeddings):
                     "Authorization": f"Bearer {api_key_str}",
                 },
                 timeout=self.timeout,
+                limits=limits,
             )
         if self.tokenizer is None:
             try:
@@ -296,16 +305,22 @@ class MistralAIEmbeddings(BaseModel, Embeddings):
             List of embeddings, one for each text.
         """
         try:
+            # Use a semaphore to cap the number of in-flight requests to
+            # max_concurrent_requests.  asyncio.gather would otherwise fire all
+            # batch coroutines simultaneously, ignoring the connection-pool
+            # limit set on the underlying httpx client.
+            semaphore = asyncio.Semaphore(self.max_concurrent_requests)
 
             @self._retry
             async def _aembed_batch(batch: list[str]) -> Response:
-                response = await self.async_client.post(
-                    url="/embeddings",
-                    json={
-                        "model": self.model,
-                        "input": batch,
-                    },
-                )
+                async with semaphore:
+                    response = await self.async_client.post(
+                        url="/embeddings",
+                        json={
+                            "model": self.model,
+                            "input": batch,
+                        },
+                    )
                 response.raise_for_status()
                 return response
 

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -407,3 +407,62 @@ def test_no_duplicate_tool_calls_when_multiple_tools() -> None:
 def test_profile() -> None:
     model = ChatMistralAI(model="mistral-large-latest")  # type: ignore[call-arg]
     assert model.profile
+
+
+def test_max_concurrent_requests_wired_to_httpx_limits() -> None:
+    """Verify max_concurrent_requests is forwarded to the httpx connection pool."""
+    chat = ChatMistralAI(max_concurrent_requests=7)  # type: ignore[call-arg]
+    # httpx.Client does not expose .limits publicly; the chosen value is
+    # visible on the underlying httpcore connection pool.
+    assert chat.client._transport._pool._max_connections == 7
+    assert chat.client._transport._pool._max_keepalive_connections == 7
+    assert chat.async_client._transport._pool._max_connections == 7
+    assert chat.async_client._transport._pool._max_keepalive_connections == 7
+
+
+def test_is_retryable_error_rate_limit() -> None:
+    """429 responses must be retried; 400 must not."""
+    from langchain_mistralai.chat_models import _is_retryable_error
+
+    rate_limit_response = MagicMock()
+    rate_limit_response.status_code = 429
+    rate_limit_exc = httpx.HTTPStatusError(
+        "rate limited", request=MagicMock(), response=rate_limit_response
+    )
+    assert _is_retryable_error(rate_limit_exc) is True
+
+    bad_request_response = MagicMock()
+    bad_request_response.status_code = 400
+    bad_request_exc = httpx.HTTPStatusError(
+        "bad request", request=MagicMock(), response=bad_request_response
+    )
+    assert _is_retryable_error(bad_request_exc) is False
+
+
+def test_is_retryable_error_server_errors() -> None:
+    """5xx server errors must be retried."""
+    from langchain_mistralai.chat_models import _is_retryable_error
+
+    for status_code in [500, 502, 503, 504]:
+        response = MagicMock()
+        response.status_code = status_code
+        exc = httpx.HTTPStatusError(
+            "server error", request=MagicMock(), response=response
+        )
+        assert _is_retryable_error(exc) is True
+
+
+def test_is_retryable_error_network_error() -> None:
+    """Raw network/connection errors (no status code) must be retried."""
+    from langchain_mistralai.chat_models import _is_retryable_error
+
+    exc = httpx.RequestError("connection reset", request=MagicMock())
+    assert _is_retryable_error(exc) is True
+
+
+def test_is_retryable_error_non_retryable() -> None:
+    """Arbitrary exceptions that are not httpx errors must not be retried."""
+    from langchain_mistralai.chat_models import _is_retryable_error
+
+    assert _is_retryable_error(ValueError("oops")) is False
+    assert _is_retryable_error(RuntimeError("oops")) is False

--- a/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
@@ -78,3 +78,53 @@ def test_dummy_tokenizer() -> None:
     tokenizer = DummyTokenizer()
     result = tokenizer.encode_batch(["hello", "world"])
     assert result == [["h", "e", "l", "l", "o"], ["w", "o", "r", "l", "d"]]
+
+
+def test_max_concurrent_requests_wired_to_httpx_limits() -> None:
+    """Verify max_concurrent_requests is forwarded to the httpx connection pool."""
+    embed = MistralAIEmbeddings(max_concurrent_requests=4)  # type: ignore[call-arg]
+    # httpx.Client does not expose .limits publicly; the chosen value is
+    # visible on the underlying httpcore connection pool.
+    assert embed.client._transport._pool._max_connections == 4
+    assert embed.client._transport._pool._max_keepalive_connections == 4
+    assert embed.async_client._transport._pool._max_connections == 4
+    assert embed.async_client._transport._pool._max_keepalive_connections == 4
+
+
+def test_aembed_documents_respects_max_concurrency() -> None:
+    """Semaphore in aembed_documents must cap concurrent HTTP calls."""
+    import asyncio
+    from unittest.mock import AsyncMock, patch
+
+    # Observe the peak concurrency during parallel batch calls.
+    peak_concurrency: list[int] = [0]
+    active: list[int] = [0]
+
+    async def _fake_post(*args: object, **kwargs: object) -> MagicMock:
+        active[0] += 1
+        peak_concurrency[0] = max(peak_concurrency[0], active[0])
+        await asyncio.sleep(0)  # yield to event loop
+        active[0] -= 1
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "data": [{"embedding": [0.1, 0.2, 0.3]}]
+        }
+        return response
+
+    embed = MistralAIEmbeddings(max_concurrent_requests=2, max_retries=None)  # type: ignore[call-arg]
+
+    # Replace DummyTokenizer so each text is its own batch (1 token each).
+    embed.tokenizer = DummyTokenizer()
+    # Patch the async client post method
+    embed.async_client.post = AsyncMock(side_effect=_fake_post)  # type: ignore[method-assign]
+
+    # 5 texts => 5 batches (each 1 char via DummyTokenizer, well under 16k limit)
+    texts = ["a", "b", "c", "d", "e"]
+    asyncio.run(embed.aembed_documents(texts))
+
+    # Peak concurrency must not exceed max_concurrent_requests.
+    assert peak_concurrency[0] <= 2, (
+        f"Expected max 2 concurrent requests but saw {peak_concurrency[0]}"
+    )


### PR DESCRIPTION
Improves retry handling and enforces concurrency limits in the Mistral integration to improve reliability of API calls.

Related to #36753