### PR TITLE
Fix typo in Visitor._validate_func error message for operators

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
## Description

In `Visitor._validate_func` (`libs/core/langchain_core/structured_query.py`), when validating an `Operator` against `allowed_operators`, the error message incorrectly says:

> "Allowed **comparators** are ..."

It should say:

> "Allowed **operators** are ..."

This is a copy-paste typo — the message was copied from the Comparator validation branch below but the word "comparators" was not updated to "operators".

## Fix

**1 line changed:** `comparators` → `operators` on line 32 of `structured_query.py`

## Related Issue

Fixes #36701

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)