### PR TITLE
fix(core): escape all JSON control characters in `parse_partial_json`

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -54,6 +54,8 @@ def _custom_parser(multiline_string: str | bytes | bytearray) -> str:
 # Adapted from https://github.com/KillianLucas/open-interpreter/blob/5b6080fae1f8c68938a1e4fa8667e3744084ee21/interpreter/utils/parse_partial_json.py
 # MIT License
 
+_MAX_JSON_CONTROL_CHAR = 0x20  # U+0000 through U+001F must be escaped per RFC 8259
+
 
 def parse_partial_json(s: str, *, strict: bool = False) -> Any:
     """Parse a JSON string that may be missing closing braces.
@@ -84,9 +86,17 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
             if char == '"' and not escaped:
                 is_inside_string = False
             elif char == "\n" and not escaped:
-                new_char = (
-                    "\\n"  # Replace the newline character with the escape sequence.
-                )
+                new_char = "\\n"
+            elif char == "\r" and not escaped:
+                new_char = "\\r"
+            elif char == "\t" and not escaped:
+                new_char = "\\t"
+            elif char == "\b" and not escaped:
+                new_char = "\\b"
+            elif char == "\f" and not escaped:
+                new_char = "\\f"
+            elif ord(char) < _MAX_JSON_CONTROL_CHAR and not escaped:
+                new_char = f"\\u{ord(char):04x}"
             elif char == "\\":
                 escaped = not escaped
             else:

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -254,6 +254,12 @@ TEST_CASES_PARTIAL = [
     ('{"foo": "bar", "bar"', '{"foo": "bar"}'),
     ('{"foo": "bar", ', '{"foo": "bar"}'),
     ('{"foo":"bar\\', '{"foo": "bar"}'),
+    ('{"key": "line1\rline2"}', '{"key": "line1\\rline2"}'),
+    ('{"key": "col1\tcol2"}', '{"key": "col1\\tcol2"}'),
+    ('{"key": "a\r\n\tb"}', '{"key": "a\\r\\n\\tb"}'),
+    ('{"key": "back\bspace"}', '{"key": "back\\bspace"}'),
+    ('{"key": "form\ffeed"}', '{"key": "form\\ffeed"}'),
+    ('{"key": "null\x00char"}', '{"key": "null\\u0000char"}'),
 ]
 
 


### PR DESCRIPTION
## Description

Fixes #36747

`parse_partial_json` only escaped raw `\n` inside JSON strings but not other control characters that are illegal per RFC 8259 (U+0000 through U+001F). LLMs can emit raw `\r`, `\t`, `\b`, `\f`, and other control characters in their output, causing `json.JSONDecodeError`.

### Changes

- **`langchain_core/utils/json.py`**: Added escaping for `\r`, `\t`, `\b`, `\f`, and a catch-all for remaining control characters using `\uXXXX` encoding
- **`tests/unit_tests/output_parsers/test_json.py`**: Added 6 test cases covering `\r`, `\t`, `\b`, `\f`, null char, and mixed control characters

### Before
```python
parse_partial_json('{"key": "line1\rline2"}')
# raises json.JSONDecodeError: Invalid control character
```

### After
```python
parse_partial_json('{"key": "line1\rline2"}')
# {'key': 'line1\rline2'}
```