### PR TITLE
fix(core): raise ValueError in InMemoryVectorStore on embedding count…

### DIFF
--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -194,6 +194,13 @@ class InMemoryVectorStore(VectorStore):
         texts = [doc.page_content for doc in documents]
         vectors = self.embedding.embed_documents(texts)
 
+        if len(documents) != len(vectors):
+            msg = (
+                f"Mismatched counts: {len(documents)} documents but "
+                f"{len(vectors)} embeddings returned."
+            )
+            raise ValueError(msg)
+
         if ids and len(ids) != len(texts):
             msg = (
                 f"ids must be the same length as texts. "
@@ -226,6 +233,13 @@ class InMemoryVectorStore(VectorStore):
     ) -> list[str]:
         texts = [doc.page_content for doc in documents]
         vectors = await self.embedding.aembed_documents(texts)
+
+        if len(documents) != len(vectors):
+            msg = (
+                f"Mismatched counts: {len(documents)} documents but "
+                f"{len(vectors)} embeddings returned."
+            )
+            raise ValueError(msg)
 
         if ids and len(ids) != len(texts):
             msg = (

--- a/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
@@ -209,8 +209,10 @@ async def test_inmemory_get_by_ids() -> None:
 async def test_inmemory_call_embeddings_async() -> None:
     embeddings_mock = Mock(
         wraps=DeterministicFakeEmbedding(size=3),
-        aembed_documents=AsyncMock(),
-        aembed_query=AsyncMock(),
+        aembed_documents=AsyncMock(
+            return_value=[[0.1, 0.2, 0.3], [0.1, 0.2, 0.3], [0.1, 0.2, 0.3]]
+        ),
+        aembed_query=AsyncMock(return_value=[0.1, 0.2, 0.3]),
     )
     store = InMemoryVectorStore(embedding=embeddings_mock)
 


### PR DESCRIPTION
### Problem
Currently, `InMemoryVectorStore` suffers from a silent data loss bug. If an embedding provider (or a custom implementation) returns a different number of vectors than the provided documents, the internal `zip(documents, vectors, strict=False)` operation silently truncates the output. Documents are dropped without raising any errors, corrupting the downstream agent's context.

### Solution
This PR introduces explicit length validation to intercept mismatches before the database processes them.

**Key Changes:**
* **`in_memory.py`:** Added strict length validation in both `add_documents` and `aadd_documents`. If `len(documents) != len(vectors)`, it now immediately raises a descriptive `ValueError`.
* **`test_in_memory.py`:** Updated `test_inmemory_call_embeddings_async`. The new strict validation successfully caught an unconfigured `AsyncMock` in the test suite, so the mock was updated to return the correct number of dummy vectors to match the document count.

Fixes #36745