### PR TITLE
fix(core): raise ValueError on embedding count mismatch in InMemoryVectorStore

### DIFF
--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -207,7 +207,7 @@ class InMemoryVectorStore(VectorStore):
 
         ids_ = []
 
-        for doc, vector in zip(documents, vectors, strict=False):
+        for doc, vector in zip(documents, vectors, strict=True):
             doc_id = next(id_iterator)
             doc_id_ = doc_id or str(uuid.uuid4())
             ids_.append(doc_id_)
@@ -239,7 +239,7 @@ class InMemoryVectorStore(VectorStore):
         )
         ids_: list[str] = []
 
-        for doc, vector in zip(documents, vectors, strict=False):
+        for doc, vector in zip(documents, vectors, strict=True):
             doc_id = next(id_iterator)
             doc_id_ = doc_id or str(uuid.uuid4())
             ids_.append(doc_id_)


### PR DESCRIPTION
## Summary

Previously, `InMemoryVectorStore.add_documents` and `aadd_documents` used `zip(documents, vectors, strict=False)`, which silently truncated documents when the embedding model returned fewer vectors than documents. This could lead to silent data loss.

Changed to `strict=True` so that a `ValueError` is raised immediately on mismatch, making debugging easier and preventing silent data loss.

Fixes #36745

## Test plan

Tested with a custom Embeddings class that returns fewer vectors than documents:

```python
class BrokenEmbeddings(Embeddings):
    def embed_documents(self, texts):
        return [[0.1, 0.2, 0.3] for _ in texts[:-1]]
    def embed_query(self, text):
        return [0.1, 0.2, 0.3]

store = InMemoryVectorStore(embedding=BrokenEmbeddings())
docs = [Document(page_content="first"), Document(page_content="second"), Document(page_content="third")]
# Previously: silently returned 2 ids. Now: raises ValueError
store.add_documents(docs)
```

- [x] Change is backward compatible (only affects broken usage that was already silently losing data)
- [x] Existing tests pass
- [x] Fix applies to both sync `add_documents` and async `aadd_documents`