### PR TITLE
fix(infra): skip codspeed for partners without benchmarks

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -316,8 +316,13 @@ if __name__ == "__main__":
                 if not filename.startswith(".")
             ] != ["README.md"]:
                 dirs_to_run["test"].add(f"libs/partners/{partner_dir}")
-                # Skip codspeed for partners without benchmarks or in IGNORED_PARTNERS
-                if partner_dir not in IGNORED_PARTNERS:
+                # Only add to codspeed if the partner has benchmarks and is not ignored
+                if (
+                    partner_dir not in IGNORED_PARTNERS
+                    and os.path.isdir(
+                        f"libs/partners/{partner_dir}/tests/benchmarks"
+                    )
+                ):
                     dirs_to_run["codspeed"].add(f"libs/partners/{partner_dir}")
             # Skip if the directory was deleted or is just a tombstone readme
         elif file.startswith("libs/"):

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -77,7 +77,5 @@ jobs:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |
             cd ${{ matrix.job-configs.working-directory }}
-            if [ "${{ matrix.job-configs.working-directory }}" = "libs/core" ] || [ "${{ matrix.job-configs.working-directory }}" = "libs/langchain_v1" ]; then
-              uv run --no-sync pytest ./tests/benchmarks --codspeed
-            fi
+            uv run --no-sync pytest ./tests/benchmarks --codspeed
           mode: ${{ matrix.job-configs.codspeed-mode }}


### PR DESCRIPTION
The CodSpeed workflow was failing on partner PRs because `check_diff.py` added every partner to the `codspeed` matrix unconditionally — even when no `tests/benchmarks/` directory exists. The workflow then ran an empty shell block for those partners, CodSpeed saw zero benchmarks, and marked the check as failed.

Currently no partner package has benchmarks, so this affected every partner PR.