### PR TITLE
fix(langchain-classic): suppress mypy errors in compat code

### DIFF
--- a/libs/langchain/langchain_classic/agents/openai_assistant/base.py
+++ b/libs/langchain/langchain_classic/agents/openai_assistant/base.py
@@ -21,7 +21,9 @@ from typing_extensions import Self, override
 
 if TYPE_CHECKING:
     import openai
-    from openai.types.beta.threads import ThreadMessage  # type: ignore[attr-defined]
+    from openai.types.beta.threads import (  # type: ignore[attr-defined,unused-ignore]
+        ThreadMessage,
+    )
     from openai.types.beta.threads.required_action_function_tool_call import (
         RequiredActionFunctionToolCall,
     )
@@ -276,10 +278,10 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
             OpenAIAssistantRunnable configured to run using the created assistant.
         """
         client = client or _get_openai_client()
-        assistant = client.beta.assistants.create(  # type: ignore[deprecated]
+        assistant = client.beta.assistants.create(  # type: ignore[deprecated,unused-ignore]
             name=name,
             instructions=instructions,
-            tools=[_get_assistants_tool(tool) for tool in tools],  # type: ignore[misc]
+            tools=[_get_assistants_tool(tool) for tool in tools],  # type: ignore[misc,unused-ignore]
             model=model,
         )
         return cls(assistant_id=assistant.id, client=client, **kwargs)
@@ -409,10 +411,10 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
         """
         async_client = async_client or _get_openai_async_client()
         openai_tools = [_get_assistants_tool(tool) for tool in tools]
-        assistant = await async_client.beta.assistants.create(  # type: ignore[deprecated]
+        assistant = await async_client.beta.assistants.create(  # type: ignore[deprecated,unused-ignore]
             name=name,
             instructions=instructions,
-            tools=openai_tools,  # type: ignore[arg-type]
+            tools=openai_tools,  # type: ignore[arg-type,unused-ignore]
             model=model,
         )
         return cls(assistant_id=assistant.id, async_client=async_client, **kwargs)
@@ -617,7 +619,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
                     if version_gte_1_14
                     else isinstance(
                         content,
-                        openai.types.beta.threads.MessageContentText,  # type: ignore[attr-defined]
+                        openai.types.beta.threads.MessageContentText,  # type: ignore[attr-defined,unused-ignore]
                     )
                 )
                 for content in answer
@@ -771,7 +773,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
                     if version_gte_1_14
                     else isinstance(
                         content,
-                        openai.types.beta.threads.MessageContentText,  # type: ignore[attr-defined]
+                        openai.types.beta.threads.MessageContentText,  # type: ignore[attr-defined,unused-ignore]
                     )
                 )
                 for content in answer

--- a/libs/langchain/langchain_classic/agents/openai_assistant/base.py
+++ b/libs/langchain/langchain_classic/agents/openai_assistant/base.py
@@ -21,7 +21,7 @@ from typing_extensions import Self, override
 
 if TYPE_CHECKING:
     import openai
-    from openai.types.beta.threads import ThreadMessage
+    from openai.types.beta.threads import ThreadMessage  # type: ignore[attr-defined]
     from openai.types.beta.threads.required_action_function_tool_call import (
         RequiredActionFunctionToolCall,
     )
@@ -276,10 +276,10 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
             OpenAIAssistantRunnable configured to run using the created assistant.
         """
         client = client or _get_openai_client()
-        assistant = client.beta.assistants.create(
+        assistant = client.beta.assistants.create(  # type: ignore[deprecated]
             name=name,
             instructions=instructions,
-            tools=[_get_assistants_tool(tool) for tool in tools],
+            tools=[_get_assistants_tool(tool) for tool in tools],  # type: ignore[misc]
             model=model,
         )
         return cls(assistant_id=assistant.id, client=client, **kwargs)
@@ -409,10 +409,10 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
         """
         async_client = async_client or _get_openai_async_client()
         openai_tools = [_get_assistants_tool(tool) for tool in tools]
-        assistant = await async_client.beta.assistants.create(
+        assistant = await async_client.beta.assistants.create(  # type: ignore[deprecated]
             name=name,
             instructions=instructions,
-            tools=openai_tools,
+            tools=openai_tools,  # type: ignore[arg-type]
             model=model,
         )
         return cls(assistant_id=assistant.id, async_client=async_client, **kwargs)
@@ -617,7 +617,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
                     if version_gte_1_14
                     else isinstance(
                         content,
-                        openai.types.beta.threads.MessageContentText,
+                        openai.types.beta.threads.MessageContentText,  # type: ignore[attr-defined]
                     )
                 )
                 for content in answer
@@ -771,7 +771,7 @@ class OpenAIAssistantRunnable(RunnableSerializable[dict, OutputType]):
                     if version_gte_1_14
                     else isinstance(
                         content,
-                        openai.types.beta.threads.MessageContentText,
+                        openai.types.beta.threads.MessageContentText,  # type: ignore[attr-defined]
                     )
                 )
                 for content in answer

--- a/libs/langchain/langchain_classic/chains/moderation.py
+++ b/libs/langchain/langchain_classic/chains/moderation.py
@@ -69,7 +69,7 @@ class OpenAIModerationChain(Chain):
             except ValueError:
                 values["openai_pre_1_0"] = True
             if values["openai_pre_1_0"]:
-                values["client"] = openai.Moderation  # type: ignore[attr-defined]
+                values["client"] = openai.Moderation  # type: ignore[attr-defined,unused-ignore]
             else:
                 values["client"] = openai.OpenAI(api_key=openai_api_key)
                 values["async_client"] = openai.AsyncOpenAI(api_key=openai_api_key)

--- a/libs/langchain/langchain_classic/chains/moderation.py
+++ b/libs/langchain/langchain_classic/chains/moderation.py
@@ -69,7 +69,7 @@ class OpenAIModerationChain(Chain):
             except ValueError:
                 values["openai_pre_1_0"] = True
             if values["openai_pre_1_0"]:
-                values["client"] = openai.Moderation
+                values["client"] = openai.Moderation  # type: ignore[attr-defined]
             else:
                 values["client"] = openai.OpenAI(api_key=openai_api_key)
                 values["async_client"] = openai.AsyncOpenAI(api_key=openai_api_key)

--- a/libs/langchain/langchain_classic/evaluation/embedding_distance/base.py
+++ b/libs/langchain/langchain_classic/evaluation/embedding_distance/base.py
@@ -60,7 +60,7 @@ def _embedding_factory() -> Embeddings:
         from langchain_openai import OpenAIEmbeddings
     except ImportError:
         try:
-            from langchain_community.embeddings.openai import (  # type: ignore[no-redef]
+            from langchain_community.embeddings.openai import (  # type: ignore[no-redef,unused-ignore]
                 OpenAIEmbeddings,
             )
         except ImportError as e:
@@ -121,7 +121,7 @@ class _EmbeddingDistanceChainMixin(Chain):
             pass
 
         try:
-            from langchain_community.embeddings.openai import (  # type: ignore[no-redef]
+            from langchain_community.embeddings.openai import (  # type: ignore[no-redef,unused-ignore]
                 OpenAIEmbeddings,
             )
 

--- a/libs/langchain/langchain_classic/evaluation/embedding_distance/base.py
+++ b/libs/langchain/langchain_classic/evaluation/embedding_distance/base.py
@@ -60,7 +60,7 @@ def _embedding_factory() -> Embeddings:
         from langchain_openai import OpenAIEmbeddings
     except ImportError:
         try:
-            from langchain_community.embeddings.openai import (
+            from langchain_community.embeddings.openai import (  # type: ignore[no-redef]
                 OpenAIEmbeddings,
             )
         except ImportError as e:
@@ -121,7 +121,7 @@ class _EmbeddingDistanceChainMixin(Chain):
             pass
 
         try:
-            from langchain_community.embeddings.openai import (
+            from langchain_community.embeddings.openai import (  # type: ignore[no-redef]
                 OpenAIEmbeddings,
             )
 

--- a/libs/langchain/langchain_classic/evaluation/loading.py
+++ b/libs/langchain/langchain_classic/evaluation/loading.py
@@ -152,7 +152,7 @@ def load_evaluator(
                 from langchain_openai import ChatOpenAI
             except ImportError:
                 try:
-                    from langchain_community.chat_models.openai import (  # type: ignore[no-redef]
+                    from langchain_community.chat_models.openai import (  # type: ignore[no-redef,unused-ignore]
                         ChatOpenAI,
                     )
                 except ImportError as e:

--- a/libs/langchain/langchain_classic/evaluation/loading.py
+++ b/libs/langchain/langchain_classic/evaluation/loading.py
@@ -152,7 +152,7 @@ def load_evaluator(
                 from langchain_openai import ChatOpenAI
             except ImportError:
                 try:
-                    from langchain_community.chat_models.openai import (
+                    from langchain_community.chat_models.openai import (  # type: ignore[no-redef]
                         ChatOpenAI,
                     )
                 except ImportError as e:


### PR DESCRIPTION
Suppress 11 mypy errors in `langchain_classic` caused by OpenAI SDK version drift and fallback import patterns. These are all in legacy compatibility code. Underlying behavior is unchanged.
