### PR TITLE
fix(langchain): prepend newline before shell marker to fix detection when command output lacks trailing newline

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -228,7 +228,7 @@ class ShellSession:
             payload = command if command.endswith("\n") else f"{command}\n"
             try:
                 self._stdin.write(payload)
-                self._stdin.write(f"printf '{marker} %s\\n' $?\n")
+                self._stdin.write(f"printf '\\n{marker} %s\\n' $?\n")
                 self._stdin.flush()
             except (BrokenPipeError, OSError):
                 # The shell exited before we could write the marker command.

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -546,3 +546,36 @@ def test_get_or_create_resources_reuses_existing(tmp_path: Path) -> None:
 
     # Clean up
     resources1.finalizer()
+
+
+def test_command_output_without_trailing_newline(tmp_path: Path) -> None:
+    """Test that commands whose output lacks a trailing newline don't cause
+    the marker to stick to the output, which would make marker detection fail
+    and eventually time out the session.
+
+    Regression test for the marker-concatenation bug where:
+      printf 'hello' -> stdout: "hello__LC_SHELL_DONE__... 0"
+    caused startswith(marker) to fail.
+    """
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+
+        result = middleware._run_shell_tool(
+            resources, {"command": "printf 'hello'"}, tool_call_id=None
+        )
+        assert isinstance(result, str)
+        assert "hello" in result
+        assert "timed out" not in result.lower()
+
+        follow_up = middleware._run_shell_tool(
+            resources, {"command": "echo alive"}, tool_call_id=None
+        )
+        assert "alive" in follow_up
+    finally:
+        middleware.after_agent(state, runtime)


### PR DESCRIPTION
Fixes #36804 

When a command's output does not end with a trailing newline (e.g. `printf 'hello'`), the done-marker gets concatenated directly to the output (`hello__LC_SHELL_DONE__ 0`), causing `startswith(marker)` detection to fail and the session to time out. This fix prepends a `\n` before the marker so it always starts on a new line.

Added a regression test `test_command_output_without_trailing_newline` to cover this scenario.

**How I verified:**
- `make format`, `make lint`, `make test` all pass.
- The new unit test reproduces the original bug (fails without the fix, passes with it).
