### PR TITLE
fix(langchain): detect shell done-marker mid-line to prevent timeout

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -265,8 +265,22 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
-                _, _, status = data.partition(" ")
+            if source == "stdout" and marker in data:
+                # The marker may appear mid-line when the preceding command's
+                # output lacks a trailing newline (e.g. ``echo -n``).  Any text
+                # before the marker belongs to the command output.
+                marker_idx = data.index(marker)
+                if marker_idx > 0:
+                    prefix = data[:marker_idx]
+                    total_lines += 1
+                    total_bytes += len(prefix.encode("utf-8", "replace"))
+                    if total_lines <= self._policy.max_output_lines and (
+                        self._policy.max_output_bytes is None
+                        or total_bytes <= self._policy.max_output_bytes
+                    ):
+                        collected.append(prefix)
+                marker_tail = data[marker_idx + len(marker) :]
+                _, _, status = marker_tail.partition(" ")
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.
                 # The stderr reader thread runs independently, so output might

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -546,3 +546,31 @@ def test_get_or_create_resources_reuses_existing(tmp_path: Path) -> None:
 
     # Clean up
     resources1.finalizer()
+
+
+def test_command_without_trailing_newline(tmp_path: Path) -> None:
+    """Test that commands whose output lacks a trailing newline don't time out.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/36804.
+    When a command like ``echo -n`` omits the trailing newline, the done-marker
+    must still be detected on its own line.
+    """
+    policy = HostExecutionPolicy(command_timeout=5.0)
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=policy)
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+
+        result = middleware._run_shell_tool(
+            resources, {"command": 'echo -n "hello"'}, tool_call_id=None
+        )
+
+        assert isinstance(result, str)
+        assert "hello" in result
+        assert "timed out" not in result.lower()
+    finally:
+        middleware.after_agent(state, runtime)


### PR DESCRIPTION
## Summary

- Fixes `ShellSession.execute()` timing out when a command's output lacks a trailing newline (e.g. `echo -n`, `printf`, `cat` on files without final newline)
- Root cause: `startswith(marker)` fails when the marker is concatenated to the last output line; switched to `marker in data` with proper prefix extraction
- Adds regression test for the no-trailing-newline scenario

Fixes https://github.com/langchain-ai/langchain/issues/36804

Coordinated on the issue: https://github.com/langchain-ai/langchain/issues/36804#issuecomment-4257493182

No duplicate PRs found for this issue.

## Test plan

- [x] `make lint` passes (ruff format, ruff check, mypy)
- [x] All 29 existing shell tool unit tests pass
- [x] New `test_command_without_trailing_newline` test passes (would time out without the fix)

## AI Disclosure

AI assistance was used in developing this fix. All changes have been reviewed and validated by a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)