### PR TITLE
fix(core): block relative symlink escapes in deprecated prompt loaders

### DIFF
--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -45,6 +45,33 @@ def _validate_path(path: Path) -> None:
         raise ValueError(msg)
 
 
+def _resolve_path_within_working_directory(path: Path) -> Path:
+    """Resolve a relative path and reject symlink targets outside the cwd.
+
+    Args:
+        path: The relative path to resolve.
+
+    Returns:
+        The resolved path.
+
+    Raises:
+        ValueError: If the resolved path escapes the current working directory.
+    """
+    resolved_path = path.resolve()
+    cwd = Path.cwd().resolve()
+
+    if resolved_path != cwd and cwd not in resolved_path.parents:
+        msg = (
+            f"Path '{path}' resolves outside the current working directory. "
+            f"Symlink targets are not allowed to escape the working directory "
+            f"when loading prompt configurations. Use direct relative paths "
+            f"instead, or pass `allow_dangerous_paths=True` if you trust the input."
+        )
+        raise ValueError(msg)
+
+    return resolved_path
+
+
 @deprecated(
     since="1.2.21",
     removal="2.0.0",
@@ -96,9 +123,11 @@ def _load_template(
         template_path = Path(config.pop(f"{var_name}_path"))
         if not allow_dangerous_paths:
             _validate_path(template_path)
+            resolved_path = _resolve_path_within_working_directory(template_path)
+        else:
+            resolved_path = template_path.resolve()
         # Resolve symlinks before checking the suffix so that a symlink named
         # "exploit.txt" pointing to a non-.txt file is caught.
-        resolved_path = template_path.resolve()
         # Load the template.
         if resolved_path.suffix == ".txt":
             template = resolved_path.read_text(encoding="utf-8")
@@ -117,10 +146,13 @@ def _load_examples(config: dict, *, allow_dangerous_paths: bool = False) -> dict
         path = Path(config["examples"])
         if not allow_dangerous_paths:
             _validate_path(path)
-        with path.open(encoding="utf-8") as f:
-            if path.suffix == ".json":
+            resolved_path = _resolve_path_within_working_directory(path)
+        else:
+            resolved_path = path.resolve()
+        with resolved_path.open(encoding="utf-8") as f:
+            if resolved_path.suffix == ".json":
                 examples = json.load(f)
-            elif path.suffix in {".yaml", ".yml"}:
+            elif resolved_path.suffix in {".yaml", ".yml"}:
                 examples = yaml.safe_load(f)
             else:
                 msg = "Invalid file format. Only json or yaml formats are supported."
@@ -251,15 +283,20 @@ def _load_prompt_from_file(
     """Load prompt from file."""
     # Convert file to a Path object.
     file_path = Path(file)
+    if not allow_dangerous_paths and not file_path.is_absolute():
+        _validate_path(file_path)
+        resolved_path = _resolve_path_within_working_directory(file_path)
+    else:
+        resolved_path = file_path.resolve()
     # Load from either json or yaml.
-    if file_path.suffix == ".json":
-        with file_path.open(encoding=encoding) as f:
+    if resolved_path.suffix == ".json":
+        with resolved_path.open(encoding=encoding) as f:
             config = json.load(f)
-    elif file_path.suffix.endswith((".yaml", ".yml")):
-        with file_path.open(encoding=encoding) as f:
+    elif resolved_path.suffix.endswith((".yaml", ".yml")):
+        with resolved_path.open(encoding=encoding) as f:
             config = yaml.safe_load(f)
     else:
-        msg = f"Got unsupported file type {file_path.suffix}"
+        msg = f"Got unsupported file type {resolved_path.suffix}"
         raise ValueError(msg)
     # Load the prompt from the config now.
     return load_prompt_from_config(config, allow_dangerous_paths=allow_dangerous_paths)

--- a/libs/core/tests/unit_tests/prompts/test_loading.py
+++ b/libs/core/tests/unit_tests/prompts/test_loading.py
@@ -162,6 +162,75 @@ def test_load_examples_allows_dangerous_paths_when_opted_in(tmp_path: Path) -> N
     assert result["examples"] == [{"input": "a", "output": "b"}]
 
 
+def test_load_template_rejects_symlink_target_outside_working_directory(
+    tmp_path: Path,
+) -> None:
+    safe_dir = tmp_path / "safe"
+    outside_dir = tmp_path / "outside"
+    safe_dir.mkdir()
+    outside_dir.mkdir()
+    (outside_dir / "secret.txt").write_text("SECRET")
+    symlink = safe_dir / "template.txt"
+    symlink.symlink_to(outside_dir / "secret.txt")
+
+    with (
+        change_directory(safe_dir),
+        pytest.raises(
+            ValueError, match="resolves outside the current working directory"
+        ),
+    ):
+        _load_template("template", {"template_path": "template.txt"})
+
+
+def test_load_examples_rejects_symlink_target_outside_working_directory(
+    tmp_path: Path,
+) -> None:
+    safe_dir = tmp_path / "safe"
+    outside_dir = tmp_path / "outside"
+    safe_dir.mkdir()
+    outside_dir.mkdir()
+    (outside_dir / "examples.json").write_text(
+        json.dumps([{"input": "top", "output": "secret"}])
+    )
+    (safe_dir / "examples.json").symlink_to(outside_dir / "examples.json")
+
+    with (
+        change_directory(safe_dir),
+        pytest.raises(
+            ValueError, match="resolves outside the current working directory"
+        ),
+    ):
+        _load_examples({"examples": "examples.json"})
+
+
+def test_load_prompt_rejects_relative_symlink_target_outside_working_directory(
+    tmp_path: Path,
+) -> None:
+    safe_dir = tmp_path / "safe"
+    outside_dir = tmp_path / "outside"
+    safe_dir.mkdir()
+    outside_dir.mkdir()
+    (outside_dir / "prompt.json").write_text(
+        json.dumps(
+            {
+                "_type": "prompt",
+                "template": "external {value}",
+                "input_variables": ["value"],
+            }
+        )
+    )
+    (safe_dir / "prompt.json").symlink_to(outside_dir / "prompt.json")
+
+    with (
+        change_directory(safe_dir),
+        suppress_langchain_deprecation_warning(),
+        pytest.raises(
+            ValueError, match="resolves outside the current working directory"
+        ),
+    ):
+        load_prompt("prompt.json")
+
+
 def test_load_prompt_from_config_rejects_absolute_template_path(
     tmp_path: Path,
 ) -> None:
@@ -274,6 +343,40 @@ def test_load_prompt_from_config_few_shot_rejects_absolute_example_prompt_path(
     with (
         suppress_langchain_deprecation_warning(),
         pytest.raises(ValueError, match="is absolute"),
+    ):
+        load_prompt_from_config(config)
+
+
+def test_load_prompt_from_config_few_shot_rejects_symlinked_examples_outside_cwd(
+    tmp_path: Path,
+) -> None:
+    safe_dir = tmp_path / "safe"
+    outside_dir = tmp_path / "outside"
+    safe_dir.mkdir()
+    outside_dir.mkdir()
+    (outside_dir / "examples.json").write_text(
+        json.dumps([{"input": "top", "output": "secret"}])
+    )
+    (safe_dir / "examples.json").symlink_to(outside_dir / "examples.json")
+
+    config = {
+        "_type": "few_shot",
+        "input_variables": ["query"],
+        "prefix": "Examples:",
+        "example_prompt": {
+            "_type": "prompt",
+            "input_variables": ["input", "output"],
+            "template": "{input}: {output}",
+        },
+        "examples": "examples.json",
+        "suffix": "Query: {query}",
+    }
+    with (
+        change_directory(safe_dir),
+        suppress_langchain_deprecation_warning(),
+        pytest.raises(
+            ValueError, match="resolves outside the current working directory"
+        ),
     ):
         load_prompt_from_config(config)
 


### PR DESCRIPTION
Fixes #36823

This narrows the remaining deprecated prompt-loading symlink escape cases by resolving relative paths before `_load_template`, `_load_examples`, and relative `load_prompt(...)` open them, then rejecting targets that escape the working directory. It keeps direct absolute-path `load_prompt(...)` behavior unchanged to minimize compatibility impact and adds regression tests for template, examples, and relative prompt-file flows.

This is intended as a narrower follow-up to #35195 on current `master`; I am happy to adjust or close it if maintainers would rather revive that broader draft instead.

Verification:
- `uv run --directory libs/core ruff check langchain_core/prompts/loading.py tests/unit_tests/prompts/test_loading.py`
- `uv run --directory libs/core ruff format --check langchain_core/prompts/loading.py tests/unit_tests/prompts/test_loading.py`
- `uv run --directory libs/core pytest tests/unit_tests/prompts/test_loading.py -q`

AI assistance: I used AI tooling to help reproduce the bug and draft the patch, and I verified the final changes locally.
