### PR TITLE
perf(core): lazy-import transformers in get_tokenizer()

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -38,13 +38,6 @@ from langchain_core.runnables import Runnable, RunnableSerializable
 if TYPE_CHECKING:
     from langchain_core.outputs import LLMResult
 
-try:
-    from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
-
-    _HAS_TRANSFORMERS = True
-except ImportError:
-    _HAS_TRANSFORMERS = False
-
 
 class LangSmithParams(TypedDict, total=False):
     """LangSmith parameters for tracing."""
@@ -86,13 +79,15 @@ def get_tokenizer() -> Any:
         The GPT-2 tokenizer instance.
 
     """
-    if not _HAS_TRANSFORMERS:
+    try:
+        from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
+    except ImportError:
         msg = (
             "Could not import transformers python package. "
             "This is needed in order to calculate get_token_ids. "
             "Please install it with `pip install transformers`."
         )
-        raise ImportError(msg)
+        raise ImportError(msg) from None
     # create a GPT-2 tokenizer instance
     return GPT2TokenizerFast.from_pretrained("gpt2")
 

--- a/libs/core/tests/unit_tests/language_models/test_base_lazy_imports.py
+++ b/libs/core/tests/unit_tests/language_models/test_base_lazy_imports.py
@@ -1,0 +1,37 @@
+"""Test that heavy optional dependencies are not imported at module level."""
+
+import sys
+
+
+def test_transformers_not_imported_on_base_import() -> None:
+    """Verify that importing BaseChatModel does not trigger a transformers import.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/36835.
+
+    When ``transformers`` is installed, the previous top-level ``try/except``
+    import added 300-500 ms to every ``from langchain_core.language_models
+    import BaseChatModel`` call.  Moving the import inside ``get_tokenizer()``
+    avoids the cost until the tokenizer is actually needed.
+    """
+    # Remove any cached transformers import so we can detect a fresh import.
+    had_transformers = "transformers" in sys.modules
+    if had_transformers:
+        saved = sys.modules.pop("transformers")
+
+    try:
+        # Re-import the module to simulate a fresh load.
+        import importlib
+
+        import langchain_core.language_models.base as base_mod
+
+        importlib.reload(base_mod)
+
+        # transformers should NOT have been imported as a side-effect.
+        assert "transformers" not in sys.modules, (
+            "transformers was imported at module level; "
+            "it should only be imported lazily inside get_tokenizer()"
+        )
+    finally:
+        # Restore original state.
+        if had_transformers:
+            sys.modules["transformers"] = saved


### PR DESCRIPTION
## Summary

Move the `from transformers import GPT2TokenizerFast` import from module level into `get_tokenizer()` so that importing `BaseChatModel` no longer triggers a 300–500 ms `transformers` import on every application startup.

## Problem

When `transformers` is installed, importing anything from `langchain_core.language_models` unconditionally imports the entire `transformers` package at module level ([base.py#L42](https://github.com/langchain-ai/langchain/blob/6fb37dba71da807af60aa7b909f71f0625a666bf/libs/core/langchain_core/language_models/base.py#L42)). This adds **300–500 ms** to every cold startup, even when the GPT-2 tokenizer is never used.

```
import time:    367927 |     851828 |   transformers
```

## Fix

- Remove the top-level `try/except` import of `GPT2TokenizerFast` and the `_HAS_TRANSFORMERS` sentinel.
- Move the import inside `get_tokenizer()`, which is `@cache`-decorated and only called as a fallback for token counting.
- The import runs exactly once on first call (due to `@cache`) and never runs if `get_tokenizer()` is not invoked.
- Added `from None` to the `raise ImportError` to suppress the noisy chained exception.

## Test

Added `test_transformers_not_imported_on_base_import` regression test that verifies `transformers` is not in `sys.modules` after importing the base module.

## Impact

- **Before:** every `from langchain_core.language_models import BaseChatModel` pays 300–500 ms.
- **After:** zero cost unless `get_tokenizer()` is actually called.
- No behavioral change for users who do call `get_tokenizer()`.

Fixes #36835