### PR TITLE
docs: add OnCell integration — persistent sandboxed environments for agents

### DIFF
--- a/docs/docs/integrations/providers/oncell.mdx
+++ b/docs/docs/integrations/providers/oncell.mdx
@@ -1,0 +1,76 @@
+# OnCell
+
+> [OnCell](https://oncell.ai) provides per-user sandboxed environments with
+> persistent storage, database, and search for AI agents.
+
+## Overview
+
+OnCell gives each user their own isolated environment. Unlike ephemeral
+sandboxes, files, database state, and search indexes persist across sessions.
+Environments auto-pause when idle and resume in 200ms.
+
+## Installation
+
+```bash
+pip install oncell
+```
+
+## Setup
+
+Get an API key from [oncell.ai](https://oncell.ai).
+
+```python
+import os
+os.environ["ONCELL_API_KEY"] = "oncell_sk_..."
+```
+
+## Usage with LangChain
+
+OnCell works as a persistent backend for LangChain agents — providing
+file storage, database, and search as tools.
+
+```python
+from oncell import OnCell
+from langchain.tools import tool
+
+oncell = OnCell()
+cell = oncell.cells.create(customer_id="user-1", agent=agent_code, permanent=True)
+
+@tool
+def save_file(path: str, content: str) -> str:
+    """Save a file to the user's persistent storage."""
+    oncell.cells.request(cell.id, "save_file", {"path": path, "content": content})
+    return f"Saved {path}"
+
+@tool
+def search_files(query: str) -> str:
+    """Search across user's files."""
+    result = oncell.cells.request(cell.id, "search", {"query": query})
+    return str(result["results"])
+
+@tool
+def run_code(code: str) -> str:
+    """Run Python code in the user's sandboxed environment."""
+    result = oncell.cells.request(cell.id, "run_shell", {"command": f"python -c '{code}'"})
+    return result["stdout"]
+```
+
+### Full example
+
+See the [OnCell cookbook](https://github.com/oncellai/oncell-cookbook/tree/main/langchain/agent-with-memory)
+for a complete LangChain agent with persistent memory, file storage, and search.
+
+## When to use OnCell
+
+- Your agent needs **per-user isolation** — each user has their own files and state
+- State needs to **persist across sessions** — not just within a single conversation
+- You need **built-in search** over user data without setting up a vector database
+- You want **crash recovery** — agent resumes from last successful step
+- You want to **avoid managing infrastructure** — no Docker, no Kubernetes, no S3
+
+## Resources
+
+- [oncell.ai](https://oncell.ai)
+- [Documentation](https://oncell.ai/docs)
+- [Cookbook](https://github.com/oncellai/oncell-cookbook)
+- [Discord](https://discord.gg/rAxyyCVDxs)


### PR DESCRIPTION
## Summary

Adds OnCell as an integration provider in the LangChain docs.

OnCell provides per-user sandboxed environments with persistent storage, database, and search — useful for LangChain agents that need per-user isolation and state that survives across sessions.

## What is OnCell?

Unlike ephemeral sandboxes, OnCell environments persist. Files, database, and search indexes survive across sessions. Environments auto-pause when idle ($0.003/hr) and resume in 200ms.

Key features:
- **Persistent storage** — files survive across sessions (local NVMe, 0ms)
- **Built-in database** — SQLite per user, no external DB needed
- **Built-in search** — full-text + vector search, no vector DB needed
- **Crash recovery** — journal-based, resumes from last step
- **Auto-pause/resume** — 200ms wake, $0.003/hr while idle

## Links

- Full example: https://github.com/oncellai/oncell-cookbook/tree/main/langchain/agent-with-memory
- SDK: https://pypi.org/project/oncell/
- Docs: https://oncell.ai/docs
- Website: https://oncell.ai