### PR TITLE
fix(core): fix XML mixed content parsing in XMLOutputParser (preserve children when text is present)

### DIFF
--- a/libs/core/langchain_core/output_parsers/xml.py
+++ b/libs/core/langchain_core/output_parsers/xml.py
@@ -268,7 +268,7 @@ class XMLOutputParser(BaseTransformOutputParser):
 
     def _root_to_dict(self, root: ET.Element) -> dict[str, str | list[Any]]:
         """Converts xml tree to python dictionary."""
-        if root.text and bool(re.search(r"\S", root.text)):
+        if len(root) == 0 and root.text and bool(re.search(r"\S", root.text)):
             # If root text contains any non-whitespace character it
             # returns {root.tag: root.text}
             return {root.tag: root.text}


### PR DESCRIPTION
Fixes #36744 

This PR fixes a bug in _root_to_dict where elements containing both text and child nodes (mixed content) were incorrectly parsed. The previous implementation returned early when root.text was non-empty, causing all child elements to be discarded.
