### PR TITLE
fix(core): fix XML mixed content parsing in XMLOutputParser (preserve children when text is present)

### DIFF
--- a/libs/core/langchain_core/output_parsers/xml.py
+++ b/libs/core/langchain_core/output_parsers/xml.py
@@ -268,16 +268,20 @@ class XMLOutputParser(BaseTransformOutputParser):
 
     def _root_to_dict(self, root: ET.Element) -> dict[str, str | list[Any]]:
         """Converts xml tree to python dictionary."""
-        if len(root) == 0 and root.text and bool(re.search(r"\S", root.text)):
-            # If root text contains any non-whitespace character it
-            # returns {root.tag: root.text}
+        if len(root) == 0:
             return {root.tag: root.text}
-        result: dict = {root.tag: []}
+
+        result: dict[str, list[Any]] = {root.tag: []}
+
+        if root.text and bool(re.search(r"\S", root.text)):
+            result[root.tag].append({"_text": root.text.strip()})
+
         for child in root:
             if len(child) == 0:
                 result[root.tag].append({child.tag: child.text})
             else:
                 result[root.tag].append(self._root_to_dict(child))
+
         return result
 
     @property

--- a/libs/core/langchain_core/output_parsers/xml.py
+++ b/libs/core/langchain_core/output_parsers/xml.py
@@ -266,7 +266,7 @@ class XMLOutputParser(BaseTransformOutputParser):
                 yield output
         streaming_parser.close()
 
-    def _root_to_dict(self, root: ET.Element) -> dict[str, str | list[Any]]:
+    def _root_to_dict(self, root: ET.Element) -> dict[str, Any]:
         """Converts xml tree to python dictionary."""
         if len(root) == 0:
             return {root.tag: root.text}

--- a/libs/core/langchain_core/output_parsers/xml.py
+++ b/libs/core/langchain_core/output_parsers/xml.py
@@ -268,7 +268,7 @@ class XMLOutputParser(BaseTransformOutputParser):
 
     def _root_to_dict(self, root: ET.Element) -> dict[str, str | list[Any]]:
         """Converts xml tree to python dictionary."""
-        if root.text and bool(re.search(r"\S", root.text)):
+        if len(root) == 0 and root.text and bool(re.search(r"\S", root.text)):
             # If root text contains any non-whitespace character it
             # returns {root.tag: root.text}
             return {root.tag: root.text}

--- a/libs/core/tests/unit_tests/output_parsers/test_xml_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_xml_parser.py
@@ -156,3 +156,16 @@ async def tests_billion_laughs_attack() -> None:
 
     with pytest.raises(OutputParserException):
         await parser.aparse(MALICIOUS_XML)
+
+
+def test_mixed_content() -> None:
+    parser = XMLOutputParser()
+    xml = "<result>Summary<detail>info</detail></result>"
+    result = parser.parse(f"```xml\n{xml}\n```")
+
+    assert result == {
+        "result": [
+            {"_text": "Summary"},
+            {"detail": "info"},
+        ]
+    }


### PR DESCRIPTION
Fixes #36744

This PR fixes a bug in _root_to_dict where elements containing both text and child nodes (mixed content) were incorrectly parsed. The previous implementation returned early when root.text was non-empty, causing all child elements to be discarded.