### PR TITLE
Fix #36761: `AzureChatOpenAI` fails to infer profile data from `model...

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -705,6 +705,18 @@ class AzureChatOpenAI(BaseChatOpenAI):
         return self
 
     def _resolve_model_profile(self) -> ModelProfile | None:
+        # Prefer `model_name` (the canonical OpenAI model identifier) when it
+        # resolves to a known profile. Azure users commonly set
+        # `azure_deployment` to an arbitrary alias, so keying profile lookup
+        # off the deployment name alone misses profile data for the
+        # underlying model. `model_name` is set by
+        # `init_chat_model("azure_openai:<model>")` and by direct
+        # `AzureChatOpenAI(model=...)` usage, both of which otherwise end up
+        # with an empty profile.
+        if self.model_name is not None:
+            profile = _get_default_model_profile(self.model_name)
+            if profile:
+                return profile
         if self.deployment_name is not None:
             return _get_default_model_profile(self.deployment_name) or None
         return None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -159,6 +159,36 @@ def test_max_completion_tokens_parameter() -> None:
     assert "max_tokens" not in payload
 
 
+def test_profile_inference() -> None:
+    """AzureChatOpenAI should infer profile from model_name, not just deployment_name."""
+    azure_kwargs = {
+        "azure_endpoint": "https://example.openai.azure.com/",
+        "api_key": "test-key",  # type: ignore[arg-type]
+        "api_version": "2024-02-01",
+    }
+
+    # model_name set, deployment_name unset (e.g. init_chat_model("azure_openai:gpt-4o"))
+    llm = AzureChatOpenAI(model="gpt-4o", **azure_kwargs)  # type: ignore[call-arg]
+    assert llm.profile, "profile should be populated when model_name is a known model"
+    assert "max_input_tokens" in llm.profile
+
+    # model_name set, deployment_name is a custom alias
+    llm = AzureChatOpenAI(  # type: ignore[call-arg]
+        model="gpt-4o",
+        azure_deployment="my-custom-deployment",
+        **azure_kwargs,
+    )
+    assert llm.profile, "profile should use model_name even with custom deployment alias"
+    assert "max_input_tokens" in llm.profile
+
+    # deployment_name matches a known model, model_name unset — existing behaviour preserved
+    llm = AzureChatOpenAI(  # type: ignore[call-arg]
+        azure_deployment="gpt-4o",
+        **azure_kwargs,
+    )
+    assert llm.profile, "profile should still resolve from deployment_name when model_name is absent"
+
+
 def test_max_tokens_converted_to_max_completion_tokens() -> None:
     """Test that max_tokens is converted to max_completion_tokens."""
     llm = AzureChatOpenAI(


### PR DESCRIPTION
## Summary

`AzureChatOpenAI._resolve_model_profile` only looked up the default profile by `deployment_name`. That breaks profile inference in two common setups:

- `init_chat_model("azure_openai:gpt-4o", ...)` — `init_chat_model` forwards the parsed name as `model=...`, leaving `deployment_name` unset, so `profile` stays `None`.
- `AzureChatOpenAI(azure_deployment="my-alias", model="gpt-4o", ...)` — the custom alias has no entry in `_MODEL_PROFILES`, so `profile` resolves to `{}` even though the canonical model name is known.

Without a populated profile, profile-dependent features (fractional token limits in middleware, `structured_output` capability checks, etc.) cannot reason about the underlying model. `ChatOpenAI` already resolves profiles from `model_name`, so OpenAI usage works — only Azure was miskeyed.

## Fix

Try `model_name` first and fall back to `deployment_name`. Existing behaviour is preserved when `deployment_name` already matches a known model identifier (e.g. `azure_deployment="gpt-4o"`), while also covering the two cases above.

```python
def _resolve_model_profile(self) -> ModelProfile | None:
    if self.model_name is not None:
        profile = _get_default_model_profile(self.model_name)
        if profile:
            return profile
    if self.deployment_name is not None:
        return _get_default_model_profile(self.deployment_name) or None
    return None
```

## Tests

Added `test_profile_inference` in `libs/partners/openai/tests/unit_tests/chat_models/test_azure.py` covering:

1. `model="gpt-4o"` with no `azure_deployment` — profile populated.
2. `model="gpt-4o"` with custom `azure_deployment="my-custom-deployment"` — profile populated from `model_name`.
3. `azure_deployment="gpt-4o"` with no `model` — existing fallback behaviour preserved.

Fixes #36761

## Disclaimer

This PR was drafted with the help of an AI coding agent. Human review confirmed the scope and verified the fix against the issue's repro before submission.