### PR TITLE
fix(openai): AzureChatOpenAI_Empty_Reasoning_Summary_F01

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4409,6 +4409,38 @@ def _get_output_text(response: Response) -> str:
     return "".join(texts)
 
 
+def _normalize_reasoning_item_for_lc(block: Mapping[str, Any]) -> dict[str, Any]:
+    """Promote reasoning ``content`` into ``summary`` when ``summary`` is empty.
+
+    Some Responses API hosts return ``reasoning_text`` items under ``content``
+    while leaving ``summary`` empty. The ``responses/v1`` AIMessage format expects
+    human-readable reasoning in ``summary`` as ``summary_text`` dicts.
+    """
+    if block.get("type") != "reasoning":
+        return dict(block)
+    merged = dict(block)
+    summary = merged.get("summary")
+    if summary:
+        return merged
+    raw_content = merged.get("content")
+    if not isinstance(raw_content, list):
+        return merged
+    synthetic: list[dict[str, str]] = []
+    for piece in raw_content:
+        if not isinstance(piece, dict):
+            continue
+        if piece.get("type") == "reasoning_text":
+            text = piece.get("text")
+            if text is None:
+                continue
+            synthetic.append({"type": "summary_text", "text": text})
+    if not synthetic:
+        return merged
+    merged["summary"] = synthetic
+    merged.pop("content", None)
+    return merged
+
+
 def _construct_lc_result_from_responses_api(
     response: Response,
     schema: type[_BM] | None = None,
@@ -4537,7 +4569,10 @@ def _construct_lc_result_from_responses_api(
             "tool_search_call",
             "tool_search_output",
         ):
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            block = output.model_dump(exclude_none=True, mode="json")
+            if output.type == "reasoning":
+                block = _normalize_reasoning_item_for_lc(block)
+            content_blocks.append(block)
 
     # Workaround for parsing structured output in the streaming case.
     #    from openai import OpenAI

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -69,6 +69,7 @@ from langchain_openai.chat_models.base import (
     OpenAIRefusalError,
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
+    _normalize_reasoning_item_for_lc,
     _convert_dict_to_message,
     _convert_message_to_dict,
     _convert_to_openai_response_format,
@@ -1648,6 +1649,66 @@ def test__construct_lc_result_from_responses_api_multiple_messages() -> None:
         {"type": "text", "text": "bar", "annotations": [], "id": "msg_234"},
     ]
     assert result.generations[0].message.id == "resp_123"
+
+
+def test_reasoning_content_promoted_to_summary_for_responses_v1_aimessage() -> None:
+    """Hosts may return reasoning under ``content`` with an empty ``summary``."""
+    reasoning_host_shape: dict[str, Any] = {
+        "type": "reasoning",
+        "id": "rs_azure",
+        "summary": [],
+        "content": [{"type": "reasoning_text", "text": "Internal chain-of-thought."}],
+    }
+    normalized = _normalize_reasoning_item_for_lc(reasoning_host_shape)
+    assert normalized == {
+        "type": "reasoning",
+        "id": "rs_azure",
+        "summary": [{"type": "summary_text", "text": "Internal chain-of-thought."}],
+    }
+
+    with_summary: dict[str, Any] = {
+        "type": "reasoning",
+        "id": "rs_openai",
+        "summary": [Summary(type="summary_text", text="Already summarized.")],
+        "content": [{"type": "reasoning_text", "text": "Should be ignored."}],
+    }
+    assert _normalize_reasoning_item_for_lc(with_summary) == dict(with_summary)
+
+    response = Response(
+        id="resp_reasoning",
+        created_at=1234567890,
+        model="o4-mini",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseReasoningItem(
+                type="reasoning",
+                id="rs_1",
+                summary=[],
+                content=[{"type": "reasoning_text", "text": "From content field."}],
+            ),
+            ResponseOutputMessage(
+                type="message",
+                id="msg_1",
+                content=[
+                    ResponseOutputText(type="output_text", text="ok", annotations=[])
+                ],
+                role="assistant",
+                status="completed",
+            ),
+        ],
+    )
+    result = _construct_lc_result_from_responses_api(response)
+    assert result.generations[0].message.content == [
+        {
+            "type": "reasoning",
+            "id": "rs_1",
+            "summary": [{"type": "summary_text", "text": "From content field."}],
+        },
+        {"type": "text", "text": "ok", "annotations": [], "id": "msg_1"},
+    ]
 
 
 def test__construct_lc_result_from_responses_api_refusal_response() -> None:


### PR DESCRIPTION
Fixes #36862 & https://github.com/langchain-ai/langgraph/issues/5447

Some Responses API hosts return reasoning under `content` as `reasoning_text` while `summary` is empty; we normalize that when building `AIMessage` from the Responses API so `summary` matches the `responses/v1` shape.

**Breaking changes:** None.

**Depends on:** None.

**How I verified:** Ran `make format`, `make lint`, and `make test` from `libs/partners/openai` (or the root workflow your team uses for the touched package). Targeted pytest: `test_reasoning_content_promoted_to_summary_for_responses_v1_aimessage`.


---

**Social handles (optional)**  
LinkedIn: [https://linkedin.com/in/subham-kumar-das](https://linkedin.com/in/subham-kumar-das)