### PR TITLE
fix(core): unxfail stream error callback test

### DIFF
--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -156,7 +156,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 
@@ -165,7 +164,7 @@ async def test_stream_error_callback() -> None:
         assert len(callback.errors_args) == 1
         llm_result: LLMResult = callback.errors_args[0]["kwargs"]["response"]
         if i == 0:
-            assert llm_result.generations == []
+            assert llm_result.generations == [[]]
         else:
             assert llm_result.generations[0][0].text == message[:i]
 


### PR DESCRIPTION
Fixes #36866

Remove the outdated `xfail` from `test_stream_error_callback` and update the empty stream error expectation to match the current callback payload shape. In the `i == 0` case, `LLMResult.generations` preserves the batch dimension, so the observed value is `[[]]` rather than `[]`.

Verified with:
- `uv run --python 3.11 --directory libs/core --group test python -m pytest tests/unit_tests/language_models/chat_models/test_base.py -k test_stream_error_callback -q -vv`
- `uv run --python 3.11 --directory libs/core --group test python -m pytest tests/unit_tests/language_models/chat_models/test_base.py -q`
