### PR TITLE
fix(core): correct xfail assertion in test_stream_error_callback

### DIFF
--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -156,7 +156,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 
@@ -165,7 +164,7 @@ async def test_stream_error_callback() -> None:
         assert len(callback.errors_args) == 1
         llm_result: LLMResult = callback.errors_args[0]["kwargs"]["response"]
         if i == 0:
-            assert llm_result.generations == []
+            assert llm_result.generations == [[]]
         else:
             assert llm_result.generations[0][0].text == message[:i]
 


### PR DESCRIPTION
The `i == 0` case in `test_stream_error_callback` was asserting `generations == []` but the callback actually receives `[[]]`, a list wrapping an empty batch which is the correct shape given how the error path constructs the `LLMResult`. The xfail marker was hiding this mismatch rather than an actual product bug. Fixes #36866.