### PR TITLE
feat(openai): add reasoning content extraction to message conversion

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -203,7 +203,10 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # Fix for azure
         # Also OpenAI returns None for tool invocations
         content = _dict.get("content", "") or ""
+        reasoning = _dict.get("reasoning", "") or ""
         additional_kwargs: dict = {}
+        if reasoning:
+            additional_kwargs['reasoning_content'] = reasoning
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
         tool_calls = []
@@ -422,7 +425,10 @@ def _convert_delta_to_message_chunk(
     id_ = _dict.get("id")
     role = cast(str, _dict.get("role"))
     content = cast(str, _dict.get("content") or "")
+    reasoning = cast(str, _dict.get("reasoning", "") or "")
     additional_kwargs: dict = {}
+    if reasoning:
+        additional_kwargs['reasoning_content'] = reasoning
     if _dict.get("function_call"):
         function_call = dict(_dict["function_call"])
         if "name" in function_call and function_call["name"] is None:


### PR DESCRIPTION
Fixes #36880

Add support for extracting and preserving reasoning content from OpenAI provider responses in message conversion utilities, enabling display of model reasoning in user interfaces.