### PR TITLE
fix(core): guard FileChatMessageHistory example against path traversal

### DIFF
--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -58,14 +58,26 @@ class BaseChatMessageHistory(ABC):
             storage_path: str
             session_id: str
 
+            def _safe_path(self) -> str:
+                # Guard against path traversal: session_id must not escape
+                # storage_path, regardless of whether it contains ".." segments
+                # or is an absolute path (os.path.join discards the base when
+                # the second argument is absolute).
+                base = os.path.realpath(self.storage_path)
+                resolved = os.path.realpath(
+                    os.path.join(self.storage_path, self.session_id)
+                )
+                if not resolved.startswith(base + os.sep) and resolved != base:
+                    raise ValueError(
+                        f"Invalid session_id '{self.session_id}': "
+                        "path resolves outside storage_path."
+                    )
+                return resolved
+
             @property
             def messages(self) -> list[BaseMessage]:
                 try:
-                    with open(
-                        os.path.join(self.storage_path, self.session_id),
-                        "r",
-                        encoding="utf-8",
-                    ) as f:
+                    with open(self._safe_path(), "r", encoding="utf-8") as f:
                         messages_data = json.load(f)
                     return messages_from_dict(messages_data)
                 except FileNotFoundError:
@@ -76,13 +88,13 @@ class BaseChatMessageHistory(ABC):
                 all_messages.extend(messages)  # Add new messages
 
                 serialized = [message_to_dict(message) for message in all_messages]
-                file_path = os.path.join(self.storage_path, self.session_id)
+                file_path = self._safe_path()
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
                 with open(file_path, "w", encoding="utf-8") as f:
                     json.dump(serialized, f)
 
             def clear(self) -> None:
-                file_path = os.path.join(self.storage_path, self.session_id)
+                file_path = self._safe_path()
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
                 with open(file_path, "w", encoding="utf-8") as f:
                     json.dump([], f)


### PR DESCRIPTION
## Summary

The `BaseChatMessageHistory` docstring contains a `FileChatMessageHistory` example that developers copy into real applications. That example uses `os.path.join(storage_path, session_id)` for every file operation without any path validation.

`session_id` is user-controlled in typical web deployments — it arrives via `RunnableWithMessageHistory`'s `configurable` dict, which is populated from request parameters.

**Two bypass vectors:**

| Vector | Example | Result |
|--------|---------|--------|
| Relative traversal | `session_id = "../../etc/shadow"` | Resolves outside `storage_path` |
| Absolute path | `session_id = "/etc/shadow"` | `os.path.join` discards the base entirely on POSIX |

**Fix:** Added `_safe_path()` helper that resolves both the base and the candidate path with `os.path.realpath()`, then asserts the result is contained within `storage_path` before any file I/O. All three operations (`messages`, `add_messages`, `clear`) now go through this helper.

```python
def _safe_path(self) -> str:
    base = os.path.realpath(self.storage_path)
    resolved = os.path.realpath(os.path.join(self.storage_path, self.session_id))
    if not resolved.startswith(base + os.sep) and resolved != base:
        raise ValueError(
            f"Invalid session_id '{self.session_id}': "
            "path resolves outside storage_path."
        )
    return resolved
```

## Impact

Example code in official docs is the pattern most developers follow. The vulnerable pattern is also present in `langchain-community`'s `FileChatMessageHistory` implementation (separate repo), which this fix should prompt a parallel update for.

## Test plan

- [ ] `session_id = "safe_session"` → works normally
- [ ] `session_id = "../../etc/passwd"` → raises `ValueError`
- [ ] `session_id = "/etc/passwd"` → raises `ValueError` (absolute path bypass)
- [ ] `session_id = "subdir/session"` → works if subdir is within storage_path

Some code in this commit was written with assistance from Claude Sonnet 4.6 (AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)