### PR TITLE
docs(langchain): correct import path in `ModelCallLimitMiddleware` docstring

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_call_limit.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_call_limit.py
@@ -108,7 +108,7 @@ class ModelCallLimitMiddleware(
 
     Example:
         ```python
-        from langchain.agents.middleware.call_tracking import ModelCallLimitMiddleware
+        from langchain.agents.middleware import ModelCallLimitMiddleware
         from langchain.agents import create_agent
 
         # Create middleware with limits


### PR DESCRIPTION
## Summary

Updates the example in `ModelCallLimitMiddleware` docstring to use the correct import path. The previous import referenced a non-existent module, which could cause confusion for users following the documentation.