### PR TITLE
fix(core): correct empty-stream error callback generations assertion

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -147,7 +147,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 
@@ -156,7 +155,7 @@ async def test_stream_error_callback() -> None:
         assert len(callback.errors_args) == 1
         llm_result: LLMResult = callback.errors_args[0]["kwargs"]["response"]
         if i == 0:
-            assert llm_result.generations == []
+            assert llm_result.generations == [[]]
         else:
             assert llm_result.generations[0][0].text == message[:i]
 


### PR DESCRIPTION
## Summary

When `error_on_chunk_number=0` (error before any chunk is emitted),
`LLMResult.generations` preserves the outer batch dimension, yielding
`\[[]]` rather than `\[]`. The test assertion and xfail marker have
not been updated since the callback path was fixed in #30228.

## Changes

- **test_base.py**: Change `assert llm_result.generations == []` →
  `assert llm_result.generations == [[]]` for the `i == 0` case
- Remove `@pytest.mark.xfail` decorator (the test passes after the fix)

Fixes #36866