### PR TITLE
fix(core): use strict=True in RunnableWithFallbacks zip calls

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -306,7 +306,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                 run_id=config.pop("run_id", None),
             )
             for cm, input_, config in zip(
-                callback_managers, inputs, configs, strict=False
+                callback_managers, inputs, configs, strict=True
             )
         ]
 
@@ -326,7 +326,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                 **kwargs,
             )
             for (i, input_), output in zip(
-                sorted(run_again.copy().items()), outputs, strict=False
+                sorted(run_again.copy().items()), outputs, strict=True
             ):
                 if isinstance(output, BaseException) and not isinstance(
                     output, self.exceptions_to_handle
@@ -403,7 +403,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     run_id=config.pop("run_id", None),
                 )
                 for cm, input_, config in zip(
-                    callback_managers, inputs, configs, strict=False
+                    callback_managers, inputs, configs, strict=True
                 )
             )
         )
@@ -425,7 +425,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             )
 
             for (i, input_), output in zip(
-                sorted(run_again.copy().items()), outputs, strict=False
+                sorted(run_again.copy().items()), outputs, strict=True
             ):
                 if isinstance(output, BaseException) and not isinstance(
                     output, self.exceptions_to_handle


### PR DESCRIPTION
## Summary

In `RunnableWithFallbacks.batch()` and `abatch()`, four `zip()` calls pair inputs with callback managers, configs, and outputs using `strict=False`. These lists are always constructed to be the same length — if they ever diverge, that indicates an upstream bug. Using `strict=False` silently truncates, producing misaligned outputs that are hard to diagnose.

Change all four `zip()` calls to `strict=True` so a `ValueError` is raised immediately on any length mismatch instead of silently misaligning results.

## Details

**File:** `libs/core/langchain_core/runnables/fallbacks.py`

| Line | Method | zip() pairs |
|------|--------|-------------|
| ~309 | `batch()` | callback_managers × inputs × configs |
| ~329 | `batch()` | run_again items × outputs |
| ~406 | `abatch()` | callback_managers × inputs × configs |
| ~428 | `abatch()` | run_again items × outputs |

All four changed from `strict=False` → `strict=True`.

Fixes #36746