### PR TITLE
fix(core): update legacy serialization mappings to target langchain_classic

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -97,7 +97,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "BasePromptTemplate",
     ),
     ("langchain", "chains", "llm", "LLMChain"): (
-        "langchain",
+        "langchain_classic",
         "chains",
         "llm",
         "LLMChain",
@@ -150,7 +150,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "AgentActionMessageLog",
     ),
     ("langchain", "schema", "agent", "ToolAgentAction"): (
-        "langchain",
+        "langchain_classic",
         "agents",
         "output_parsers",
         "tools",
@@ -181,7 +181,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "Document",
     ),
     ("langchain", "output_parsers", "fix", "OutputFixingParser"): (
-        "langchain",
+        "langchain_classic",
         "output_parsers",
         "fix",
         "OutputFixingParser",
@@ -193,7 +193,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "AIMessagePromptTemplate",
     ),
     ("langchain", "output_parsers", "regex", "RegexParser"): (
-        "langchain",
+        "langchain_classic",
         "output_parsers",
         "regex",
         "RegexParser",
@@ -421,7 +421,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "VertexAI",
     ),
     ("langchain", "output_parsers", "combining", "CombiningOutputParser"): (
-        "langchain",
+        "langchain_classic",
         "output_parsers",
         "combining",
         "CombiningOutputParser",
@@ -477,7 +477,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "ChatPromptValueConcrete",
     ),
     ("langchain", "schema", "runnable", "HubRunnable"): (
-        "langchain",
+        "langchain_classic",
         "runnables",
         "hub",
         "HubRunnable",
@@ -489,7 +489,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "RunnableBindingBase",
     ),
     ("langchain", "schema", "runnable", "OpenAIFunctionsRouter"): (
-        "langchain",
+        "langchain_classic",
         "runnables",
         "openai_functions",
         "OpenAIFunctionsRouter",
@@ -608,7 +608,7 @@ _OG_SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "ImagePromptTemplate",
     ),
     ("langchain", "schema", "agent", "OpenAIToolAgentAction"): (
-        "langchain",
+        "langchain_classic",
         "agents",
         "output_parsers",
         "openai_tools",


### PR DESCRIPTION
## Problem

Several entries in `SERIALIZABLE_MAPPING` and `_OG_SERIALIZABLE_MAPPING` still resolve to the legacy `"langchain"` namespace for classes that were moved to `langchain_classic` during the package reorganization. This causes `ImportError` when deserializing legacy serialized objects that reference these class paths.

## Affected mappings (8 entries)

| Legacy Key | Stale Target | Fixed Target |
|---|---|---|
| `("langchain", "chains", "llm", "LLMChain")` | langchain.chains.llm | langchain_classic.chains.llm |
| `("langchain", "schema", "agent", "ToolAgentAction")` | langchain.agents | langchain_classic.agents |
| `("langchain", "output_parsers", "fix", ...)` | langchain.output_parsers | langchain_classic.output_parsers |
| `("langchain", "output_parsers", "regex", ...)` | langchain.output_parsers | langchain_classic.output_parsers |
| `("langchain", "output_parsers", "combining", ...)` | langchain.output_parsers | langchain_classic.output_parsers |
| `("langchain", "schema", "runnable", "HubRunnable")` | langchain.runnables.hub | langchain_classic.runnables.hub |
| `("langchain", "schema", "runnable", "OpenAIFunctionsRouter")` | langchain.runnables | langchain_classic.runnables |
| `("langchain", "schema", "agent", "OpenAIToolAgentAction")` | langchain.agents | langchain_classic.agents |

## Fix

Update the target namespace from `"langchain"` to `"langchain_classic"` for all 8 stale entries.

Fixes #36230