### PR TITLE
fix(core): support string data in Blob.as_bytes_io()

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f

--- a/libs/core/tests/unit_tests/documents/test_document.py
+++ b/libs/core/tests/unit_tests/documents/test_document.py
@@ -1,4 +1,4 @@
-from langchain_core.documents import Document
+from langchain_core.documents import Blob, Document
 
 
 def test_init() -> None:
@@ -10,3 +10,9 @@ def test_init() -> None:
         Document(page_content="foo", id=1),
     ]:
         assert isinstance(doc, Document)
+
+
+def test_blob_as_bytes_io_with_string_data() -> None:
+    blob = Blob.from_data("hello")
+    with blob.as_bytes_io() as f:
+        assert f.read() == b"hello"


### PR DESCRIPTION
## Summary

 raises  when the blob contains string data, even though  and  both handle strings correctly. This adds the missing `str` branch to `as_bytes_io()`, encoding string data using `self.encoding` (consistent with `as_bytes()`).

Fixes #36667

## Details

- Added `isinstance(self.data, str)` check in `Blob.as_bytes_io()` that yields a `BytesIO` wrapping the encoded string
- Added unit test `test_blob_as_bytes_io_with_string_data`
- No behavior change for existing bytes/path code paths