### PR TITLE
fix(core): skip eviction when updating existing key in InMemoryCache

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -226,9 +226,11 @@ class InMemoryCache(BaseCache):
 
                 The value is a list of `Generation` (or subclasses).
         """
-        if self._maxsize is not None and len(self._cache) == self._maxsize:
-            del self._cache[next(iter(self._cache))]
-        self._cache[prompt, llm_string] = return_val
+        key = (prompt, llm_string)
+        if key not in self._cache:
+            if self._maxsize is not None and len(self._cache) == self._maxsize:
+                del self._cache[next(iter(self._cache))]
+        self._cache[key] = return_val
 
     @override
     def clear(self, **kwargs: Any) -> None:

--- a/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
+++ b/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
@@ -69,6 +69,24 @@ def test_update_with_maxsize() -> None:
     assert cache.lookup(prompt3, llm_string3) == generations3
 
 
+def test_update_existing_key_does_not_evict() -> None:
+    """Updating an existing key at maxsize should not evict other entries."""
+    cache = InMemoryCache(maxsize=2)
+
+    p1, ll1, g1 = cache_item(1)
+    cache.update(p1, ll1, g1)
+
+    p2, ll2, g2 = cache_item(2)
+    cache.update(p2, ll2, g2)
+
+    # Cache is full (2/2). Updating an existing key must not evict anything.
+    g2_updated = [Generation(text="updated_text")]
+    cache.update(p2, ll2, g2_updated)
+
+    assert cache.lookup(p1, ll1) == g1  # prompt1 still present
+    assert cache.lookup(p2, ll2) == g2_updated  # prompt2 updated
+
+
 def test_clear(cache: InMemoryCache) -> None:
     """Test the clear method of InMemoryCache."""
     prompt, llm_string, generations = cache_item(1)


### PR DESCRIPTION
## Description

InMemoryCache.update() evicts the oldest entry whenever the cache is at maxsize, even when the key being updated already exists in the cache. This means that refreshing a cached value can unexpectedly drop unrelated entries.

**Before this fix:** Updating any key at maxsize always evicts the oldest entry (FIFO), even for existing keys.
**After this fix:** Eviction only happens when adding a **new** key that would exceed maxsize. Existing keys are updated in-place without affecting other entries.

Fixes #36750 (InMemoryCache maxsize update bug portion).

## Changes

- **caches.py**: Check if the key exists before deciding to evict — only new keys trigger eviction at capacity
- **test_in_memory_cache.py**: Add `test_update_existing_key_does_not_evict` to cover this case