### PR TITLE
fix(langchain): ensure done-marker starts on new line to prevent ShellSession timeout

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -228,6 +228,7 @@ class ShellSession:
             payload = command if command.endswith("\n") else f"{command}\n"
             try:
                 self._stdin.write(payload)
+                self._stdin.write("printf '\\n'")
                 self._stdin.write(f"printf '{marker} %s\\n' $?\n")
                 self._stdin.flush()
             except (BrokenPipeError, OSError):


### PR DESCRIPTION
## Summary

When a command output does not end with a trailing newline (`\n`), the done-marker written to stdin gets concatenated directly onto the last line of output. Since `_collect_output` detects completion via `data.startswith(marker)`, the marker is never found and `execute()` hangs until timeout.

This affects common commands: `echo -n`, `printf` without `\n`, `cat` on files missing a final newline, `tr -d "\n"`, etc.

## Fix

Emit an extra `\n` via `printf` before writing the done-marker, so it always starts on a fresh line regardless of what the command produced.

**1 line changed.**

Closes #36804