### PR TITLE
fix(core): validate batch size is positive in _batch and _abatch

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -90,6 +90,8 @@ def _hash_nested_dict(
 
 def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError("batch size must be a positive integer")
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))
@@ -100,6 +102,8 @@ def _batch(size: int, iterable: Iterable[T]) -> Iterator[list[T]]:
 
 async def _abatch(size: int, iterable: AsyncIterable[T]) -> AsyncIterator[list[T]]:
     """Utility batching function."""
+    if size <= 0:
+        raise ValueError("batch size must be a positive integer")
     batch: list[T] = []
     async for element in iterable:
         if len(batch) < size:


### PR DESCRIPTION
## Issue

Fixes #36647 — passing `size=0` to `_batch` or `_abatch` in `langchain_core.indexing.api` causes problematic behavior:

- `_abatch(0, ...)` enters an infinite loop yielding empty batches
- `_batch(0, ...)` silently returns no results (no error, no items)

## Changes

Add a `ValueError` guard at the top of both functions when `size <= 0`. This matches the standard library pattern (e.g., `itertools.islice` with negative/zero size) and gives callers a clear error message instead of silent failure or infinite loops.

**4 lines added**, no API changes, no test changes needed.