### PR TITLE
feat(langchain): add progress guard for repeated tool failures

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -12,6 +12,10 @@ from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddlewar
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
+from langchain.agents.middleware.progress_guard import (
+    AgentProgressStalledError,
+    ProgressGuardMiddleware,
+)
 from langchain.agents.middleware.shell_tool import (
     CodexSandboxExecutionPolicy,
     DockerExecutionPolicy,
@@ -45,6 +49,7 @@ from langchain.agents.middleware.types import (
 
 __all__ = [
     "AgentMiddleware",
+    "AgentProgressStalledError",
     "AgentState",
     "ClearToolUsesEdit",
     "CodexSandboxExecutionPolicy",
@@ -65,6 +70,7 @@ __all__ = [
     "ModelRetryMiddleware",
     "PIIDetectionError",
     "PIIMiddleware",
+    "ProgressGuardMiddleware",
     "RedactionRule",
     "Runtime",
     "ShellToolMiddleware",

--- a/libs/langchain_v1/langchain/agents/middleware/_progress.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_progress.py
@@ -71,9 +71,7 @@ def build_tool_exchange_signature(
     )
 
 
-def validate_max_consecutive_steps(
-    max_consecutive_steps: int, *, parameter_name: str
-) -> None:
+def validate_max_consecutive_steps(max_consecutive_steps: int, *, parameter_name: str) -> None:
     """Validate a progress detection threshold."""
     if max_consecutive_steps < _MIN_CONSECUTIVE_STEPS:
         msg = f"{parameter_name} must be >= {_MIN_CONSECUTIVE_STEPS}"

--- a/libs/langchain_v1/langchain/agents/middleware/_progress.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_progress.py
@@ -1,0 +1,125 @@
+"""Shared helpers for agent progress detection."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+_MIN_CONSECUTIVE_STEPS = 2
+_TRACEBACK_RE = re.compile(r"Traceback \(most recent call last\):.*", re.DOTALL)
+_UUID_RE = re.compile(
+    r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"
+)
+_REQUEST_ID_RE = re.compile(r"(?i)\b(?:request|req)(?:[_ -]?id)?\b\s*[:=]\s*[\w-]+")
+_TIMESTAMP_RE = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}[tT ][0-2]\d:[0-5]\d:[0-5]\d(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?\b"
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def stable_json_dumps(value: Any) -> str:
+    """Serialize values deterministically for signature comparison."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=repr)
+
+
+def default_progress_output_normalizer(output: str) -> str:
+    """Normalize volatile output details before signature comparison."""
+    normalized = _TRACEBACK_RE.sub("", output)
+    normalized = _UUID_RE.sub("<uuid>", normalized)
+    normalized = _REQUEST_ID_RE.sub("request_id=<request_id>", normalized)
+    normalized = _TIMESTAMP_RE.sub("<timestamp>", normalized)
+    return _WHITESPACE_RE.sub(" ", normalized).strip()
+
+
+def summarize_progress_output(output: str) -> str:
+    """Prepare an output string for user-facing messages."""
+    return _WHITESPACE_RE.sub(" ", output).strip()
+
+
+def build_tool_failure_signature(
+    *,
+    tool_name: str,
+    tool_args: Mapping[str, Any],
+    error_message: str,
+    error_normalizer: Callable[[str], str],
+) -> str:
+    """Build a stable signature for a retry-exhausted tool failure."""
+    return stable_json_dumps(
+        {
+            "tool_name": tool_name,
+            "tool_args": tool_args,
+            "error": error_normalizer(error_message),
+        }
+    )
+
+
+def build_tool_exchange_signature(
+    *,
+    tool_calls: Sequence[Mapping[str, Any]],
+    tool_outputs: Sequence[Mapping[str, Any]],
+) -> str:
+    """Build a stable signature for a completed AI/tool exchange."""
+    return stable_json_dumps(
+        {
+            "tool_calls": tool_calls,
+            "tool_outputs": tool_outputs,
+        }
+    )
+
+
+def validate_max_consecutive_steps(
+    max_consecutive_steps: int, *, parameter_name: str
+) -> None:
+    """Validate a progress detection threshold."""
+    if max_consecutive_steps < _MIN_CONSECUTIVE_STEPS:
+        msg = f"{parameter_name} must be >= {_MIN_CONSECUTIVE_STEPS}"
+        raise ValueError(msg)
+
+
+def build_progress_stalled_message(*, consecutive_steps: int, description: str) -> str:
+    """Build the final progress-stalled notification shown to users."""
+    return (
+        "Agent stopped because no_progress_detected: repeated the same tool "
+        f"exchange {consecutive_steps} consecutive times. Last exchange: {description}"
+    )
+
+
+class AgentProgressStalledError(Exception):
+    """Raised when an agent repeats equivalent tool exchanges without progress.
+
+    The `reason` attribute is always `"no_progress_detected"` so callers can handle
+    this stop condition without parsing the exception message.
+    """
+
+    reason = "no_progress_detected"
+
+    def __init__(
+        self,
+        *,
+        consecutive_steps: int,
+        max_consecutive_identical_steps: int,
+        description: str,
+        exchange_signature: str | None = None,
+    ) -> None:
+        """Initialize the exception with progress stall details.
+
+        Args:
+            consecutive_steps: Number of equivalent tool exchanges observed.
+            max_consecutive_identical_steps: Configured threshold that was reached.
+            description: Concise description of the repeated exchange.
+            exchange_signature: Stable signature for the repeated exchange, if available.
+        """
+        self.consecutive_steps = consecutive_steps
+        self.max_consecutive_identical_steps = max_consecutive_identical_steps
+        self.description = description
+        self.exchange_signature = exchange_signature
+
+        msg = build_progress_stalled_message(
+            consecutive_steps=consecutive_steps,
+            description=description,
+        )
+        super().__init__(msg)

--- a/libs/langchain_v1/langchain/agents/middleware/progress_guard.py
+++ b/libs/langchain_v1/langchain/agents/middleware/progress_guard.py
@@ -1,0 +1,429 @@
+"""Progress guard middleware for agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Annotated, Any, Literal
+
+from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
+from langgraph.channels.untracked_value import UntrackedValue
+from typing_extensions import NotRequired, override
+
+from langchain.agents.middleware._progress import (
+    AgentProgressStalledError,
+    build_progress_stalled_message,
+    build_tool_exchange_signature,
+    default_progress_output_normalizer,
+    stable_json_dumps,
+    summarize_progress_output,
+    validate_max_consecutive_steps,
+)
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    PrivateStateAttr,
+    ResponseT,
+    ToolCallRequest,
+    hook_config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain_core.tools import BaseTool
+    from langgraph.runtime import Runtime
+    from langgraph.types import Command
+
+
+_INITIALIZED_KEY = "run_progress_guard_initialized"
+_LAST_PROCESSED_EXCHANGE_KEY = "run_progress_guard_last_processed_exchange_id"
+_LAST_SIGNATURE_KEY = "run_progress_guard_last_signature"
+_CONSECUTIVE_COUNT_KEY = "run_progress_guard_consecutive_count"
+
+
+@dataclass(frozen=True)
+class _ProgressObservation:
+    """Stable description of a completed AI/tool exchange."""
+
+    exchange_id: str
+    signature: str
+    description: str
+
+
+class ProgressGuardState(AgentState[ResponseT]):
+    """State schema for `ProgressGuardMiddleware`.
+
+    The middleware keeps a run-scoped ledger of the last processed AI/tool exchange and
+    the current consecutive equivalent exchange streak.
+    """
+
+    run_progress_guard_initialized: NotRequired[
+        Annotated[bool, UntrackedValue, PrivateStateAttr]
+    ]
+    run_progress_guard_last_processed_exchange_id: NotRequired[
+        Annotated[str | None, UntrackedValue, PrivateStateAttr]
+    ]
+    run_progress_guard_last_signature: NotRequired[
+        Annotated[str | None, UntrackedValue, PrivateStateAttr]
+    ]
+    run_progress_guard_consecutive_count: NotRequired[
+        Annotated[int, UntrackedValue, PrivateStateAttr]
+    ]
+
+
+def _fetch_last_ai_and_tool_messages(
+    messages: list[AnyMessage],
+) -> tuple[AIMessage | None, list[ToolMessage]]:
+    """Return the last AI message and any subsequent tool messages."""
+    for index in range(len(messages) - 1, -1, -1):
+        message = messages[index]
+        if isinstance(message, AIMessage):
+            last_ai_message = message
+            tool_messages = [msg for msg in messages[index + 1 :] if isinstance(msg, ToolMessage)]
+            return last_ai_message, tool_messages
+    return None, []
+
+
+def _build_exchange_id(message: AIMessage) -> str:
+    """Build a stable identifier for the latest AI/tool exchange."""
+    if message.id:
+        return str(message.id)
+    return stable_json_dumps(
+        {
+            "content": message.content,
+            "tool_calls": message.tool_calls,
+        }
+    )
+
+
+class ProgressGuardMiddleware(
+    AgentMiddleware[ProgressGuardState[ResponseT], ContextT, ResponseT]
+):
+    """Stop agent loops that repeat the same completed tool exchange.
+
+    Use this guard when an agent keeps making the same tool calls and receives the
+    same tool outputs. It detects repeated successful outputs and repeated error
+    outputs by comparing the tool name, tool arguments, output status, and normalized
+    output content.
+
+    By default, this middleware only observes completed `ToolMessage` objects that
+    already exist. It does not catch raw tool exceptions. Set
+    `catch_tool_exceptions=True` only when this guard should also catch monitored tool
+    exceptions and convert them into observable error `ToolMessage`s.
+
+    !!! warning
+
+        This middleware is opt-in because repeated tool calls can be valid for polling,
+        pagination, or workflows where unchanged output is expected. Scope `tools` or
+        raise `max_consecutive_identical_steps` for tools that may legitimately repeat.
+
+    Prefer `ToolRetryMiddleware(max_consecutive_identical_failures=...)` for the
+    narrower case where you only need to stop repeated retry-exhausted tool failures.
+    Do not enable both mechanisms for the same tool unless layered detection is
+    intentional.
+
+    Examples:
+        !!! example "Stop repeated no-progress tool exchanges"
+
+            ```python
+            from langchain.agents import create_agent
+            from langchain.agents.middleware import ProgressGuardMiddleware
+
+            agent = create_agent(
+                model,
+                tools=[search_tool],
+                middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=3)],
+            )
+            ```
+
+        !!! example "End gracefully instead of raising"
+
+            ```python
+            guard = ProgressGuardMiddleware(
+                max_consecutive_identical_steps=3,
+                exit_behavior="end",
+            )
+            ```
+
+            With `exit_behavior="end"`, the agent appends a final `AIMessage` explaining
+            that no progress was detected and exits normally.
+
+        !!! example "Catch raw tool exceptions in the guard"
+
+            ```python
+            guard = ProgressGuardMiddleware(
+                max_consecutive_identical_steps=3,
+                catch_tool_exceptions=True,
+            )
+            ```
+
+            Without `catch_tool_exceptions=True`, raw tool exceptions still abort the
+            run.
+
+        !!! example "Normalize volatile output"
+
+            ```python
+            import re
+
+
+            def normalize_search_output(output: str) -> str:
+                return re.sub("request_id=[A-Za-z0-9_]+", "request_id=<id>", output)
+
+
+            guard = ProgressGuardMiddleware(output_normalizer=normalize_search_output)
+            ```
+    """
+
+    state_schema = ProgressGuardState  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        *,
+        max_consecutive_identical_steps: int = 3,
+        tools: list[BaseTool | str] | None = None,
+        exit_behavior: Literal["error", "end"] = "error",
+        output_normalizer: Callable[[str], str] | None = None,
+        catch_tool_exceptions: bool = False,
+    ) -> None:
+        """Initialize the progress guard.
+
+        Args:
+            max_consecutive_identical_steps: Number of equivalent completed tool
+                exchanges allowed before treating the loop as stalled. Must be `>= 2`.
+            tools: Optional list of tools or tool names to monitor. If `None`,
+                monitors every tool.
+            exit_behavior: What to do once no progress is detected.
+
+                - `'error'`: Raise `AgentProgressStalledError`.
+                - `'end'`: Append a final `AIMessage` with the `no_progress_detected`
+                    reason and stop the agent normally.
+            output_normalizer: Optional callable that turns raw tool output into a
+                stable comparison key. The default normalizer strips common volatile
+                details such as tracebacks, request IDs, UUIDs, timestamps, and repeated
+                whitespace.
+            catch_tool_exceptions: Whether to convert monitored tool exceptions into
+                `ToolMessage(status="error")`.
+
+        Raises:
+            ValueError: If `max_consecutive_identical_steps < 2` or `exit_behavior`
+                is invalid.
+        """
+        super().__init__()
+
+        validate_max_consecutive_steps(
+            max_consecutive_identical_steps,
+            parameter_name="max_consecutive_identical_steps",
+        )
+
+        if exit_behavior not in {"error", "end"}:
+            msg = "exit_behavior must be 'error' or 'end'"
+            raise ValueError(msg)
+
+        self.max_consecutive_identical_steps = max_consecutive_identical_steps
+        self.exit_behavior = exit_behavior
+        self._output_normalizer = output_normalizer or default_progress_output_normalizer
+        self.catch_tool_exceptions = catch_tool_exceptions
+        self.tools = []
+        self._tool_filter = (
+            {tool.name if not isinstance(tool, str) else tool for tool in tools}
+            if tools is not None
+            else None
+        )
+
+    def _matches_tool_filter(self, tool_name: str) -> bool:
+        """Check whether the progress guard should monitor the tool."""
+        if self._tool_filter is None:
+            return True
+        return tool_name in self._tool_filter
+
+    @staticmethod
+    def _format_tool_failure_message(tool_name: str, exc: Exception) -> str:
+        """Format tool exceptions as stable error messages for the model."""
+        exc_type = type(exc).__name__
+        summarized_error = summarize_progress_output(str(exc))
+        return f"Tool '{tool_name}' failed with {exc_type}: {summarized_error}. Please try again."
+
+    def _extract_progress_observation(
+        self,
+        *,
+        last_ai_message: AIMessage | None,
+        tool_messages: list[ToolMessage],
+    ) -> _ProgressObservation | None:
+        """Extract a stable signature from the latest completed tool exchange."""
+        if last_ai_message is None or not last_ai_message.tool_calls:
+            return None
+
+        tool_calls: list[dict[str, Any]] = []
+        tool_outputs: list[dict[str, Any]] = []
+        descriptions: list[str] = []
+
+        for tool_call in last_ai_message.tool_calls:
+            tool_name = tool_call["name"]
+            if not self._matches_tool_filter(tool_name):
+                return None
+
+            matching_tool_messages = [
+                message for message in tool_messages if message.tool_call_id == tool_call["id"]
+            ]
+            if len(matching_tool_messages) != 1:
+                return None
+            tool_message = matching_tool_messages[0]
+
+            raw_output = tool_message.text
+            normalized_output = self._output_normalizer(raw_output)
+            tool_calls.append(
+                {
+                    "name": tool_name,
+                    "args": tool_call["args"],
+                }
+            )
+            tool_outputs.append(
+                {
+                    "name": tool_message.name or tool_name,
+                    "status": tool_message.status,
+                    "output": normalized_output,
+                }
+            )
+            descriptions.append(
+                f"{tool_name}({stable_json_dumps(tool_call['args'])}) -> "
+                f"{tool_message.status}: {summarize_progress_output(raw_output)}"
+            )
+
+        signature = build_tool_exchange_signature(
+            tool_calls=tool_calls,
+            tool_outputs=tool_outputs,
+        )
+        description = "; ".join(descriptions)
+
+        return _ProgressObservation(
+            exchange_id=_build_exchange_id(last_ai_message),
+            signature=signature,
+            description=description,
+        )
+
+    @staticmethod
+    def _reset_state(*, exchange_id: str | None) -> dict[str, Any]:
+        """Clear the current progress-stalled streak."""
+        return {
+            _LAST_PROCESSED_EXCHANGE_KEY: exchange_id,
+            _LAST_SIGNATURE_KEY: None,
+            _CONSECUTIVE_COUNT_KEY: 0,
+        }
+
+    @override
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Optionally convert monitored tool exceptions into error `ToolMessage`s."""
+        tool_name = request.tool.name if request.tool is not None else request.tool_call["name"]
+        if not self.catch_tool_exceptions or not self._matches_tool_filter(tool_name):
+            return handler(request)
+
+        try:
+            return handler(request)
+        except Exception as exc:
+            return ToolMessage(
+                content=self._format_tool_failure_message(tool_name, exc),
+                tool_call_id=request.tool_call["id"],
+                name=tool_name,
+                status="error",
+            )
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Async version of `wrap_tool_call`."""
+        tool_name = request.tool.name if request.tool is not None else request.tool_call["name"]
+        if not self.catch_tool_exceptions or not self._matches_tool_filter(tool_name):
+            return await handler(request)
+
+        try:
+            return await handler(request)
+        except Exception as exc:
+            return ToolMessage(
+                content=self._format_tool_failure_message(tool_name, exc),
+                tool_call_id=request.tool_call["id"],
+                name=tool_name,
+                status="error",
+            )
+
+    @hook_config(can_jump_to=["end"])
+    @override
+    def before_model(
+        self,
+        state: ProgressGuardState[ResponseT],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Inspect the latest completed tool exchange before the next model call."""
+        messages = state.get("messages", [])
+        last_ai_message, tool_messages = _fetch_last_ai_and_tool_messages(messages)
+        current_exchange_id = (
+            _build_exchange_id(last_ai_message) if last_ai_message is not None else None
+        )
+
+        if not state.get(_INITIALIZED_KEY, False):
+            return {
+                _INITIALIZED_KEY: True,
+                **self._reset_state(exchange_id=current_exchange_id),
+            }
+
+        if current_exchange_id is None:
+            return self._reset_state(exchange_id=None)
+
+        if current_exchange_id == state.get(_LAST_PROCESSED_EXCHANGE_KEY):
+            return None
+
+        observation = self._extract_progress_observation(
+            last_ai_message=last_ai_message,
+            tool_messages=tool_messages,
+        )
+        if observation is None:
+            return self._reset_state(exchange_id=current_exchange_id)
+
+        previous_signature = state.get(_LAST_SIGNATURE_KEY)
+        previous_count = state.get(_CONSECUTIVE_COUNT_KEY, 0)
+        consecutive_steps = previous_count + 1 if previous_signature == observation.signature else 1
+
+        if consecutive_steps >= self.max_consecutive_identical_steps:
+            if self.exit_behavior == "error":
+                raise AgentProgressStalledError(
+                    consecutive_steps=consecutive_steps,
+                    max_consecutive_identical_steps=self.max_consecutive_identical_steps,
+                    description=observation.description,
+                    exchange_signature=observation.signature,
+                )
+
+            return {
+                "jump_to": "end",
+                "messages": [
+                    AIMessage(
+                        content=build_progress_stalled_message(
+                            consecutive_steps=consecutive_steps,
+                            description=observation.description,
+                        )
+                    )
+                ],
+                _LAST_PROCESSED_EXCHANGE_KEY: observation.exchange_id,
+                _LAST_SIGNATURE_KEY: observation.signature,
+                _CONSECUTIVE_COUNT_KEY: consecutive_steps,
+            }
+
+        return {
+            _LAST_PROCESSED_EXCHANGE_KEY: observation.exchange_id,
+            _LAST_SIGNATURE_KEY: observation.signature,
+            _CONSECUTIVE_COUNT_KEY: consecutive_steps,
+        }
+
+    @hook_config(can_jump_to=["end"])
+    async def abefore_model(
+        self,
+        state: ProgressGuardState[ResponseT],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Async version of `before_model`."""
+        return self.before_model(state, runtime)

--- a/libs/langchain_v1/langchain/agents/middleware/progress_guard.py
+++ b/libs/langchain_v1/langchain/agents/middleware/progress_guard.py
@@ -103,9 +103,12 @@ class ProgressGuardMiddleware(
     """Stop agent loops that repeat the same completed tool exchange.
 
     Use this guard when an agent keeps making the same tool calls and receives the
-    same tool outputs. It detects repeated successful outputs and repeated error
-    outputs by comparing the tool name, tool arguments, output status, and normalized
-    output content.
+    same error outputs. It detects repeated failures by comparing the tool name, tool
+    arguments, output status, and normalized output content.
+
+    By default, `failure_only=True` so repeated successful outputs are ignored. Set
+    `failure_only=False` only when you want broader detection of repeated successful
+    outputs as well.
 
     By default, this middleware only observes completed `ToolMessage` objects that
     already exist. It does not catch raw tool exceptions. Set
@@ -124,7 +127,7 @@ class ProgressGuardMiddleware(
     intentional.
 
     Examples:
-        !!! example "Stop repeated no-progress tool exchanges"
+        !!! example "Stop repeated failures for one tool"
 
             ```python
             from langchain.agents import create_agent
@@ -132,10 +135,18 @@ class ProgressGuardMiddleware(
 
             agent = create_agent(
                 model,
-                tools=[search_tool],
-                middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=3)],
+                tools=[search_db],
+                middleware=[
+                    ProgressGuardMiddleware(
+                        tools=["search_db"],
+                        max_consecutive_identical_steps=3,
+                    )
+                ],
             )
             ```
+
+            Tool scoping is optional, but recommended when only some tools are likely
+            to get stuck on repeated failures.
 
         !!! example "End gracefully instead of raising"
 
@@ -173,6 +184,18 @@ class ProgressGuardMiddleware(
 
             guard = ProgressGuardMiddleware(output_normalizer=normalize_search_output)
             ```
+
+        !!! example "Detect repeated successful outputs"
+
+            ```python
+            guard = ProgressGuardMiddleware(
+                tools=["poll_job"],
+                failure_only=False,
+            )
+            ```
+
+            Use this broader mode only for tools where unchanged successful output
+            means the agent is not making progress.
     """
 
     state_schema = ProgressGuardState  # type: ignore[assignment]
@@ -185,6 +208,7 @@ class ProgressGuardMiddleware(
         exit_behavior: Literal["error", "end"] = "error",
         output_normalizer: Callable[[str], str] | None = None,
         catch_tool_exceptions: bool = False,
+        failure_only: bool = True,
     ) -> None:
         """Initialize the progress guard.
 
@@ -204,6 +228,9 @@ class ProgressGuardMiddleware(
                 whitespace.
             catch_tool_exceptions: Whether to convert monitored tool exceptions into
                 `ToolMessage(status="error")`.
+            failure_only: Whether to count only exchanges whose tool outputs all have
+                `status="error"`. Set to `False` to also detect repeated successful
+                outputs.
 
         Raises:
             ValueError: If `max_consecutive_identical_steps < 2` or `exit_behavior`
@@ -224,6 +251,7 @@ class ProgressGuardMiddleware(
         self.exit_behavior = exit_behavior
         self._output_normalizer = output_normalizer or default_progress_output_normalizer
         self.catch_tool_exceptions = catch_tool_exceptions
+        self.failure_only = failure_only
         self.tools = []
         self._tool_filter = (
             {tool.name if not isinstance(tool, str) else tool for tool in tools}
@@ -269,6 +297,9 @@ class ProgressGuardMiddleware(
             if len(matching_tool_messages) != 1:
                 return None
             tool_message = matching_tool_messages[0]
+
+            if self.failure_only and tool_message.status != "error":
+                return None
 
             raw_output = tool_message.text
             normalized_output = self._output_normalizer(raw_output)

--- a/libs/langchain_v1/langchain/agents/middleware/progress_guard.py
+++ b/libs/langchain_v1/langchain/agents/middleware/progress_guard.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
 
 from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
 from langgraph.channels.untracked_value import UntrackedValue
@@ -27,6 +27,8 @@ from langchain.agents.middleware.types import (
     ToolCallRequest,
     hook_config,
 )
+
+__all__ = ["AgentProgressStalledError", "ProgressGuardMiddleware"]
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -58,9 +60,7 @@ class ProgressGuardState(AgentState[ResponseT]):
     the current consecutive equivalent exchange streak.
     """
 
-    run_progress_guard_initialized: NotRequired[
-        Annotated[bool, UntrackedValue, PrivateStateAttr]
-    ]
+    run_progress_guard_initialized: NotRequired[Annotated[bool, UntrackedValue, PrivateStateAttr]]
     run_progress_guard_last_processed_exchange_id: NotRequired[
         Annotated[str | None, UntrackedValue, PrivateStateAttr]
     ]
@@ -97,9 +97,7 @@ def _build_exchange_id(message: AIMessage) -> str:
     )
 
 
-class ProgressGuardMiddleware(
-    AgentMiddleware[ProgressGuardState[ResponseT], ContextT, ResponseT]
-):
+class ProgressGuardMiddleware(AgentMiddleware[ProgressGuardState[ResponseT], ContextT, ResponseT]):
     """Stop agent loops that repeat the same completed tool exchange.
 
     Use this guard when an agent keeps making the same tool calls and receives the
@@ -417,7 +415,7 @@ class ProgressGuardMiddleware(
             return self._reset_state(exchange_id=current_exchange_id)
 
         previous_signature = state.get(_LAST_SIGNATURE_KEY)
-        previous_count = state.get(_CONSECUTIVE_COUNT_KEY, 0)
+        previous_count = cast("int", state.get(_CONSECUTIVE_COUNT_KEY, 0))
         consecutive_steps = previous_count + 1 if previous_signature == observation.signature else 1
 
         if consecutive_steps >= self.max_consecutive_identical_steps:

--- a/libs/langchain_v1/langchain/agents/middleware/tool_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_retry.py
@@ -489,8 +489,7 @@ class ToolRetryMiddleware(AgentMiddleware[ToolRetryState[ResponseT], ContextT, R
                 consecutive_steps=consecutive_failures,
                 max_consecutive_identical_steps=max_consecutive_failures,
                 description=(
-                    f"{tool_name}({request.tool_call['args']!r}) -> "
-                    f"error: {tool_message.text}"
+                    f"{tool_name}({request.tool_call['args']!r}) -> error: {tool_message.text}"
                 ),
                 exchange_signature=signature,
             )
@@ -538,9 +537,7 @@ class ToolRetryMiddleware(AgentMiddleware[ToolRetryState[ResponseT], ContextT, R
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
                     # Exception is not retryable, handle failure immediately
-                    tool_message = self._handle_failure(
-                        tool_name, tool_call_id, exc, attempts_made
-                    )
+                    tool_message = self._handle_failure(tool_name, tool_call_id, exc, attempts_made)
                     return self._handle_exhausted_failure(request, tool_name, tool_message)
 
                 # Check if we have more retries left
@@ -558,9 +555,7 @@ class ToolRetryMiddleware(AgentMiddleware[ToolRetryState[ResponseT], ContextT, R
                     # Continue to next retry
                 else:
                     # No more retries, handle failure
-                    tool_message = self._handle_failure(
-                        tool_name, tool_call_id, exc, attempts_made
-                    )
+                    tool_message = self._handle_failure(tool_name, tool_call_id, exc, attempts_made)
                     return self._handle_exhausted_failure(request, tool_name, tool_message)
 
         # Unreachable: loop always returns via handler success or _handle_failure
@@ -603,9 +598,7 @@ class ToolRetryMiddleware(AgentMiddleware[ToolRetryState[ResponseT], ContextT, R
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
                     # Exception is not retryable, handle failure immediately
-                    tool_message = self._handle_failure(
-                        tool_name, tool_call_id, exc, attempts_made
-                    )
+                    tool_message = self._handle_failure(tool_name, tool_call_id, exc, attempts_made)
                     return self._handle_exhausted_failure(request, tool_name, tool_message)
 
                 # Check if we have more retries left
@@ -623,9 +616,7 @@ class ToolRetryMiddleware(AgentMiddleware[ToolRetryState[ResponseT], ContextT, R
                     # Continue to next retry
                 else:
                     # No more retries, handle failure
-                    tool_message = self._handle_failure(
-                        tool_name, tool_call_id, exc, attempts_made
-                    )
+                    tool_message = self._handle_failure(tool_name, tool_call_id, exc, attempts_made)
                     return self._handle_exhausted_failure(request, tool_name, tool_message)
 
         # Unreachable: loop always returns via handler success or _handle_failure

--- a/libs/langchain_v1/langchain/agents/middleware/tool_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_retry.py
@@ -5,10 +5,20 @@ from __future__ import annotations
 import asyncio
 import time
 import warnings
-from typing import TYPE_CHECKING, Any
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Annotated, Any
 
 from langchain_core.messages import ToolMessage
+from langgraph.channels.untracked_value import UntrackedValue
+from langgraph.types import Command
+from typing_extensions import NotRequired
 
+from langchain.agents.middleware._progress import (
+    AgentProgressStalledError,
+    build_tool_failure_signature,
+    default_progress_output_normalizer,
+    validate_max_consecutive_steps,
+)
 from langchain.agents.middleware._retry import (
     OnFailure,
     RetryOn,
@@ -16,18 +26,39 @@ from langchain.agents.middleware._retry import (
     should_retry_exception,
     validate_retry_params,
 )
-from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ResponseT
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    PrivateStateAttr,
+    ResponseT,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-    from langgraph.types import Command
-
     from langchain.agents.middleware.types import ToolCallRequest
     from langchain.tools import BaseTool
 
+_PROGRESS_SIGNATURE_KEY = "run_tool_retry_last_failure_signature"
+_PROGRESS_COUNT_KEY = "run_tool_retry_consecutive_failure_count"
 
-class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
+
+class ToolRetryState(AgentState[ResponseT]):
+    """State schema for `ToolRetryMiddleware`.
+
+    Adds run-scoped private fields used only when retry progress detection is enabled.
+    """
+
+    run_tool_retry_last_failure_signature: NotRequired[
+        Annotated[str | None, UntrackedValue, PrivateStateAttr]
+    ]
+    run_tool_retry_consecutive_failure_count: NotRequired[
+        Annotated[int, UntrackedValue, PrivateStateAttr]
+    ]
+
+
+class ToolRetryMiddleware(AgentMiddleware[ToolRetryState[ResponseT], ContextT, ResponseT]):
     """Middleware that automatically retries failed tool calls with configurable backoff.
 
     Supports retrying on specific exceptions and exponential backoff.
@@ -123,7 +154,47 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
                 on_failure="error",  # Re-raise exception instead of returning message
             )
             ```
+
+        !!! example "Stop repeated retry-exhaustion loops"
+
+            Use this when the model keeps calling the same failing tool after retries
+            have already been exhausted.
+
+            ```python
+            from langchain.agents.middleware import (
+                AgentProgressStalledError,
+                ToolRetryMiddleware,
+            )
+
+
+            retry = ToolRetryMiddleware(
+                max_retries=2,
+                max_consecutive_identical_failures=3,
+            )
+
+            try:
+                agent.invoke({"messages": [{"role": "user", "content": "search again"}]})
+            except AgentProgressStalledError as exc:
+                print(exc.reason)  # "no_progress_detected"
+            ```
+
+            Stall detection is disabled by default. When enabled, it counts one failure
+            per tool call after retries are exhausted. Retry attempts inside the same
+            tool call do not count separately.
+
+            Keep the default `on_failure="continue"`. Do not use
+            `on_failure="error"` with this option. The constructor raises `ValueError`
+            for that combination because raw exceptions stop the run before repeated
+            failures can be counted.
+
+            Do not also enable `ProgressGuardMiddleware` for the same tool unless you
+            intentionally want layered detection.
+
+            Custom tool-call wrappers should pass through both `ToolMessage` and
+            `Command` results.
     """
+
+    state_schema = ToolRetryState  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -136,6 +207,8 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
         initial_delay: float = 1.0,
         max_delay: float = 60.0,
         jitter: bool = True,
+        max_consecutive_identical_failures: int | None = None,
+        stall_error_normalizer: Callable[[str], str] | None = None,
     ) -> None:
         """Initialize `ToolRetryMiddleware`.
 
@@ -178,14 +251,32 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
 
                 Caps exponential backoff growth.
             jitter: Whether to add random jitter (`±25%`) to delay to avoid thundering herd.
+            max_consecutive_identical_failures: Optional threshold for stopping an
+                agent loop that repeatedly exhausts retries for the same tool, same
+                arguments, and same normalized final error. Must be `>= 2` when set.
+
+                `None` disables stall detection. Retry attempts inside one tool call do
+                not increment this counter; only the final failure returned to the
+                model counts.
+            stall_error_normalizer: Optional callable used to normalize final failure
+                messages before comparing them for stall detection. The default
+                normalizer strips common volatile details such as tracebacks, request
+                IDs, UUIDs, timestamps, and repeated whitespace.
 
         Raises:
-            ValueError: If `max_retries < 0` or delays are negative.
+            ValueError: If `max_retries < 0`, delays are negative, the stall
+                threshold is invalid, or stall detection is enabled with
+                `on_failure='error'`.
         """
         super().__init__()
 
         # Validate parameters
         validate_retry_params(max_retries, initial_delay, max_delay, backoff_factor)
+        if max_consecutive_identical_failures is not None:
+            validate_max_consecutive_steps(
+                max_consecutive_identical_failures,
+                parameter_name="max_consecutive_identical_failures",
+            )
 
         # Handle backwards compatibility for deprecated on_failure values
         if on_failure == "raise":  # type: ignore[comparison-overlap]
@@ -203,6 +294,14 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
             warnings.warn(msg, DeprecationWarning, stacklevel=2)
             on_failure = "continue"
 
+        if max_consecutive_identical_failures is not None and on_failure == "error":
+            msg = (
+                "max_consecutive_identical_failures cannot be used with "
+                "on_failure='error' because raw exceptions abort the run before "
+                "repeated failure observations can be counted."
+            )
+            raise ValueError(msg)
+
         self.max_retries = max_retries
 
         # Extract tool names from BaseTool instances or strings
@@ -219,6 +318,10 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
         self.initial_delay = initial_delay
         self.max_delay = max_delay
         self.jitter = jitter
+        self.max_consecutive_identical_failures = max_consecutive_identical_failures
+        self._failure_output_normalizer = (
+            stall_error_normalizer or default_progress_output_normalizer
+        )
 
     def _should_retry_tool(self, tool_name: str) -> bool:
         """Check if retry logic should apply to this tool.
@@ -285,6 +388,121 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
             status="error",
         )
 
+    def _progress_detection_enabled(self) -> bool:
+        """Check whether retry-exhaustion stall detection is enabled."""
+        return self.max_consecutive_identical_failures is not None
+
+    @staticmethod
+    def _has_progress_state(state: Any) -> bool:
+        """Check whether there is retry stall state to clear."""
+        if not isinstance(state, Mapping):
+            return False
+        return state.get(_PROGRESS_SIGNATURE_KEY) is not None or bool(
+            state.get(_PROGRESS_COUNT_KEY)
+        )
+
+    @staticmethod
+    def _reset_progress_state_update() -> dict[str, Any]:
+        """Build an update that clears retry stall state for this run."""
+        return {
+            _PROGRESS_SIGNATURE_KEY: None,
+            _PROGRESS_COUNT_KEY: 0,
+        }
+
+    @staticmethod
+    def _as_tool_message_command(
+        tool_message: ToolMessage, state_update: dict[str, Any]
+    ) -> Command[Any]:
+        """Attach private state updates while preserving the tool message."""
+        return Command(update={"messages": [tool_message], **state_update})
+
+    @staticmethod
+    def _as_command_with_state_update(
+        command: Command[Any], state_update: dict[str, Any]
+    ) -> Command[Any]:
+        """Attach private state updates to a command with a dict update."""
+        if not isinstance(command.update, Mapping):
+            return command
+
+        return Command(
+            graph=command.graph,
+            update={**command.update, **state_update},
+            resume=command.resume,
+            goto=command.goto,
+        )
+
+    def _handle_success_result(
+        self,
+        request: ToolCallRequest,
+        result: ToolMessage | Command[Any],
+    ) -> ToolMessage | Command[Any]:
+        """Reset stall state after a successful observed tool result."""
+        if not self._progress_detection_enabled():
+            return result
+
+        if not self._has_progress_state(request.state):
+            return result
+
+        if isinstance(result, ToolMessage) and result.status != "error":
+            return self._as_tool_message_command(result, self._reset_progress_state_update())
+
+        if isinstance(result, Command):
+            messages = result.update.get("messages") if isinstance(result.update, Mapping) else None
+            if isinstance(messages, list) and any(
+                isinstance(message, ToolMessage) and message.status != "error"
+                for message in messages
+            ):
+                return self._as_command_with_state_update(
+                    result,
+                    self._reset_progress_state_update(),
+                )
+
+        return result
+
+    def _handle_exhausted_failure(
+        self,
+        request: ToolCallRequest,
+        tool_name: str,
+        tool_message: ToolMessage,
+    ) -> ToolMessage | Command[Any]:
+        """Count final retry failures and raise if they form a stall."""
+        if not self._progress_detection_enabled():
+            return tool_message
+
+        state = request.state if isinstance(request.state, Mapping) else {}
+        signature = build_tool_failure_signature(
+            tool_name=tool_name,
+            tool_args=request.tool_call["args"],
+            error_message=tool_message.text,
+            error_normalizer=self._failure_output_normalizer,
+        )
+        previous_signature = state.get(_PROGRESS_SIGNATURE_KEY)
+        previous_count = state.get(_PROGRESS_COUNT_KEY, 0)
+        consecutive_failures = previous_count + 1 if previous_signature == signature else 1
+
+        max_consecutive_failures = self.max_consecutive_identical_failures
+        if (
+            max_consecutive_failures is not None
+            and consecutive_failures >= max_consecutive_failures
+        ):
+            raise AgentProgressStalledError(
+                consecutive_steps=consecutive_failures,
+                max_consecutive_identical_steps=max_consecutive_failures,
+                description=(
+                    f"{tool_name}({request.tool_call['args']!r}) -> "
+                    f"error: {tool_message.text}"
+                ),
+                exchange_signature=signature,
+            )
+
+        return self._as_tool_message_command(
+            tool_message,
+            {
+                _PROGRESS_SIGNATURE_KEY: signature,
+                _PROGRESS_COUNT_KEY: consecutive_failures,
+            },
+        )
+
     def wrap_tool_call(
         self,
         request: ToolCallRequest,
@@ -313,14 +531,17 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
         # Initial attempt + retries
         for attempt in range(self.max_retries + 1):
             try:
-                return handler(request)
+                return self._handle_success_result(request, handler(request))
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
                     # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(tool_name, tool_call_id, exc, attempts_made)
+                    tool_message = self._handle_failure(
+                        tool_name, tool_call_id, exc, attempts_made
+                    )
+                    return self._handle_exhausted_failure(request, tool_name, tool_message)
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -337,7 +558,10 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
                     # Continue to next retry
                 else:
                     # No more retries, handle failure
-                    return self._handle_failure(tool_name, tool_call_id, exc, attempts_made)
+                    tool_message = self._handle_failure(
+                        tool_name, tool_call_id, exc, attempts_made
+                    )
+                    return self._handle_exhausted_failure(request, tool_name, tool_message)
 
         # Unreachable: loop always returns via handler success or _handle_failure
         msg = "Unexpected: retry loop completed without returning"
@@ -372,14 +596,17 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
         # Initial attempt + retries
         for attempt in range(self.max_retries + 1):
             try:
-                return await handler(request)
+                return self._handle_success_result(request, await handler(request))
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
                     # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(tool_name, tool_call_id, exc, attempts_made)
+                    tool_message = self._handle_failure(
+                        tool_name, tool_call_id, exc, attempts_made
+                    )
+                    return self._handle_exhausted_failure(request, tool_name, tool_message)
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -396,7 +623,10 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
                     # Continue to next retry
                 else:
                     # No more retries, handle failure
-                    return self._handle_failure(tool_name, tool_call_id, exc, attempts_made)
+                    tool_message = self._handle_failure(
+                        tool_name, tool_call_id, exc, attempts_made
+                    )
+                    return self._handle_exhausted_failure(request, tool_name, tool_message)
 
         # Unreachable: loop always returns via handler success or _handle_failure
         msg = "Unexpected: retry loop completed without returning"

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_progress_guard.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_progress_guard.py
@@ -53,6 +53,7 @@ def test_progress_guard_initialization_defaults() -> None:
     assert guard.max_consecutive_identical_steps == 3
     assert guard.exit_behavior == "error"
     assert guard.catch_tool_exceptions is False
+    assert guard.failure_only is True
     assert guard.tools == []
     assert guard._tool_filter is None
 
@@ -66,8 +67,8 @@ def test_progress_guard_invalid_initialization() -> None:
         ProgressGuardMiddleware(exit_behavior="continue")  # type: ignore[arg-type]
 
 
-def test_progress_guard_detects_repeated_successful_tool_output() -> None:
-    """Test repeated successful tool exchanges are treated as no progress."""
+def test_progress_guard_ignores_repeated_successful_tool_output_by_default() -> None:
+    """Test repeated successful tool exchanges are ignored by default."""
     model = FakeToolCallingModel(
         tool_calls=[
             [ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
@@ -81,6 +82,35 @@ def test_progress_guard_detects_repeated_successful_tool_output() -> None:
         model=model,
         tools=[working_tool],
         middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=3)],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    tool_messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+    assert len(tool_messages) == 3
+    assert model.index == 4
+
+
+def test_progress_guard_can_detect_repeated_successful_tool_output() -> None:
+    """Test repeated successful tool exchanges can be treated as no progress."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-2")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-3")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=3,
+                failure_only=False,
+            )
+        ],
     )
 
     with pytest.raises(AgentProgressStalledError, match="no_progress_detected") as exc_info:
@@ -146,7 +176,12 @@ def test_progress_guard_detects_repeated_multi_tool_exchange() -> None:
     agent = create_agent(
         model=model,
         tools=[working_tool, other_working_tool],
-        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=2)],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=2,
+                failure_only=False,
+            )
+        ],
     )
 
     with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):
@@ -238,6 +273,7 @@ def test_progress_guard_end_behavior_appends_final_ai_message() -> None:
             ProgressGuardMiddleware(
                 max_consecutive_identical_steps=2,
                 exit_behavior="end",
+                failure_only=False,
             )
         ],
     )
@@ -301,7 +337,12 @@ def test_progress_guard_resets_when_args_change() -> None:
     agent = create_agent(
         model=model,
         tools=[working_tool],
-        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=3)],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=3,
+                failure_only=False,
+            )
+        ],
     )
 
     result = agent.invoke({"messages": [HumanMessage("keep trying")]})
@@ -324,7 +365,12 @@ def test_progress_guard_resets_when_tool_name_changes() -> None:
     agent = create_agent(
         model=model,
         tools=[working_tool, other_working_tool],
-        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=2)],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=2,
+                failure_only=False,
+            )
+        ],
     )
 
     result = agent.invoke({"messages": [HumanMessage("keep trying")]})
@@ -355,7 +401,12 @@ def test_progress_guard_resets_when_output_changes() -> None:
     agent = create_agent(
         model=model,
         tools=[changing_output_tool],
-        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=2)],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=2,
+                failure_only=False,
+            )
+        ],
     )
 
     result = agent.invoke({"messages": [HumanMessage("keep trying")]})
@@ -392,7 +443,10 @@ def test_progress_guard_resets_when_status_changes() -> None:
         model=model,
         tools=[working_tool],
         middleware=[
-            ProgressGuardMiddleware(max_consecutive_identical_steps=2),
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=2,
+                failure_only=False,
+            ),
             changing_status_middleware,
         ],
     )
@@ -422,6 +476,7 @@ def test_progress_guard_resets_on_unmonitored_tool() -> None:
             ProgressGuardMiddleware(
                 max_consecutive_identical_steps=2,
                 tools=["working_tool"],
+                failure_only=False,
             )
         ],
     )
@@ -487,7 +542,12 @@ def test_progress_guard_ignores_preexisting_history_on_run_start() -> None:
     agent = create_agent(
         model=model,
         tools=[working_tool],
-        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=2)],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=2,
+                failure_only=False,
+            )
+        ],
     )
 
     result = agent.invoke({"messages": prior_messages})
@@ -511,7 +571,12 @@ async def test_progress_guard_async_parity() -> None:
     agent = create_agent(
         model=model,
         tools=[working_tool],
-        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=3)],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=3,
+                failure_only=False,
+            )
+        ],
     )
 
     with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_progress_guard.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_progress_guard.py
@@ -1,0 +1,520 @@
+"""Tests for ProgressGuardMiddleware."""
+
+from typing import Any
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+from langchain_core.tools import tool
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware import (
+    AgentProgressStalledError,
+    ProgressGuardMiddleware,
+    wrap_tool_call,
+)
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+class FailureCounter:
+    """Track tool invocations while returning controlled failures."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def fail(self, value: str) -> str:
+        """Always raise a deterministic failure for the given value."""
+        self.calls += 1
+        msg = f"backend failure for {value}"
+        raise ValueError(msg)
+
+    def fail_with_request_id(self, value: str) -> str:
+        """Raise a failure whose request ID changes on each call."""
+        self.calls += 1
+        msg = f"backend failure for {value} request_id=req-{self.calls}"
+        raise ValueError(msg)
+
+
+@tool
+def working_tool(value: str) -> str:
+    """Return a successful value."""
+    return f"success: {value}"
+
+
+@tool
+def other_working_tool(value: str) -> str:
+    """Return another successful value."""
+    return f"other success: {value}"
+
+
+def test_progress_guard_initialization_defaults() -> None:
+    """Test default initialization values."""
+    guard = ProgressGuardMiddleware()
+
+    assert guard.max_consecutive_identical_steps == 3
+    assert guard.exit_behavior == "error"
+    assert guard.catch_tool_exceptions is False
+    assert guard.tools == []
+    assert guard._tool_filter is None
+
+
+def test_progress_guard_invalid_initialization() -> None:
+    """Test initialization validation."""
+    with pytest.raises(ValueError, match="max_consecutive_identical_steps must be >= 2"):
+        ProgressGuardMiddleware(max_consecutive_identical_steps=1)
+
+    with pytest.raises(ValueError, match="exit_behavior must be 'error' or 'end'"):
+        ProgressGuardMiddleware(exit_behavior="continue")  # type: ignore[arg-type]
+
+
+def test_progress_guard_detects_repeated_successful_tool_output() -> None:
+    """Test repeated successful tool exchanges are treated as no progress."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-2")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-3")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool],
+        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=3)],
+    )
+
+    with pytest.raises(AgentProgressStalledError, match="no_progress_detected") as exc_info:
+        agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    assert exc_info.value.reason == "no_progress_detected"
+    assert exc_info.value.consecutive_steps == 3
+    assert model.index == 3
+
+
+def test_progress_guard_detects_repeated_error_messages_from_other_middleware() -> None:
+    """Test repeated error ToolMessages are detected without catching exceptions."""
+
+    @wrap_tool_call
+    def return_error_message(request: Any, handler: Any) -> ToolMessage:
+        """Short-circuit tool execution with an error ToolMessage."""
+        return ToolMessage(
+            content="backend unavailable",
+            tool_call_id=request.tool_call["id"],
+            name=request.tool_call["name"],
+            status="error",
+        )
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool],
+        middleware=[
+            ProgressGuardMiddleware(max_consecutive_identical_steps=2),
+            return_error_message,
+        ],
+    )
+
+    with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):
+        agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    assert model.index == 2
+
+
+def test_progress_guard_detects_repeated_multi_tool_exchange() -> None:
+    """Test repeated identical multi-tool exchanges are treated as no progress."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [
+                ToolCall(name="working_tool", args={"value": "same"}, id="call-1"),
+                ToolCall(name="other_working_tool", args={"value": "same"}, id="call-2"),
+            ],
+            [
+                ToolCall(name="working_tool", args={"value": "same"}, id="call-3"),
+                ToolCall(name="other_working_tool", args={"value": "same"}, id="call-4"),
+            ],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool, other_working_tool],
+        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=2)],
+    )
+
+    with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):
+        agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    assert model.index == 2
+
+
+def test_progress_guard_can_preserve_raw_tool_exception_behavior() -> None:
+    """Test raw tool exceptions still abort when error handling is disabled."""
+    failure_counter = FailureCounter()
+
+    @tool
+    def failing_tool(value: str) -> str:
+        """Always fail with the same error."""
+        return failure_counter.fail(value)
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="call-2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[failing_tool],
+        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=2)],
+    )
+
+    with pytest.raises(ValueError, match="backend failure for same"):
+        agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    assert failure_counter.calls == 1
+    assert model.index == 1
+
+
+def test_progress_guard_can_catch_tool_exceptions() -> None:
+    """Test repeated caught tool exceptions are treated as no progress."""
+    failure_counter = FailureCounter()
+
+    @tool
+    def failing_tool(value: str) -> str:
+        """Always fail with the same error."""
+        return failure_counter.fail(value)
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="call-2")],
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="call-3")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[failing_tool],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=3,
+                catch_tool_exceptions=True,
+            )
+        ],
+    )
+
+    with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):
+        agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    assert failure_counter.calls == 3
+    assert model.index == 3
+
+
+def test_progress_guard_end_behavior_appends_final_ai_message() -> None:
+    """Test graceful termination appends a final AI message."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=2,
+                exit_behavior="end",
+            )
+        ],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    assert result["messages"][-1].content.startswith(
+        "Agent stopped because no_progress_detected"
+    )
+    assert model.index == 2
+
+
+def test_progress_guard_normalizes_volatile_output_details() -> None:
+    """Test changing request IDs do not break equivalent exchange detection."""
+    failure_counter = FailureCounter()
+
+    @tool
+    def failing_tool(value: str) -> str:
+        """Always fail with a changing request ID."""
+        return failure_counter.fail_with_request_id(value)
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="call-2")],
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="call-3")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[failing_tool],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=3,
+                catch_tool_exceptions=True,
+            )
+        ],
+    )
+
+    with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):
+        agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    assert failure_counter.calls == 3
+
+
+def test_progress_guard_resets_when_args_change() -> None:
+    """Test changed tool arguments break the no-progress streak."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "one"}, id="call-1")],
+            [ToolCall(name="working_tool", args={"value": "one"}, id="call-2")],
+            [ToolCall(name="working_tool", args={"value": "two"}, id="call-3")],
+            [ToolCall(name="working_tool", args={"value": "one"}, id="call-4")],
+            [ToolCall(name="working_tool", args={"value": "one"}, id="call-5")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool],
+        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=3)],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    tool_messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+    assert len(tool_messages) == 5
+    assert model.index == 6
+
+
+def test_progress_guard_resets_when_tool_name_changes() -> None:
+    """Test changed tool name breaks the no-progress streak."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="other_working_tool", args={"value": "same"}, id="call-2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool, other_working_tool],
+        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=2)],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    tool_messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+    assert len(tool_messages) == 2
+    assert model.index == 3
+
+
+def test_progress_guard_resets_when_output_changes() -> None:
+    """Test changed tool output breaks the no-progress streak."""
+    calls = {"count": 0}
+
+    @tool
+    def changing_output_tool(value: str) -> str:
+        """Return a different message on each call."""
+        calls["count"] += 1
+        return f"success: {value} {calls['count']}"
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="changing_output_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="changing_output_tool", args={"value": "same"}, id="call-2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[changing_output_tool],
+        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=2)],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    tool_messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+    assert len(tool_messages) == 2
+    assert model.index == 3
+
+
+def test_progress_guard_resets_when_status_changes() -> None:
+    """Test changed output status breaks the no-progress streak."""
+    calls = {"count": 0}
+
+    @wrap_tool_call
+    def changing_status_middleware(request: Any, handler: Any) -> ToolMessage:
+        calls["count"] += 1
+        status = "error" if calls["count"] == 1 else "success"
+        return ToolMessage(
+            content="same output",
+            tool_call_id=request.tool_call["id"],
+            name=request.tool_call["name"],
+            status=status,
+        )
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-2")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool],
+        middleware=[
+            ProgressGuardMiddleware(max_consecutive_identical_steps=2),
+            changing_status_middleware,
+        ],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    tool_messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+    assert len(tool_messages) == 2
+    assert model.index == 3
+
+
+def test_progress_guard_resets_on_unmonitored_tool() -> None:
+    """Test an unmonitored tool exchange resets progress tracking."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="other_working_tool", args={"value": "same"}, id="call-2")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-3")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool, other_working_tool],
+        middleware=[
+            ProgressGuardMiddleware(
+                max_consecutive_identical_steps=2,
+                tools=["working_tool"],
+            )
+        ],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("keep trying")]})
+
+    tool_messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+    assert len(tool_messages) == 3
+    assert model.index == 4
+
+
+def test_progress_guard_resets_on_missing_tool_result() -> None:
+    """Test an incomplete tool exchange resets progress tracking."""
+    guard = ProgressGuardMiddleware(max_consecutive_identical_steps=2)
+    state = {
+        "messages": [
+            AIMessage(
+                content="",
+                id="ai-1",
+                tool_calls=[ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
+            )
+        ],
+        "run_progress_guard_initialized": True,
+        "run_progress_guard_last_processed_exchange_id": "previous",
+        "run_progress_guard_last_signature": "previous-signature",
+        "run_progress_guard_consecutive_count": 1,
+    }
+
+    update = guard.before_model(state, runtime=None)  # type: ignore[arg-type]
+
+    assert update == {
+        "run_progress_guard_last_processed_exchange_id": "ai-1",
+        "run_progress_guard_last_signature": None,
+        "run_progress_guard_consecutive_count": 0,
+    }
+
+
+def test_progress_guard_ignores_preexisting_history_on_run_start() -> None:
+    """Test existing thread history is baselined instead of counted immediately."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "same"}, id="new-call-1")],
+            [],
+        ]
+    )
+
+    prior_messages: list[Any] = [
+        HumanMessage("Earlier attempt"),
+        AIMessage(
+            content="",
+            id="prior-ai",
+            tool_calls=[ToolCall(name="working_tool", args={"value": "same"}, id="prior-call")],
+        ),
+        ToolMessage(
+            content="success: same",
+            tool_call_id="prior-call",
+            name="working_tool",
+            status="success",
+        ),
+        HumanMessage("Try again"),
+    ]
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool],
+        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=2)],
+    )
+
+    result = agent.invoke({"messages": prior_messages})
+
+    tool_messages = [message for message in result["messages"] if isinstance(message, ToolMessage)]
+    assert len(tool_messages) == 2
+    assert model.index == 2
+
+
+async def test_progress_guard_async_parity() -> None:
+    """Test async execution detects repeated no-progress exchanges."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-1")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-2")],
+            [ToolCall(name="working_tool", args={"value": "same"}, id="call-3")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[working_tool],
+        middleware=[ProgressGuardMiddleware(max_consecutive_identical_steps=3)],
+    )
+
+    with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):
+        await agent.ainvoke({"messages": [HumanMessage("keep trying")]})
+
+    assert model.index == 3

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_progress_guard.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_progress_guard.py
@@ -280,9 +280,7 @@ def test_progress_guard_end_behavior_appends_final_ai_message() -> None:
 
     result = agent.invoke({"messages": [HumanMessage("keep trying")]})
 
-    assert result["messages"][-1].content.startswith(
-        "Agent stopped because no_progress_detected"
-    )
+    assert result["messages"][-1].content.startswith("Agent stopped because no_progress_detected")
     assert model.index == 2
 
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_retry.py
@@ -12,6 +12,7 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
 from langchain.agents.factory import create_agent
+from langchain.agents.middleware import AgentProgressStalledError
 from langchain.agents.middleware._retry import calculate_delay
 from langchain.agents.middleware.tool_retry import ToolRetryMiddleware
 from langchain.agents.middleware.types import wrap_tool_call
@@ -74,6 +75,7 @@ def test_tool_retry_initialization_defaults() -> None:
     assert retry.initial_delay == 1.0
     assert retry.max_delay == 60.0
     assert retry.jitter is True
+    assert retry.max_consecutive_identical_failures is None
 
 
 def test_tool_retry_initialization_custom() -> None:
@@ -148,6 +150,21 @@ def test_tool_retry_invalid_backoff_factor() -> None:
     """Test ToolRetryMiddlewareraises error for invalid backoff_factor."""
     with pytest.raises(ValueError, match="backoff_factor must be >= 0"):
         ToolRetryMiddleware(backoff_factor=-1.0)
+
+
+def test_tool_retry_invalid_stall_detection_threshold() -> None:
+    """Test ToolRetryMiddleware raises error for invalid stall threshold."""
+    with pytest.raises(ValueError, match="max_consecutive_identical_failures must be >= 2"):
+        ToolRetryMiddleware(max_consecutive_identical_failures=1)
+
+
+def test_tool_retry_stall_detection_rejects_error_failure_mode() -> None:
+    """Test stall detection cannot be combined with raw exception failure mode."""
+    with pytest.raises(ValueError, match="cannot be used with on_failure='error'"):
+        ToolRetryMiddleware(
+            max_consecutive_identical_failures=2,
+            on_failure="error",
+        )
 
 
 def test_tool_retry_working_tool_no_retry_needed() -> None:
@@ -748,6 +765,30 @@ async def test_tool_retry_async_failing_tool() -> None:
     assert tool_messages[0].status == "error"
 
 
+async def test_tool_retry_async_stall_detection_raises() -> None:
+    """Test async ToolRetryMiddleware raises after repeated exhausted failures."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="1")],
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="2")],
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="3")],
+            [],
+        ]
+    )
+
+    retry = ToolRetryMiddleware(
+        max_retries=0,
+        max_consecutive_identical_failures=3,
+    )
+
+    agent = create_agent(model=model, tools=[failing_tool], middleware=[retry])
+
+    with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):
+        await agent.ainvoke({"messages": [HumanMessage("Use failing tool repeatedly")]})
+
+    assert model.index == 3
+
+
 async def test_tool_retry_async_succeeds_after_retries() -> None:
     """Test ToolRetryMiddlewareasync execution succeeds after temporary failures."""
     temp_fail = TemporaryFailureTool(fail_count=2)
@@ -862,6 +903,253 @@ def test_tool_retry_zero_retries() -> None:
     # Should fail after 1 attempt (no retries)
     assert "1 attempt" in tool_messages[0].content
     assert tool_messages[0].status == "error"
+
+
+def test_tool_retry_stall_detection_raises_after_identical_exhausted_failures() -> None:
+    """Test ToolRetryMiddleware raises after repeated exhausted failures across turns."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="1")],
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="2")],
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="3")],
+            [],
+        ]
+    )
+
+    retry = ToolRetryMiddleware(
+        max_retries=1,
+        initial_delay=0.01,
+        jitter=False,
+        max_consecutive_identical_failures=3,
+    )
+
+    agent = create_agent(model=model, tools=[failing_tool], middleware=[retry])
+
+    with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):
+        agent.invoke({"messages": [HumanMessage("Use failing tool repeatedly")]})
+
+    # Each model turn exhausts initial attempt + one retry. Retry attempts are not
+    # counted as separate stall observations.
+    assert model.index == 3
+
+
+def test_tool_retry_stall_detection_does_not_count_retry_attempts() -> None:
+    """Test retry attempts inside one tool call do not trigger stall detection."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="1")],
+            [],
+        ]
+    )
+
+    retry = ToolRetryMiddleware(
+        max_retries=3,
+        initial_delay=0.01,
+        jitter=False,
+        max_consecutive_identical_failures=2,
+    )
+
+    agent = create_agent(model=model, tools=[failing_tool], middleware=[retry])
+    result = agent.invoke({"messages": [HumanMessage("Use failing tool once")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert "4 attempts" in tool_messages[0].content
+    assert model.index == 2
+
+
+def test_tool_retry_stall_detection_resets_on_success() -> None:
+    """Test a successful monitored tool result resets the stall streak."""
+
+    @tool
+    def sometimes_failing_tool(value: str) -> str:
+        """Fail unless value is `ok`."""
+        if value == "ok":
+            return "Success: ok"
+        msg = f"Failed: {value}"
+        raise ValueError(msg)
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="sometimes_failing_tool", args={"value": "same"}, id="1")],
+            [ToolCall(name="sometimes_failing_tool", args={"value": "same"}, id="2")],
+            [ToolCall(name="sometimes_failing_tool", args={"value": "ok"}, id="3")],
+            [ToolCall(name="sometimes_failing_tool", args={"value": "same"}, id="4")],
+            [ToolCall(name="sometimes_failing_tool", args={"value": "same"}, id="5")],
+            [],
+        ]
+    )
+
+    retry = ToolRetryMiddleware(
+        max_retries=0,
+        max_consecutive_identical_failures=3,
+    )
+
+    agent = create_agent(model=model, tools=[sometimes_failing_tool], middleware=[retry])
+    result = agent.invoke({"messages": [HumanMessage("Use tool repeatedly")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 5
+    assert model.index == 6
+
+
+def test_tool_retry_stall_detection_resets_on_command_success() -> None:
+    """Test a successful command-backed tool result resets the stall streak."""
+
+    @tool
+    def sometimes_failing_tool(value: str) -> str:
+        """Fail unless value is `ok`."""
+        if value == "ok":
+            return "Success: ok"
+        msg = f"Failed: {value}"
+        raise ValueError(msg)
+
+    @wrap_tool_call
+    def command_success_middleware(
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        result = handler(request)
+        if isinstance(result, ToolMessage) and result.status != "error":
+            return Command(update={"messages": [result]})
+        return result
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="sometimes_failing_tool", args={"value": "same"}, id="1")],
+            [ToolCall(name="sometimes_failing_tool", args={"value": "same"}, id="2")],
+            [ToolCall(name="sometimes_failing_tool", args={"value": "ok"}, id="3")],
+            [ToolCall(name="sometimes_failing_tool", args={"value": "same"}, id="4")],
+            [ToolCall(name="sometimes_failing_tool", args={"value": "same"}, id="5")],
+            [],
+        ]
+    )
+
+    retry = ToolRetryMiddleware(
+        max_retries=0,
+        max_consecutive_identical_failures=3,
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[sometimes_failing_tool],
+        middleware=[retry, command_success_middleware],
+    )
+    result = agent.invoke({"messages": [HumanMessage("Use tool repeatedly")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 5
+    assert model.index == 6
+
+
+def test_tool_retry_stall_detection_resets_on_changed_args() -> None:
+    """Test changed tool args break the stall signature."""
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="failing_tool", args={"value": "one"}, id="1")],
+            [ToolCall(name="failing_tool", args={"value": "two"}, id="2")],
+            [],
+        ]
+    )
+
+    retry = ToolRetryMiddleware(max_retries=0, max_consecutive_identical_failures=2)
+
+    agent = create_agent(model=model, tools=[failing_tool], middleware=[retry])
+    result = agent.invoke({"messages": [HumanMessage("Use failing tool")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 2
+    assert model.index == 3
+
+
+def test_tool_retry_stall_detection_resets_on_changed_error() -> None:
+    """Test changed final error content breaks the stall signature."""
+    calls = {"count": 0}
+
+    @tool
+    def changing_error_tool(value: str) -> str:
+        """Fail with a different message on each call."""
+        calls["count"] += 1
+        msg = f"Failed: {value} attempt {calls['count']}"
+        raise ValueError(msg)
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="changing_error_tool", args={"value": "same"}, id="1")],
+            [ToolCall(name="changing_error_tool", args={"value": "same"}, id="2")],
+            [],
+        ]
+    )
+
+    retry = ToolRetryMiddleware(max_retries=0, max_consecutive_identical_failures=2)
+
+    agent = create_agent(model=model, tools=[changing_error_tool], middleware=[retry])
+    result = agent.invoke({"messages": [HumanMessage("Use changing error tool")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 2
+    assert model.index == 3
+
+
+def test_tool_retry_stall_detection_resets_on_changed_tool_name() -> None:
+    """Test changed tool name breaks the stall signature."""
+
+    @tool
+    def other_failing_tool(value: str) -> str:
+        """Tool that always fails."""
+        msg = f"Failed: {value}"
+        raise ValueError(msg)
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="failing_tool", args={"value": "same"}, id="1")],
+            [ToolCall(name="other_failing_tool", args={"value": "same"}, id="2")],
+            [],
+        ]
+    )
+
+    retry = ToolRetryMiddleware(max_retries=0, max_consecutive_identical_failures=2)
+
+    agent = create_agent(
+        model=model,
+        tools=[failing_tool, other_failing_tool],
+        middleware=[retry],
+    )
+    result = agent.invoke({"messages": [HumanMessage("Use failing tools")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 2
+    assert model.index == 3
+
+
+def test_tool_retry_stall_detection_normalizes_volatile_error_details() -> None:
+    """Test changing request IDs still count as the same final failure."""
+    calls = {"count": 0}
+
+    @tool
+    def request_id_failing_tool(value: str) -> str:
+        """Fail with a volatile request ID."""
+        calls["count"] += 1
+        msg = f"Failed: {value} request_id=req-{calls['count']}"
+        raise ValueError(msg)
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="request_id_failing_tool", args={"value": "same"}, id="1")],
+            [ToolCall(name="request_id_failing_tool", args={"value": "same"}, id="2")],
+            [ToolCall(name="request_id_failing_tool", args={"value": "same"}, id="3")],
+            [],
+        ]
+    )
+
+    retry = ToolRetryMiddleware(max_retries=0, max_consecutive_identical_failures=3)
+
+    agent = create_agent(model=model, tools=[request_id_failing_tool], middleware=[retry])
+
+    with pytest.raises(AgentProgressStalledError, match="no_progress_detected"):
+        agent.invoke({"messages": [HumanMessage("Use request id failing tool")]})
+
+    assert model.index == 3
 
 
 def test_tool_retry_multiple_middleware_composition() -> None:


### PR DESCRIPTION
Fixes #36139

Adds opt-in progress detection for agents that repeat the same tool call with the same failure, with conservative defaults to reduce false positives. `ProgressGuardMiddleware` is failure-only by default, while broader repeated-output detection requires `failure_only=False`.

No breaking changes.

Verified with:
- `uv run --group test pytest tests/unit_tests/agents/middleware/implementations/test_progress_guard.py tests/unit_tests/agents/middleware/implementations/test_tool_retry.py`



## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Github: @failuresmith
