### PR TITLE
openai: fall back to raw HTTP body when parsed response has null choices

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -548,6 +548,29 @@ def _handle_openai_api_error(e: openai.APIError) -> None:
     raise
 
 
+def _extract_raw_response_dict(raw_response: Any) -> dict | None:
+    """Try to read the raw HTTP JSON body from an OpenAI raw response wrapper.
+
+    Some OpenAI-compatible APIs (e.g., vLLM) return responses where the
+    OpenAI Python SDK's Pydantic parser drops the `choices` field (setting
+    it to None) even though the raw HTTP body contains valid choices.
+    When that happens, fall back to the raw JSON body attached to the
+    response by the OpenAI SDK's `with_raw_response` wrapper.
+
+    Returns a dict on success, or None if the raw body cannot be recovered.
+    """
+    if raw_response is None:
+        return None
+    http_response = getattr(raw_response, "http_response", None)
+    if http_response is None:
+        return None
+    try:
+        raw = http_response.json()
+    except (ValueError, AttributeError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
 _RESPONSES_API_ONLY_PREFIXES = (
     "gpt-5-pro",
     "gpt-5.2-pro",
@@ -1511,7 +1534,7 @@ class BaseChatOpenAI(BaseChatModel):
             and hasattr(raw_response, "headers")
         ):
             generation_info = {"headers": dict(raw_response.headers)}
-        return self._create_chat_result(response, generation_info)
+        return self._create_chat_result(response, generation_info, raw_response)
 
     def _use_responses_api(self, payload: dict) -> bool:
         if isinstance(self.use_responses_api, bool):
@@ -1563,6 +1586,7 @@ class BaseChatOpenAI(BaseChatModel):
         self,
         response: dict | openai.BaseModel,
         generation_info: dict | None = None,
+        raw_response: Any = None,
     ) -> ChatResult:
         generations = []
 
@@ -1590,16 +1614,25 @@ class BaseChatOpenAI(BaseChatModel):
             raise KeyError(msg) from e
 
         if choices is None:
-            # Some OpenAI-compatible APIs (e.g., vLLM) may return null choices
-            # when the response format differs or an error occurs without
-            # populating the error field. Provide a more helpful error message.
-            msg = (
-                "Received response with null value for 'choices'. "
-                "This can happen when using OpenAI-compatible APIs (e.g., vLLM) "
-                "that return a response in an unexpected format. "
-                f"Full response keys: {list(response_dict.keys())}"
-            )
-            raise TypeError(msg)
+            # Some OpenAI-compatible APIs (e.g., vLLM on certain runtimes) return
+            # a response where the parsed `ChatCompletion` has `choices=None`
+            # even though the raw HTTP body contains valid choices (this happens
+            # when the OpenAI Python SDK silently drops fields that fail strict
+            # validation). Fall back to the raw HTTP response body if available.
+            # See: https://github.com/langchain-ai/langchain/issues/32252
+            raw_dict = _extract_raw_response_dict(raw_response)
+            if raw_dict is not None and raw_dict.get("choices"):
+                response_dict = raw_dict
+                choices = response_dict["choices"]
+            else:
+                msg = (
+                    "Received response with null value for 'choices'. "
+                    "This can happen when using OpenAI-compatible APIs "
+                    "(e.g., vLLM) that return a response in an unexpected "
+                    "format. "
+                    f"Full response keys: {list(response_dict.keys())}"
+                )
+                raise TypeError(msg)
 
         token_usage = response_dict.get("usage")
         service_tier = response_dict.get("service_tier")
@@ -1778,7 +1811,7 @@ class BaseChatOpenAI(BaseChatModel):
         ):
             generation_info = {"headers": dict(raw_response.headers)}
         return await run_in_executor(
-            None, self._create_chat_result, response, generation_info
+            None, self._create_chat_result, response, generation_info, raw_response
         )
 
     @property

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1446,6 +1446,88 @@ def test_create_chat_result_avoids_parsed_model_dump_warning() -> None:
     assert result.generations[0].message.additional_kwargs["parsed"] == parsed_response
 
 
+def test_create_chat_result_null_choices_falls_back_to_raw_response() -> None:
+    """When the parsed response has choices=None but the raw HTTP body has
+    valid choices (as happens with some vLLM setups), we should use the raw
+    body instead of raising TypeError.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/32252
+    """
+
+    class MockChatCompletion(openai.BaseModel):
+        id: str = "chatcmpl-vllm"
+        object: str = "chat.completion"
+        created: int = 0
+        model: str = "vllm-model"
+        choices: list[Any] | None = None
+        usage: dict[str, int] | None = None
+
+    # Parsed response has choices=None (the bug scenario)
+    parsed_response = MockChatCompletion.model_construct(choices=None)
+
+    # Raw HTTP body contains valid choices
+    raw_body = {
+        "id": "chatcmpl-vllm",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "vllm-model",
+        "choices": [
+            {
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Hello from vLLM"},
+            }
+        ],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8},
+    }
+    raw_response = MagicMock()
+    raw_response.http_response.json.return_value = raw_body
+
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key="test")
+    result = llm._create_chat_result(parsed_response, raw_response=raw_response)
+
+    assert len(result.generations) == 1
+    assert result.generations[0].message.content == "Hello from vLLM"
+
+
+def test_create_chat_result_null_choices_no_raw_response_raises() -> None:
+    """If choices is null and no raw response is available, the informative
+    TypeError should still be raised.
+    """
+
+    class MockChatCompletion(openai.BaseModel):
+        id: str = "chatcmpl-1"
+        object: str = "chat.completion"
+        created: int = 0
+        model: str = "some-model"
+        choices: list[Any] | None = None
+
+    parsed_response = MockChatCompletion.model_construct(choices=None)
+
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key="test")
+    with pytest.raises(TypeError, match="null value for 'choices'"):
+        llm._create_chat_result(parsed_response)
+
+
+def test_create_chat_result_null_choices_raw_also_null_raises() -> None:
+    """If both parsed and raw response have null choices, still raise."""
+
+    class MockChatCompletion(openai.BaseModel):
+        id: str = "chatcmpl-1"
+        object: str = "chat.completion"
+        created: int = 0
+        model: str = "some-model"
+        choices: list[Any] | None = None
+
+    parsed_response = MockChatCompletion.model_construct(choices=None)
+    raw_response = MagicMock()
+    raw_response.http_response.json.return_value = {"choices": None}
+
+    llm = ChatOpenAI(model="gpt-4o-mini", api_key="test")
+    with pytest.raises(TypeError, match="null value for 'choices'"):
+        llm._create_chat_result(parsed_response, raw_response=raw_response)
+
+
 def test_structured_outputs_parser_valid_falsy_response() -> None:
     class LunchBox(BaseModel):
         sandwiches: list[str]


### PR DESCRIPTION
Some OpenAI-compatible APIs (notably vLLM on certain runtimes) return responses where the OpenAI Python SDK parses ChatCompletion.choices as None even though the raw HTTP body contains valid choices. This causes LangChain to raise TypeError even though the request succeeded.

When choices is None on the parsed response, fall back to reading the raw JSON body from the OpenAI SDK's with_raw_response wrapper. If the raw body also lacks choices, preserve the existing TypeError.

Added an optional raw_response parameter to _create_chat_result (backward compatible — subclasses without this parameter keep working).

Tests cover: parsed choices=None with valid raw body, no raw_response available, and both parsed + raw being null.

Fixes #32252

Fixes #

<!-- Replace everything above this line with a 1-2 sentence description of your change. Keep the "Fixes #xx" keyword and update the issue number. -->

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangChain! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

  - Examples:
    - fix(anthropic): resolve flag parsing error
    - feat(core): add multi-tenant support
    - test(openai): update API usage tests
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langchain/blob/master/.github/workflows/pr_lint.yml#L15-L33

2. PR description:

  - Write 1-2 sentences summarizing the change.
  - The `Fixes #xx` line at the top is **required** for external contributions — update the issue number and keep the keyword. This links your PR to the approved issue and auto-closes it on merge.
  - If there are any breaking changes, please clearly describe them.
  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

4. How did you verify your code works?

Additional guidelines:

  - All external PRs must link to an issue or discussion where a solution has been approved by a maintainer, and you must be assigned to that issue. PRs without prior approval will be closed.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/
