### PR TITLE
fix(core): escape all RFC 8259 control characters in parse_partial_json

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -84,9 +84,17 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
             if char == '"' and not escaped:
                 is_inside_string = False
             elif char == "\n" and not escaped:
-                new_char = (
-                    "\\n"  # Replace the newline character with the escape sequence.
-                )
+                new_char = "\\n"
+            elif char == "\r" and not escaped:
+                new_char = "\\r"
+            elif char == "\t" and not escaped:
+                new_char = "\\t"
+            elif char == "\b" and not escaped:
+                new_char = "\\b"
+            elif char == "\f" and not escaped:
+                new_char = "\\f"
+            elif not escaped and ord(char) < 0x20:  # noqa: PLR2004
+                new_char = f"\\u{ord(char):04x}"
             elif char == "\\":
                 escaped = not escaped
             else:

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -264,6 +264,18 @@ def test_parse_partial_json(json_strings: tuple[str, str]) -> None:
     assert parsed == json.loads(expected)
 
 
+@pytest.mark.parametrize(
+    "raw_char",
+    ["\r", "\t", "\b", "\f", "\x00", "\x1f"],
+)
+def test_parse_partial_json_control_characters(raw_char: str) -> None:
+    s = '{"key": "before' + raw_char + 'after"}'
+    parsed = parse_partial_json(s)
+    assert parsed is not None
+    assert "before" in parsed["key"]
+    assert "after" in parsed["key"]
+
+
 STREAMED_TOKENS = """
 {
 


### PR DESCRIPTION
## Summary

`parse_partial_json` only escaped raw `\n` inside JSON strings, but left `\r`, `\t`, `\b`, `\f`, and other control characters (U+0000–U+001F) unescaped. This caused `json.loads` to fail and the function to return `None` instead of the expected dict.

This happens in practice when LLMs emit raw control characters in their JSON output — especially `\r\n` line endings (Windows-style) and tab characters in code snippets.

### Changes

- Added escape handling for `\r`, `\t`, `\b`, `\f`, and a catch-all `\uXXXX` escape for remaining control characters (U+0000–U+001F) in `parse_partial_json`
- Added parametrized tests covering all six character classes

### Testing

All 43 existing JSON parser tests pass, plus 6 new tests for control character handling.

Fixes #36747