### PR TITLE
fix: ignore empty string reasoning_content in _extract_reasoning_from_additional_kwargs

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content and isinstance(reasoning_content, str):
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None


### PR DESCRIPTION
Fixes #36194.

**Bug**

`_extract_reasoning_from_additional_kwargs` uses `reasoning_content is not None` to detect a valid reasoning block. Some providers (e.g. Groq) emit `"reasoning_content": ""` in `additional_kwargs` even when no reasoning was produced. This caused an empty `ReasoningContentBlock` (`{"type": "reasoning", "reasoning": ""}`) to be prepended to the message content list, which some downstream consumers treat as an error.

**Fix**

Change the guard from `is not None` to a truthy check:

```python
# Before
if reasoning_content is not None and isinstance(reasoning_content, str):

# After
if reasoning_content and isinstance(reasoning_content, str):
```

An empty string is falsy, so it is now skipped. A non-empty string still produces the reasoning block as before.