### PR TITLE
fix(core): remove unnecessary `type: ignore` comments in `ai.py`

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -281,10 +281,11 @@ class AIMessage(BaseMessage):
                         "name": tool_call["name"],
                         "args": tool_call["args"],
                     }
-                    if "index" in tool_call:
-                        tool_call_block["index"] = tool_call["index"]  # type: ignore[typeddict-item]
-                    if "extras" in tool_call:
-                        tool_call_block["extras"] = tool_call["extras"]  # type: ignore[typeddict-item]
+                    _tc = cast("dict[str, Any]", tool_call)
+                    if "index" in _tc:
+                        tool_call_block["index"] = _tc["index"]
+                    if "extras" in _tc:
+                        tool_call_block["extras"] = _tc["extras"]
                     blocks.append(tool_call_block)
 
         # Best-effort reasoning extraction from additional_kwargs
@@ -581,8 +582,7 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 ):
                     self.content[idx] = cast("dict[str, Any]", id_to_tc[call_id])
                     if "extras" in block:
-                        # mypy does not account for instance check for dict above
-                        self.content[idx]["extras"] = block["extras"]  # type: ignore[index]
+                        cast("dict[str, Any]", self.content[idx])["extras"] = block["extras"]
 
         return self
 
@@ -609,8 +609,9 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                     try:
                         args = json.loads(args_str)
                         if isinstance(args, dict):
-                            self.content[idx]["type"] = "server_tool_call"  # type: ignore[index]
-                            self.content[idx]["args"] = args  # type: ignore[index]
+                            content_block = cast("dict[str, Any]", self.content[idx])
+                            content_block["type"] = "server_tool_call"
+                            content_block["args"] = args
                     except json.JSONDecodeError:
                         pass
         return self

--- a/libs/core/tests/unit_tests/test_type_ignore_cleanup.py
+++ b/libs/core/tests/unit_tests/test_type_ignore_cleanup.py
@@ -1,0 +1,161 @@
+"""Bug condition exploration test for type: ignore cleanup in ai.py.
+
+Validates: Requirements 1.1, 1.2, 1.3, 1.4, 1.5
+
+For each removable `type: ignore` comment in ai.py, this test strips the
+comment, writes a temp shadow file, and runs mypy with ``--shadow-file`` so
+the project context (imports, pydantic plugin) is preserved.
+
+On UNFIXED code, mypy will report errors — confirming the ignores are currently
+necessary. Once the fix is applied (type: ignore replaced with cast()), mypy
+should pass cleanly on the fixed code as-is.
+"""
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Path to the source file under test
+AI_PY = Path(__file__).resolve().parents[2] / "langchain_core" / "messages" / "ai.py"
+
+# Project root for running mypy with correct config
+CORE_ROOT = AI_PY.resolve().parents[2]
+
+# Patterns for the 5 originally-removable type: ignore lines.
+# On UNFIXED code these lines contain both the pattern AND a type: ignore comment.
+# On FIXED code the type: ignore comments have been replaced with cast() calls,
+# so the original patterns may no longer appear verbatim.
+_REMOVABLE_PATTERNS: list[tuple[str, str]] = [
+    # (substring unique to the line, expected mypy error code)
+    ('tool_call_block["index"] = tool_call["index"]', "typeddict-item"),
+    ('tool_call_block["extras"] = tool_call["extras"]', "typeddict-item"),
+    ('self.content[idx]["extras"] = block["extras"]', "index"),
+    ('self.content[idx]["type"] = "server_tool_call"', "index"),
+    ('self.content[idx]["args"] = args', "index"),
+]
+
+# Regex to match type: ignore comments (with optional error codes)
+TYPE_IGNORE_RE = re.compile(r"\s*#\s*type:\s*ignore\[.*?\]")
+
+
+def _find_removable_lines() -> list[tuple[int, str]]:
+    """Find the actual line numbers of the removable type: ignore comments.
+
+    Returns an empty list if the fix has already been applied (no type: ignore
+    comments remain on the target lines).
+    """
+    source_lines = AI_PY.read_text().splitlines()
+    result: list[tuple[int, str]] = []
+    for pattern, error_code in _REMOVABLE_PATTERNS:
+        for i, line in enumerate(source_lines, 1):
+            if pattern in line and "type: ignore" in line:
+                result.append((i, error_code))
+                break
+    return result
+
+
+def _code_is_fixed() -> bool:
+    """Check whether the fix has been applied.
+
+    The fix replaces the 5 removable type: ignore comments with cast() calls.
+    If none of the original patterns have type: ignore comments, the fix is applied.
+    """
+    return len(_find_removable_lines()) == 0
+
+
+REMOVABLE_LINES = _find_removable_lines()
+CODE_IS_FIXED = _code_is_fixed()
+
+
+def _strip_type_ignore(source: str, target_line: int) -> str:
+    """Remove the type: ignore comment from a specific line number (1-indexed)."""
+    lines = source.splitlines(keepends=True)
+    idx = target_line - 1
+    lines[idx] = TYPE_IGNORE_RE.sub("", lines[idx])
+    return "".join(lines)
+
+
+def _run_mypy_on_source(source_text: str) -> subprocess.CompletedProcess[str]:
+    """Run mypy on a modified version of ai.py using --shadow-file."""
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False
+    ) as tmp:
+        tmp.write(source_text)
+        tmp.flush()
+        shadow_path = tmp.name
+
+    try:
+        return subprocess.run(
+            [
+                "uv",
+                "run",
+                "--group",
+                "typing",
+                "mypy",
+                "--no-incremental",
+                "--shadow-file",
+                str(AI_PY),
+                shadow_path,
+                "--no-error-summary",
+                str(AI_PY),
+            ],
+            capture_output=True,
+            text=True,
+            cwd=str(CORE_ROOT),
+        )
+    finally:
+        Path(shadow_path).unlink(missing_ok=True)
+
+
+@pytest.mark.skipif(
+    CODE_IS_FIXED,
+    reason="Fix already applied — type: ignore comments removed; see test_fixed_code_passes_mypy",
+)
+@pytest.mark.parametrize(
+    ("line_number", "expected_error_code"),
+    REMOVABLE_LINES if REMOVABLE_LINES else [pytest.param(0, "", marks=pytest.mark.skip)],
+    ids=[f"line_{ln}" for ln, _ in REMOVABLE_LINES] if REMOVABLE_LINES else ["skip"],
+)
+def test_type_ignore_removable(line_number: int, expected_error_code: str) -> None:
+    """Stripping a removable type: ignore should leave mypy clean.
+
+    On UNFIXED code this test FAILS — mypy reports errors without the ignore.
+    After the fix is applied, mypy should pass (exit 0).
+    """
+    source = AI_PY.read_text()
+    modified = _strip_type_ignore(source, line_number)
+    result = _run_mypy_on_source(modified)
+
+    # We assert mypy exits cleanly (code 0).
+    # On unfixed code this will FAIL because mypy reports errors.
+    assert result.returncode == 0, (
+        f"mypy reported errors on line {line_number} after removing "
+        f"type: ignore[{expected_error_code}]:\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.skipif(
+    not CODE_IS_FIXED,
+    reason="Fix not yet applied — run test_type_ignore_removable instead",
+)
+def test_fixed_code_passes_mypy() -> None:
+    """After the fix, the current ai.py should pass mypy cleanly.
+
+    Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5
+
+    The fix replaced the 5 removable type: ignore comments with cast() calls.
+    This test verifies mypy passes on the fixed code as-is.
+    """
+    source = AI_PY.read_text()
+    result = _run_mypy_on_source(source)
+
+    assert result.returncode == 0, (
+        f"mypy reported errors on fixed ai.py:\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )

--- a/libs/core/tests/unit_tests/test_type_ignore_preservation.py
+++ b/libs/core/tests/unit_tests/test_type_ignore_preservation.py
@@ -1,0 +1,431 @@
+"""Preservation property tests for AIMessage/AIMessageChunk runtime behavior.
+
+These tests verify baseline behavior on UNFIXED code and must PASS before
+any type-ignore cleanup changes are applied.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+"""
+
+import json
+from typing import Any
+
+import pytest
+
+from langchain_core.messages.ai import AIMessage, AIMessageChunk
+
+
+# ---------------------------------------------------------------------------
+# content_blocks preservation (lines 286, 288)
+# ---------------------------------------------------------------------------
+
+# Generate multiple tool call configurations: index only, extras only, both, neither
+_TOOL_CALL_CONFIGS: list[tuple[str, dict[str, Any]]] = [
+    (
+        "index_only",
+        {
+            "name": "get_weather",
+            "args": {"city": "Paris"},
+            "id": "tc_idx",
+            "type": "tool_call",
+            "index": 0,
+        },
+    ),
+    (
+        "extras_only",
+        {
+            "name": "search",
+            "args": {"q": "langchain"},
+            "id": "tc_ext",
+            "type": "tool_call",
+            "extras": {"provider": "openai"},
+        },
+    ),
+    (
+        "both_index_and_extras",
+        {
+            "name": "calculate",
+            "args": {"expr": "1+1"},
+            "id": "tc_both",
+            "type": "tool_call",
+            "index": 2,
+            "extras": {"model": "gpt-4"},
+        },
+    ),
+    (
+        "neither_index_nor_extras",
+        {
+            "name": "echo",
+            "args": {"text": "hi"},
+            "id": "tc_none",
+            "type": "tool_call",
+        },
+    ),
+    (
+        "index_string_type",
+        {
+            "name": "lookup",
+            "args": {"key": "abc"},
+            "id": "tc_str_idx",
+            "type": "tool_call",
+            "index": "block-0",
+        },
+    ),
+    (
+        "extras_nested",
+        {
+            "name": "deep_tool",
+            "args": {},
+            "id": "tc_nested",
+            "type": "tool_call",
+            "extras": {"meta": {"nested": True, "level": 2}},
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "tool_call_dict"),
+    _TOOL_CALL_CONFIGS,
+    ids=[c[0] for c in _TOOL_CALL_CONFIGS],
+)
+def test_content_blocks_preserves_index_and_extras(
+    label: str, tool_call_dict: dict[str, Any]
+) -> None:
+    """content_blocks returns blocks with correct index/extras values.
+
+    Uses model_construct to bypass validators and inject tool_calls with
+    extra fields that the ToolCall TypedDict (tool.py) doesn't declare.
+    """
+    msg = AIMessage.model_construct(
+        content="test",
+        tool_calls=[tool_call_dict],
+        response_metadata={},
+        additional_kwargs={},
+        invalid_tool_calls=[],
+        usage_metadata=None,
+        type="ai",
+        name=None,
+        id=None,
+    )
+
+    blocks = msg.content_blocks
+    tc_blocks = [b for b in blocks if b.get("type") == "tool_call"]
+
+    assert len(tc_blocks) == 1, f"Expected 1 tool_call block, got {len(tc_blocks)}"
+    block = tc_blocks[0]
+
+    # Core fields always present
+    assert block["name"] == tool_call_dict["name"]
+    assert block["args"] == tool_call_dict["args"]
+    assert block["id"] == tool_call_dict["id"]
+
+    # index preserved when present
+    if "index" in tool_call_dict:
+        assert block["index"] == tool_call_dict["index"]
+    else:
+        assert "index" not in block
+
+    # extras preserved when present
+    if "extras" in tool_call_dict:
+        assert block["extras"] == tool_call_dict["extras"]
+    else:
+        assert "extras" not in block
+
+
+
+# ---------------------------------------------------------------------------
+# init_tool_calls preservation (line 586)
+# ---------------------------------------------------------------------------
+
+_INIT_TOOL_CALLS_CONFIGS: list[tuple[str, dict[str, Any], dict[str, Any]]] = [
+    (
+        "extras_simple",
+        {
+            "type": "tool_call_chunk",
+            "id": "tc1",
+            "name": "foo",
+            "args": json.dumps({"a": 1}),
+            "index": 0,
+            "extras": {"provider_key": "val1"},
+        },
+        {"provider_key": "val1"},
+    ),
+    (
+        "extras_nested_dict",
+        {
+            "type": "tool_call_chunk",
+            "id": "tc2",
+            "name": "bar",
+            "args": json.dumps({"x": "y"}),
+            "index": 1,
+            "extras": {"meta": {"nested": True}},
+        },
+        {"meta": {"nested": True}},
+    ),
+    (
+        "extras_empty_dict",
+        {
+            "type": "tool_call_chunk",
+            "id": "tc3",
+            "name": "baz",
+            "args": json.dumps({}),
+            "index": 0,
+            "extras": {},
+        },
+        {},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "content_block", "expected_extras"),
+    _INIT_TOOL_CALLS_CONFIGS,
+    ids=[c[0] for c in _INIT_TOOL_CALLS_CONFIGS],
+)
+def test_init_tool_calls_preserves_extras(
+    label: str,
+    content_block: dict[str, Any],
+    expected_extras: dict[str, Any],
+) -> None:
+    """init_tool_calls replaces tool_call_chunk with parsed ToolCall and preserves extras.
+
+    Constructs AIMessageChunk with chunk_position="last",
+    response_metadata={"output_version": "v1"}, and content containing
+    tool_call_chunk blocks with extras.
+    """
+    chunk = AIMessageChunk(
+        content=[content_block],
+        tool_call_chunks=[
+            {
+                "name": content_block["name"],
+                "args": content_block["args"],
+                "id": content_block["id"],
+                "index": content_block.get("index"),
+                "type": "tool_call_chunk",
+            }
+        ],
+        chunk_position="last",
+        response_metadata={"output_version": "v1"},
+    )
+
+    # Content should be mutated: tool_call_chunk replaced with tool_call
+    assert isinstance(chunk.content, list)
+    assert len(chunk.content) == 1
+
+    result_block = chunk.content[0]
+    assert isinstance(result_block, dict)
+    assert result_block["type"] == "tool_call"
+    assert result_block["name"] == content_block["name"]
+    assert result_block["id"] == content_block["id"]
+    assert isinstance(result_block["args"], dict)
+
+    # extras preserved
+    assert result_block.get("extras") == expected_extras
+
+
+def test_init_tool_calls_no_extras_no_key() -> None:
+    """When tool_call_chunk has no extras, the replaced block has no extras key."""
+    chunk = AIMessageChunk(
+        content=[
+            {
+                "type": "tool_call_chunk",
+                "id": "tc_no_extras",
+                "name": "plain",
+                "args": json.dumps({"k": "v"}),
+                "index": 0,
+            }
+        ],
+        tool_call_chunks=[
+            {
+                "name": "plain",
+                "args": json.dumps({"k": "v"}),
+                "id": "tc_no_extras",
+                "index": 0,
+                "type": "tool_call_chunk",
+            }
+        ],
+        chunk_position="last",
+        response_metadata={"output_version": "v1"},
+    )
+
+    result_block = chunk.content[0]
+    assert isinstance(result_block, dict)
+    assert result_block["type"] == "tool_call"
+    assert "extras" not in result_block
+
+
+# ---------------------------------------------------------------------------
+# init_server_tool_calls preservation (lines 613-614)
+# ---------------------------------------------------------------------------
+
+_SERVER_TOOL_CALL_CONFIGS: list[tuple[str, dict[str, Any], dict[str, Any]]] = [
+    (
+        "simple_args",
+        {
+            "type": "server_tool_call_chunk",
+            "id": "stc1",
+            "name": "web_search",
+            "args": json.dumps({"query": "test"}),
+        },
+        {"query": "test"},
+    ),
+    (
+        "nested_args",
+        {
+            "type": "server_tool_call_chunk",
+            "id": "stc2",
+            "name": "code_exec",
+            "args": json.dumps({"code": "print(1)", "env": {"timeout": 30}}),
+        },
+        {"code": "print(1)", "env": {"timeout": 30}},
+    ),
+    (
+        "empty_args",
+        {
+            "type": "server_tool_call_chunk",
+            "id": "stc3",
+            "name": "noop",
+            "args": json.dumps({}),
+        },
+        {},
+    ),
+    (
+        "server_tool_call_type_also_parsed",
+        {
+            "type": "server_tool_call",
+            "id": "stc4",
+            "name": "search",
+            "args": json.dumps({"q": "hello"}),
+        },
+        {"q": "hello"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("label", "content_block", "expected_args"),
+    _SERVER_TOOL_CALL_CONFIGS,
+    ids=[c[0] for c in _SERVER_TOOL_CALL_CONFIGS],
+)
+def test_init_server_tool_calls_parses_args(
+    label: str,
+    content_block: dict[str, Any],
+    expected_args: dict[str, Any],
+) -> None:
+    """init_server_tool_calls parses string args to dict and sets type to server_tool_call.
+
+    Constructs AIMessageChunk with chunk_position="last",
+    response_metadata={"output_version": "v1"}, and content containing
+    server_tool_call_chunk blocks with string args.
+    """
+    chunk = AIMessageChunk(
+        content=[content_block],
+        chunk_position="last",
+        response_metadata={"output_version": "v1"},
+    )
+
+    assert isinstance(chunk.content, list)
+    assert len(chunk.content) == 1
+
+    result_block = chunk.content[0]
+    assert isinstance(result_block, dict)
+    assert result_block["type"] == "server_tool_call"
+    assert result_block["args"] == expected_args
+    assert isinstance(result_block["args"], dict)
+
+
+def test_init_server_tool_calls_invalid_json_unchanged() -> None:
+    """When args is not valid JSON, the block is left unchanged."""
+    chunk = AIMessageChunk(
+        content=[
+            {
+                "type": "server_tool_call_chunk",
+                "id": "stc_bad",
+                "name": "broken",
+                "args": "{not valid json",
+            }
+        ],
+        chunk_position="last",
+        response_metadata={"output_version": "v1"},
+    )
+
+    result_block = chunk.content[0]
+    assert isinstance(result_block, dict)
+    assert result_block["type"] == "server_tool_call_chunk"
+    assert result_block["args"] == "{not valid json"
+
+
+def test_init_server_tool_calls_non_dict_json_unchanged() -> None:
+    """When args parses to non-dict JSON (e.g. a list), the block is left unchanged."""
+    chunk = AIMessageChunk(
+        content=[
+            {
+                "type": "server_tool_call_chunk",
+                "id": "stc_list",
+                "name": "list_tool",
+                "args": json.dumps([1, 2, 3]),
+            }
+        ],
+        chunk_position="last",
+        response_metadata={"output_version": "v1"},
+    )
+
+    result_block = chunk.content[0]
+    assert isinstance(result_block, dict)
+    # type should remain unchanged since args is not a dict
+    assert result_block["type"] == "server_tool_call_chunk"
+    assert result_block["args"] == "[1, 2, 3]"
+
+
+# ---------------------------------------------------------------------------
+# Intentional ignores remain (lines 420, 619)
+# ---------------------------------------------------------------------------
+
+
+def test_ai_message_chunk_type_is_ai_message_chunk() -> None:
+    """AIMessageChunk.type is 'AIMessageChunk' (line 420 ignore preserved).
+
+    This is an intentional Liskov substitution violation for deserialization.
+    """
+    chunk = AIMessageChunk(content="hello")
+    assert chunk.type == "AIMessageChunk"
+
+
+def test_ai_message_chunk_type_field_default() -> None:
+    """The type field default is 'AIMessageChunk' across various constructions."""
+    # Empty content
+    assert AIMessageChunk(content="").type == "AIMessageChunk"
+    # List content
+    assert AIMessageChunk(content=["a", "b"]).type == "AIMessageChunk"
+    # With tool_call_chunks
+    assert AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {"name": "t", "args": "{}", "id": "1", "index": 0, "type": "tool_call_chunk"}
+        ],
+    ).type == "AIMessageChunk"
+
+
+@pytest.mark.parametrize(
+    ("left_content", "right_content"),
+    [
+        ("hello ", "world"),
+        ("", "test"),
+        ("abc", ""),
+    ],
+    ids=["both_nonempty", "left_empty", "right_empty"],
+)
+def test_ai_message_chunk_add_returns_ai_message_chunk(
+    left_content: str, right_content: str
+) -> None:
+    """AIMessageChunk.__add__ returns AIMessageChunk (line 619 ignore preserved).
+
+    This is an intentional override of BaseMessage.__add__ which returns
+    ChatPromptTemplate.
+    """
+    left = AIMessageChunk(content=left_content)
+    right = AIMessageChunk(content=right_content)
+    result = left + right
+
+    assert isinstance(result, AIMessageChunk)
+    assert result.content == left_content + right_content


### PR DESCRIPTION
Replaced 5 unnecessary `type: ignore` comments in `AIMessage` and `AIMessageChunk`
with `cast("dict[str, Any]", ...)` calls, improving type safety with zero runtime cost.

---

The suppressed mypy errors fell into two categories:

- `typeddict-item` on `content_blocks` — `ToolCall` (from `tool.py`) lacks `index`/`extras`
  fields, but they exist at runtime. A `cast` to `dict[str, Any]` satisfies mypy while
  preserving the existing `in` guard.

- `index` on `init_tool_calls` / `init_server_tool_calls` — `self.content[idx]` is typed
  as `str | dict` and mypy can't narrow it from an `isinstance` check on a separate
  variable. A `cast` on the indexed element resolves this.

The 2 intentional ignores (`type: ignore[assignment]` on the `type` discriminator and
`type: ignore[override]` on `__add__`) are unchanged.

New test files validate both the bug condition (mypy passes without the old ignores) and
preservation of runtime behavior across `content_blocks`, `init_tool_calls`, and
`init_server_tool_calls`.

Linkedin: https://www.linkedin.com/in/cheonudev/
