### PR TITLE
fix(core): replace 5 unnecessary type: ignore comments with cast() in ai.py

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -282,9 +282,9 @@ class AIMessage(BaseMessage):
                         "args": tool_call["args"],
                     }
                     if "index" in tool_call:
-                        tool_call_block["index"] = tool_call["index"]  # type: ignore[typeddict-item]
+                        cast("dict[str, Any]", tool_call_block)["index"] = tool_call["index"]
                     if "extras" in tool_call:
-                        tool_call_block["extras"] = tool_call["extras"]  # type: ignore[typeddict-item]
+                        cast("dict[str, Any]", tool_call_block)["extras"] = tool_call["extras"]
                     blocks.append(tool_call_block)
 
         # Best-effort reasoning extraction from additional_kwargs
@@ -582,7 +582,7 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                     self.content[idx] = cast("dict[str, Any]", id_to_tc[call_id])
                     if "extras" in block:
                         # mypy does not account for instance check for dict above
-                        self.content[idx]["extras"] = block["extras"]  # type: ignore[index]
+                        cast("dict[str, Any]", self.content[idx])["extras"] = block["extras"]
 
         return self
 
@@ -609,8 +609,8 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                     try:
                         args = json.loads(args_str)
                         if isinstance(args, dict):
-                            self.content[idx]["type"] = "server_tool_call"  # type: ignore[index]
-                            self.content[idx]["args"] = args  # type: ignore[index]
+                            cast("dict[str, Any]", self.content[idx])["type"] = "server_tool_call"
+                            cast("dict[str, Any]", self.content[idx])["args"] = args
                     except json.JSONDecodeError:
                         pass
         return self


### PR DESCRIPTION
## Summary

Replaces 5 unnecessary `type: ignore` comments in `libs/core/langchain_core/messages/ai.py` with proper `cast('dict[str, Any]', ...)` calls.

### Changes

| Line | Before | After |
|------|--------|-------|
| 285 | `tool_call_block['index'] = ...\  # type: ignore[typeddict-item]` | `cast('dict[str, Any]', tool_call_block)['index'] = ...` |
| 287 | `tool_call_block['extras'] = ...\  # type: ignore[typeddict-item]` | `cast('dict[str, Any]', tool_call_block)['extras'] = ...` |
| 585 | `self.content[idx]['extras'] = ...\  # type: ignore[index]` | `cast('dict[str, Any]', self.content[idx])['extras'] = ...` |
| 612 | `self.content[idx]['type'] = ...\  # type: ignore[index]` | `cast('dict[str, Any]', self.content[idx])['type'] = ...` |
| 613 | `self.content[idx]['args'] = ...\  # type: ignore[index]` | `cast('dict[str, Any]', self.content[idx])['args'] = ...` |

The 2 intentional ignores (line 419 assignment, line 618 overload override) are **preserved** — those are correct architectural decisions.

### Why

- `cast()` has zero runtime cost (`cast(x, y)` just returns `y`)
- Preserves full mypy type checking instead of silently suppressing errors
- Matches the existing pattern already used on line 584 for the same file

Fixes #36931