### PR TITLE
fix(core): defer transformers import to avoid ~850ms overhead on BaseChatModel import

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -38,12 +38,20 @@ from langchain_core.runnables import Runnable, RunnableSerializable
 if TYPE_CHECKING:
     from langchain_core.outputs import LLMResult
 
-try:
-    from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
+_HAS_TRANSFORMERS: bool | None = None
 
-    _HAS_TRANSFORMERS = True
-except ImportError:
-    _HAS_TRANSFORMERS = False
+
+def _check_transformers() -> bool:
+    """Lazily check and cache whether transformers is available."""
+    global _HAS_TRANSFORMERS  # noqa: PLW0603
+    if _HAS_TRANSFORMERS is None:
+        try:
+            import transformers  # noqa: F401
+
+            _HAS_TRANSFORMERS = True
+        except ImportError:
+            _HAS_TRANSFORMERS = False
+    return _HAS_TRANSFORMERS
 
 
 class LangSmithParams(TypedDict, total=False):
@@ -86,13 +94,15 @@ def get_tokenizer() -> Any:
         The GPT-2 tokenizer instance.
 
     """
-    if not _HAS_TRANSFORMERS:
+    if not _check_transformers():
         msg = (
             "Could not import transformers python package. "
             "This is needed in order to calculate get_token_ids. "
             "Please install it with `pip install transformers`."
         )
         raise ImportError(msg)
+    from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
+
     # create a GPT-2 tokenizer instance
     return GPT2TokenizerFast.from_pretrained("gpt2")
 


### PR DESCRIPTION
## Summary

The module-level `from transformers import GPT2TokenizerFast` (wrapped in try/except) still triggers the full transformers import chain when `BaseChatModel` is imported, adding **~850ms of overhead** even when token counting is never used.

## Changes

- Replace eager module-level `import transformers` with a lazy `_check_transformers()` helper
- Move the actual `GPT2TokenizerFast` import inside `get_tokenizer()`, where it is consumed
- Transformers is now only loaded when `get_token_ids` / token counting is actually invoked

## Before / After

```bash
# Before: importing BaseChatModel loads all of transformers (~850ms)
python -X importtime -c "from langchain_core.language_models import BaseChatModel" | grep transformers
# → 850ms+ of transformer imports

# After: no transformers import until get_tokenizer() is called
python -X importtime -c "from langchain_core.language_models import BaseChatModel" | grep transformers  
# → (no output)
```

Fixes #36835