### PR TITLE
core[patch]: preserve MIME type on base64 file blocks in openai translator

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -545,7 +545,7 @@ def _convert_openai_format_to_data_block(
         filename = block["file"].get("filename")
         return types.create_file_block(
             base64=parsed["data"],
-            mime_type="application/pdf",
+            mime_type=parsed["mime_type"],
             filename=filename,
             **all_extras,
         )

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -317,6 +317,49 @@ def test_convert_to_v1_from_openai_input() -> None:
     assert _content_blocks_equal_ignore_id(message.content_blocks, expected)
 
 
+def test_convert_to_v1_file_block_preserves_non_pdf_mime_type() -> None:
+    """Base64 file blocks must preserve the MIME type from the data URI.
+
+    Regression: `_convert_openai_format_to_data_block` used to hard-code
+    `mime_type="application/pdf"` for any base64 file block, so non-PDF
+    attachments (e.g. CSVs, spreadsheets, text files) were silently
+    relabeled as PDFs on the way into the v1 content-block representation.
+    """
+    message = HumanMessage(
+        content=[
+            {
+                "type": "file",
+                "file": {
+                    "filename": "sheet.csv",
+                    "file_data": "data:text/csv;base64,aGVsbG8=",
+                },
+            },
+            {
+                "type": "file",
+                "file": {
+                    "file_data": "data:text/plain;base64,aGVsbG8=",
+                },
+            },
+        ]
+    )
+
+    expected: list[types.ContentBlock] = [
+        {
+            "type": "file",
+            "base64": "aGVsbG8=",
+            "mime_type": "text/csv",
+            "extras": {"filename": "sheet.csv"},
+        },
+        {
+            "type": "file",
+            "base64": "aGVsbG8=",
+            "mime_type": "text/plain",
+        },
+    ]
+
+    assert _content_blocks_equal_ignore_id(message.content_blocks, expected)
+
+
 def test_compat_responses_v03() -> None:
     # Check compatibility with v0.3 legacy message format
     message_v03 = AIMessage(


### PR DESCRIPTION
Fixes #36939.

The file branch of `_convert_openai_format_to_data_block` hard-codes `mime_type="application/pdf"`, while the image branch right above it uses `parsed["mime_type"]` from the data URI. So a CSV sent via the OpenAI file block shape comes out with `mime_type="application/pdf"` in the v1 content block.

One-line change to read it off the parsed data URI, same as the image branch. `_parse_data_uri` returns `None` when the mime_type is missing, so `parsed["mime_type"]` is always set inside this branch.

Test added with a CSV and a text/plain data URI. Existing tests still pass since they use `data:application/pdf;...`.
