### PR TITLE
fix(core): correct 'operators' wording in `Visitor._validate_func` error

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (

--- a/libs/core/tests/unit_tests/test_structured_query.py
+++ b/libs/core/tests/unit_tests/test_structured_query.py
@@ -1,0 +1,39 @@
+"""Unit tests for `langchain_core.structured_query`."""
+
+import pytest
+
+from langchain_core.structured_query import (
+    Comparator,
+    Comparison,
+    Operation,
+    Operator,
+    StructuredQuery,
+    Visitor,
+)
+
+
+class _StubVisitor(Visitor):
+    allowed_comparators = (Comparator.EQ,)
+    allowed_operators = (Operator.AND,)
+
+    def visit_operation(self, operation: Operation) -> None:
+        return None
+
+    def visit_comparison(self, comparison: Comparison) -> None:
+        return None
+
+    def visit_structured_query(self, structured_query: StructuredQuery) -> None:
+        return None
+
+
+def test_validate_func_disallowed_operator_message_mentions_operators() -> None:
+    visitor = _StubVisitor()
+    with pytest.raises(ValueError, match="Allowed operators are") as exc_info:
+        visitor._validate_func(Operator.OR)
+    assert "comparators" not in str(exc_info.value)
+
+
+def test_validate_func_disallowed_comparator_message_mentions_comparators() -> None:
+    visitor = _StubVisitor()
+    with pytest.raises(ValueError, match="Allowed comparators are"):
+        visitor._validate_func(Comparator.NE)


### PR DESCRIPTION
Closes #36701

---

`Visitor._validate_func` raises a `ValueError` when an `Operator` is passed that is not in `allowed_operators`. The message text says *"Allowed comparators are ..."* but lists the operators sequence — a copy-paste leftover from the comparator branch right below it. The fix changes one word in the message and adds a focused unit test for both branches.

> AI agent involvement: this contribution was drafted with assistance from an AI coding agent.