### PR TITLE
fix(core): use strict zip in `RunnableWithFallbacks` batch/abatch

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -306,7 +306,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                 run_id=config.pop("run_id", None),
             )
             for cm, input_, config in zip(
-                callback_managers, inputs, configs, strict=False
+                callback_managers, inputs, configs, strict=True
             )
         ]
 
@@ -326,7 +326,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                 **kwargs,
             )
             for (i, input_), output in zip(
-                sorted(run_again.copy().items()), outputs, strict=False
+                sorted(run_again.copy().items()), outputs, strict=True
             ):
                 if isinstance(output, BaseException) and not isinstance(
                     output, self.exceptions_to_handle
@@ -403,7 +403,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                     run_id=config.pop("run_id", None),
                 )
                 for cm, input_, config in zip(
-                    callback_managers, inputs, configs, strict=False
+                    callback_managers, inputs, configs, strict=True
                 )
             )
         )
@@ -425,7 +425,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             )
 
             for (i, input_), output in zip(
-                sorted(run_again.copy().items()), outputs, strict=False
+                sorted(run_again.copy().items()), outputs, strict=True
             ):
                 if isinstance(output, BaseException) and not isinstance(
                     output, self.exceptions_to_handle


### PR DESCRIPTION
Closes #36746

---

`RunnableWithFallbacks.batch` and `abatch` pair `inputs`, `configs`, `callback_managers`, and per-step `outputs` using four `zip(..., strict=False)` calls. Each pair is constructed to be the same length, so a length mismatch would indicate an upstream bug — silently truncating just hides it. Switching to `strict=True` preserves all current behavior on correct inputs and surfaces invariant violations immediately. The existing `test_fallbacks` suite still passes unchanged.

> AI agent involvement: this contribution was drafted with assistance from an AI coding agent.