### PR TITLE
fix(core): preserve children in `XMLOutputParser` mixed-content nodes

### DIFF
--- a/libs/core/langchain_core/output_parsers/xml.py
+++ b/libs/core/langchain_core/output_parsers/xml.py
@@ -268,9 +268,9 @@ class XMLOutputParser(BaseTransformOutputParser):
 
     def _root_to_dict(self, root: ET.Element) -> dict[str, str | list[Any]]:
         """Converts xml tree to python dictionary."""
-        if root.text and bool(re.search(r"\S", root.text)):
-            # If root text contains any non-whitespace character it
-            # returns {root.tag: root.text}
+        if len(root) == 0 and root.text and bool(re.search(r"\S", root.text)):
+            # Leaf element with text content -> {tag: text}.
+            # When children exist, fall through so they are not dropped.
             return {root.tag: root.text}
         result: dict = {root.tag: []}
         for child in root:

--- a/libs/core/tests/unit_tests/output_parsers/test_xml_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_xml_parser.py
@@ -147,6 +147,15 @@ MALICIOUS_XML = """<?xml version="1.0"?>
 <lolz>&lol9;</lolz>"""
 
 
+def test_mixed_content_preserves_children() -> None:
+    """Children of an element with text content must not be silently dropped."""
+    xml_parser = XMLOutputParser(parser="xml")
+    parsed = xml_parser.parse(
+        "```xml\n<result>Summary<detail>info</detail></result>\n```"
+    )
+    assert parsed == {"result": [{"detail": "info"}]}
+
+
 async def tests_billion_laughs_attack() -> None:
     # Testing with standard XML parser since it's safe to use in
     # newer versions of Python


### PR DESCRIPTION
Closes #36744

---

`XMLOutputParser._root_to_dict` returns `{tag: text}` whenever an element has any non-whitespace text. For an element that *also* has child elements, this early return silently discards the children — e.g. `<result>Summary<detail>info</detail></result>` parses to `{'result': 'Summary'}` and `<detail>` is lost.

The early return is the correct behavior for leaf nodes (a tag wrapping plain text). The fix restricts it to elements with no children (`len(root) == 0`), so non-leaf elements fall through into the existing loop that walks children. Output shape for leaves and pure-children parents is unchanged. Preserving the parent's `text` alongside its children is a separate enhancement and is out of scope here.

> AI agent involvement: this contribution was drafted with assistance from an AI coding agent.