### PR TITLE
fix(core): support string data in `Blob.as_bytes_io`

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f

--- a/libs/core/tests/unit_tests/documents/test_base.py
+++ b/libs/core/tests/unit_tests/documents/test_base.py
@@ -1,0 +1,21 @@
+"""Tests for `langchain_core.documents.base.Blob`."""
+
+from langchain_core.documents.base import Blob
+
+
+def test_as_bytes_io_with_string_data() -> None:
+    blob = Blob.from_data("hello")
+    with blob.as_bytes_io() as stream:
+        assert stream.read() == b"hello"
+
+
+def test_as_bytes_io_with_string_data_respects_encoding() -> None:
+    blob = Blob.from_data("café", encoding="utf-16")
+    with blob.as_bytes_io() as stream:
+        assert stream.read() == "café".encode("utf-16")
+
+
+def test_as_bytes_io_with_bytes_data() -> None:
+    blob = Blob.from_data(b"\x00\x01\x02")
+    with blob.as_bytes_io() as stream:
+        assert stream.read() == b"\x00\x01\x02"


### PR DESCRIPTION
Closes #36667

---

`Blob.as_string` and `Blob.as_bytes` both handle `data: str` (encoding it via `self.encoding` when bytes are needed), but `Blob.as_bytes_io` only handled `bytes` and file paths and raised `NotImplementedError` for string data. The fix adds the missing `isinstance(self.data, str)` branch, encoding with the blob's configured `encoding` for parity with `as_bytes`.

> AI agent involvement: this contribution was drafted with assistance from an AI coding agent.