### PR TITLE
fix(openai): handle missing cached/reasoning tokens in `service_tier` math

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3856,12 +3856,13 @@ def _create_usage_metadata(
     }
     if service_tier is not None:
         # Avoid counting cache and reasoning tokens towards the service tier token
-        # counts, since service tier tokens are already priced differently
-        input_token_details[service_tier] = input_tokens - input_token_details.get(
-            f"{service_tier_prefix}cache_read", 0
+        # counts, since service tier tokens are already priced differently.
+        # Use `or 0` because the keys above store None when the API omits them.
+        input_token_details[service_tier] = input_tokens - (
+            input_token_details.get(f"{service_tier_prefix}cache_read") or 0
         )
-        output_token_details[service_tier] = output_tokens - output_token_details.get(
-            f"{service_tier_prefix}reasoning", 0
+        output_token_details[service_tier] = output_tokens - (
+            output_token_details.get(f"{service_tier_prefix}reasoning") or 0
         )
     return UsageMetadata(
         input_tokens=input_tokens,
@@ -3897,12 +3898,13 @@ def _create_usage_metadata_responses(
     }
     if service_tier is not None:
         # Avoid counting cache and reasoning tokens towards the service tier token
-        # counts, since service tier tokens are already priced differently
-        output_token_details[service_tier] = output_tokens - output_token_details.get(
-            f"{service_tier_prefix}reasoning", 0
+        # counts, since service tier tokens are already priced differently.
+        # Use `or 0` because the keys above store None when the API omits them.
+        output_token_details[service_tier] = output_tokens - (
+            output_token_details.get(f"{service_tier_prefix}reasoning") or 0
         )
-        input_token_details[service_tier] = input_tokens - input_token_details.get(
-            f"{service_tier_prefix}cache_read", 0
+        input_token_details[service_tier] = input_tokens - (
+            input_token_details.get(f"{service_tier_prefix}cache_read") or 0
         )
     return UsageMetadata(
         input_tokens=input_tokens,

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1119,6 +1119,38 @@ def test__create_usage_metadata_responses() -> None:
     )
 
 
+def test__create_usage_metadata_service_tier_missing_token_details() -> None:
+    """`service_tier` arithmetic must tolerate missing cached/reasoning fields."""
+    usage_metadata = {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+        "prompt_tokens_details": {},
+        "completion_tokens_details": {},
+    }
+    result = _create_usage_metadata(usage_metadata, service_tier="priority")
+    assert result["input_tokens"] == 100
+    assert result["output_tokens"] == 50
+    assert result["input_token_details"]["priority"] == 100
+    assert result["output_token_details"]["priority"] == 50
+
+
+def test__create_usage_metadata_responses_service_tier_missing_token_details() -> None:
+    """Same regression as above for the responses-API helper."""
+    usage_metadata = {
+        "input_tokens": 80,
+        "output_tokens": 40,
+        "total_tokens": 120,
+        "input_tokens_details": {},
+        "output_tokens_details": {},
+    }
+    result = _create_usage_metadata_responses(usage_metadata, service_tier="flex")
+    assert result["input_tokens"] == 80
+    assert result["output_tokens"] == 40
+    assert result["input_token_details"]["flex"] == 80
+    assert result["output_token_details"]["flex"] == 40
+
+
 def test__resize_caps_dimensions_preserving_ratio() -> None:
     """Larger side capped at 2048 then smaller at 768 keeping aspect ratio."""
     assert _resize(2048, 4096) == (768, 1536)


### PR DESCRIPTION
Closes #36657

---

When `service_tier` is `priority` or `flex`, `_create_usage_metadata` (and the responses-API equivalent) compute the per-tier input/output token counts by subtracting cached and reasoning tokens from the totals. Both detail dicts are populated via `.get("cached_tokens")` / `.get("reasoning_tokens")`, which store `None` when the API omits the field. The follow-up `dict.get(key, 0)` then returns `None` (the key exists with value `None`), and `int - None` raises `TypeError`.

Switching to `dict.get(key) or 0` coerces the absent-or-`None` case to `0`, matching the pattern already used elsewhere in this module after #36500. Adds regression tests for both helpers covering the empty-`*_tokens_details` path with `service_tier` set.

> AI agent involvement: this contribution was drafted with assistance from an AI coding agent.