### PR TITLE
test(core): fix expected `generations` shape in `test_stream_error_callback`

### DIFF
--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -156,7 +156,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 
@@ -165,7 +164,9 @@ async def test_stream_error_callback() -> None:
         assert len(callback.errors_args) == 1
         llm_result: LLMResult = callback.errors_args[0]["kwargs"]["response"]
         if i == 0:
-            assert llm_result.generations == []
+            # The callback receives an `LLMResult` that preserves the batch
+            # dimension even when no chunks were produced.
+            assert llm_result.generations == [[]]
         else:
             assert llm_result.generations[0][0].text == message[:i]
 


### PR DESCRIPTION
Closes #36866

---

`test_stream_error_callback` was marked `xfail` because the `i == 0` branch asserted `llm_result.generations == []`, but the callback receives an `LLMResult` whose `generations` preserves the batch dimension — the actual value is `[[]]`. Since #30228 the assertion executes correctly, so the `xfail` was hiding a stale test expectation rather than a product bug.

Fix updates the assertion to `[[]]` and removes the `xfail` marker so the test now exercises and protects the callback path.

> AI agent involvement: this contribution was drafted with assistance from an AI coding agent.