### PR TITLE
fix(core): escape raw `\r` and `\t` in `parse_partial_json` strings

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -77,16 +77,18 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
     is_inside_string = False
     escaped = False
 
+    # JSON forbids raw control characters inside strings (RFC 8259); replace the
+    # ones models commonly emit raw with their escape sequences.
+    _control_escapes = {"\n": "\\n", "\r": "\\r", "\t": "\\t"}
+
     # Process each character in the string one at a time.
     for char in s:
         new_char = char
         if is_inside_string:
             if char == '"' and not escaped:
                 is_inside_string = False
-            elif char == "\n" and not escaped:
-                new_char = (
-                    "\\n"  # Replace the newline character with the escape sequence.
-                )
+            elif char in _control_escapes and not escaped:
+                new_char = _control_escapes[char]
             elif char == "\\":
                 escaped = not escaped
             else:

--- a/libs/core/tests/unit_tests/output_parsers/test_json.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_json.py
@@ -264,6 +264,22 @@ def test_parse_partial_json(json_strings: tuple[str, str]) -> None:
     assert parsed == json.loads(expected)
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ('{"key": "line1\nline2"}', {"key": "line1\nline2"}),
+        ('{"key": "line1\rline2"}', {"key": "line1\rline2"}),
+        ('{"key": "col1\tcol2"}', {"key": "col1\tcol2"}),
+        ('{"key": "a\rb\nc\td"}', {"key": "a\rb\nc\td"}),
+    ],
+)
+def test_parse_partial_json_escapes_raw_control_chars(
+    raw: str, expected: dict[str, str]
+) -> None:
+    r"""Raw `\n`, `\r`, `\t` inside string values must be escaped, not raised on."""
+    assert parse_partial_json(raw, strict=True) == expected
+
+
 STREAMED_TOKENS = """
 {
 


### PR DESCRIPTION
Closes #36747

---

`parse_partial_json` already replaces a raw `\n` inside a JSON string value with the `\\n` escape sequence so the partial parse can succeed under `strict=True` (RFC 8259 forbids unescaped control characters in strings). Models also commonly emit raw `\r` and `\t`, which currently fall through and cause `json.JSONDecodeError: Invalid control character at: ...`.

The fix factors the per-character substitution into a small `{"\n": "\\n", "\r": "\\r", "\t": "\\t"}` map and escapes the same way for all three. Other control characters (`\b`, `\f`, `\x00–\x1f`) remain unhandled, matching the prior scope. Adds a parametrised regression test covering each escape under `strict=True`.

> AI agent involvement: this contribution was drafted with assistance from an AI coding agent.