### PR TITLE
fix(chroma): raise `ValueError` when async client is passed to `Chroma`

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -6,6 +6,7 @@ It contains the Chroma class which is a vector store for handling various tasks.
 from __future__ import annotations
 
 import base64
+import inspect
 import logging
 import uuid
 from collections.abc import Callable, Iterable, Sequence
@@ -367,6 +368,20 @@ class Chroma(VectorStore):
             raise ValueError(msg)
 
         if client is not None:
+            if inspect.iscoroutine(client):
+                msg = (
+                    "An async Chroma client (coroutine) was passed to `Chroma`, "
+                    "which only supports synchronous clients. If you are using "
+                    "`chromadb.AsyncHttpClient`, use `chromadb.HttpClient` instead."
+                )
+                raise ValueError(msg)
+            if isinstance(client, chromadb.AsyncClientAPI):
+                msg = (
+                    "An async Chroma client was passed to `Chroma`, which only "
+                    "supports synchronous clients. If you are using "
+                    "`chromadb.AsyncHttpClient`, use `chromadb.HttpClient` instead."
+                )
+                raise ValueError(msg)
             self._client = client
 
         # PersistentClient

--- a/libs/partners/chroma/tests/unit_tests/test_async_client_rejection.py
+++ b/libs/partners/chroma/tests/unit_tests/test_async_client_rejection.py
@@ -1,0 +1,34 @@
+"""Tests for async client rejection in Chroma."""
+
+import inspect
+from unittest.mock import MagicMock
+
+import pytest
+
+from langchain_chroma.vectorstores import Chroma
+
+
+def test_rejects_unawaited_async_client() -> None:
+    """Passing an unawaited AsyncHttpClient (a coroutine) should raise ValueError."""
+
+    async def fake_async_client() -> MagicMock:
+        return MagicMock()
+
+    coro = fake_async_client()
+    assert inspect.iscoroutine(coro)
+
+    with pytest.raises(ValueError, match="async"):
+        Chroma(client=coro, collection_name="test")  # type: ignore[arg-type]
+
+    # Close the coroutine to avoid RuntimeWarning
+    coro.close()
+
+
+def test_rejects_awaited_async_client() -> None:
+    """Passing an awaited AsyncClientAPI instance should raise ValueError."""
+    import chromadb
+
+    mock_async_client = MagicMock(spec=chromadb.AsyncClientAPI)
+
+    with pytest.raises(ValueError, match="async"):
+        Chroma(client=mock_async_client, collection_name="test")  # type: ignore[arg-type]


### PR DESCRIPTION
Closes #30704

---

Passing a `chromadb.AsyncHttpClient` to the `Chroma` constructor causes a confusing `AttributeError: 'coroutine' object has no attribute 'get_or_create_collection'`. This happens because `AsyncHttpClient` is an async factory that returns a coroutine, and the sync `__ensure_collection` method tries to call `.get_or_create_collection()` on it directly.

This adds early validation in `__init__` to detect two cases:
- An unawaited `AsyncHttpClient(...)` call (a coroutine object)
- An awaited `AsyncClientAPI` instance

Both now raise a `ValueError` with a clear message pointing the user to `chromadb.HttpClient` as the synchronous alternative.