### PR TITLE
fix(core): support string data in `Blob.as_bytes_io`

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f

--- a/libs/core/tests/unit_tests/documents/test_blob.py
+++ b/libs/core/tests/unit_tests/documents/test_blob.py
@@ -1,0 +1,19 @@
+from langchain_core.documents.base import Blob
+
+
+def test_as_bytes_io_from_string_data() -> None:
+    blob = Blob.from_data("hello")
+    with blob.as_bytes_io() as f:
+        assert f.read() == b"hello"
+
+
+def test_as_bytes_io_from_bytes_data() -> None:
+    blob = Blob.from_data(b"hello")
+    with blob.as_bytes_io() as f:
+        assert f.read() == b"hello"
+
+
+def test_as_bytes_io_respects_encoding() -> None:
+    blob = Blob.from_data("héllo", encoding="latin-1")
+    with blob.as_bytes_io() as f:
+        assert f.read() == "héllo".encode("latin-1")


### PR DESCRIPTION
Closes #36667

---

`Blob.as_bytes_io()` raised `NotImplementedError` when the blob's `data` was a string, even though `as_bytes()` and `as_string()` both handle string data. This inconsistency forces callers to branch on the underlying representation — `from_data("hello")` works for `as_bytes()` and `as_string()` but crashes `as_bytes_io()`, so any code that picks the streaming variant for memory reasons is silently unsafe against string blobs.

Add the `isinstance(self.data, str)` branch to `as_bytes_io`, mirroring `as_bytes` — encode with `self.encoding` and yield a `BytesIO`.

## Test coverage
- [x] Added unit tests for `as_bytes_io` covering string, bytes, and custom-encoding string inputs.

_AI-assisted contribution._