### PR TITLE
fix(core): don't evict on `InMemoryCache` refresh of existing key

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -226,9 +226,14 @@ class InMemoryCache(BaseCache):
 
                 The value is a list of `Generation` (or subclasses).
         """
-        if self._maxsize is not None and len(self._cache) == self._maxsize:
+        key = (prompt, llm_string)
+        if (
+            key not in self._cache
+            and self._maxsize is not None
+            and len(self._cache) >= self._maxsize
+        ):
             del self._cache[next(iter(self._cache))]
-        self._cache[prompt, llm_string] = return_val
+        self._cache[key] = return_val
 
     @override
     def clear(self, **kwargs: Any) -> None:

--- a/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
+++ b/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
@@ -69,6 +69,45 @@ def test_update_with_maxsize() -> None:
     assert cache.lookup(prompt3, llm_string3) == generations3
 
 
+def test_update_existing_key_does_not_evict() -> None:
+    """Updating an already-cached key must not evict another entry.
+
+    Regression test for a bug where `InMemoryCache.update` always pruned the
+    oldest entry when `len(cache) == maxsize`, shrinking the cache on an
+    in-place refresh of an existing key.
+    """
+    cache = InMemoryCache(maxsize=2)
+
+    prompt1, llm_string1, generations1 = cache_item(1)
+    prompt2, llm_string2, generations2 = cache_item(2)
+    cache.update(prompt1, llm_string1, generations1)
+    cache.update(prompt2, llm_string2, generations2)
+
+    new_generations = [Generation(text="refreshed")]
+    cache.update(prompt2, llm_string2, new_generations)
+
+    assert cache.lookup(prompt1, llm_string1) == generations1
+    assert cache.lookup(prompt2, llm_string2) == new_generations
+    assert len(cache._cache) == 2
+
+
+async def test_aupdate_existing_key_does_not_evict() -> None:
+    """Async counterpart of `test_update_existing_key_does_not_evict`."""
+    cache = InMemoryCache(maxsize=2)
+
+    prompt1, llm_string1, generations1 = cache_item(1)
+    prompt2, llm_string2, generations2 = cache_item(2)
+    await cache.aupdate(prompt1, llm_string1, generations1)
+    await cache.aupdate(prompt2, llm_string2, generations2)
+
+    new_generations = [Generation(text="refreshed")]
+    await cache.aupdate(prompt2, llm_string2, new_generations)
+
+    assert await cache.alookup(prompt1, llm_string1) == generations1
+    assert await cache.alookup(prompt2, llm_string2) == new_generations
+    assert len(cache._cache) == 2
+
+
 def test_clear(cache: InMemoryCache) -> None:
     """Test the clear method of InMemoryCache."""
     prompt, llm_string, generations = cache_item(1)


### PR DESCRIPTION
Closes #36750 (scoped to the `InMemoryCache` half of the report; the `Language.PERL` separators issue is a separate change.)

---

`InMemoryCache.update` always evaluated `len(cache) == maxsize` and pruned the oldest entry, even when the caller was rewriting a key that was already in the cache. That shrunk the cache on what should have been an in-place refresh — at `maxsize=2`, calling `update` on an existing key dropped an unrelated neighbor.

The fix skips the eviction branch when the target key is already present (`dict` preserves insertion order, so an existing entry stays where it was). New keys still trigger the usual "evict oldest" behavior, and the condition uses `>=` rather than `==` for safety on the strict maxsize invariant.

Covered by new sync and async regression tests in `libs/core/tests/unit_tests/caches/test_in_memory_cache.py`.

_Disclaimer: this contribution was prepared with AI-agent assistance._