### PR TITLE
chore(partners): standardize integration test invocation

### DIFF
--- a/libs/partners/anthropic/Makefile
+++ b/libs/partners/anthropic/Makefile
@@ -15,7 +15,7 @@ test tests:
 	uv run --group test pytest -vvv $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -n auto -vvv --timeout 30 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto --timeout 30 $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/chroma/Makefile
+++ b/libs/partners/chroma/Makefile
@@ -15,7 +15,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/deepseek/Makefile
+++ b/libs/partners/deepseek/Makefile
@@ -21,7 +21,7 @@ test_watch:
 
 # integration tests are run without the --disable-socket flag to allow network calls
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest --timeout=30 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto --timeout=30 $(TEST_FILE)
 
 ######################
 # LINTING AND FORMATTING

--- a/libs/partners/exa/Makefile
+++ b/libs/partners/exa/Makefile
@@ -10,10 +10,13 @@ UV_FROZEN = true
 TEST_FILE ?= tests/unit_tests/
 PYTEST_EXTRA ?=
 
-integration_tests: TEST_FILE=tests/integration_tests/
+integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
-test integration_tests:
+test:
 	uv run --group test --group test_integration pytest $(PYTEST_EXTRA) $(TEST_FILE)
+
+integration_test integration_tests:
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(PYTEST_EXTRA) $(TEST_FILE)
 
 tests:
 	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)

--- a/libs/partners/fireworks/Makefile
+++ b/libs/partners/fireworks/Makefile
@@ -15,7 +15,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/groq/Makefile
+++ b/libs/partners/groq/Makefile
@@ -16,7 +16,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest --retries 3 --retry-delay 1 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto --retries 3 --retry-delay 1 $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/huggingface/Makefile
+++ b/libs/partners/huggingface/Makefile
@@ -16,7 +16,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/mistralai/Makefile
+++ b/libs/partners/mistralai/Makefile
@@ -21,7 +21,7 @@ test_watch:
 
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 
 ######################

--- a/libs/partners/nomic/Makefile
+++ b/libs/partners/nomic/Makefile
@@ -10,10 +10,13 @@ UV_FROZEN = true
 TEST_FILE ?= tests/unit_tests/
 PYTEST_EXTRA ?=
 
-integration_tests: TEST_FILE = tests/integration_tests/
+integration_test integration_tests: TEST_FILE = tests/integration_tests/
 
-test integration_tests:
+test:
 	uv run --group test --group test_integration pytest $(PYTEST_EXTRA) $(TEST_FILE)
+
+integration_test integration_tests:
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(PYTEST_EXTRA) $(TEST_FILE)
 
 tests:
 	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)

--- a/libs/partners/ollama/Makefile
+++ b/libs/partners/ollama/Makefile
@@ -26,7 +26,7 @@ test_watch:
 
 
 # integration tests are run without the --disable-socket flag to allow network calls
-integration_test integration_tests:
+integration_test:
 	OLLAMA_TEST_MODEL=$(OLLAMA_TEST_MODEL) OLLAMA_REASONING_TEST_MODEL=$(OLLAMA_REASONING_TEST_MODEL) uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 # CI integration tests - disabled until ollama service is configured in CI

--- a/libs/partners/ollama/Makefile
+++ b/libs/partners/ollama/Makefile
@@ -9,7 +9,7 @@ UV_FROZEN = true
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 PYTEST_EXTRA ?=
-integration_test: TEST_FILE = tests/integration_tests/
+integration_test integration_tests: TEST_FILE = tests/integration_tests/
 # TODO(erick) configure ollama server to run in CI, in separate repo
 
 # Define variables for test model configuration
@@ -26,8 +26,8 @@ test_watch:
 
 
 # integration tests are run without the --disable-socket flag to allow network calls
-integration_test:
-	OLLAMA_TEST_MODEL=$(OLLAMA_TEST_MODEL) OLLAMA_REASONING_TEST_MODEL=$(OLLAMA_REASONING_TEST_MODEL) uv run --group test --group test_integration pytest $(TEST_FILE)
+integration_test integration_tests:
+	OLLAMA_TEST_MODEL=$(OLLAMA_TEST_MODEL) OLLAMA_REASONING_TEST_MODEL=$(OLLAMA_REASONING_TEST_MODEL) uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 # CI integration tests - disabled until ollama service is configured in CI
 

--- a/libs/partners/ollama/Makefile
+++ b/libs/partners/ollama/Makefile
@@ -9,7 +9,7 @@ UV_FROZEN = true
 # Define a variable for the test file path.
 TEST_FILE ?= tests/unit_tests/
 PYTEST_EXTRA ?=
-integration_test integration_tests: TEST_FILE = tests/integration_tests/
+integration_test: TEST_FILE = tests/integration_tests/
 # TODO(erick) configure ollama server to run in CI, in separate repo
 
 # Define variables for test model configuration

--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -25,7 +25,7 @@ test tests:
 	TIKTOKEN_CACHE_DIR=tiktoken_cache uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 # Run VCR cassette-backed integration tests in playback-only mode (no API keys needed).
 # Catches stale cassettes caused by test input changes without re-recording.

--- a/libs/partners/openrouter/Makefile
+++ b/libs/partners/openrouter/Makefile
@@ -21,7 +21,7 @@ test_watch:
 
 # integration tests are run without the --disable-socket flag to allow network calls
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest --timeout=120 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto --timeout=120 $(TEST_FILE)
 
 ######################
 # LINTING AND FORMATTING

--- a/libs/partners/perplexity/Makefile
+++ b/libs/partners/perplexity/Makefile
@@ -19,7 +19,7 @@ test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 ######################
 # LINTING AND FORMATTING

--- a/libs/partners/qdrant/Makefile
+++ b/libs/partners/qdrant/Makefile
@@ -16,7 +16,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/xai/Makefile
+++ b/libs/partners/xai/Makefile
@@ -19,7 +19,7 @@ test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -p no:benchmark -n auto $(TEST_FILE)
 
 ######################
 # LINTING AND FORMATTING


### PR DESCRIPTION
Standardize the `integration_tests` Makefile target across all 15 partner packages in `libs/partners/`, mirroring the deepagents `libs/evals` pattern (`-v --tb=short`). Previously each partner had its own ad-hoc flag stack (some missing `-n auto`, some with `-vvv`, others with nothing), and every partner that used `-n auto` was emitting a `PytestBenchmarkWarning` because `pytest-benchmark` is pulled in transitively via `langchain-tests` even though no partner has benchmark tests.