### PR TITLE
feat(core): allow _format_output to pass through list of ToolOutputMixin instances

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1265,8 +1265,15 @@ def _format_output(
         status: The execution status.
 
     Returns:
-        The formatted output, either as a `ToolMessage` or the original content.
+        The formatted output, either as a `ToolMessage`, the original content,
+        or an unchanged list of `ToolOutputMixin` instances.
     """
+    if (
+        isinstance(content, list)
+        and content
+        and all(isinstance(item, ToolOutputMixin) for item in content)
+    ):
+        return content
     if isinstance(content, ToolOutputMixin) or tool_call_id is None:
         return content
     if not _is_message_content_type(content):

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -138,6 +138,9 @@ class _FakeOutput(ToolOutputMixin):
     def __eq__(self, other: object) -> bool:
         return isinstance(other, _FakeOutput) and self.value == other.value
 
+    def __hash__(self) -> int:
+        return hash(self.value)
+
     def __repr__(self) -> str:
         return f"_FakeOutput({self.value})"
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -58,6 +58,7 @@ from langchain_core.tools.base import (
     InjectedToolCallId,
     SchemaAnnotationError,
     _DirectlyInjectedToolArg,
+    _format_output,
     _is_message_content_block,
     _is_message_content_type,
     get_all_basemodel_annotations,
@@ -126,6 +127,19 @@ class _MockStructuredTool(BaseTool):
 
     async def _arun(self, *, arg1: int, arg2: bool, arg3: dict | None = None) -> str:
         raise NotImplementedError
+
+
+class _FakeOutput(ToolOutputMixin):
+    """Minimal ToolOutputMixin subclass used only in tests."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _FakeOutput) and self.value == other.value
+
+    def __repr__(self) -> str:
+        return f"_FakeOutput({self.value})"
 
 
 def test_structured_args() -> None:
@@ -3653,3 +3667,74 @@ def test_tool_default_factory_not_required() -> None:
     schema = convert_to_openai_tool(some_func)
     params = schema["function"]["parameters"]
     assert "names" not in params.get("required", [])
+
+
+def test_format_output_list_of_tool_messages() -> None:
+    """A list of ToolMessages passes through unchanged."""
+    msgs = [
+        ToolMessage("a", tool_call_id="1", name="t"),
+        ToolMessage("b", tool_call_id="2", name="t"),
+    ]
+    result = _format_output(
+        msgs, artifact=None, tool_call_id="0", name="t", status="success"
+    )
+    assert result is msgs
+
+
+def test_format_output_list_of_custom_mixin_instances() -> None:
+    """A list of custom ToolOutputMixin subclass instances passes through."""
+    items = [_FakeOutput(1), _FakeOutput(2)]
+    result = _format_output(
+        items, artifact=None, tool_call_id="0", name="t", status="success"
+    )
+    assert result is items
+
+
+def test_format_output_mixed_mixin_subclasses() -> None:
+    """A list mixing ToolMessage and custom ToolOutputMixin passes through."""
+    items: list[ToolOutputMixin] = [
+        ToolMessage("a", tool_call_id="1", name="t"),
+        _FakeOutput(42),
+    ]
+    result = _format_output(
+        items, artifact=None, tool_call_id="0", name="t", status="success"
+    )
+    assert result is items
+
+
+def test_format_output_list_with_non_mixin_element() -> None:
+    """A list containing a non-ToolOutputMixin falls through to stringify."""
+    items = [ToolMessage("a", tool_call_id="1", name="t"), "oops"]
+    result = _format_output(
+        items, artifact=None, tool_call_id="0", name="t", status="success"
+    )
+    assert isinstance(result, ToolMessage)
+    assert result.tool_call_id == "0"
+
+
+def test_format_output_empty_list() -> None:
+    """An empty list falls through to stringify-and-wrap."""
+    result = _format_output(
+        [], artifact=None, tool_call_id="0", name="t", status="success"
+    )
+    assert isinstance(result, ToolMessage)
+    assert result.tool_call_id == "0"
+
+
+def test_tool_invoke_returns_list_of_mixin() -> None:
+    """End-to-end: a tool returning a list of ToolOutputMixin via invoke."""
+
+    @tool
+    def multi(x: int) -> list:  # type: ignore[type-arg]
+        """Return multiple outputs."""
+        return [
+            ToolMessage(f"result-{i}", tool_call_id=f"sub-{i}", name="multi")
+            for i in range(x)
+        ]
+
+    result = multi.invoke(
+        {"type": "tool_call", "args": {"x": 3}, "name": "multi", "id": "outer"}
+    )
+    assert isinstance(result, list)
+    assert len(result) == 3
+    assert all(isinstance(m, ToolMessage) for m in result)

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3728,7 +3728,7 @@ def test_tool_invoke_returns_list_of_mixin() -> None:
     """End-to-end: a tool returning a list of ToolOutputMixin via invoke."""
 
     @tool
-    def multi(x: int) -> list:  # type: ignore[type-arg]
+    def multi(x: int) -> list:
         """Return multiple outputs."""
         return [
             ToolMessage(f"result-{i}", tool_call_id=f"sub-{i}", name="multi")


### PR DESCRIPTION
## Summary

`BaseTool._format_output` now passes through a non-empty list whose elements are all `ToolOutputMixin` instances, instead of stringifying it and wrapping it in a single `ToolMessage`. This lets a single tool invocation return multiple structured outputs without losing structure at the `BaseTool` boundary.

## Problem

When a tool returns a **list** of `ToolOutputMixin` instances (e.g. multiple `ToolMessage`s or langgraph `Command`s), `_format_output` does not recognize the list as a pass-through type. It hits the `_stringify` branch, converting the list to its string representation and wrapping it in a single `ToolMessage`. All structure is lost. There is no supported way for one tool invocation to emit multiple structured results.

## Changes

**`libs/core/langchain_core/tools/base.py`**

Added a guard clause at the top of `_format_output` that checks whether `content` is a non-empty list where every element is a `ToolOutputMixin` instance. If so, the list is returned unchanged — no stringification, no wrapping.

```python
if (
    isinstance(content, list)
    and content
    and all(isinstance(item, ToolOutputMixin) for item in content)
):
    return content
```

The check uses `ToolOutputMixin` as the sole discriminator — no new imports, no knowledge of any particular subclass. Empty lists fall through to the existing stringify-and-wrap path (they are semantically distinct from a non-empty list of outputs).

All existing return shapes are unaffected:
- Single `ToolOutputMixin` → pass-through (unchanged)
- String → wrap in `ToolMessage` (unchanged)
- Content-block dicts → wrap in `ToolMessage` (unchanged)
- Mixed lists (some `ToolOutputMixin`, some not) → stringify-and-wrap (unchanged)
- Arbitrary non-mixin lists → stringify-and-wrap (unchanged)

**`libs/core/tests/unit_tests/test_tools.py`**

Added tests covering the new behavior and confirming existing behavior is preserved:
- List of `ToolMessage`s passes through
- List of custom `ToolOutputMixin` subclass instances passes through
- Mixed `ToolMessage` + custom mixin list passes through
- Empty list falls through to stringify
- End-to-end test via `tool.invoke()`
