### PR TITLE
feat(anthropic): prevent silent streaming hangs in `ChatAnthropic`

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/__init__.py
+++ b/libs/partners/anthropic/langchain_anthropic/__init__.py
@@ -1,5 +1,6 @@
 """Claude (Anthropic) partner package for LangChain."""
 
+from langchain_anthropic._client_utils import StreamChunkTimeoutError
 from langchain_anthropic._version import __version__
 from langchain_anthropic.chat_models import (
     ChatAnthropic,
@@ -10,6 +11,7 @@ from langchain_anthropic.llms import AnthropicLLM
 __all__ = [
     "AnthropicLLM",
     "ChatAnthropic",
+    "StreamChunkTimeoutError",
     "__version__",
     "convert_to_anthropic_tool",
 ]

--- a/libs/partners/anthropic/langchain_anthropic/_client_utils.py
+++ b/libs/partners/anthropic/langchain_anthropic/_client_utils.py
@@ -1,21 +1,358 @@
-"""Helpers for creating Anthropic API clients.
+"""Helpers for Anthropic httpx client construction, transport tuning, and streaming.
 
-This module allows for the caching of httpx clients to avoid creating new instances
-for each instance of ChatAnthropic.
+Covers cached default client builders, proxy-aware variants for the
+`anthropic_proxy` path, kernel-level TCP keepalive / `TCP_USER_TIMEOUT` socket
+options, and the `_astream_with_chunk_timeout` wrapper that bounds per-chunk
+wall-clock time on async SSE streams.
 
-Logic is largely replicated from anthropic._base_client.
+Client-builder boilerplate mirrors the patterns in `anthropic._base_client`;
+socket-option tuning and the streaming timeout are original to this module.
 """
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
+import socket
+import sys
+import urllib.request
+from collections.abc import AsyncIterator, Sequence
 from functools import lru_cache
-from typing import Any
+from typing import Any, TypeVar
 
 import anthropic
+import httpx
+
+logger = logging.getLogger(__name__)
 
 _NOT_GIVEN: Any = object()
+
+SocketOption = tuple[int, int, int]
+
+# socket.TCP_KEEPIDLE etc. are absent on darwin/win32; use raw UAPI constants.
+_LINUX_TCP_KEEPIDLE = 4
+_LINUX_TCP_KEEPINTVL = 5
+_LINUX_TCP_KEEPCNT = 6
+_LINUX_TCP_USER_TIMEOUT = 18
+
+# macOS: same semantics, different constants from <netinet/tcp.h>.
+_DARWIN_TCP_KEEPALIVE = 0x10  # idle seconds before first probe
+_DARWIN_TCP_KEEPINTVL = 0x101
+_DARWIN_TCP_KEEPCNT = 0x102
+
+# Matches `anthropic.DEFAULT_CONNECTION_LIMITS` (max_connections=1000,
+# max_keepalive_connections=100). `keepalive_expiry=5.0` is httpx's default,
+# set explicitly here for clarity — passing a custom `transport=` otherwise
+# leaves the setting implicit and makes it look like we're changing it.
+_DEFAULT_CONNECTION_LIMITS = httpx.Limits(
+    max_connections=1000,
+    max_keepalive_connections=100,
+    keepalive_expiry=5.0,
+)
+
+
+def _int_env(name: str, default: int, *, allow_negative: bool = False) -> int:
+    """Read an int env var with graceful fallback + discoverable warning.
+
+    Unparseable or (by default) negative values fall back to `default` and
+    emit a single `WARNING` naming the offending variable. A misconfigured
+    environment still loads, but operators see the fallback in their logs
+    rather than silently getting a surprising default.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid value for %s=%r (not an int); falling back to %d.",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if not allow_negative and value < 0:
+        logger.warning(
+            "Invalid value for %s=%r (negative); falling back to %d.",
+            name,
+            raw,
+            default,
+        )
+        return default
+    return value
+
+
+def _float_env(name: str, default: float, *, allow_negative: bool = False) -> float:
+    """Read a float env var with graceful fallback + discoverable warning.
+
+    See `_int_env`. Negative values are rejected by default so a typo in
+    `LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S=-10` can't silently disable the
+    wrapper it was meant to configure.
+    """
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid value for %s=%r (not a float); falling back to %s.",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if not allow_negative and value < 0:
+        logger.warning(
+            "Invalid value for %s=%r (negative); falling back to %s.",
+            name,
+            raw,
+            default,
+        )
+        return default
+    return value
+
+
+def _filter_supported(opts: list[SocketOption]) -> list[SocketOption]:
+    """Drop socket options the running platform rejects.
+
+    Probes each option against a throwaway socket via `setsockopt` and keeps
+    only those the kernel accepts. This keeps the library-computed defaults
+    non-fatal across platforms that don't implement every Linux option —
+    `TCP_USER_TIMEOUT` in particular is Linux-only and silently missing on
+    macOS, some minimal kernels, and older gVisor builds. Dropped options
+    are logged at `DEBUG` so an operator can confirm whether a kernel-level
+    knob took effect on their platform.
+
+    If the probe socket cannot be created (sandboxed runtimes, `pytest-socket`
+    under `--disable-socket`, tight seccomp policies), the input list is
+    returned unfiltered. This preserves the pass-through behavior used for
+    explicit user overrides: unsupported options will surface as a clear
+    `OSError` at the first real `connect()` rather than being silently
+    dropped during `ChatAnthropic` construction.
+    """
+    try:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    except Exception:
+        # Broad catch is deliberate: `pytest_socket` under `--disable-socket`
+        # raises `SocketBlockedError` (a `RuntimeError`, not `OSError`), and
+        # seccomp/sandboxed runtimes have been observed to raise other
+        # `OSError` subclasses and `PermissionError`. The intent is "any
+        # inability to create a probe socket -> pass through unfiltered,"
+        # and narrowing the type would silently regress sandboxed CI.
+        return list(opts)
+    try:
+        supported: list[SocketOption] = []
+        dropped: list[SocketOption] = []
+        for level, optname, optval in opts:
+            try:
+                probe.setsockopt(level, optname, optval)
+            except OSError:
+                dropped.append((level, optname, optval))
+                continue
+            supported.append((level, optname, optval))
+        if dropped:
+            logger.debug(
+                "Dropped %d unsupported socket option(s) on %s: %s",
+                len(dropped),
+                sys.platform,
+                dropped,
+            )
+        return supported
+    finally:
+        probe.close()
+
+
+def _default_socket_options() -> tuple[SocketOption, ...]:
+    """Return default TCP socket options, or `()` if disabled via env.
+
+    Always returns a tuple (never None) so callers and `@lru_cache` keys
+    remain uniform: `()` is the single shape for "no options".
+
+    Target behavior on Linux/gVisor with the full option set: silent peers
+    are surfaced within ~90-120s via `SO_KEEPALIVE` + `TCP_USER_TIMEOUT`
+    (keepalive path gives a ~90s floor at the defaults; `TCP_USER_TIMEOUT`
+    caps at 120s). On platforms that reject some options,
+    `_filter_supported` drops them and the bound degrades to whatever the
+    remaining options provide.
+    """
+    if os.environ.get("LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE", "1") == "0":
+        return ()
+
+    keepidle = _int_env("LANGCHAIN_ANTHROPIC_TCP_KEEPIDLE", 60)
+    keepintvl = _int_env("LANGCHAIN_ANTHROPIC_TCP_KEEPINTVL", 10)
+    keepcnt = _int_env("LANGCHAIN_ANTHROPIC_TCP_KEEPCNT", 3)
+    user_timeout_ms = _int_env("LANGCHAIN_ANTHROPIC_TCP_USER_TIMEOUT_MS", 120000)
+
+    opts: list[SocketOption] = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+    if sys.platform == "linux":
+        opts += [
+            (socket.IPPROTO_TCP, _LINUX_TCP_KEEPIDLE, keepidle),
+            (socket.IPPROTO_TCP, _LINUX_TCP_KEEPINTVL, keepintvl),
+            (socket.IPPROTO_TCP, _LINUX_TCP_KEEPCNT, keepcnt),
+            (socket.IPPROTO_TCP, _LINUX_TCP_USER_TIMEOUT, user_timeout_ms),
+        ]
+    elif sys.platform == "darwin":
+        opts += [
+            (socket.IPPROTO_TCP, _DARWIN_TCP_KEEPALIVE, keepidle),
+            (socket.IPPROTO_TCP, _DARWIN_TCP_KEEPINTVL, keepintvl),
+            (socket.IPPROTO_TCP, _DARWIN_TCP_KEEPCNT, keepcnt),
+        ]
+    # Windows (win32): SO_KEEPALIVE only; per-option tuning requires WSAIoctl.
+    return tuple(_filter_supported(opts))
+
+
+_PROXY_ENV_VARS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+)
+_proxy_env_warning_emitted = False
+_proxy_env_bypass_info_emitted = False
+
+
+def _proxy_env_detected() -> bool:
+    """True when httpx would pick up a proxy from env or system config.
+
+    Mirrors the surface httpx reads (`urllib.request.getproxies()` plus the
+    uppercase env var names) so a positive result means env-proxy
+    auto-detection is live on pre-PR code paths.
+    """
+    if any(os.environ.get(name) for name in _PROXY_ENV_VARS):
+        return True
+    try:
+        return bool(urllib.request.getproxies())
+    except Exception:
+        return False
+
+
+def _should_bypass_socket_options_for_proxy_env(
+    *,
+    http_socket_options: Sequence[SocketOption] | None,
+    anthropic_proxy: str | None,
+) -> bool:
+    """True when default shape + env proxy detected → skip transport injection.
+
+    Preserves pre-PR behavior for apps relying on httpx's env-proxy
+    auto-detection. Only triggers when the user has made no explicit choice
+    that would signal they want the custom transport:
+
+    - `http_socket_options` left at `None` (default, not `()` or a sequence)
+    - `LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE` is not `0` (kill-switch is its own path)
+    - No `anthropic_proxy` supplied
+    - A proxy env var / system proxy is visible to httpx
+
+    If any of those are set, the user has opted in to the transport path
+    (directly or via `anthropic_proxy`) and normal behavior — including the
+    shadowed-proxy WARNING — applies. When the kill-switch is set,
+    `_default_socket_options` already returns `()`, so the bypass INFO
+    would be noise; route through the normal path instead.
+    """
+    if http_socket_options is not None:
+        return False
+    if os.environ.get("LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE", "1") == "0":
+        return False
+    if anthropic_proxy:
+        return False
+    return _proxy_env_detected()
+
+
+def _log_proxy_env_bypass_once() -> None:
+    """Emit a one-time INFO when the proxy-env bypass triggers.
+
+    Visibility for operators running with a custom log pipeline: the bypass
+    is the *safe* outcome (env-proxy auto-detection preserved), but it means
+    socket-level keepalive / `TCP_USER_TIMEOUT` aren't applied on this
+    instance. INFO-level, since it's not a problem — just a diagnostic.
+    """
+    global _proxy_env_bypass_info_emitted
+    if _proxy_env_bypass_info_emitted:
+        return
+    _proxy_env_bypass_info_emitted = True
+    active = [name for name in _PROXY_ENV_VARS if os.environ.get(name)]
+    source = ", ".join(active) if active else "system proxy configuration"
+    logger.info(
+        "langchain-anthropic detected %s and no explicit `http_socket_options` / "
+        "`anthropic_proxy`; skipping the custom `httpx` transport so httpx's "
+        "env-proxy auto-detection applies. Pass `http_socket_options=[...]` to "
+        "opt back into kernel-level TCP keepalive tuning on top of the env proxy.",
+        source,
+    )
+
+
+def _warn_if_proxy_env_shadowed(
+    socket_options: tuple[SocketOption, ...],
+    *,
+    anthropic_proxy: str | None,
+) -> None:
+    """Warn once if a custom transport will shadow httpx's proxy auto-detection.
+
+    When `socket_options` is non-empty we pass a custom `httpx` transport,
+    which disables httpx's native proxy auto-detection — both the uppercase
+    `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` env vars and their lowercase
+    equivalents, plus macOS/Windows system proxy config. If the user
+    supplies `anthropic_proxy` explicitly we route through it and the env-var
+    handling is moot. Otherwise, a user whose app was transparently relying
+    on any of those sources will silently stop using them on upgrade —
+    emit a single WARNING so the behavior change is discoverable.
+
+    Detection uses `urllib.request.getproxies()` — the same surface httpx
+    reads — so lowercase env vars and macOS/Windows system proxy settings
+    are caught alongside the uppercase names.
+    """
+    global _proxy_env_warning_emitted
+    if _proxy_env_warning_emitted or not socket_options or anthropic_proxy:
+        return
+    active = [name for name in _PROXY_ENV_VARS if os.environ.get(name)]
+    try:
+        detected = bool(urllib.request.getproxies())
+    except Exception:
+        detected = False
+    if not active and not detected:
+        return
+    _proxy_env_warning_emitted = True
+    if active:
+        source = ", ".join(active) + " set in environment"
+    else:
+        source = "system proxy configuration detected"
+    logger.warning(
+        "langchain-anthropic injected a custom httpx transport to apply "
+        "`http_socket_options`, which disables httpx's proxy "
+        "auto-detection (%s). Set "
+        "`LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE=0` or pass `http_socket_options=()` "
+        "to restore default proxy behavior, or supply `anthropic_proxy` to "
+        "take full control.",
+        source,
+    )
+
+
+def _resolve_socket_options(
+    value: Sequence[SocketOption] | None,
+) -> tuple[SocketOption, ...]:
+    """Normalize the user-facing field to the tuple form builders expect.
+
+    - `None` => env-driven defaults (may itself be `()` if the user set
+        `LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE=0`). This path runs through
+        `_filter_supported()` inside `_default_socket_options()` because
+        the library-computed option set is aspirational and silent degradation
+        is the right posture.
+    - Any other sequence (including empty) => retupled for cache hashability.
+        An empty tuple is the explicit "disabled" signal. A non-empty sequence
+        is passed verbatim — **not** filtered. The user chose these options
+        explicitly, so an unsupported constant should surface as a clear
+        `OSError` at connect time, not be silently dropped.
+
+    Always returns a tuple — never `None` — so downstream signatures take
+    `tuple[SocketOption, ...]` with `()` as the single "no options" shape.
+    """
+    if value is None:
+        return _default_socket_options()
+    return tuple(value)
 
 
 class _SyncHttpxClientWrapper(anthropic.DefaultHttpxClient):
@@ -45,12 +382,12 @@ class _AsyncHttpxClientWrapper(anthropic.DefaultAsyncHttpxClient):
             pass
 
 
-@lru_cache
-def _get_default_httpx_client(
+def _build_sync_httpx_client(
     *,
     base_url: str | None,
     timeout: Any = _NOT_GIVEN,
     anthropic_proxy: str | None = None,
+    socket_options: tuple[SocketOption, ...] = (),
 ) -> _SyncHttpxClientWrapper:
     kwargs: dict[str, Any] = {
         "base_url": base_url
@@ -61,15 +398,29 @@ def _get_default_httpx_client(
         kwargs["timeout"] = timeout
     if anthropic_proxy is not None:
         kwargs["proxy"] = anthropic_proxy
+    if socket_options:
+        # httpx ignores limits= when transport= is provided; set it explicitly
+        # on the transport to avoid silently shrinking the connection pool.
+        transport_kwargs: dict[str, Any] = {
+            "socket_options": list(socket_options),
+            "limits": _DEFAULT_CONNECTION_LIMITS,
+        }
+        if anthropic_proxy is not None:
+            # Wrap in httpx.Proxy for version-stable behavior — HTTPTransport's
+            # proxy= is stricter about string coercion than Client's.
+            transport_kwargs["proxy"] = httpx.Proxy(anthropic_proxy)
+            # `proxy` is handled by the transport; drop the Client-level key.
+            kwargs.pop("proxy", None)
+        kwargs["transport"] = httpx.HTTPTransport(**transport_kwargs)
     return _SyncHttpxClientWrapper(**kwargs)
 
 
-@lru_cache
-def _get_default_async_httpx_client(
+def _build_async_httpx_client(
     *,
     base_url: str | None,
     timeout: Any = _NOT_GIVEN,
     anthropic_proxy: str | None = None,
+    socket_options: tuple[SocketOption, ...] = (),
 ) -> _AsyncHttpxClientWrapper:
     kwargs: dict[str, Any] = {
         "base_url": base_url
@@ -80,4 +431,228 @@ def _get_default_async_httpx_client(
         kwargs["timeout"] = timeout
     if anthropic_proxy is not None:
         kwargs["proxy"] = anthropic_proxy
+    if socket_options:
+        # See _build_sync_httpx_client for the limits= rationale.
+        transport_kwargs: dict[str, Any] = {
+            "socket_options": list(socket_options),
+            "limits": _DEFAULT_CONNECTION_LIMITS,
+        }
+        if anthropic_proxy is not None:
+            transport_kwargs["proxy"] = httpx.Proxy(anthropic_proxy)
+            kwargs.pop("proxy", None)
+        kwargs["transport"] = httpx.AsyncHTTPTransport(**transport_kwargs)
     return _AsyncHttpxClientWrapper(**kwargs)
+
+
+@lru_cache
+def _cached_sync_httpx_client(
+    *,
+    base_url: str | None,
+    timeout: Any = _NOT_GIVEN,
+    anthropic_proxy: str | None = None,
+    socket_options: tuple[SocketOption, ...] = (),
+) -> _SyncHttpxClientWrapper:
+    return _build_sync_httpx_client(
+        base_url=base_url,
+        timeout=timeout,
+        anthropic_proxy=anthropic_proxy,
+        socket_options=socket_options,
+    )
+
+
+@lru_cache
+def _cached_async_httpx_client(
+    *,
+    base_url: str | None,
+    timeout: Any = _NOT_GIVEN,
+    anthropic_proxy: str | None = None,
+    socket_options: tuple[SocketOption, ...] = (),
+) -> _AsyncHttpxClientWrapper:
+    return _build_async_httpx_client(
+        base_url=base_url,
+        timeout=timeout,
+        anthropic_proxy=anthropic_proxy,
+        socket_options=socket_options,
+    )
+
+
+def _get_default_httpx_client(
+    *,
+    base_url: str | None,
+    timeout: Any = _NOT_GIVEN,
+    anthropic_proxy: str | None = None,
+    socket_options: tuple[SocketOption, ...] = (),
+) -> _SyncHttpxClientWrapper:
+    """Get default httpx client.
+
+    Uses cached client unless timeout is `httpx.Timeout`, which is not hashable.
+    """
+    try:
+        hash(timeout)
+    except TypeError:
+        return _build_sync_httpx_client(
+            base_url=base_url,
+            timeout=timeout,
+            anthropic_proxy=anthropic_proxy,
+            socket_options=socket_options,
+        )
+    else:
+        return _cached_sync_httpx_client(
+            base_url=base_url,
+            timeout=timeout,
+            anthropic_proxy=anthropic_proxy,
+            socket_options=socket_options,
+        )
+
+
+def _get_default_async_httpx_client(
+    *,
+    base_url: str | None,
+    timeout: Any = _NOT_GIVEN,
+    anthropic_proxy: str | None = None,
+    socket_options: tuple[SocketOption, ...] = (),
+) -> _AsyncHttpxClientWrapper:
+    """Get default httpx client.
+
+    Uses cached client unless timeout is `httpx.Timeout`, which is not hashable.
+    """
+    try:
+        hash(timeout)
+    except TypeError:
+        return _build_async_httpx_client(
+            base_url=base_url,
+            timeout=timeout,
+            anthropic_proxy=anthropic_proxy,
+            socket_options=socket_options,
+        )
+    else:
+        return _cached_async_httpx_client(
+            base_url=base_url,
+            timeout=timeout,
+            anthropic_proxy=anthropic_proxy,
+            socket_options=socket_options,
+        )
+
+
+T = TypeVar("T")
+
+# On Python <=3.10, asyncio.TimeoutError and builtins.TimeoutError are distinct
+# hierarchies, so subclassing only asyncio.TimeoutError would not be caught by
+# `except TimeoutError:`. On Python ≥3.11 they are the same object, so listing
+# both bases would raise TypeError: duplicate base class. We resolve this at
+# class-definition time.
+_StreamChunkTimeoutBases: tuple[type, ...] = (
+    (asyncio.TimeoutError,)
+    if issubclass(asyncio.TimeoutError, TimeoutError)
+    else (asyncio.TimeoutError, TimeoutError)
+)
+
+
+class StreamChunkTimeoutError(*_StreamChunkTimeoutBases):  # type: ignore[misc]
+    """Raised when no streaming chunk arrives within `stream_chunk_timeout`.
+
+    `issubclass(StreamChunkTimeoutError, asyncio.TimeoutError)` and
+    `issubclass(StreamChunkTimeoutError, TimeoutError)` both hold on all
+    supported Python versions, so existing `except asyncio.TimeoutError:`
+    and `except TimeoutError:` handlers keep catching the exception. On
+    Python 3.11+ the two exceptions are the same object, so only
+    `asyncio.TimeoutError` appears in `__bases__`.
+
+    Structured attributes (`timeout_s`, `model_name`, `chunks_received`)
+    mirror the WARNING log's `extra=` payload so diagnostic code doesn't
+    need to regex the message.
+    """
+
+    def __init__(
+        self,
+        timeout_s: float,
+        *,
+        model_name: str | None = None,
+        chunks_received: int = 0,
+    ) -> None:
+        self.timeout_s = timeout_s
+        self.model_name = model_name
+        self.chunks_received = chunks_received
+        context = []
+        if model_name:
+            context.append(f"model={model_name}")
+        context.append(f"chunks_received={chunks_received}")
+        suffix = f" ({', '.join(context)})"
+        super().__init__(
+            f"No streaming chunk received for {timeout_s:.1f}s{suffix}. The "
+            f"connection may be alive at the TCP layer but is not producing "
+            f"content. Tune or disable via the `stream_chunk_timeout` "
+            f"constructor kwarg (set to None or 0 to disable) or the "
+            f"`LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S` env var. See also "
+            f"`http_socket_options` for the kernel-level TCP timeout that "
+            f"catches dead TCP peers."
+        )
+
+
+async def _astream_with_chunk_timeout(
+    source: AsyncIterator[T],
+    timeout: float | None,
+    *,
+    model_name: str | None = None,
+) -> AsyncIterator[T]:
+    """Yield from `source` but bound the per-chunk wait time.
+
+    If `timeout` is None or <=0, yields directly with no wall-clock bound.
+    Otherwise, each `__anext__` is wrapped in
+    `asyncio.wait_for(..., timeout)`. A timeout raises
+    `StreamChunkTimeoutError` (a `TimeoutError` subclass) whose message
+    names the knob, the env-var override, the model, and how many chunks
+    were received before the stall. A single-line structured log also
+    fires at WARNING so the signal is visible in aggregate logging systems
+    even when the exception is caught upstream.
+
+    When the timeout is active, the source iterator is explicitly
+    `aclose()`-d on early exit (timeout, consumer break, any exception) so
+    the underlying httpx streaming connection is released promptly. The
+    pass-through branch (timeout disabled) relies on httpx's GC-driven
+    cleanup instead — matching the behavior of unwrapped streams.
+    """
+    if not timeout or timeout <= 0:
+        async for item in source:
+            yield item
+        return
+
+    chunks_received = 0
+    it = source.__aiter__()
+    try:
+        while True:
+            try:
+                chunk = await asyncio.wait_for(it.__anext__(), timeout=timeout)
+            except StopAsyncIteration:
+                return
+            except asyncio.TimeoutError as e:
+                logger.warning(
+                    "langchain_anthropic.stream_chunk_timeout fired",
+                    extra={
+                        "source": "stream_chunk_timeout",
+                        "timeout_s": timeout,
+                        "model_name": model_name,
+                        "chunks_received": chunks_received,
+                    },
+                )
+                raise StreamChunkTimeoutError(
+                    timeout,
+                    model_name=model_name,
+                    chunks_received=chunks_received,
+                ) from e
+            chunks_received += 1
+            yield chunk
+    finally:
+        aclose = getattr(it, "aclose", None)
+        if aclose is not None:
+            try:
+                await aclose()
+            except Exception as cleanup_exc:
+                # Best-effort cleanup; don't mask the original exception,
+                # but leave a DEBUG trace so pool/transport bugs stay
+                # discoverable at the right log level.
+                logger.debug(
+                    "aclose() during _astream_with_chunk_timeout cleanup "
+                    "raised; ignoring",
+                    exc_info=cleanup_exc,
+                )

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import datetime
 import json
+import logging
 import re
 import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
@@ -54,17 +55,33 @@ from langchain_core.utils.function_calling import (
 )
 from langchain_core.utils.pydantic import is_basemodel_subclass
 from langchain_core.utils.utils import _build_model_kwargs
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 from typing_extensions import NotRequired, TypedDict
 
 from langchain_anthropic import __version__
 from langchain_anthropic._client_utils import (
+    SocketOption,
+    _astream_with_chunk_timeout,
+    _float_env,
     _get_default_async_httpx_client,
     _get_default_httpx_client,
+    _log_proxy_env_bypass_once,
+    _resolve_socket_options,
+    _should_bypass_socket_options_for_proxy_env,
+    _warn_if_proxy_env_shadowed,
 )
 from langchain_anthropic._compat import _convert_from_v1_to_anthropic
 from langchain_anthropic.data._profiles import _PROFILES
 from langchain_anthropic.output_parsers import extract_tool_calls
+
+logger = logging.getLogger(__name__)
 
 _message_type_lookups = {
     "human": "user",
@@ -802,6 +819,106 @@ class ChatAnthropic(BaseChatModel):
     variable.
     """
 
+    http_socket_options: Sequence[SocketOption] | None = Field(
+        default=None, exclude=True
+    )
+    """TCP socket options applied to the httpx transports built by this instance.
+
+    Defaults to a conservative TCP-keepalive + `TCP_USER_TIMEOUT` profile that
+    targets a ~2-minute bound on silent connection hangs (silent mid-stream peer
+    loss, gVisor/NAT idle timeouts, silent TCP black holes) on platforms that
+    support the full option set. On platforms that only support a subset
+    (macOS without `TCP_USER_TIMEOUT`, Windows with only `SO_KEEPALIVE`,
+    minimal kernels), unsupported options are silently dropped and the bound
+    degrades to whatever the remaining options + OS defaults provide — still
+    better than indefinite hang.
+
+    Accepted values:
+
+    - `None` (default): use env-driven defaults. Matches the "unset" convention
+        used elsewhere on this class.
+    - `()` (empty): disable socket-option injection entirely. Inherits the OS
+        defaults and restores httpx's native env-proxy auto-detection.
+    - A non-empty sequence of `(level, option, value)` tuples: explicit
+        override; passed verbatim to the transport (not filtered). Unsupported
+        options raise `OSError` at connect time rather than being silently
+        dropped — the user chose them explicitly.
+
+    Environment variables (only consulted when this field is `None`):
+    `LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE` (set to `0` to disable entirely — the
+    kill-switch), `LANGCHAIN_ANTHROPIC_TCP_KEEPIDLE`,
+    `LANGCHAIN_ANTHROPIC_TCP_KEEPINTVL`, `LANGCHAIN_ANTHROPIC_TCP_KEEPCNT`,
+    `LANGCHAIN_ANTHROPIC_TCP_USER_TIMEOUT_MS`.
+
+    !!! note "Interaction with env-proxy auto-detection"
+
+        When a custom `httpx` transport is active, `httpx` disables its
+        native env-proxy auto-detection (`HTTP_PROXY` / `HTTPS_PROXY` /
+        `ALL_PROXY` / `NO_PROXY` and macOS/Windows system proxy settings).
+
+        To keep the default shape safe, `ChatAnthropic` detects the
+        "proxy-env-shadow" pattern and **skips the custom transport
+        entirely** when **all** of the following hold:
+
+        - `http_socket_options` is left at its default (`None`)
+        - No `anthropic_proxy` supplied
+        - A proxy env var or system proxy is visible to httpx
+
+        On that specific shape, the instance falls back to pre-PR behavior
+        and httpx's env-proxy auto-detection applies (a one-time `INFO` log
+        records the bypass for observability).
+
+        If you explicitly set `http_socket_options=[...]` while a proxy
+        env var is also set, no bypass — you opted into the transport, and
+        a one-time `WARNING` records the shadowing. Set
+        `http_socket_options=()` or `LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE=0` to
+        disable transport injection explicitly. The `anthropic_proxy`
+        constructor kwarg is unaffected — socket options are applied
+        cleanly through the proxied transport on that path.
+    """
+
+    stream_chunk_timeout: float | None = Field(
+        default_factory=lambda: _float_env(
+            "LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S", 120.0
+        ),
+        exclude=True,
+    )
+    """Per-chunk wall-clock timeout (seconds) on async streaming responses.
+
+    Applies to async invocations only (`astream`, `ainvoke` with streaming,
+    etc.). Sync streaming (`stream`) is not affected.
+
+    Fires between content chunks yielded by the anthropic SDK's streaming
+    iterator (i.e., each call to `__anext__` on the response). Crucially, this
+    is **not** the same as httpx's `timeout.read`:
+
+    - httpx's read timeout is inter-byte and gets reset every time *any* bytes
+        arrive on the socket — including the SSE `ping` heartbeat events the
+        Messages API sends during long model generations. A stream that's
+        silent on *content* but still producing pings looks alive forever
+        to httpx.
+    - `stream_chunk_timeout` measures the gap between *parsed chunks*. The
+        anthropic SDK's SSE parser filters `event: ping` heartbeats internally
+        and does not emit them as chunks, so pings do *not* reset this timer.
+        It fires on genuine content silence.
+
+    When it fires, a `StreamChunkTimeoutError`
+    (subclass of `asyncio.TimeoutError`) is raised with a self-describing
+    message naming this knob, the env-var override, the model, and the
+    number of chunks received before the stall. A WARNING log with
+    `extra={"source": "stream_chunk_timeout", "timeout_s": <value>,
+    "model_name": <value>, "chunks_received": <value>}` also fires so
+    aggregate logging can distinguish app-layer timeouts from
+    transport-layer failures.
+
+    Defaults to 120s. Set to `None` or `0` to disable. Overridable via the
+    `LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S` env var. Negative values
+    (from either the env var or the constructor kwarg — e.g., hydrated
+    from YAML/JSON configs) fall back to the default with a `WARNING` log
+    rather than silently disabling the wrapper, so a misconfigured value
+    still boots safely and the fallback is visible.
+    """
+
     default_headers: Mapping[str, str] | None = None
     """Headers to pass to the Anthropic clients, will be used for every API call."""
 
@@ -999,6 +1116,27 @@ class ChatAnthropic(BaseChatModel):
         all_required_field_names = get_pydantic_field_names(cls)
         return _build_model_kwargs(values, all_required_field_names)
 
+    @field_validator("stream_chunk_timeout", mode="after")
+    @classmethod
+    def _validate_stream_chunk_timeout(cls, value: float | None) -> float | None:
+        """Reject negative constructor values; fall back to the env-driven default.
+
+        Matches the env-var path in `_float_env`: a negative value is a typo,
+        not an opt-out (`None`/`0` are the documented off switches). Configs
+        hydrated from YAML/JSON would otherwise silently disable the wrapper
+        and reintroduce the indefinite-stream hang the feature prevents.
+        """
+        if value is not None and value < 0:
+            fallback = _float_env("LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S", 120.0)
+            logger.warning(
+                "Invalid `stream_chunk_timeout=%r` (negative); "
+                "falling back to %s. Pass `None` or `0` to disable.",
+                value,
+                fallback,
+            )
+            return fallback
+        return value
+
     def _resolve_model_profile(self) -> ModelProfile | None:
         profile = _get_default_model_profile(self.model) or None
         if profile is not None and self.betas and "context-1m-2025-08-07" in self.betas:
@@ -1027,9 +1165,32 @@ class ChatAnthropic(BaseChatModel):
         return client_params
 
     @cached_property
+    def _resolved_socket_options(self) -> tuple[SocketOption, ...]:
+        """Resolve `http_socket_options` with proxy-env-shadow bypass applied.
+
+        When the default-shape construction coincides with a proxy env var
+        visible to httpx, return `()` so no custom transport is injected and
+        httpx's env-proxy auto-detection still applies. Otherwise, normalize
+        the user-facing field to the tuple form the builders expect and emit
+        the shadowing warning if applicable.
+        """
+        if _should_bypass_socket_options_for_proxy_env(
+            http_socket_options=self.http_socket_options,
+            anthropic_proxy=self.anthropic_proxy,
+        ):
+            _log_proxy_env_bypass_once()
+            return ()
+        resolved = _resolve_socket_options(self.http_socket_options)
+        _warn_if_proxy_env_shadowed(resolved, anthropic_proxy=self.anthropic_proxy)
+        return resolved
+
+    @cached_property
     def _client(self) -> anthropic.Client:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
+        http_client_params: dict[str, Any] = {
+            "base_url": client_params["base_url"],
+            "socket_options": self._resolved_socket_options,
+        }
         if "timeout" in client_params:
             http_client_params["timeout"] = client_params["timeout"]
         if self.anthropic_proxy:
@@ -1044,7 +1205,10 @@ class ChatAnthropic(BaseChatModel):
     @cached_property
     def _async_client(self) -> anthropic.AsyncClient:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
+        http_client_params: dict[str, Any] = {
+            "base_url": client_params["base_url"],
+            "socket_options": self._resolved_socket_options,
+        }
         if "timeout" in client_params:
             http_client_params["timeout"] = client_params["timeout"]
         if self.anthropic_proxy:
@@ -1292,7 +1456,11 @@ class ChatAnthropic(BaseChatModel):
                 and not _compact_in_params(payload)
             )
             block_start_event = None
-            async for event in stream:
+            async for event in _astream_with_chunk_timeout(
+                stream,
+                self.stream_chunk_timeout,
+                model_name=self.model,
+            ):
                 msg, block_start_event = self._make_message_chunk_from_anthropic_event(
                     event,
                     stream_usage=stream_usage,

--- a/libs/partners/anthropic/tests/unit_tests/test_client_utils.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_client_utils.py
@@ -1,16 +1,46 @@
-"""Test client utility functions."""
+"""Unit tests for `langchain_anthropic._client_utils`.
+
+Asserts socket-options plumbing at the boundary between our helpers and the
+httpx layer — not on httpx internals. Locks the wiring, env-driven defaults,
+the `()` kill-switch contract, and the precedence between constructor kwargs,
+env vars, and user-supplied clients.
+"""
 
 from __future__ import annotations
 
-from langchain_anthropic._client_utils import (
-    _get_default_async_httpx_client,
-    _get_default_httpx_client,
-)
+import logging
+import os
+import socket
+from typing import Any
+
+import httpx
+import pytest
+
+from langchain_anthropic import ChatAnthropic, _client_utils
+
+SOL_SOCKET = socket.SOL_SOCKET
+SO_KEEPALIVE = socket.SO_KEEPALIVE
+
+_MODEL = "claude-opus-4-7"
+
+
+@pytest.fixture(autouse=True)
+def _clear_langchain_anthropic_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure LANGCHAIN_ANTHROPIC_* env vars don't leak between tests."""
+    for name in list(os.environ):
+        if name.startswith("LANGCHAIN_ANTHROPIC_") or name == "ANTHROPIC_API_KEY":
+            monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    # Reset module-level one-shot latches between tests.
+    monkeypatch.setattr(_client_utils, "_proxy_env_warning_emitted", False)
+    monkeypatch.setattr(_client_utils, "_proxy_env_bypass_info_emitted", False)
 
 
 def test_sync_client_without_proxy() -> None:
     """Test sync client creation without proxy."""
-    client = _get_default_httpx_client(base_url="https://api.anthropic.com")
+    client = _client_utils._get_default_httpx_client(
+        base_url="https://api.anthropic.com"
+    )
 
     # Should not have proxy configured
     assert not hasattr(client, "proxies") or client.proxies is None
@@ -19,19 +49,19 @@ def test_sync_client_without_proxy() -> None:
 def test_sync_client_with_proxy() -> None:
     """Test sync client creation with proxy."""
     proxy_url = "http://proxy.example.com:8080"
-    client = _get_default_httpx_client(
+    client = _client_utils._get_default_httpx_client(
         base_url="https://api.anthropic.com", anthropic_proxy=proxy_url
     )
 
-    # Check internal _transport since httpx stores proxy configuration in the transport
-    # layer
     transport = getattr(client, "_transport", None)
     assert transport is not None
 
 
 def test_async_client_without_proxy() -> None:
     """Test async client creation without proxy."""
-    client = _get_default_async_httpx_client(base_url="https://api.anthropic.com")
+    client = _client_utils._get_default_async_httpx_client(
+        base_url="https://api.anthropic.com"
+    )
 
     assert not hasattr(client, "proxies") or client.proxies is None
 
@@ -39,7 +69,7 @@ def test_async_client_without_proxy() -> None:
 def test_async_client_with_proxy() -> None:
     """Test async client creation with proxy."""
     proxy_url = "http://proxy.example.com:8080"
-    client = _get_default_async_httpx_client(
+    client = _client_utils._get_default_async_httpx_client(
         base_url="https://api.anthropic.com", anthropic_proxy=proxy_url
     )
 
@@ -49,14 +79,713 @@ def test_async_client_with_proxy() -> None:
 
 def test_client_proxy_none_value() -> None:
     """Test that explicitly passing None for proxy works correctly."""
-    sync_client = _get_default_httpx_client(
+    sync_client = _client_utils._get_default_httpx_client(
         base_url="https://api.anthropic.com", anthropic_proxy=None
     )
 
-    async_client = _get_default_async_httpx_client(
+    async_client = _client_utils._get_default_async_httpx_client(
         base_url="https://api.anthropic.com", anthropic_proxy=None
     )
 
-    # Both should be created successfully with None proxy
     assert sync_client is not None
     assert async_client is not None
+
+
+@pytest.mark.skipif(
+    __import__("sys").platform != "linux",
+    reason="Default option set is platform-specific; Linux values asserted here.",
+)
+def test_default_socket_options_linux() -> None:
+    """On Linux, the full option set should be present with default values."""
+    opts = _client_utils._default_socket_options()
+    expected = {
+        (SOL_SOCKET, SO_KEEPALIVE, 1),
+        (socket.IPPROTO_TCP, _client_utils._LINUX_TCP_KEEPIDLE, 60),
+        (socket.IPPROTO_TCP, _client_utils._LINUX_TCP_KEEPINTVL, 10),
+        (socket.IPPROTO_TCP, _client_utils._LINUX_TCP_KEEPCNT, 3),
+        (socket.IPPROTO_TCP, _client_utils._LINUX_TCP_USER_TIMEOUT, 120000),
+    }
+    assert set(opts) == expected
+
+
+def test_default_socket_options_disabled_returns_empty_tuple(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Kill-switch: `()` is the single 'no options' shape, never None."""
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE", "0")
+    opts = _client_utils._default_socket_options()
+    assert opts == ()
+    assert isinstance(opts, tuple)
+
+
+@pytest.mark.enable_socket
+def test_filter_supported_drops_unsupported() -> None:
+    """An option with a deliberately-bogus level should be silently dropped."""
+    good = (SOL_SOCKET, SO_KEEPALIVE, 1)
+    bogus = (0xDEAD, 0xBEEF, 1)
+    try:
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM).close()
+    except OSError:
+        pytest.skip("probe socket unavailable in this environment")
+    result = _client_utils._filter_supported([good, bogus])
+    assert good in result
+    assert bogus not in result
+
+
+def test_build_async_httpx_client_boundary_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Did our helper decide to inject a transport or not?"""
+    recorded: list[dict[str, Any]] = []
+
+    original = _client_utils._AsyncHttpxClientWrapper.__init__
+
+    def spy(self: Any, **kwargs: Any) -> None:
+        recorded.append(kwargs)
+        original(self, **kwargs)
+
+    monkeypatch.setattr(_client_utils._AsyncHttpxClientWrapper, "__init__", spy)
+
+    _client_utils._build_async_httpx_client(
+        base_url=None,
+        socket_options=((SOL_SOCKET, SO_KEEPALIVE, 1),),
+    )
+    assert recorded, "expected one call when socket_options populated"
+    assert "transport" in recorded[-1]
+
+    recorded.clear()
+    _client_utils._build_async_httpx_client(base_url=None, socket_options=())
+    assert recorded, "expected one call when socket_options empty"
+    assert "transport" not in recorded[-1]
+
+
+def test_build_async_httpx_client_transport_carries_socket_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Transport should receive our options + the mirrored limits."""
+    recorded: list[dict[str, Any]] = []
+
+    original_cls = _client_utils.httpx.AsyncHTTPTransport
+
+    class Recorder(original_cls):  # type: ignore[misc, valid-type]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            recorded.append(kwargs)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "langchain_anthropic._client_utils.httpx.AsyncHTTPTransport",
+        Recorder,
+    )
+
+    _client_utils._build_async_httpx_client(
+        base_url=None,
+        socket_options=((SOL_SOCKET, SO_KEEPALIVE, 1),),
+    )
+
+    assert recorded, "expected httpx.AsyncHTTPTransport to be constructed"
+    kwargs = recorded[-1]
+    assert kwargs.get("socket_options") == [(SOL_SOCKET, SO_KEEPALIVE, 1)]
+    assert kwargs.get("limits") is _client_utils._DEFAULT_CONNECTION_LIMITS
+
+
+def test_http_socket_options_none_vs_empty_tuple_vs_populated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discriminates the three input shapes at the builder boundary.
+
+    Also locks the no-filter contract for user overrides: the populated-case
+    assertion is verbatim, proving `_resolve_socket_options` does not run
+    user overrides through `_filter_supported`.
+    """
+    recorded: list[tuple[str, tuple]] = []
+
+    def spy_async(**kwargs: Any) -> Any:
+        socket_options = kwargs.get("socket_options", ())
+        recorded.append(("async", tuple(socket_options)))
+        return _client_utils._AsyncHttpxClientWrapper(
+            base_url=kwargs.get("base_url") or "https://api.anthropic.com",
+        )
+
+    def spy_sync(**kwargs: Any) -> Any:
+        socket_options = kwargs.get("socket_options", ())
+        recorded.append(("sync", tuple(socket_options)))
+        return _client_utils._SyncHttpxClientWrapper(
+            base_url=kwargs.get("base_url") or "https://api.anthropic.com",
+        )
+
+    monkeypatch.setattr(
+        "langchain_anthropic.chat_models._get_default_async_httpx_client",
+        spy_async,
+    )
+    monkeypatch.setattr(
+        "langchain_anthropic.chat_models._get_default_httpx_client",
+        spy_sync,
+    )
+
+    # (1) Unset -> None -> env-driven defaults (non-empty on linux/darwin CI).
+    llm = ChatAnthropic(model=_MODEL)
+    # Trigger lazy client construction.
+    _ = llm._client
+    _ = llm._async_client
+    assert recorded, "expected a default-client build"
+    _, opts1 = recorded[-1]
+    assert isinstance(opts1, tuple)
+
+    # (2) Explicit empty tuple -> ().
+    recorded.clear()
+    llm = ChatAnthropic(model=_MODEL, http_socket_options=())
+    _ = llm._client
+    _ = llm._async_client
+    assert recorded
+    assert all(opts == () for _, opts in recorded)
+
+    # (3) Populated sequence -> verbatim passthrough (not filtered).
+    recorded.clear()
+    llm = ChatAnthropic(
+        model=_MODEL,
+        http_socket_options=[(SOL_SOCKET, SO_KEEPALIVE, 1)],
+    )
+    _ = llm._client
+    _ = llm._async_client
+    assert recorded
+    for _, opts in recorded:
+        assert opts == ((SOL_SOCKET, SO_KEEPALIVE, 1),)
+
+
+def test_anthropic_proxy_applies_socket_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`anthropic_proxy` path must forward socket options to the builder."""
+    recorded: list[dict[str, Any]] = []
+
+    def sync_spy(**kwargs: Any) -> Any:
+        recorded.append({"kind": "sync", **kwargs})
+        return _client_utils._SyncHttpxClientWrapper(
+            base_url=kwargs.get("base_url") or "https://api.anthropic.com",
+        )
+
+    def async_spy(**kwargs: Any) -> Any:
+        recorded.append({"kind": "async", **kwargs})
+        return _client_utils._AsyncHttpxClientWrapper(
+            base_url=kwargs.get("base_url") or "https://api.anthropic.com",
+        )
+
+    monkeypatch.setattr(
+        "langchain_anthropic.chat_models._get_default_httpx_client",
+        sync_spy,
+    )
+    monkeypatch.setattr(
+        "langchain_anthropic.chat_models._get_default_async_httpx_client",
+        async_spy,
+    )
+
+    llm = ChatAnthropic(
+        model=_MODEL,
+        anthropic_proxy="http://proxy.example.com:3128",
+        http_socket_options=[(SOL_SOCKET, SO_KEEPALIVE, 1)],
+    )
+    _ = llm._client
+    _ = llm._async_client
+
+    for record in recorded:
+        assert record.get("anthropic_proxy") == "http://proxy.example.com:3128"
+        assert record.get("socket_options") == ((SOL_SOCKET, SO_KEEPALIVE, 1),)
+
+
+def test_default_path_opt_out_is_strict_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE=0 we inject no transport."""
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE", "0")
+
+    recorded_sync: list[dict[str, Any]] = []
+    recorded_async: list[dict[str, Any]] = []
+
+    sync_original = _client_utils._SyncHttpxClientWrapper.__init__
+    async_original = _client_utils._AsyncHttpxClientWrapper.__init__
+
+    def sync_spy(self: Any, **kwargs: Any) -> None:
+        recorded_sync.append(kwargs)
+        sync_original(self, **kwargs)
+
+    def async_spy(self: Any, **kwargs: Any) -> None:
+        recorded_async.append(kwargs)
+        async_original(self, **kwargs)
+
+    monkeypatch.setattr(_client_utils._SyncHttpxClientWrapper, "__init__", sync_spy)
+    monkeypatch.setattr(_client_utils._AsyncHttpxClientWrapper, "__init__", async_spy)
+
+    # Clear cached builder results so env changes take effect.
+    _client_utils._cached_sync_httpx_client.cache_clear()
+    _client_utils._cached_async_httpx_client.cache_clear()
+
+    llm = ChatAnthropic(model=_MODEL)
+    _ = llm._client
+    _ = llm._async_client
+
+    assert recorded_sync, "expected the sync default client to be built"
+    assert "transport" not in recorded_sync[-1]
+    assert recorded_async, "expected the async default client to be built"
+    assert "transport" not in recorded_async[-1]
+
+
+def test_invalid_env_values_degrade_safely(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Garbage in LANGCHAIN_ANTHROPIC_TCP_* env vars must not crash model init."""
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_TCP_KEEPIDLE", "not-an-int")
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_TCP_KEEPINTVL", "")
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_TCP_KEEPCNT", "NaN")
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_TCP_USER_TIMEOUT_MS", "abc")
+
+    opts = _client_utils._default_socket_options()
+    assert isinstance(opts, tuple)
+    assert (SOL_SOCKET, SO_KEEPALIVE, 1) in opts
+
+    # Instantiating a model doesn't raise.
+    ChatAnthropic(model=_MODEL)
+
+
+def test_invalid_stream_chunk_timeout_env_degrades_safely(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Garbage in LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S must not crash init."""
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S", "not-a-float")
+    model = ChatAnthropic(model=_MODEL)
+    assert model.stream_chunk_timeout == 120.0
+
+
+def test_default_socket_options_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """macOS: `TCP_USER_TIMEOUT` is unavailable, but keepalive trio maps to darwin."""
+    monkeypatch.setattr(_client_utils.sys, "platform", "darwin")
+    opts = _client_utils._default_socket_options()
+    assert (SOL_SOCKET, SO_KEEPALIVE, 1) in opts
+    darwin_keepalive = (
+        socket.IPPROTO_TCP,
+        _client_utils._DARWIN_TCP_KEEPALIVE,
+        60,
+    )
+    assert darwin_keepalive in opts or opts == ((SOL_SOCKET, SO_KEEPALIVE, 1),)
+
+
+def test_default_socket_options_other_platform(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown platform (e.g. win32): `SO_KEEPALIVE` only."""
+    monkeypatch.setattr(_client_utils.sys, "platform", "win32")
+    opts = _client_utils._default_socket_options()
+    assert opts in (((SOL_SOCKET, SO_KEEPALIVE, 1),), ())
+
+
+def test_filter_supported_probe_failure_returns_unfiltered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Contract: probe-socket failure -> input is returned verbatim."""
+
+    def _raise(*args: Any, **kwargs: Any) -> None:
+        msg = "sandboxed"
+        raise OSError(msg)
+
+    monkeypatch.setattr(_client_utils.socket, "socket", _raise)
+    good = (SOL_SOCKET, SO_KEEPALIVE, 1)
+    bogus = (0xDEAD, 0xBEEF, 1)
+    result = _client_utils._filter_supported([good, bogus])
+    assert result == [good, bogus]
+
+
+def test_invalid_tcp_env_emits_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Int env fallback must log a WARNING naming the offending variable."""
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_TCP_KEEPIDLE", "not-an-int")
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+    _client_utils._default_socket_options()
+    assert any(
+        "LANGCHAIN_ANTHROPIC_TCP_KEEPIDLE" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+def test_negative_tcp_env_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Negative keepalive counts fall back to the default with a WARNING."""
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_TCP_KEEPCNT", "-5")
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+    value = _client_utils._int_env("LANGCHAIN_ANTHROPIC_TCP_KEEPCNT", 3)
+    assert value == 3
+    assert any(
+        "negative" in r.getMessage().lower()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+@pytest.mark.enable_socket
+def test_filter_supported_logs_drops_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dropped options are visible at DEBUG so a macOS user can confirm the filter."""
+    try:
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM).close()
+    except OSError:
+        pytest.skip("probe socket unavailable in this environment")
+    caplog.set_level(logging.DEBUG, logger="langchain_anthropic._client_utils")
+    good = (SOL_SOCKET, SO_KEEPALIVE, 1)
+    bogus = (0xDEAD, 0xBEEF, 1)
+    _client_utils._filter_supported([good, bogus])
+    assert any(
+        "Dropped" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.DEBUG
+    )
+
+
+def test_build_sync_httpx_client_with_proxy_wraps_transport() -> None:
+    """Non-empty socket_options + proxy -> transport carries Proxy(...)."""
+    client = _client_utils._build_sync_httpx_client(
+        base_url=None,
+        anthropic_proxy="http://proxy.example:3128",
+        socket_options=((SOL_SOCKET, SO_KEEPALIVE, 1),),
+    )
+    assert isinstance(client, httpx.Client)
+
+
+def test_build_async_httpx_client_with_proxy_wraps_transport() -> None:
+    """Async variant: non-empty socket_options + proxy -> transport path."""
+    client = _client_utils._build_async_httpx_client(
+        base_url=None,
+        anthropic_proxy="http://proxy.example:3128",
+        socket_options=((SOL_SOCKET, SO_KEEPALIVE, 1),),
+    )
+    assert isinstance(client, httpx.AsyncClient)
+
+
+def test_warn_if_proxy_env_shadowed_emits_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One WARNING per process when a proxy env var is shadowed by our transport."""
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.example:3128")
+    monkeypatch.setattr(_client_utils, "_proxy_env_warning_emitted", False)
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+    opts = ((SOL_SOCKET, SO_KEEPALIVE, 1),)
+    _client_utils._warn_if_proxy_env_shadowed(opts, anthropic_proxy=None)
+    _client_utils._warn_if_proxy_env_shadowed(opts, anthropic_proxy=None)
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "HTTP_PROXY" in r.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+def test_warn_if_proxy_env_shadowed_detects_lowercase(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Lowercase `http_proxy` is picked up by httpx; the warning must fire for it."""
+    for name in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("http_proxy", "http://proxy.example:3128")
+    monkeypatch.setattr(_client_utils, "_proxy_env_warning_emitted", False)
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+    opts = ((SOL_SOCKET, SO_KEEPALIVE, 1),)
+    _client_utils._warn_if_proxy_env_shadowed(opts, anthropic_proxy=None)
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "http_proxy" in r.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+def test_warn_if_proxy_env_shadowed_detects_system_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """macOS/Windows system proxies shadow the transport too; warning should fire."""
+    for name in _client_utils._PROXY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(_client_utils, "_proxy_env_warning_emitted", False)
+    monkeypatch.setattr(
+        _client_utils.urllib.request,
+        "getproxies",
+        lambda: {"http": "http://system.proxy:3128"},
+    )
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+    opts = ((SOL_SOCKET, SO_KEEPALIVE, 1),)
+    _client_utils._warn_if_proxy_env_shadowed(opts, anthropic_proxy=None)
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "system proxy" in r.getMessage()
+    ]
+    assert len(warnings) == 1
+
+
+def test_warn_if_proxy_env_shadowed_skipped_when_anthropic_proxy_set(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Explicit `anthropic_proxy` suppresses the warn (proxy handling is controlled)."""
+    monkeypatch.setenv("HTTP_PROXY", "http://proxy.example:3128")
+    monkeypatch.setattr(_client_utils, "_proxy_env_warning_emitted", False)
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+    opts = ((SOL_SOCKET, SO_KEEPALIVE, 1),)
+    _client_utils._warn_if_proxy_env_shadowed(
+        opts, anthropic_proxy="http://proxy.example:3128"
+    )
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_proxy_env_bypass_default_shape_triggers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Default-shape + env proxy => bypass socket-option transport."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    assert _client_utils._should_bypass_socket_options_for_proxy_env(
+        http_socket_options=None,
+        anthropic_proxy=None,
+    )
+
+
+def test_proxy_env_bypass_no_env_does_not_trigger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No proxy env/system proxy => no bypass, even with everything else default."""
+    for name in _client_utils._PROXY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(_client_utils.urllib.request, "getproxies", dict)
+    assert not _client_utils._should_bypass_socket_options_for_proxy_env(
+        http_socket_options=None,
+        anthropic_proxy=None,
+    )
+
+
+def test_proxy_env_bypass_blocked_by_explicit_socket_options(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit `http_socket_options` => user opted in, no bypass."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    assert not _client_utils._should_bypass_socket_options_for_proxy_env(
+        http_socket_options=[(SOL_SOCKET, SO_KEEPALIVE, 1)],
+        anthropic_proxy=None,
+    )
+    # Empty tuple is also an explicit choice (kill-switch), no bypass.
+    assert not _client_utils._should_bypass_socket_options_for_proxy_env(
+        http_socket_options=(),
+        anthropic_proxy=None,
+    )
+
+
+def test_proxy_env_bypass_blocked_by_kill_switch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE=0` => kill-switch owns the disable path."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE", "0")
+    assert not _client_utils._should_bypass_socket_options_for_proxy_env(
+        http_socket_options=None,
+        anthropic_proxy=None,
+    )
+
+
+def test_proxy_env_bypass_blocked_by_anthropic_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`anthropic_proxy` handles proxying explicitly => no bypass."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    assert not _client_utils._should_bypass_socket_options_for_proxy_env(
+        http_socket_options=None,
+        anthropic_proxy="http://anthropic.proxy:3128",
+    )
+
+
+def test_proxy_env_bypass_detects_lowercase_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Lowercase `https_proxy` also triggers the bypass."""
+    for name in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("https_proxy", "http://proxy.example:3128")
+    assert _client_utils._should_bypass_socket_options_for_proxy_env(
+        http_socket_options=None,
+        anthropic_proxy=None,
+    )
+
+
+def test_proxy_env_bypass_detects_system_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """macOS/Windows system proxy config triggers the bypass too."""
+    for name in _client_utils._PROXY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(
+        _client_utils.urllib.request,
+        "getproxies",
+        lambda: {"http": "http://system.proxy:3128"},
+    )
+    assert _client_utils._should_bypass_socket_options_for_proxy_env(
+        http_socket_options=None,
+        anthropic_proxy=None,
+    )
+
+
+def test_log_proxy_env_bypass_once_emits_info_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One INFO per process when the bypass kicks in."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    monkeypatch.setattr(_client_utils, "_proxy_env_bypass_info_emitted", False)
+    caplog.set_level(logging.INFO, logger="langchain_anthropic._client_utils")
+    _client_utils._log_proxy_env_bypass_once()
+    _client_utils._log_proxy_env_bypass_once()
+    infos = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "HTTPS_PROXY" in r.getMessage()
+    ]
+    assert len(infos) == 1
+
+
+def test_client_build_skips_transport_on_proxy_env_default_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: default-shape ChatAnthropic + HTTPS_PROXY => no custom transport."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    monkeypatch.setattr(_client_utils, "_proxy_env_bypass_info_emitted", False)
+    monkeypatch.setattr(_client_utils, "_proxy_env_warning_emitted", False)
+    _client_utils._cached_sync_httpx_client.cache_clear()
+    _client_utils._cached_async_httpx_client.cache_clear()
+
+    recorded: list[tuple[Any, ...]] = []
+
+    original_build = _client_utils._build_async_httpx_client
+
+    def spy(**kwargs: Any) -> Any:
+        recorded.append(kwargs.get("socket_options", ()))
+        return original_build(**kwargs)
+
+    monkeypatch.setattr(_client_utils, "_build_async_httpx_client", spy)
+    monkeypatch.setattr(_client_utils, "_cached_async_httpx_client", spy)
+
+    llm = ChatAnthropic(model=_MODEL)
+    _ = llm._async_client
+
+    assert recorded, "async builder should have been called"
+    assert all(opts == () for opts in recorded), (
+        f"expected bypass (no socket options), got {recorded!r}"
+    )
+
+
+def test_client_build_applies_socket_options_when_user_opts_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit `http_socket_options` => transport applied, bypass skipped."""
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    monkeypatch.setattr(_client_utils, "_proxy_env_bypass_info_emitted", False)
+    monkeypatch.setattr(_client_utils, "_proxy_env_warning_emitted", False)
+    _client_utils._cached_sync_httpx_client.cache_clear()
+    _client_utils._cached_async_httpx_client.cache_clear()
+
+    recorded: list[tuple[Any, ...]] = []
+    original_build = _client_utils._build_async_httpx_client
+
+    def spy(**kwargs: Any) -> Any:
+        recorded.append(kwargs.get("socket_options", ()))
+        return original_build(**kwargs)
+
+    monkeypatch.setattr(_client_utils, "_build_async_httpx_client", spy)
+    monkeypatch.setattr(_client_utils, "_cached_async_httpx_client", spy)
+
+    explicit = [(SOL_SOCKET, SO_KEEPALIVE, 1)]
+    llm = ChatAnthropic(model=_MODEL, http_socket_options=explicit)
+    _ = llm._async_client
+
+    assert recorded, "async builder should have been called"
+    assert all(tuple(opts) == tuple(explicit) for opts in recorded), (
+        f"expected user-supplied opts, got {recorded!r}"
+    )
+
+
+def test_resolved_socket_options_is_cached_and_logs_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`_resolved_socket_options` must be a cached_property.
+
+    A regression to a plain `property` would cause `_log_proxy_env_bypass_once`
+    to re-evaluate on every `_client` / `_async_client` access. One proxy-env
+    bypass INFO per instance, not per client build.
+    """
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:3128")
+    monkeypatch.setattr(_client_utils, "_proxy_env_bypass_info_emitted", False)
+    caplog.set_level(logging.INFO, logger="langchain_anthropic._client_utils")
+
+    llm = ChatAnthropic(model=_MODEL)
+    first = llm._resolved_socket_options
+    second = llm._resolved_socket_options
+    # Property caching: same object returned.
+    assert first is second
+    # Triggering lazy clients shouldn't re-compute or re-log.
+    _ = llm._client
+    _ = llm._async_client
+    infos = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.INFO and "HTTPS_PROXY" in r.getMessage()
+    ]
+    assert len(infos) == 1
+
+
+def test_build_async_httpx_client_with_proxy_pops_client_proxy_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """proxy + socket_options: proxy lands on the transport, not the Client.
+
+    When `socket_options` is populated we build an `httpx.AsyncHTTPTransport`
+    and must pop the top-level `proxy=` kwarg so httpx doesn't try to also
+    wrap the transport (which would raise).
+    """
+    recorded_client: list[dict[str, Any]] = []
+    recorded_transport: list[dict[str, Any]] = []
+
+    client_original = _client_utils._AsyncHttpxClientWrapper.__init__
+
+    def client_spy(self: Any, **kwargs: Any) -> None:
+        recorded_client.append(kwargs)
+        client_original(self, **kwargs)
+
+    monkeypatch.setattr(_client_utils._AsyncHttpxClientWrapper, "__init__", client_spy)
+
+    transport_original = _client_utils.httpx.AsyncHTTPTransport
+
+    class TransportRecorder(transport_original):  # type: ignore[misc, valid-type]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            recorded_transport.append(kwargs)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "langchain_anthropic._client_utils.httpx.AsyncHTTPTransport",
+        TransportRecorder,
+    )
+
+    _client_utils._build_async_httpx_client(
+        base_url=None,
+        anthropic_proxy="http://proxy.example:3128",
+        socket_options=((SOL_SOCKET, SO_KEEPALIVE, 1),),
+    )
+
+    assert recorded_client
+    # Client must NOT receive proxy= when transport= is used, otherwise httpx
+    # raises ValueError for double-configured proxies.
+    assert "proxy" not in recorded_client[-1]
+    assert "transport" in recorded_client[-1]
+
+    assert recorded_transport
+    transport_kwargs = recorded_transport[-1]
+    assert isinstance(transport_kwargs.get("proxy"), _client_utils.httpx.Proxy)
+    assert transport_kwargs.get("socket_options") == [(SOL_SOCKET, SO_KEEPALIVE, 1)]

--- a/libs/partners/anthropic/tests/unit_tests/test_imports.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_imports.py
@@ -5,6 +5,7 @@ EXPECTED_ALL = [
     "ChatAnthropic",
     "convert_to_anthropic_tool",
     "AnthropicLLM",
+    "StreamChunkTimeoutError",
 ]
 
 

--- a/libs/partners/anthropic/tests/unit_tests/test_stream_chunk_timeout.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_stream_chunk_timeout.py
@@ -1,0 +1,321 @@
+"""Unit tests for `_astream_with_chunk_timeout` and `StreamChunkTimeoutError`.
+
+- Pass-through when items arrive in time.
+- Timeout fires with a self-describing message + subclasses TimeoutError.
+- Structured WARNING log carries `source=stream_chunk_timeout` +
+    `timeout_s` so aggregate logging can distinguish app-layer from
+    transport-layer timeouts.
+- Source iterator's `aclose()` is called on early exit to release the
+    underlying httpx connection promptly.
+- Garbage in `LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S` degrades safely.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncGenerator
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+
+from langchain_anthropic import ChatAnthropic
+from langchain_anthropic._client_utils import (
+    StreamChunkTimeoutError,
+    _astream_with_chunk_timeout,
+)
+
+MODEL = "claude-opus-4-7"
+
+
+class _FakeSource:
+    """AsyncIterator with an observable aclose() for leak-testing."""
+
+    def __init__(self, items: list[Any], per_item_sleep: float = 0.0) -> None:
+        self._items = list(items)
+        self._sleep = per_item_sleep
+        self.aclose_count = 0
+
+    def __aiter__(self) -> _FakeSource:
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._sleep:
+            await asyncio.sleep(self._sleep)
+        if not self._items:
+            raise StopAsyncIteration
+        return self._items.pop(0)
+
+    async def aclose(self) -> None:
+        self.aclose_count += 1
+
+
+async def test_astream_with_chunk_timeout_passes_through() -> None:
+    """Fast source + generous timeout: every item should be delivered."""
+    source = _FakeSource(["a", "b", "c"], per_item_sleep=0.0)
+    collected = [item async for item in _astream_with_chunk_timeout(source, 5.0)]
+    assert collected == ["a", "b", "c"]
+
+
+async def test_astream_with_chunk_timeout_disabled_passes_through() -> None:
+    """timeout=None / timeout=0 disables the bound; still iterates normally."""
+    source_none = _FakeSource(["a", "b"])
+    collected_none = [
+        item async for item in _astream_with_chunk_timeout(source_none, None)
+    ]
+    assert collected_none == ["a", "b"]
+
+    source_zero = _FakeSource(["x", "y"])
+    collected_zero = [
+        item async for item in _astream_with_chunk_timeout(source_zero, 0.0)
+    ]
+    assert collected_zero == ["x", "y"]
+
+
+async def test_astream_with_chunk_timeout_fires() -> None:
+    """Slow source + tight timeout: `StreamChunkTimeoutError` fires."""
+    source = _FakeSource(["a", "b"], per_item_sleep=0.2)
+    with pytest.raises(StreamChunkTimeoutError) as exc_info:
+        async for _ in _astream_with_chunk_timeout(source, 0.05):
+            pass
+
+    # Backward-compat: existing `except TimeoutError:` handlers must still catch.
+    assert isinstance(exc_info.value, asyncio.TimeoutError)
+    assert isinstance(exc_info.value, TimeoutError)
+
+    # Self-describing message names the knob and env var so operators can act.
+    msg = str(exc_info.value)
+    assert "stream_chunk_timeout" in msg
+    assert "LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S" in msg
+
+
+async def test_astream_with_chunk_timeout_logs_on_fire(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Structured log carries source + timeout_s for aggregate-log filtering."""
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+
+    source = _FakeSource(["a"], per_item_sleep=0.2)
+    with pytest.raises(StreamChunkTimeoutError):
+        async for _ in _astream_with_chunk_timeout(source, 0.05):
+            pass
+
+    records = [
+        r
+        for r in caplog.records
+        if r.name == "langchain_anthropic._client_utils"
+        and getattr(r, "source", None) == "stream_chunk_timeout"
+    ]
+    assert len(records) == 1, f"expected one structured record, got {len(records)}"
+    record = records[0]
+    assert record.levelno == logging.WARNING
+    assert record.__dict__["timeout_s"] == 0.05
+
+
+async def test_astream_with_chunk_timeout_closes_source_on_early_exit() -> None:
+    """aclose() is called on early exit so the httpx connection is released promptly.
+
+    Covers both the timeout-fires path and the consumer-closes-wrapper path.
+    """
+    # Case 1: timeout fires -> aclose() propagates.
+    timed_out_source = _FakeSource(["a"], per_item_sleep=0.2)
+    with pytest.raises(StreamChunkTimeoutError):
+        async for _ in _astream_with_chunk_timeout(timed_out_source, 0.05):
+            pass
+    assert timed_out_source.aclose_count == 1
+
+    # Case 2: consumer explicitly closes the wrapper after one yield.
+    closer_source = _FakeSource(["a", "b", "c"], per_item_sleep=0.0)
+    wrapper = cast(
+        "AsyncGenerator[Any, None]",
+        _astream_with_chunk_timeout(closer_source, 5.0),
+    )
+    got = await wrapper.__anext__()
+    assert got == "a"
+    await wrapper.aclose()
+    assert closer_source.aclose_count == 1
+
+
+def test_invalid_stream_chunk_timeout_env_degrades_safely(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Garbage env var -> model init succeeds with the 120s default."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S", "not-a-float")
+    model = ChatAnthropic(model=MODEL)
+    assert model.stream_chunk_timeout == 120.0
+
+
+def test_stream_chunk_timeout_env_kill_switch_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Env-var kill-switch: `_S=0` should disable the wrapper on the model."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S", "0")
+    model = ChatAnthropic(model=MODEL)
+    assert model.stream_chunk_timeout == 0.0
+
+
+def test_stream_chunk_timeout_kwarg_none_disables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Constructor kwarg opt-out: `stream_chunk_timeout=None` persists."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    model = ChatAnthropic(model=MODEL, stream_chunk_timeout=None)
+    assert model.stream_chunk_timeout is None
+
+
+def test_stream_chunk_timeout_error_has_structured_attrs() -> None:
+    """Structured payload mirrors the log `extra=`; no message-regex needed."""
+    err = StreamChunkTimeoutError(0.5, model_name=MODEL, chunks_received=3)
+    assert err.timeout_s == 0.5
+    assert err.model_name == MODEL
+    assert err.chunks_received == 3
+    text = str(err)
+    assert MODEL in text
+    assert "chunks_received=3" in text
+
+
+async def test_astream_with_chunk_timeout_threads_model_name(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`model_name` flows into both the raised error and the structured log."""
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+    source = _FakeSource(["a", "b"], per_item_sleep=0.2)
+    with pytest.raises(StreamChunkTimeoutError) as exc_info:
+        async for _ in _astream_with_chunk_timeout(
+            source, 0.05, model_name="claude-3-5-sonnet"
+        ):
+            pass
+    assert exc_info.value.model_name == "claude-3-5-sonnet"
+    records = [
+        r
+        for r in caplog.records
+        if getattr(r, "source", None) == "stream_chunk_timeout"
+    ]
+    assert records
+    assert records[0].__dict__["model_name"] == "claude-3-5-sonnet"
+
+
+def test_invalid_stream_chunk_timeout_env_emits_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fallback is logged at WARNING so the typo is discoverable."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S", "nonsense")
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+    ChatAnthropic(model=MODEL)
+    assert any(
+        "LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+def test_negative_stream_chunk_timeout_env_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Negative timeout typo must not silently disable the wrapper."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.setenv("LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S", "-10")
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic._client_utils")
+    model = ChatAnthropic(model=MODEL)
+    assert model.stream_chunk_timeout == 120.0
+    assert any(
+        "negative" in r.getMessage().lower()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+def test_negative_stream_chunk_timeout_kwarg_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Negative kwarg (e.g., from YAML/JSON configs) must not disable the wrapper."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    caplog.set_level(logging.WARNING, logger="langchain_anthropic.chat_models")
+    model = ChatAnthropic(model=MODEL, stream_chunk_timeout=-10)
+    assert model.stream_chunk_timeout == 120.0
+    assert any(
+        "negative" in r.getMessage().lower()
+        and "stream_chunk_timeout" in r.getMessage()
+        for r in caplog.records
+        if r.levelno == logging.WARNING
+    )
+
+
+def test_zero_stream_chunk_timeout_kwarg_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`stream_chunk_timeout=0` is the documented opt-out and must persist."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    model = ChatAnthropic(model=MODEL, stream_chunk_timeout=0)
+    assert model.stream_chunk_timeout == 0
+
+
+class _SlowAsyncStream:
+    """Async iterator that sleeps between streamed events."""
+
+    def __init__(self, events: list[Any], per_item_sleep: float) -> None:
+        self._events = iter(events)
+        self._sleep = per_item_sleep
+
+    def __aiter__(self) -> _SlowAsyncStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        await asyncio.sleep(self._sleep)
+        try:
+            return next(self._events)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+async def test_astream_integration_raises_stream_chunk_timeout_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: slow async stream + tight timeout must raise.
+
+    Guards against a refactor that drops the `_astream_with_chunk_timeout`
+    wrapper from the `_astream` path — unit tests on the helper alone
+    wouldn't catch that regression.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    llm = ChatAnthropic(model=MODEL, stream_chunk_timeout=0.05)
+
+    # A single dummy event that never arrives in time (sleep > timeout).
+    fake_events: list[Any] = [
+        {"type": "message_start", "message": {"model": MODEL, "usage": {}}},
+    ]
+
+    async def fake_acreate(payload: dict) -> _SlowAsyncStream:
+        return _SlowAsyncStream(fake_events, per_item_sleep=0.3)
+
+    with (
+        patch.object(llm, "_acreate", side_effect=fake_acreate),
+        pytest.raises(StreamChunkTimeoutError) as exc_info,
+    ):
+        async for _ in llm._astream([]):
+            pass
+    assert exc_info.value.model_name == MODEL
+
+
+async def test_astream_integration_passes_through_when_timeout_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With `stream_chunk_timeout=None` a slow stream must not raise."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    llm = ChatAnthropic(model=MODEL, stream_chunk_timeout=None)
+
+    fake_events: list[Any] = []  # no events -> clean stop
+
+    async def fake_acreate(payload: dict) -> _SlowAsyncStream:
+        return _SlowAsyncStream(fake_events, per_item_sleep=0.0)
+
+    with patch.object(llm, "_acreate", side_effect=fake_acreate):
+        collected = [chunk async for chunk in llm._astream([])]
+    assert collected == []

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.13' and platform_python_implementation == 'PyPy'",
@@ -660,7 +660,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.0a3"
+version = "1.3.0"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Port of [#36949](https://github.com/langchain-ai/langchain/pull/36949) from `langchain-openai` to `langchain-anthropic`. Streaming `ChatAnthropic` calls could hang forever when the underlying TCP connection silently died mid-stream (idle NAT/LB timeouts, sandboxed runtimes killing long-lived connections, peer gone without a FIN or RST). httpx's read timeout doesn't help because it resets on any bytes arriving on the socket, including the Messages API's `event: ping` SSE heartbeats — a stream that's silent on content but still pinging looks alive forever. This adds two bounded-hang knobs with safe defaults.

## Changes

- Add `stream_chunk_timeout` to `ChatAnthropic` (default 120s, `None`/`0` to disable, env override `LANGCHAIN_ANTHROPIC_STREAM_CHUNK_TIMEOUT_S`). Wraps the async SDK stream iterator in `asyncio.wait_for` per chunk. Measures the gap between *parsed* SSE chunks, so the anthropic SDK's ping-filter keeps heartbeats from resetting the timer. Sync `stream()` is untouched.
- Add `StreamChunkTimeoutError` — subclass of `asyncio.TimeoutError` and `TimeoutError` on both Python 3.10 and 3.11+ via a dynamic base-class tuple, so existing `except TimeoutError:` handlers still catch it. Carries structured attributes `timeout_s`, `model_name`, `chunks_received` mirrored in a WARNING log's `extra=` for alerting without message-regex. Exported from the top-level package.
- Add `http_socket_options` to `ChatAnthropic`. Defaults to `SO_KEEPALIVE` + `TCP_KEEPIDLE` / `TCP_KEEPINTVL` / `TCP_KEEPCNT` + `TCP_USER_TIMEOUT` on Linux (macOS equivalents where available, Windows falls back to `SO_KEEPALIVE` only). Unsupported options are probed against a throwaway socket and silently dropped so the default set is non-fatal across platforms. Env overrides `LANGCHAIN_ANTHROPIC_TCP_KEEPALIVE` (kill-switch), `LANGCHAIN_ANTHROPIC_TCP_KEEPIDLE`, `LANGCHAIN_ANTHROPIC_TCP_KEEPINTVL`, `LANGCHAIN_ANTHROPIC_TCP_KEEPCNT`, `LANGCHAIN_ANTHROPIC_TCP_USER_TIMEOUT_MS`. Unparseable or negative env values fall back with a discoverable WARNING rather than silently applying a surprising default.
- Enterprise-proxy-safe default shape. A custom `httpx` transport disables httpx's env-proxy auto-detection. To avoid silently breaking users relying on `HTTP_PROXY` / `HTTPS_PROXY` / `ALL_PROXY` / system proxies, `ChatAnthropic` detects the "proxy-env-shadow" pattern and **skips the custom transport entirely** when `http_socket_options` is at default (`None`), no `anthropic_proxy` is supplied, and a proxy env var / system proxy is visible to httpx. A one-time `INFO` records the bypass. Users who explicitly set `http_socket_options=[...]` alongside an env proxy get the original shadowing behavior with a one-time `WARNING`.
- Cached `_resolved_socket_options` property threads the resolved option tuple into both `_client` and `_async_client` so the bypass / shadow warnings fire once per instance, not once per client build. When `anthropic_proxy` and socket options are combined, proxy is wrapped in `httpx.Proxy(...)` on the transport and the Client-level `proxy=` key is popped to avoid httpx's double-configuration error.
- Pool limits set explicitly on the custom transport (`httpx.Limits(max_connections=1000, max_keepalive_connections=100, keepalive_expiry=5.0)`) — matches `anthropic.DEFAULT_CONNECTION_LIMITS`. Without this, passing `transport=` to `httpx.AsyncClient` silently shrinks the connection pool.
- Negative constructor values for `stream_chunk_timeout` (e.g., hydrated from YAML/JSON configs) fall back to the default with a WARNING via a pydantic `field_validator`, rather than silently treating negatives as an opt-out. `None` and `0` remain the documented off-switches.

## Behavior change

- Async streaming calls that would previously have hung forever now raise `StreamChunkTimeoutError` after 120s of content silence. Existing `except TimeoutError:` / `except asyncio.TimeoutError:` handlers catch it unchanged.
- Opt-outs: `stream_chunk_timeout=None` (or `…_TIMEOUT_S=0`), `http_socket_options=()` (or `…_TCP_KEEPALIVE=0`).
