### PR TITLE
Fix typo in Visitor._validate_func error message

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
Good day

I noticed a small typo in the error message for operators. The error message in Visitor._validate_func says 'Allowed comparators are' but this is for operators, not comparators.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithRoof

Reference: #36701