### PR TITLE
fix(core): remove 5 unnecessary type: ignore comments in ai.py

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -282,9 +282,13 @@ class AIMessage(BaseMessage):
                         "args": tool_call["args"],
                     }
                     if "index" in tool_call:
-                        tool_call_block["index"] = tool_call["index"]  # type: ignore[typeddict-item]
+                        tool_call_block["index"] = cast("dict[str, Any]", tool_call)[
+                            "index"
+                        ]
                     if "extras" in tool_call:
-                        tool_call_block["extras"] = tool_call["extras"]  # type: ignore[typeddict-item]
+                        tool_call_block["extras"] = cast("dict[str, Any]", tool_call)[
+                            "extras"
+                        ]
                     blocks.append(tool_call_block)
 
         # Best-effort reasoning extraction from additional_kwargs
@@ -581,8 +585,9 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 ):
                     self.content[idx] = cast("dict[str, Any]", id_to_tc[call_id])
                     if "extras" in block:
-                        # mypy does not account for instance check for dict above
-                        self.content[idx]["extras"] = block["extras"]  # type: ignore[index]
+                        cast("dict[str, Any]", self.content[idx])["extras"] = block[
+                            "extras"
+                        ]
 
         return self
 
@@ -609,8 +614,9 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                     try:
                         args = json.loads(args_str)
                         if isinstance(args, dict):
-                            self.content[idx]["type"] = "server_tool_call"  # type: ignore[index]
-                            self.content[idx]["args"] = args  # type: ignore[index]
+                            block_dict = cast("dict[str, Any]", self.content[idx])
+                            block_dict["type"] = "server_tool_call"
+                            block_dict["args"] = args
                     except json.JSONDecodeError:
                         pass
         return self


### PR DESCRIPTION
Fixes #36931

---

Five `# type: ignore` comments in `AIMessage.content_blocks`, `AIMessageChunk.init_tool_calls`, and `AIMessageChunk.init_server_tool_calls` were silencing mypy rather than addressing what it was complaining about. Swap each one for a `cast("dict[str, Any]", ...)` placed at the site where narrowing is actually needed.

For the `typeddict-item` sites the source `ToolCall` TypedDict in `messages.tool` does not declare `index` or `extras`, even though they exist at runtime — casting the source `tool_call` to `dict[str, Any]` lets mypy read those keys without silencing the diagnostic. For the three `index` sites, `self.content[idx]` is typed `str | dict[str, Any]` and mypy cannot narrow it from the outer `isinstance(block, dict)` check on a separate loop variable — casting the target to `dict[str, Any]` at the assignment point expresses the intent directly.

Runtime behavior is identical. The two load-bearing ignores called out in the issue (the `type` field override on `AIMessageChunk` and the `__add__` overload) are left in place — they encode real architectural choices, not suppressed bugs.

Before:

```python
tool_call_block["index"] = tool_call["index"]  # type: ignore[typeddict-item]
```

After:

```python
tool_call_block["index"] = cast("dict[str, Any]", tool_call)["index"]
```

`mypy langchain_core` and `mypy tests` both still come back clean, and the full `libs/core` unit test suite passes locally.

> Disclosure: this contribution was prepared with assistance from an AI coding agent; a human reviewed the change before opening the PR.