### PR TITLE
fix(core): propagate MIME type when parsing OpenAI file blocks

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -545,7 +545,7 @@ def _convert_openai_format_to_data_block(
         filename = block["file"].get("filename")
         return types.create_file_block(
             base64=parsed["data"],
-            mime_type="application/pdf",
+            mime_type=parsed["mime_type"],
             filename=filename,
             **all_extras,
         )

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -317,6 +317,63 @@ def test_convert_to_v1_from_openai_input() -> None:
     assert _content_blocks_equal_ignore_id(message.content_blocks, expected)
 
 
+def test_convert_to_v1_from_openai_input_file_mime_types() -> None:
+    """File blocks should preserve the MIME type from the data URI.
+
+    Previously the base64 file branch hard-coded `application/pdf`, which
+    silently mangled non-PDF uploads (e.g. CSV, plain text) that OpenAI
+    otherwise accepts.
+    """
+    message = HumanMessage(
+        content=[
+            {
+                "type": "file",
+                "file": {
+                    "filename": "greeting.csv",
+                    "file_data": "data:text/csv;base64,aGVsbG8=",
+                },
+            },
+            {
+                "type": "file",
+                "file": {
+                    "filename": "notes.txt",
+                    "file_data": "data:text/plain;base64,bm90ZXM=",
+                },
+            },
+            {
+                "type": "file",
+                "file": {
+                    "filename": "draconomicon.pdf",
+                    "file_data": "data:application/pdf;base64,<base64 string>",
+                },
+            },
+        ]
+    )
+
+    expected: list[types.ContentBlock] = [
+        {
+            "type": "file",
+            "base64": "aGVsbG8=",
+            "mime_type": "text/csv",
+            "extras": {"filename": "greeting.csv"},
+        },
+        {
+            "type": "file",
+            "base64": "bm90ZXM=",
+            "mime_type": "text/plain",
+            "extras": {"filename": "notes.txt"},
+        },
+        {
+            "type": "file",
+            "base64": "<base64 string>",
+            "mime_type": "application/pdf",
+            "extras": {"filename": "draconomicon.pdf"},
+        },
+    ]
+
+    assert _content_blocks_equal_ignore_id(message.content_blocks, expected)
+
+
 def test_compat_responses_v03() -> None:
     # Check compatibility with v0.3 legacy message format
     message_v03 = AIMessage(


### PR DESCRIPTION
Fixes #36939

---

The base64 branch of `_convert_openai_format_to_data_block` hard-coded `application/pdf` when constructing the resulting `FileContentBlock`, so any non-PDF upload — CSV, plain text, DOCX, and so on — quietly lost its real MIME type even though the data URI already carried it. The sibling image branch already pulls `parsed["mime_type"]`; this change mirrors that behavior for files.

The surrounding walrus guard (`parsed := _parse_data_uri(...)`) only enters this branch when `_parse_data_uri` returns a dict, and that helper bails out with `None` whenever the MIME segment is missing, so no extra `None` check is needed.

Added a focused regression test alongside the existing file-block coverage that exercises CSV (from the issue reproducer), plain text, and PDF inputs to confirm the propagated `mime_type` matches the data URI on each.

> Disclosure: this contribution was prepared with AI-agent assistance; a human reviewed and ran the gates locally.