### PR TITLE
fix(core): warn when with_structured_output() drops pre-bound tools

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -8,6 +8,7 @@ import contextlib
 import functools
 import inspect
 import threading
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import (
     AsyncGenerator,
@@ -6098,6 +6099,33 @@ class RunnableBinding(RunnableBindingBase[Input, Output]):  # type: ignore[no-re
             config=self.config,
             config_factories=self.config_factories,
         )
+
+    def with_structured_output(self, *args: Any, **kwargs: Any) -> Runnable:
+        """Forward ``with_structured_output`` to the bound runnable.
+
+        Warns if this binding has pre-bound kwargs (e.g., ``tools``,
+        ``tool_choice``) that the underlying model's
+        ``with_structured_output`` cannot see and will silently drop.
+
+        See: https://github.com/langchain-ai/langchain/issues/35320
+        """
+        _conflicting_keys = {"tools", "tool_choice"}
+        pre_bound = _conflicting_keys.intersection(self.kwargs or {})
+        if pre_bound:
+            warnings.warn(
+                f"with_structured_output() was called on a RunnableBinding "
+                f"that has pre-bound {sorted(pre_bound)} via .bind(). "
+                f"These will be silently dropped because "
+                f"with_structured_output() creates new bindings internally "
+                f"that do not preserve previously bound kwargs. "
+                f"To combine tools with structured output, pass them "
+                f"directly: model.with_structured_output(schema, "
+                f"tools=[...], strict=True, include_raw=True). "
+                f"See: https://github.com/langchain-ai/langchain/issues/35320",
+                UserWarning,
+                stacklevel=2,
+            )
+        return self.bound.with_structured_output(*args, **kwargs)
 
     @override
     def __getattr__(self, name: str) -> Any:  # type: ignore[misc]

--- a/libs/core/tests/unit_tests/runnables/test_structured_output_warning.py
+++ b/libs/core/tests/unit_tests/runnables/test_structured_output_warning.py
@@ -1,0 +1,69 @@
+"""Test that RunnableBinding warns when pre-bound tools will be dropped.
+
+See: https://github.com/langchain-ai/langchain/issues/35320
+"""
+
+import warnings
+
+from langchain_core.runnables import RunnableBinding, RunnableLambda
+
+
+def _make_base() -> RunnableLambda:
+    base = RunnableLambda(lambda x: x)
+    base.with_structured_output = lambda *args, **kwargs: "chain"  # type: ignore[attr-defined]
+    return base
+
+
+def test_warns_when_tools_pre_bound() -> None:
+    base = _make_base()
+    binding = RunnableBinding(
+        bound=base, kwargs={"tools": [{"type": "web_search"}]}
+    )
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        binding.with_structured_output("Schema")
+        assert len(w) == 1
+        assert "pre-bound" in str(w[0].message)
+        assert "tools" in str(w[0].message)
+
+
+def test_warns_when_tool_choice_pre_bound() -> None:
+    base = _make_base()
+    binding = RunnableBinding(
+        bound=base, kwargs={"tool_choice": "auto"}
+    )
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        binding.with_structured_output("Schema")
+        assert len(w) == 1
+        assert "tool_choice" in str(w[0].message)
+
+
+def test_warns_when_both_pre_bound() -> None:
+    base = _make_base()
+    binding = RunnableBinding(
+        bound=base,
+        kwargs={"tools": [{"type": "web_search"}], "tool_choice": "auto"},
+    )
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        binding.with_structured_output("Schema")
+        assert len(w) == 1
+        assert "tools" in str(w[0].message)
+        assert "tool_choice" in str(w[0].message)
+
+
+def test_no_warning_when_no_conflicting_kwargs() -> None:
+    base = _make_base()
+    binding = RunnableBinding(bound=base, kwargs={"stop": ["x"]})
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        binding.with_structured_output("Schema")
+        assert len(w) == 0
+
+
+def test_forwards_to_bound_model() -> None:
+    base = _make_base()
+    binding = RunnableBinding(bound=base, kwargs={"stop": ["x"]})
+    result = binding.with_structured_output("Schema")
+    assert result == "chain"


### PR DESCRIPTION
Fixes #35320

Added a `with_structured_output` method to `RunnableBinding` that warns when pre-bound `tools` or `tool_choice` kwargs from `.bind()` will be silently dropped.

When a user calls `.bind(tools=[...]).with_structured_output(schema)`, the pre-bound tools are lost because `RunnableBinding` has no `with_structured_output` override — the call falls through `__getattr__` to the underlying model, which cannot see the binding's stored kwargs. he model returns hallucinated data with no error or warning.

The new method checks `self.kwargs` for conflicting keys and emits a `UserWarning` with a clear message explaining the problem and the fix:
use `model.with_structured_output(schema, tools=[...], strict=True, include_raw=True)` instead of chaining `.bind().with_structured_output()`.