### PR TITLE
fix(anthropic): strip stream-only metadata from compaction blocks

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -584,6 +584,14 @@ def _format_messages(
                                 if k in ("type", "cache_control", "data")
                             },
                         )
+                    elif block["type"] == "compaction":
+                        content.append(
+                            {
+                                k: v
+                                for k, v in block.items()
+                                if k in ("type", "content", "cache_control")
+                            },
+                        )
                     elif (
                         block["type"] == "tool_result"
                         and isinstance(block.get("content"), list)

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -808,6 +808,32 @@ def test__format_tool_use_block() -> None:
     assert result == (None, [expected])
 
 
+def test__format_compaction_block() -> None:
+    message = AIMessage(
+        [
+            {
+                "type": "compaction",
+                "content": "summary text",
+                "cache_control": {"type": "ephemeral"},
+                "index": 0,
+                "signature": "stream-only-metadata",
+            }
+        ]
+    )
+    result = _format_messages([message])
+    expected = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "compaction",
+                "content": "summary text",
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+    }
+    assert result == (None, [expected])
+
+
 def test__format_messages_with_str_content_and_tool_calls() -> None:
     system = SystemMessage("fuzz")  # type: ignore[misc]
     human = HumanMessage("foo")  # type: ignore[misc]


### PR DESCRIPTION
Fixes #36976

---

Strip stream-only metadata from Anthropic `compaction` blocks before replaying them into follow-up requests. Added a unit regression test for streamed compaction blocks and verified the original live reproduction now succeeds on the second `print_mode=messages` invoke.

Verified locally with the focused Anthropic unit tests, the original live Anthropic reproduction, and `uv` ruff/mypy on the touched files.

This contribution was prepared with AI-agent assistance and manually validated.