### PR TITLE
fix(core): prevent ls_provider string concatenation during streaming metadata merge

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,8 +57,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k
-                    in {"id", "output_version", "model_provider", "ls_provider"}
+                    right_k in {"id", "output_version", "model_provider", "ls_provider"}
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,8 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {"id", "output_version", "model_provider", "ls_provider"}
                     and merged[right_k] == right_v
                 ):
                     continue


### PR DESCRIPTION
Fixes #36993

The fix prevents `ls_provider` from being concatenated across merged streaming chunks by treating it as a stable metadata field, ensuring it remains a single constant value instead of growing with each merge.