### PR TITLE
Add intent-aware model routing middleware for agents

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -10,6 +10,7 @@ from langchain.agents.middleware.human_in_the_loop import (
 )
 from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddleware
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
+from langchain.agents.middleware.model_routing import IntentAwareModelRouterMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
 from langchain.agents.middleware.shell_tool import (
@@ -60,6 +61,7 @@ __all__ = [
     "ModelCallLimitMiddleware",
     "ModelCallResult",
     "ModelFallbackMiddleware",
+    "IntentAwareModelRouterMiddleware",
     "ModelRequest",
     "ModelResponse",
     "ModelRetryMiddleware",

--- a/libs/langchain_v1/langchain/agents/middleware/model_routing.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_routing.py
@@ -1,0 +1,189 @@
+"""Intent-aware model routing middleware for agents."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    ModelRequest,
+    ModelResponse,
+    ResponseT,
+)
+from langchain.chat_models import init_chat_model
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain_core.language_models.chat_models import BaseChatModel
+    from langchain_core.messages import AIMessage, BaseMessage
+
+
+class IntentAwareModelRouterMiddleware(
+    AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]
+):
+    """Route model calls to fast, balanced, or quality model by request intent.
+
+    The middleware inspects user-facing message content and applies a simple policy:
+
+    - High-stakes intents (e.g., legal/medical/financial) -> quality model
+    - Clearly simple tasks (summarize/extract/rewrite/classify, short prompt) -> fast model
+    - Everything else -> balanced model
+
+    It also annotates the resulting AI message with a routing trace in `response_metadata`.
+    """
+
+    _HIGH_STAKES_KEYWORDS = (
+        "legal",
+        "medical",
+        "diagnosis",
+        "financial",
+        "investment",
+        "tax",
+        "compliance",
+        "contract",
+        "security vulnerability",
+        "production incident",
+    )
+    _SIMPLE_TASK_KEYWORDS = (
+        "summarize",
+        "summary",
+        "rewrite",
+        "rephrase",
+        "extract",
+        "classify",
+        "translate",
+        "proofread",
+    )
+
+    def __init__(
+        self,
+        *,
+        fast_model: str | BaseChatModel,
+        balanced_model: str | BaseChatModel,
+        quality_model: str | BaseChatModel,
+        short_prompt_char_limit: int = 600,
+        policy_version: str = "v1",
+    ) -> None:
+        """Initialize routing middleware with model tiers."""
+        super().__init__()
+        self.fast_model = self._coerce_model(fast_model)
+        self.balanced_model = self._coerce_model(balanced_model)
+        self.quality_model = self._coerce_model(quality_model)
+        self.short_prompt_char_limit = short_prompt_char_limit
+        self.policy_version = policy_version
+
+    @staticmethod
+    def _coerce_model(model: str | BaseChatModel) -> BaseChatModel:
+        if isinstance(model, str):
+            return init_chat_model(model)
+        return model
+
+    @staticmethod
+    def _extract_message_text(message: BaseMessage) -> str:
+        content = message.content
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts: list[str] = []
+            for item in content:
+                if isinstance(item, str):
+                    parts.append(item)
+                elif isinstance(item, dict):
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            return " ".join(parts)
+        return ""
+
+    def _combined_prompt_text(self, request: ModelRequest[ContextT]) -> str:
+        return " ".join(self._extract_message_text(msg) for msg in request.messages)
+
+    def _choose_model(
+        self, request: ModelRequest[ContextT]
+    ) -> tuple[BaseChatModel, str, dict[str, object]]:
+        prompt_text = self._combined_prompt_text(request).lower()
+        prompt_length = len(prompt_text)
+
+        high_stakes_hits = [k for k in self._HIGH_STAKES_KEYWORDS if k in prompt_text]
+        simple_task_hits = [k for k in self._SIMPLE_TASK_KEYWORDS if k in prompt_text]
+        is_short_prompt = prompt_length <= self.short_prompt_char_limit
+
+        if high_stakes_hits:
+            return (
+                self.quality_model,
+                "high_stakes",
+                {
+                    "high_stakes_hits": high_stakes_hits,
+                    "simple_task_hits": simple_task_hits,
+                    "prompt_length": prompt_length,
+                    "is_short_prompt": is_short_prompt,
+                },
+            )
+        if simple_task_hits and is_short_prompt:
+            return (
+                self.fast_model,
+                "simple_short_task",
+                {
+                    "high_stakes_hits": high_stakes_hits,
+                    "simple_task_hits": simple_task_hits,
+                    "prompt_length": prompt_length,
+                    "is_short_prompt": is_short_prompt,
+                },
+            )
+        return (
+            self.balanced_model,
+            "default_balanced",
+            {
+                "high_stakes_hits": high_stakes_hits,
+                "simple_task_hits": simple_task_hits,
+                "prompt_length": prompt_length,
+                "is_short_prompt": is_short_prompt,
+            },
+        )
+
+    def _annotate_routing_trace(
+        self,
+        response: ModelResponse[ResponseT],
+        reason: str,
+        decision_features: dict[str, object],
+    ) -> None:
+        first_message = response.result[0] if response.result else None
+        if first_message is None or not hasattr(first_message, "response_metadata"):
+            return
+
+        metadata = getattr(first_message, "response_metadata", None)
+        if not isinstance(metadata, dict):
+            metadata = {}
+            first_message.response_metadata = metadata  # type: ignore[attr-defined]
+
+        metadata["routing"] = {
+            "policy": "intent_aware_router",
+            "policy_version": self.policy_version,
+            "route_reason": reason,
+            "decision_features": decision_features,
+        }
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
+    ) -> ModelResponse[ResponseT] | AIMessage:
+        model, reason, features = self._choose_model(request)
+        response = handler(request.override(model=model))
+        if isinstance(response, ModelResponse):
+            self._annotate_routing_trace(response, reason, features)
+        return response
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT] | AIMessage:
+        model, reason, features = self._choose_model(request)
+        response = await handler(request.override(model=model))
+        if isinstance(response, ModelResponse):
+            self._annotate_routing_trace(response, reason, features)
+        return response

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_routing.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_routing.py
@@ -1,0 +1,138 @@
+"""Unit tests for IntentAwareModelRouterMiddleware."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from typing_extensions import override
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
+from langchain.agents.middleware.model_routing import IntentAwareModelRouterMiddleware
+
+if TYPE_CHECKING:
+    from langchain_core.callbacks import CallbackManagerForLLMRun
+
+
+def test_routes_short_simple_task_to_fast_model() -> None:
+    """Simple extraction requests should use fast model."""
+    router = IntentAwareModelRouterMiddleware(
+        fast_model=GenericFakeChatModel(messages=iter([AIMessage(content="fast")])),
+        balanced_model=GenericFakeChatModel(messages=iter([AIMessage(content="balanced")])),
+        quality_model=GenericFakeChatModel(messages=iter([AIMessage(content="quality")])),
+    )
+
+    agent = create_agent(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content="primary")])),
+        middleware=[router],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Summarize this short note.")]})
+
+    assert result["messages"][-1].content == "fast"
+
+
+def test_routes_high_stakes_request_to_quality_model() -> None:
+    """High-stakes prompts should use quality model."""
+    router = IntentAwareModelRouterMiddleware(
+        fast_model=GenericFakeChatModel(messages=iter([AIMessage(content="fast")])),
+        balanced_model=GenericFakeChatModel(messages=iter([AIMessage(content="balanced")])),
+        quality_model=GenericFakeChatModel(messages=iter([AIMessage(content="quality")])),
+    )
+
+    agent = create_agent(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content="primary")])),
+        middleware=[router],
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Give legal guidance for this contract clause.")]}
+    )
+
+    assert result["messages"][-1].content == "quality"
+
+
+def test_routes_default_to_balanced_model() -> None:
+    """Requests that are not simple/high-stakes should use balanced model."""
+    router = IntentAwareModelRouterMiddleware(
+        fast_model=GenericFakeChatModel(messages=iter([AIMessage(content="fast")])),
+        balanced_model=GenericFakeChatModel(messages=iter([AIMessage(content="balanced")])),
+        quality_model=GenericFakeChatModel(messages=iter([AIMessage(content="quality")])),
+    )
+
+    agent = create_agent(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content="primary")])),
+        middleware=[router],
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Propose three architecture tradeoffs for this service.")]}
+    )
+
+    assert result["messages"][-1].content == "balanced"
+
+
+def test_routing_middleware_adds_trace_metadata() -> None:
+    """Routing decisions should be exposed in response metadata."""
+    router = IntentAwareModelRouterMiddleware(
+        fast_model=GenericFakeChatModel(messages=iter([AIMessage(content="fast")])),
+        balanced_model=GenericFakeChatModel(messages=iter([AIMessage(content="balanced")])),
+        quality_model=GenericFakeChatModel(messages=iter([AIMessage(content="quality")])),
+    )
+
+    agent = create_agent(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content="primary")])),
+        middleware=[router],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Extract key fields from this receipt.")]})
+    last = result["messages"][-1]
+    assert isinstance(last, AIMessage)
+    routing_meta = last.response_metadata.get("routing")
+    assert isinstance(routing_meta, dict)
+    assert routing_meta.get("policy") == "intent_aware_router"
+    assert routing_meta.get("route_reason") == "simple_short_task"
+
+
+def test_routing_and_fallback_middleware_compose() -> None:
+    """Selected routed model can fail and fallback middleware recovers."""
+
+    class AlwaysFailModel(BaseChatModel):
+        """Model that always errors."""
+
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            msg = "routed model failed"
+            raise ValueError(msg)
+
+        @property
+        def _llm_type(self) -> str:
+            return "always_fail"
+
+    router = IntentAwareModelRouterMiddleware(
+        fast_model=AlwaysFailModel(),
+        balanced_model=GenericFakeChatModel(messages=iter([AIMessage(content="balanced")])),
+        quality_model=GenericFakeChatModel(messages=iter([AIMessage(content="quality")])),
+    )
+    fallback = ModelFallbackMiddleware(
+        GenericFakeChatModel(messages=iter([AIMessage(content="fallback-success")]))
+    )
+    agent = create_agent(
+        model=GenericFakeChatModel(messages=iter([AIMessage(content="primary")])),
+        middleware=[router, fallback],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Summarize this short note.")]})
+    assert result["messages"][-1].content == "fallback-success"
+


### PR DESCRIPTION
Resolves #37010

## Summary
- add IntentAwareModelRouterMiddleware to route model calls to fast, balanced, or quality model tiers based on prompt intent
- add routing trace metadata to model responses (policy, policy_version, route_reason, and decision_features) for transparency and debugging
- export the middleware in the public middleware API and add focused unit tests for route selection and fallback composition

## Test plan
- [x] PYTHONPATH=libs/langchain_v1 .venv/bin/pytest libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_routing.py
- [x] PYTHONPATH=libs/langchain_v1 .venv/bin/pytest libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_routing.py libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_model_call.py