### PR TITLE
fix(core): forward feedback_config in EvaluatorCallbackHandler (#31802)

### DIFF
--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -199,6 +199,9 @@ class EvaluatorCallbackHandler(BaseTracer):
                 source_info=source_info_,
                 source_run_id=res.source_run_id or source_run_id,
                 feedback_source_type=langsmith.schemas.FeedbackSourceType.MODEL,
+                # Forward feedback_config so any user-supplied configuration on the
+                # EvaluationResult is preserved instead of being silently dropped.
+                feedback_config=res.feedback_config,
             )
         return results
 

--- a/libs/core/tests/unit_tests/tracers/test_evaluation.py
+++ b/libs/core/tests/unit_tests/tracers/test_evaluation.py
@@ -1,0 +1,72 @@
+"""Tests for the EvaluatorCallbackHandler tracer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import langsmith
+from langsmith.evaluation.evaluator import EvaluationResult
+
+from langchain_core.tracers.evaluation import EvaluatorCallbackHandler
+from langchain_core.tracers.schemas import Run
+
+
+def _make_run() -> Run:
+    """Build a minimal completed Run for testing."""
+    now = datetime.now(timezone.utc)
+    return Run(
+        id=uuid4(),
+        name="test_run",
+        run_type="chain",
+        start_time=now,
+        end_time=now,
+        inputs={},
+        outputs={"result": "ok"},
+    )
+
+
+def test_log_evaluation_feedback_forwards_feedback_config() -> None:
+    """`feedback_config` on EvaluationResult must be forwarded to create_feedback.
+
+    Regression test for langchain-ai/langchain#31802. Previously the callback
+    handler dropped `feedback_config` when calling `client.create_feedback`,
+    silently discarding any user-supplied feedback configuration.
+    """
+    client = MagicMock(spec=langsmith.Client)
+    handler = EvaluatorCallbackHandler(evaluators=[], client=client)
+
+    feedback_config: dict[str, Any] = {
+        "type": "continuous",
+        "min": 0,
+        "max": 1,
+    }
+    eval_result = EvaluationResult(
+        key="sentiment",
+        score=0.9,
+        feedback_config=feedback_config,
+    )
+    run = _make_run()
+
+    handler._log_evaluation_feedback(eval_result, run)
+
+    client.create_feedback.assert_called_once()
+    _, kwargs = client.create_feedback.call_args
+    assert kwargs["feedback_config"] == feedback_config
+
+
+def test_log_evaluation_feedback_forwards_none_feedback_config() -> None:
+    """When feedback_config is None it should still be forwarded as None."""
+    client = MagicMock(spec=langsmith.Client)
+    handler = EvaluatorCallbackHandler(evaluators=[], client=client)
+
+    eval_result = EvaluationResult(key="quality", score=0.5)
+    run = _make_run()
+
+    handler._log_evaluation_feedback(eval_result, run)
+
+    client.create_feedback.assert_called_once()
+    _, kwargs = client.create_feedback.call_args
+    assert kwargs["feedback_config"] is None


### PR DESCRIPTION
## Summary
Fixes #31802. `EvaluatorCallbackHandler._log_evaluation_feedback` in `libs/core/langchain_core/tracers/evaluation.py` did not pass `feedback_config` from the `EvaluationResult` through to `client.create_feedback()`. Anything users put in `EvaluationResult.feedback_config` was silently dropped at the callback boundary.

## Fix
Forward `feedback_config=res.feedback_config` to `create_feedback`. One-line change, fully BC — the kwarg already accepts `None`.

## History
Two prior closed PRs (#36607, #36429) attempted the identical fix but were auto-closed by the `missing-issue-link` bot. This PR explicitly references issue #31802.

## Files changed
- `libs/core/langchain_core/tracers/evaluation.py` — 3 lines added
- `libs/core/tests/unit_tests/tracers/test_evaluation.py` — new file, 71 lines, 2 tests

## Test plan
- ruff format + ruff check clean
- pytest: both new tests pass (forwards-feedback-config, forwards-None-feedback-config)
