### PR TITLE
feat(anthropic): expose response headers in response metadata

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -917,6 +917,9 @@ class ChatAnthropic(BaseChatModel):
     docs for more information.
     """
 
+    include_response_headers: bool = False
+    """Whether to include response headers in the output message `response_metadata`."""
+
     @property
     def _llm_type(self) -> str:
         """Return type of chat model."""
@@ -1228,10 +1231,22 @@ class ChatAnthropic(BaseChatModel):
             return self._client.beta.messages.create(**payload)
         return self._client.messages.create(**payload)
 
+    def _create_with_raw_response(self, payload: dict) -> Any:
+        if "betas" in payload:
+            return self._client.beta.messages.with_raw_response.create(**payload)
+        return self._client.messages.with_raw_response.create(**payload)
+
     async def _acreate(self, payload: dict) -> Any:
         if "betas" in payload:
             return await self._async_client.beta.messages.create(**payload)
         return await self._async_client.messages.create(**payload)
+
+    async def _acreate_with_raw_response(self, payload: dict) -> Any:
+        if "betas" in payload:
+            return await self._async_client.beta.messages.with_raw_response.create(
+                **payload
+            )
+        return await self._async_client.messages.with_raw_response.create(**payload)
 
     def _stream(
         self,
@@ -1247,7 +1262,13 @@ class ChatAnthropic(BaseChatModel):
         kwargs["stream"] = True
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
         try:
-            stream = self._create(payload)
+            if self.include_response_headers:
+                raw_response = self._create_with_raw_response(payload)
+                stream = raw_response.parse()
+                response_headers = {"headers": dict(raw_response.headers)}
+            else:
+                stream = self._create(payload)
+                response_headers = {}
             coerce_content_to_string = (
                 not _tools_in_params(payload)
                 and not _documents_in_params(payload)
@@ -1255,6 +1276,7 @@ class ChatAnthropic(BaseChatModel):
                 and not _compact_in_params(payload)
             )
             block_start_event = None
+            is_first_chunk = True
             for event in stream:
                 msg, block_start_event = self._make_message_chunk_from_anthropic_event(
                     event,
@@ -1263,9 +1285,12 @@ class ChatAnthropic(BaseChatModel):
                     block_start_event=block_start_event,
                 )
                 if msg is not None:
+                    if is_first_chunk and response_headers:
+                        msg.response_metadata.update(response_headers)
                     chunk = ChatGenerationChunk(message=msg)
                     if run_manager and isinstance(msg.content, str):
                         run_manager.on_llm_new_token(msg.content, chunk=chunk)
+                    is_first_chunk = False
                     yield chunk
         except anthropic.BadRequestError as e:
             _handle_anthropic_bad_request(e)
@@ -1284,7 +1309,13 @@ class ChatAnthropic(BaseChatModel):
         kwargs["stream"] = True
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
         try:
-            stream = await self._acreate(payload)
+            if self.include_response_headers:
+                raw_response = await self._acreate_with_raw_response(payload)
+                stream = raw_response.parse()
+                response_headers = {"headers": dict(raw_response.headers)}
+            else:
+                stream = await self._acreate(payload)
+                response_headers = {}
             coerce_content_to_string = (
                 not _tools_in_params(payload)
                 and not _documents_in_params(payload)
@@ -1292,6 +1323,7 @@ class ChatAnthropic(BaseChatModel):
                 and not _compact_in_params(payload)
             )
             block_start_event = None
+            is_first_chunk = True
             async for event in stream:
                 msg, block_start_event = self._make_message_chunk_from_anthropic_event(
                     event,
@@ -1300,9 +1332,12 @@ class ChatAnthropic(BaseChatModel):
                     block_start_event=block_start_event,
                 )
                 if msg is not None:
+                    if is_first_chunk and response_headers:
+                        msg.response_metadata.update(response_headers)
                     chunk = ChatGenerationChunk(message=msg)
                     if run_manager and isinstance(msg.content, str):
                         await run_manager.on_llm_new_token(msg.content, chunk=chunk)
+                    is_first_chunk = False
                     yield chunk
         except anthropic.BadRequestError as e:
             _handle_anthropic_bad_request(e)
@@ -1494,7 +1529,9 @@ class ChatAnthropic(BaseChatModel):
             message_chunk.response_metadata["model_provider"] = "anthropic"
         return message_chunk, block_start_event
 
-    def _format_output(self, data: Any, **kwargs: Any) -> ChatResult:
+    def _format_output(
+        self, data: Any, response_headers: dict[str, str] | None = None, **kwargs: Any
+    ) -> ChatResult:
         """Format the output from the Anthropic API to LC."""
         data_dict = data.model_dump()
         content = data_dict["content"]
@@ -1529,6 +1566,8 @@ class ChatAnthropic(BaseChatModel):
         response_metadata = {"model_provider": "anthropic"}
         if "model" in llm_output and "model_name" not in llm_output:
             llm_output["model_name"] = llm_output["model"]
+        if response_headers:
+            response_metadata["headers"] = response_headers
         if (
             len(content) == 1
             and content[0]["type"] == "text"
@@ -1561,10 +1600,16 @@ class ChatAnthropic(BaseChatModel):
     ) -> ChatResult:
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
         try:
-            data = self._create(payload)
+            if self.include_response_headers:
+                raw_response = self._create_with_raw_response(payload)
+                data = raw_response.parse()
+                response_headers = dict(raw_response.headers)
+            else:
+                data = self._create(payload)
+                response_headers = None
         except anthropic.BadRequestError as e:
             _handle_anthropic_bad_request(e)
-        return self._format_output(data, **kwargs)
+        return self._format_output(data, response_headers=response_headers, **kwargs)
 
     async def _agenerate(
         self,
@@ -1575,10 +1620,16 @@ class ChatAnthropic(BaseChatModel):
     ) -> ChatResult:
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
         try:
-            data = await self._acreate(payload)
+            if self.include_response_headers:
+                raw_response = await self._acreate_with_raw_response(payload)
+                data = raw_response.parse()
+                response_headers = dict(raw_response.headers)
+            else:
+                data = await self._acreate(payload)
+                response_headers = None
         except anthropic.BadRequestError as e:
             _handle_anthropic_bad_request(e)
-        return self._format_output(data, **kwargs)
+        return self._format_output(data, response_headers=response_headers, **kwargs)
 
     def _get_llm_for_structured_output_when_thinking_is_enabled(
         self,

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -7,7 +7,7 @@ import os
 import warnings
 from collections.abc import Callable
 from typing import Any, Literal, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import anthropic
 import pytest
@@ -36,6 +36,19 @@ from langchain_anthropic.chat_models import (
 os.environ["ANTHROPIC_API_KEY"] = "foo"
 
 MODEL_NAME = "claude-sonnet-4-5-20250929"
+
+
+def _anthropic_text_message(text: str = "bar") -> Message:
+    return Message(
+        id="foo",
+        content=[TextBlock(type="text", text=text)],
+        model=MODEL_NAME,
+        role="assistant",
+        stop_reason=None,
+        stop_sequence=None,
+        usage=Usage(input_tokens=2, output_tokens=1),
+        type="message",
+    )
 
 
 def test_initialization() -> None:
@@ -230,6 +243,140 @@ def test__format_output() -> None:
     llm = ChatAnthropic(model=MODEL_NAME, anthropic_api_key="test")  # type: ignore[call-arg, call-arg]
     actual = llm._format_output(anthropic_msg)
     assert actual.generations[0].message == expected
+
+
+def test__format_output_with_response_headers() -> None:
+    llm = ChatAnthropic(model=MODEL_NAME, anthropic_api_key="test")  # type: ignore[call-arg, call-arg]
+    actual = llm._format_output(
+        _anthropic_text_message(), response_headers={"request-id": "req_123"}
+    )
+    message = actual.generations[0].message
+
+    assert message.response_metadata["model_provider"] == "anthropic"
+    assert message.response_metadata["headers"]["request-id"] == "req_123"
+
+
+def test_chat_anthropic_invoke_without_response_headers() -> None:
+    llm = ChatAnthropic(model=MODEL_NAME, anthropic_api_key="test")  # type: ignore[call-arg, call-arg]
+
+    with patch.object(llm, "_client") as mock_client:
+        mock_client.messages.create.return_value = _anthropic_text_message()
+        result = llm._generate([HumanMessage(content="foo")])
+
+    message = result.generations[0].message
+    assert "headers" not in message.response_metadata
+    assert mock_client.messages.create.called
+    assert not mock_client.messages.with_raw_response.create.called
+
+
+def test_chat_anthropic_invoke_with_response_headers() -> None:
+    llm = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME, anthropic_api_key="test", include_response_headers=True
+    )
+    mock_raw_response = MagicMock()
+    mock_raw_response.parse.return_value = _anthropic_text_message()
+    mock_raw_response.headers = {"request-id": "req_123"}
+
+    with patch.object(llm, "_client") as mock_client:
+        mock_client.messages.with_raw_response.create.return_value = mock_raw_response
+        result = llm._generate([HumanMessage(content="foo")])
+
+    message = result.generations[0].message
+    assert message.response_metadata["model_provider"] == "anthropic"
+    assert message.response_metadata["headers"]["request-id"] == "req_123"
+    assert mock_client.messages.with_raw_response.create.called
+
+
+async def test_chat_anthropic_ainvoke_with_response_headers() -> None:
+    llm = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME, anthropic_api_key="test", include_response_headers=True
+    )
+    mock_raw_response = MagicMock()
+    mock_raw_response.parse.return_value = _anthropic_text_message()
+    mock_raw_response.headers = {"request-id": "req_456"}
+
+    with patch.object(llm, "_async_client") as mock_client:
+        mock_client.messages.with_raw_response.create = AsyncMock(
+            return_value=mock_raw_response
+        )
+        result = await llm._agenerate([HumanMessage(content="foo")])
+
+    message = result.generations[0].message
+    assert message.response_metadata["model_provider"] == "anthropic"
+    assert message.response_metadata["headers"]["request-id"] == "req_456"
+    assert mock_client.messages.with_raw_response.create.called
+
+
+def _message_start_event() -> MagicMock:
+    event = MagicMock()
+    event.type = "message_start"
+    event.message.model = MODEL_NAME
+    return event
+
+
+def _text_delta_event(text: str) -> MagicMock:
+    event = MagicMock()
+    event.type = "content_block_delta"
+    event.index = 0
+    event.delta.type = "text_delta"
+    event.delta.text = text
+    return event
+
+
+class _AsyncStream:
+    def __init__(self, events: list[MagicMock]) -> None:
+        self.events = events
+
+    def __aiter__(self) -> _AsyncStream:
+        return self
+
+    async def __anext__(self) -> MagicMock:
+        if not self.events:
+            raise StopAsyncIteration
+        return self.events.pop(0)
+
+
+def test_chat_anthropic_stream_with_response_headers_on_first_chunk_only() -> None:
+    llm = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME, anthropic_api_key="test", include_response_headers=True
+    )
+    mock_raw_response = MagicMock()
+    mock_raw_response.parse.return_value = [
+        _message_start_event(),
+        _text_delta_event("bar"),
+    ]
+    mock_raw_response.headers = {"request-id": "req_stream"}
+
+    with patch.object(llm, "_client") as mock_client:
+        mock_client.messages.with_raw_response.create.return_value = mock_raw_response
+        chunks = list(llm._stream([HumanMessage(content="foo")]))
+
+    assert chunks[0].message.response_metadata["model_provider"] == "anthropic"
+    assert chunks[0].message.response_metadata["headers"]["request-id"] == "req_stream"
+    assert "headers" not in chunks[1].message.response_metadata
+
+
+async def test_chat_anthropic_astream_with_response_headers_on_first_chunk_only() -> (
+    None
+):
+    llm = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME, anthropic_api_key="test", include_response_headers=True
+    )
+    mock_raw_response = MagicMock()
+    mock_raw_response.parse.return_value = _AsyncStream(
+        [_message_start_event(), _text_delta_event("bar")]
+    )
+    mock_raw_response.headers = {"request-id": "req_astream"}
+
+    with patch.object(llm, "_async_client") as mock_client:
+        mock_client.messages.with_raw_response.create = AsyncMock(
+            return_value=mock_raw_response
+        )
+        chunks = [chunk async for chunk in llm._astream([HumanMessage(content="foo")])]
+
+    assert chunks[0].message.response_metadata["model_provider"] == "anthropic"
+    assert chunks[0].message.response_metadata["headers"]["request-id"] == "req_astream"
+    assert "headers" not in chunks[1].message.response_metadata
 
 
 def test__format_output_cached() -> None:


### PR DESCRIPTION
## What
Add `include_response_headers` to `ChatAnthropic` and surface Anthropic HTTP response headers under `AIMessage.response_metadata[headers]` when enabled.

## Why
This lets users capture Anthropic request ids and rate-limit headers for production logging and observability, matching the existing OpenAI integration behavior.

## How
- Route sync and async non-streaming calls through Anthropic SDK `with_raw_response` when the flag is enabled.
- Attach response headers to existing response metadata without replacing provider metadata.
- Attach streaming response headers to the first emitted chunk only for sync and async streams.
- Add unit tests for opt-in sync, async, stream, and astream behavior.

## Issue
Closes #36983

## Validation
- `uv run --group lint ruff check langchain_anthropic/chat_models.py tests/unit_tests/test_chat_models.py`
- `uv run --group test pytest tests/unit_tests/test_chat_models.py -k response_headers`
- `uv run --group test pytest tests/unit_tests`
- `uv build`