### PR TITLE
fix(core): convert empty list tool message content to empty string

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1276,6 +1276,8 @@ def _format_output(
         return content
     if isinstance(content, ToolOutputMixin) or tool_call_id is None:
         return content
+    if isinstance(content, list) and not content:
+        content = ""
     if not _is_message_content_type(content):
         content = _stringify(content)
     return ToolMessage(

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3716,12 +3716,13 @@ def test_format_output_list_with_non_mixin_element() -> None:
 
 
 def test_format_output_empty_list() -> None:
-    """An empty list falls through to stringify-and-wrap."""
+    """An empty list should be converted to empty string to avoid provider errors."""
     result = _format_output(
         [], artifact=None, tool_call_id="0", name="t", status="success"
     )
     assert isinstance(result, ToolMessage)
     assert result.tool_call_id == "0"
+    assert result.content == ""
 
 
 def test_tool_invoke_returns_list_of_mixin() -> None:


### PR DESCRIPTION
Fixes #33758

---

When a tool returns an empty list (`[]`) as message content, `_is_message_content_type` in `libs/core/langchain_core/tools/base.py` incorrectly validates it as acceptable content because Python's `all()` returns `True` for empty iterables. This allows the empty list to pass through to provider APIs without conversion, causing deserialization errors at runtime (e.g., DeepSeek API: `"invalid type: sequence, expected a string"`).

**Why this approach:**

The previous attempt (#34505) modified `_is_message_content_type` to reject empty lists entirely, which raises concerns about breaking the documented type contract `str | list[str | dict]` where an empty list is technically valid. This alternative approach handles empty lists in `_format_output` during serialization — converting `[]` to `""` right before creating the `ToolMessage`. This:

- Preserves the internal type system (`_is_message_content_type` behavior is unchanged)
- Fixes the provider-side error at the boundary where content leaves the framework
- Is non-breaking for any existing code that inspects tool message content types

**What changed:**

- Added an early check in `_format_output` to convert empty `list` content to `""` before further processing
- Updated `test_format_output_empty_list` to assert the conversion result

This is a minimal, targeted fix that addresses the root cause (empty lists reaching provider APIs) without modifying validation logic in `_is_message_content_type`.