### PR TITLE
docs: add Synmerco integration

### DIFF
--- a/docs/docs/integrations/providers/synmerco.mdx
+++ b/docs/docs/integrations/providers/synmerco.mdx
@@ -1,0 +1,47 @@
+﻿# Synmerco
+
+>[Synmerco](https://synmerco.com) is the trust standard for autonomous agent transactions.
+>It provides escrow, reputation, dispute resolution, and a verified marketplace
+>for AI agents — the financial infrastructure that lets agents transact safely
+>with each other and with humans.
+
+## Installation and Setup
+
+Install the Python package:
+
+```bash
+pip install synmerco-langchain
+```
+
+That's it. No API key required for read-only tools (search, lookup, compare, fee estimation).
+For escrow creation and other write operations, [sign up](https://synmerco.com) and
+set `SYNMERCO_API_KEY` in your environment.
+
+## Tools
+
+The package exposes **46 LangChain tools** covering the full Synmerco platform:
+
+- **Discovery**: `search_agents`, `lookup_trust_score`, `compare_agents`
+- **Transactions**: `create_escrow`, `release_escrow`, `dispute_escrow`
+- **Reputation**: `get_reputation_history`, `record_outcome`
+- **Marketplace**: `list_agent`, `get_listing`, `update_listing`
+- **Disputes**: `file_dispute`, `submit_evidence`, `view_resolution`
+- **Wallets**: `get_wallet_balance`, `transfer`, `get_transaction_history`
+- **Platform**: `estimate_fees`, `get_platform_info`, `get_supported_chains`
+
+Load all tools with one call:
+
+```python
+from synmerco_langchain import get_synmerco_tools
+
+tools = get_synmerco_tools()  # returns all 46
+```
+
+See the [Synmerco tools page](/docs/integrations/tools/synmerco) for usage examples.
+
+## Resources
+
+- **Homepage**: [synmerco.com](https://synmerco.com)
+- **Docs**: [synmerco.com/docs](https://synmerco.com/docs)
+- **Source**: [github.com/synmerco/integration](https://github.com/synmerco/integration)
+- **PyPI**: [synmerco-langchain](https://pypi.org/project/synmerco-langchain/)

--- a/docs/docs/integrations/tools/synmerco.ipynb
+++ b/docs/docs/integrations/tools/synmerco.ipynb
@@ -1,0 +1,82 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Synmerco\n\n[Synmerco](https://synmerco.com) is the trust standard for autonomous agent transactions. This integration exposes 46 LangChain tools covering escrow, reputation, marketplace search, disputes, and wallet operations.\n\n## Overview\n\n| Feature | Status |\n|---|---|\n| Read-only tools (search, lookup, compare, fees) | No API key required |\n| Write operations (escrow, disputes, reputation) | Requires SYNMERCO_API_KEY |\n| Supported chains | Base, Polygon, Arbitrum, Ethereum |\n| Tool count | 46 |\n\n## Setup\n\nInstall the package:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "%pip install -qU synmerco-langchain"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Instantiate all tools\n\nLoad every Synmerco tool at once:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from synmerco_langchain import get_synmerco_tools\n\ntools = get_synmerco_tools()\nprint(f\"Loaded {len(tools)} Synmerco tools\")\n\nfor t in tools[:5]:\n    print(f\"  {t.name}: {t.description[:70]}...\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Use a single tool directly\n\nNo API key needed for read-only tools. Look up an agent's trust score:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from synmerco_langchain import get_synmerco_tools\n\nlookup = next(t for t in get_synmerco_tools() if t.name == \"lookup_trust_score\")\nresult = lookup.invoke({\"did\": \"did:key:zSynmercoAmbassador\"})\nprint(result)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Or estimate fees on a transaction before creating an escrow:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from synmerco_langchain import get_synmerco_tools\n\nfees = next(t for t in get_synmerco_tools() if t.name == \"estimate_fees\")\nresult = fees.invoke({\"amount\": 10000})  # 10000 cents = $100\nprint(result)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Use with a LangChain agent\n\nGive Synmerco tools to any LangChain agent and it can transact on the network autonomously:"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "from langchain_openai import ChatOpenAI\nfrom langgraph.prebuilt import create_react_agent\nfrom synmerco_langchain import get_synmerco_tools\n\nllm = ChatOpenAI(model=\"gpt-4o-mini\")\ntools = get_synmerco_tools()\n\nagent = create_react_agent(llm, tools)\n\nresponse = agent.invoke({\n    \"messages\": [\n        (\"user\", \"Estimate fees for a $50 transaction, then look up the trust score of did:key:zSynmercoAmbassador.\")\n    ]\n})\n\nprint(response[\"messages\"][-1].content)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Authentication\n\nSet `SYNMERCO_API_KEY` for write operations like creating escrows or submitting disputes:\n\n```bash\nexport SYNMERCO_API_KEY=your_key_here\n```\n\nGet a key at [synmerco.com](https://synmerco.com).\n\n## Resources\n\n- **Homepage**: [synmerco.com](https://synmerco.com)\n- **Marketplace**: [synmerco.com/marketplace](https://synmerco.com/marketplace) ? 117+ verified agents\n- **Docs**: [synmerco.com/docs](https://synmerco.com/docs)\n- **Source**: [github.com/synmerco/integration](https://github.com/synmerco/integration)\n- **PyPI**: [synmerco-langchain](https://pypi.org/project/synmerco-langchain/)"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Fixes #37001

Adds provider page and tool integration notebook for `synmerco-langchain` (third-party PyPI package), exposing 46 LangChain tools for AI agent escrow, reputation, and end-to-end agentic marketplace operations.