### PR TITLE
perf(core): cache openai-function schema and char count per tool instance

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2247,24 +2247,19 @@ def count_tokens_approximately(
     last_ai_total_tokens: int | None = None
     approx_at_last_ai: float | None = None
 
-    # Count tokens for tools if provided. For BaseTool instances we stash the
-    # JSON-serialized length on the tool under `_openai_function_chars` (paired
-    # with the `_openai_function_dict` schema cache) so successive calls don't
-    # re-run json.dumps over a dict that hasn't changed. `BaseTool.__setattr__`
-    # pops both keys when schema-affecting fields mutate, so dynamic tool
-    # re-registration or in-place edits invalidate this correctly.
+    # Count tokens for tools if provided. For ChildTool instances the char count
+    # is served from _openai_function_chars (a cached_property invalidated by
+    # ChildTool.__setattr__ on schema-affecting field mutations). For plain dicts
+    # or other tool-like objects we fall back to a fresh json.dumps.
     if tools:
         tools_chars = 0
         for tool in tools:
             if isinstance(tool, dict):
                 tools_chars += len(json.dumps(tool))
-                continue
-            cached_chars = tool.__dict__.get("_openai_function_chars")
-            if cached_chars is None:
-                tool_dict = convert_to_openai_tool(tool)
-                cached_chars = len(json.dumps(tool_dict))
-                tool.__dict__["_openai_function_chars"] = cached_chars
-            tools_chars += cached_chars
+            elif hasattr(tool, "_openai_function_chars"):
+                tools_chars += tool._openai_function_chars
+            else:
+                tools_chars += len(json.dumps(convert_to_openai_tool(tool)))
         token_count += math.ceil(tools_chars / chars_per_token)
 
     for message in converted_messages:

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2247,12 +2247,24 @@ def count_tokens_approximately(
     last_ai_total_tokens: int | None = None
     approx_at_last_ai: float | None = None
 
-    # Count tokens for tools if provided
+    # Count tokens for tools if provided. For BaseTool instances we stash the
+    # JSON-serialized length on the tool under `_openai_function_chars` (paired
+    # with the `_openai_function_dict` schema cache) so successive calls don't
+    # re-run json.dumps over a dict that hasn't changed. `BaseTool.__setattr__`
+    # pops both keys when schema-affecting fields mutate, so dynamic tool
+    # re-registration or in-place edits invalidate this correctly.
     if tools:
         tools_chars = 0
         for tool in tools:
-            tool_dict = tool if isinstance(tool, dict) else convert_to_openai_tool(tool)
-            tools_chars += len(json.dumps(tool_dict))
+            if isinstance(tool, dict):
+                tools_chars += len(json.dumps(tool))
+                continue
+            cached_chars = tool.__dict__.get("_openai_function_chars")
+            if cached_chars is None:
+                tool_dict = convert_to_openai_tool(tool)
+                cached_chars = len(json.dumps(tool_dict))
+                tool.__dict__["_openai_function_chars"] = cached_chars
+            tools_chars += cached_chars
         token_count += math.ceil(tools_chars / chars_per_token)
 
     for message in converted_messages:

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -555,6 +555,12 @@ class ChildTool(BaseTool):
         ignored_types=(functools.cached_property,),
     )
 
+    def __setattr__(self, name: str, value: Any) -> None:
+        super().__setattr__(name, value)
+        if name in {"args_schema", "description", "name"}:
+            self.__dict__.pop("tool_call_schema", None)
+            self.__dict__.pop("args", None)
+
     @property
     def is_single_input(self) -> bool:
         """Check if the tool accepts only a single input argument.

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -560,6 +560,7 @@ class ChildTool(BaseTool):
         if name in {"args_schema", "description", "name"}:
             self.__dict__.pop("tool_call_schema", None)
             self.__dict__.pop("args", None)
+            self.__dict__.pop("_openai_function_dict", None)
 
     @property
     def is_single_input(self) -> bool:

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -561,6 +561,7 @@ class ChildTool(BaseTool):
             self.__dict__.pop("tool_call_schema", None)
             self.__dict__.pop("args", None)
             self.__dict__.pop("_openai_function_dict", None)
+            self.__dict__.pop("_openai_function_chars", None)
 
     @property
     def is_single_input(self) -> bool:

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -552,6 +552,7 @@ class ChildTool(BaseTool):
 
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
+        ignored_types=(functools.cached_property,),
     )
 
     @property
@@ -564,7 +565,7 @@ class ChildTool(BaseTool):
         keys = {k for k in self.args if k != "kwargs"}
         return len(keys) == 1
 
-    @property
+    @functools.cached_property
     def args(self) -> dict:
         """Get the tool's input arguments schema.
 
@@ -583,7 +584,7 @@ class ChildTool(BaseTool):
                 json_schema = input_schema.model_json_schema()
         return cast("dict", json_schema["properties"])
 
-    @property
+    @functools.cached_property
     def tool_call_schema(self) -> ArgsSchema:
         """Get the schema for tool calls, excluding injected arguments.
 

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -55,6 +55,7 @@ from langchain_core.runnables import (
 from langchain_core.runnables.config import set_config_context
 from langchain_core.runnables.utils import coro_with_context
 from langchain_core.utils.function_calling import (
+    _format_tool_to_openai_function,
     _parse_google_docstring,
     _py_38_safe_origin,
 )
@@ -562,6 +563,16 @@ class ChildTool(BaseTool):
             self.__dict__.pop("args", None)
             self.__dict__.pop("_openai_function_dict", None)
             self.__dict__.pop("_openai_function_chars", None)
+
+    @functools.cached_property
+    def _openai_function_dict(self) -> dict[str, Any]:
+        """OpenAI function description for this tool, cached per instance."""
+        return _format_tool_to_openai_function(self)
+
+    @functools.cached_property
+    def _openai_function_chars(self) -> int:
+        """JSON character count of the full OpenAI tool dict, cached per instance."""
+        return len(json.dumps({"type": "function", "function": self._openai_function_dict}))
 
     @property
     def is_single_input(self) -> bool:

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -337,25 +337,17 @@ def _format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
     Returns:
         The function description.
     """
-    # The result is cached on the tool instance under `_openai_function_dict`.
-    # `BaseTool.__setattr__` pops this key when `args_schema` / `description` /
-    # `name` are mutated (alongside the existing `tool_call_schema` and `args`
-    # caches), so the invalidation path is already wired up.
-    cached = tool.__dict__.get("_openai_function_dict")
-    if cached is not None:
-        return cached
-
     is_simple_oai_tool = (
         isinstance(tool, langchain_core.tools.simple.Tool) and not tool.args_schema
     )
     schema = tool.tool_call_schema
     if schema and not is_simple_oai_tool:
         if isinstance(schema, dict):
-            result = _convert_json_schema_to_openai_function(
+            return _convert_json_schema_to_openai_function(
                 schema, name=tool.name, description=tool.description
             )
         elif issubclass(schema, (BaseModel, BaseModelV1)):
-            result = _convert_pydantic_to_openai_function(
+            return _convert_pydantic_to_openai_function(
                 schema, name=tool.name, description=tool.description
             )
         else:
@@ -364,26 +356,22 @@ def _format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
                 "Tool call schema must be a JSON schema dict or a Pydantic model."
             )
             raise ValueError(error_msg)
-    else:
-        result = {
-            "name": tool.name,
-            "description": tool.description,
-            "parameters": {
-                # This is a hack to get around the fact that some tools
-                # do not expose an args_schema, and expect an argument
-                # which is a string.
-                # And Open AI does not support an array type for the
-                # parameters.
-                "properties": {
-                    "__arg1": {"title": "__arg1", "type": "string"},
-                },
-                "required": ["__arg1"],
-                "type": "object",
+    return {
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": {
+            # This is a hack to get around the fact that some tools
+            # do not expose an args_schema, and expect an argument
+            # which is a string.
+            # And Open AI does not support an array type for the
+            # parameters.
+            "properties": {
+                "__arg1": {"title": "__arg1", "type": "string"},
             },
-        }
-
-    tool.__dict__["_openai_function_dict"] = result
-    return result
+            "required": ["__arg1"],
+            "type": "object",
+        },
+    }
 
 
 def convert_to_openai_function(
@@ -457,7 +445,10 @@ def convert_to_openai_function(
             "dict", _convert_typed_dict_to_openai_function(cast("type", function))
         )
     elif isinstance(function, langchain_core.tools.base.BaseTool):
-        oai_function = cast("dict", _format_tool_to_openai_function(function))
+        # _openai_function_dict is a cached_property on ChildTool that calls
+        # _format_tool_to_openai_function; going through it here ensures the
+        # result is cached on the tool for the lifetime of the instance.
+        oai_function = cast("dict", function._openai_function_dict)  # type: ignore[attr-defined]
     elif callable(function):
         oai_function = cast(
             "dict", _convert_python_function_to_openai_function(function)

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -337,40 +337,53 @@ def _format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
     Returns:
         The function description.
     """
+    # The result is cached on the tool instance under `_openai_function_dict`.
+    # `BaseTool.__setattr__` pops this key when `args_schema` / `description` /
+    # `name` are mutated (alongside the existing `tool_call_schema` and `args`
+    # caches), so the invalidation path is already wired up.
+    cached = tool.__dict__.get("_openai_function_dict")
+    if cached is not None:
+        return cached
+
     is_simple_oai_tool = (
         isinstance(tool, langchain_core.tools.simple.Tool) and not tool.args_schema
     )
     schema = tool.tool_call_schema
     if schema and not is_simple_oai_tool:
         if isinstance(schema, dict):
-            return _convert_json_schema_to_openai_function(
+            result = _convert_json_schema_to_openai_function(
                 schema, name=tool.name, description=tool.description
             )
-        if issubclass(schema, (BaseModel, BaseModelV1)):
-            return _convert_pydantic_to_openai_function(
+        elif issubclass(schema, (BaseModel, BaseModelV1)):
+            result = _convert_pydantic_to_openai_function(
                 schema, name=tool.name, description=tool.description
             )
-        error_msg = (
-            f"Unsupported tool call schema: {schema}. "
-            "Tool call schema must be a JSON schema dict or a Pydantic model."
-        )
-        raise ValueError(error_msg)
-    return {
-        "name": tool.name,
-        "description": tool.description,
-        "parameters": {
-            # This is a hack to get around the fact that some tools
-            # do not expose an args_schema, and expect an argument
-            # which is a string.
-            # And Open AI does not support an array type for the
-            # parameters.
-            "properties": {
-                "__arg1": {"title": "__arg1", "type": "string"},
+        else:
+            error_msg = (
+                f"Unsupported tool call schema: {schema}. "
+                "Tool call schema must be a JSON schema dict or a Pydantic model."
+            )
+            raise ValueError(error_msg)
+    else:
+        result = {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": {
+                # This is a hack to get around the fact that some tools
+                # do not expose an args_schema, and expect an argument
+                # which is a string.
+                # And Open AI does not support an array type for the
+                # parameters.
+                "properties": {
+                    "__arg1": {"title": "__arg1", "type": "string"},
+                },
+                "required": ["__arg1"],
+                "type": "object",
             },
-            "required": ["__arg1"],
-            "type": "object",
-        },
-    }
+        }
+
+    tool.__dict__["_openai_function_dict"] = result
+    return result
 
 
 def convert_to_openai_function(

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -340,17 +340,18 @@ def _format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
     is_simple_oai_tool = (
         isinstance(tool, langchain_core.tools.simple.Tool) and not tool.args_schema
     )
-    if tool.tool_call_schema and not is_simple_oai_tool:
-        if isinstance(tool.tool_call_schema, dict):
+    schema = tool.tool_call_schema
+    if schema and not is_simple_oai_tool:
+        if isinstance(schema, dict):
             return _convert_json_schema_to_openai_function(
-                tool.tool_call_schema, name=tool.name, description=tool.description
+                schema, name=tool.name, description=tool.description
             )
-        if issubclass(tool.tool_call_schema, (BaseModel, BaseModelV1)):
+        if issubclass(schema, (BaseModel, BaseModelV1)):
             return _convert_pydantic_to_openai_function(
-                tool.tool_call_schema, name=tool.name, description=tool.description
+                schema, name=tool.name, description=tool.description
             )
         error_msg = (
-            f"Unsupported tool call schema: {tool.tool_call_schema}. "
+            f"Unsupported tool call schema: {schema}. "
             "Tool call schema must be a JSON schema dict or a Pydantic model."
         )
         raise ValueError(error_msg)

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3741,3 +3741,42 @@ def test_tool_invoke_returns_list_of_mixin() -> None:
     assert isinstance(result, list)
     assert len(result) == 3
     assert all(isinstance(m, ToolMessage) for m in result)
+
+
+def test_tool_call_schema_cache_invalidated_on_field_mutation() -> None:
+    """Verify cached tool_call_schema is invalidated when schema-affecting fields change."""
+
+    @tool
+    def my_tool(x: int) -> str:
+        """Original description."""
+        return str(x)
+
+    schema_before = my_tool.tool_call_schema
+    my_tool.description = "Updated description"
+    schema_after = my_tool.tool_call_schema
+
+    assert schema_before is not schema_after
+    assert schema_after.__doc__ == "Updated description"
+
+
+def test_args_cache_invalidated_on_args_schema_change() -> None:
+    """Verify cached args is invalidated when args_schema changes."""
+
+    class SchemaA(BaseModel):
+        x: int
+
+    class SchemaB(BaseModel):
+        y: str
+
+    @tool(args_schema=SchemaA)
+    def my_tool(x: int) -> str:
+        """A tool."""
+        return str(x)
+
+    args_before = my_tool.args
+    assert "x" in args_before
+
+    my_tool.args_schema = SchemaB
+    args_after = my_tool.args
+    assert "y" in args_after
+    assert "x" not in args_after

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -69,6 +69,7 @@ test = [
     "pytest-xdist<4.0.0,>=3.6.1",
     "pytest-mock",
     "pytest-benchmark>=5.1.0,<6.0.0",
+    "pytest-codspeed>=3.0.0,<4.0.0",
     "syrupy>=5.0.0,<6.0.0",
     "toml>=0.10.2,<1.0.0",
     "blockbuster>=1.5.26,<1.6.0",

--- a/libs/langchain_v1/tests/benchmarks/test_create_agent.py
+++ b/libs/langchain_v1/tests/benchmarks/test_create_agent.py
@@ -1,8 +1,14 @@
+from __future__ import annotations
+
+import tracemalloc
+from itertools import cycle
 from typing import TYPE_CHECKING, Any
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from langchain.agents import create_agent
@@ -18,27 +24,272 @@ if TYPE_CHECKING:
     from langchain.agents.middleware import AgentMiddleware
 
 
+# ---------------------------------------------------------------------------
+# Tool fixtures — a realistic mix of simple, structured, and nested schemas
+# ---------------------------------------------------------------------------
+
+
+@tool
+def simple_tool_1(x: int) -> str:
+    """Add one to a number."""
+    return str(x + 1)
+
+
+@tool
+def simple_tool_2(text: str) -> str:
+    """Reverse a string."""
+    return text[::-1]
+
+
+@tool
+def simple_tool_3(a: float, b: float) -> float:
+    """Multiply two numbers."""
+    return a * b
+
+
+@tool
+def simple_tool_4(items: list[str]) -> int:
+    """Count items in a list."""
+    return len(items)
+
+
+@tool
+def simple_tool_5(flag: bool, value: str) -> str:
+    """Return value if flag is true."""
+    return value if flag else ""
+
+
+class AddressSchema(BaseModel):
+    street: str = Field(description="Street address")
+    city: str = Field(description="City name")
+    zip_code: str = Field(description="ZIP code")
+
+
+class PersonSchema(BaseModel):
+    name: str = Field(description="Full name")
+    age: int = Field(description="Age in years")
+    address: AddressSchema = Field(description="Home address")
+    tags: list[str] = Field(default_factory=list, description="Tags")
+
+
+@tool(args_schema=PersonSchema)
+def structured_tool_1(name: str, age: int, address: AddressSchema, tags: list[str]) -> str:
+    """Look up a person by their details."""
+    return f"{name}, {age}"
+
+
+class SearchSchema(BaseModel):
+    query: str = Field(description="Search query string")
+    max_results: int = Field(default=10, description="Maximum results to return")
+    filters: dict[str, str] = Field(default_factory=dict, description="Filter map")
+
+
+@tool(args_schema=SearchSchema)
+def structured_tool_2(query: str, max_results: int, filters: dict[str, str]) -> list[str]:
+    """Search a database with filters."""
+    return [query] * min(max_results, 3)
+
+
+class FileSchema(BaseModel):
+    path: str = Field(description="File path")
+    encoding: str = Field(default="utf-8", description="File encoding")
+    lines: list[int] = Field(default_factory=list, description="Line numbers to read")
+
+
+@tool(args_schema=FileSchema)
+def structured_tool_3(path: str, encoding: str, lines: list[int]) -> str:
+    """Read a file at a given path."""
+    return f"content of {path}"
+
+
+class MatrixSchema(BaseModel):
+    rows: int = Field(description="Number of rows")
+    cols: int = Field(description="Number of columns")
+    fill: float = Field(default=0.0, description="Fill value")
+
+
+@tool(args_schema=MatrixSchema)
+def structured_tool_4(rows: int, cols: int, fill: float) -> list[list[float]]:
+    """Create a matrix filled with a value."""
+    return [[fill] * cols for _ in range(rows)]
+
+
+@tool
+def complex_tool_1(
+    name: str,
+    metadata: dict[str, Any],
+    tags: list[str],
+    priority: int = 0,
+) -> dict[str, Any]:
+    """Create an item with metadata."""
+    return {"name": name, "metadata": metadata, "tags": tags, "priority": priority}
+
+
+@tool
+def complex_tool_2(
+    source: str,
+    destination: str,
+    options: dict[str, str] | None = None,
+) -> bool:
+    """Copy data from source to destination."""
+    return True
+
+
+@tool
+def complex_tool_3(
+    ids: list[int],
+    batch_size: int = 10,
+    retry: bool = False,
+) -> dict[str, list[int]]:
+    """Process a batch of IDs."""
+    return {"processed": ids[:batch_size]}
+
+
+@tool
+def complex_tool_4(
+    expression: str,
+    variables: dict[str, float],
+    precision: int = 6,
+) -> float:
+    """Evaluate a mathematical expression."""
+    return 0.0
+
+
+@tool
+def complex_tool_5(
+    url: str,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    body: str | None = None,
+    timeout: int = 30,
+) -> dict[str, Any]:
+    """Make an HTTP request."""
+    return {"status": 200, "body": ""}
+
+
+SMALL_TOOLS = [simple_tool_1, simple_tool_2, simple_tool_3]
+MEDIUM_TOOLS = [
+    simple_tool_1,
+    simple_tool_2,
+    simple_tool_3,
+    simple_tool_4,
+    simple_tool_5,
+    structured_tool_1,
+    structured_tool_2,
+]
+LARGE_TOOLS = [
+    simple_tool_1,
+    simple_tool_2,
+    simple_tool_3,
+    simple_tool_4,
+    simple_tool_5,
+    structured_tool_1,
+    structured_tool_2,
+    structured_tool_3,
+    structured_tool_4,
+    complex_tool_1,
+    complex_tool_2,
+    complex_tool_3,
+    complex_tool_4,
+    complex_tool_5,
+]
+
+
+def _make_model() -> GenericFakeChatModel:
+    return GenericFakeChatModel(messages=cycle([AIMessage(content="ok")]))
+
+
+# ---------------------------------------------------------------------------
+# Benchmarks
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.benchmark
 def test_create_agent_instantiation(benchmark: BenchmarkFixture) -> None:
-    def instantiate_agent() -> None:
-        create_agent(model=GenericFakeChatModel(messages=iter([AIMessage(content="ok")])))
-
-    benchmark(instantiate_agent)
+    """Baseline: no tools."""
+    benchmark(lambda: create_agent(model=_make_model()))
 
 
 @pytest.mark.benchmark
-def test_create_agent_instantiation_with_middleware(
-    benchmark: BenchmarkFixture,
-) -> None:
-    def instantiate_agent() -> None:
-        middleware: Sequence[AgentMiddleware[Any, Any]] = (
-            TodoListMiddleware(),
-            ToolRetryMiddleware(),
-            ModelRetryMiddleware(),
-        )
-        create_agent(
-            model=GenericFakeChatModel(messages=iter([AIMessage(content="ok")])),
+def test_create_agent_small_tools(benchmark: BenchmarkFixture) -> None:
+    """3 simple tools."""
+    benchmark(lambda: create_agent(model=_make_model(), tools=SMALL_TOOLS))
+
+
+@pytest.mark.benchmark
+def test_create_agent_medium_tools(benchmark: BenchmarkFixture) -> None:
+    """7 mixed tools."""
+    benchmark(lambda: create_agent(model=_make_model(), tools=MEDIUM_TOOLS))
+
+
+@pytest.mark.benchmark
+def test_create_agent_large_tools(benchmark: BenchmarkFixture) -> None:
+    """14 tools including complex nested schemas."""
+    benchmark(lambda: create_agent(model=_make_model(), tools=LARGE_TOOLS))
+
+
+@pytest.mark.benchmark
+def test_create_agent_large_tools_with_middleware(benchmark: BenchmarkFixture) -> None:
+    """14 tools + full middleware stack."""
+    middleware: Sequence[AgentMiddleware[Any, Any]] = (
+        TodoListMiddleware(),
+        ToolRetryMiddleware(),
+        ModelRetryMiddleware(),
+    )
+    benchmark(
+        lambda: create_agent(
+            model=_make_model(),
+            tools=LARGE_TOOLS,
             middleware=middleware,
         )
+    )
 
-    benchmark(instantiate_agent)
+
+@pytest.mark.benchmark
+def test_tool_call_schema_repeated_access(benchmark: BenchmarkFixture) -> None:
+    """Measure cost of repeated .tool_call_schema access on a complex tool."""
+    t = structured_tool_1
+
+    def access_schema_10x() -> None:
+        for _ in range(10):
+            _ = t.tool_call_schema
+
+    benchmark(access_schema_10x)
+
+
+@pytest.mark.benchmark
+def test_tool_args_repeated_access(benchmark: BenchmarkFixture) -> None:
+    """Measure cost of repeated .args access on a complex tool."""
+    t = structured_tool_1
+
+    def access_args_10x() -> None:
+        for _ in range(10):
+            _ = t.args
+
+    benchmark(access_args_10x)
+
+
+@pytest.mark.benchmark
+def test_create_agent_instantiation_with_middleware(benchmark: BenchmarkFixture) -> None:
+    """Baseline with middleware, no tools."""
+    middleware: Sequence[AgentMiddleware[Any, Any]] = (
+        TodoListMiddleware(),
+        ToolRetryMiddleware(),
+        ModelRetryMiddleware(),
+    )
+    benchmark(lambda: create_agent(model=_make_model(), middleware=middleware))
+
+
+# ---------------------------------------------------------------------------
+# Memory snapshot (not a codspeed benchmark — uses tracemalloc directly)
+# ---------------------------------------------------------------------------
+
+
+def test_create_agent_large_tools_memory() -> None:
+    """Record peak memory for large-tools agent creation. Not a perf benchmark."""
+    tracemalloc.start()
+    create_agent(model=_make_model(), tools=LARGE_TOOLS)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    # Soft assertion: 50 MB is a generous ceiling for a single agent instantiation.
+    assert peak < 50 * 1024 * 1024, f"Peak memory {peak / 1024 / 1024:.1f} MB exceeded 50 MB"

--- a/libs/langchain_v1/tests/benchmarks/test_create_agent.py
+++ b/libs/langchain_v1/tests/benchmarks/test_create_agent.py
@@ -114,6 +114,35 @@ def structured_tool_4(rows: int, cols: int, fill: float) -> list[list[float]]:
     return [[fill] * cols for _ in range(rows)]
 
 
+class CoordinateSchema(BaseModel):
+    lat: float = Field(description="Latitude")
+    lon: float = Field(description="Longitude")
+
+
+class LocationSchema(BaseModel):
+    name: str = Field(description="Location name")
+    coordinate: CoordinateSchema = Field(description="GPS coordinate")
+    altitude_m: float = Field(default=0.0, description="Altitude in meters")
+
+
+class RouteSchema(BaseModel):
+    origin: LocationSchema = Field(description="Starting location")
+    destination: LocationSchema = Field(description="Ending location")
+    waypoints: list[LocationSchema] = Field(default_factory=list, description="Intermediate stops")
+    max_distance_km: float = Field(default=1000.0, description="Maximum route distance")
+
+
+@tool(args_schema=RouteSchema)
+def deep_nested_tool(
+    origin: LocationSchema,
+    destination: LocationSchema,
+    waypoints: list[LocationSchema],
+    max_distance_km: float,
+) -> dict[str, Any]:
+    """Plan a route between locations with deep nested schema."""
+    return {"origin": origin.name, "destination": destination.name}
+
+
 @tool
 def complex_tool_1(
     name: str,
@@ -187,6 +216,7 @@ LARGE_TOOLS = [
     structured_tool_2,
     structured_tool_3,
     structured_tool_4,
+    deep_nested_tool,
     complex_tool_1,
     complex_tool_2,
     complex_tool_3,
@@ -224,47 +254,48 @@ def test_create_agent_medium_tools(benchmark: BenchmarkFixture) -> None:
 
 @pytest.mark.benchmark
 def test_create_agent_large_tools(benchmark: BenchmarkFixture) -> None:
-    """14 tools including complex nested schemas."""
+    """15 tools including complex nested schemas."""
     benchmark(lambda: create_agent(model=_make_model(), tools=LARGE_TOOLS))
 
 
 @pytest.mark.benchmark
 def test_create_agent_large_tools_with_middleware(benchmark: BenchmarkFixture) -> None:
-    """14 tools + full middleware stack."""
-    middleware: Sequence[AgentMiddleware[Any, Any]] = (
-        TodoListMiddleware(),
-        ToolRetryMiddleware(),
-        ModelRetryMiddleware(),
-    )
-    benchmark(
-        lambda: create_agent(
+    """15 tools + full middleware stack."""
+    def run() -> None:
+        middleware: Sequence[AgentMiddleware[Any, Any]] = (
+            TodoListMiddleware(),
+            ToolRetryMiddleware(),
+            ModelRetryMiddleware(),
+        )
+        create_agent(
             model=_make_model(),
             tools=LARGE_TOOLS,
             middleware=middleware,
         )
-    )
+
+    benchmark(run)
 
 
 @pytest.mark.benchmark
 def test_tool_call_schema_repeated_access(benchmark: BenchmarkFixture) -> None:
-    """Measure cost of repeated .tool_call_schema access on a complex tool."""
+    """Measure cost of repeated .tool_call_schema access on a complex tool (10 accesses per iteration)."""
     t = structured_tool_1
 
     def access_schema_10x() -> None:
         for _ in range(10):
-            _ = t.tool_call_schema
+            t.tool_call_schema
 
     benchmark(access_schema_10x)
 
 
 @pytest.mark.benchmark
 def test_tool_args_repeated_access(benchmark: BenchmarkFixture) -> None:
-    """Measure cost of repeated .args access on a complex tool."""
+    """Measure cost of repeated .args access on a complex tool (10 accesses per iteration)."""
     t = structured_tool_1
 
     def access_args_10x() -> None:
         for _ in range(10):
-            _ = t.args
+            t.args
 
     benchmark(access_args_10x)
 
@@ -272,12 +303,15 @@ def test_tool_args_repeated_access(benchmark: BenchmarkFixture) -> None:
 @pytest.mark.benchmark
 def test_create_agent_instantiation_with_middleware(benchmark: BenchmarkFixture) -> None:
     """Baseline with middleware, no tools."""
-    middleware: Sequence[AgentMiddleware[Any, Any]] = (
-        TodoListMiddleware(),
-        ToolRetryMiddleware(),
-        ModelRetryMiddleware(),
-    )
-    benchmark(lambda: create_agent(model=_make_model(), middleware=middleware))
+    def run() -> None:
+        middleware: Sequence[AgentMiddleware[Any, Any]] = (
+            TodoListMiddleware(),
+            ToolRetryMiddleware(),
+            ModelRetryMiddleware(),
+        )
+        create_agent(model=_make_model(), middleware=middleware)
+
+    benchmark(run)
 
 
 # ---------------------------------------------------------------------------
@@ -285,11 +319,19 @@ def test_create_agent_instantiation_with_middleware(benchmark: BenchmarkFixture)
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.benchmark
 def test_create_agent_large_tools_memory() -> None:
-    """Record peak memory for large-tools agent creation. Not a perf benchmark."""
+    """Observe peak memory for large-tools agent creation.
+
+    This is not a hard assertion — it records the tracemalloc peak for the
+    memory allocated *during* create_agent. Run before and after optimization
+    passes to track improvement. Update the printed baseline comment below
+    when the number changes significantly.
+    """
     tracemalloc.start()
     create_agent(model=_make_model(), tools=LARGE_TOOLS)
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
-    # Soft assertion: 50 MB is a generous ceiling for a single agent instantiation.
-    assert peak < 50 * 1024 * 1024, f"Peak memory {peak / 1024 / 1024:.1f} MB exceeded 50 MB"
+    peak_kb = peak / 1024
+    # Baseline (pre-optimization): ~recorded after first run
+    print(f"\nPeak memory during create_agent (15 tools): {peak_kb:.1f} KB")

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1989,6 +1989,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-socket" },
@@ -2044,6 +2045,7 @@ test = [
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6.0.0" },
+    { name = "pytest-codspeed", specifier = ">=3.0.0,<4.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0,<8.0.0" },
     { name = "pytest-mock" },
     { name = "pytest-socket", specifier = ">=0.6.0,<1.0.0" },
@@ -4184,28 +4186,24 @@ wheels = [
 
 [[package]]
 name = "pytest-codspeed"
-version = "4.2.0"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi" },
     { name = "pytest" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/e8/27fcbe6516a1c956614a4b61a7fccbf3791ea0b992e07416e8948184327d/pytest_codspeed-4.2.0.tar.gz", hash = "sha256:04b5d0bc5a1851ba1504d46bf9d7dbb355222a69f2cd440d54295db721b331f7", size = 113263, upload-time = "2025-10-24T09:02:55.704Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/98/16fe3895b1b8a6d537a89eecb120b97358df8f0002c6ecd11555d6304dc8/pytest_codspeed-3.2.0.tar.gz", hash = "sha256:f9d1b1a3b2c69cdc0490a1e8b1ced44bffbd0e8e21d81a7160cfdd923f6e8155", size = 18409, upload-time = "2025-01-31T14:28:26.165Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/b8/d599a466c50af3f04001877ae8b17c12b803f3b358235736b91a0769de0d/pytest_codspeed-4.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:609828b03972966b75b9b7416fa2570c4a0f6124f67e02d35cd3658e64312a7b", size = 261943, upload-time = "2025-10-24T09:02:37.962Z" },
-    { url = "https://files.pythonhosted.org/packages/74/19/ccc1a2fcd28357a8db08ba6b60f381832088a3850abc262c8e0b3406491a/pytest_codspeed-4.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23a0c0fbf8bb4de93a3454fd9e5efcdca164c778aaef0a9da4f233d85cb7f5b8", size = 250782, upload-time = "2025-10-24T09:02:39.617Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/2d/f0083a2f14ecf008d961d40439a71da0ae0d568e5f8dc2fccd3e8a2ab3e4/pytest_codspeed-4.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2de87bde9fbc6fd53f0fd21dcf2599c89e0b8948d49f9bad224edce51c47e26b", size = 261960, upload-time = "2025-10-24T09:02:40.665Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/0c/1f514c553db4ea5a69dfbe2706734129acd0eca8d5101ec16f1dd00dbc0f/pytest_codspeed-4.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95aeb2479ca383f6b18e2cc9ebcd3b03ab184980a59a232aea6f370bbf59a1e3", size = 250808, upload-time = "2025-10-24T09:02:42.07Z" },
-    { url = "https://files.pythonhosted.org/packages/81/04/479905bd6653bc981c0554fcce6df52d7ae1594e1eefd53e6cf31810ec7f/pytest_codspeed-4.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7d4fefbd4ae401e2c60f6be920a0be50eef0c3e4a1f0a1c83962efd45be38b39", size = 262084, upload-time = "2025-10-24T09:02:43.155Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/46/d6f345d7907bac6cbb6224bd697ecbc11cf7427acc9e843c3618f19e3476/pytest_codspeed-4.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:309b4227f57fcbb9df21e889ea1ae191d0d1cd8b903b698fdb9ea0461dbf1dfe", size = 251100, upload-time = "2025-10-24T09:02:44.168Z" },
-    { url = "https://files.pythonhosted.org/packages/de/dc/e864f45e994a50390ff49792256f1bdcbf42f170e3bc0470ee1a7d2403f3/pytest_codspeed-4.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72aab8278452a6d020798b9e4f82780966adb00f80d27a25d1274272c54630d5", size = 262057, upload-time = "2025-10-24T09:02:45.791Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/1c/f1d2599784486879cf6579d8d94a3e22108f0e1f130033dab8feefd29249/pytest_codspeed-4.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:684fcd9491d810ded653a8d38de4835daa2d001645f4a23942862950664273f8", size = 251013, upload-time = "2025-10-24T09:02:46.937Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/fd/eafd24db5652a94b4d00fe9b309b607de81add0f55f073afb68a378a24b6/pytest_codspeed-4.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50794dabea6ec90d4288904452051e2febace93e7edf4ca9f2bce8019dd8cd37", size = 262065, upload-time = "2025-10-24T09:02:48.018Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/14/8d9340d7dc0ae647991b28a396e16b3403e10def883cde90d6b663d3f7ec/pytest_codspeed-4.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0ebd87f2a99467a1cfd8e83492c4712976e43d353ee0b5f71cbb057f1393aca", size = 251057, upload-time = "2025-10-24T09:02:49.102Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/39/48cf6afbca55bc7c8c93c3d4ae926a1068bcce3f0241709db19b078d5418/pytest_codspeed-4.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbbb2d61b85bef8fc7e2193f723f9ac2db388a48259d981bbce96319043e9830", size = 267983, upload-time = "2025-10-24T09:02:50.558Z" },
-    { url = "https://files.pythonhosted.org/packages/33/86/4407341efb5dceb3e389635749ce1d670542d6ca148bd34f9d5334295faf/pytest_codspeed-4.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:748411c832147bfc85f805af78a1ab1684f52d08e14aabe22932bbe46c079a5f", size = 256732, upload-time = "2025-10-24T09:02:51.603Z" },
-    { url = "https://files.pythonhosted.org/packages/25/0e/8cb71fd3ed4ed08c07aec1245aea7bc1b661ba55fd9c392db76f1978d453/pytest_codspeed-4.2.0-py3-none-any.whl", hash = "sha256:e81bbb45c130874ef99aca97929d72682733527a49f84239ba575b5cb843bab0", size = 113726, upload-time = "2025-10-24T09:02:54.785Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/31/62b93ee025ca46016d01325f58997d32303752286bf929588c8796a25b13/pytest_codspeed-3.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5165774424c7ab8db7e7acdb539763a0e5657996effefdf0664d7fd95158d34", size = 26802, upload-time = "2025-01-31T14:28:10.723Z" },
+    { url = "https://files.pythonhosted.org/packages/89/60/2bc46bdf8c8ddb7e59cd9d480dc887d0ac6039f88c856d1ae3d29a4e648d/pytest_codspeed-3.2.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9bd55f92d772592c04a55209950c50880413ae46876e66bd349ef157075ca26c", size = 25442, upload-time = "2025-01-31T14:28:11.774Z" },
+    { url = "https://files.pythonhosted.org/packages/31/56/1b65ba0ae1af7fd7ce14a66e7599833efe8bbd0fcecd3614db0017ca224a/pytest_codspeed-3.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4cf6f56067538f4892baa8d7ab5ef4e45bb59033be1ef18759a2c7fc55b32035", size = 26810, upload-time = "2025-01-31T14:28:12.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e6/d1fafb09a1c4983372f562d9e158735229cb0b11603a61d4fad05463f977/pytest_codspeed-3.2.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a687b05c3d145642061b45ea78e47e12f13ce510104d1a2cda00eee0e36f58", size = 25442, upload-time = "2025-01-31T14:28:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/8b/9e95472589d17bb68960f2a09cfa8f02c4d43c82de55b73302bbe0fa4350/pytest_codspeed-3.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46a1afaaa1ac4c2ca5b0700d31ac46d80a27612961d031067d73c6ccbd8d3c2b", size = 27182, upload-time = "2025-01-31T14:28:15.828Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/18/82aaed8095e84d829f30dda3ac49fce4e69685d769aae463614a8d864cdd/pytest_codspeed-3.2.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c48ce3af3dfa78413ed3d69d1924043aa1519048dbff46edccf8f35a25dab3c2", size = 25933, upload-time = "2025-01-31T14:28:17.151Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/15/60b18d40da66e7aa2ce4c4c66d5a17de20a2ae4a89ac09a58baa7a5bc535/pytest_codspeed-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66692506d33453df48b36a84703448cb8b22953eea51f03fbb2eb758dc2bdc4f", size = 27180, upload-time = "2025-01-31T14:28:18.056Z" },
+    { url = "https://files.pythonhosted.org/packages/51/bd/6b164d4ae07d8bea5d02ad664a9762bdb63f83c0805a3c8fe7dc6ec38407/pytest_codspeed-3.2.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:479774f80d0bdfafa16112700df4dbd31bf2a6757fac74795fd79c0a7b3c389b", size = 25923, upload-time = "2025-01-31T14:28:19.725Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/9b/952c70bd1fae9baa58077272e7f191f377c86d812263c21b361195e125e6/pytest_codspeed-3.2.0-py3-none-any.whl", hash = "sha256:54b5c2e986d6a28e7b0af11d610ea57bd5531cec8326abe486f1b55b09d91c39", size = 15007, upload-time = "2025-01-31T14:28:24.458Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Every call to `convert_to_openai_tool(tool)` re-ran `schema.model_json_schema()` on the cached Pydantic model, rebuilding the full JSON-schema tree on every model invocation. In agent runs with many tools this compounds fast: summarization middleware's `count_tokens_approximately` (called twice per model call) plus prompt-caching middleware's `bind_tools` meant ~3 fresh schema generations × 15 tools × 500 model calls — tens of seconds of redundant Pydantic work per run.

This PR adds two new caches on the `BaseTool` instance, layered on top of the `tool_call_schema`/`args` caching already merged to `master`:

1. **`perf(core): cache _format_tool_to_openai_function per tool instance`** — stashes the OpenAI function dict under `tool.__dict__["_openai_function_dict"]`. The first call pays the `model_json_schema()` cost once per tool; all subsequent calls are a dict lookup. `BaseTool.__setattr__` already invalidates `tool_call_schema` and `args` on `args_schema`/`name`/`description` mutation; this extends that invalidation set to include the new key.

2. **`perf(core): cache tool openai-function JSON-char count`** — `count_tokens_approximately` was calling `json.dumps(tool_dict)` and discarding everything but the `.len` on every invocation. The char count is now stashed alongside the dict under `_openai_function_chars`, invalidated by the same `__setattr__` path.

**Areas requiring careful review:**

- `BaseTool.__setattr__` invalidation — the two new `__dict__` keys must be popped on exactly the same mutations that already invalidate `tool_call_schema`/`args`. Worth confirming the invalidation field set is complete.
- Thread safety: `__dict__` mutation in `__setattr__` is unprotected, matching the existing `tool_call_schema` pattern — should be fine, but worth a second look.

> AI agents (Claude) were involved in drafting these commits.