### PR TITLE
feat(text-splitters): add Perl language support to RecursiveCharacterTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -701,6 +701,50 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 " ",
                 "",
             ]
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "
+sub ",
+                # Split along variable declarations
+                "
+my ",
+                "
+our ",
+                "
+local ",
+                # Split along package declarations
+                "
+package ",
+                # Split along module imports
+                "
+use ",
+                "
+require ",
+                # Split along control flow statements
+                "
+if ",
+                "
+unless ",
+                "
+for ",
+                "
+foreach ",
+                "
+while ",
+                "
+until ",
+                "
+do ",
+                # Split by the normal type of lines
+                "
+
+",
+                "
+",
+                " ",
+                "",
+            ]
         if language == Language.HASKELL:
             return [
                 # Split along function definitions


### PR DESCRIPTION
## Summary

`Language.PERL` was listed in the `Language` enum but had no implementation in `get_separators_for_language()`, causing a `ValueError: Language perl is not implemented yet!` at runtime.

Added a Perl separator list with:
- `\nsub ` — subroutine definitions
- `\nmy `, `\nour `, `\nlocal ` — variable declarations
- `\npackage ` — package declarations
- `\nuse `, `\nrequire ` — module imports
- `\nif `, `\nunless `, `\nfor `, `\nforeach `, `\nwhile `, `\nuntil `, `\ndo ` — control flow

## Issue

Closes #37049

## Types of changes

- [x] Bug fix / feature implementation

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] Lint and unit tests pass locally with my changes