### PR TITLE
fix(openai): merge stop tokens from model_kwargs with runtime parameters

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1688,10 +1688,19 @@ class BaseChatOpenAI(BaseChatModel):
         **kwargs: Any,
     ) -> dict:
         messages = self._convert_input(input_).to_messages()
-        if stop is not None:
-            kwargs["stop"] = stop
-
         payload = {**self._default_params, **kwargs}
+
+        # Merge stop tokens from model_kwargs and runtime stop parameter
+        if stop is not None:
+            existing_stop = payload.get("stop")
+            if existing_stop is None:
+                payload["stop"] = stop
+            else:
+                if isinstance(existing_stop, str):
+                    existing_stop = [existing_stop]
+                if isinstance(stop, str):
+                    stop = [stop]
+                payload["stop"] = list(dict.fromkeys(existing_stop + stop))
 
         if self._use_responses_api(payload):
             if self.use_previous_response_id:


### PR DESCRIPTION
Fixes #29323

## What changed
- Removed the old behavior where runtime `stop` parameter silently 
  overwrote `stop` set in `model_kwargs`
- Added merging logic that combines both sources and deduplicates

## Why
When users set `stop` tokens via `model_kwargs` and also pass `stop` 
at runtime, the runtime value was silently discarding the model_kwargs 
value. This caused unexpected behavior especially with vLLM and other 
OpenAI-compatible APIs.

## Testing
The fix is backward-compatible — if only one source of stop tokens 
exists, behavior is unchanged.