### PR TITLE
fix(openai): handle empty parsed response in structured output parser

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3964,6 +3964,18 @@ def _oai_structured_outputs_parser(
         raise OpenAIRefusalError(refusal)
     if ai_msg.tool_calls:
         return None
+
+    if isinstance(ai_msg.content, str) and ai_msg.content.strip():
+        try:
+            data = json.loads(ai_msg.content)
+            if isinstance(data, dict):
+                return schema(**data)
+        except (JSONDecodeError, ValidationError):
+            pass
+
+    if not ai_msg.content:
+        return None
+
     msg = (
         "Structured Output response does not have a 'parsed' field nor a 'refusal' "
         f"field. Received message:\n\n{ai_msg}"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3454,6 +3454,41 @@ def test_openai_structured_output_refusal_handling_responses_api() -> None:
         pytest.fail(f"This is a wrong behavior. Error details: {e}")
 
 
+def test_oai_structured_outputs_parser_json_content_fallback() -> None:
+    """When parsed is None but content has valid JSON, parse it as the schema."""
+
+    class MathResult(BaseModel):
+        answer: int
+
+    ai_msg = AIMessage(
+        content='{"answer": 42}',
+        additional_kwargs={"parsed": None, "refusal": None},
+    )
+    result = _oai_structured_outputs_parser(ai_msg, MathResult)
+    assert isinstance(result, MathResult)
+    assert result.answer == 42
+
+
+def test_oai_structured_outputs_parser_empty_content_returns_none() -> None:
+    """When parsed is None and content is empty, return None instead of raising."""
+    ai_msg = AIMessage(
+        content="",
+        additional_kwargs={"parsed": None, "refusal": None},
+    )
+    result = _oai_structured_outputs_parser(ai_msg, BaseModel)
+    assert result is None
+
+
+def test_oai_structured_outputs_parser_non_json_content_raises() -> None:
+    """When parsed is None and content is non-JSON, raise ValueError."""
+    ai_msg = AIMessage(
+        content="This is not JSON at all",
+        additional_kwargs={"parsed": None, "refusal": None},
+    )
+    with pytest.raises(ValueError, match="does not have a 'parsed' field"):
+        _oai_structured_outputs_parser(ai_msg, BaseModel)
+
+
 # Test fixtures for context overflow error tests
 _CONTEXT_OVERFLOW_ERROR_BODY = {
     "error": {


### PR DESCRIPTION
## Summary

Fixes `_oai_structured_outputs_parser` crashing with `ValueError` when the API returns `parsed=None, refusal=None` with empty content. This occurs on some OpenAI-compatible providers (e.g. NVIDIA NIM) during multi-turn conversations using `with_structured_output()`.

The parser previously only checked for `parsed`, `refusal`, refusal content blocks, and `tool_calls`. If none matched, it raised `ValueError` unconditionally. This PR adds two fallback paths before the error:

- **JSON content fallback**: if `ai_msg.content` is a non-empty string, attempt to parse it as JSON and instantiate the schema. Some providers return structured data in `content` instead of `parsed`.
- **Empty content guard**: if `ai_msg.content` is empty/falsy, return `None` — consistent with the existing `tool_calls` guard.

The `ValueError` is preserved for the case where content exists but is not valid JSON for the schema.

## Issue

Closes #36916

## Types of changes

- [x] Bug fix

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] Lint and unit tests pass locally with my changes
