### PR TITLE
docs(qdrant): fix missing await in async similarity_search example

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -167,7 +167,7 @@ class QdrantVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud",k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)


### PR DESCRIPTION
Fixes #37058 

The async example for `asimilarity_search` is missing an `await`, which results in a coroutine being returned instead of actual results.

This PR adds the missing `await` for correctness and consistency with other async examples.
