### PR TITLE
Security: fix ShellToolMiddleware default, APIChain SSRF, and secret deserialization

### DIFF
--- a/libs/core/langchain_core/load/load.py
+++ b/libs/core/langchain_core/load/load.py
@@ -310,6 +310,7 @@ class Reviver:
         *,
         ignore_unserializable_fields: bool = False,
         init_validator: InitValidator | None = default_init_validator,
+        secrets_from_env_allowlist: Iterable[str] | None = None,
     ) -> None:
         """Initialize the reviver.
 
@@ -336,6 +337,13 @@ class Reviver:
                 its `secret` fields, so enabling this on untrusted data can leak
                 sensitive values. Keep this `False` (the default) unless the
                 serialized data is fully trusted.
+            secrets_from_env_allowlist: Optional allowlist of environment variable
+                names that may be loaded when `secrets_from_env` is `True`.
+
+                If provided, only secrets whose names are in this allowlist will
+                be read from the environment. This limits the blast radius of
+                crafted payloads. Use this instead of unrestricted
+                `secrets_from_env=True`.
             additional_import_mappings: A dictionary of additional namespace mappings.
 
                 You can use this to override default mappings or add new mappings.
@@ -354,6 +362,9 @@ class Reviver:
         """
         self.secrets_from_env = secrets_from_env
         self.secrets_map = secrets_map or {}
+        self.secrets_from_env_allowlist = (
+            set(secrets_from_env_allowlist) if secrets_from_env_allowlist else None
+        )
         # By default, only support langchain, but user can pass in additional namespaces
         self.valid_namespaces = (
             [*DEFAULT_NAMESPACES, *valid_namespaces]
@@ -415,6 +426,11 @@ class Reviver:
             if key in self.secrets_map:
                 return self.secrets_map[key]
             if self.secrets_from_env and key in os.environ and os.environ[key]:
+                if (
+                    self.secrets_from_env_allowlist is not None
+                    and key not in self.secrets_from_env_allowlist
+                ):
+                    return None
                 return os.environ[key]
             return None
 
@@ -519,6 +535,7 @@ def loads(
     additional_import_mappings: dict[tuple[str, ...], tuple[str, ...]] | None = None,
     ignore_unserializable_fields: bool = False,
     init_validator: InitValidator | None = default_init_validator,
+    secrets_from_env_allowlist: Iterable[str] | None = None,
 ) -> Any:
     """Revive a LangChain class from a JSON string.
 
@@ -562,6 +579,8 @@ def loads(
             `secret` fields, so enabling this on untrusted data can leak
             sensitive values. Keep this `False` (the default) unless the
             serialized data is fully trusted.
+        secrets_from_env_allowlist: Optional allowlist of environment variable
+            names that may be loaded when `secrets_from_env` is `True`.
         additional_import_mappings: A dictionary of additional namespace mappings.
 
             You can use this to override default mappings or add new mappings.
@@ -595,6 +614,7 @@ def loads(
         additional_import_mappings=additional_import_mappings,
         ignore_unserializable_fields=ignore_unserializable_fields,
         init_validator=init_validator,
+        secrets_from_env_allowlist=secrets_from_env_allowlist,
     )
 
 
@@ -609,6 +629,7 @@ def load(
     additional_import_mappings: dict[tuple[str, ...], tuple[str, ...]] | None = None,
     ignore_unserializable_fields: bool = False,
     init_validator: InitValidator | None = default_init_validator,
+    secrets_from_env_allowlist: Iterable[str] | None = None,
 ) -> Any:
     """Revive a LangChain class from a JSON object.
 
@@ -654,6 +675,8 @@ def load(
             `secret` fields, so enabling this on untrusted data can leak
             sensitive values. Keep this `False` (the default) unless the
             serialized data is fully trusted.
+        secrets_from_env_allowlist: Optional allowlist of environment variable
+            names that may be loaded when `secrets_from_env` is `True`.
         additional_import_mappings: A dictionary of additional namespace mappings.
 
             You can use this to override default mappings or add new mappings.
@@ -707,6 +730,7 @@ def load(
         additional_import_mappings,
         ignore_unserializable_fields=ignore_unserializable_fields,
         init_validator=init_validator,
+        secrets_from_env_allowlist=secrets_from_env_allowlist,
     )
 
     def _load(obj: Any) -> Any:

--- a/libs/langchain/langchain_classic/chains/api/base.py
+++ b/libs/langchain/langchain_classic/chains/api/base.py
@@ -247,16 +247,13 @@ try:
             """Check that allowed domains are valid."""
             # This check must be a pre=True check, so that a default of None
             # won't be set to limit_to_domains if it's not provided.
-            if "limit_to_domains" not in values:
+            if "limit_to_domains" not in values or values.get("limit_to_domains") is None:
                 msg = (
                     "You must specify a list of domains to limit access using "
                     "`limit_to_domains`"
                 )
                 raise ValueError(msg)
-            if (
-                not values["limit_to_domains"]
-                and values["limit_to_domains"] is not None
-            ):
+            if not values["limit_to_domains"]:
                 msg = (
                     "Please provide a list of domains to limit access using "
                     "`limit_to_domains`."

--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -562,7 +562,11 @@ class ShellToolMiddleware(AgentMiddleware[ShellToolState[ResponseT], ContextT, R
         if execution_policy is not None:
             self._execution_policy = execution_policy
         else:
-            self._execution_policy = HostExecutionPolicy()
+            msg = (
+                "ShellToolMiddleware requires an explicit execution_policy. "
+                "Use HostExecutionPolicy() only if you fully trust the agent environment."
+            )
+            raise ValueError(msg)
         rules = redaction_rules or ()
         self._redaction_rules: tuple[ResolvedRedactionRule, ...] = tuple(
             rule.resolve() for rule in rules

--- a/libs/langchain_v1/tests/integration_tests/agents/middleware/test_shell_tool_integration.py
+++ b/libs/langchain_v1/tests/integration_tests/agents/middleware/test_shell_tool_integration.py
@@ -9,7 +9,7 @@ from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 
 from langchain.agents import create_agent
-from langchain.agents.middleware.shell_tool import ShellToolMiddleware
+from langchain.agents.middleware.shell_tool import HostExecutionPolicy, ShellToolMiddleware
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -37,7 +37,7 @@ def test_shell_tool_basic_execution(tmp_path: Path, provider: str) -> None:
     workspace = tmp_path / "workspace"
     agent: CompiledStateGraph[Any, Any, _InputAgentState, Any] = create_agent(
         model=_get_model(provider),
-        middleware=[ShellToolMiddleware(workspace_root=workspace)],
+        middleware=[ShellToolMiddleware(workspace_root=workspace, execution_policy=HostExecutionPolicy())],
     )
 
     result = agent.invoke(
@@ -59,7 +59,7 @@ def test_shell_session_persistence(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     agent: CompiledStateGraph[Any, Any, _InputAgentState, Any] = create_agent(
         model=_get_model("anthropic"),
-        middleware=[ShellToolMiddleware(workspace_root=workspace)],
+        middleware=[ShellToolMiddleware(workspace_root=workspace, execution_policy=HostExecutionPolicy())],
     )
 
     result = agent.invoke(
@@ -86,7 +86,7 @@ def test_shell_tool_error_handling(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     agent: CompiledStateGraph[Any, Any, _InputAgentState, Any] = create_agent(
         model=_get_model("anthropic"),
-        middleware=[ShellToolMiddleware(workspace_root=workspace)],
+        middleware=[ShellToolMiddleware(workspace_root=workspace, execution_policy=HostExecutionPolicy())],
     )
 
     result = agent.invoke(
@@ -124,7 +124,7 @@ def test_shell_tool_with_custom_tools(tmp_path: Path) -> None:
     agent: CompiledStateGraph[Any, Any, _InputAgentState, Any] = create_agent(
         model=_get_model("anthropic"),
         tools=[custom_greeting],
-        middleware=[ShellToolMiddleware(workspace_root=workspace)],
+        middleware=[ShellToolMiddleware(workspace_root=workspace, execution_policy=HostExecutionPolicy())],
     )
 
     result = agent.invoke(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -27,7 +27,7 @@ def _empty_state() -> ShellToolState:
 
 def test_executes_command_and_persists_state(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
-    middleware = ShellToolMiddleware(workspace_root=workspace)
+    middleware = ShellToolMiddleware(workspace_root=workspace, execution_policy=HostExecutionPolicy())
     runtime = Runtime()
     state = _empty_state()
     try:
@@ -49,7 +49,7 @@ def test_executes_command_and_persists_state(tmp_path: Path) -> None:
 
 
 def test_restart_resets_session_environment(tmp_path: Path) -> None:
-    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy())
     runtime = Runtime()
     state = _empty_state()
     try:
@@ -109,7 +109,7 @@ def test_timeout_returns_error(tmp_path: Path) -> None:
 
 def test_redaction_policy_applies(tmp_path: Path) -> None:
     middleware = ShellToolMiddleware(
-        workspace_root=tmp_path / "workspace",
+        workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy(),
         redaction_rules=(RedactionRule(pii_type="email", strategy="redact"),),
     )
     runtime = Runtime()
@@ -133,7 +133,7 @@ def test_redaction_policy_applies(tmp_path: Path) -> None:
 def test_startup_and_shutdown_commands(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     middleware = ShellToolMiddleware(
-        workspace_root=workspace,
+        workspace_root=workspace, execution_policy=HostExecutionPolicy(),
         startup_commands=("touch startup.txt",),
         shutdown_commands=("touch shutdown.txt",),
     )
@@ -198,19 +198,19 @@ def test_shell_tool_input_validation() -> None:
 def test_normalize_shell_command_empty() -> None:
     """Test that empty shell command raises an error."""
     with pytest.raises(ValueError, match="at least one argument"):
-        ShellToolMiddleware(shell_command=[])
+        ShellToolMiddleware(execution_policy=HostExecutionPolicy(), shell_command=[])
 
 
 def test_normalize_env_non_string_keys() -> None:
     """Test that non-string environment keys raise an error."""
     with pytest.raises(TypeError, match="must be strings"):
-        ShellToolMiddleware(env={123: "value"})  # type: ignore[dict-item]
+        ShellToolMiddleware(execution_policy=HostExecutionPolicy(), env={123: "value"})  # type: ignore[dict-item]
 
 
 def test_normalize_env_coercion(tmp_path: Path) -> None:
     """Test that environment values are coerced to strings."""
     middleware = ShellToolMiddleware(
-        workspace_root=tmp_path / "workspace", env={"NUM": 42, "BOOL": True}
+        workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy(), env={"NUM": 42, "BOOL": True}
     )
     runtime = Runtime()
     state = _empty_state()
@@ -230,7 +230,7 @@ def test_normalize_env_coercion(tmp_path: Path) -> None:
 
 def test_shell_tool_missing_command_string(tmp_path: Path) -> None:
     """Test that shell tool raises an error when command is not a string."""
-    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy())
     runtime = Runtime()
     state = _empty_state()
     try:
@@ -254,7 +254,7 @@ def test_shell_tool_missing_command_string(tmp_path: Path) -> None:
 
 def test_tool_message_formatting_with_id(tmp_path: Path) -> None:
     """Test that tool messages are properly formatted with tool_call_id."""
-    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy())
     runtime = Runtime()
     state = _empty_state()
     try:
@@ -278,7 +278,7 @@ def test_tool_message_formatting_with_id(tmp_path: Path) -> None:
 
 def test_nonzero_exit_code_returns_error(tmp_path: Path) -> None:
     """Test that non-zero exit codes are marked as errors."""
-    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy())
     runtime = Runtime()
     state = _empty_state()
     try:
@@ -374,7 +374,7 @@ def test_shutdown_command_timeout_logged(tmp_path: Path) -> None:
 
 def test_empty_output_replaced_with_no_output(tmp_path: Path) -> None:
     """Test that empty command output is replaced with '<no output>'."""
-    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy())
     runtime = Runtime()
     state = _empty_state()
     try:
@@ -396,7 +396,7 @@ def test_empty_output_replaced_with_no_output(tmp_path: Path) -> None:
 
 def test_stderr_output_labeling(tmp_path: Path) -> None:
     """Test that stderr output is properly labeled."""
-    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy())
     runtime = Runtime()
     state = _empty_state()
     try:
@@ -430,14 +430,14 @@ def test_normalize_commands_string_tuple_list(
 ) -> None:
     """Test various command normalization formats."""
     middleware = ShellToolMiddleware(
-        workspace_root=tmp_path / "workspace", startup_commands=startup_commands
+        workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy(), startup_commands=startup_commands
     )
     assert middleware._startup_commands == expected
 
 
 async def test_async_methods_delegate_to_sync(tmp_path: Path) -> None:
     """Test that async methods properly delegate to sync methods."""
-    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=HostExecutionPolicy())
     try:
         state = _empty_state()
 
@@ -463,7 +463,7 @@ def test_shell_middleware_resumable_after_interrupt(tmp_path: Path) -> None:
     5. The shell session is reused (not recreated)
     """
     workspace = tmp_path / "workspace"
-    middleware = ShellToolMiddleware(workspace_root=workspace)
+    middleware = ShellToolMiddleware(workspace_root=workspace, execution_policy=HostExecutionPolicy())
 
     # Simulate first execution (before interrupt)
     runtime = Runtime()
@@ -510,7 +510,7 @@ def test_shell_middleware_resumable_after_interrupt(tmp_path: Path) -> None:
 def test_get_or_create_resources_creates_when_missing(tmp_path: Path) -> None:
     """Test that _get_or_create_resources creates resources when they don't exist."""
     workspace = tmp_path / "workspace"
-    middleware = ShellToolMiddleware(workspace_root=workspace)
+    middleware = ShellToolMiddleware(workspace_root=workspace, execution_policy=HostExecutionPolicy())
 
     state = _empty_state()
 
@@ -531,7 +531,7 @@ def test_get_or_create_resources_creates_when_missing(tmp_path: Path) -> None:
 def test_get_or_create_resources_reuses_existing(tmp_path: Path) -> None:
     """Test that _get_or_create_resources reuses existing resources."""
     workspace = tmp_path / "workspace"
-    middleware = ShellToolMiddleware(workspace_root=workspace)
+    middleware = ShellToolMiddleware(workspace_root=workspace, execution_policy=HostExecutionPolicy())
 
     state = _empty_state()
 


### PR DESCRIPTION
Fixes critical security findings:

1. ShellToolMiddleware host default: Require explicit execution_policy; defaulting to HostExecutionPolicy() now raises ValueError.
2. APIChain SSRF: Reject None for limit_to_domains in validator.
3. Secret deserialization: Added secrets_from_env_allowlist parameter to Reviver, load(), and loads() to restrict env-var exfiltration.

Related tests pass.
