### PR TITLE
langchain_openai: round-trip reasoning_content for OpenAI-compatible providers (DeepSeek fix)

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -228,6 +228,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
                     )
         if audio := _dict.get("audio"):
             additional_kwargs["audio"] = audio
+        if reasoning_content := _dict.get("reasoning_content"):
+            additional_kwargs["reasoning_content"] = reasoning_content
         return AIMessage(
             content=content,
             additional_kwargs=additional_kwargs,
@@ -405,6 +407,10 @@ def _convert_message_to_dict(
             )
         if audio:
             message_dict["audio"] = audio
+        if "reasoning_content" in message.additional_kwargs:
+            message_dict["reasoning_content"] = message.additional_kwargs[
+                "reasoning_content"
+            ]
     elif isinstance(message, SystemMessage):
         message_dict["role"] = message.additional_kwargs.get(
             "__openai_role__", "system"
@@ -438,6 +444,8 @@ def _convert_delta_to_message_chunk(
         if "name" in function_call and function_call["name"] is None:
             function_call["name"] = ""
         additional_kwargs["function_call"] = function_call
+    if reasoning_content := _dict.get("reasoning_content"):
+        additional_kwargs["reasoning_content"] = reasoning_content
     tool_call_chunks = []
     if raw_tool_calls := _dict.get("tool_calls"):
         try:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -69,6 +69,7 @@ from langchain_openai.chat_models.base import (
     OpenAIRefusalError,
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
+    _convert_delta_to_message_chunk,
     _convert_dict_to_message,
     _convert_message_to_dict,
     _convert_to_openai_response_format,
@@ -3776,3 +3777,112 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: reasoning_content round-trip for OpenAI-compatible providers
+# (e.g. DeepSeek thinking mode)
+#
+# DeepSeek returns `reasoning_content` alongside `content` in assistant
+# messages and requires it to be passed back verbatim on subsequent turns.
+# langchain-openai must preserve it through the full receive → send cycle.
+# Fixes: https://github.com/langchain-ai/langchain/issues/34166
+# ---------------------------------------------------------------------------
+
+DEEPSEEK_REASONING_STREAM_DATA = '{"id":"r1","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":"Let me"},"finish_reason":null}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk","usage":null}\n{"id":"r1","choices":[{"index":0,"delta":{"role":"assistant","content":"","reasoning_content":" think"},"finish_reason":null}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk","usage":null}\n{"id":"r1","choices":[{"index":0,"delta":{"role":"assistant","content":"42","reasoning_content":null},"finish_reason":null}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk","usage":null}\n{"id":"r1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"created":1,"model":"deepseek-chat","object":"chat.completion.chunk","usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}\n[DONE]'  # noqa: E501
+
+
+@pytest.fixture
+def mock_deepseek_reasoning_completion() -> list[dict]:
+    result_list = []
+    for line in DEEPSEEK_REASONING_STREAM_DATA.split("\n"):
+        if line != "[DONE]":
+            result_list.append(json.loads(line))
+    return result_list
+
+
+def test__convert_dict_to_message_ai_with_reasoning_content() -> None:
+    """reasoning_content must be captured into AIMessage.additional_kwargs."""
+    message = {
+        "role": "assistant",
+        "content": "42",
+        "reasoning_content": "Let me think...",
+    }
+    result = _convert_dict_to_message(message)
+    assert isinstance(result, AIMessage)
+    assert result.content == "42"
+    assert result.additional_kwargs.get("reasoning_content") == "Let me think..."
+
+
+def test__convert_message_to_dict_ai_with_reasoning_content() -> None:
+    """reasoning_content stored in additional_kwargs must be re-emitted on send."""
+    ai_msg = AIMessage(
+        content="42",
+        additional_kwargs={"reasoning_content": "Let me think..."},
+    )
+    result = _convert_message_to_dict(ai_msg)
+    assert result["role"] == "assistant"
+    assert result["content"] == "42"
+    assert result.get("reasoning_content") == "Let me think..."
+
+
+def test__convert_dict_to_message_ai_roundtrip_with_reasoning_content() -> None:
+    """Full roundtrip: receive → AIMessage → send must preserve reasoning_content."""
+    incoming = {
+        "role": "assistant",
+        "content": "42",
+        "reasoning_content": "Let me think...",
+    }
+    ai_msg = _convert_dict_to_message(incoming)
+    outgoing = _convert_message_to_dict(ai_msg)
+    assert outgoing.get("reasoning_content") == "Let me think..."
+    assert outgoing["content"] == "42"
+
+
+def test__convert_delta_to_message_chunk_with_reasoning_content() -> None:
+    """reasoning_content in a streaming delta must appear in AIMessageChunk."""
+    delta = {"role": "assistant", "content": "", "reasoning_content": "Let me think"}
+    chunk = _convert_delta_to_message_chunk(delta, AIMessageChunk)
+    assert isinstance(chunk, AIMessageChunk)
+    assert chunk.additional_kwargs.get("reasoning_content") == "Let me think"
+
+
+def test__convert_delta_reasoning_content_accumulates() -> None:
+    """Multiple reasoning_content chunks must concatenate on AIMessageChunk merge."""
+    delta1 = {"role": "assistant", "content": "", "reasoning_content": "Let me"}
+    delta2 = {"role": "assistant", "content": "", "reasoning_content": " think"}
+    delta3 = {"role": "assistant", "content": "42", "reasoning_content": None}
+
+    chunk1 = _convert_delta_to_message_chunk(delta1, AIMessageChunk)
+    chunk2 = _convert_delta_to_message_chunk(delta2, AIMessageChunk)
+    chunk3 = _convert_delta_to_message_chunk(delta3, AIMessageChunk)
+
+    merged = chunk1 + chunk2 + chunk3
+    assert merged.content == "42"
+    assert merged.additional_kwargs.get("reasoning_content") == "Let me think"
+
+
+def test_deepseek_reasoning_stream(
+    mock_deepseek_reasoning_completion: list,
+) -> None:
+    """Stream with reasoning_content: chunks captured, final message has it."""
+    llm = ChatOpenAI(model="deepseek-chat", api_key="fake")
+    mock_client = MagicMock()
+
+    def mock_create(*args: Any, **kwargs: Any) -> MockSyncContextManager:
+        return MockSyncContextManager(mock_deepseek_reasoning_completion)
+
+    mock_client.create = mock_create
+
+    chunks: list[AIMessageChunk] = []
+    with patch.object(llm, "client", mock_client):
+        for chunk in llm.stream("What is 6x7?"):
+            assert isinstance(chunk, AIMessageChunk)
+            chunks.append(chunk)
+
+    final = chunks[0]
+    for c in chunks[1:]:
+        final = final + c
+
+    assert final.content == "42"
+    assert final.additional_kwargs.get("reasoning_content") == "Let me think"


### PR DESCRIPTION
## Summary

Fixes `BadRequestError: 400 - The reasoning_content in the thinking mode must be passed back to the API` when using DeepSeek (or any OpenAI-compatible provider with thinking/reasoning mode) in multi-turn conversations or with tool use via `ChatOpenAI`.

**Root cause:** Three module-level helpers silently drop `reasoning_content`:

| Function | Direction | Problem |
|---|---|---|
| `_convert_dict_to_message` | Receive (non-stream) | `reasoning_content` from API response not captured into `AIMessage.additional_kwargs` |
| `_convert_delta_to_message_chunk` | Receive (stream) | Same — delta field dropped |
| `_convert_message_to_dict` | Send | `reasoning_content` in `additional_kwargs` not re-emitted to next API call |

**Fix:** 3-line changes — capture on receive, re-emit on send.

## Reproduction

```python
from langchain_openai import ChatOpenAI
from langchain_core.tools import tool

@tool
def get_time() -> str:
    """Return current time."""
    return "12:00"

llm = ChatOpenAI(
    model="deepseek-chat",
    base_url="https://api.deepseek.com/",
    api_key="...",
)
llm_with_tools = llm.bind_tools([get_time])

# Turn 1: model returns reasoning_content
r1 = llm_with_tools.invoke("What time is it?")

# Turn 2: passes r1 back → BadRequestError without this fix
llm_with_tools.invoke([..., r1, tool_result])
```

## Tests

Added 6 unit tests covering:
- `_convert_dict_to_message` captures `reasoning_content`
- `_convert_message_to_dict` re-emits `reasoning_content`
- Full receive→send roundtrip
- `_convert_delta_to_message_chunk` captures from streaming delta
- Multiple `reasoning_content` chunks accumulate correctly via `AIMessageChunk.__add__`
- End-to-end stream test with mocked DeepSeek response

## Related issues

Fixes #34166
Related: #35059, #35901, #36400

## Checklist

- [x] Changes are backward-compatible (new field in `additional_kwargs` only written when present)
- [x] Unit tests added and passing
- [x] No changes to public API