### PR TITLE
docs: await async vector store searches

### DIFF
--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -132,7 +132,7 @@ class InMemoryVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud", k=1)
+        # results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)

--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -271,7 +271,7 @@ class Chroma(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)

--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -167,7 +167,7 @@ class QdrantVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)


### PR DESCRIPTION
Fixes #37058

## Summary
- add the missing `await` in the Qdrant async `asimilarity_search` doc example
- apply the same small correction to matching InMemory and Chroma vector store async examples
- normalize the affected examples spacing while touching the lines

## Tests
- `/opt/homebrew/bin/python3.13 -m py_compile libs/partners/qdrant/langchain_qdrant/qdrant.py libs/core/langchain_core/vectorstores/in_memory.py libs/partners/chroma/langchain_chroma/vectorstores.py`
- `git diff --check`
- `git grep -n "# results = vector_store.asimilarity_search"` returns no remaining matches
