### PR TITLE
fix: add Perl separators for Language.PERL in RecursiveCharacterTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -788,6 +788,29 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "",
             ]
 
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "\nsub ",
+                # Split along variable declarations
+                "\nmy ",
+                "\nour ",
+                # Split along control structures
+                "\nif ",
+                "\nforeach ",
+                "\nwhile ",
+                # Split along module declarations
+                "\nuse ",
+                "\npackage ",
+                # Split along end marker
+                "\n__END__",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
+
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"
             raise ValueError(msg)


### PR DESCRIPTION
## Summary

Fixes #37049

`Language.PERL` is listed in the `Language` enum but `get_separators_for_language()` raises `ValueError: Language perl is not implemented yet!` at runtime.

## Changes

Added Perl separator list before the fallback `ValueError`:

```python
if language == Language.PERL:
    return [
        "\nsub ", "\nmy ", "\nour ", "\nif ",
        "\nforeach ", "\nwhile ", "\nuse ",
        "\npackage ", "\n__END__", "\n\n", "\n", " ", "",
    ]
```

Perl block-level keywords: `sub` (subroutines), `my`/`our` (variable scoping), `if`, `foreach`, `while` (control flow), `use` (module imports), `package` (namespace). `__END__` marks end of code.

Closes #37049
