### PR TITLE
chore(core): update delta content blocks

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -37,10 +37,14 @@ import json
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain_protocol.protocol import (
+    BlockDelta,
+    BlockDeltaFields,
     ContentBlock,
+    ContentBlockDelta,
     ContentBlockDeltaData,
     ContentBlockFinishData,
     ContentBlockStartData,
+    DataDelta,
     FinalizedContentBlock,
     InvalidToolCall,
     MessageFinishData,
@@ -48,9 +52,11 @@ from langchain_protocol.protocol import (
     MessagesData,
     MessageStartData,
     ReasoningContentBlock,
+    ReasoningDelta,
     ServerToolCall,
     ServerToolCallChunk,
     TextContentBlock,
+    TextDelta,
     ToolCall,
     ToolCallChunk,
     UsageInfo,
@@ -99,6 +105,32 @@ def _to_protocol_block(block: CompatBlock) -> ContentBlock:
 def _to_finalized_block(block: CompatBlock) -> FinalizedContentBlock:
     """Counterpart of `_to_protocol_block` for finalized blocks."""
     return cast("FinalizedContentBlock", block)
+
+
+def _to_block_delta_fields(block: CompatBlock) -> BlockDeltaFields:
+    """Narrow an internal working dict to protocol block-delta fields."""
+    return cast("BlockDeltaFields", block)
+
+
+def _to_content_delta(block: CompatBlock) -> ContentBlockDelta:
+    """Convert a content-block slice/snapshot to an explicit protocol delta."""
+    btype = block.get("type")
+    if btype == "text":
+        return TextDelta(type="text-delta", text=block.get("text", ""))
+    if btype == "reasoning":
+        return ReasoningDelta(
+            type="reasoning-delta",
+            reasoning=block.get("reasoning", ""),
+        )
+    if "data" in block:
+        delta = DataDelta(type="data-delta", data=block.get("data", ""))
+        if block.get("encoding") == "base64":
+            delta["encoding"] = "base64"
+        return delta
+    return BlockDelta(
+        type="block-delta",
+        fields=_to_block_delta_fields(block),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -236,6 +268,8 @@ def _should_emit_delta(block: CompatBlock) -> bool:
         return bool(
             block.get("args") or block.get("id") or block.get("name"),
         )
+    if "data" in block:
+        return bool(block.get("data"))
     return False
 
 
@@ -281,6 +315,15 @@ def _accumulate(state: CompatBlock | None, delta: CompatBlock) -> CompatBlock:
             state["id"] = delta["id"]
         if delta.get("name") is not None:
             state["name"] = delta["name"]
+    elif btype == dtype and "data" in delta:
+        state["data"] = (state.get("data", "") or "") + (delta.get("data") or "")
+        for key, value in delta.items():
+            if key in ("type", "data") or value is None:
+                continue
+            if key == "extras" and isinstance(value, dict):
+                state["extras"] = {**(state.get("extras") or {}), **value}
+            else:
+                state[key] = value
     else:
         # Self-contained or already-finalized types: replace wholesale.
         state.clear()
@@ -429,11 +472,11 @@ def _to_protocol_usage(usage: dict[str, Any] | None) -> UsageInfo | None:
     """Convert accumulated usage to the protocol's `UsageInfo` shape."""
     if usage is None:
         return None
-    result: UsageInfo = {}
+    result: dict[str, Any] = {}
     for key in ("input_tokens", "output_tokens", "total_tokens", "cached_tokens"):
         if key in usage:
             result[key] = usage[key]
-    return result or None
+    return cast("UsageInfo", result) if result else None
 
 
 # ---------------------------------------------------------------------------
@@ -445,10 +488,10 @@ def _build_message_start(
     msg: BaseMessage,
     message_id: str | None,
 ) -> MessageStartData:
-    start_data = MessageStartData(event="message-start", role="ai")
+    start_data = MessageStartData(event="message-start", role="ai", id="")
     resolved_id = message_id if message_id is not None else getattr(msg, "id", None)
     if resolved_id:
-        start_data["message_id"] = resolved_id
+        start_data["id"] = resolved_id
     start_metadata = _extract_start_metadata(msg.response_metadata or {})
     if start_metadata:
         start_data["metadata"] = start_metadata
@@ -464,13 +507,13 @@ def _build_message_finish(
     # `MessageFinishData`; the provider's raw `finish_reason` /
     # `stop_reason` now rides inside `metadata` alongside other
     # response metadata. Pass it through unchanged.
-    finish_data = MessageFinishData(event="message-finish")
+    finish_data: dict[str, Any] = {"event": "message-finish"}
     usage_info = _to_protocol_usage(usage)
     if usage_info is not None:
         finish_data["usage"] = usage_info
     if response_metadata:
         finish_data["metadata"] = dict(response_metadata)
-    return finish_data
+    return cast("MessageFinishData", finish_data)
 
 
 def _finalize_and_build_finish(
@@ -481,7 +524,7 @@ def _finalize_and_build_finish(
     return ContentBlockFinishData(
         event="content-block-finish",
         index=wire_idx,
-        content_block=_finalize_block(block),
+        content=_finalize_block(block),
     )
 
 
@@ -555,15 +598,20 @@ def chunks_to_events(
                 yield ContentBlockStartData(
                     event="content-block-start",
                     index=open_wire_idx,
-                    content_block=_start_skeleton(block),
+                    content=_start_skeleton(block),
                 )
             else:
                 open_block = _accumulate(open_block, block)
             if _should_emit_delta(block):
+                is_block_delta = block.get("type") in (
+                    "tool_call_chunk",
+                    "server_tool_call_chunk",
+                )
+                delta_source = open_block if is_block_delta else block
                 yield ContentBlockDeltaData(
                     event="content-block-delta",
                     index=open_wire_idx,
-                    content_block=_to_protocol_block(block),
+                    delta=_to_content_delta(delta_source or block),
                 )
 
         if msg.usage_metadata:
@@ -625,15 +673,20 @@ async def achunks_to_events(
                 yield ContentBlockStartData(
                     event="content-block-start",
                     index=open_wire_idx,
-                    content_block=_start_skeleton(block),
+                    content=_start_skeleton(block),
                 )
             else:
                 open_block = _accumulate(open_block, block)
             if _should_emit_delta(block):
+                is_block_delta = block.get("type") in (
+                    "tool_call_chunk",
+                    "server_tool_call_chunk",
+                )
+                delta_source = open_block if is_block_delta else block
                 yield ContentBlockDeltaData(
                     event="content-block-delta",
                     index=open_wire_idx,
-                    content_block=_to_protocol_block(block),
+                    delta=_to_content_delta(delta_source or block),
                 )
 
         if msg.usage_metadata:
@@ -682,18 +735,18 @@ def message_to_events(
         yield ContentBlockStartData(
             event="content-block-start",
             index=wire_idx,
-            content_block=_start_skeleton(block),
+            content=_start_skeleton(block),
         )
         if _should_emit_delta(block):
             yield ContentBlockDeltaData(
                 event="content-block-delta",
                 index=wire_idx,
-                content_block=_to_protocol_block(block),
+                delta=_to_content_delta(block),
             )
         yield ContentBlockFinishData(
             event="content-block-finish",
             index=wire_idx,
-            content_block=_finalize_block(block),
+            content=_finalize_block(block),
         )
 
     yield _build_message_finish(

--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -37,14 +37,10 @@ import json
 from typing import TYPE_CHECKING, Any, cast
 
 from langchain_protocol.protocol import (
-    BlockDelta,
-    BlockDeltaFields,
     ContentBlock,
-    ContentBlockDelta,
     ContentBlockDeltaData,
     ContentBlockFinishData,
     ContentBlockStartData,
-    DataDelta,
     FinalizedContentBlock,
     InvalidToolCall,
     MessageFinishData,
@@ -52,11 +48,9 @@ from langchain_protocol.protocol import (
     MessagesData,
     MessageStartData,
     ReasoningContentBlock,
-    ReasoningDelta,
     ServerToolCall,
     ServerToolCallChunk,
     TextContentBlock,
-    TextDelta,
     ToolCall,
     ToolCallChunk,
     UsageInfo,
@@ -66,6 +60,15 @@ from langchain_core.messages import AIMessageChunk, BaseMessage
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
+
+    from langchain_protocol.protocol import (
+        BlockDelta,
+        BlockDeltaFields,
+        ContentBlockDelta,
+        DataDelta,
+        ReasoningDelta,
+        TextDelta,
+    )
 
     from langchain_core.outputs import ChatGenerationChunk
 
@@ -116,20 +119,26 @@ def _to_content_delta(block: CompatBlock) -> ContentBlockDelta:
     """Convert a content-block slice/snapshot to an explicit protocol delta."""
     btype = block.get("type")
     if btype == "text":
-        return TextDelta(type="text-delta", text=block.get("text", ""))
+        return cast("TextDelta", {"type": "text-delta", "text": block.get("text", "")})
     if btype == "reasoning":
-        return ReasoningDelta(
-            type="reasoning-delta",
-            reasoning=block.get("reasoning", ""),
+        return cast(
+            "ReasoningDelta",
+            {
+                "type": "reasoning-delta",
+                "reasoning": block.get("reasoning", ""),
+            },
         )
     if "data" in block:
-        delta = DataDelta(type="data-delta", data=block.get("data", ""))
+        delta = cast("DataDelta", {"type": "data-delta", "data": block.get("data", "")})
         if block.get("encoding") == "base64":
             delta["encoding"] = "base64"
         return delta
-    return BlockDelta(
-        type="block-delta",
-        fields=_to_block_delta_fields(block),
+    return cast(
+        "BlockDelta",
+        {
+            "type": "block-delta",
+            "fields": _to_block_delta_fields(block),
+        },
     )
 
 

--- a/libs/core/langchain_core/language_models/chat_model_stream.py
+++ b/libs/core/langchain_core/language_models/chat_model_stream.py
@@ -1398,10 +1398,10 @@ class AsyncChatModelStream(_ChatModelStreamBase):
 
     # -- Internal API (extend base to drive async projections) -------------
 
-    def _record_event(self, event: MessagesData) -> None:
+    def _record_event(self, event: Mapping[str, Any]) -> None:
         """Record event and push to async event replay projection."""
         super()._record_event(event)
-        self._events_proj.push(event)
+        self._events_proj.push(cast("MessagesData", event))
 
     def _finish(self, data: MessageFinishData) -> None:
         """Finish base projections and async-only projections."""

--- a/libs/core/langchain_core/language_models/chat_model_stream.py
+++ b/libs/core/langchain_core/language_models/chat_model_stream.py
@@ -575,7 +575,7 @@ class _ChatModelStreamBase:
 
     # -- Event ingestion (public) ------------------------------------------
 
-    def dispatch(self, event: MessagesData) -> None:
+    def dispatch(self, event: Mapping[str, Any]) -> None:
         """Route a protocol event to the appropriate internal handler.
 
         Public entry point for feeding events into the stream. Called by
@@ -598,9 +598,9 @@ class _ChatModelStreamBase:
 
     # -- Internal push API (called by dispatch) ----------------------------
 
-    def _record_event(self, event: MessagesData) -> None:
+    def _record_event(self, event: Mapping[str, Any]) -> None:
         """Append a raw event to the replay buffer."""
-        self._events.append(event)
+        self._events.append(cast("MessagesData", event))
 
     def _push_message_start(self, data: MessageStartData) -> None:
         """Process a `message-start` event."""

--- a/libs/core/langchain_core/language_models/chat_model_stream.py
+++ b/libs/core/langchain_core/language_models/chat_model_stream.py
@@ -24,7 +24,7 @@ from langchain_core.language_models._compat_bridge import finalize_tool_call_chu
 from langchain_core.messages import AIMessage
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Generator, Iterator
+    from collections.abc import Awaitable, Callable, Generator, Iterator, Mapping
 
     from langchain_protocol.protocol import (
         ContentBlockDeltaData,
@@ -63,6 +63,54 @@ def _merge_chunk_into_store(
         existing["name"] = block["name"]
     existing["args"] = existing.get("args", "") + (block.get("args") or "")
     store[idx] = existing
+
+
+def _merge_block_delta_into_store(
+    store: dict[int, dict[str, Any]],
+    idx: int,
+    fields: dict[str, Any],
+) -> None:
+    """Shallow-merge a block-delta snapshot into an indexed chunk store."""
+    existing = store.get(idx, {})
+    for key, value in fields.items():
+        if value is not None:
+            existing[key] = value
+    store[idx] = existing
+
+
+def _event_content_block(data: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Return start/finish content, tolerating the pre-delta field name."""
+    block = data.get("content") or data.get("content_block")
+    return block if isinstance(block, dict) else None
+
+
+def _legacy_block_to_delta(block: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert the old content-block delta shape to an explicit delta."""
+    btype = block.get("type")
+    if btype == "text":
+        return {"type": "text-delta", "text": block.get("text", "")}
+    if btype == "reasoning":
+        return {
+            "type": "reasoning-delta",
+            "reasoning": block.get("reasoning", ""),
+        }
+    if "data" in block:
+        delta = {"type": "data-delta", "data": block.get("data", "")}
+        if block.get("encoding") == "base64":
+            delta["encoding"] = "base64"
+        return delta
+    return {"type": "legacy-block-delta", "fields": block}
+
+
+def _event_delta(data: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Return an explicit delta, converting legacy content-block deltas."""
+    delta = data.get("delta")
+    if isinstance(delta, dict):
+        return delta
+    block = data.get("content_block")
+    if isinstance(block, dict):
+        return _legacy_block_to_delta(block)
+    return None
 
 
 def _sweep_chunk_store(
@@ -557,18 +605,20 @@ class _ChatModelStreamBase:
     def _push_message_start(self, data: MessageStartData) -> None:
         """Process a `message-start` event."""
         self._start_metadata = data.get("metadata")
+        message_id = data.get("id")
+        if message_id:
+            self._message_id = message_id
 
     def _push_content_block_delta(self, data: ContentBlockDeltaData) -> None:
         """Process a `content-block-delta` event."""
-        block = data.get("content_block")
-        if block is None:
+        delta = _event_delta(data)
+        if delta is None:
             return
-        btype = block.get("type", "")
         event_idx = data.get("index")
+        dtype = delta.get("type", "")
 
-        if btype == "text":
-            text_block = cast("TextContentBlock", block)
-            delta_text = text_block.get("text", "")
+        if dtype == "text-delta":
+            delta_text = delta.get("text", "")
             if delta_text:
                 self._text_acc += delta_text
                 if event_idx is not None:
@@ -576,9 +626,8 @@ class _ChatModelStreamBase:
                         self._text_per_block.get(event_idx, "") + delta_text
                     )
                 self._text_proj.push(delta_text)
-        elif btype == "reasoning":
-            reasoning_block = cast("ReasoningContentBlock", block)
-            delta_r = reasoning_block.get("reasoning", "")
+        elif dtype == "reasoning-delta":
+            delta_r = delta.get("reasoning", "")
             if delta_r:
                 self._reasoning_acc += delta_r
                 if event_idx is not None:
@@ -586,35 +635,94 @@ class _ChatModelStreamBase:
                         self._reasoning_per_block.get(event_idx, "") + delta_r
                     )
                 self._reasoning_proj.push(delta_r)
-        elif btype == "tool_call_chunk":
+        elif dtype == "block-delta":
+            fields = delta.get("fields")
+            if not isinstance(fields, dict):
+                return
+            btype = fields.get("type", "")
+            if btype == "tool_call_chunk":
+                tcc = cast("ToolCallChunk", fields)
+                idx = data.get("index")
+                if idx is None:
+                    idx = tcc.get("index", len(self._tool_call_chunks))
+                _merge_block_delta_into_store(self._tool_call_chunks, idx, dict(tcc))
+                chunk_block: ToolCallChunk = {
+                    "type": "tool_call_chunk",
+                    "id": tcc.get("id"),
+                    "name": tcc.get("name"),
+                    "args": tcc.get("args"),
+                }
+                if "index" in tcc:
+                    chunk_block["index"] = tcc["index"]
+                self._tool_calls_proj.push(chunk_block)
+            elif btype == "server_tool_call_chunk":
+                stcc = cast("ServerToolCallChunk", fields)
+                idx = data.get("index")
+                if idx is None:
+                    idx = len(self._server_tool_call_chunks)
+                _merge_block_delta_into_store(
+                    self._server_tool_call_chunks,
+                    idx,
+                    dict(stcc),
+                )
+        elif dtype == "legacy-block-delta":
+            fields = delta.get("fields")
+            if not isinstance(fields, dict):
+                return
+            btype = fields.get("type", "")
+            if btype == "tool_call_chunk":
+                tcc = cast("ToolCallChunk", fields)
+                idx = data.get("index")
+                if idx is None:
+                    idx = tcc.get("index", len(self._tool_call_chunks))
+                _merge_chunk_into_store(self._tool_call_chunks, idx, dict(tcc))
+                legacy_chunk_block: ToolCallChunk = {
+                    "type": "tool_call_chunk",
+                    "id": tcc.get("id"),
+                    "name": tcc.get("name"),
+                    "args": tcc.get("args"),
+                }
+                if "index" in tcc:
+                    legacy_chunk_block["index"] = tcc["index"]
+                self._tool_calls_proj.push(legacy_chunk_block)
+            elif btype == "server_tool_call_chunk":
+                stcc = cast("ServerToolCallChunk", fields)
+                idx = data.get("index")
+                if idx is None:
+                    idx = len(self._server_tool_call_chunks)
+                _merge_chunk_into_store(
+                    self._server_tool_call_chunks,
+                    idx,
+                    dict(stcc),
+                )
+        elif dtype == "data-delta":
+            # Binary/modal payload deltas are reflected in the final
+            # content-block finish event; there is no dedicated projection.
+            return
+        else:
+            # Transitional legacy path for old `content_block` deltas that
+            # should not be reachable after `_event_delta` conversion, kept
+            # here for custom in-tree test fixtures or third-party emitters.
+            block = data.get("content_block")
+            if not isinstance(block, dict):
+                return
+            btype = block.get("type", "")
+            if btype != "tool_call_chunk":
+                return
             tcc = cast("ToolCallChunk", block)
-            # The protocol puts the block index on the event
-            # (`ContentBlockDeltaData`), not inside `content_block`.
-            # Fall back to `content_block.index` for providers that echo
-            # it there.
             idx = data.get("index")
             if idx is None:
                 idx = tcc.get("index", len(self._tool_call_chunks))
             _merge_chunk_into_store(self._tool_call_chunks, idx, dict(tcc))
-            chunk_block: ToolCallChunk = {
+            fallback_chunk_block: ToolCallChunk = {
                 "type": "tool_call_chunk",
                 "id": tcc.get("id"),
                 "name": tcc.get("name"),
                 "args": tcc.get("args"),
             }
             if "index" in tcc:
-                chunk_block["index"] = tcc["index"]
-            self._tool_calls_proj.push(chunk_block)
-        elif btype == "server_tool_call_chunk":
-            stcc = cast("ServerToolCallChunk", block)
-            idx = data.get("index")
-            if idx is None:
-                idx = len(self._server_tool_call_chunks)
-            _merge_chunk_into_store(
-                self._server_tool_call_chunks,
-                idx,
-                dict(stcc),
-            )
+                fallback_chunk_block["index"] = tcc["index"]
+            self._tool_calls_proj.push(fallback_chunk_block)
 
     def _resolve_block_text(self, idx: int | None, full_text: str) -> str:
         """Return authoritative text for a single text block at `idx`.
@@ -681,7 +789,7 @@ class _ChatModelStreamBase:
 
     def _push_content_block_finish(self, data: ContentBlockFinishData) -> None:
         """Process a `content-block-finish` event."""
-        block = data.get("content_block")
+        block = _event_content_block(data)
         if block is None:
             return
         btype = block.get("type", "")
@@ -764,7 +872,7 @@ class _ChatModelStreamBase:
         ):
             if btype == "server_tool_call" and idx is not None:
                 self._server_tool_call_chunks.pop(idx, None)
-            finalized = block
+            finalized = cast("FinalizedContentBlock", block)
 
         if finalized is not None and idx is not None:
             # Backfill the wire index onto the finalized block when the
@@ -785,7 +893,7 @@ class _ChatModelStreamBase:
         """Process a `message-finish` event."""
         self._done = True
         self._usage_value = data.get("usage")
-        self._finish_metadata = data.get("metadata")
+        self._finish_metadata = cast("dict[str, Any] | None", data.get("metadata"))
 
         # Finalize any unswept chunks — both client- and server-side.
         _sweep_chunk_store(

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "packaging>=23.2.0",
     "pydantic>=2.7.4,<3.0.0",
     "uuid-utils>=0.12.0,<1.0",
-    "langchain-protocol>=0.0.10",
+    "langchain-protocol>=0.0.14",
 ]
 
 [project.urls]
@@ -82,7 +82,6 @@ test_integration = []
 constraint-dependencies = ["pygments>=2.20.0"]  # CVE-2026-4539
 
 [tool.uv.sources]
-langchain-protocol = { git = "https://github.com/langchain-ai/agent-protocol", branch = "cb/chat-model-delta", subdirectory = "streaming/py" }
 langchain-tests = { path = "../standard-tests" }
 langchain-text-splitters = { path = "../text-splitters" }
 

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -82,6 +82,7 @@ test_integration = []
 constraint-dependencies = ["pygments>=2.20.0"]  # CVE-2026-4539
 
 [tool.uv.sources]
+langchain-protocol = { git = "https://github.com/langchain-ai/agent-protocol", branch = "cb/chat-model-delta", subdirectory = "streaming/py" }
 langchain-tests = { path = "../standard-tests" }
 langchain-text-splitters = { path = "../text-splitters" }
 

--- a/libs/core/tests/unit_tests/language_models/test_chat_model_stream.py
+++ b/libs/core/tests/unit_tests/language_models/test_chat_model_stream.py
@@ -16,7 +16,7 @@ from langchain_core.language_models.chat_model_stream import (
 )
 
 if TYPE_CHECKING:
-    from langchain_protocol.protocol import ContentBlockFinishData, MessagesData
+    from langchain_protocol.protocol import ContentBlockFinishData
 
 # ---------------------------------------------------------------------------
 # Projection unit tests
@@ -244,7 +244,7 @@ class TestAsyncProjection:
         """Concurrent `stream.text` + `await stream.output` both drive the pump."""
         stream = AsyncChatModelStream(message_id="m1")
 
-        events: list[MessagesData] = [
+        events: list[dict[str, Any]] = [
             {
                 "event": "message-start",
                 "role": "ai",
@@ -313,7 +313,7 @@ class TestChatModelStream:
 
     def test_text_deltas_via_pump(self) -> None:
         stream = ChatModelStream()
-        events: list[MessagesData] = [
+        events: list[dict[str, Any]] = [
             {"event": "message-start", "role": "ai"},
             {
                 "event": "content-block-delta",
@@ -363,7 +363,7 @@ class TestChatModelStream:
             }
         )
         stream.dispatch(
-            {  # type: ignore[arg-type,misc]
+            {
                 "event": "content-block-delta",
                 "index": 0,
                 "content_block": {

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
         InvalidToolCall,
         MessageFinishData,
         MessageStartData,
-        ReasoningContentBlock,
         ServerToolCall,
         TextContentBlock,
         ToolCall,
@@ -199,12 +198,12 @@ def test_chunks_to_events_block_transitions_close_previous_block() -> None:
 
     starts: list[Any] = [e for e in events if e["event"] == "content-block-start"]
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    assert [s["content_block"]["type"] for s in starts] == [
+    assert [s["content"]["type"] for s in starts] == [
         "reasoning",
         "reasoning",
         "text",
     ]
-    assert [f["content_block"]["type"] for f in finishes] == [
+    assert [f["content"]["type"] for f in finishes] == [
         "reasoning",
         "reasoning",
         "text",
@@ -231,9 +230,9 @@ def test_chunks_to_events_block_transitions_close_previous_block() -> None:
     ]
 
     # Each finish carries the accumulated content for its block.
-    assert finishes[0]["content_block"]["reasoning"] == "hmm then"
-    assert finishes[1]["content_block"]["reasoning"] == "different"
-    assert finishes[2]["content_block"]["text"] == "answer: 42"
+    assert finishes[0]["content"]["reasoning"] == "hmm then"
+    assert finishes[1]["content"]["reasoning"] == "different"
+    assert finishes[2]["content"]["text"] == "answer: 42"
 
 
 def test_chunks_to_events_tool_call_multichunk() -> None:
@@ -284,7 +283,7 @@ def test_chunks_to_events_tool_call_multichunk() -> None:
         e for e in events if e["event"] == "content-block-finish"
     ]
     assert len(finish_events) == 1
-    finalized = cast("ToolCall", finish_events[0]["content_block"])
+    finalized = cast("ToolCall", finish_events[0]["content"])
     assert finalized["type"] == "tool_call"
     assert finalized["args"] == {"q": "test"}
 
@@ -323,7 +322,7 @@ def test_chunks_to_events_invalid_tool_call_keeps_stop_reason() -> None:
         e for e in events if e["event"] == "content-block-finish"
     ]
     assert len(finish_events) == 1
-    assert finish_events[0]["content_block"]["type"] == "invalid_tool_call"
+    assert finish_events[0]["content"]["type"] == "invalid_tool_call"
     assert "finish_reason" not in (
         cast("MessageFinishData", events[-1]).get("metadata") or {}
     )
@@ -350,7 +349,7 @@ def test_chunks_to_events_anthropic_server_tool_use_routes_through_translator() 
 
     events = list(chunks_to_events(iter(chunks)))
     finish_blocks: list[Any] = [
-        e["content_block"] for e in events if e["event"] == "content-block-finish"
+        e["content"] for e in events if e["event"] == "content-block-finish"
     ]
     block_types = [b.get("type") for b in finish_blocks]
     assert "server_tool_call" in block_types
@@ -372,7 +371,7 @@ def test_chunks_to_events_unregistered_provider_falls_back() -> None:
     finish_events: list[Any] = [
         e for e in events if e["event"] == "content-block-finish"
     ]
-    assert [e["content_block"]["type"] for e in finish_events] == ["text"]
+    assert [e["content"]["type"] for e in finish_events] == ["text"]
 
 
 def test_chunks_to_events_no_provider_text_plus_tool_call() -> None:
@@ -402,7 +401,7 @@ def test_chunks_to_events_no_provider_text_plus_tool_call() -> None:
 
     events = list(chunks_to_events(iter(chunks)))
     finish_blocks: list[Any] = [
-        e["content_block"] for e in events if e["event"] == "content-block-finish"
+        e["content"] for e in events if e["event"] == "content-block-finish"
     ]
     types = [b.get("type") for b in finish_blocks]
     assert "text" in types
@@ -423,7 +422,7 @@ def test_chunks_to_events_reasoning_in_additional_kwargs() -> None:
 
     events = list(chunks_to_events(iter(chunks)))
     finish_blocks: list[Any] = [
-        e["content_block"] for e in events if e["event"] == "content-block-finish"
+        e["content"] for e in events if e["event"] == "content-block-finish"
     ]
     types = [b.get("type") for b in finish_blocks]
     assert "reasoning" in types
@@ -448,11 +447,10 @@ def test_message_to_events_text_only() -> None:
         "message-finish",
     ]
     start = cast("MessageStartData", events[0])
-    assert start["message_id"] == "msg-1"
+    assert start["id"] == "msg-1"
 
     delta_event = cast("ContentBlockDeltaData", events[2])
-    delta = cast("TextContentBlock", delta_event["content_block"])
-    assert delta["text"] == "Hello world"
+    assert delta_event["delta"] == {"type": "text-delta", "text": "Hello world"}
 
     final = cast("MessageFinishData", events[-1])
     assert "finish_reason" not in (final.get("metadata") or {})
@@ -477,15 +475,16 @@ def test_message_to_events_reasoning_text_order() -> None:
 
     starts: list[Any] = [e for e in events if e["event"] == "content-block-start"]
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    assert [s["content_block"]["type"] for s in starts] == ["reasoning", "text"]
-    assert [f["content_block"]["type"] for f in finishes] == ["reasoning", "text"]
+    assert [s["content"]["type"] for s in starts] == ["reasoning", "text"]
+    assert [f["content"]["type"] for f in finishes] == ["reasoning", "text"]
 
     deltas: list[Any] = [e for e in events if e["event"] == "content-block-delta"]
     assert len(deltas) == 2
-    assert cast("ReasoningContentBlock", deltas[0]["content_block"])["reasoning"] == (
-        "think hard"
-    )
-    assert cast("TextContentBlock", deltas[1]["content_block"])["text"] == "the answer"
+    assert deltas[0]["delta"] == {
+        "type": "reasoning-delta",
+        "reasoning": "think hard",
+    }
+    assert deltas[1]["delta"] == {"type": "text-delta", "text": "the answer"}
 
 
 def test_message_to_events_tool_call_skips_delta() -> None:
@@ -505,7 +504,7 @@ def test_message_to_events_tool_call_skips_delta() -> None:
 
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
     assert len(finishes) == 1
-    tc = cast("ToolCall", finishes[0]["content_block"])
+    tc = cast("ToolCall", finishes[0]["content"])
     assert tc["type"] == "tool_call"
     assert tc["args"] == {"q": "hi"}
 
@@ -536,7 +535,7 @@ def test_message_to_events_invalid_tool_calls_surfaced_from_field() -> None:
     )
     events = list(message_to_events(msg))
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    types = [f["content_block"]["type"] for f in finishes]
+    types = [f["content"]["type"] for f in finishes]
     assert "invalid_tool_call" in types
 
 
@@ -585,7 +584,7 @@ def test_message_to_events_message_id_override() -> None:
     msg = AIMessage(content="x", id="msg-orig")
     events = list(message_to_events(msg, message_id="msg-override"))
     start = cast("MessageStartData", events[0])
-    assert start["message_id"] == "msg-override"
+    assert start["id"] == "msg-override"
 
 
 def test_message_to_events_self_contained_start_strips_heavy_fields() -> None:
@@ -622,32 +621,32 @@ def test_message_to_events_self_contained_start_strips_heavy_fields() -> None:
     events = list(message_to_events(msg))
 
     starts: list[Any] = [e for e in events if e["event"] == "content-block-start"]
-    assert [s["content_block"]["type"] for s in starts] == [
+    assert [s["content"]["type"] for s in starts] == [
         "image",
         "audio",
         "non_standard",
     ]
 
-    image_start = starts[0]["content_block"]
+    image_start = starts[0]["content"]
     assert image_start["id"] == "img-1"
     assert image_start["mime_type"] == "image/png"
     assert "data" not in image_start
 
-    audio_start = starts[1]["content_block"]
+    audio_start = starts[1]["content"]
     assert audio_start["id"] == "aud-1"
     assert audio_start["mime_type"] == "audio/mp3"
     assert "data" not in audio_start
     assert "transcript" not in audio_start
 
-    ns_start = starts[2]["content_block"]
+    ns_start = starts[2]["content"]
     assert ns_start["type"] == "non_standard"
     assert ns_start["value"] == {}
 
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    assert finishes[0]["content_block"]["data"] == "A" * 1024
-    assert finishes[1]["content_block"]["data"] == "B" * 1024
-    assert finishes[1]["content_block"]["transcript"] == "hello"
-    assert finishes[2]["content_block"]["value"] == {"big": "C" * 1024}
+    assert finishes[0]["content"]["data"] == "A" * 1024
+    assert finishes[1]["content"]["data"] == "B" * 1024
+    assert finishes[1]["content"]["transcript"] == "hello"
+    assert finishes[2]["content"]["value"] == {"big": "C" * 1024}
 
 
 def test_message_to_events_finalized_tool_call_start_strips_args() -> None:
@@ -668,14 +667,14 @@ def test_message_to_events_finalized_tool_call_start_strips_args() -> None:
 
     starts: list[Any] = [e for e in events if e["event"] == "content-block-start"]
     assert len(starts) == 1
-    tc_start = starts[0]["content_block"]
+    tc_start = starts[0]["content"]
     assert tc_start["type"] == "tool_call"
     assert tc_start["id"] == "tc1"
     assert tc_start["name"] == "search"
     assert tc_start["args"] == {}
 
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    tc_finish = cast("ToolCall", finishes[0]["content_block"])
+    tc_finish = cast("ToolCall", finishes[0]["content"])
     assert tc_finish["args"] == {"q": "big payload " * 100}
 
 
@@ -756,10 +755,10 @@ def test_lifecycle_validator_openai_chat_completions_style() -> None:
     assert_valid_event_stream(events)
 
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    types = [f["content_block"]["type"] for f in finishes]
+    types = [f["content"]["type"] for f in finishes]
     assert types == ["text", "tool_call"]
-    assert finishes[0]["content_block"]["text"] == "Hello there"
-    assert finishes[1]["content_block"]["args"] == {"q": "pie"}
+    assert finishes[0]["content"]["text"] == "Hello there"
+    assert finishes[1]["content"]["args"] == {"q": "pie"}
 
 
 def test_lifecycle_validator_openai_responses_style() -> None:
@@ -783,7 +782,7 @@ def test_lifecycle_validator_openai_responses_style() -> None:
     starts: list[Any] = [e for e in events if e["event"] == "content-block-start"]
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
     # Four distinct blocks: reasoning, text, reasoning, text
-    assert [s["content_block"]["type"] for s in starts] == [
+    assert [s["content"]["type"] for s in starts] == [
         "reasoning",
         "text",
         "reasoning",
@@ -791,10 +790,10 @@ def test_lifecycle_validator_openai_responses_style() -> None:
     ]
     assert [s["index"] for s in starts] == [0, 1, 2, 3]
     assert [f["index"] for f in finishes] == [0, 1, 2, 3]
-    assert finishes[0]["content_block"]["reasoning"] == "hmm first"
-    assert finishes[1]["content_block"]["text"] == "Answer: 42"
-    assert finishes[2]["content_block"]["reasoning"] == "actually"
-    assert finishes[3]["content_block"]["text"] == "42!"
+    assert finishes[0]["content"]["reasoning"] == "hmm first"
+    assert finishes[1]["content"]["text"] == "Answer: 42"
+    assert finishes[2]["content"]["reasoning"] == "actually"
+    assert finishes[3]["content"]["text"] == "42!"
 
 
 def test_lifecycle_validator_anthropic_style_text_and_thinking() -> None:
@@ -815,9 +814,9 @@ def test_lifecycle_validator_anthropic_style_text_and_thinking() -> None:
     assert_valid_event_stream(events)
 
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    assert [f["content_block"]["type"] for f in finishes] == ["reasoning", "text"]
-    assert finishes[0]["content_block"]["reasoning"] == "Let me think more"
-    assert finishes[1]["content_block"]["text"] == "The answer is 42."
+    assert [f["content"]["type"] for f in finishes] == ["reasoning", "text"]
+    assert finishes[0]["content"]["reasoning"] == "Let me think more"
+    assert finishes[1]["content"]["text"] == "The answer is 42."
 
 
 def test_lifecycle_validator_anthropic_reasoning_preserves_signature() -> None:
@@ -853,7 +852,7 @@ def test_lifecycle_validator_anthropic_reasoning_preserves_signature() -> None:
     assert_valid_event_stream(events)
 
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    reasoning_finish = finishes[0]["content_block"]
+    reasoning_finish = finishes[0]["content"]
     assert reasoning_finish["type"] == "reasoning"
     assert reasoning_finish["reasoning"] == "Let me think more"
     assert reasoning_finish.get("extras", {}).get("signature") == "sig-abc123"
@@ -899,9 +898,9 @@ def test_lifecycle_validator_anthropic_style_tool_use_after_text() -> None:
     assert_valid_event_stream(events)
 
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    assert [f["content_block"]["type"] for f in finishes] == ["text", "tool_call"]
-    assert finishes[1]["content_block"]["args"] == {"query": "42"}
-    assert finishes[1]["content_block"]["id"] == "toolu_1"
+    assert [f["content"]["type"] for f in finishes] == ["text", "tool_call"]
+    assert finishes[1]["content"]["args"] == {"query": "42"}
+    assert finishes[1]["content"]["id"] == "toolu_1"
 
 
 def test_lifecycle_validator_inline_image_block() -> None:
@@ -925,11 +924,17 @@ def test_lifecycle_validator_inline_image_block() -> None:
     starts: list[Any] = [e for e in events if e["event"] == "content-block-start"]
     deltas: list[Any] = [e for e in events if e["event"] == "content-block-delta"]
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
-    assert [s["content_block"]["type"] for s in starts] == ["image"]
-    # Self-contained block: no delta, and start has heavy fields stripped.
-    assert deltas == []
-    assert "data" not in starts[0]["content_block"]
-    assert finishes[0]["content_block"]["data"] == "AAAA"
+    assert [s["content"]["type"] for s in starts] == ["image"]
+    # Data payload rides as an explicit data-delta; start has heavy fields stripped.
+    assert deltas == [
+        {
+            "event": "content-block-delta",
+            "index": 0,
+            "delta": {"type": "data-delta", "data": "AAAA"},
+        }
+    ]
+    assert "data" not in starts[0]["content"]
+    assert finishes[0]["content"]["data"] == "AAAA"
 
 
 def test_lifecycle_validator_invalid_tool_call_args() -> None:
@@ -956,7 +961,7 @@ def test_lifecycle_validator_invalid_tool_call_args() -> None:
 
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
     assert len(finishes) == 1
-    assert finishes[0]["content_block"]["type"] == "invalid_tool_call"
+    assert finishes[0]["content"]["type"] == "invalid_tool_call"
 
 
 def test_lifecycle_validator_empty_stream() -> None:

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -28,6 +28,11 @@ if TYPE_CHECKING:
     )
 
 
+def _event_metadata(event: Any) -> dict[str, Any]:
+    """Return event metadata for protocol versions that type it as extensible."""
+    return cast("dict[str, Any]", cast("dict[str, Any]", event).get("metadata") or {})
+
+
 # ---------------------------------------------------------------------------
 # Pure helpers
 # ---------------------------------------------------------------------------
@@ -134,7 +139,7 @@ def test_chunks_to_events_text_only() -> None:
     # No provider finish_reason in fixtures — metadata carries no
     # `finish_reason` key (the bridge passes response_metadata through
     # unchanged).
-    assert "finish_reason" not in (finish.get("metadata") or {})
+    assert "finish_reason" not in _event_metadata(finish)
 
 
 def test_chunks_to_events_empty_iterator() -> None:
@@ -291,9 +296,7 @@ def test_chunks_to_events_tool_call_multichunk() -> None:
     # not synthesize one. It deliberately does not infer `"tool_use"`
     # from the presence of a valid tool_call either; terminal reasons
     # are provider-specific (see `_build_message_finish`).
-    assert "finish_reason" not in (
-        cast("MessageFinishData", events[-1]).get("metadata") or {}
-    )
+    assert "finish_reason" not in _event_metadata(events[-1])
 
 
 def test_chunks_to_events_invalid_tool_call_keeps_stop_reason() -> None:
@@ -323,9 +326,7 @@ def test_chunks_to_events_invalid_tool_call_keeps_stop_reason() -> None:
     ]
     assert len(finish_events) == 1
     assert finish_events[0]["content"]["type"] == "invalid_tool_call"
-    assert "finish_reason" not in (
-        cast("MessageFinishData", events[-1]).get("metadata") or {}
-    )
+    assert "finish_reason" not in _event_metadata(events[-1])
 
 
 def test_chunks_to_events_anthropic_server_tool_use_routes_through_translator() -> None:
@@ -453,7 +454,7 @@ def test_message_to_events_text_only() -> None:
     assert delta_event["delta"] == {"type": "text-delta", "text": "Hello world"}
 
     final = cast("MessageFinishData", events[-1])
-    assert "finish_reason" not in (final.get("metadata") or {})
+    assert "finish_reason" not in _event_metadata(final)
 
 
 def test_message_to_events_empty_content_yields_start_finish_only() -> None:
@@ -512,7 +513,7 @@ def test_message_to_events_tool_call_skips_delta() -> None:
     # bridge does not synthesize one and does not second-guess based on
     # the presence of a tool_call.
     final = cast("MessageFinishData", events[-1])
-    assert "finish_reason" not in (final.get("metadata") or {})
+    assert "finish_reason" not in _event_metadata(final)
 
 
 def test_message_to_events_invalid_tool_calls_surfaced_from_field() -> None:
@@ -557,7 +558,7 @@ def test_message_to_events_preserves_finish_reason_and_metadata() -> None:
     # Passthrough: response_metadata lands on `metadata` unchanged,
     # including the raw provider `finish_reason`.
     final = cast("MessageFinishData", events[-1])
-    assert final["metadata"] == {
+    assert _event_metadata(final) == {
         "finish_reason": "length",
         "model_name": "test-model",
         "stop_sequence": "</end>",

--- a/libs/core/tests/unit_tests/language_models/test_stream_v2.py
+++ b/libs/core/tests/unit_tests/language_models/test_stream_v2.py
@@ -133,7 +133,7 @@ class TestChatModelStream:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=TextContentBlock(type="text", text="Hello"),
+                delta={"type": "text-delta", "text": "Hello"},
             )
         )
         assert stream._text_acc == "Hello"
@@ -144,9 +144,7 @@ class TestChatModelStream:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=ReasoningContentBlock(
-                    type="reasoning", reasoning="think"
-                ),
+                delta={"type": "reasoning-delta", "reasoning": "think"},
             )
         )
         assert stream._reasoning_acc == "think"
@@ -157,7 +155,7 @@ class TestChatModelStream:
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=0,
-                content_block=ToolCall(
+                content=ToolCall(
                     type="tool_call",
                     id="tc1",
                     name="search",
@@ -188,12 +186,12 @@ class TestChatModelStream:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=TextContentBlock(type="text", text="Hi"),
+                delta={"type": "text-delta", "text": "Hi"},
             ),
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=TextContentBlock(type="text", text=" there"),
+                delta={"type": "text-delta", "text": " there"},
             ),
         ]
         finish = MessageFinishData(event="message-finish")
@@ -228,14 +226,14 @@ class TestAsyncChatModelStream:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=TextContentBlock(type="text", text="Hello"),
+                delta={"type": "text-delta", "text": "Hello"},
             )
         )
         stream._push_content_block_delta(
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=TextContentBlock(type="text", text=" world"),
+                delta={"type": "text-delta", "text": " world"},
             )
         )
         stream._finish(MessageFinishData(event="message-finish"))
@@ -253,7 +251,7 @@ class TestAsyncChatModelStream:
                 ContentBlockDeltaData(
                     event="content-block-delta",
                     index=0,
-                    content_block=TextContentBlock(type="text", text="a"),
+                    delta={"type": "text-delta", "text": "a"},
                 )
             )
             await asyncio.sleep(0)
@@ -261,7 +259,7 @@ class TestAsyncChatModelStream:
                 ContentBlockDeltaData(
                     event="content-block-delta",
                     index=0,
-                    content_block=TextContentBlock(type="text", text="b"),
+                    delta={"type": "text-delta", "text": "b"},
                 )
             )
             await asyncio.sleep(0)
@@ -279,7 +277,7 @@ class TestAsyncChatModelStream:
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=0,
-                content_block=ToolCall(
+                content=ToolCall(
                     type="tool_call",
                     id="tc1",
                     name="search",
@@ -575,9 +573,7 @@ class TestPerBlockAccumulation:
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=0,
-                content_block=ReasoningContentBlock(
-                    type="reasoning", reasoning="thinking"
-                ),
+                content=ReasoningContentBlock(type="reasoning", reasoning="thinking"),
             )
         )
         stream.dispatch(MessageFinishData(event="message-finish"))

--- a/libs/core/tests/unit_tests/language_models/test_stream_v2.py
+++ b/libs/core/tests/unit_tests/language_models/test_stream_v2.py
@@ -389,14 +389,14 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=TextContentBlock(type="text", text="A"),
+                delta={"type": "text-delta", "text": "A"},
             )
         )
         stream.dispatch(
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=0,
-                content_block=TextContentBlock(type="text", text="A"),
+                content=TextContentBlock(type="text", text="A"),
             )
         )
         # Block 1: "B"
@@ -404,14 +404,14 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=1,
-                content_block=TextContentBlock(type="text", text="B"),
+                delta={"type": "text-delta", "text": "B"},
             )
         )
         stream.dispatch(
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=1,
-                content_block=TextContentBlock(type="text", text="B"),
+                content=TextContentBlock(type="text", text="B"),
             )
         )
         stream.dispatch(MessageFinishData(event="message-finish"))
@@ -435,14 +435,14 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=ReasoningContentBlock(type="reasoning", reasoning="one"),
+                delta={"type": "reasoning-delta", "reasoning": "one"},
             )
         )
         stream.dispatch(
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=0,
-                content_block=ReasoningContentBlock(type="reasoning", reasoning="one"),
+                content=ReasoningContentBlock(type="reasoning", reasoning="one"),
             )
         )
         # Block 1: "two"
@@ -450,14 +450,14 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=1,
-                content_block=ReasoningContentBlock(type="reasoning", reasoning="two"),
+                delta={"type": "reasoning-delta", "reasoning": "two"},
             )
         )
         stream.dispatch(
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=1,
-                content_block=ReasoningContentBlock(type="reasoning", reasoning="two"),
+                content=ReasoningContentBlock(type="reasoning", reasoning="two"),
             )
         )
         stream.dispatch(MessageFinishData(event="message-finish"))
@@ -482,14 +482,14 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=TextContentBlock(type="text", text="hel"),
+                delta={"type": "text-delta", "text": "hel"},
             )
         )
         stream.dispatch(
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=0,
-                content_block=TextContentBlock(type="text", text="hello"),
+                content=TextContentBlock(type="text", text="hello"),
             )
         )
         stream.dispatch(MessageFinishData(event="message-finish"))
@@ -520,7 +520,7 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=TextContentBlock(type="text", text="aaa"),
+                delta={"type": "text-delta", "text": "aaa"},
             )
         )
         # Block 1 streams deltas before block 0 finishes.
@@ -528,7 +528,7 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=1,
-                content_block=TextContentBlock(type="text", text="bb"),
+                delta={"type": "text-delta", "text": "bb"},
             )
         )
         # Block 0 finishes with authoritative text different from deltas.
@@ -536,14 +536,14 @@ class TestPerBlockAccumulation:
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=0,
-                content_block=TextContentBlock(type="text", text="XXX"),
+                content=TextContentBlock(type="text", text="XXX"),
             )
         )
         stream.dispatch(
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=1,
-                content_block=TextContentBlock(type="text", text="bb"),
+                content=TextContentBlock(type="text", text="bb"),
             )
         )
         stream.dispatch(MessageFinishData(event="message-finish"))
@@ -566,7 +566,7 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=ReasoningContentBlock(type="reasoning", reasoning="thi"),
+                delta={"type": "reasoning-delta", "reasoning": "thi"},
             )
         )
         stream.dispatch(
@@ -594,14 +594,14 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=0,
-                content_block=TextContentBlock(type="text", text="before"),
+                delta={"type": "text-delta", "text": "before"},
             )
         )
         stream.dispatch(
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=0,
-                content_block=TextContentBlock(type="text", text="before"),
+                content=TextContentBlock(type="text", text="before"),
             )
         )
         # Block 1: tool_call
@@ -609,7 +609,7 @@ class TestPerBlockAccumulation:
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=1,
-                content_block=ToolCall(
+                content=ToolCall(
                     type="tool_call",
                     id="tc1",
                     name="search",
@@ -622,14 +622,14 @@ class TestPerBlockAccumulation:
             ContentBlockDeltaData(
                 event="content-block-delta",
                 index=2,
-                content_block=TextContentBlock(type="text", text="after"),
+                delta={"type": "text-delta", "text": "after"},
             )
         )
         stream.dispatch(
             ContentBlockFinishData(
                 event="content-block-finish",
                 index=2,
-                content_block=TextContentBlock(type="text", text="after"),
+                content=TextContentBlock(type="text", text="after"),
             )
         )
         stream.dispatch(MessageFinishData(event="message-finish"))

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1046,7 +1046,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -1091,10 +1091,14 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.13"
-source = { git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta#ad89e84bf8db5519aed7d11c069d73e29e29e199" }
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1046,7 +1046,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -1091,19 +1091,15 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
-source = { registry = "https://pypi.org/simple" }
+version = "0.0.13"
+source = { git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta#ad89e84bf8db5519aed7d11c069d73e29e29e199" }
 dependencies = [
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { directory = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2618,7 +2618,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -2849,19 +2849,19 @@ wheels = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2225,7 +2225,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -2456,19 +2456,19 @@ wheels = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/model-profiles/uv.lock
+++ b/libs/model-profiles/uv.lock
@@ -549,7 +549,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -712,14 +712,14 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -69,6 +69,7 @@ typing = [
 
 
 [tool.uv.sources]
+langchain-protocol = { git = "https://github.com/langchain-ai/agent-protocol", branch = "cb/chat-model-delta", subdirectory = "streaming/py" }
 langchain-core = { path = "../../core", editable = true }
 langchain-tests = { path = "../../standard-tests", editable = true }
 langchain = { path = "../../langchain_v1", editable = true }

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -69,7 +69,6 @@ typing = [
 
 
 [tool.uv.sources]
-langchain-protocol = { git = "https://github.com/langchain-ai/agent-protocol", branch = "cb/chat-model-delta", subdirectory = "streaming/py" }
 langchain-core = { path = "../../core", editable = true }
 langchain-tests = { path = "../../standard-tests", editable = true }
 langchain = { path = "../../langchain_v1", editable = true }

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3187,16 +3187,16 @@ def test_anthropic_stream_v2_lifecycle() -> None:
     assert_valid_event_stream(stream_events)
 
     finishes = [e for e in stream_events if e["event"] == "content-block-finish"]
-    types = [f["content_block"]["type"] for f in finishes]
+    types = [f["content"]["type"] for f in finishes]
     assert types == ["reasoning", "text", "tool_call"]
 
     wire_indices = [f["index"] for f in finishes]
     assert wire_indices == [0, 1, 2]
 
     # Content accumulation reaches content-block-finish intact.
-    reasoning_block = cast("dict[str, Any]", finishes[0]["content_block"])
-    text_block = cast("dict[str, Any]", finishes[1]["content_block"])
-    tool_block = cast("dict[str, Any]", finishes[2]["content_block"])
+    reasoning_block = cast("dict[str, Any]", finishes[0]["content"])
+    text_block = cast("dict[str, Any]", finishes[1]["content"])
+    tool_block = cast("dict[str, Any]", finishes[2]["content"])
     assert reasoning_block["reasoning"] == "Let me think."
     assert text_block["text"] == "The answer is 42."
     assert tool_block["args"] == {"q": "weather"}

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3206,6 +3206,6 @@ def test_anthropic_stream_v2_lifecycle() -> None:
     # (protocol 0.0.9 moved the finish reason off the top-level event
     # and into `metadata`, where the bridge deposits the provider's raw
     # `stop_reason` alongside other response metadata).
-    message_finish = stream_events[-1]
+    message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -677,7 +677,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -722,19 +722,15 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
-source = { registry = "https://pypi.org/simple" }
+version = "0.0.13"
+source = { git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta#ad89e84bf8db5519aed7d11c069d73e29e29e199" }
 dependencies = [
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -677,7 +677,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -722,10 +722,14 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.13"
-source = { git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta#ad89e84bf8db5519aed7d11c069d73e29e29e199" }
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]

--- a/libs/partners/chroma/uv.lock
+++ b/libs/partners/chroma/uv.lock
@@ -841,7 +841,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -886,19 +886,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/deepseek/uv.lock
+++ b/libs/partners/deepseek/uv.lock
@@ -408,7 +408,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -552,19 +552,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/exa/uv.lock
+++ b/libs/partners/exa/uv.lock
@@ -434,7 +434,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -539,19 +539,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/fireworks/uv.lock
+++ b/libs/partners/fireworks/uv.lock
@@ -714,7 +714,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -827,19 +827,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/groq/uv.lock
+++ b/libs/partners/groq/uv.lock
@@ -352,7 +352,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -456,19 +456,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/huggingface/uv.lock
+++ b/libs/partners/huggingface/uv.lock
@@ -992,7 +992,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.1.5,<1.2.0" },
+    { name = "langgraph", specifier = ">=1.1.10,<1.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -1070,7 +1070,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -1197,19 +1197,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },
@@ -1254,7 +1254,7 @@ typing = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.6"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1264,9 +1264,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/e5/d3f72ead3c7f15769d5a9c07e373628f1fbaf6cbe7735694d7085859acf6/langgraph-1.1.6.tar.gz", hash = "sha256:1783f764b08a607e9f288dbcf6da61caeb0dd40b337e5c9fb8b412341fbc0b60", size = 549634, upload-time = "2026-04-03T19:01:32.561Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/e6/b36ecdb3ff4ba9a290708d514bae89ebbe2f554b6abbe4642acf3fddbe51/langgraph-1.1.6-py3-none-any.whl", hash = "sha256:fdbf5f54fa5a5a4c4b09b7b5e537f1b2fa283d2f0f610d3457ddeecb479458b9", size = 169755, upload-time = "2026-04-03T19:01:30.686Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
 ]
 
 [[package]]
@@ -1284,15 +1284,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.9"
+version = "1.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/4c/06dac899f4945bedb0c3a1583c19484c2cc894114ea30d9a538dd270086e/langgraph_prebuilt-1.0.9.tar.gz", hash = "sha256:93de7512e9caade4b77ead92428f6215c521fdb71b8ffda8cd55f0ad814e64de", size = 165850, upload-time = "2026-04-03T14:06:37.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/8b/5fff4c63bbfef1475d577e13f5970f91955a4069d8dc4adbaeef92f36732/langgraph_prebuilt-1.0.12.tar.gz", hash = "sha256:edcb11ff29996def816243f267fb2c85c0a2e4fb618c275f3d238aee8dd6a5ec", size = 172831, upload-time = "2026-04-27T17:14:27.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/a2/8368ac187b75e7f9d938ca075d34f116683f5cfc48d924029ee79aea147b/langgraph_prebuilt-1.0.9-py3-none-any.whl", hash = "sha256:776c8e3154a5aef5ad0e5bf3f263f2dcaab3983786cc20014b7f955d99d2d1b2", size = 35958, upload-time = "2026-04-03T14:06:36.58Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/1e6e6fd478a1b1e643de03505570103dcb89c57c429c0fd3084d521e522e/langgraph_prebuilt-1.0.12-py3-none-any.whl", hash = "sha256:ab83822d2724d434d3536dc127b86c7d16fe3fb8dc02a89a683bc77b2e55f6e9", size = 37195, upload-time = "2026-04-27T17:14:25.788Z" },
 ]
 
 [[package]]

--- a/libs/partners/mistralai/uv.lock
+++ b/libs/partners/mistralai/uv.lock
@@ -387,7 +387,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -490,19 +490,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/nomic/uv.lock
+++ b/libs/partners/nomic/uv.lock
@@ -400,7 +400,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -507,19 +507,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/ollama/uv.lock
+++ b/libs/partners/ollama/uv.lock
@@ -326,7 +326,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -427,19 +427,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -72,7 +72,6 @@ typing = [
 ]
 
 [tool.uv.sources]
-langchain-protocol = { git = "https://github.com/langchain-ai/agent-protocol", branch = "cb/chat-model-delta", subdirectory = "streaming/py" }
 langchain-core = { path = "../../core", editable = true }
 langchain-tests = { path = "../../standard-tests", editable = true }
 langchain = { path = "../../langchain_v1", editable = true }

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -72,6 +72,7 @@ typing = [
 ]
 
 [tool.uv.sources]
+langchain-protocol = { git = "https://github.com/langchain-ai/agent-protocol", branch = "cb/chat-model-delta", subdirectory = "streaming/py" }
 langchain-core = { path = "../../core", editable = true }
 langchain-tests = { path = "../../standard-tests", editable = true }
 langchain = { path = "../../langchain_v1", editable = true }

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -634,7 +634,7 @@ def test_openai_stream_v2_lifecycle(mock_openai_completion: list) -> None:
     # At minimum, a text block with the accumulated answer.
     finishes = [e for e in events if e["event"] == "content-block-finish"]
     assert len(finishes) >= 1
-    text_finishes = [f for f in finishes if f["content_block"]["type"] == "text"]
+    text_finishes = [f for f in finishes if f["content"]["type"] == "text"]
     assert len(text_finishes) == 1
 
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
@@ -786,14 +786,12 @@ def test_responses_stream_v2_emits_reasoning_lifecycle() -> None:
     reasoning_starts = [
         e
         for e in events
-        if e["event"] == "content-block-start"
-        and e["content_block"]["type"] == "reasoning"
+        if e["event"] == "content-block-start" and e["content"]["type"] == "reasoning"
     ]
     reasoning_finishes = [
         e
         for e in events
-        if e["event"] == "content-block-finish"
-        and e["content_block"]["type"] == "reasoning"
+        if e["event"] == "content-block-finish" and e["content"]["type"] == "reasoning"
     ]
 
     # The mock stream carries four reasoning summary parts (two per reasoning
@@ -803,9 +801,7 @@ def test_responses_stream_v2_emits_reasoning_lifecycle() -> None:
         f"expected 4 reasoning start events, got {len(reasoning_starts)}"
     )
     all_finish_types = [
-        e["content_block"]["type"]
-        for e in events
-        if e["event"] == "content-block-finish"
+        e["content"]["type"] for e in events if e["event"] == "content-block-finish"
     ]
     assert len(reasoning_finishes) == 4, (
         f"expected 4 reasoning finish events, got {len(reasoning_finishes)}: "
@@ -814,8 +810,7 @@ def test_responses_stream_v2_emits_reasoning_lifecycle() -> None:
 
     # Finish events must carry the accumulated reasoning text.
     reasoning_texts = [
-        cast("dict[str, Any]", f["content_block"])["reasoning"]
-        for f in reasoning_finishes
+        cast("dict[str, Any]", f["content"])["reasoning"] for f in reasoning_finishes
     ]
     assert reasoning_texts == [
         "reasoning block one",

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -587,7 +587,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.1.5,<1.2.0" },
+    { name = "langgraph", specifier = ">=1.1.10,<1.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -641,7 +641,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -773,19 +773,15 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
-source = { registry = "https://pypi.org/simple" }
+version = "0.0.13"
+source = { git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta#ad89e84bf8db5519aed7d11c069d73e29e29e199" }
 dependencies = [
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },
@@ -830,7 +826,7 @@ typing = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.5"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -840,9 +836,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a4/8a/47b983e33d3afc8c2c2385d2d8f3731ddfb5cb08e88f307f75105252a94c/langgraph-1.1.5.tar.gz", hash = "sha256:24b85d2d40cd002766d489e76f18027f947e4151366ac7ed97bab030ce50e494", size = 548492, upload-time = "2026-04-03T14:12:33.14Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/6a/542bb56c8270d3df858285be138aec5e292b4e43dadb6b0b6fe051f535c1/langgraph-1.1.5-py3-none-any.whl", hash = "sha256:cb25c20d135167837951906c0feeb26c91c733bd5001a920c4cb1ffb92a1097c", size = 169354, upload-time = "2026-04-03T14:12:31.879Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
 ]
 
 [[package]]
@@ -860,15 +856,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.9"
+version = "1.0.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/4c/06dac899f4945bedb0c3a1583c19484c2cc894114ea30d9a538dd270086e/langgraph_prebuilt-1.0.9.tar.gz", hash = "sha256:93de7512e9caade4b77ead92428f6215c521fdb71b8ffda8cd55f0ad814e64de", size = 165850, upload-time = "2026-04-03T14:06:37.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/8b/5fff4c63bbfef1475d577e13f5970f91955a4069d8dc4adbaeef92f36732/langgraph_prebuilt-1.0.12.tar.gz", hash = "sha256:edcb11ff29996def816243f267fb2c85c0a2e4fb618c275f3d238aee8dd6a5ec", size = 172831, upload-time = "2026-04-27T17:14:27.152Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/a2/8368ac187b75e7f9d938ca075d34f116683f5cfc48d924029ee79aea147b/langgraph_prebuilt-1.0.9-py3-none-any.whl", hash = "sha256:776c8e3154a5aef5ad0e5bf3f263f2dcaab3983786cc20014b7f955d99d2d1b2", size = 35958, upload-time = "2026-04-03T14:06:36.58Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/1e6e6fd478a1b1e643de03505570103dcb89c57c429c0fd3084d521e522e/langgraph_prebuilt-1.0.12-py3-none-any.whl", hash = "sha256:ab83822d2724d434d3536dc127b86c7d16fe3fb8dc02a89a683bc77b2e55f6e9", size = 37195, upload-time = "2026-04-27T17:14:25.788Z" },
 ]
 
 [[package]]

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -641,7 +641,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -773,10 +773,14 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.13"
-source = { git = "https://github.com/langchain-ai/agent-protocol?subdirectory=streaming%2Fpy&branch=cb%2Fchat-model-delta#ad89e84bf8db5519aed7d11c069d73e29e29e199" }
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]

--- a/libs/partners/openrouter/uv.lock
+++ b/libs/partners/openrouter/uv.lock
@@ -363,7 +363,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -458,19 +458,19 @@ typing = [{ name = "mypy", specifier = ">=1.19.1,<2.0.0" }]
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/perplexity/uv.lock
+++ b/libs/partners/perplexity/uv.lock
@@ -451,7 +451,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -569,19 +569,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/qdrant/uv.lock
+++ b/libs/partners/qdrant/uv.lock
@@ -545,7 +545,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -590,14 +590,14 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
@@ -677,7 +677,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/xai/uv.lock
+++ b/libs/partners/xai/uv.lock
@@ -693,7 +693,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -788,19 +788,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.6"
+version = "1.1.7"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/standard-tests/langchain_tests/utils/stream_lifecycle.py
+++ b/libs/standard-tests/langchain_tests/utils/stream_lifecycle.py
@@ -107,7 +107,7 @@ def assert_valid_event_stream(events: Iterable[Any]) -> None:
                 f"still open (event {i}); blocks must not interleave"
             )
             open_idx = idx
-            start_events[idx] = event["content_block"]
+            start_events[idx] = event.get("content") or event["content_block"]
             delta_accum[idx] = {}
             expected_next_idx += 1
         elif ev == "content-block-delta":
@@ -116,15 +116,17 @@ def assert_valid_event_stream(events: Iterable[Any]) -> None:
                 f"content-block-delta at idx={idx} but currently-open block is "
                 f"{open_idx} (event {i})"
             )
-            block = event["content_block"]
-            _accumulate_delta(delta_accum[idx], block)
+            delta = event.get("delta")
+            if delta is None and "content_block" in event:
+                delta = _legacy_block_to_delta(event["content_block"])
+            _accumulate_delta(delta_accum[idx], delta)
         elif ev == "content-block-finish":
             idx = event["index"]
             assert idx == open_idx, (
                 f"content-block-finish at idx={idx} but currently-open block is "
                 f"{open_idx} (event {i})"
             )
-            finish_events[idx] = event["content_block"]
+            finish_events[idx] = event.get("content") or event["content_block"]
             open_idx = None
         else:
             # Unknown event types are accepted; the CDDL allows extensions.
@@ -143,21 +145,40 @@ def assert_valid_event_stream(events: Iterable[Any]) -> None:
         _assert_delta_matches_finish(idx, delta_accum[idx], finish_block)
 
 
-def _accumulate_delta(accum: dict[str, Any], block: dict[str, Any]) -> None:
-    """Fold a delta block into the running accumulator for its index."""
+def _legacy_block_to_delta(block: dict[str, Any]) -> dict[str, Any]:
+    """Convert the old content-block delta shape to an explicit delta."""
     btype = block.get("type")
-    if btype not in _DELTAABLE_TYPES:
-        return
     if btype == "text":
-        accum["text"] = accum.get("text", "") + block.get("text", "")
-    elif btype == "reasoning":
-        accum["reasoning"] = accum.get("reasoning", "") + block.get("reasoning", "")
-    else:  # tool_call_chunk / server_tool_call_chunk
-        accum["args"] = accum.get("args", "") + (block.get("args") or "")
-        if block.get("id") is not None:
-            accum["id"] = block["id"]
-        if block.get("name") is not None:
-            accum["name"] = block["name"]
+        return {"type": "text-delta", "text": block.get("text", "")}
+    if btype == "reasoning":
+        return {
+            "type": "reasoning-delta",
+            "reasoning": block.get("reasoning", ""),
+        }
+    if "data" in block:
+        return {"type": "data-delta", "data": block.get("data", "")}
+    return {"type": "block-delta", "fields": block}
+
+
+def _accumulate_delta(accum: dict[str, Any], delta: dict[str, Any] | None) -> None:
+    """Fold a delta block into the running accumulator for its index."""
+    if delta is None:
+        return
+    dtype = delta.get("type")
+    if dtype == "text-delta":
+        accum["text"] = accum.get("text", "") + delta.get("text", "")
+    elif dtype == "reasoning-delta":
+        accum["reasoning"] = accum.get("reasoning", "") + delta.get("reasoning", "")
+    elif dtype == "data-delta":
+        accum["data"] = accum.get("data", "") + delta.get("data", "")
+    elif dtype == "block-delta":
+        fields = delta.get("fields")
+        if not isinstance(fields, dict):
+            return
+        btype = fields.get("type")
+        if btype not in _DELTAABLE_TYPES:
+            return
+        accum.update({k: v for k, v in fields.items() if v is not None})
 
 
 def _assert_delta_matches_finish(
@@ -197,6 +218,8 @@ def _assert_delta_matches_finish(
         except json.JSONDecodeError:
             parsed = None
         assert finish_block.get("args") == parsed
+    elif "data" in accum:
+        assert finish_block.get("data") == accum["data"]
 
 
 __all__ = ["assert_valid_event_stream"]

--- a/libs/standard-tests/uv.lock
+++ b/libs/standard-tests/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10.0, <4.0.0"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -341,7 +341,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -386,14 +386,14 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]

--- a/libs/text-splitters/uv.lock
+++ b/libs/text-splitters/uv.lock
@@ -1203,7 +1203,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -1248,14 +1248,14 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Update Python chat model streaming to consume and emit explicit content block deltas: `text-delta`, `reasoning-delta`, `data-delta`, and `block-delta`.
- Switch protocol event payloads to the new `delta` and `content` fields while keeping transitional tolerance for legacy `content_block` events.
- Point `langchain-protocol` at the `langchain-ai/agent-protocol` `cb/chat-model-delta` branch until a dev release is available.
