### PR TITLE
Docs: clarify EvaluationResult feedback_config schema ownership

### DIFF
--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -1,4 +1,10 @@
-"""A tracer that runs evaluators over completed runs."""
+"""A tracer that runs evaluators over completed runs.
+
+Note:
+    ``EvaluationResult`` is imported from ``langsmith.evaluation.evaluator``.
+    Any ``feedback_config`` behavior is determined by LangSmith's
+    ``FeedbackConfig`` schema rather than by this wrapper module.
+"""
 
 from __future__ import annotations
 

--- a/libs/langchain/langchain_classic/smith/evaluation/config.py
+++ b/libs/langchain/langchain_classic/smith/evaluation/config.py
@@ -1,4 +1,9 @@
-"""Configuration for run evaluators."""
+"""Configuration for run evaluators.
+
+``EvaluationResult`` objects are provided by LangSmith.
+For ``feedback_config`` inputs, validation and accepted keys are defined by
+LangSmith's ``FeedbackConfig`` schema.
+"""
 
 from collections.abc import Callable, Sequence
 from typing import Any


### PR DESCRIPTION
## Summary

Adds a small docs-oriented clarification in LangChain evaluation wrappers that EvaluationResult comes from LangSmith and that feedback_config semantics are defined by LangSmith's FeedbackConfig schema.

## Why

Issue discussions indicate confusion when users expect arbitrary dict passthrough for feedback_config. This change reduces ambiguity in LangChain-facing code/docs touchpoints.

## Changes

1. Added a module note in libs/core/langchain_core/tracers/evaluation.py.
2. Added a matching note in libs/langchain/langchain_classic/smith/evaluation/config.py.

## Related

References: https://github.com/langchain-ai/langchain/issues/31802

## Validation

python -m compileall -q on changed files