### PR TITLE
fix(core): raise ValueError when draw_png fails instead of silently returning None

### DIFF
--- a/libs/core/langchain_core/runnables/graph_png.py
+++ b/libs/core/langchain_core/runnables/graph_png.py
@@ -149,9 +149,21 @@ class PngDrawer:
 
         # Save the graph as PNG
         try:
-            return cast("bytes | None", viz.draw(output_path, format="png", prog="dot"))
+            result = viz.draw(output_path, format="png", prog="dot")
+        except Exception as e:
+            msg = f"Failed to draw graph as PNG: {e}"
+            raise ValueError(msg) from e
         finally:
             viz.close()
+
+        if result is None and output_path is None:
+            msg = (
+                "Graph rendering returned no output. This may be caused by "
+                "invalid node types or labels that pygraphviz cannot render."
+            )
+            raise ValueError(msg)
+
+        return cast("bytes | None", result)
 
     def add_nodes(self, viz: Any, graph: Graph) -> None:
         """Add nodes to the graph.


### PR DESCRIPTION
## Summary

Fixes #30719

`Graph.draw_png()` silently returns `None` when rendering fails (e.g., invalid node types), causing downstream `TypeError: object of type 'NoneType' has no len()` crashes that are hard to debug.

## Bug

```python
from langchain_core.runnables.graph import Graph

graph = Graph()
n1 = graph.add_node(object(), id="node1")  # Invalid node type
n2 = graph.add_node(lambda x: x, id="node2")
graph.add_edge(n1, n2, data=None, conditional=False)

png_bytes = graph.draw_png(output_file_path=None)
len(png_bytes)  # TypeError: object of type 'NoneType' has no len()
```

`PngDrawer.draw()` calls `viz.draw()` which returns `None` on failure, but this None is propagated silently to the caller.

## Fix

- If `viz.draw()` raises an exception, catch it and re-raise as `ValueError` with a descriptive message
- If `viz.draw()` returns `None` when `output_path` is `None` (meaning the caller expects bytes back), raise `ValueError` explaining that rendering failed, likely due to invalid node types

This makes debugging much easier by failing fast with a clear error message instead of a confusing `TypeError` later.