### PR TITLE
fix(text-splitters): raise ImportError before argument validation in NLTKTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/nltk.py
+++ b/libs/text-splitters/langchain_text_splitters/nltk.py
@@ -43,12 +43,12 @@ class NLTKTextSplitter(TextSplitter):
         self._separator = separator
         self._language = language
         self._use_span_tokenize = use_span_tokenize
-        if self._use_span_tokenize and self._separator:
-            msg = "When use_span_tokenize is True, separator should be ''"
-            raise ValueError(msg)
         if not _HAS_NLTK:
             msg = "NLTK is not installed, please install it with `pip install nltk`."
             raise ImportError(msg)
+        if self._use_span_tokenize and self._separator:
+            msg = "When use_span_tokenize is True, separator should be ''"
+            raise ValueError(msg)
         if self._use_span_tokenize:
             self._tokenizer = nltk.tokenize._get_punkt_tokenizer(self._language)  # noqa: SLF001
         else:

--- a/libs/text-splitters/tests/unit_tests/test_nltk.py
+++ b/libs/text-splitters/tests/unit_tests/test_nltk.py
@@ -1,0 +1,36 @@
+"""Unit tests for `NLTKTextSplitter`."""
+
+from __future__ import annotations
+
+import pytest
+
+from langchain_text_splitters import nltk as nltk_module
+from langchain_text_splitters.nltk import NLTKTextSplitter
+
+
+def test_missing_nltk_raises_import_error_before_arg_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing NLTK install must surface before argument validation.
+
+    `ImportError` for a missing NLTK install must take precedence over
+    argument-combination validation, so users see the real prerequisite first.
+    """
+    monkeypatch.setattr(nltk_module, "_HAS_NLTK", False)
+
+    with pytest.raises(ImportError, match="NLTK is not installed"):
+        NLTKTextSplitter(use_span_tokenize=True)
+
+
+def test_missing_nltk_raises_import_error_with_default_args(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing NLTK install raises `ImportError` even with default args.
+
+    Even with valid argument combinations, a missing NLTK install must
+    raise `ImportError`.
+    """
+    monkeypatch.setattr(nltk_module, "_HAS_NLTK", False)
+
+    with pytest.raises(ImportError, match="NLTK is not installed"):
+        NLTKTextSplitter()


### PR DESCRIPTION
Fixes #37075 

---

`NLTKTextSplitter.__init__` currently checks the argument combination before checking if NLTK is installed. Because of this, users without NLTK may see a ValueError about the separator instead of the actual ImportError.

This is misleading, since the real issue is the missing dependency.

This PR fixes the order by checking for NLTK first, so the correct error is shown immediately.

It also adds two unit tests to ensure ImportError is raised when NLTK is not available.

---

Twitter: @abhishekbuild
LinkedIn: https://linkedin.com/in/abhishekbuild