### PR TITLE
fix(text-splitters): add `Language.PERL` separators to `RecursiveCharacterTextSplitter`

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -788,6 +788,34 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "",
             ]
 
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "\nsub ",
+                # Split along package declarations
+                "\npackage ",
+                # Split along module imports
+                "\nuse ",
+                # Split along variable declarations
+                "\nmy ",
+                "\nour ",
+                "\nlocal ",
+                # Split along control flow statements
+                "\nif ",
+                "\nelsif ",
+                "\nelse ",
+                "\nunless ",
+                "\nfor ",
+                "\nforeach ",
+                "\nwhile ",
+                "\nuntil ",
+                "\ndo ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"
             raise ValueError(msg)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -2456,6 +2456,40 @@ end
     ]
 
 
+def test_perl_code_splitter() -> None:
+    splitter = RecursiveCharacterTextSplitter.from_language(
+        Language.PERL, chunk_size=CHUNK_SIZE, chunk_overlap=0
+    )
+    code = """
+package MyModule;
+use strict;
+use warnings;
+
+sub hello_world {
+    my $message = 'Hello, World!';
+    print $message;
+}
+
+hello_world();
+    """
+    chunks = splitter.split_text(code)
+    assert chunks == [
+        "package",
+        "MyModule;",
+        "use strict;",
+        "use warnings;",
+        "sub hello_world",
+        "{",
+        "my $message",
+        "= 'Hello,",
+        "World!';",
+        "print",
+        "$message;",
+        "}",
+        "hello_world();",
+    ]
+
+
 def test_haskell_code_splitter() -> None:
     splitter = RecursiveCharacterTextSplitter.from_language(
         Language.HASKELL, chunk_size=CHUNK_SIZE, chunk_overlap=0


### PR DESCRIPTION
Closes #37049

---

`Language.PERL` has been listed in the `Language` enum since it was added, but `get_separators_for_language()` in `RecursiveCharacterTextSplitter` never had a handler for it. Calling `RecursiveCharacterTextSplitter.from_language(Language.PERL, ...)` therefore raised a `ValueError: Language perl is not implemented yet!` at runtime, despite the enum value appearing to signal full support.

This PR adds a Perl-specific separator list, following the same pattern used by every other language in the same method. The separators cover:

- Subroutine definitions (`sub `)
- Package declarations (`package `)
- Module imports (`use `)
- Variable declarations (`my `, `our `, `local `)
- Control-flow keywords (`if`, `elsif`, `else`, `unless`, `for`, `foreach`, `while`, `until`, `do`)
- Fallback line and whitespace splits

A new unit test (`test_perl_code_splitter`) verifies that a representative Perl snippet is chunked correctly with a chunk size of 16 characters.

> **Note:** This contribution was developed with the assistance of an AI agent (Claude Code).

https://claude.ai/code/session_01KsFoPGL793dWt2sphtT8sT