### PR TITLE
fix(text-splitters): add `Language.PERL` separators to `RecursiveCharacterTextSplitter`

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -788,6 +788,35 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "",
             ]
 
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "\nsub ",
+                # Split along package declarations
+                "\npackage ",
+                # Split along variable declarations
+                "\nmy ",
+                "\nour ",
+                "\nlocal ",
+                # Split along control flow statements
+                "\nif ",
+                "\nelsif ",
+                "\nelse ",
+                "\nunless ",
+                "\nwhile ",
+                "\nuntil ",
+                "\nfor ",
+                "\nforeach ",
+                "\ndo ",
+                # Split along module imports
+                "\nuse ",
+                "\nrequire ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"
             raise ValueError(msg)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -4243,3 +4243,53 @@ def test_character_text_splitter_chunk_size_effect(
         keep_separator=False,
     )
     assert splitter.split_text(text) == expected
+
+
+def test_perl_code_splitter() -> None:
+    splitter = RecursiveCharacterTextSplitter.from_language(
+        Language.PERL, chunk_size=CHUNK_SIZE, chunk_overlap=0
+    )
+    code = """
+use strict;
+use warnings;
+
+sub hello_world {
+    my $name = shift;
+    print "Hello, $name!\\n";
+}
+
+my $greeting = "World";
+hello_world($greeting);
+
+if ($greeting) {
+    foreach my $char (split //, $greeting) {
+        print "$char\\n";
+    }
+}
+    """
+    chunks = splitter.split_text(code)
+    assert chunks == [
+        "use strict;",
+        "use warnings;",
+        "sub hello_world",
+        "{",
+        "my $name =",
+        "shift;",
+        "print",
+        '"Hello,',
+        '$name!\\n";',
+        "}",
+        "my $greeting =",
+        '"World";',
+        "hello_world($gr",
+        "eeting);",
+        "if ($greeting)",
+        "{",
+        "foreach my",
+        "$char (split",
+        "//, $greeting)",
+        "{",
+        "print",
+        '"$char\\n";',
+        "}\n}",
+    ]


### PR DESCRIPTION
Closes #37049

---

`Language.PERL` has been present in the `Language` enum since it was added, but
`get_separators_for_language` in `RecursiveCharacterTextSplitter` had no handler
for it. Any call to `RecursiveCharacterTextSplitter.from_language(Language.PERL, ...)`
fell through to the *"not implemented yet"* guard and raised a `ValueError` at
runtime — despite the enum advertising Perl as a supported language.

## What this PR does

Adds a Perl separator list that mirrors the structure used by the other languages.
The separators are ordered from most-structural to least, following the same
priority pattern as existing entries:

1. **Subroutine definitions** — `\nsub ` — the primary code unit in Perl.
2. **Package declarations** — `\npackage ` — namespace boundaries.
3. **Variable declarations** — `\nmy `, `\nour `, `\nlocal `.
4. **Control-flow keywords** — `if`, `elsif`, `else`, `unless`, `while`, `until`,
   `for`, `foreach`, `do`.
5. **Module directives** — `use`, `require`.
6. **Standard fallbacks** — blank line → newline → space → character.

A unit test (`test_perl_code_splitter`) is added that exercises the splitter
against a representative Perl snippet and asserts the expected chunk boundaries.

---

*This contribution was made with AI-agent assistance.*