### PR TITLE
fix(text-splitters): implement `Language.PERL` separators in `get_separators_for_language`

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -701,6 +701,33 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 " ",
                 "",
             ]
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "\nsub ",
+                # Split along package declarations
+                "\npackage ",
+                # Split along module import statements
+                "\nuse ",
+                "\nrequire ",
+                # Split along variable declarations
+                "\nmy ",
+                "\nour ",
+                "\nlocal ",
+                # Split along control flow statements
+                "\nif ",
+                "\nunless ",
+                "\nwhile ",
+                "\nuntil ",
+                "\nfor ",
+                "\nforeach ",
+                "\ndo ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
         if language == Language.HASKELL:
             return [
                 # Split along function definitions

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -2456,6 +2456,48 @@ end
     ]
 
 
+def test_perl_code_splitter() -> None:
+    splitter = RecursiveCharacterTextSplitter.from_language(
+        Language.PERL, chunk_size=CHUNK_SIZE, chunk_overlap=0
+    )
+    code = """
+package Animals;
+
+use strict;
+
+my $name = "cat";
+our $count = 0;
+
+sub describe {
+    if ($name) {
+        print $name;
+    }
+}
+
+foreach my $item (1..5) {
+    $count++;
+}
+"""
+    chunks = splitter.split_text(code)
+    assert chunks == [
+        "package",
+        "Animals;",
+        "use strict;",
+        "my $name =",
+        '"cat";',
+        "our $count = 0;",
+        "sub describe {",
+        "if ($name)",
+        "{",
+        "print",
+        "$name;",
+        "}\n}",
+        "foreach my",
+        "$item (1..5) {",
+        "$count++;\n}",
+    ]
+
+
 def test_haskell_code_splitter() -> None:
     splitter = RecursiveCharacterTextSplitter.from_language(
         Language.HASKELL, chunk_size=CHUNK_SIZE, chunk_overlap=0


### PR DESCRIPTION
Fixes #37049

---

`Language.PERL` was declared in the `Language` enum but
`get_separators_for_language()` had no matching branch for it. Every
call to `RecursiveCharacterTextSplitter.from_language(Language.PERL,
...)` therefore fell through to the fallback and raised:

```
ValueError: Language perl is not implemented yet!
```

**Fix:** add a Perl-specific separator list, placed adjacent to `LUA`
to preserve the enum declaration order. The separators cover:

- Subroutine declarations (`sub`)
- Package / module statements (`package`, `use`, `require`)
- Variable declarations (`my`, `our`, `local`)
- Control-flow keywords (`if`, `unless`, `while`, `until`, `for`,
  `foreach`, `do`)

A unit test (`test_perl_code_splitter`) is added that mirrors the
pattern used by the existing `test_lua_code_splitter` and
`test_haskell_code_splitter` tests.

> **Note:** this contribution was prepared with AI-agent assistance
> (Claude Code). The code and tests have been manually reviewed for
> correctness against Perl language semantics.