### PR TITLE
feat(langchain): register `perplexity_search` in `load_tools` registry

### DIFF
--- a/libs/langchain/langchain_classic/agents/__init__.py
+++ b/libs/langchain/langchain_classic/agents/__init__.py
@@ -59,9 +59,7 @@ from langchain_classic.agents.xml.base import XMLAgent, create_xml_agent
 if TYPE_CHECKING:
     from langchain_community.agent_toolkits.json.base import create_json_agent
     from langchain_community.agent_toolkits.load_tools import (
-        get_all_tool_names,
         load_huggingface_tool,
-        load_tools,
     )
     from langchain_community.agent_toolkits.openapi.base import create_openapi_agent
     from langchain_community.agent_toolkits.powerbi.base import create_pbi_agent
@@ -70,6 +68,11 @@ if TYPE_CHECKING:
     )
     from langchain_community.agent_toolkits.spark_sql.base import create_spark_sql_agent
     from langchain_community.agent_toolkits.sql.base import create_sql_agent
+
+    from langchain_classic.agents.load_tools import (
+        get_all_tool_names,
+        load_tools,
+    )
 
 DEPRECATED_CODE = [
     "create_csv_agent",
@@ -88,9 +91,9 @@ DEPRECATED_LOOKUP = {
     "create_pbi_chat_agent": "langchain_community.agent_toolkits.powerbi.chat_base",
     "create_spark_sql_agent": "langchain_community.agent_toolkits.spark_sql.base",
     "create_sql_agent": "langchain_community.agent_toolkits.sql.base",
-    "load_tools": "langchain_community.agent_toolkits.load_tools",
+    "load_tools": "langchain_classic.agents.load_tools",
     "load_huggingface_tool": "langchain_community.agent_toolkits.load_tools",
-    "get_all_tool_names": "langchain_community.agent_toolkits.load_tools",
+    "get_all_tool_names": "langchain_classic.agents.load_tools",
 }
 
 _import_attribute = create_importer(__package__, deprecated_lookups=DEPRECATED_LOOKUP)

--- a/libs/langchain/langchain_classic/agents/load_tools.py
+++ b/libs/langchain/langchain_classic/agents/load_tools.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from langchain_core.tools import BaseTool
+
 from langchain_classic._api import create_importer
 
 _importer = create_importer(
@@ -8,6 +10,55 @@ _importer = create_importer(
 )
 
 
+def _get_perplexity_search(**kwargs: Any) -> BaseTool:
+    """Construct a `PerplexitySearchResults` tool.
+
+    Requires the `langchain-perplexity` package.
+    """
+    try:
+        from langchain_perplexity import PerplexitySearchResults
+    except ImportError as e:
+        msg = (
+            "Could not import langchain_perplexity python package. "
+            "Please install it with `pip install -U langchain-perplexity`."
+        )
+        raise ImportError(msg) from e
+    return PerplexitySearchResults(**kwargs)
+
+
+_EXTRA_OPTIONAL_TOOLS: dict[str, Any] = {
+    "perplexity_search": (_get_perplexity_search, []),
+}
+
+
+def load_tools(tool_names: list[str], **kwargs: Any) -> list[BaseTool]:
+    """Load tools by name.
+
+    Extends `langchain_community.agent_toolkits.load_tools.load_tools` with
+    partner-package tools registered locally (e.g. `perplexity_search`).
+    """
+    local_names = [n for n in tool_names if n in _EXTRA_OPTIONAL_TOOLS]
+    remaining = [n for n in tool_names if n not in _EXTRA_OPTIONAL_TOOLS]
+
+    tools: list[BaseTool] = []
+    for name in local_names:
+        get_tool_func, extra_keys = _EXTRA_OPTIONAL_TOOLS[name]
+        sub_kwargs = {k: kwargs[k] for k in extra_keys if k in kwargs}
+        tools.append(get_tool_func(**sub_kwargs))
+
+    if remaining:
+        community_load_tools = _importer("load_tools")
+        tools.extend(community_load_tools(remaining, **kwargs))
+
+    return tools
+
+
+def get_all_tool_names() -> list[str]:
+    """Return all tool names known to `load_tools`, including local extensions."""
+    community_get_all_tool_names = _importer("get_all_tool_names")
+    return list(_EXTRA_OPTIONAL_TOOLS) + community_get_all_tool_names()
+
+
 def __getattr__(name: str) -> Any:
-    """Look up attributes dynamically."""
+    """Look up attributes dynamically, falling back to langchain_community."""
     return _importer(name)

--- a/libs/langchain/tests/unit_tests/agents/test_load_tools.py
+++ b/libs/langchain/tests/unit_tests/agents/test_load_tools.py
@@ -1,0 +1,52 @@
+"""Tests for the local extensions to ``load_tools``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from langchain_classic.agents.load_tools import (
+    _EXTRA_OPTIONAL_TOOLS,
+    _get_perplexity_search,
+    get_all_tool_names,
+    load_tools,
+)
+
+
+def test_perplexity_search_in_registry() -> None:
+    """``perplexity_search`` must be a known string-loadable tool name."""
+    assert "perplexity_search" in _EXTRA_OPTIONAL_TOOLS
+
+
+def test_perplexity_search_factory_signature() -> None:
+    """The registry entry must be a (factory, extra_keys) tuple."""
+    factory, extra_keys = _EXTRA_OPTIONAL_TOOLS["perplexity_search"]
+    assert callable(factory)
+    assert isinstance(extra_keys, list)
+
+
+def test_perplexity_search_import_error_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing ``langchain_perplexity`` must produce a friendly install hint."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name: str, *args: Any, **kwargs: Any) -> Any:
+        if name == "langchain_perplexity" or name.startswith("langchain_perplexity."):
+            msg = "langchain_perplexity is not installed"
+            raise ImportError(msg)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match="pip install -U langchain-perplexity"):
+        _get_perplexity_search()
+
+
+def test_load_tools_module_exposes_load_tools() -> None:
+    """The local module must expose ``load_tools`` and ``get_all_tool_names``."""
+    assert callable(load_tools)
+    assert callable(get_all_tool_names)

--- a/libs/langchain/tests/unit_tests/test_imports.py
+++ b/libs/langchain/tests/unit_tests/test_imports.py
@@ -97,7 +97,7 @@ def test_no_more_changes_to_proxy_community() -> None:
         # most cases.
         hash_ += len(str(sorted(deprecated_lookup.items())))
 
-    evil_magic_number = 38644
+    evil_magic_number = 38624
 
     assert hash_ == evil_magic_number, (
         "If you're triggering this test, you're likely adding a new import "


### PR DESCRIPTION
Closes #37089

---

Registers `perplexity_search` as a string-loadable tool name in `langchain_classic.agents.load_tools`, so that `load_tools(["perplexity_search"])` returns a `[PerplexitySearchResults()]` from the `langchain-perplexity` partner package.

The factory lazily imports `langchain_perplexity` and raises a friendly `ImportError` ("Install langchain-perplexity: pip install -U langchain-perplexity") when the package is missing, mirroring the lazy-import / pip-install-hint pattern used for the other partner-package tools registered in `langchain_community.agent_toolkits.load_tools` (e.g. `serpapi`, `metaphor-search`).

The local `load_tools` and `get_all_tool_names` wrap the community implementations: `perplexity_search` is handled locally; every other name passes through to `langchain_community` unchanged.

`tests/unit_tests/test_imports.py::test_no_more_changes_to_proxy_community` is hash-based and intentionally bumped to reflect the redirect of `load_tools` / `get_all_tool_names` from `langchain_community` to the local module — this is a *reduction* of imports from `langchain` into `langchain_community`, which is the direction the test guards.

## Verification

- `make format` — clean
- `make lint` — clean (ruff + mypy)
- `make test` from `libs/langchain/` — 647 passed, 84 skipped, 1 xfailed
- New unit test `tests/unit_tests/agents/test_load_tools.py` does NOT require `langchain-perplexity` or any API key (uses `monkeypatch` on `__import__` to assert the install-hint message).

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/