### PR TITLE
fix(openai): promote reasoning_text to summary for Azure reasoning items

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4693,7 +4693,23 @@ def _construct_lc_result_from_responses_api(
             "tool_search_call",
             "tool_search_output",
         ):
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            block = output.model_dump(exclude_none=True, mode="json")
+            # Azure/some providers return reasoning items with summary=[]
+            # but reasoning text in content[].reasoning_text. Promote these
+            # to summary entries so consumers see human-readable reasoning.
+            if (
+                output.type == "reasoning"
+                and not block.get("summary")
+                and block.get("content")
+            ):
+                summary_entries = [
+                    {"type": "summary_text", "text": item["text"]}
+                    for item in block["content"]
+                    if isinstance(item, dict) and item.get("type") == "reasoning_text"
+                ]
+                if summary_entries:
+                    block["summary"] = summary_entries
+            content_blocks.append(block)
 
     # Workaround for parsing structured output in the streaming case.
     #    from openai import OpenAI

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1672,6 +1672,105 @@ def test__construct_lc_result_from_responses_api_multiple_messages() -> None:
     assert result.generations[0].message.id == "resp_123"
 
 
+def test__construct_lc_result_from_responses_api_reasoning_empty_summary() -> None:
+    """Test reasoning item with empty summary but content with reasoning_text.
+
+    Some providers (e.g. Azure) return reasoning items where summary=[] but
+    reasoning text is in content[].reasoning_text. The conversion should promote
+    these to summary entries so consumers see human-readable reasoning.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/36862
+    """
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="o4-mini",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseReasoningItem(
+                type="reasoning",
+                id="rs_123",
+                summary=[],
+                content=[
+                    {"type": "reasoning_text", "text": "internal chain-of-thought"}
+                ],
+            ),
+            ResponseOutputMessage(
+                type="message",
+                id="msg_123",
+                content=[
+                    ResponseOutputText(
+                        type="output_text", text="visible reply", annotations=[]
+                    )
+                ],
+                role="assistant",
+                status="completed",
+            ),
+        ],
+    )
+
+    result = _construct_lc_result_from_responses_api(response)
+
+    reasoning = next(
+        b
+        for b in result.generations[0].message.content
+        if isinstance(b, dict) and b.get("type") == "reasoning"
+    )
+    # summary should be populated from content reasoning_text items
+    assert reasoning["summary"] == [
+        {"type": "summary_text", "text": "internal chain-of-thought"}
+    ]
+
+
+def test__construct_lc_result_from_responses_api_reasoning_existing_summary() -> None:
+    """Test that existing summary is NOT overwritten when already populated."""
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="o4-mini",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseReasoningItem(
+                type="reasoning",
+                id="rs_123",
+                summary=[Summary(type="summary_text", text="existing summary")],
+                content=[
+                    {"type": "reasoning_text", "text": "internal reasoning"}
+                ],
+            ),
+            ResponseOutputMessage(
+                type="message",
+                id="msg_123",
+                content=[
+                    ResponseOutputText(
+                        type="output_text", text="reply", annotations=[]
+                    )
+                ],
+                role="assistant",
+                status="completed",
+            ),
+        ],
+    )
+
+    result = _construct_lc_result_from_responses_api(response)
+
+    reasoning = next(
+        b
+        for b in result.generations[0].message.content
+        if isinstance(b, dict) and b.get("type") == "reasoning"
+    )
+    # existing summary should be preserved, not overwritten
+    assert reasoning["summary"] == [
+        {"type": "summary_text", "text": "existing summary"}
+    ]
+
+
 def test__construct_lc_result_from_responses_api_refusal_response() -> None:
     """Test a response with a refusal."""
     response = Response(


### PR DESCRIPTION
Fixes #36862.

Azure returns `ResponseReasoningItem` with `summary=[]` and reasoning text inside `content[].reasoning_text` instead of `summary`. Downstream consumers always see an empty summary even when reasoning output exists.

When a reasoning item has an empty `summary` but `content` has `reasoning_text` entries, promote them to `summary_text` entries in `summary`. Existing populated summaries are never touched. Added two unit tests - one for the promotion case, one verifying existing summaries are preserved. All 14 existing tests pass.