### PR TITLE
fix(text-splitters): add Perl separators to get_separators_for_language

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -788,6 +788,53 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "",
             ]
 
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "
+sub ",
+                # Split along variable declarations
+                "
+my ",
+                "
+our ",
+                "
+local ",
+                # Split along control flow statements
+                "
+if ",
+                "
+elsif ",
+                "
+else ",
+                "
+unless ",
+                "
+for ",
+                "
+foreach ",
+                "
+while ",
+                "
+until ",
+                "
+do ",
+                # Split along module/package declarations
+                "
+package ",
+                "
+use ",
+                "
+require ",
+                # Split by the normal type of lines
+                "
+
+",
+                "
+",
+                " ",
+                "",
+            ]
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"
             raise ValueError(msg)


### PR DESCRIPTION
Fixes #37049

## Problem

`Language.PERL` exists in the `Language` enum in `base.py` but `get_separators_for_language()` in `character.py` has no handler for it. Calling:

```python
RecursiveCharacterTextSplitter.from_language(Language.PERL, chunk_size=50, chunk_overlap=0)
```

raises:

```
ValueError: Language perl is not implemented yet!
```

Users can see PERL in the enum (it autocompletes, it's documented) so the missing case is misleading.

## Fix

Add a PERL case in `get_separators_for_language()` with sensible split boundaries based on Perl syntax:

- Subroutine definitions (`sub`)
- Variable declarations (`my`, `our`, `local`)
- Control flow (`if`, `elsif`, `else`, `unless`, `for`, `foreach`, `while`, `until`, `do`)
- Module/package declarations (`package`, `use`, `require`)
- Fallback newlines and whitespace

This mirrors the pattern used for other scripting languages in the file.