### PR TITLE
fix(core): correct misleading error message in Visitor._validate_func

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
## Summary

Fixes a copy-paste typo in `Visitor._validate_func` in `libs/core/langchain_core/structured_query.py`.

When an **operator** is disallowed, the error message incorrectly said:
```
Received disallowed operator <op>. Allowed comparators are ...
```
It should say:
```
Received disallowed operator <op>. Allowed operators are ...
```

The bug was introduced when the comparator validation block was copy-pasted to create the operator validation block, but the word "comparators" in the error message was not updated to "operators".

Fixes #36701

## Changes

- `libs/core/langchain_core/structured_query.py`: Change `"comparators are {self.allowed_operators}"` → `"operators are {self.allowed_operators}"` in the operator validation branch of `_validate_func`.

## Test plan

- [ ] Reproduce the issue before the fix:
  ```python
  from langchain_core.structured_query import Visitor, Operator, Comparator

  class TestVisitor(Visitor):
      allowed_comparators = (Comparator.EQ,)
      allowed_operators = (Operator.AND,)
      def visit_operation(self, op): pass
      def visit_comparison(self, cmp): pass
      def visit_structured_query(self, sq): pass

  v = TestVisitor()
  v._validate_func(Operator.OR)
  # Before: "Received disallowed operator Operator.OR. Allowed comparators are (Operator.AND,)"
  # After:  "Received disallowed operator Operator.OR. Allowed operators are (Operator.AND,)"
  ```
- [ ] Confirm the error message now correctly says "operators" when an operator is disallowed.