### PR TITLE
release(langchain): 1.2.17

### DIFF
--- a/libs/langchain_v1/langchain/__init__.py
+++ b/libs/langchain_v1/langchain/__init__.py
@@ -1,3 +1,3 @@
 """Main entrypoint into LangChain."""
 
-__version__ = "1.2.16"
+__version__ = "1.2.17"

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.2.16"
+version = "1.2.17"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.3.2,<2.0.0",


### PR DESCRIPTION
Bumps `langchain` from 1.2.16 → 1.2.17.

Picks up:
- `respond` decision added to HITL middleware (#37095)

> This PR was opened with AI-agent assistance.