### PR TITLE
fix(qdrant): add missing await to asimilarity_search example

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -167,7 +167,7 @@ class QdrantVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)


### PR DESCRIPTION
Fixes #37058 - Add missing `await` to `asimilarity_search` example in QdrantVectorStore docstring.

The async example was missing `await`, returning a coroutine instead of results. This is inconsistent with other async examples in the same section.