### PR TITLE
fix(text-splitters): add Language.PERL support to RecursiveCharacterTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -684,6 +684,32 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 " ",
                 "",
             ]
+        if language == Language.PERL:
+            return [
+                # Split along function/method definitions
+                "\nsub ",
+                "\nmy ",
+                "\nour ",
+                # Split along control flow statements
+                "\nif ",
+                "\nelse ",
+                "\nforeach ",
+                "\nfor ",
+                "\nwhile ",
+                "\nuntil ",
+                "\nunless ",
+                # Split along package and use statements
+                "\npackage ",
+                "\nuse ",
+                "\nrequire ",
+                # Split along class definitions
+                "\npackage ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
         if language == Language.LUA:
             return [
                 # Split along variable and table definitions


### PR DESCRIPTION
Fixes #37049 - Add `Language.PERL` separator list to `RecursiveCharacterTextSplitter`.

`Language.PERL` is listed in the enum but `get_separators_for_language()` had no handler, causing a `ValueError` at runtime. This adds proper Perl-aware separators for `\nsub`, `\nmy`, `\nour`, control flow statements, and package/use statements.