### PR TITLE
fix(core): prevent `ls_provider` duplication during streaming metadata merge

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k in {"id", "output_version", "model_provider", "ls_provider"}
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,18 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # 'ls_provider' should not be concatenated across streaming chunks
+        (
+            {"ls_provider": "amazon_bedrock"},
+            {"ls_provider": "amazon_bedrock"},
+            {"ls_provider": "amazon_bedrock"},
+        ),
+        # 'model_provider' should not be concatenated across streaming chunks
+        (
+            {"model_provider": "openai"},
+            {"model_provider": "openai"},
+            {"model_provider": "openai"},
+        ),
     ],
 )
 def test_merge_dicts(


### PR DESCRIPTION
Fixes #36993

---

`merge_dicts()` string-concatenates all `str` values by default when merging streaming chunks. For metadata keys like `ls_provider` that carry a fixed provider identifier (e.g. `"amazon_bedrock"`), this causes the value to grow with every chunk — after 20 chunks it becomes `"amazon_bedrock"` repeated 20 times.

There was already a skip-concatenation guard for `model_provider` and other identity keys (`id`, `output_version`). This change adds `ls_provider` to that same guard set so identical values are preserved rather than concatenated.

Includes a regression test verifying `ls_provider` is not concatenated when both sides carry the same value.