### PR TITLE
release(core): 1.4.0a1

### DIFF
--- a/libs/core/langchain_core/version.py
+++ b/libs/core/langchain_core/version.py
@@ -1,3 +1,3 @@
 """langchain-core version information and utilities."""
 
-VERSION = "1.3.2"
+VERSION = "1.4.0a1"

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.3.2"
+version = "1.4.0a1"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langsmith>=0.3.45,<1.0.0",

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.2"
+version = "1.4.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
First alpha of the 1.4.0 cycle for `langchain-core`, cut from `v1.4` to publish the new `stream_events(version="v3")` protocol (#37111) for ecosystem testing.

Partner package `langchain-core` floors are intentionally left at `>=1.3.2,<2.0.0` — partners pick up the alpha for testing without making it a published-floor requirement.