### PR TITLE
feat(langchain): wire stream_events(version='v3') into create_agent

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -22,6 +22,7 @@ from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.constants import END, START
 from langgraph.graph.state import StateGraph
+from langgraph.prebuilt import ToolCallTransformer
 from langgraph.prebuilt.tool_node import ToolNode
 from langgraph.types import Command, Send
 from langsmith import traceable
@@ -704,6 +705,7 @@ def create_agent(
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache[Any] | None = None,
+    transformers: Sequence[Callable[..., Any]] | None = None,
 ) -> CompiledStateGraph[
     AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]
 ]:
@@ -799,6 +801,11 @@ def create_agent(
             another graph as a subgraph node - particularly useful for building
             multi-agent systems.
         cache: An optional `BaseCache` instance to enable caching of graph execution.
+        transformers: Optional sequence of scope-aware `StreamTransformer`
+            factories to register on the compiled graph in addition to
+            the agent defaults. Each factory is invoked per-scope
+            (`factory(scope)`) so subgraph mini-muxes get fresh
+            instances. Appended after the built-in `ToolCallTransformer`.
 
     Returns:
         A compiled `StateGraph` that can be used for chat interactions.
@@ -1665,6 +1672,7 @@ def create_agent(
         debug=debug,
         name=name,
         cache=cache,
+        transformers=[ToolCallTransformer, *(transformers or ())],
     ).with_config(config)
 
 

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -705,7 +705,7 @@ def create_agent(
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache[Any] | None = None,
-    transformers: Sequence[Callable[..., Any]] | None = None,
+    transformers: Sequence[Callable[[tuple[str, ...]], Any]] | None = None,
 ) -> CompiledStateGraph[
     AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]
 ]:

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -25,7 +25,7 @@ version = "1.2.17"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.4.0a2,<2.0.0",
-    "langgraph>=1.2.0a4,<1.3.0",
+    "langgraph>=1.2.0a5,<1.3.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
 version = "1.2.17"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.3.2,<2.0.0",
-    "langgraph>=1.1.10,<1.2.0",
+    "langchain-core>=1.4.0a2,<2.0.0",
+    "langgraph>=1.2.0a4,<1.3.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_streaming.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_streaming.py
@@ -6,7 +6,9 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from langchain_core.messages import HumanMessage
+from langchain_core.runnables import RunnableConfig  # noqa: TC002
 from langchain_core.tools import tool
+from langgraph.prebuilt import ToolCallTransformer
 from langgraph.stream import StreamChannel, StreamTransformer
 
 from langchain.agents import create_agent
@@ -55,7 +57,7 @@ def _single_tool_call_script(name: str, **args: Any) -> list[list[dict[str, Any]
     ]
 
 
-class TestAgentStreamV2Sync:
+class TestAgentStreamV3Sync:
     def test_stream_returns_agent_run_stream(self) -> None:
         model = FakeToolCallingModel(tool_calls=_single_tool_call_script("echo", text="x"))
         agent = create_agent(model, [echo])
@@ -145,6 +147,20 @@ class TestAgentStreamV2Sync:
         # Both the agent default and the user transformer are registered.
         assert "tool_calls" in run._mux.extensions  # type: ignore[attr-defined]
         assert "marker" in run._mux.extensions  # type: ignore[attr-defined]
+
+        # `ToolCallTransformer` must come BEFORE the user's transformer in
+        # the registration order so it processes `tools` events first. The
+        # docstring on `create_agent` promises caller transformers are
+        # appended after the built-in.
+        transformers = run._mux._transformers  # type: ignore[attr-defined]
+        tool_call_idx = next(
+            i for i, t in enumerate(transformers) if isinstance(t, ToolCallTransformer)
+        )
+        marker_idx = next(i for i, t in enumerate(transformers) if isinstance(t, _Marker))
+        assert tool_call_idx < marker_idx, (
+            "ToolCallTransformer must be registered before user-supplied transformers"
+        )
+
         list(run.tool_calls)
 
     def test_tool_error_sets_error_field(self) -> None:
@@ -173,8 +189,76 @@ class TestAgentStreamV2Sync:
         assert "nope" in collected[0].error
         assert collected[0].completed is True
 
+    def test_inner_agent_tool_calls_via_subgraph(self) -> None:
+        """An inner `create_agent` invoked from a tool exposes its own tool calls.
 
-class TestAgentStreamV2Async:
+        Wiring a sub-agent through a `@tool` is the canonical pattern
+        for hierarchical agents. The outer caller iterates `run.subgraphs`
+        and finds a `tool_calls` projection on each subgraph handle
+        — populated by a fresh per-scope `ToolCallTransformer` instance.
+        """
+
+        @tool
+        def inner_echo(text: str) -> str:
+            """Echo via inner agent."""
+            return text
+
+        inner_model = FakeToolCallingModel(
+            tool_calls=_single_tool_call_script("inner_echo", text="leaf"),
+        )
+        inner_agent = create_agent(inner_model, [inner_echo])
+
+        @tool
+        def run_inner(query: str, config: RunnableConfig) -> str:
+            """Delegate `query` to the inner agent and return its reply."""
+            result = inner_agent.invoke(
+                {"messages": [HumanMessage(query)]},
+                config,
+            )
+            return str(result["messages"][-1].content)
+
+        outer_model = FakeToolCallingModel(
+            tool_calls=_single_tool_call_script("run_inner", query="leaf"),
+        )
+        outer_agent = create_agent(outer_model, [run_inner])
+
+        run = outer_agent.stream_events(
+            {"messages": [HumanMessage("go")]},
+            version="v3",
+        )
+
+        outer_tool_calls: list[ToolCallStream] = []
+        inner_tool_calls: list[ToolCallStream] = []
+
+        # `tool_calls` and `subgraphs` are single-subscriber channels, so
+        # interleave them through the run's round-robin cursor. Drilling
+        # into `sub.tool_calls` inside the loop body subscribes the inner
+        # mini-mux before the next pump cycle, satisfying the lazy-subscribe
+        # contract on subgraph handles.
+        for name, item in run.interleave("tool_calls", "subgraphs"):
+            if name == "tool_calls":
+                outer_tool_calls.append(item)
+            else:  # "subgraphs"
+                for tc in item.tool_calls:
+                    inner_tool_calls.append(tc)
+                    list(tc.output_deltas)
+
+        # Outer's `tool_calls` projection owns only its own scope: it has
+        # the call to `run_inner` and nothing from the inner subgraph.
+        assert len(outer_tool_calls) == 1
+        assert outer_tool_calls[0].tool_name == "run_inner"
+        assert outer_tool_calls[0].completed is True
+        assert outer_tool_calls[0].error is None
+
+        # The inner agent's `inner_echo` tool call is reachable via the
+        # subgraph's per-scope `tool_calls` projection.
+        assert len(inner_tool_calls) == 1
+        assert inner_tool_calls[0].tool_name == "inner_echo"
+        assert inner_tool_calls[0].completed is True
+        assert inner_tool_calls[0].error is None
+
+
+class TestAgentStreamV3Async:
     @pytest.mark.anyio
     async def test_astream_returns_async_agent_run_stream(self) -> None:
         model = FakeToolCallingModel(tool_calls=_single_tool_call_script("echo", text="x"))

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_streaming.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_streaming.py
@@ -1,0 +1,201 @@
+"""Unit tests for create_agent graphs streaming via `stream_events(version="v3")`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.stream import StreamChannel, StreamTransformer
+
+from langchain.agents import create_agent
+from langchain.tools import ToolRuntime  # noqa: TC001
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+if TYPE_CHECKING:
+    from langgraph.prebuilt._tool_call_stream import ToolCallStream
+    from langgraph.stream._types import ProtocolEvent
+
+
+@tool
+def echo(text: str) -> str:
+    """Return the input unchanged."""
+    return text
+
+
+@tool
+def streamer(text: str, runtime: ToolRuntime) -> str:
+    """Stream two chunks, then return the full text."""
+    for chunk in ("one", "two"):
+        runtime.emit_output_delta(chunk)
+    return text
+
+
+@tool
+async def astreamer(text: str, runtime: ToolRuntime) -> str:
+    """Async: stream two chunks, then return the full text."""
+    runtime.emit_output_delta(text)
+    runtime.emit_output_delta(text + "!")
+    return text
+
+
+@tool
+def boom() -> str:
+    """Raise unconditionally."""
+    msg = "nope"
+    raise ValueError(msg)
+
+
+def _single_tool_call_script(name: str, **args: Any) -> list[list[dict[str, Any]]]:
+    """Script: one tool call on turn 0, finish on turn 1."""
+    return [
+        [{"name": name, "args": args, "id": "tc1"}],
+        [],
+    ]
+
+
+class TestAgentStreamV2Sync:
+    def test_stream_returns_agent_run_stream(self) -> None:
+        model = FakeToolCallingModel(tool_calls=_single_tool_call_script("echo", text="x"))
+        agent = create_agent(model, [echo])
+
+        run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
+
+        # Drain so the run closes cleanly.
+        list(run.tool_calls)
+
+    def test_tool_calls_populated_without_opt_in(self) -> None:
+        """`ToolCallTransformer` is registered by default on the agent streamer."""
+        model = FakeToolCallingModel(tool_calls=_single_tool_call_script("echo", text="x"))
+        agent = create_agent(model, [echo])
+
+        run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
+
+        collected: list[ToolCallStream] = list(run.tool_calls)
+        assert len(collected) == 1
+        tc = collected[0]
+        assert tc.tool_name == "echo"
+        assert tc.tool_call_id == "tc1"
+        assert tc.completed is True
+        assert tc.error is None
+
+    def test_tool_output_deltas_flow_through(self) -> None:
+        model = FakeToolCallingModel(tool_calls=_single_tool_call_script("streamer", text="x"))
+        agent = create_agent(model, [streamer])
+
+        run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
+
+        tool_calls: list[ToolCallStream] = []
+        for tc in run.tool_calls:
+            tool_calls.append(tc)
+            assert list(tc.output_deltas) == ["one", "two"]
+        assert len(tool_calls) == 1
+
+    def test_no_tools_run_is_still_usable(self) -> None:
+        """`.tool_calls` is empty when the model never calls a tool."""
+        model = FakeToolCallingModel()  # no tool calls scripted
+        agent = create_agent(model, [])
+
+        run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
+        assert list(run.tool_calls) == []
+        assert run.output is not None
+
+    def test_messages_projection_present(self) -> None:
+        """`MessagesTransformer` is inherited from `GraphStreamer.builtin_factories`."""
+        model = FakeToolCallingModel(tool_calls=_single_tool_call_script("echo", text="x"))
+        agent = create_agent(model, [echo])
+
+        run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
+        # The native `messages` projection is bound as an instance attribute
+        # by `BaseRunStream.__init__` whenever `MessagesTransformer` is
+        # registered. Content population is covered by langgraph tests —
+        # here we only assert the agent streamer inherits the built-in.
+        assert "messages" in run._mux.extensions  # type: ignore[attr-defined]
+        assert hasattr(run, "messages")
+        # Drain so the run closes cleanly.
+        for tc in run.tool_calls:
+            list(tc.output_deltas)
+
+    def test_caller_transformers_appended_not_replaced(self) -> None:
+        """User-supplied transformers add to, rather than replace, the agent defaults."""
+
+        class _Marker(StreamTransformer):
+            required_stream_modes = ()
+
+            def __init__(self, scope: tuple[str, ...] = ()) -> None:
+                super().__init__(scope)
+                self._log: StreamChannel[int] = StreamChannel()
+
+            def init(self) -> dict[str, Any]:
+                return {"marker": self._log}
+
+            def process(self, event: ProtocolEvent) -> bool:
+                del event
+                return True
+
+        model = FakeToolCallingModel(tool_calls=_single_tool_call_script("echo", text="x"))
+        agent = create_agent(model, [echo])
+
+        run = agent.stream_events(
+            {"messages": [HumanMessage("hi")]},
+            version="v3",
+            transformers=[_Marker],
+        )
+        # Both the agent default and the user transformer are registered.
+        assert "tool_calls" in run._mux.extensions  # type: ignore[attr-defined]
+        assert "marker" in run._mux.extensions  # type: ignore[attr-defined]
+        list(run.tool_calls)
+
+    def test_tool_error_sets_error_field(self) -> None:
+        """Tool errors are surfaced on the `ToolCallStream.error` field.
+
+        `create_agent`'s default tool-error handler re-raises, so the
+        overall run fails — the assertion here is that the error is
+        attached to the scoped `ToolCallStream` *before* the run raises.
+        """
+        model = FakeToolCallingModel(tool_calls=_single_tool_call_script("boom"))
+        agent = create_agent(model, [boom])
+
+        run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
+
+        collected: list[ToolCallStream] = []
+
+        def _drive() -> None:
+            for tc in run.tool_calls:
+                collected.append(tc)
+                list(tc.output_deltas)
+
+        with pytest.raises(ValueError, match="nope"):
+            _drive()
+        assert len(collected) == 1
+        assert collected[0].error is not None
+        assert "nope" in collected[0].error
+        assert collected[0].completed is True
+
+
+class TestAgentStreamV2Async:
+    @pytest.mark.anyio
+    async def test_astream_returns_async_agent_run_stream(self) -> None:
+        model = FakeToolCallingModel(tool_calls=_single_tool_call_script("echo", text="x"))
+        agent = create_agent(model, [echo])
+
+        run = await agent.astream_events({"messages": [HumanMessage("hi")]}, version="v3")
+        async for tc in run.tool_calls:
+            async for _ in tc.output_deltas:
+                pass
+
+    @pytest.mark.anyio
+    async def test_async_tool_deltas_flow(self) -> None:
+        model = FakeToolCallingModel(tool_calls=_single_tool_call_script("astreamer", text="hi"))
+        agent = create_agent(model, [astreamer])
+
+        run = await agent.astream_events({"messages": [HumanMessage("hi")]}, version="v3")
+
+        collected: list[ToolCallStream] = []
+        async for tc in run.tool_calls:
+            collected.append(tc)
+            deltas = [d async for d in tc.output_deltas]
+            assert deltas == ["hi", "hi!"]
+        assert len(collected) == 1
+        assert collected[0].completed is True

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2025,7 +2025,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.1.10,<1.2.0" },
+    { name = "langgraph", specifier = ">=1.2.0a4,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -2208,7 +2208,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.2"
+version = "1.4.0a2"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2603,7 +2603,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.10"
+version = "1.2.0a4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2613,35 +2613,35 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/c8/29aed2d8e8be2f46d293477dc68a302ebc38579310f0c2c18ee966d00d7a/langgraph-1.2.0a4.tar.gz", hash = "sha256:86409bacac063463c285c2fb8d3e3321c06731e1daa521ac08461f534912af8b", size = 669266, upload-time = "2026-05-01T16:07:08.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/82/f1c40638ee63250bc931eb1d446ac8dc83dad5ca8439e23ca1ca55a253fd/langgraph-1.2.0a4-py3-none-any.whl", hash = "sha256:7fb7695344f0eb740eab941dc2eb3f50b8283d7acb72e8bc51eb114af75c7b45", size = 227086, upload-time = "2026-05-01T16:07:06.885Z" },
 ]
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.0"
+version = "4.1.0a3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/76/55a18c59dedf39688d72c4b06af73a5e3ea0d1a01bc867b88fbf0659f203/langgraph_checkpoint-4.0.0.tar.gz", hash = "sha256:814d1bd050fac029476558d8e68d87bce9009a0262d04a2c14b918255954a624", size = 137320, upload-time = "2026-01-12T20:30:26.38Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/43/b1009af9fe5e90f611b998bb8df6435ceec5c7b980057a17e0335493d027/langgraph_checkpoint-4.1.0a3.tar.gz", hash = "sha256:5bdcc807cef760c1b49adb9f0bc6cec02ed06ee84ad162c7cc133490ea60de1b", size = 180097, upload-time = "2026-05-01T15:26:38.528Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/de/ddd53b7032e623f3c7bcdab2b44e8bf635e468f62e10e5ff1946f62c9356/langgraph_checkpoint-4.0.0-py3-none-any.whl", hash = "sha256:3fa9b2635a7c5ac28b338f631abf6a030c3b508b7b9ce17c22611513b589c784", size = 46329, upload-time = "2026-01-12T20:30:25.2Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/7c/22414710fc77b78ce7b9a876897bbdee1761d88f586fc037ed094a3572cd/langgraph_checkpoint-4.1.0a3-py3-none-any.whl", hash = "sha256:101d746cd9299f8da5576509930f3d52f6c67190e129a0954594da6daf22eb35", size = 55009, upload-time = "2026-05-01T15:26:37.505Z" },
 ]
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.12"
+version = "1.1.0a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/8b/5fff4c63bbfef1475d577e13f5970f91955a4069d8dc4adbaeef92f36732/langgraph_prebuilt-1.0.12.tar.gz", hash = "sha256:edcb11ff29996def816243f267fb2c85c0a2e4fb618c275f3d238aee8dd6a5ec", size = 172831, upload-time = "2026-04-27T17:14:27.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/e9/42ebf1831a0e7b9a40388279e39a2492ac46e46923590a38913dbfa68ea7/langgraph_prebuilt-1.1.0a1.tar.gz", hash = "sha256:0454e01b3922926a82b3b5a4398bd4b163efeeb6afcdc4a7ec564466f79ceace", size = 178150, upload-time = "2026-05-01T15:58:09.82Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/75/1e6e6fd478a1b1e643de03505570103dcb89c57c429c0fd3084d521e522e/langgraph_prebuilt-1.0.12-py3-none-any.whl", hash = "sha256:ab83822d2724d434d3536dc127b86c7d16fe3fb8dc02a89a683bc77b2e55f6e9", size = 37195, upload-time = "2026-04-27T17:14:25.788Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/89/59509833058a17cdf446ace070cc9d46eda985f3a5a99bb282ceb0d8dbe1/langgraph_prebuilt-1.1.0a1-py3-none-any.whl", hash = "sha256:8330907dd6c5ee8ea1f7c6819b70961b84d7483a8603909d41513a4879ffda57", size = 40978, upload-time = "2026-05-01T15:58:08.965Z" },
 ]
 
 [[package]]

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2025,7 +2025,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.2.0a4,<1.3.0" },
+    { name = "langgraph", specifier = ">=1.2.0a5,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -2603,7 +2603,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.0a4"
+version = "1.2.0a5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2613,9 +2613,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/c8/29aed2d8e8be2f46d293477dc68a302ebc38579310f0c2c18ee966d00d7a/langgraph-1.2.0a4.tar.gz", hash = "sha256:86409bacac063463c285c2fb8d3e3321c06731e1daa521ac08461f534912af8b", size = 669266, upload-time = "2026-05-01T16:07:08.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/76/d09367be5481415018366f059e06a7e3850d6a3b744c0a57cecd5a7a42e5/langgraph-1.2.0a5.tar.gz", hash = "sha256:b5cd7e9eac3a615120414b1621754ff4f621bf67e90bb4630b257beab03e61ec", size = 670110, upload-time = "2026-05-01T18:07:48.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/82/f1c40638ee63250bc931eb1d446ac8dc83dad5ca8439e23ca1ca55a253fd/langgraph-1.2.0a4-py3-none-any.whl", hash = "sha256:7fb7695344f0eb740eab941dc2eb3f50b8283d7acb72e8bc51eb114af75c7b45", size = 227086, upload-time = "2026-05-01T16:07:06.885Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2f/5c02e8b3bef032c21ed13c950e6fcfb8688535010d8603f8f8239c954f63/langgraph-1.2.0a5-py3-none-any.whl", hash = "sha256:62b24c04e0a7f1db9cd1e4e1eecb1f944927ebec5279c5ceaddf9a77f08431dd", size = 227367, upload-time = "2026-05-01T18:07:46.268Z" },
 ]
 
 [[package]]
@@ -2633,15 +2633,15 @@ wheels = [
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.1.0a1"
+version = "1.1.0a2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/e9/42ebf1831a0e7b9a40388279e39a2492ac46e46923590a38913dbfa68ea7/langgraph_prebuilt-1.1.0a1.tar.gz", hash = "sha256:0454e01b3922926a82b3b5a4398bd4b163efeeb6afcdc4a7ec564466f79ceace", size = 178150, upload-time = "2026-05-01T15:58:09.82Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/4a/591a5c39f318c5b3059504133aa58ca39b47c37e61cc71ac8bd42f546772/langgraph_prebuilt-1.1.0a2.tar.gz", hash = "sha256:0ed039cd83afee5a626d0e631fcae758c9a4d5d76ff45775c85c0f310827564d", size = 178837, upload-time = "2026-05-01T18:03:06.226Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/89/59509833058a17cdf446ace070cc9d46eda985f3a5a99bb282ceb0d8dbe1/langgraph_prebuilt-1.1.0a1-py3-none-any.whl", hash = "sha256:8330907dd6c5ee8ea1f7c6819b70961b84d7483a8603909d41513a4879ffda57", size = 40978, upload-time = "2026-05-01T15:58:08.965Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/e0/99653a3776d018c9382eae9167da257e7d0a831cb76829652a1d8ed83a8f/langgraph_prebuilt-1.1.0a2-py3-none-any.whl", hash = "sha256:6e59b8a37d897d926c44c5bc4c5f0348930fa95a9ecebfde6c5e825078fa9441", size = 41062, upload-time = "2026-05-01T18:03:05.254Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Brings the v3 streaming protocol to \`langchain.agents.create_agent\` so callers can consume content-block events and typed projections through the new \`Pregel.stream_events(version="v3")\` / \`astream_events(version="v3")\` paths.

## What's in here

- \`create_agent\` accepts a \`transformers=\` parameter that's appended after the built-in \`ToolCallTransformer\`, registered on the compiled graph so subgraph mini-muxes get fresh per-scope instances.
- Bumps \`langchain-core>=1.4.0a2,<2.0.0\` (v3 protocol shipped in 1.4.0a2 with the unwound \`astream_events\` return type).
- Bumps \`langgraph>=1.2.0a4,<1.3.0\` (1.2.0a4 widened the \`langgraph-prebuilt\` constraint to pull in 1.1.0a1, which exposes \`ToolCallTransformer\`).
- Drops the \`nh/streaming-for-alpha-release\` git pin and the \`override-dependencies = ["langchain-core"]\` workaround now that the upstream alphas are published.
- New \`tests/unit_tests/agents/test_agent_streaming.py\` covering sync + async v3 dispatch through \`create_agent\`.