### PR TITLE
fix(text-splitters): add Perl separator support for Language.PERL

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -788,6 +788,32 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "",
             ]
 
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "\nsub ",
+                # Split along variable declarations
+                "\nmy ",
+                "\nour ",
+                "\nlocal ",
+                # Split along control flow statements
+                "\nif ",
+                "\nelse ",
+                "\nforeach ",
+                "\nfor ",
+                "\nwhile ",
+                "\nunless ",
+                # Split along module/package declarations
+                "\nuse ",
+                "\nrequire ",
+                "\npackage ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
+
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"
             raise ValueError(msg)


### PR DESCRIPTION
## Description

Fixes #37049.

`Language.PERL` was defined in the `Language` enum but missing from `get_separators_for_language()`, causing a `ValueError: Language perl is not implemented yet!` at runtime.

### Changes
- Adds Perl keyword separators (`\nsub`, `\nmy`, `\nour`, `\nforeach`, `\nwhile`, `\nuse`, `\npackage`, etc.) to `character.py`
- Follows the same structure and formatting as existing language handlers
- Enables `RecursiveCharacterTextSplitter.from_language(Language.PERL, ...)` to work as documented

### Testing
- Verified syntax passes `py_compile`
- Matches the exact separators requested in the issue
- No existing tests broken (isolated addition)