### PR TITLE
fix(text-splitters): check NLTK availability before validating separator in NLTKTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/nltk.py
+++ b/libs/text-splitters/langchain_text_splitters/nltk.py
@@ -43,12 +43,12 @@ class NLTKTextSplitter(TextSplitter):
         self._separator = separator
         self._language = language
         self._use_span_tokenize = use_span_tokenize
-        if self._use_span_tokenize and self._separator:
-            msg = "When use_span_tokenize is True, separator should be ''"
-            raise ValueError(msg)
         if not _HAS_NLTK:
             msg = "NLTK is not installed, please install it with `pip install nltk`."
             raise ImportError(msg)
+        if self._use_span_tokenize and self._separator:
+            msg = "When use_span_tokenize is True, separator should be ''"
+            raise ValueError(msg)
         if self._use_span_tokenize:
             self._tokenizer = nltk.tokenize._get_punkt_tokenizer(self._language)  # noqa: SLF001
         else:


### PR DESCRIPTION
Reorder __init__ checks so ImportError is raised before ValueError when NLTK is not installed and use_span_tokenize=True. Previously, users saw a misleading 'separator should be empty' error instead of the actual 'NLTK not installed' error.

Closes #37075