### PR TITLE
fix(qdrant): add missing await to asimilarity_search example in docstring

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -167,7 +167,7 @@ class QdrantVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud",k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)


### PR DESCRIPTION
## Summary

Fixes #37058 — Missing await in async similarity_search example.

## Changes

- **langchain_qdrant/qdrant.py**: Added `await` to `asimilarity_search` call in the Async section of the docstring

## Before

```python
# results = vector_store.asimilarity_search(query="thud",k=1)
```

## After

```python
# results = await vector_store.asimilarity_search(query="thud",k=1)
```

This was inconsistent with other async examples in the same docstring (e.g. `asimilarity_search_with_score`) which correctly use `await`.