### PR TITLE
fix(deepseek): pass reasoning_content back in multi-turn requests

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -269,20 +269,37 @@ class ChatDeepSeek(BaseChatOpenAI):
         **kwargs: Any,
     ) -> dict:
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+
+        # DeepSeek thinking models require reasoning_content to be echoed back in
+        # every subsequent request. The parent's _convert_message_to_dict drops
+        # additional_kwargs, so we re-inject it here from the original AIMessages.
+        original_messages = self._convert_input(input_).to_messages()
+        reasoning_contents = [
+            msg.additional_kwargs.get("reasoning_content")
+            for msg in original_messages
+            if isinstance(msg, AIMessage)
+        ]
+
+        ai_idx = 0
         for message in payload["messages"]:
             if message["role"] == "tool" and isinstance(message["content"], list):
                 message["content"] = json.dumps(message["content"])
-            elif message["role"] == "assistant" and isinstance(
-                message["content"], list
-            ):
-                # DeepSeek API expects assistant content to be a string, not a list.
-                # Extract text blocks and join them, or use empty string if none exist.
-                text_parts = [
-                    block.get("text", "")
-                    for block in message["content"]
-                    if isinstance(block, dict) and block.get("type") == "text"
-                ]
-                message["content"] = "".join(text_parts) if text_parts else ""
+            elif message["role"] == "assistant":
+                if isinstance(message["content"], list):
+                    # DeepSeek API expects assistant content to be a string, not a list.
+                    # Extract text blocks and join them, or use empty string if none exist.
+                    text_parts = [
+                        block.get("text", "")
+                        for block in message["content"]
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    message["content"] = "".join(text_parts) if text_parts else ""
+                if (
+                    ai_idx < len(reasoning_contents)
+                    and reasoning_contents[ai_idx] is not None
+                ):
+                    message["reasoning_content"] = reasoning_contents[ai_idx]
+                ai_idx += 1
 
         # Azure-hosted DeepSeek does not support the dict/object form of
         # tool_choice (e.g. {"type": "function", "function": {"name": "..."}}).


### PR DESCRIPTION
## Summary

Fixes #37178

- DeepSeek thinking models (`deepseek-r1`, `deepseek-v4-flash`) require `reasoning_content` to be echoed back in every subsequent API request when in thinking mode
- `_create_chat_result()` already correctly stores it in `AIMessage.additional_kwargs["reasoning_content"]`
- But `_get_request_payload()` delegates to the parent `BaseChatOpenAI`, which serializes messages via `_convert_message_to_dict()` — that function drops `additional_kwargs` entirely
- Result: `400 - "The reasoning_content in the thinking mode must be passed back to the API."` on the second LLM call in any agent loop

**Fix:** In `_get_request_payload()`, after the parent builds the payload, convert `input_` back to original `BaseMessage` objects via `self._convert_input(input_).to_messages()`, collect `reasoning_content` values from `AIMessage` objects in order, then inject them into the corresponding `"assistant"` message dicts before the request is sent.

## Test plan

- [ ] Existing unit tests pass: `cd libs/partners/deepseek && poetry run pytest tests/unit_tests/`
- [ ] Manual: create a multi-turn agent with a tool using `deepseek-r1` or `deepseek-v4-flash` — no longer raises 400 on the second LLM call
- [ ] Non-thinking models unaffected (no `reasoning_content` in `additional_kwargs`, so nothing is injected)

authored-by: Shweta Lodha <shwetalenka@hotmail.com>