### PR TITLE
docs(core): update retired claude-2 model in `RunnableWithMessageHistory`

### DIFF
--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -135,7 +135,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):  # type: ignore[no-redef]
             ]
         )
 
-        chain = prompt | ChatAnthropic(model="claude-sonnet-4-5-20250514")
+        chain = prompt | ChatAnthropic(model="claude-sonnet-4-6")
 
         chain_with_history = RunnableWithMessageHistory(
             chain,
@@ -188,7 +188,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):  # type: ignore[no-redef]
             ]
         )
 
-        chain = prompt | ChatAnthropic(model="claude-sonnet-4-5-20250514")
+        chain = prompt | ChatAnthropic(model="claude-sonnet-4-6")
 
         with_message_history = RunnableWithMessageHistory(
             chain,

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -135,7 +135,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):  # type: ignore[no-redef]
             ]
         )
 
-        chain = prompt | ChatAnthropic(model="claude-2")
+        chain = prompt | ChatAnthropic(model="claude-sonnet-4-5-20250514")
 
         chain_with_history = RunnableWithMessageHistory(
             chain,
@@ -188,7 +188,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):  # type: ignore[no-redef]
             ]
         )
 
-        chain = prompt | ChatAnthropic(model="claude-2")
+        chain = prompt | ChatAnthropic(model="claude-sonnet-4-5-20250514")
 
         with_message_history = RunnableWithMessageHistory(
             chain,


### PR DESCRIPTION
## Summary

Updates the  references in  docstrings to , since Anthropic retired the  model family.

## Changes

-  lines 138 and 191: replace  with 

## Motivation

Anyone copy-pasting the current docstring examples gets a 404 error from the Anthropic API:

```
anthropic.NotFoundError: Error code: 404 - {"type":"error","error":{"type":"not_found_error","message":"model: claude-2"}}
```

Fixes #37173
