### PR TITLE
fix(core): add 'ls_provider' to merge_dicts skip-guard

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k in {"id", "output_version", "model_provider", "ls_provider"}
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,12 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # 'ls_provider' should not be concatenated (streaming chunk metadata)
+        (
+            {"ls_provider": "amazon_bedrock"},
+            {"ls_provider": "amazon_bedrock"},
+            {"ls_provider": "amazon_bedrock"},
+        ),
     ],
 )
 def test_merge_dicts(

--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -167,7 +167,7 @@ class QdrantVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud",k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)


### PR DESCRIPTION
## Summary

Fixes #36993 — `merge_dicts()` concatenates `ls_provider` across streaming chunks, inflating response_metadata.

## Root Cause

`merge_dicts()` concatenates string values when merging chunks. The skip-concatenation guard on line 60 protects `model_provider` but does not protect `ls_provider`:

```python
right_k in {"id", "output_version", "model_provider"}  # ls_provider missing
```

After merging ~20 streaming chunks, `ls_provider` becomes `"amazon_bedrock"` repeated 20 times (280 chars instead of 14), contributing to request payload bloat in LangGraph agents.

## Fix

Add `"ls_provider"` to the existing guard, matching the pattern already established for `"model_provider"`.

## Changes

- **langchain_core/utils/_merge.py**: Added `"ls_provider"` to the skip-guard set (line 60)
- **tests/unit_tests/utils/test_utils.py**: Added test case verifying `ls_provider` is not concatenated

## Reproduction

```python
from langchain_core.utils._merge import merge_dicts

left = {"ls_provider": "amazon_bedrock"}
right = {"ls_provider": "amazon_bedrock"}

# Before:
merge_dicts(left, right)  # {"ls_provider": "amazon_bedrockamazon_bedrock"}

# After:
merge_dicts(left, right)  # {"ls_provider": "amazon_bedrock"}
```