### PR TITLE
fix(langchain): omit empty tool bindings for provider strategy

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1231,10 +1231,15 @@ def create_agent(
         if isinstance(effective_response_format, ProviderStrategy):
             # (Backward compatibility) Use OpenAI format structured output
             kwargs = effective_response_format.to_model_kwargs()
+            if final_tools:
+                return (
+                    request.model.bind_tools(
+                        final_tools, strict=True, **kwargs, **request.model_settings
+                    ),
+                    effective_response_format,
+                )
             return (
-                request.model.bind_tools(
-                    final_tools, strict=True, **kwargs, **request.model_settings
-                ),
+                request.model.bind(**kwargs, **request.model_settings),
                 effective_response_format,
             )
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -871,6 +871,43 @@ class TestDynamicModelWithResponseFormat:
         assert ai_message.tool_calls == []
         assert ai_message.content == json.dumps(WEATHER_DATA)
 
+    def test_provider_strategy_without_tools_does_not_bind_empty_tool_list(self) -> None:
+        class CustomModel(GenericFakeChatModel):
+            tool_bindings: list[Any] = Field(default_factory=list)
+            bind_kwargs: list[dict[str, Any]] = Field(default_factory=list)
+
+            def bind_tools(
+                self,
+                tools: Sequence[
+                    dict[str, Any] | type[BaseModel] | Callable[..., Any] | BaseTool
+                ],
+                **kwargs: Any,
+            ) -> Runnable[LanguageModelInput, AIMessage]:
+                self.tool_bindings.append(list(tools))
+                self.bind_kwargs.append(kwargs)
+                return self
+
+            def bind(self, **kwargs: Any) -> Runnable[LanguageModelInput, AIMessage]:
+                self.bind_kwargs.append(kwargs)
+                return self
+
+        model = CustomModel(messages=iter([json.dumps(WEATHER_DATA)]))
+
+        with patch(
+            "langchain.agents.factory._supports_provider_strategy",
+            return_value=True,
+        ):
+            agent = create_agent(
+                model=model,
+                response_format=WeatherBaseModel,
+            )
+            response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+        assert model.tool_bindings == []
+        assert len(model.bind_kwargs) == 1
+        assert "response_format" in model.bind_kwargs[0]
+
 
 def test_union_of_types() -> None:
     """Test response_format as ProviderStrategy with Union (if supported)."""


### PR DESCRIPTION
## Summary

This PR avoids calling `model.bind_tools([])` when `create_agent(...)` resolves structured output to `ProviderStrategy` and there are no user tools.

Instead, in the provider-strategy branch, `create_agent` now:
- calls `model.bind_tools(...)` when there is at least one tool
- calls `model.bind(...)` with `response_format` when the final tool list is empty

This prevents serializing an empty `tools` field for providers that reject `tools: []`.

## Motivation

This surfaced with newer vLLM validation behavior, which rejects requests where `tools` is present but empty and requires omitting the field entirely.

Related upstream context:
- vllm-project/vllm#39741

In practice, this affected `create_agent(..., response_format=...)` flows using provider-native structured output with no tools.

## Why this change is scoped here

I placed the fix in `create_agent` rather than a provider-specific adapter because the issue is at the agent orchestration layer:

- `create_agent` already knows whether the final tool list is empty
- binding through `bind_tools([])` is unnecessary in that case
- avoiding the empty tool binding keeps behavior unchanged when tools are actually present
- this makes the behavior more robust across OpenAI-compatible providers, not just vLLM

## Behavior before

When `ProviderStrategy` was selected and `final_tools == []`, `create_agent` still called:

```python
model.bind_tools([], strict=True, response_format=..., ...)
```

For providers such as vLLM, this could result in a 400 because the request contained `tools: []`.

## Behavior after

When `ProviderStrategy` is selected and `final_tools` is empty, `create_agent` now calls:

```python
model.bind(response_format=..., ...)
```

So the `tools` field is omitted entirely.

## Tests

Added a regression test in:

- `libs/langchain_v1/tests/unit_tests/agents/test_response_format.py`

The test verifies that:
- `ProviderStrategy` without tools does not call `bind_tools([])`
- structured output still parses correctly

## Issue / discussion

LangChain issue or approved discussion:
- langchain-ai/langchain#37184

Related provider issue:
- vllm-project/vllm#39741