### PR TITLE
Fix: omit empty tools array in ProviderStrategy (fixes #37184)

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1231,12 +1231,20 @@ def create_agent(
         if isinstance(effective_response_format, ProviderStrategy):
             # (Backward compatibility) Use OpenAI format structured output
             kwargs = effective_response_format.to_model_kwargs()
-            return (
-                request.model.bind_tools(
-                    final_tools, strict=True, **kwargs, **request.model_settings
-                ),
-                effective_response_format,
-            )
+            if final_tools:
+                return (
+                    request.model.bind_tools(
+                        final_tools, strict=True, **kwargs, **request.model_settings
+                    ),
+                    effective_response_format,
+                )
+            else:
+                # No tools provided - omit tools field to avoid empty tools list
+                # which some providers (e.g., vLLM ≥ 0.20.0) strictly reject
+                return (
+                    request.model.bind(**kwargs, **request.model_settings),
+                    effective_response_format,
+                )
 
         if isinstance(effective_response_format, ToolStrategy):
             # Current implementation requires that tools used for structured output

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -786,6 +786,31 @@ class TestResponseFormatAsProviderStrategy:
         assert response["structured_response"] == EXPECTED_WEATHER_DICT
         assert len(response["messages"]) == 4
 
+    def test_provider_strategy_without_tools(self) -> None:
+        """Test that ProviderStrategy works with response_format but NO tools.
+
+        This is a regression test for the bug where create_agent(..., response_format=MySchema)
+        without any tools would bind an empty tools list `tools=[]`, which OpenAI-compatible
+        providers (like vLLM ≥ 0.20.0) strictly reject.
+
+        The fix ensures that when there are no tools, bind() is called instead of bind_tools([])
+        to omit the tools field entirely.
+        """
+        model = FakeToolCallingModel(structured_response=EXPECTED_WEATHER_PYDANTIC)
+
+        # Create agent with response_format but NO tools (no tools parameter)
+        agent = create_agent(
+            model,
+            response_format=ProviderStrategy(WeatherBaseModel),
+        )
+
+        # Should work without raising an error about empty tools list
+        response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        # Verify the structured response was parsed correctly
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+        assert len(response["messages"]) == 2  # human + ai response only
+
 
 class TestDynamicModelWithResponseFormat:
     """Test response_format with middleware that modifies the model."""

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2136,7 +2136,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.2"
+version = "1.4.3"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Fixes #37184

Prevent binding of an empty tools array in ProviderStrategy by skipping `bind_tools([])` and omitting the `tools` field when no tools are provided, ensuring compatibility with OpenAI-compatible providers.