### PR TITLE
feat(langchain): `SecretMiddleware` for tool-call credential detection

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -12,6 +12,12 @@ from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddlewar
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
+from langchain.agents.middleware.secret import (
+    BUILTIN_SECRET_TYPES,
+    SecretMatch,
+    SecretMiddleware,
+    find_secrets,
+)
 from langchain.agents.middleware.shell_tool import (
     CodexSandboxExecutionPolicy,
     DockerExecutionPolicy,
@@ -44,6 +50,7 @@ from langchain.agents.middleware.types import (
 )
 
 __all__ = [
+    "BUILTIN_SECRET_TYPES",
     "AgentMiddleware",
     "AgentState",
     "ClearToolUsesEdit",
@@ -67,6 +74,8 @@ __all__ = [
     "PIIMiddleware",
     "RedactionRule",
     "Runtime",
+    "SecretMatch",
+    "SecretMiddleware",
     "ShellToolMiddleware",
     "SummarizationMiddleware",
     "TodoListMiddleware",
@@ -78,6 +87,7 @@ __all__ = [
     "before_agent",
     "before_model",
     "dynamic_prompt",
+    "find_secrets",
     "hook_config",
     "wrap_model_call",
     "wrap_tool_call",

--- a/libs/langchain_v1/langchain/agents/middleware/secret.py
+++ b/libs/langchain_v1/langchain/agents/middleware/secret.py
@@ -1,0 +1,467 @@
+"""Secret detection middleware for agent tool calls."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from langchain_core.messages import ToolMessage
+from typing_extensions import override
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    ResponseT,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Iterable
+
+    from langgraph.types import Command
+
+    from langchain.agents.middleware.types import ToolCallRequest
+    from langchain.tools import BaseTool
+
+
+# ---------------------------------------------------------------------------
+# Built-in patterns
+# ---------------------------------------------------------------------------
+# Each entry anchors on a fixed, high-entropy token prefix plus a shape
+# constraint. Common high-entropy strings that are *not* credentials —
+# commit SHAs, UUIDs, ULIDs, base64 blobs without a known prefix, the
+# bare fragment "sk-" in prose — must not match. False positives here
+# block legitimate tool calls, so the regexes are intentionally tight.
+
+# No `\b` word-boundary anchors: the prefix + length + alphabet of each
+# pattern is tight enough on its own, and `\b` would block matches when
+# the secret is concatenated with alphanumeric characters (e.g. inside
+# a JSON blob the agent built up by string interpolation). The negative
+# corpus in the tests demonstrates the FP rate stays at zero without it.
+_BUILTIN_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    # GitHub classic tokens: ghp_ / gho_ / ghu_ / ghs_ / ghr_ + 36 base62.
+    ("github_classic_token", re.compile(r"gh[pousr]_[A-Za-z0-9]{36}")),
+    # GitHub fine-grained PATs: github_pat_ + 22 + _ + 59 chars.
+    ("github_fine_grained_pat", re.compile(r"github_pat_[A-Za-z0-9_]{82}")),
+    # LangSmith API keys: lsv2_(pt|sk)_<32hex>_<16hex>.
+    ("langsmith_key", re.compile(r"lsv2_(?:pt|sk)_[a-f0-9]{32}_[a-f0-9]{16}")),
+    # Anthropic API keys: sk-ant-api<NN>- + long base64url-ish blob.
+    ("anthropic_key", re.compile(r"sk-ant-api\d{2}-[A-Za-z0-9_\-]{60,}")),
+    # OpenAI project keys: sk-proj- + long alphanumeric blob.
+    ("openai_project_key", re.compile(r"sk-proj-[A-Za-z0-9_\-]{40,}")),
+    # OpenAI legacy keys: sk- + exactly 48 base62.
+    ("openai_legacy_key", re.compile(r"sk-[A-Za-z0-9]{48}")),
+    # AWS Access Key IDs (long-term and STS-temporary).
+    ("aws_access_key_id", re.compile(r"(?:AKIA|ASIA)[0-9A-Z]{16}")),
+    # JWT: three base64url segments, header begins with eyJ (b64url of `{"`).
+    (
+        "jwt",
+        re.compile(r"eyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}"),
+    ),
+)
+
+#: Names of the built-in secret detectors, suitable for the ``secret_types`` argument.
+BUILTIN_SECRET_TYPES: frozenset[str] = frozenset(name for name, _ in _BUILTIN_PATTERNS)
+
+
+@dataclass(frozen=True)
+class SecretMatch:
+    """One detected secret occurrence inside a tool-call argument tree.
+
+    Attributes:
+        secret_type: Built-in or custom detector name (e.g. ``"github_classic_token"``).
+        path: Dotted/bracketed location string for nested args
+            (e.g. ``"actions[0].body.code"``). Empty string for a top-level scalar.
+        start: Byte offset where the match begins within the matched string.
+        end: Byte offset where the match ends within the matched string.
+    """
+
+    secret_type: str
+    path: str
+    start: int
+    end: int
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+def _walk(value: Any, path: str) -> Iterable[tuple[str, str]]:
+    """Yield (path, string-value) pairs for every string scalar reachable from ``value``."""
+    if isinstance(value, str):
+        yield path, value
+        return
+    if isinstance(value, dict):
+        for k, v in value.items():
+            child = f"{path}.{k}" if path else str(k)
+            yield from _walk(v, child)
+        return
+    if isinstance(value, list | tuple):
+        for i, v in enumerate(value):
+            child = f"{path}[{i}]" if path else f"[{i}]"
+            yield from _walk(v, child)
+
+
+def find_secrets(
+    value: Any,
+    *,
+    detectors: Iterable[tuple[str, Callable[[str], Iterable[tuple[int, int]]]]] | None = None,
+) -> list[SecretMatch]:
+    """Recursively scan strings inside ``value`` for known secret patterns.
+
+    Walks dicts, lists, and tuples; non-string scalars (numbers, bools, ``None``)
+    are ignored.
+
+    Args:
+        value: Any Python object. Strings reachable through dict/list/tuple
+            recursion are scanned; other scalars are ignored.
+        detectors: Optional iterable of ``(secret_type, finder)`` pairs replacing
+            the built-in detectors. Each ``finder`` takes a string and returns an
+            iterable of ``(start, end)`` byte offsets for each match. If ``None``,
+            the built-in pattern set is used.
+
+    Returns:
+        One :class:`SecretMatch` per detected occurrence. A single string can
+        contribute multiple matches.
+    """
+    pairs: list[tuple[str, Callable[[str], Iterable[tuple[int, int]]]]]
+    if detectors is None:
+        pairs = [(name, _make_regex_finder(pat)) for name, pat in _BUILTIN_PATTERNS]
+    else:
+        pairs = list(detectors)
+
+    out: list[SecretMatch] = []
+    for path, s in _walk(value, ""):
+        for secret_type, finder in pairs:
+            for start, end in finder(s):
+                out.append(SecretMatch(secret_type=secret_type, path=path, start=start, end=end))
+    return out
+
+
+def _make_regex_finder(
+    pattern: re.Pattern[str],
+) -> Callable[[str], Iterable[tuple[int, int]]]:
+    def finder(s: str) -> Iterable[tuple[int, int]]:
+        for m in pattern.finditer(s):
+            yield m.start(), m.end()
+
+    return finder
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+
+_Strategy = Literal["block", "redact"]
+
+
+class SecretMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
+    r"""Detect known credential patterns in tool-call arguments.
+
+    Models can be steered by attacker-controllable input (system prompts,
+    retrieved documents, tool-result content) into emitting tool calls that
+    embed credentials they have read from elsewhere — exfiltrating them
+    through the legitimate tool surface. This middleware is a chokepoint
+    in front of tool execution that catches that.
+
+    By default it ships with detectors for GitHub tokens (classic and
+    fine-grained), LangSmith keys, Anthropic keys, OpenAI keys (legacy and
+    project), AWS Access Key IDs, and JWTs. Each detector is anchored on
+    a fixed, high-entropy prefix, so commit SHAs, UUIDs, ULIDs, and other
+    legitimate high-entropy strings are not flagged.
+
+    Strategies:
+
+    - ``block`` (default): Return a ``ToolMessage(status="error")`` instead
+      of executing the tool. The agent sees a generic rejection — the
+      matched substring is **not** echoed back, which would re-publish the
+      secret into the agent's context window.
+    - ``redact``: Replace each matched substring with
+      ``[REDACTED_<SECRET_TYPE>]`` in the tool args and execute the tool
+      with the rewritten args. Useful when the tool legitimately needs to
+      receive the surrounding string but must not see the credential
+      itself.
+
+    Examples:
+        !!! example "Default — block any tool call carrying a known secret"
+
+            ```python
+            from langchain.agents import create_agent
+            from langchain.agents.middleware import SecretMiddleware
+
+            agent = create_agent(
+                "openai:gpt-5",
+                tools=[...],
+                middleware=[SecretMiddleware()],
+            )
+            ```
+
+        !!! example "Redact instead of block"
+
+            ```python
+            agent = create_agent(
+                "openai:gpt-5",
+                tools=[...],
+                middleware=[SecretMiddleware(strategy="redact")],
+            )
+            ```
+
+        !!! example "Limit which tools the middleware applies to"
+
+            ```python
+            agent = create_agent(
+                "openai:gpt-5",
+                tools=[search_tool, post_to_slack],
+                middleware=[SecretMiddleware(tools=[post_to_slack])],
+            )
+            ```
+
+        !!! example "Limit which secret types are checked"
+
+            ```python
+            from langchain.agents.middleware import BUILTIN_SECRET_TYPES, SecretMiddleware
+
+            print(BUILTIN_SECRET_TYPES)
+            # frozenset({"github_classic_token", "github_fine_grained_pat",
+            #            "langsmith_key", "anthropic_key", ...})
+
+            agent = create_agent(
+                "openai:gpt-5",
+                tools=[...],
+                middleware=[
+                    SecretMiddleware(secret_types=["github_classic_token", "aws_access_key_id"])
+                ],
+            )
+            ```
+
+        !!! example "Add a custom detector"
+
+            ```python
+            import re
+            from langchain.agents.middleware import SecretMiddleware
+
+            INTERNAL_TOKEN = re.compile(r"\\bACME-[A-Z0-9]{20}\\b")
+
+            agent = create_agent(
+                "openai:gpt-5",
+                tools=[...],
+                middleware=[
+                    SecretMiddleware(
+                        custom_detectors={
+                            "acme_internal_token": lambda s: [
+                                (m.start(), m.end()) for m in INTERNAL_TOKEN.finditer(s)
+                            ],
+                        },
+                    )
+                ],
+            )
+            ```
+    """
+
+    def __init__(
+        self,
+        *,
+        strategy: _Strategy = "block",
+        tools: list[BaseTool | str] | None = None,
+        secret_types: Iterable[str] | None = None,
+        custom_detectors: dict[str, Callable[[str], Iterable[tuple[int, int]]]] | None = None,
+    ) -> None:
+        """Initialize ``SecretMiddleware``.
+
+        Args:
+            strategy: How to handle a tool call whose args contain a detected secret.
+
+                - ``"block"`` (default): Short-circuit with
+                  ``ToolMessage(status="error")``; the tool is never executed.
+                - ``"redact"``: Replace each matched substring with
+                  ``[REDACTED_<SECRET_TYPE>]`` and execute the tool with the
+                  rewritten args.
+
+            tools: Optional list of tools (``BaseTool`` instances or tool name
+                strings) to apply the check to. If ``None``, all tools are
+                checked.
+            secret_types: Optional iterable of built-in secret-type names to
+                enable. If ``None``, all built-in detectors are enabled. Pass
+                an empty iterable to disable built-ins (use only
+                ``custom_detectors``). See :data:`BUILTIN_SECRET_TYPES` for
+                names.
+            custom_detectors: Optional mapping of ``secret_type`` →
+                ``finder``. Each finder takes a string and returns an iterable
+                of ``(start, end)`` byte-offset pairs for each match. Custom
+                detectors run alongside the enabled built-ins.
+
+        Raises:
+            ValueError: If ``secret_types`` references an unknown built-in name,
+                or if ``strategy`` is not ``"block"`` / ``"redact"``.
+        """
+        super().__init__()
+
+        if strategy not in ("block", "redact"):
+            msg = f"strategy must be 'block' or 'redact', got {strategy!r}"
+            raise ValueError(msg)
+
+        self.strategy: _Strategy = strategy
+
+        if tools is not None:
+            self._tool_filter: set[str] | None = {
+                t.name if not isinstance(t, str) else t for t in tools
+            }
+        else:
+            self._tool_filter = None
+
+        self.tools = []  # The middleware does not register any tools of its own.
+
+        # Resolve enabled built-ins.
+        builtin_lookup = dict(_BUILTIN_PATTERNS)
+        if secret_types is None:
+            enabled_builtins = list(_BUILTIN_PATTERNS)
+        else:
+            enabled_builtins = []
+            for name in secret_types:
+                if name not in builtin_lookup:
+                    msg = (
+                        f"Unknown secret_type {name!r}. "
+                        f"Built-ins: {sorted(builtin_lookup)}. "
+                        f"For non-built-in detectors, use custom_detectors."
+                    )
+                    raise ValueError(msg)
+                enabled_builtins.append((name, builtin_lookup[name]))
+
+        self._detectors: list[tuple[str, Callable[[str], Iterable[tuple[int, int]]]]] = [
+            (name, _make_regex_finder(pat)) for name, pat in enabled_builtins
+        ]
+        if custom_detectors:
+            self._detectors.extend(custom_detectors.items())
+
+    # ------------------------------------------------------------------
+    # AgentMiddleware hooks
+    # ------------------------------------------------------------------
+
+    @override
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Block or redact secret-bearing tool calls before execution."""
+        new_request, rejection = self._handle(request)
+        if rejection is not None:
+            return rejection
+        return handler(new_request)
+
+    @override
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Async version of :meth:`wrap_tool_call`."""
+        new_request, rejection = self._handle(request)
+        if rejection is not None:
+            return rejection
+        return await handler(new_request)
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _handle(self, request: ToolCallRequest) -> tuple[ToolCallRequest, ToolMessage | None]:
+        """Decide whether to short-circuit, rewrite, or pass through.
+
+        Returns ``(request, None)`` for pass-through (no secrets, or tool
+        not in the filter). Returns ``(request, ToolMessage)`` for ``block``.
+        Returns ``(rewritten_request, None)`` for ``redact``.
+        """
+        call = request.tool_call
+        name = call.get("name") or "tool"
+
+        if self._tool_filter is not None and name not in self._tool_filter:
+            return request, None
+
+        args = call.get("args") or {}
+        matches = find_secrets(args, detectors=self._detectors)
+        if not matches:
+            return request, None
+
+        if self.strategy == "block":
+            return request, ToolMessage(
+                content=_format_block_message(name, matches),
+                tool_call_id=call["id"],
+                name=name,
+                status="error",
+            )
+
+        # Strategy is "redact" — rewrite args and let handler run on the result.
+        new_args = _redact(args, self._detectors)
+        new_call = {**call, "args": new_args}
+        return request.override(tool_call=new_call), None
+
+
+# ---------------------------------------------------------------------------
+# Helpers — block message + redaction
+# ---------------------------------------------------------------------------
+
+
+def _format_block_message(tool_name: str, matches: list[SecretMatch]) -> str:
+    kinds = sorted({m.secret_type for m in matches})
+    return (
+        f"Tool call to '{tool_name}' was blocked: arguments contained content "
+        f"matching a known credential pattern ({', '.join(kinds)}). The agent "
+        "must not pass raw API keys, GitHub tokens, JWTs, or other secrets as "
+        "tool arguments. Reissue the call without the credential value."
+    )
+
+
+def _redact(
+    value: Any,
+    detectors: list[tuple[str, Callable[[str], Iterable[tuple[int, int]]]]],
+) -> Any:
+    """Return a deep copy of ``value`` with every detector match replaced.
+
+    Strings are scanned; matches across all detectors are merged and replaced
+    in a single left-to-right pass with ``[REDACTED_<SECRET_TYPE>]``. Dicts,
+    lists, and tuples are walked recursively. Non-string scalars are
+    returned unchanged.
+    """
+    if isinstance(value, str):
+        spans: list[tuple[int, int, str]] = []
+        for secret_type, finder in detectors:
+            for start, end in finder(value):
+                spans.append((start, end, secret_type))
+        if not spans:
+            return value
+        spans.sort()
+        merged: list[tuple[int, int, str]] = []
+        for span in spans:
+            if merged and span[0] < merged[-1][1]:
+                # Overlap: keep the earlier match's label, extend the end.
+                prev = merged[-1]
+                merged[-1] = (prev[0], max(prev[1], span[1]), prev[2])
+            else:
+                merged.append(span)
+        out: list[str] = []
+        cursor = 0
+        for start, end, secret_type in merged:
+            out.append(value[cursor:start])
+            out.append(f"[REDACTED_{secret_type.upper()}]")
+            cursor = end
+        out.append(value[cursor:])
+        return "".join(out)
+    if isinstance(value, dict):
+        return {k: _redact(v, detectors) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact(v, detectors) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_redact(v, detectors) for v in value)
+    return value
+
+
+__all__ = [
+    "BUILTIN_SECRET_TYPES",
+    "SecretMatch",
+    "SecretMiddleware",
+    "find_secrets",
+]

--- a/libs/langchain_v1/langchain/agents/middleware/secret.py
+++ b/libs/langchain_v1/langchain/agents/middleware/secret.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from langchain_core.messages import ToolMessage
 from typing_extensions import override
@@ -19,6 +19,7 @@ from langchain.agents.middleware.types import (
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterable
 
+    from langchain_core.messages import ToolCall
     from langgraph.types import Command
 
     from langchain.agents.middleware.types import ToolCallRequest
@@ -396,7 +397,7 @@ class SecretMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Response
 
         # Strategy is "redact" — rewrite args and let handler run on the result.
         new_args = _redact(args, self._detectors)
-        new_call = {**call, "args": new_args}
+        new_call = cast("ToolCall", {**call, "args": new_args})
         return request.override(tool_call=new_call), None
 
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_secret.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_secret.py
@@ -1,0 +1,512 @@
+"""Tests for SecretMiddleware."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import FrozenInstanceError
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import HumanMessage, ToolCall, ToolMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.prebuilt.tool_node import ToolCallRequest
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware.secret import (
+    BUILTIN_SECRET_TYPES,
+    SecretMatch,
+    SecretMiddleware,
+    find_secrets,
+)
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+# ---------------------------------------------------------------------------
+# Fake credentials with the right shape but obviously not real values.
+# ---------------------------------------------------------------------------
+
+FAKE_GHP = "ghp_" + "A" * 36
+FAKE_GHO = "gho_" + "B" * 36
+FAKE_GHS = "ghs_" + "C" * 36
+FAKE_GHU = "ghu_" + "D" * 36
+FAKE_GHR = "ghr_" + "E" * 36
+FAKE_GH_PAT = "github_pat_" + "F" * 22 + "_" + "G" * 59
+FAKE_LSV2_PT = "lsv2_pt_" + "a" * 32 + "_" + "b" * 16
+FAKE_LSV2_SK = "lsv2_sk_" + "1" * 32 + "_" + "2" * 16
+FAKE_ANTHROPIC = "sk-ant-api03-" + "X" * 80
+FAKE_OPENAI_PROJECT = "sk-proj-" + "y" * 60
+FAKE_OPENAI_LEGACY = "sk-" + "Z" * 48
+FAKE_AWS_AKIA = "AKIA" + "0" * 16
+FAKE_AWS_ASIA = "ASIA" + "9" * 16
+FAKE_JWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY.signaturePart12345678"
+
+
+def _request(name: str, args: dict, call_id: str = "tc-1") -> ToolCallRequest:
+    return ToolCallRequest(
+        tool_call={"id": call_id, "name": name, "args": args, "type": "tool_call"},
+        tool=None,
+        state=None,
+        runtime=None,  # type: ignore[arg-type]
+    )
+
+
+# ---------------------------------------------------------------------------
+# find_secrets — pattern coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("secret_type", "token"),
+    [
+        ("github_classic_token", FAKE_GHP),
+        ("github_classic_token", FAKE_GHO),
+        ("github_classic_token", FAKE_GHS),
+        ("github_classic_token", FAKE_GHU),
+        ("github_classic_token", FAKE_GHR),
+        ("github_fine_grained_pat", FAKE_GH_PAT),
+        ("langsmith_key", FAKE_LSV2_PT),
+        ("langsmith_key", FAKE_LSV2_SK),
+        ("anthropic_key", FAKE_ANTHROPIC),
+        ("openai_project_key", FAKE_OPENAI_PROJECT),
+        ("openai_legacy_key", FAKE_OPENAI_LEGACY),
+        ("aws_access_key_id", FAKE_AWS_AKIA),
+        ("aws_access_key_id", FAKE_AWS_ASIA),
+        ("jwt", FAKE_JWT),
+    ],
+)
+def test_find_secrets_detects_each_builtin_pattern(secret_type: str, token: str) -> None:
+    matches = find_secrets(token)
+    assert any(m.secret_type == secret_type for m in matches), (
+        f"expected {secret_type} match in {token!r}, got {[m.secret_type for m in matches]}"
+    )
+
+
+def test_find_secrets_walks_nested_dict_with_path() -> None:
+    payload = {
+        "actions": [{"body": {"code_evaluators": [{"code": f"K = '{FAKE_GHP}'"}]}}],
+    }
+    matches = find_secrets(payload)
+    assert any(m.secret_type == "github_classic_token" for m in matches)  # noqa: S105
+    assert any(m.path == "actions[0].body.code_evaluators[0].code" for m in matches)
+
+
+def test_find_secrets_returns_offsets_into_matched_string() -> None:
+    text = f"prefix {FAKE_GHP} suffix"
+    matches = find_secrets(text)
+    assert len(matches) == 1
+    m = matches[0]
+    assert text[m.start : m.end] == FAKE_GHP
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "ghp_",  # bare prefix, no body
+        "lsv2_",
+        "sk-ant-",
+        "AKIA",
+        "",
+        " ",
+        "the docs mention sk- as a prefix",
+        "00000000-0000-0000-0000-000000000000",  # zero UUID
+        "1f2a3b4c5d6e7f8090a1b2c3d4e5f607",  # plain 32-hex
+        "1f2a3b4c5d6e7f8090a1b2c3d4e5f6071f2a3b4c",  # git SHA shape (40 hex)
+        "01HV2C8M0F7R3K9X4N5W6E7T8B",  # ULID
+        "sk-test",
+        "TEST" + "0" * 16,  # 4-letter prefix that isn't AKIA/ASIA
+        "eyJhbGciOi.eyJzdWIiOi",  # 2-segment "JWT" — not a real JWT
+        '{"lc": 1, "type": "constructor"}',
+    ],
+)
+def test_find_secrets_negative_corpus(value: str) -> None:
+    assert find_secrets(value) == [], (
+        f"unexpected match in {value!r}: {[m.secret_type for m in find_secrets(value)]}"
+    )
+
+
+def test_find_secrets_ignores_non_string_scalars() -> None:
+    assert find_secrets(None) == []
+    assert find_secrets(42) == []
+    assert find_secrets(value=True) == []
+    assert find_secrets(3.14) == []
+
+
+def test_secret_match_is_frozen() -> None:
+    m = SecretMatch(secret_type="github_classic_token", path="body", start=0, end=40)  # noqa: S106
+    with pytest.raises(FrozenInstanceError):
+        m.secret_type = "other"  # type: ignore[misc]  # noqa: S105
+
+
+# ---------------------------------------------------------------------------
+# Middleware — direct hook tests
+# ---------------------------------------------------------------------------
+
+
+def test_block_strategy_short_circuits_handler() -> None:
+    middleware = SecretMiddleware()  # default strategy="block"
+    handler = MagicMock(side_effect=AssertionError("handler should not run"))
+
+    result = middleware.wrap_tool_call(
+        _request("save_ao", {"content": f"# AO\n{FAKE_GHP}\n"}),
+        handler,
+    )
+
+    handler.assert_not_called()
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.tool_call_id == "tc-1"
+    assert result.name == "save_ao"
+    assert "save_ao" in str(result.content)
+    assert "github_classic_token" in str(result.content)
+    # Critically: the secret substring must not be echoed back into context.
+    assert FAKE_GHP not in str(result.content)
+
+
+def test_clean_payload_passes_through_handler() -> None:
+    middleware = SecretMiddleware()
+    expected = ToolMessage(content="ok", tool_call_id="tc-2", name="save_ao")
+    handler = MagicMock(return_value=expected)
+
+    result = middleware.wrap_tool_call(
+        _request("save_ao", {"content": "no secrets here"}, "tc-2"),
+        handler,
+    )
+
+    handler.assert_called_once()
+    assert result is expected
+
+
+def test_redact_strategy_rewrites_args_and_calls_handler() -> None:
+    middleware = SecretMiddleware(strategy="redact")
+    captured: list[ToolCallRequest] = []
+
+    def handler(req: ToolCallRequest) -> ToolMessage:
+        captured.append(req)
+        return ToolMessage(content="ok", tool_call_id=req.tool_call["id"], name="t")
+
+    request = _request(
+        "t",
+        {
+            "outer": f"prefix {FAKE_GHP} suffix",
+            "nested": {"k": [f"a{FAKE_LSV2_PT}b"]},
+        },
+        "tc-3",
+    )
+    result = middleware.wrap_tool_call(request, handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.content == "ok"
+    assert len(captured) == 1
+    new_args = captured[0].tool_call["args"]
+    # Top-level string was redacted in place, surrounding text preserved.
+    assert new_args["outer"] == "prefix [REDACTED_GITHUB_CLASSIC_TOKEN] suffix"
+    # Nested string was redacted under the right path.
+    assert new_args["nested"] == {"k": ["a[REDACTED_LANGSMITH_KEY]b"]}
+    # The original request object is left intact (immutable override pattern).
+    assert request.tool_call["args"]["outer"] == f"prefix {FAKE_GHP} suffix"
+
+
+def test_tool_filter_skips_unlisted_tools() -> None:
+    middleware = SecretMiddleware(tools=["post_to_slack"])
+    handler = MagicMock(return_value=ToolMessage(content="ok", tool_call_id="tc-4", name="search"))
+
+    result = middleware.wrap_tool_call(
+        _request("search", {"query": f"why is {FAKE_GHP} leaking"}, "tc-4"),
+        handler,
+    )
+
+    handler.assert_called_once()
+    assert isinstance(result, ToolMessage)
+    assert result.content == "ok"
+
+
+def test_tool_filter_applies_to_listed_tools() -> None:
+    middleware = SecretMiddleware(tools=["post_to_slack"])
+    handler = MagicMock(side_effect=AssertionError("handler should not run"))
+
+    result = middleware.wrap_tool_call(
+        _request("post_to_slack", {"text": f"check this: {FAKE_GHP}"}, "tc-5"),
+        handler,
+    )
+
+    handler.assert_not_called()
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+
+
+def test_secret_types_filter_disables_others() -> None:
+    """With secret_types=['aws_access_key_id'], a GitHub token should pass."""
+    middleware = SecretMiddleware(secret_types=["aws_access_key_id"])
+    expected = ToolMessage(content="ok", tool_call_id="tc-6", name="t")
+    handler = MagicMock(return_value=expected)
+
+    result = middleware.wrap_tool_call(
+        _request("t", {"content": f"only github here: {FAKE_GHP}"}, "tc-6"),
+        handler,
+    )
+
+    handler.assert_called_once()
+    assert result is expected
+
+
+def test_secret_types_filter_still_catches_listed() -> None:
+    middleware = SecretMiddleware(secret_types=["aws_access_key_id"])
+    handler = MagicMock(side_effect=AssertionError("handler should not run"))
+
+    result = middleware.wrap_tool_call(
+        _request("t", {"content": f"aws here: {FAKE_AWS_AKIA}"}, "tc-7"),
+        handler,
+    )
+
+    handler.assert_not_called()
+    assert isinstance(result, ToolMessage)
+    assert "aws_access_key_id" in str(result.content)
+
+
+def test_unknown_secret_type_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown secret_type"):
+        SecretMiddleware(secret_types=["not_a_real_type"])
+
+
+def test_invalid_strategy_raises() -> None:
+    with pytest.raises(ValueError, match="strategy must be"):
+        SecretMiddleware(strategy="mask")  # type: ignore[arg-type]
+
+
+def test_custom_detector_runs_alongside_builtins() -> None:
+    pattern = re.compile(r"\bACME-[A-Z0-9]{20}\b")
+
+    def acme_finder(s: str):
+        for m in pattern.finditer(s):
+            yield m.start(), m.end()
+
+    middleware = SecretMiddleware(custom_detectors={"acme_internal_token": acme_finder})
+    handler = MagicMock(side_effect=AssertionError("handler should not run"))
+
+    fake_acme = "ACME-" + "Z" * 20
+    result = middleware.wrap_tool_call(
+        _request("t", {"content": f"saw {fake_acme} in trace"}, "tc-8"),
+        handler,
+    )
+
+    handler.assert_not_called()
+    assert isinstance(result, ToolMessage)
+    assert "acme_internal_token" in str(result.content)
+
+
+def test_custom_detector_only_disables_builtins() -> None:
+    """secret_types=[] disables all built-ins; only custom detectors run."""
+    pattern = re.compile(r"\bACME-[A-Z0-9]{20}\b")
+
+    def acme_finder(s: str):
+        for m in pattern.finditer(s):
+            yield m.start(), m.end()
+
+    middleware = SecretMiddleware(
+        secret_types=[],
+        custom_detectors={"acme_internal_token": acme_finder},
+    )
+    expected = ToolMessage(content="ok", tool_call_id="tc-9", name="t")
+    handler = MagicMock(return_value=expected)
+
+    result = middleware.wrap_tool_call(
+        _request("t", {"content": f"github token {FAKE_GHP} but no acme"}, "tc-9"),
+        handler,
+    )
+
+    handler.assert_called_once()
+    assert result is expected
+
+
+def test_missing_args_field_is_handled() -> None:
+    middleware = SecretMiddleware()
+    expected = ToolMessage(content="ok", tool_call_id="tc-10", name="ls")
+    handler = MagicMock(return_value=expected)
+
+    request = ToolCallRequest(
+        tool_call={"id": "tc-10", "name": "ls", "type": "tool_call"},  # type: ignore[typeddict-item]
+        tool=None,
+        state=None,
+        runtime=None,  # type: ignore[arg-type]
+    )
+    result = middleware.wrap_tool_call(request, handler)
+
+    handler.assert_called_once()
+    assert result is expected
+
+
+def test_redact_collapses_overlapping_matches() -> None:
+    """Overlapping detector spans get merged in a single redaction.
+
+    If two detectors hit overlapping spans, redaction merges them rather
+    than double-substituting (which would corrupt offsets).
+    """
+
+    def covers_full_string(s: str):
+        if s:
+            yield 0, len(s)
+
+    captured: list[ToolCallRequest] = []
+
+    def handler(req: ToolCallRequest) -> ToolMessage:
+        captured.append(req)
+        return ToolMessage(content="ok", tool_call_id=req.tool_call["id"], name="t")
+
+    middleware_redact = SecretMiddleware(
+        strategy="redact",
+        secret_types=["github_classic_token"],
+        custom_detectors={"covers_all": covers_full_string},
+    )
+    request = _request("t", {"x": f"{FAKE_GHP}"}, "tc-11")
+    result = middleware_redact.wrap_tool_call(request, handler)
+    assert isinstance(result, ToolMessage)
+    # The merged span ends up labelled with the first-sorted match's label
+    # — what matters is that the output is a single redaction marker, not
+    # nested or double-substituted text.
+    assert captured[0].tool_call["args"]["x"].count("[REDACTED_") == 1
+
+
+# ---------------------------------------------------------------------------
+# Async variant
+# ---------------------------------------------------------------------------
+
+
+_HANDLER_CALLED_MSG = "handler should not run"
+
+
+async def test_async_block_short_circuits_handler() -> None:
+    middleware = SecretMiddleware()
+
+    async def handler(_req: ToolCallRequest) -> ToolMessage:
+        raise AssertionError(_HANDLER_CALLED_MSG)
+
+    result = await middleware.awrap_tool_call(
+        _request("t", {"content": FAKE_GHP}, "tc-async-1"),
+        handler,
+    )
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert FAKE_GHP not in str(result.content)
+
+
+async def test_async_clean_payload_awaits_handler() -> None:
+    middleware = SecretMiddleware()
+    awaited: list[ToolCallRequest] = []
+
+    async def handler(req: ToolCallRequest) -> ToolMessage:
+        awaited.append(req)
+        return ToolMessage(content="ok", tool_call_id=req.tool_call["id"], name="t")
+
+    result = await middleware.awrap_tool_call(
+        _request("t", {"content": "no secrets"}, "tc-async-2"),
+        handler,
+    )
+
+    assert len(awaited) == 1
+    assert isinstance(result, ToolMessage)
+    assert result.content == "ok"
+
+
+# ---------------------------------------------------------------------------
+# create_agent end-to-end
+# ---------------------------------------------------------------------------
+
+
+@tool
+def echo_tool(value: str) -> str:
+    """Echo the value back."""
+    return f"echoed: {value}"
+
+
+def test_e2e_block_returns_error_tool_message() -> None:
+    """End-to-end: a poisoned tool call surfaces as a single error ToolMessage.
+
+    The middleware integrates with create_agent: a poisoned tool call
+    surfaces as a single ``ToolMessage(status='error')`` and the tool body
+    is never reached (echoed value would otherwise appear).
+    """
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="echo_tool", args={"value": FAKE_GHP}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[echo_tool],
+        middleware=[SecretMiddleware()],
+        checkpointer=InMemorySaver(),
+    )
+
+    result: dict[str, Any] = agent.invoke(
+        {"messages": [HumanMessage("Echo the test value")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    msg = tool_messages[0]
+    assert msg.status == "error"
+    assert "echo_tool" in str(msg.content)
+    assert "github_classic_token" in str(msg.content)
+    # Secret must not survive into the message stream.
+    assert FAKE_GHP not in str(msg.content)
+    # Tool body never ran.
+    assert not any("echoed:" in str(m.content) for m in tool_messages)
+
+
+def test_e2e_redact_runs_tool_with_redacted_args() -> None:
+    """End-to-end: with strategy='redact', the tool runs on rewritten args.
+
+    With ``strategy='redact'``, the tool body executes against the
+    rewritten args. The agent receives the tool's normal output, computed
+    over the redacted string.
+    """
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="echo_tool", args={"value": FAKE_GHP}, id="1")],
+            [],
+        ]
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[echo_tool],
+        middleware=[SecretMiddleware(strategy="redact")],
+        checkpointer=InMemorySaver(),
+    )
+
+    result: dict[str, Any] = agent.invoke(
+        {"messages": [HumanMessage("Echo the test value")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    content = str(tool_messages[0].content)
+    assert "echoed:" in content
+    assert "[REDACTED_GITHUB_CLASSIC_TOKEN]" in content
+    assert FAKE_GHP not in content
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_secret_types_is_frozen_set_of_known_names() -> None:
+    assert isinstance(BUILTIN_SECRET_TYPES, frozenset)
+    expected = {
+        "github_classic_token",
+        "github_fine_grained_pat",
+        "langsmith_key",
+        "anthropic_key",
+        "openai_project_key",
+        "openai_legacy_key",
+        "aws_access_key_id",
+        "jwt",
+    }
+    assert expected == BUILTIN_SECRET_TYPES


### PR DESCRIPTION
## Description

Adds a tool-call middleware (`SecretMiddleware`) that detects known credential patterns in tool-call arguments and either blocks the call or redacts the matched substring before the tool runs.

## Motivation

Agents that read attacker-controllable input — system prompts, retrieved documents, tool-result content from upstream tools — can be steered (via prompt injection) into emitting tool calls that embed credentials they read from elsewhere, exfiltrating them through the legitimate tool surface. The egress allowlist on the agent's environment can't help here because the destination host is exactly the one you have to allow for legitimate use.

A chokepoint in front of tool execution that inspects args closes that gap. It's the natural complement to `PIIMiddleware` (which scans messages for PII) — different threat surface (tool args), different patterns (credentials), but the same shape of solution.

## API

```python
from langchain.agents import create_agent
from langchain.agents.middleware import SecretMiddleware

# Default: block any tool call carrying a known secret.
agent = create_agent("openai:gpt-5", tools=[...], middleware=[SecretMiddleware()])

# Or redact in place and let the tool run on rewritten args.
agent = create_agent(
    "openai:gpt-5",
    tools=[...],
    middleware=[SecretMiddleware(strategy="redact")],
)
```

Other constructor args:
- `tools=[...]` — limit to specific tools (mirrors `ToolRetryMiddleware`).
- `secret_types=[...]` — limit to specific built-in detectors. See `BUILTIN_SECRET_TYPES` for the full set: `github_classic_token`, `github_fine_grained_pat`, `langsmith_key`, `anthropic_key`, `openai_project_key`, `openai_legacy_key`, `aws_access_key_id`, `jwt`.
- `custom_detectors={"name": finder}` — register additional detectors. Each finder takes a string and yields `(start, end)` byte-offset pairs.

Public surface: `SecretMiddleware`, `SecretMatch`, `find_secrets`, `BUILTIN_SECRET_TYPES`.

## Design notes

**No `\b` word-boundary anchors on the patterns.** Each detector relies on prefix + length + alphabet to be tight on its own. Boundaries would block matches when secrets are concatenated with alphanumeric characters in JSON the agent built up by interpolation — exactly the case attackers exploit. The negative corpus in `test_find_secrets_negative_corpus` (commit SHAs, UUIDs, ULIDs, `{"lc": 1, ...}` manifest snippets, prose like `"the docs mention sk- as a prefix"`) confirms FP rate stays at zero without them.

**Block strategy never echoes the matched substring back.** Returning the match in the `ToolMessage` content would re-publish the secret into the agent's context window, defeating the purpose. The rejection mentions only the *type* (e.g. `github_classic_token`) and the tool name.

**Redact uses `request.override`** to produce a new `ToolCallRequest` with rewritten args, leaving the original immutable.

## Tests

51 tests covering: each built-in pattern detected, negative corpus, nested dict walking with path tracking, offset reporting, block strategy, redact strategy (incl. nested + overlapping spans), `tools` filter, `secret_types` filter, custom detectors with and without built-ins, async wrap, missing args dict, and end-to-end `create_agent` integration for both strategies.

```
51 passed in 3.60s
```

Lint clean (`uv run --group lint ruff check`), formatted (`uv run --group lint ruff format`).