### PR TITLE
Fix LangChain core message/runnable utility issues

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f

--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -275,17 +275,19 @@ class AIMessage(BaseMessage):
             }
             for tool_call in self.tool_calls:
                 if (id_ := tool_call.get("id")) and id_ not in content_tool_call_ids:
-                    tool_call_block: types.ToolCall = {
+                    tool_call_block: dict[str, Any] = {
                         "type": "tool_call",
                         "id": id_,
                         "name": tool_call["name"],
                         "args": tool_call["args"],
                     }
                     if "index" in tool_call:
-                        tool_call_block["index"] = tool_call["index"]  # type: ignore[typeddict-item]
+                        tool_call_block["index"] = cast("int", tool_call["index"])
                     if "extras" in tool_call:
-                        tool_call_block["extras"] = tool_call["extras"]  # type: ignore[typeddict-item]
-                    blocks.append(tool_call_block)
+                        tool_call_block["extras"] = cast(
+                            "dict[str, Any]", tool_call["extras"]
+                        )
+                    blocks.append(cast("types.ContentBlock", tool_call_block))
 
         # Best-effort reasoning extraction from additional_kwargs
         # Only add reasoning if not already present

--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -135,7 +135,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):  # type: ignore[no-redef]
             ]
         )
 
-        chain = prompt | ChatAnthropic(model="claude-2")
+        chain = prompt | ChatAnthropic(model="claude-3-haiku-20240307")
 
         chain_with_history = RunnableWithMessageHistory(
             chain,
@@ -188,7 +188,7 @@ class RunnableWithMessageHistory(RunnableBindingBase):  # type: ignore[no-redef]
             ]
         )
 
-        chain = prompt | ChatAnthropic(model="claude-2")
+        chain = prompt | ChatAnthropic(model="claude-3-haiku-20240307")
 
         with_message_history = RunnableWithMessageHistory(
             chain,

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (

--- a/libs/text-splitters/langchain_text_splitters/nltk.py
+++ b/libs/text-splitters/langchain_text_splitters/nltk.py
@@ -43,12 +43,12 @@ class NLTKTextSplitter(TextSplitter):
         self._separator = separator
         self._language = language
         self._use_span_tokenize = use_span_tokenize
-        if self._use_span_tokenize and self._separator:
-            msg = "When use_span_tokenize is True, separator should be ''"
-            raise ValueError(msg)
         if not _HAS_NLTK:
             msg = "NLTK is not installed, please install it with `pip install nltk`."
             raise ImportError(msg)
+        if self._use_span_tokenize and self._separator:
+            msg = "When use_span_tokenize is True, separator should be ''"
+            raise ValueError(msg)
         if self._use_span_tokenize:
             self._tokenizer = nltk.tokenize._get_punkt_tokenizer(self._language)  # noqa: SLF001
         else:


### PR DESCRIPTION
## Summary
- Update deprecated ChatAnthropic examples from claude-2 to claude-3-haiku-20240307.
- Fix comparator wording in structured query validation errors.
- Support string input in Blob.as_bytes_io().
- Reorder NLTK checks so missing package errors are raised before span-tokenize separator validation.
- Remove typed dict item ignores by casting values when generating AI message tool-call content blocks.

## Testing
- Not run (per instruction).
