### PR TITLE
ci(infra): pin `pypa/gh-action-pypi-publish` to commit SHA

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -207,7 +207,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Publish to test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: ${{ inputs.working-directory }}/dist/
           verbose: true
@@ -492,7 +492,7 @@ jobs:
           path: ${{ inputs.working-directory }}/dist/
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: ${{ inputs.working-directory }}/dist/
           verbose: true


### PR DESCRIPTION
The two `pypa/gh-action-pypi-publish` invocations in the release workflow were still pinned to the floating `release/v1` branch on `v0.3`. Pin them to a full-length commit SHA, matching what was already done on `master` in #37206.

The SHA used is the current head of `release/v1` (verified via the GitHub API), so behavior is unchanged — only the pin is tightened to satisfy the SHA-pinning policy.

*Disclaimer: this contribution was prepared with AI-agent assistance.*