### PR TITLE
fix: implement Language.PERL in RecursiveCharacterTextSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -788,6 +788,33 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "",
             ]
 
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "\nsub ",
+                # Split along variable declarations
+                "\nmy ",
+                "\nour ",
+                "\nlocal ",
+                # Split along control flow statements
+                "\nif ",
+                "\nelsif ",
+                "\nelse ",
+                "\nunless ",
+                "\nfor ",
+                "\nforeach ",
+                "\nwhile ",
+                "\nuntil ",
+                # Split along module and package statements
+                "\npackage ",
+                "\nuse ",
+                "\nrequire ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"
             raise ValueError(msg)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3503,6 +3503,35 @@ def test_visualbasic6_code_splitter() -> None:
     ]
 
 
+def test_perl_code_splitter() -> None:
+    splitter = RecursiveCharacterTextSplitter.from_language(
+        Language.PERL, chunk_size=CHUNK_SIZE, chunk_overlap=0
+    )
+    code = """
+use strict;
+use warnings;
+
+my $x = 10;
+
+sub add {
+    my ($a, $b) = @_;
+    return $a + $b;
+}
+    """
+    chunks = splitter.split_text(code)
+    assert chunks == [
+        "use strict;",
+        "use warnings;",
+        "my $x = 10;",
+        "sub add {",
+        "my ($a, $b) =",
+        "@_;",
+        "return $a +",
+        "$b;",
+        "}",
+    ]
+
+
 def custom_iframe_extractor(iframe_tag: Tag) -> str:
     iframe_src = iframe_tag.get("src", "")
     return f"[iframe:{iframe_src}]({iframe_src})"


### PR DESCRIPTION
## Description

`Language.PERL` is declared in the `Language` enum but calling `RecursiveCharacterTextSplitter.from_language(Language.PERL, ...)` throws:

```
ValueError: Language perl is not implemented yet!
```

This PR implements Perl separator logic in `get_separators_for_language()`, fixing the broken enum value.

Fixes #37049

## Changes

- **`libs/text-splitters/langchain_text_splitters/character.py`**: Add `Language.PERL` case with separators covering subroutine definitions (`sub`), variable declarations (`my`, `our`, `local`), control flow (`if`, `elsif`, `else`, `unless`, `for`, `foreach`, `while`, `until`), and module statements (`package`, `use`, `require`)
- **`libs/text-splitters/tests/unit_tests/test_text_splitters.py`**: Add `test_perl_code_splitter` following the same pattern as all other language splitter tests

## Testing

Added unit test `test_perl_code_splitter` with a representative Perl snippet covering the key separators.