### PR TITLE
feat(openai): add input_video type support in responses API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4529,7 +4529,7 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                         new_blocks.append(
                             _convert_chat_completions_blocks_to_responses(block)
                         )
-                    elif block["type"] in ("input_text", "input_image", "input_file"):
+                    elif block["type"] in ("input_text", "input_image", "input_file", "input_video"):
                         new_blocks.append(block)
                     elif block["type"] in non_message_item_types:
                         input_.append(block)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3776,3 +3776,25 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+def test_construct_responses_api_input_with_input_video():
+    """Test that input_video type is properly handled in responses API input."""
+    from langchain_openai.chat_models.base import _construct_responses_api_input
+    from langchain_core.messages import HumanMessage
+
+    messages = [
+        HumanMessage(
+            content=[
+                {"type": "input_text", "text": "Describe this video"},
+                {"type": "input_video", "video_url": "https://example.com/video.mp4"},
+            ]
+        )
+    ]
+
+    result = _construct_responses_api_input(messages)
+    
+    assert len(result) == 2
+    assert result[0]["type"] == "input_text"
+    assert result[0]["text"] == "Describe this video"
+    assert result[1]["type"] == "input_video"
+    assert result[1]["video_url"] == "https://example.com/video.mp4"


### PR DESCRIPTION
## Summary

Add support for `input_video` type in the OpenAI Responses API to enable BytePlus (ByteDance) video functionality.

## Changes

- Added `input_video` to the list of supported content types in `_construct_responses_api_input`
- Added unit test to verify `input_video` type is properly handled

## Related Issue

Fixes langchain-ai/langchain#36414