### PR TITLE
fix(huggingface): pass model= in _stream and _astream text_generation calls

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_endpoint.py
@@ -417,7 +417,7 @@ class HuggingFaceEndpoint(LLM):
         invocation_params = self._invocation_params(stop, **kwargs)
 
         for response in self.client.text_generation(
-            prompt, **invocation_params, stream=True
+            prompt, model=self.model, **invocation_params, stream=True
         ):
             # identify stop sequence in generated text, if any
             stop_seq_found: str | None = None
@@ -453,7 +453,7 @@ class HuggingFaceEndpoint(LLM):
     ) -> AsyncIterator[GenerationChunk]:
         invocation_params = self._invocation_params(stop, **kwargs)
         async for response in await self.async_client.text_generation(
-            prompt, **invocation_params, stream=True
+            prompt, model=self.model, **invocation_params, stream=True
         ):
             # identify stop sequence in generated text, if any
             stop_seq_found: str | None = None


### PR DESCRIPTION
Fixes #29521

## Problem

`_call` (non-streaming) and `_acall` (async non-streaming) both correctly pass `model=self.model` to `client.text_generation()`, ensuring the user-supplied model is used. However `_stream` and `_astream` omit this argument:

```python
# _stream (L419) — missing model=
for response in self.client.text_generation(
    prompt, **invocation_params, stream=True
):

# _astream (L455) — missing model=
async for response in await self.async_client.text_generation(
    prompt, **invocation_params, stream=True
):
```

When `InferenceClient` is initialised with a `model` in the constructor, it uses that as the default for subsequent calls. But if the model was resolved at init time to a deployment URL or if the client's default differs from `self.model`, the streaming path silently uses the wrong model — a hard-to-debug inconsistency since non-streaming calls work correctly.

## Fix

Add `model=self.model` to both `_stream` and `_astream` call sites, consistent with `_call` and `_acall`.