### PR TITLE
Guard criteria parser against inconsistent verdicts

### DIFF
--- a/libs/langchain/langchain_classic/evaluation/criteria/eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/criteria/eval_chain.py
@@ -62,6 +62,39 @@ _SUPPORTED_CRITERIA = {
     Criteria.DETAIL: "Does the submission demonstrate attention to detail?",
 }
 
+_NEGATIVE_REASONING_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\bdoes\s+not\s+(?:meet|satisfy|fulfill)\b",
+        r"\bnot\s+(?:meet|satisfy|fulfill)\b",
+        r"\bis\s+not\s+(?:correct|accurate|factual|helpful|relevant|concise)\b",
+        r"\b(?:fails|failed)\s+(?:the\s+)?(?:criterion|criteria|requirement|requirements)\b",
+        r"\bincomplete\b",
+        r"\bdoes\s+not\s+fulfill\s+the\s+objective\b",
+    )
+]
+_POSITIVE_REASONING_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\b(?:meets|satisfies|fulfills)\s+(?:the\s+)?(?:criterion|criteria|requirement|requirements|objective)\b",
+        r"\bis\s+(?:correct|accurate|factual|helpful|relevant|concise)\b",
+        r"\bfulfills\s+the\s+objective\b",
+    )
+]
+
+
+def _verdict_inconsistent_with_reasoning(verdict: str, reasoning: str) -> bool:
+    conclusion = reasoning.strip().rsplit("\n\n", maxsplit=1)[-1]
+    if verdict.upper() == "Y":
+        return any(
+            pattern.search(conclusion) for pattern in _NEGATIVE_REASONING_PATTERNS
+        )
+    if verdict.upper() == "N":
+        return any(
+            pattern.search(conclusion) for pattern in _POSITIVE_REASONING_PATTERNS
+        )
+    return False
+
 
 class CriteriaResultOutputParser(BaseOutputParser[dict]):
     """A parser for the output of the CriteriaEvalChain."""
@@ -98,15 +131,23 @@ class CriteriaResultOutputParser(BaseOutputParser[dict]):
             splits = text.strip().rsplit("\n", maxsplit=1)
             verdict = splits[-1]
 
+        verdict_inconsistent_with_reasoning = False
         if verdict:
             score = (
                 1 if verdict.upper() == "Y" else (0 if verdict.upper() == "N" else None)
             )
+            verdict_inconsistent_with_reasoning = (
+                score is not None
+                and _verdict_inconsistent_with_reasoning(verdict, text)
+            )
+            if verdict_inconsistent_with_reasoning:
+                score = None
 
         return {
             "reasoning": text.strip(),
             "value": verdict,
             "score": score,
+            "verdict_inconsistent_with_reasoning": verdict_inconsistent_with_reasoning,
         }
 
 

--- a/libs/langchain/tests/unit_tests/evaluation/criteria/test_eval_chain.py
+++ b/libs/langchain/tests/unit_tests/evaluation/criteria/test_eval_chain.py
@@ -49,6 +49,32 @@ def test_resolve_criteria_str() -> None:
                 "score": 1,
             },
         ),
+        (
+            "The submission only interacts with the return date picker.\n\n"
+            "The submission does not meet the criteria of correctness because it "
+            "fails the requirements and is incomplete.\n\n"
+            "Y",
+            {
+                "reasoning": (
+                    "The submission only interacts with the return date picker.\n\n"
+                    "The submission does not meet the criteria of correctness because "
+                    "it fails the requirements and is incomplete."
+                ),
+                "value": "Y",
+                "score": None,
+            },
+        ),
+        (
+            "The submitted answer matches the reference answer.\n\n"
+            "Therefore, the submission meets the criteria.\n\n"
+            "N",
+            {
+                "reasoning": "The submitted answer matches the reference answer.\n\n"
+                "Therefore, the submission meets the criteria.",
+                "value": "N",
+                "score": None,
+            },
+        ),
     ],
 )
 def test_criteria_result_output_parser_parse(text: str, want: dict) -> None:


### PR DESCRIPTION
## Summary
- Adds a conservative consistency check in `CriteriaResultOutputParser` for cases where the terminal `Y`/`N` verdict contradicts clear conclusion language in the reasoning.
- Marks contradictory parser outputs as `score=None` and exposes `verdict_inconsistent_with_reasoning=True` instead of silently returning the wrong score.
- Adds unit coverage for the reported `Y` despite failing reasoning case and the symmetric `N` despite passing reasoning case.

Fixes #31870.

## Verification
- `python -m pytest libs\langchain\tests\unit_tests\evaluation\criteria\test_eval_chain.py -q` -> 23 passed
- `python -m ruff check libs\langchain\langchain_classic\evaluation\criteria\eval_chain.py libs\langchain\tests\unit_tests\evaluation\criteria\test_eval_chain.py`
- `python -m compileall libs\langchain\langchain_classic\evaluation\criteria\eval_chain.py libs\langchain\tests\unit_tests\evaluation\criteria\test_eval_chain.py`
- `git diff --check`

## AANA gate
- Intake gate: pass, recommended action `accept`
- Code-change guardrail: pass, recommended action `accept`
- AIx score: 1.0
- Violations: none
