### PR TITLE
fix(langchain): handle phased multi-text JSON in `ProviderStrategyBinding` (#36290)

### DIFF
--- a/libs/langchain_v1/langchain/agents/structured_output.py
+++ b/libs/langchain_v1/langchain/agents/structured_output.py
@@ -423,11 +423,26 @@ class ProviderStrategyBinding(Generic[SchemaT]):
     def _extract_text_content_from_message(message: AIMessage) -> str:
         """Extract text content from an `AIMessage`.
 
+        Handles three content shapes:
+
+        - ``str``: returned as-is.
+        - ``list`` of text parts that together form a single JSON document
+          (e.g. streamed/split payload): joined and returned.
+        - ``list`` of text parts where one or more individual parts are
+          themselves complete JSON documents (e.g. a "phased" response from
+          the OpenAI Responses API containing both ``commentary`` and
+          ``final_answer`` text blocks): the last individually-valid JSON
+          block is returned. Concatenating such phased responses would
+          produce invalid JSON like ``{...}{...}`` and fail downstream
+          ``json.loads``. Returning the last valid block matches the
+          intended answer (``final_answer`` is emitted after
+          ``commentary``) while remaining provider-agnostic.
+
         Args:
             message: The AI message to extract text from
 
         Returns:
-            The extracted text content
+            The extracted text content ready to be passed to ``json.loads``.
         """
         content = message.content
         if isinstance(content, str):
@@ -441,6 +456,22 @@ class ProviderStrategyBinding(Generic[SchemaT]):
                     parts.append(c["content"])
             else:
                 parts.append(str(c))
+
+        # If any individual part is itself a complete JSON document, prefer
+        # the last such part. This correctly handles phased responses where
+        # multiple sibling text blocks each contain a standalone JSON
+        # payload, without disturbing the existing behaviour for payloads
+        # that are split across parts (joined below).
+        for part in reversed(parts):
+            stripped = part.strip()
+            if not stripped:
+                continue
+            try:
+                json.loads(stripped)
+            except ValueError:
+                continue
+            return part
+
         return "".join(parts)
 
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_responses.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_responses.py
@@ -266,6 +266,42 @@ class TestProviderStrategyBinding:
         assert result.age == 30
         assert result.email == "default@example.com"  # default value
 
+    def test_parse_phased_multi_text_blocks(self) -> None:
+        """Regression test for issue #36290.
+
+        When an ``AIMessage`` content list contains multiple text parts that
+        are each a complete JSON document (the "phased" response shape emitted
+        by the OpenAI Responses API with ``commentary`` and ``final_answer``
+        phases), parsing must not naively concatenate the parts — that would
+        yield invalid JSON like ``{...}{...}`` and fail.
+
+        The extractor should return the last individually-valid JSON block,
+        which matches the intended answer (``final_answer`` is emitted after
+        ``commentary``).
+        """
+        schema_spec = _SchemaSpec(schema=_TestModel)
+        tool_binding = ProviderStrategyBinding.from_schema_spec(schema_spec)
+
+        message = AIMessage(
+            content=[
+                {
+                    "type": "text",
+                    "text": '{"name": "commentary-name", "age": 10}',
+                    "phase": "commentary",
+                },
+                {
+                    "type": "text",
+                    "text": '{"name": "final-name", "age": 42}',
+                    "phase": "final_answer",
+                },
+            ]
+        )
+        result = tool_binding.parse(message)
+
+        assert isinstance(result, _TestModel)
+        assert result.name == "final-name"
+        assert result.age == 42
+
 
 class TestEdgeCases:
     """Test edge cases and error conditions."""


### PR DESCRIPTION
Closes #36290

---

`ProviderStrategyBinding.parse` fails with `json.decoder.JSONDecodeError: Extra data` whenever `AIMessage.content` is a list of multiple text parts that are each a complete JSON document — the "phased" response shape emitted by the OpenAI Responses API, which contains both a `commentary` and a `final_answer` text block. The failure manifests on every run whose conversation includes replayed/mocked phased assistant messages (common in eval harnesses), and intermittently on live `gpt-5.x` reasoning calls when the per-message `phase` field isn't round-tripped.

The root cause is in `_extract_text_content_from_message`: it concatenates every `type: "text"` part into a single string before calling `json.loads`, so two sibling JSON payloads collide into `{"some_field":"x"}{"some_field":"y"}` and parsing raises. The current concatenation behaviour is deliberately present to support the opposite case — payloads split across parts (exercised by `test_parse_content_list`) — so we can't simply pick one part unconditionally.

### Fix

Before falling back to concatenation, walk the extracted parts in reverse and return the first part that itself parses as valid JSON. This:

- Correctly selects `final_answer` over `commentary` for phased responses (phases are emitted in order, so the last valid-JSON block is the final answer).
- Preserves behaviour for split-JSON payloads — no individual part parses, so we fall through to the concatenation branch as before.
- Stays entirely inside `langchain_v1` with no reference to OpenAI-specific fields like `phase`, so the earlier concern from #36307 about leaking provider details into `langchain` does not apply here.

### Why not simply pick the `phase: "final_answer"` block

That would require `langchain_v1` to know about an OpenAI-specific content-part field, which @ccurme explicitly flagged as undesirable on #36290. The "last individually-valid JSON block" heuristic gets the same answer for phased responses while remaining provider-agnostic and making no assumptions about the shape of future multi-block responses from other providers.

### Tests

Added `test_parse_phased_multi_text_blocks` as a regression test in `tests/unit_tests/agents/test_responses.py`. It reproduces the exact scenario from the issue body — a commentary + final_answer block — and asserts the parsed result reflects the `final_answer` payload. The existing `test_parse_content_list` (split-JSON) continues to pass, confirming the fallback path is preserved.

Full `tests/unit_tests/agents/` suite: 732 passed, 14 skipped. `ruff check` and `ruff format` clean.

_Disclosure: this contribution was drafted with AI-agent assistance._
