### PR TITLE
Nightly OSS: legacy serialization mapping points to outdated module namespace

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -97,7 +97,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "BasePromptTemplate",
     ),
     ("langchain", "chains", "llm", "LLMChain"): (
-        "langchain",
+        "langchain_classic",
         "chains",
         "llm",
         "LLMChain",
@@ -150,7 +150,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "AgentActionMessageLog",
     ),
     ("langchain", "schema", "agent", "ToolAgentAction"): (
-        "langchain",
+        "langchain_classic",
         "agents",
         "output_parsers",
         "tools",
@@ -181,7 +181,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "Document",
     ),
     ("langchain", "output_parsers", "fix", "OutputFixingParser"): (
-        "langchain",
+        "langchain_classic",
         "output_parsers",
         "fix",
         "OutputFixingParser",
@@ -193,7 +193,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "AIMessagePromptTemplate",
     ),
     ("langchain", "output_parsers", "regex", "RegexParser"): (
-        "langchain",
+        "langchain_classic",
         "output_parsers",
         "regex",
         "RegexParser",
@@ -421,7 +421,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "VertexAI",
     ),
     ("langchain", "output_parsers", "combining", "CombiningOutputParser"): (
-        "langchain",
+        "langchain_classic",
         "output_parsers",
         "combining",
         "CombiningOutputParser",
@@ -477,7 +477,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "ChatPromptValueConcrete",
     ),
     ("langchain", "schema", "runnable", "HubRunnable"): (
-        "langchain",
+        "langchain_classic",
         "runnables",
         "hub",
         "HubRunnable",
@@ -489,7 +489,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "RunnableBindingBase",
     ),
     ("langchain", "schema", "runnable", "OpenAIFunctionsRouter"): (
-        "langchain",
+        "langchain_classic",
         "runnables",
         "openai_functions",
         "OpenAIFunctionsRouter",
@@ -608,7 +608,7 @@ _OG_SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "ImagePromptTemplate",
     ),
     ("langchain", "schema", "agent", "OpenAIToolAgentAction"): (
-        "langchain",
+        "langchain_classic",
         "agents",
         "output_parsers",
         "openai_tools",

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -942,6 +942,64 @@ class TestJinja2SecurityBlocking:
 class TestClassSpecificValidatorsInLoad:
     """Tests that load() properly integrates with class-specific validators."""
 
+    def test_legacy_langchain_classic_mappings(self) -> None:
+        """Legacy IDs should resolve to the package that owns their classes."""
+        expected_mappings = {
+            ("langchain", "chains", "llm", "LLMChain"): (
+                "langchain_classic",
+                "chains",
+                "llm",
+                "LLMChain",
+            ),
+            ("langchain", "schema", "agent", "ToolAgentAction"): (
+                "langchain_classic",
+                "agents",
+                "output_parsers",
+                "tools",
+                "ToolAgentAction",
+            ),
+            ("langchain", "output_parsers", "fix", "OutputFixingParser"): (
+                "langchain_classic",
+                "output_parsers",
+                "fix",
+                "OutputFixingParser",
+            ),
+            ("langchain", "output_parsers", "regex", "RegexParser"): (
+                "langchain_classic",
+                "output_parsers",
+                "regex",
+                "RegexParser",
+            ),
+            ("langchain", "output_parsers", "combining", "CombiningOutputParser"): (
+                "langchain_classic",
+                "output_parsers",
+                "combining",
+                "CombiningOutputParser",
+            ),
+            ("langchain", "schema", "runnable", "HubRunnable"): (
+                "langchain_classic",
+                "runnables",
+                "hub",
+                "HubRunnable",
+            ),
+            ("langchain", "schema", "runnable", "OpenAIFunctionsRouter"): (
+                "langchain_classic",
+                "runnables",
+                "openai_functions",
+                "OpenAIFunctionsRouter",
+            ),
+            ("langchain", "schema", "agent", "OpenAIToolAgentAction"): (
+                "langchain_classic",
+                "agents",
+                "output_parsers",
+                "openai_tools",
+                "OpenAIToolAgentAction",
+            ),
+        }
+
+        for legacy_id, class_path in expected_mappings.items():
+            assert ALL_SERIALIZABLE_MAPPINGS[legacy_id] == class_path
+
     def test_validator_registry_keys_in_serializable_mapping(self) -> None:
         """All CLASS_INIT_VALIDATORS keys must exist in ALL_SERIALIZABLE_MAPPINGS."""
         all_known_paths = set(ALL_SERIALIZABLE_MAPPINGS.keys()) | set(


### PR DESCRIPTION
Automated nightly Codex contribution for https://github.com/langchain-ai/langchain/issues/36230.

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

This PR is generated by xodn348/oss-nightly-control and is opened ready for maintainer review when the local nightly verification step succeeds.
