### PR TITLE
chore(langchain-classic): deprecate hub, limit loads/dumps

### DIFF
--- a/libs/langchain/langchain_classic/hub.py
+++ b/libs/langchain/langchain_classic/hub.py
@@ -22,7 +22,7 @@ def push(
     *,
     api_url: str | None = None,
     api_key: str | None = None,
-    parent_commit_hash: str | None = None,
+    parent_commit_hash: str = "latest",
     new_repo_is_public: bool = False,
     new_repo_description: str | None = None,
     readme: str | None = None,

--- a/libs/langchain/langchain_classic/hub.py
+++ b/libs/langchain/langchain_classic/hub.py
@@ -2,57 +2,20 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
-from typing import Any, Literal
+from typing import Any
 
 from langchain_core._api.deprecation import deprecated
-from langchain_core.load.dump import dumps
-from langchain_core.load.load import loads
-from langchain_core.prompts import BasePromptTemplate
+from langsmith import Client as LangSmithClient
 
 
-def _get_client(
-    api_key: str | None = None,
-    api_url: str | None = None,
-) -> Any:
-    """Get a client for interacting with the LangChain Hub.
-
-    Attempts to use LangSmith client if available, otherwise falls back to
-    the legacy `langchainhub` client.
-
-    Args:
-        api_key: API key to authenticate with the LangChain Hub API.
-        api_url: URL of the LangChain Hub API.
-
-    Returns:
-        Client instance for interacting with the hub.
-
-    Raises:
-        ImportError: If neither `langsmith` nor `langchainhub` can be imported.
-    """
-    try:
-        from langsmith import Client as LangSmithClient
-
-        ls_client = LangSmithClient(api_url, api_key=api_key)
-        if hasattr(ls_client, "push_prompt") and hasattr(ls_client, "pull_prompt"):
-            return ls_client
-        from langchainhub import Client as LangChainHubClient
-
-        return LangChainHubClient(api_url, api_key=api_key)
-    except ImportError:
-        try:
-            from langchainhub import Client as LangChainHubClient
-
-            return LangChainHubClient(api_url, api_key=api_key)
-        except ImportError as e:
-            msg = (
-                "Could not import langsmith or langchainhub (deprecated),"
-                "please install with `pip install langsmith`."
-            )
-            raise ImportError(msg) from e
-
-
+@deprecated(
+    since="1.0.6",
+    removal="2.0.0",
+    message=(
+        "langchain_classic.hub.push is deprecated. Use the LangSmith SDK instead."
+    ),
+)
 def push(
     repo_full_name: str,
     object: Any,  # noqa: A002
@@ -84,28 +47,15 @@ def push(
     Returns:
         URL where the pushed object can be viewed in a browser.
     """
-    client = _get_client(api_key=api_key, api_url=api_url)
-
-    # Then it's langsmith
-    if hasattr(client, "push_prompt"):
-        return client.push_prompt(
-            repo_full_name,
-            object=object,
-            parent_commit_hash=parent_commit_hash,
-            is_public=new_repo_is_public,
-            description=new_repo_description,
-            readme=readme,
-            tags=tags,
-        )
-
-    # Then it's langchainhub
-    manifest_json = dumps(object)
-    return client.push(
+    client = LangSmithClient(api_url, api_key=api_key)
+    return client.push_prompt(
         repo_full_name,
-        manifest_json,
+        object=object,
         parent_commit_hash=parent_commit_hash,
-        new_repo_is_public=new_repo_is_public,
-        new_repo_description=new_repo_description,
+        is_public=new_repo_is_public,
+        description=new_repo_description,
+        readme=readme,
+        tags=tags,
     )
 
 
@@ -163,26 +113,5 @@ def pull(
     Returns:
         The pulled LangChain object.
     """
-    client = _get_client(api_key=api_key, api_url=api_url)
-
-    # Then it's langsmith
-    if hasattr(client, "pull_prompt"):
-        return client.pull_prompt(owner_repo_commit, include_model=include_model)
-
-    # Then it's langchainhub
-    if hasattr(client, "pull_repo"):
-        # >= 0.1.15
-        res_dict = client.pull_repo(owner_repo_commit)
-        allowed_objects: Literal["all", "core"] = "all" if include_model else "core"
-        obj = loads(json.dumps(res_dict["manifest"]), allowed_objects=allowed_objects)
-        if isinstance(obj, BasePromptTemplate):
-            if obj.metadata is None:
-                obj.metadata = {}
-            obj.metadata["lc_hub_owner"] = res_dict["owner"]
-            obj.metadata["lc_hub_repo"] = res_dict["repo"]
-            obj.metadata["lc_hub_commit_hash"] = res_dict["commit_hash"]
-        return obj
-
-    # Then it's < 0.1.15 langchainhub
-    resp: str = client.pull(owner_repo_commit)
-    return loads(resp, allowed_objects="core")
+    client = LangSmithClient(api_url, api_key=api_key)
+    return client.pull_prompt(owner_repo_commit, include_model=include_model)

--- a/libs/langchain/langchain_classic/runnables/hub.py
+++ b/libs/langchain/langchain_classic/runnables/hub.py
@@ -1,9 +1,17 @@
 from typing import Any
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.runnables.base import RunnableBindingBase
 from langchain_core.runnables.utils import Input, Output
 
 
+@deprecated(
+    since="1.0.7",
+    removal="2.0.0",
+    message=(
+        "langchain_classic.hub.pull is deprecated. Use the LangSmith SDK instead."
+    ),
+)
 class HubRunnable(RunnableBindingBase[Input, Output]):  # type: ignore[no-redef]
     """An instance of a runnable stored in the LangChain Hub."""
 

--- a/libs/langchain/langchain_classic/smith/evaluation/string_run_evaluator.py
+++ b/libs/langchain/langchain_classic/smith/evaluation/string_run_evaluator.py
@@ -31,7 +31,9 @@ def _get_messages_from_run_dict(messages: list[dict]) -> list[BaseMessage]:
         return []
     first_message = messages[0]
     if "lc" in first_message:
-        return [load(dumpd(message)) for message in messages]
+        return [
+            load(dumpd(message), allowed_objects="messages") for message in messages
+        ]
     return messages_from_dict(messages)
 
 

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -94,7 +94,6 @@ test_integration = [
     "wrapt>=1.15.0,<3.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "cassio>=0.1.0,<1.0.0; python_version < '3.14'",
-    "langchainhub>=0.1.16,<1.0.0",
     "langchain-core",
     "langchain-text-splitters",
 ]

--- a/libs/langchain/tests/unit_tests/test_hub.py
+++ b/libs/langchain/tests/unit_tests/test_hub.py
@@ -14,7 +14,7 @@ class TestHubPullDeprecation:
         mock_client.pull_prompt = MagicMock(return_value=MagicMock())
 
         with (
-            patch("langchain_classic.hub._get_client", return_value=mock_client),
+            patch("langchain_classic.hub.LangSmithClient", return_value=mock_client),
             warnings.catch_warnings(record=True) as w,
         ):
             warnings.simplefilter("always")

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2738,7 +2738,6 @@ test-integration = [
     { name = "cassio", marker = "python_full_version < '3.14'" },
     { name = "langchain-core" },
     { name = "langchain-text-splitters" },
-    { name = "langchainhub" },
     { name = "python-dotenv" },
     { name = "vcrpy" },
     { name = "wrapt" },
@@ -2831,7 +2830,6 @@ test-integration = [
     { name = "cassio", marker = "python_full_version < '3.14'", specifier = ">=0.1.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "langchain-text-splitters", editable = "../text-splitters" },
-    { name = "langchainhub", specifier = ">=0.1.16,<1.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
     { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
     { name = "wrapt", specifier = ">=1.15.0,<3.0.0" },
@@ -3269,19 +3267,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1e/50/721db990f9eff5ebd07ca7c06dfa4745406980c90554a2f508bd2a178f91/langchain_xai-1.2.2.tar.gz", hash = "sha256:5d88d31ae078b211eb341d238cc6518818b8e8816efdfc4d98e5e14767629639", size = 175995, upload-time = "2026-01-26T04:26:12.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/3d/a0217c207482ec4f5b5813aaf07173421a3ff55bfec172905b90571b23a5/langchain_xai-1.2.2-py3-none-any.whl", hash = "sha256:f7bab093d2256efa2079a1d2df32cd3a6432118f3e6d0beca110111d0f2a8ec7", size = 11101, upload-time = "2026-01-26T04:26:11.948Z" },
-]
-
-[[package]]
-name = "langchainhub"
-version = "0.1.18"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-    { name = "types-requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/62/19/77c02f66dba977154174d863d414652e5b612041d4ef62460b8d01688c01/langchainhub-0.1.18.tar.gz", hash = "sha256:f2d0d8bf3abe4ca5e70511d8220bdc9ccea28d5267bcfd0e5ef9c53bd5bd3bad", size = 4050, upload-time = "2024-06-07T17:25:32.997Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/2f/e6c64fc13d181c422a25642c358a50918b0c973946f9bd5aa2d835fd1963/langchainhub-0.1.18-py3-none-any.whl", hash = "sha256:11501f15e7f34715ecc8892587daa35c6f2a3005e1f2926c9bcabd31fc2c100c", size = 4780, upload-time = "2024-06-07T17:25:31.56Z" },
 ]
 
 [[package]]

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2136,7 +2136,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.2"
+version = "1.4.3"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2298,7 +2298,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.2"
+version = "1.3.3"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
deprecate hub classic and hub runnable. This code path isn't expected to be active for most users (it's dependent on having a very old version of the langsmith sdk). harden usage of loads/dumps.