### PR TITLE
docs: legacy serialization mapping points to outdated module namespace

### DIFF
--- a/libs/core/langchain_core/load/load.py
+++ b/libs/core/langchain_core/load/load.py
@@ -124,6 +124,7 @@ from langchain_core.load.validators import CLASS_INIT_VALIDATORS
 
 DEFAULT_NAMESPACES = [
     "langchain",
+    "langchain_classic",
     "langchain_core",
     "langchain_community",
     "langchain_anthropic",

--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -97,7 +97,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "BasePromptTemplate",
     ),
     ("langchain", "chains", "llm", "LLMChain"): (
-        "langchain",
+        "langchain_classic",
         "chains",
         "llm",
         "LLMChain",
@@ -150,7 +150,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "AgentActionMessageLog",
     ),
     ("langchain", "schema", "agent", "ToolAgentAction"): (
-        "langchain",
+        "langchain_classic",
         "agents",
         "output_parsers",
         "tools",
@@ -181,7 +181,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "Document",
     ),
     ("langchain", "output_parsers", "fix", "OutputFixingParser"): (
-        "langchain",
+        "langchain_classic",
         "output_parsers",
         "fix",
         "OutputFixingParser",
@@ -193,7 +193,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "AIMessagePromptTemplate",
     ),
     ("langchain", "output_parsers", "regex", "RegexParser"): (
-        "langchain",
+        "langchain_classic",
         "output_parsers",
         "regex",
         "RegexParser",
@@ -421,7 +421,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "VertexAI",
     ),
     ("langchain", "output_parsers", "combining", "CombiningOutputParser"): (
-        "langchain",
+        "langchain_classic",
         "output_parsers",
         "combining",
         "CombiningOutputParser",
@@ -477,7 +477,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "ChatPromptValueConcrete",
     ),
     ("langchain", "schema", "runnable", "HubRunnable"): (
-        "langchain",
+        "langchain_classic",
         "runnables",
         "hub",
         "HubRunnable",
@@ -489,7 +489,7 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "RunnableBindingBase",
     ),
     ("langchain", "schema", "runnable", "OpenAIFunctionsRouter"): (
-        "langchain",
+        "langchain_classic",
         "runnables",
         "openai_functions",
         "OpenAIFunctionsRouter",
@@ -608,7 +608,7 @@ _OG_SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "ImagePromptTemplate",
     ),
     ("langchain", "schema", "agent", "OpenAIToolAgentAction"): (
-        "langchain",
+        "langchain_classic",
         "agents",
         "output_parsers",
         "openai_tools",

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -13,6 +13,7 @@ from langchain_core.documents import Document
 from langchain_core.load import InitValidator, Serializable, dumpd, dumps, load, loads
 from langchain_core.load.load import (
     ALL_SERIALIZABLE_MAPPINGS,
+    DEFAULT_NAMESPACES,
     _get_default_allowed_class_paths,
 )
 from langchain_core.load.serializable import _is_field_useful
@@ -58,6 +59,65 @@ def test_simple_serialization() -> None:
         "repr": "Foo(bar=1, baz='hello')",
         "type": "not_implemented",
     }
+
+
+def test_legacy_langchain_targets_resolve_to_classic_namespace() -> None:
+    moved_paths = {
+        ("langchain", "chains", "llm", "LLMChain"): (
+            "langchain_classic",
+            "chains",
+            "llm",
+            "LLMChain",
+        ),
+        ("langchain", "schema", "agent", "ToolAgentAction"): (
+            "langchain_classic",
+            "agents",
+            "output_parsers",
+            "tools",
+            "ToolAgentAction",
+        ),
+        ("langchain", "output_parsers", "fix", "OutputFixingParser"): (
+            "langchain_classic",
+            "output_parsers",
+            "fix",
+            "OutputFixingParser",
+        ),
+        ("langchain", "output_parsers", "regex", "RegexParser"): (
+            "langchain_classic",
+            "output_parsers",
+            "regex",
+            "RegexParser",
+        ),
+        ("langchain", "output_parsers", "combining", "CombiningOutputParser"): (
+            "langchain_classic",
+            "output_parsers",
+            "combining",
+            "CombiningOutputParser",
+        ),
+        ("langchain", "schema", "runnable", "HubRunnable"): (
+            "langchain_classic",
+            "runnables",
+            "hub",
+            "HubRunnable",
+        ),
+        ("langchain", "schema", "runnable", "OpenAIFunctionsRouter"): (
+            "langchain_classic",
+            "runnables",
+            "openai_functions",
+            "OpenAIFunctionsRouter",
+        ),
+        ("langchain", "schema", "agent", "OpenAIToolAgentAction"): (
+            "langchain_classic",
+            "agents",
+            "output_parsers",
+            "openai_tools",
+            "OpenAIToolAgentAction",
+        ),
+    }
+
+    assert DEFAULT_NAMESPACES.count("langchain_classic") == 1
+    for legacy_path, classic_path in moved_paths.items():
+        assert ALL_SERIALIZABLE_MAPPINGS[legacy_path] == classic_path
 
 
 def test_simple_serialization_is_serializable() -> None:


### PR DESCRIPTION
Automated Codex contribution for https://github.com/langchain-ai/langchain/issues/36230.

Fixes #36230

Verification:
- See the uploaded nightly artifacts for the Codex final report.
- See this workflow run for exact commands and logs.

Generated by xodn348/oss-nightly-control and opened ready for maintainer review after local nightly verification succeeded.
