### PR TITLE
fix(core): support string data in `Blob.as_bytes_io`

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f

--- a/libs/core/tests/unit_tests/documents/test_base.py
+++ b/libs/core/tests/unit_tests/documents/test_base.py
@@ -1,0 +1,60 @@
+"""Tests for `langchain_core.documents.base`."""
+
+from io import BufferedReader, BytesIO
+from pathlib import Path
+
+import pytest
+
+from langchain_core.documents.base import Blob
+
+
+def test_blob_as_bytes_io_with_string_data() -> None:
+    """`as_bytes_io` should yield a byte stream when the blob holds string data.
+
+    Regression test for an inconsistency where `as_string` and `as_bytes`
+    accepted string data but `as_bytes_io` raised `NotImplementedError`.
+    """
+    blob = Blob.from_data("hello")
+    with blob.as_bytes_io() as stream:
+        assert isinstance(stream, BytesIO)
+        assert stream.read() == b"hello"
+
+
+def test_blob_as_bytes_io_with_bytes_data() -> None:
+    """`as_bytes_io` should yield a byte stream for raw bytes data."""
+    blob = Blob.from_data(b"hello")
+    with blob.as_bytes_io() as stream:
+        assert isinstance(stream, BytesIO)
+        assert stream.read() == b"hello"
+
+
+def test_blob_as_bytes_io_respects_encoding() -> None:
+    """String data should be encoded with the blob's `encoding`."""
+    blob = Blob.from_data("héllo", encoding="latin-1")
+    with blob.as_bytes_io() as stream:
+        assert stream.read() == "héllo".encode("latin-1")
+
+
+def test_blob_as_bytes_io_consistent_with_as_bytes_for_string() -> None:
+    """`as_bytes_io` and `as_bytes` should produce the same bytes for string data."""
+    blob = Blob.from_data("hello world")
+    with blob.as_bytes_io() as stream:
+        from_stream = stream.read()
+    assert from_stream == blob.as_bytes()
+
+
+def test_blob_as_bytes_io_with_path(tmp_path: Path) -> None:
+    """`as_bytes_io` should yield a buffered file reader when reading from a path."""
+    file_path = tmp_path / "blob.txt"
+    file_path.write_bytes(b"hello from disk")
+    blob = Blob.from_path(file_path)
+    with blob.as_bytes_io() as stream:
+        assert isinstance(stream, BufferedReader)
+        assert stream.read() == b"hello from disk"
+
+
+def test_blob_as_bytes_io_raises_when_no_data() -> None:
+    """`as_bytes_io` should raise `NotImplementedError` when the blob has no data."""
+    blob = Blob(data=None, path=None)
+    with pytest.raises(NotImplementedError), blob.as_bytes_io():
+        pass


### PR DESCRIPTION
Closes #36667

---

`Blob.as_string` and `Blob.as_bytes` both accept string data and convert it transparently, but `Blob.as_bytes_io` only handled `bytes` data and the path-backed case, raising `NotImplementedError` for blobs constructed from a string. The reproducer in the linked issue (`Blob.from_data("hello")` followed by `as_bytes_io()`) hits this gap.

The fix mirrors what `as_bytes` already does for string data: encode with the blob's `encoding` and yield a `BytesIO`. The change is additive and does not alter the existing bytes or path branches, so previously working callers are unaffected. The error path remains in place for the truly unsupported case where a blob has neither data nor a path.

The added unit tests cover string data, bytes data, the path-backed reader, a non-default encoding, consistency with `as_bytes`, and the unsupported case so the new logic is exercised end-to-end.

Disclaimer: this contribution was prepared with the assistance of an AI agent; the diff has been reviewed by a human and verified against the project's `make format` and `make lint` checks.