### PR TITLE
fix(core): remove exploitable SSRF bypass in `validate_safe_url`

### DIFF
--- a/libs/core/langchain_core/_security/_policy.py
+++ b/libs/core/langchain_core/_security/_policy.py
@@ -228,7 +228,7 @@ def validate_hostname(hostname: str, policy: SSRFPolicy) -> None:
 def _effective_allowed_hosts(policy: SSRFPolicy) -> frozenset[str]:
     """Return allowed_hosts, augmented for local environments."""
     extra: set[str] = set()
-    if os.environ.get("LANGCHAIN_ENV", "").startswith("local"):
+    if os.environ.get("LANGCHAIN_ENV") in {"local_test", "local_dev"}:
         extra.update({"localhost", "testserver"})
     if extra:
         return policy.allowed_hosts | frozenset(extra)

--- a/libs/core/langchain_core/_security/_ssrf_protection.py
+++ b/libs/core/langchain_core/_security/_ssrf_protection.py
@@ -3,7 +3,6 @@
 Delegates all validation to `langchain_core._security._policy`.
 """
 
-import os
 import socket
 from typing import Annotated, Any
 from urllib.parse import urlparse
@@ -64,14 +63,6 @@ def validate_safe_url(
     url_str = str(url)
     parsed = urlparse(url_str)
     hostname = parsed.hostname or ""
-
-    # Test-environment bypass (preserved from original implementation)
-    if (
-        os.environ.get("LANGCHAIN_ENV") == "local_test"
-        and hostname.startswith("test")
-        and "server" in hostname
-    ):
-        return url_str
 
     policy = _policy_for(allow_private=allow_private, allow_http=allow_http)
 

--- a/libs/core/tests/unit_tests/test_ssrf_protection.py
+++ b/libs/core/tests/unit_tests/test_ssrf_protection.py
@@ -124,6 +124,51 @@ class TestValidateSafeUrl:
         assert result == url
 
 
+class TestSSRFBypassRemoval:
+    """Regression tests for the removed test-environment bypass in validate_safe_url.
+
+    Previously, LANGCHAIN_ENV=local_test combined with a hostname matching
+    `startswith("test") and "server" in hostname` caused validate_safe_url to
+    return the URL unchecked. These tests verify that path no longer exists.
+    """
+
+    def test_exploit_hostname_blocked_even_with_local_test(
+        self, monkeypatch: Any
+    ) -> None:
+        # Hostname satisfies the old bypass conditions but must not be whitelisted.
+        monkeypatch.setenv("LANGCHAIN_ENV", "local_test")
+        with pytest.raises(ValueError):
+            validate_safe_url("http://test.attacker.server.com/steal")
+
+    def test_local_test_still_allows_testserver(self, monkeypatch: Any) -> None:
+        # Legitimate use-case: LANGCHAIN_ENV=local_test whitelists testserver
+        # via the policy path, not the (now-removed) raw bypass.
+        monkeypatch.setenv("LANGCHAIN_ENV", "local_test")
+        result = validate_safe_url("http://testserver/api")
+        assert result == "http://testserver/api"
+
+    def test_local_dev_still_allows_testserver(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("LANGCHAIN_ENV", "local_dev")
+        result = validate_safe_url("http://testserver/api")
+        assert result == "http://testserver/api"
+
+    def test_arbitrary_local_prefix_no_longer_whitelists(
+        self, monkeypatch: Any
+    ) -> None:
+        # local_staging was previously whitelisted by startswith("local").
+        # After the fix it must NOT get the automatic allowlist expansion.
+        monkeypatch.setenv("LANGCHAIN_ENV", "local_staging")
+        with pytest.raises(ValueError):
+            validate_safe_url("http://testserver/api")
+
+    def test_no_env_var_does_not_whitelist_testserver(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.delenv("LANGCHAIN_ENV", raising=False)
+        with pytest.raises(ValueError):
+            validate_safe_url("http://testserver/api")
+
+
 class TestIsSafeUrl:
     """Tests for is_safe_url function (non-throwing version)."""
 


### PR DESCRIPTION
Fixes #37297

---

`validate_safe_url` contained a raw-return bypass block that skipped all SSRF checks when `LANGCHAIN_ENV=local_test` and the hostname matched `startswith("test") and "server" in hostname`. Attacker-controlled hostnames such as `test.attacker.server.com` satisfy both predicates, bypassing scheme, private-IP, and cloud-metadata validation entirely.

A second issue in `_effective_allowed_hosts`: `startswith("local")` expanded the allowlist for any env var prefixed with `"local"` (e.g. `"local_staging"`).

Fix: remove the bypass block entirely (test environments already get `testserver`/`localhost` via the policy path) and tighten the env var check to an exact membership set `{"local_test", "local_dev"}`.

Environments using `local_test` or `local_dev` are unaffected. Five regression tests added.

> This contribution was prepared with AI-agent assistance.