### PR TITLE
fix(core, openai): backport SSRF-safe transport for image token counting to v0.3

### DIFF
--- a/libs/core/langchain_core/_security/__init__.py
+++ b/libs/core/langchain_core/_security/__init__.py
@@ -1,0 +1,36 @@
+"""SSRF protection and security utilities.
+
+This is an **internal** module (note the `_security` prefix). It is NOT part of
+the public `langchain-core` API and may change or be removed at any time without
+notice. External code should not import from or depend on anything in this
+module. Any vulnerability reports should target the public APIs that use these
+utilities, not this internal module directly.
+"""
+
+from langchain_core._security._exceptions import SSRFBlockedError
+from langchain_core._security._policy import (
+    SSRFPolicy,
+    validate_hostname,
+    validate_resolved_ip,
+    validate_url,
+    validate_url_sync,
+)
+from langchain_core._security._transport import (
+    SSRFSafeSyncTransport,
+    SSRFSafeTransport,
+    ssrf_safe_async_client,
+    ssrf_safe_client,
+)
+
+__all__ = [
+    "SSRFBlockedError",
+    "SSRFPolicy",
+    "SSRFSafeSyncTransport",
+    "SSRFSafeTransport",
+    "ssrf_safe_async_client",
+    "ssrf_safe_client",
+    "validate_hostname",
+    "validate_resolved_ip",
+    "validate_url",
+    "validate_url_sync",
+]

--- a/libs/core/langchain_core/_security/_exceptions.py
+++ b/libs/core/langchain_core/_security/_exceptions.py
@@ -1,0 +1,9 @@
+"""SSRF protection exceptions."""
+
+
+class SSRFBlockedError(Exception):
+    """Raised when a request is blocked by SSRF protection policy."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(f"SSRF blocked: {reason}")

--- a/libs/core/langchain_core/_security/_policy.py
+++ b/libs/core/langchain_core/_security/_policy.py
@@ -1,0 +1,308 @@
+"""SSRF protection policy with IP validation and DNS-aware URL checking."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import ipaddress
+import os
+import socket
+import urllib.parse
+
+from langchain_core._security._exceptions import SSRFBlockedError
+
+# ---------------------------------------------------------------------------
+# Blocklist constants
+# ---------------------------------------------------------------------------
+
+_BLOCKED_IPV4_NETWORKS: tuple[ipaddress.IPv4Network, ...] = tuple(
+    ipaddress.IPv4Network(n)
+    for n in (
+        "10.0.0.0/8",  # RFC 1918 - private class A
+        "172.16.0.0/12",  # RFC 1918 - private class B
+        "192.168.0.0/16",  # RFC 1918 - private class C
+        "127.0.0.0/8",  # RFC 1122 - loopback
+        "169.254.0.0/16",  # RFC 3927 - link-local
+        "0.0.0.0/8",  # RFC 1122 - "this network"
+        "100.64.0.0/10",  # RFC 6598 - shared/CGN address space
+        "192.0.0.0/24",  # RFC 6890 - IETF protocol assignments
+        "192.0.2.0/24",  # RFC 5737 - TEST-NET-1 (documentation)
+        "198.18.0.0/15",  # RFC 2544 - benchmarking
+        "198.51.100.0/24",  # RFC 5737 - TEST-NET-2 (documentation)
+        "203.0.113.0/24",  # RFC 5737 - TEST-NET-3 (documentation)
+        "224.0.0.0/4",  # RFC 5771 - multicast
+        "240.0.0.0/4",  # RFC 1112 - reserved for future use
+        "255.255.255.255/32",  # RFC 919  - limited broadcast
+    )
+)
+
+_BLOCKED_IPV6_NETWORKS: tuple[ipaddress.IPv6Network, ...] = tuple(
+    ipaddress.IPv6Network(n)
+    for n in (
+        "::1/128",  # RFC 4291 - loopback
+        "fc00::/7",  # RFC 4193 - unique local addresses (ULA)
+        "fe80::/10",  # RFC 4291 - link-local
+        "ff00::/8",  # RFC 4291 - multicast
+        "::ffff:0:0/96",  # RFC 4291 - IPv4-mapped IPv6 addresses
+        "::0.0.0.0/96",  # RFC 4291 - IPv4-compatible IPv6 (deprecated)
+        "64:ff9b::/96",  # RFC 6052 - NAT64 well-known prefix
+        "64:ff9b:1::/48",  # RFC 8215 - NAT64 discovery prefix
+    )
+)
+
+_CLOUD_METADATA_IPS: frozenset[str] = frozenset(
+    {
+        "169.254.169.254",  # AWS, GCP, Azure, DigitalOcean, Oracle Cloud
+        "169.254.170.2",  # AWS ECS task metadata
+        "169.254.170.23",  # AWS EKS Pod Identity Agent
+        "100.100.100.200",  # Alibaba Cloud metadata
+        "fd00:ec2::254",  # AWS EC2 IMDSv2 over IPv6 (Nitro instances)
+        "fd00:ec2::23",  # AWS EKS Pod Identity Agent (IPv6)
+        "fe80::a9fe:a9fe",  # OpenStack Nova metadata (IPv6 link-local)
+    }
+)
+
+# Network ranges that are always blocked when block_cloud_metadata=True,
+# independent of block_private_ips.  The entire link-local range is used by
+# cloud metadata services across providers.
+_CLOUD_METADATA_NETWORKS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
+    ipaddress.IPv4Network("169.254.0.0/16"),
+)
+
+_CLOUD_METADATA_HOSTNAMES: frozenset[str] = frozenset(
+    {
+        "metadata.google.internal",
+        "metadata.amazonaws.com",
+        "metadata",
+        "instance-data",
+    }
+)
+
+_LOCALHOST_NAMES: frozenset[str] = frozenset(
+    {
+        "localhost",
+        "localhost.localdomain",
+        "host.docker.internal",
+    }
+)
+
+_K8S_SUFFIX = ".svc.cluster.local"
+
+_LOOPBACK_IPV4 = ipaddress.IPv4Network("127.0.0.0/8")
+_LOOPBACK_IPV6 = ipaddress.IPv6Address("::1")
+
+# NAT64 well-known prefixes
+_NAT64_PREFIX = ipaddress.IPv6Network("64:ff9b::/96")
+_NAT64_DISCOVERY_PREFIX = ipaddress.IPv6Network("64:ff9b:1::/48")
+
+
+# ---------------------------------------------------------------------------
+# SSRFPolicy
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class SSRFPolicy:
+    """Immutable policy controlling which URLs/IPs are considered safe."""
+
+    allowed_schemes: frozenset[str] = frozenset({"http", "https"})
+    block_private_ips: bool = True
+    block_localhost: bool = True
+    block_cloud_metadata: bool = True
+    block_k8s_internal: bool = True
+    allowed_hosts: frozenset[str] = frozenset()
+    additional_blocked_cidrs: tuple[
+        ipaddress.IPv4Network | ipaddress.IPv6Network, ...
+    ] = ()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_embedded_ipv4(
+    addr: ipaddress.IPv6Address,
+) -> ipaddress.IPv4Address | None:
+    """Extract an embedded IPv4 from IPv4-mapped or NAT64 IPv6 addresses."""
+    # Check ipv4_mapped first (covers ::ffff:x.x.x.x)
+    if addr.ipv4_mapped is not None:
+        return addr.ipv4_mapped
+
+    # Check NAT64 prefixes — embedded IPv4 is in the last 4 bytes
+    if addr in _NAT64_PREFIX or addr in _NAT64_DISCOVERY_PREFIX:
+        raw = addr.packed
+        return ipaddress.IPv4Address(raw[-4:])
+
+    return None
+
+
+def _ip_in_blocked_networks(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    policy: SSRFPolicy,
+) -> str | None:
+    """Return a reason string if *addr* falls in a blocked range, else None."""
+    # NOTE: if profiling shows this is a hot path, consider memoising with
+    # @functools.lru_cache (key on (addr, id(policy))).
+    if isinstance(addr, ipaddress.IPv4Address):
+        if policy.block_private_ips:
+            for net in _BLOCKED_IPV4_NETWORKS:
+                if addr in net:
+                    return "private IP range"
+        for net in policy.additional_blocked_cidrs:  # type: ignore[assignment]
+            if isinstance(net, ipaddress.IPv4Network) and addr in net:
+                return "blocked CIDR"
+    else:
+        if policy.block_private_ips:
+            for net in _BLOCKED_IPV6_NETWORKS:  # type: ignore[assignment]
+                if addr in net:
+                    return "private IP range"
+        for net in policy.additional_blocked_cidrs:  # type: ignore[assignment]
+            if isinstance(net, ipaddress.IPv6Network) and addr in net:
+                return "blocked CIDR"
+
+    # Loopback check — independent of block_private_ips so that
+    # block_localhost=True still catches 127.x.x.x / ::1 even when
+    # private IPs are allowed.
+    if policy.block_localhost:
+        if isinstance(addr, ipaddress.IPv4Address) and (
+            addr in _LOOPBACK_IPV4 or addr in ipaddress.IPv4Network("0.0.0.0/8")
+        ):
+            return "localhost address"
+        if isinstance(addr, ipaddress.IPv6Address) and addr == _LOOPBACK_IPV6:
+            return "localhost address"
+
+    # Cloud metadata check — IP set *and* network ranges (e.g. 169.254.0.0/16).
+    # Independent of block_private_ips so that allow_private=True still blocks
+    # cloud metadata endpoints.
+    if policy.block_cloud_metadata:
+        if str(addr) in _CLOUD_METADATA_IPS:
+            return "cloud metadata endpoint"
+        for net in _CLOUD_METADATA_NETWORKS:  # type: ignore[assignment]
+            if addr in net:
+                return "cloud metadata endpoint"
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public validation functions
+# ---------------------------------------------------------------------------
+
+
+def validate_resolved_ip(ip_str: str, policy: SSRFPolicy) -> None:
+    """Validate a resolved IP address against the SSRF policy.
+
+    Raises SSRFBlockedError if the IP is blocked.
+    """
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError as exc:
+        raise SSRFBlockedError("invalid IP address") from exc
+
+    if isinstance(addr, ipaddress.IPv6Address):
+        inner = _extract_embedded_ipv4(addr)
+        if inner is not None:
+            addr = inner
+
+    reason = _ip_in_blocked_networks(addr, policy)
+    if reason is not None:
+        raise SSRFBlockedError(reason)
+
+
+def validate_hostname(hostname: str, policy: SSRFPolicy) -> None:
+    """Validate a hostname against the SSRF policy.
+
+    Raises SSRFBlockedError if the hostname is blocked.
+    """
+    lower = hostname.lower()
+
+    if policy.block_localhost and lower in _LOCALHOST_NAMES:
+        raise SSRFBlockedError("localhost address")
+
+    if policy.block_cloud_metadata and lower in _CLOUD_METADATA_HOSTNAMES:
+        raise SSRFBlockedError("cloud metadata endpoint")
+
+    if policy.block_k8s_internal and lower.endswith(_K8S_SUFFIX):
+        raise SSRFBlockedError("Kubernetes internal DNS")
+
+
+def _effective_allowed_hosts(policy: SSRFPolicy) -> frozenset[str]:
+    """Return allowed_hosts, augmented for local environments."""
+    extra: set[str] = set()
+    if os.environ.get("LANGCHAIN_ENV", "").startswith("local"):
+        extra.update({"localhost", "testserver"})
+    if extra:
+        return policy.allowed_hosts | frozenset(extra)
+    return policy.allowed_hosts
+
+
+async def validate_url(url: str, policy: SSRFPolicy = SSRFPolicy()) -> None:
+    """Validate a URL against the SSRF policy, including DNS resolution.
+
+    This is the primary entry-point for async code paths. It delegates
+    scheme/hostname/allowed-hosts checks to `validate_url_sync`, then
+    resolves DNS and validates every resolved IP.
+
+    Raises:
+        SSRFBlockedError: If the URL violates the policy.
+    """
+    parsed = urllib.parse.urlparse(url)
+    hostname = parsed.hostname or ""
+
+    validate_url_sync(url, policy)
+
+    allowed = {h.lower() for h in _effective_allowed_hosts(policy)}
+    if hostname.lower() in allowed:
+        return
+
+    scheme = (parsed.scheme or "").lower()
+    port = parsed.port or (443 if scheme == "https" else 80)
+    try:
+        addrinfo = await asyncio.to_thread(
+            socket.getaddrinfo, hostname, port, type=socket.SOCK_STREAM
+        )
+    except socket.gaierror as exc:
+        msg = "DNS resolution failed"
+        raise SSRFBlockedError(msg) from exc
+
+    for _family, _type, _proto, _canonname, sockaddr in addrinfo:
+        validate_resolved_ip(str(sockaddr[0]), policy)
+
+
+def validate_url_sync(url: str, policy: SSRFPolicy = SSRFPolicy()) -> None:
+    """Synchronous URL validation (no DNS resolution).
+
+    Suitable for Pydantic validators and other sync contexts. Checks scheme
+    and hostname patterns only - use `validate_url` for full DNS-aware checking.
+
+    Raises:
+        SSRFBlockedError: If the URL violates the policy.
+    """
+    parsed = urllib.parse.urlparse(url)
+
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in policy.allowed_schemes:
+        msg = f"scheme '{scheme}' not allowed"
+        raise SSRFBlockedError(msg)
+
+    hostname = parsed.hostname
+    if not hostname:
+        msg = "missing hostname"
+        raise SSRFBlockedError(msg)
+
+    allowed = _effective_allowed_hosts(policy)
+    if hostname.lower() in {h.lower() for h in allowed}:
+        return
+
+    try:
+        ipaddress.ip_address(hostname)
+        validate_resolved_ip(hostname, policy)
+    except SSRFBlockedError:
+        raise
+    except ValueError:
+        pass
+    else:
+        return
+
+    validate_hostname(hostname, policy)

--- a/libs/core/langchain_core/_security/_ssrf_protection.py
+++ b/libs/core/langchain_core/_security/_ssrf_protection.py
@@ -1,0 +1,157 @@
+"""SSRF Protection - thin wrapper raising ValueError for internal callers.
+
+Delegates all validation to `langchain_core._security._policy`.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+from typing import Annotated, Any
+from urllib.parse import urlparse
+
+from pydantic import (
+    AnyHttpUrl,
+    BeforeValidator,
+    HttpUrl,
+)
+
+from langchain_core._security._exceptions import SSRFBlockedError
+from langchain_core._security._policy import (
+    SSRFPolicy,
+)
+from langchain_core._security._policy import (
+    validate_resolved_ip as _validate_resolved_ip,
+)
+from langchain_core._security._policy import (
+    validate_url_sync as _validate_url_sync,
+)
+
+
+def _policy_for(*, allow_private: bool, allow_http: bool) -> SSRFPolicy:
+    """Build an `SSRFPolicy` from the legacy flag interface."""
+    schemes = frozenset({"http", "https"}) if allow_http else frozenset({"https"})
+    return SSRFPolicy(
+        allowed_schemes=schemes,
+        block_private_ips=not allow_private,
+        block_localhost=not allow_private,
+        block_cloud_metadata=True,
+        block_k8s_internal=True,
+    )
+
+
+def validate_safe_url(
+    url: str | AnyHttpUrl,
+    *,
+    allow_private: bool = False,
+    allow_http: bool = True,
+) -> str:
+    """Validate a URL for SSRF protection.
+
+    This function validates URLs to prevent Server-Side Request Forgery (SSRF) attacks
+    by blocking requests to private networks and cloud metadata endpoints.
+
+    Args:
+        url: The URL to validate (string or Pydantic HttpUrl).
+        allow_private: If `True`, allows private IPs and localhost (for development).
+                      Cloud metadata endpoints are ALWAYS blocked.
+        allow_http: If `True`, allows both HTTP and HTTPS.  If `False`, only HTTPS.
+
+    Returns:
+        The validated URL as a string.
+
+    Raises:
+        ValueError: If URL is invalid or potentially dangerous.
+    """
+    url_str = str(url)
+    parsed = urlparse(url_str)
+    hostname = parsed.hostname or ""
+
+    # Test-environment bypass (preserved from original implementation)
+    if (
+        os.environ.get("LANGCHAIN_ENV") == "local_test"
+        and hostname.startswith("test")
+        and "server" in hostname
+    ):
+        return url_str
+
+    policy = _policy_for(allow_private=allow_private, allow_http=allow_http)
+
+    # Synchronous scheme + hostname checks
+    try:
+        _validate_url_sync(url_str, policy)
+    except SSRFBlockedError as exc:
+        raise ValueError(str(exc)) from exc
+
+    # DNS resolution and IP validation
+    try:
+        addr_info = socket.getaddrinfo(
+            hostname,
+            parsed.port or (443 if parsed.scheme == "https" else 80),
+            socket.AF_UNSPEC,
+            socket.SOCK_STREAM,
+        )
+
+        for result in addr_info:
+            ip_str: str = result[4][0]  # type: ignore[assignment]
+            try:
+                _validate_resolved_ip(ip_str, policy)
+            except SSRFBlockedError as exc:
+                raise ValueError(str(exc)) from exc
+
+    except socket.gaierror as e:
+        msg = f"Failed to resolve hostname '{hostname}': {e}"
+        raise ValueError(msg) from e
+    except OSError as e:
+        msg = f"Network error while validating URL: {e}"
+        raise ValueError(msg) from e
+
+    return url_str
+
+
+def is_safe_url(
+    url: str | AnyHttpUrl,
+    *,
+    allow_private: bool = False,
+    allow_http: bool = True,
+) -> bool:
+    """Non-throwing version of `validate_safe_url`."""
+    try:
+        validate_safe_url(url, allow_private=allow_private, allow_http=allow_http)
+    except ValueError:
+        return False
+    else:
+        return True
+
+
+def _validate_url_ssrf_strict(v: Any) -> Any:
+    """Validate URL for SSRF protection (strict mode)."""
+    if isinstance(v, str):
+        validate_safe_url(v, allow_private=False, allow_http=True)
+    return v
+
+
+def _validate_url_ssrf_https_only(v: Any) -> Any:
+    if isinstance(v, str):
+        validate_safe_url(v, allow_private=False, allow_http=False)
+    return v
+
+
+def _validate_url_ssrf_relaxed(v: Any) -> Any:
+    """Validate URL for SSRF protection (relaxed mode - allows private IPs)."""
+    if isinstance(v, str):
+        validate_safe_url(v, allow_private=True, allow_http=True)
+    return v
+
+
+# Annotated types with SSRF protection
+SSRFProtectedUrl = Annotated[HttpUrl, BeforeValidator(_validate_url_ssrf_strict)]
+SSRFProtectedUrlRelaxed = Annotated[
+    HttpUrl, BeforeValidator(_validate_url_ssrf_relaxed)
+]
+SSRFProtectedHttpsUrl = Annotated[
+    HttpUrl, BeforeValidator(_validate_url_ssrf_https_only)
+]
+SSRFProtectedHttpsUrlStr = Annotated[
+    str, BeforeValidator(_validate_url_ssrf_https_only)
+]

--- a/libs/core/langchain_core/_security/_transport.py
+++ b/libs/core/langchain_core/_security/_transport.py
@@ -1,0 +1,252 @@
+"""SSRF-safe httpx transport with DNS resolution and IP pinning."""
+
+import asyncio
+import socket
+
+import httpx
+
+from langchain_core._security._exceptions import SSRFBlockedError
+from langchain_core._security._policy import (
+    SSRFPolicy,
+    _effective_allowed_hosts,
+    validate_resolved_ip,
+    validate_url_sync,
+)
+
+# Keys that AsyncHTTPTransport accepts (forwarded from factory kwargs).
+_TRANSPORT_KWARGS = frozenset(
+    {
+        "verify",
+        "cert",
+        "trust_env",
+        "http1",
+        "http2",
+        "limits",
+        "retries",
+    }
+)
+
+
+class SSRFSafeTransport(httpx.AsyncBaseTransport):
+    """httpx async transport that validates DNS results against an SSRF policy.
+
+    For every outgoing request the transport:
+    1. Checks the URL scheme against `policy.allowed_schemes`.
+    2. Validates the hostname against blocked patterns.
+    3. Resolves DNS and validates **all** returned IPs.
+    4. Rewrites the request to connect to the first valid IP while
+       preserving the original `Host` header and TLS SNI hostname.
+
+    Redirects are re-validated on each hop because `follow_redirects`
+    is set on the *client*, causing `handle_async_request` to be called
+    again for each redirect target.
+    """
+
+    def __init__(
+        self,
+        policy: SSRFPolicy = SSRFPolicy(),
+        **transport_kwargs: object,
+    ) -> None:
+        self._policy = policy
+        self._inner = httpx.AsyncHTTPTransport(**transport_kwargs)  # type: ignore[arg-type]
+
+    # ------------------------------------------------------------------ #
+    # Core request handler
+    # ------------------------------------------------------------------ #
+
+    async def handle_async_request(
+        self,
+        request: httpx.Request,
+    ) -> httpx.Response:
+        hostname = request.url.host or ""
+        scheme = request.url.scheme.lower()
+
+        # 1-3. Scheme, hostname, and pattern checks (reuse sync validator).
+        try:
+            validate_url_sync(str(request.url), self._policy)
+        except SSRFBlockedError:
+            raise
+
+        # Allowed-hosts bypass - skip DNS/IP validation entirely.
+        allowed = {h.lower() for h in _effective_allowed_hosts(self._policy)}
+        if hostname.lower() in allowed:
+            return await self._inner.handle_async_request(request)
+
+        # 4. DNS resolution
+        port = request.url.port or (443 if scheme == "https" else 80)
+        try:
+            addrinfo = await asyncio.to_thread(
+                socket.getaddrinfo,
+                hostname,
+                port,
+                type=socket.SOCK_STREAM,
+            )
+        except socket.gaierror as exc:
+            raise SSRFBlockedError("DNS resolution failed") from exc
+
+        if not addrinfo:
+            raise SSRFBlockedError("DNS resolution returned no results")
+
+        # 5. Validate ALL resolved IPs - any blocked means reject.
+        for _family, _type, _proto, _canonname, sockaddr in addrinfo:
+            ip_str: str = sockaddr[0]  # type: ignore[assignment]
+            validate_resolved_ip(ip_str, self._policy)
+
+        # 6. Pin to first resolved IP.
+        pinned_ip = addrinfo[0][4][0]
+
+        # 7. Rewrite URL to use pinned IP, preserving Host header and SNI.
+        pinned_url = request.url.copy_with(host=pinned_ip)
+
+        # Build extensions dict, adding sni_hostname for HTTPS so TLS
+        # certificate validation uses the original hostname.
+        extensions = dict(request.extensions)
+        if scheme == "https":
+            extensions["sni_hostname"] = hostname.encode("ascii")
+
+        pinned_request = httpx.Request(
+            method=request.method,
+            url=pinned_url,
+            headers=request.headers,  # Host header already set to original
+            content=request.content,
+            extensions=extensions,
+        )
+
+        return await self._inner.handle_async_request(pinned_request)
+
+    # ------------------------------------------------------------------ #
+    # Lifecycle
+    # ------------------------------------------------------------------ #
+
+    async def aclose(self) -> None:
+        await self._inner.aclose()
+
+
+# ---------------------------------------------------------------------- #
+# Factory
+# ---------------------------------------------------------------------- #
+
+
+class SSRFSafeSyncTransport(httpx.BaseTransport):
+    """httpx sync transport that validates DNS results against an SSRF policy.
+
+    Sync mirror of `SSRFSafeTransport`. See that class for full documentation.
+    """
+
+    def __init__(
+        self,
+        policy: SSRFPolicy = SSRFPolicy(),
+        **transport_kwargs: object,
+    ) -> None:
+        self._policy = policy
+        self._inner = httpx.HTTPTransport(**transport_kwargs)  # type: ignore[arg-type]
+
+    def handle_request(
+        self,
+        request: httpx.Request,
+    ) -> httpx.Response:
+        hostname = request.url.host or ""
+        scheme = request.url.scheme.lower()
+
+        validate_url_sync(str(request.url), self._policy)
+
+        allowed = {h.lower() for h in _effective_allowed_hosts(self._policy)}
+        if hostname.lower() in allowed:
+            return self._inner.handle_request(request)
+
+        port = request.url.port or (443 if scheme == "https" else 80)
+        try:
+            addrinfo = socket.getaddrinfo(
+                hostname,
+                port,
+                type=socket.SOCK_STREAM,
+            )
+        except socket.gaierror as exc:
+            raise SSRFBlockedError("DNS resolution failed") from exc
+
+        if not addrinfo:
+            raise SSRFBlockedError("DNS resolution returned no results")
+
+        for _family, _type, _proto, _canonname, sockaddr in addrinfo:
+            ip_str: str = sockaddr[0]  # type: ignore[assignment]
+            validate_resolved_ip(ip_str, self._policy)
+
+        pinned_ip = addrinfo[0][4][0]
+        pinned_url = request.url.copy_with(host=pinned_ip)
+
+        extensions = dict(request.extensions)
+        if scheme == "https":
+            extensions["sni_hostname"] = hostname.encode("ascii")
+
+        pinned_request = httpx.Request(
+            method=request.method,
+            url=pinned_url,
+            headers=request.headers,
+            content=request.content,
+            extensions=extensions,
+        )
+
+        return self._inner.handle_request(pinned_request)
+
+    def close(self) -> None:
+        self._inner.close()
+
+
+# ---------------------------------------------------------------------- #
+# Factories
+# ---------------------------------------------------------------------- #
+
+
+def ssrf_safe_client(
+    policy: SSRFPolicy = SSRFPolicy(),
+    **kwargs: object,
+) -> httpx.Client:
+    """Create an `httpx.Client` with SSRF protection."""
+    transport_kwargs: dict[str, object] = {}
+    client_kwargs: dict[str, object] = {}
+    for key, value in kwargs.items():
+        if key in _TRANSPORT_KWARGS:
+            transport_kwargs[key] = value
+        else:
+            client_kwargs[key] = value
+
+    transport = SSRFSafeSyncTransport(policy=policy, **transport_kwargs)
+
+    client_kwargs.setdefault("follow_redirects", True)
+    client_kwargs.setdefault("max_redirects", 10)
+
+    return httpx.Client(
+        transport=transport,
+        **client_kwargs,  # type: ignore[arg-type]
+    )
+
+
+def ssrf_safe_async_client(
+    policy: SSRFPolicy = SSRFPolicy(),
+    **kwargs: object,
+) -> httpx.AsyncClient:
+    """Create an `httpx.AsyncClient` with SSRF protection.
+
+    Drop-in replacement for `httpx.AsyncClient(...)` - callers just swap
+    the constructor call.  Transport-specific kwargs (`verify`, `cert`,
+    `retries`, etc.) are forwarded to the inner `AsyncHTTPTransport`;
+    everything else goes to the `AsyncClient`.
+    """
+    transport_kwargs: dict[str, object] = {}
+    client_kwargs: dict[str, object] = {}
+    for key, value in kwargs.items():
+        if key in _TRANSPORT_KWARGS:
+            transport_kwargs[key] = value
+        else:
+            client_kwargs[key] = value
+
+    transport = SSRFSafeTransport(policy=policy, **transport_kwargs)
+
+    # Apply defaults only if not overridden by caller.
+    client_kwargs.setdefault("follow_redirects", True)
+    client_kwargs.setdefault("max_redirects", 10)
+
+    return httpx.AsyncClient(
+        transport=transport,
+        **client_kwargs,  # type: ignore[arg-type]
+    )

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -122,8 +122,10 @@ ignore-var-parameters = true  # ignore missing documentation for *args and **kwa
 [tool.ruff.lint.per-file-ignores]
 "langchain_core/utils/mustache.py" = [ "PLW0603",]
 "tests/unit_tests/test_tools.py" = [ "ARG",]
-"tests/**" = [ "D1", "S", "SLF",]
+"tests/**" = [ "ARG", "D1", "S", "SLF",]
 "scripts/**" = [ "INP", "S",]
+"langchain_core/_security/_policy.py" = [ "EM101", "EM102", "TRY003", "B008", "TRY300",]
+"langchain_core/_security/_transport.py" = [ "EM101", "EM102", "TRY003", "TRY203", "B008",]
 
 [tool.coverage.run]
 omit = [ "tests/*",]

--- a/libs/core/tests/unit_tests/test_ssrf_policy_transport.py
+++ b/libs/core/tests/unit_tests/test_ssrf_policy_transport.py
@@ -1,0 +1,427 @@
+import socket
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from langchain_core._security import (
+    SSRFBlockedError,
+    SSRFPolicy,
+    SSRFSafeSyncTransport,
+    SSRFSafeTransport,
+    ssrf_safe_async_client,
+    ssrf_safe_client,
+    validate_hostname,
+    validate_resolved_ip,
+    validate_url_sync,
+)
+
+
+def _fake_addrinfo(ip: str, port: int = 80) -> list[Any]:
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, port))]
+
+
+def _fake_addrinfo_v6(ip: str, port: int = 80) -> list[Any]:
+    return [(socket.AF_INET6, socket.SOCK_STREAM, 6, "", (ip, port, 0, 0))]
+
+
+def _ok_response(request: httpx.Request) -> httpx.Response:
+    return httpx.Response(200, text="ok")
+
+
+def test_validate_resolved_ip_blocks_nat64_embedded_private_ip() -> None:
+    policy = SSRFPolicy()
+
+    with pytest.raises(SSRFBlockedError, match="private IP range"):
+        validate_resolved_ip("64:ff9b::c0a8:101", policy)
+
+
+def test_validate_resolved_ip_blocks_cgnat() -> None:
+    policy = SSRFPolicy()
+
+    with pytest.raises(SSRFBlockedError, match="private IP range"):
+        validate_resolved_ip("100.64.0.1", policy)
+
+
+def test_validate_hostname_blocks_kubernetes_internal_dns() -> None:
+    policy = SSRFPolicy()
+
+    with pytest.raises(SSRFBlockedError, match="Kubernetes internal DNS"):
+        validate_hostname("api.default.svc.cluster.local", policy)
+
+
+def test_validate_url_sync_allows_explicit_allowed_host() -> None:
+    policy = SSRFPolicy(allowed_hosts=frozenset({"metadata.google.internal"}))
+
+    validate_url_sync("http://metadata.google.internal/path", policy)
+
+
+def test_validate_url_sync_blocks_metadata_without_allowlist() -> None:
+    policy = SSRFPolicy()
+
+    with pytest.raises(SSRFBlockedError, match="cloud metadata endpoint"):
+        validate_url_sync("http://metadata.google.internal/path", policy)
+
+
+class _RecordingAsyncTransport(httpx.AsyncBaseTransport):
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return httpx.Response(200, request=request, text="ok")
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_ssrf_safe_transport_pins_ip_and_sets_sni() -> None:
+    transport = SSRFSafeTransport()
+    recorder = _RecordingAsyncTransport()
+    transport._inner = recorder  # type: ignore[assignment]
+
+    addrinfo = [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            6,
+            "",
+            ("93.184.216.34", 443),
+        )
+    ]
+
+    with patch(
+        "langchain_core._security._transport.socket.getaddrinfo",
+        return_value=addrinfo,
+    ):
+        request = httpx.Request("GET", "https://example.com/resource")
+        response = await transport.handle_async_request(request)
+
+    assert response.status_code == 200
+    assert len(recorder.requests) == 1
+    pinned_request = recorder.requests[0]
+    assert pinned_request.url.host == "93.184.216.34"
+    assert pinned_request.headers["host"] == "example.com"
+    assert pinned_request.extensions["sni_hostname"] == b"example.com"
+
+
+@pytest.mark.asyncio
+async def test_ssrf_safe_transport_blocks_private_resolution() -> None:
+    transport = SSRFSafeTransport()
+
+    addrinfo = [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            6,
+            "",
+            ("127.0.0.1", 443),
+        )
+    ]
+
+    with patch(
+        "langchain_core._security._transport.socket.getaddrinfo",
+        return_value=addrinfo,
+    ):
+        request = httpx.Request("GET", "https://example.com/resource")
+        with pytest.raises(SSRFBlockedError, match="private IP range"):
+            await transport.handle_async_request(request)
+
+
+@pytest.mark.asyncio
+async def test_ssrf_safe_async_client_sets_redirect_defaults() -> None:
+    client = ssrf_safe_async_client()
+    try:
+        assert client.follow_redirects is True
+        assert client.max_redirects == 10
+    finally:
+        await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Policy toggle: block_private_ips=False still blocks loopback/metadata/k8s
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://10.0.0.1:8080/api",
+        "http://172.16.0.1:3000/",
+        "http://192.168.1.100/webhook",
+    ],
+)
+def test_private_ip_allowed_when_block_disabled(url: str) -> None:
+    policy = SSRFPolicy(block_private_ips=False)
+    validate_url_sync(url, policy)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8080/",
+        "http://127.0.0.2/",
+        "http://[::1]:8080/",
+    ],
+)
+def test_loopback_still_blocked_when_private_ips_allowed(url: str) -> None:
+    policy = SSRFPolicy(block_private_ips=False)
+    with pytest.raises(SSRFBlockedError):
+        validate_url_sync(url, policy)
+
+
+def test_docker_internal_blocked() -> None:
+    policy = SSRFPolicy()
+    with pytest.raises(SSRFBlockedError, match="localhost"):
+        validate_url_sync("http://host.docker.internal:8080/", policy)
+
+
+def test_metadata_still_blocked_when_private_ips_allowed() -> None:
+    policy = SSRFPolicy(block_private_ips=False)
+    with pytest.raises(SSRFBlockedError):
+        validate_url_sync("http://metadata.google.internal/", policy)
+
+
+def test_k8s_still_blocked_when_private_ips_allowed() -> None:
+    policy = SSRFPolicy(block_private_ips=False)
+    with pytest.raises(SSRFBlockedError):
+        validate_url_sync("http://myservice.default.svc.cluster.local/", policy)
+
+
+# ---------------------------------------------------------------------------
+# Cloud metadata: link-local range and restored IPs blocked even with
+# block_private_ips=False (regression test for dropped ranges/IPs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "169.254.169.254",
+        "169.254.170.2",
+        "169.254.170.23",  # AWS EKS Pod Identity Agent
+        "100.100.100.200",
+        "fd00:ec2::254",
+        "fd00:ec2::23",  # AWS EKS Pod Identity Agent (IPv6)
+        "fe80::a9fe:a9fe",  # OpenStack Nova metadata
+    ],
+)
+def test_cloud_metadata_ips_blocked_when_private_ips_allowed(ip: str) -> None:
+    policy = SSRFPolicy(block_private_ips=False)
+    with pytest.raises(SSRFBlockedError, match="cloud metadata endpoint"):
+        validate_resolved_ip(ip, policy)
+
+
+@pytest.mark.parametrize(
+    "ip",
+    [
+        "169.254.1.2",
+        "169.254.255.254",
+        "169.254.42.99",
+    ],
+)
+def test_link_local_range_blocked_as_cloud_metadata_when_private_ips_allowed(
+    ip: str,
+) -> None:
+    policy = SSRFPolicy(block_private_ips=False)
+    with pytest.raises(SSRFBlockedError, match="cloud metadata endpoint"):
+        validate_resolved_ip(ip, policy)
+
+
+# ---------------------------------------------------------------------------
+# Transport: redirect to private IP blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_redirect_to_private_ip_blocked(monkeypatch: Any) -> None:
+    call_count = 0
+
+    def _routing_addrinfo(*args: Any, **kwargs: Any) -> list[Any]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _fake_addrinfo("93.184.216.34")
+        return _fake_addrinfo("127.0.0.1")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _routing_addrinfo)
+
+    def _redirect_responder(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            302,
+            headers={"Location": "http://evil.com/pwned"},
+        )
+
+    transport = SSRFSafeTransport()
+    transport._inner = httpx.MockTransport(_redirect_responder)  # type: ignore[assignment]
+
+    client = httpx.AsyncClient(
+        transport=transport,
+        follow_redirects=True,
+        max_redirects=5,
+    )
+
+    with pytest.raises(SSRFBlockedError):
+        await client.get("http://safe.com/start")
+
+    await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Transport: IPv6-mapped IPv4, scheme rejection, DNS fail-closed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ipv6_mapped_ipv4_blocked(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: _fake_addrinfo_v6("::ffff:127.0.0.1"),
+    )
+
+    transport = SSRFSafeTransport()
+    request = httpx.Request("GET", "http://evil.com/")
+    with pytest.raises(SSRFBlockedError):
+        await transport.handle_async_request(request)
+
+
+@pytest.mark.asyncio
+async def test_scheme_blocked() -> None:
+    transport = SSRFSafeTransport()
+    request = httpx.Request("GET", "ftp://evil.com/file")
+    with pytest.raises(SSRFBlockedError, match="scheme"):
+        await transport.handle_async_request(request)
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_host_blocked(monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *a, **kw: (_ for _ in ()).throw(
+            socket.gaierror("Name or service not known")
+        ),
+    )
+
+    transport = SSRFSafeTransport()
+    request = httpx.Request("GET", "http://nonexistent.invalid/")
+    with pytest.raises(SSRFBlockedError, match="DNS resolution failed"):
+        await transport.handle_async_request(request)
+
+
+# ---------------------------------------------------------------------------
+# Transport: allowed_hosts bypass and local env behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_allowed_host_bypass() -> None:
+    policy = SSRFPolicy(allowed_hosts=frozenset({"special.host"}))
+    transport = SSRFSafeTransport(policy=policy)
+    transport._inner = httpx.MockTransport(_ok_response)  # type: ignore[assignment]
+
+    request = httpx.Request("GET", "http://special.host/api")
+    response = await transport.handle_async_request(request)
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("env", ["local_dev", "local_test", "local_docker"])
+async def test_localhost_allowed_in_local_env(monkeypatch: Any, env: str) -> None:
+    monkeypatch.setenv("LANGCHAIN_ENV", env)
+    transport = SSRFSafeTransport()
+    transport._inner = httpx.MockTransport(_ok_response)  # type: ignore[assignment]
+
+    request = httpx.Request("GET", "http://localhost:8084/mcp")
+    response = await transport.handle_async_request(request)
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_localhost_blocked_in_production(monkeypatch: Any) -> None:
+    monkeypatch.setenv("LANGCHAIN_ENV", "production")
+    transport = SSRFSafeTransport()
+
+    request = httpx.Request("GET", "http://localhost:8084/mcp")
+    with pytest.raises(SSRFBlockedError):
+        await transport.handle_async_request(request)
+
+
+# ---------------------------------------------------------------------------
+# Sync transport tests
+# ---------------------------------------------------------------------------
+
+
+def test_sync_transport_pins_ip_and_sets_sni() -> None:
+    transport = SSRFSafeSyncTransport()
+    transport._inner = httpx.MockTransport(_ok_response)  # type: ignore[assignment]
+
+    addrinfo = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+    with patch(
+        "langchain_core._security._transport.socket.getaddrinfo",
+        return_value=addrinfo,
+    ):
+        request = httpx.Request("GET", "https://example.com/resource")
+        response = transport.handle_request(request)
+
+    assert response.status_code == 200
+
+
+def test_sync_transport_blocks_private_resolution() -> None:
+    transport = SSRFSafeSyncTransport()
+
+    addrinfo = [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 443))]
+
+    with patch(
+        "langchain_core._security._transport.socket.getaddrinfo",
+        return_value=addrinfo,
+    ):
+        request = httpx.Request("GET", "https://example.com/resource")
+        with pytest.raises(SSRFBlockedError, match="private IP range"):
+            transport.handle_request(request)
+
+
+def test_sync_transport_redirect_to_private_blocked(monkeypatch: Any) -> None:
+    call_count = 0
+
+    def _routing_addrinfo(*args: Any, **kwargs: Any) -> list[Any]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _fake_addrinfo("93.184.216.34")
+        return _fake_addrinfo("127.0.0.1")
+
+    monkeypatch.setattr(socket, "getaddrinfo", _routing_addrinfo)
+
+    def _redirect_responder(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            302,
+            headers={"Location": "http://evil.com/pwned"},
+        )
+
+    transport = SSRFSafeSyncTransport()
+    transport._inner = httpx.MockTransport(_redirect_responder)  # type: ignore[assignment]
+
+    client = httpx.Client(
+        transport=transport,
+        follow_redirects=True,
+        max_redirects=5,
+    )
+
+    with pytest.raises(SSRFBlockedError):
+        client.get("http://safe.com/start")
+
+    client.close()
+
+
+def test_ssrf_safe_client_sets_redirect_defaults() -> None:
+    client = ssrf_safe_client()
+    try:
+        assert client.follow_redirects is True
+        assert client.max_redirects == 10
+    finally:
+        client.close()

--- a/libs/core/tests/unit_tests/test_ssrf_protection.py
+++ b/libs/core/tests/unit_tests/test_ssrf_protection.py
@@ -1,0 +1,238 @@
+"""Tests for SSRF protection utilities."""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from langchain_core._security._ssrf_protection import (
+    SSRFProtectedUrl,
+    SSRFProtectedUrlRelaxed,
+    is_safe_url,
+    validate_safe_url,
+)
+
+
+class TestValidateSafeUrl:
+    """Tests for validate_safe_url function."""
+
+    def test_valid_public_https_url(self) -> None:
+        """Test that valid public HTTPS URLs are accepted."""
+        url = "https://hooks.slack.com/services/xxx"
+        result = validate_safe_url(url)
+        assert result == url
+
+    def test_valid_public_http_url(self) -> None:
+        """Test that valid public HTTP URLs are accepted."""
+        url = "http://example.com/webhook"
+        result = validate_safe_url(url)
+        assert result == url
+
+    def test_localhost_blocked_by_default(self) -> None:
+        """Test that localhost URLs are blocked by default."""
+        with pytest.raises(ValueError, match="localhost"):
+            validate_safe_url("http://localhost:8080/webhook")
+
+        with pytest.raises(ValueError, match="private IP"):
+            validate_safe_url("http://127.0.0.1:8080/webhook")
+
+    def test_localhost_allowed_with_flag(self) -> None:
+        """Test that localhost is allowed with allow_private=True."""
+        url = "http://localhost:8080/webhook"
+        result = validate_safe_url(url, allow_private=True)
+        assert result == url
+
+        url = "http://127.0.0.1:8080/webhook"
+        result = validate_safe_url(url, allow_private=True)
+        assert result == url
+
+    def test_private_ip_blocked_by_default(self) -> None:
+        """Test that private IPs are blocked by default."""
+        with pytest.raises(ValueError, match="private IP"):
+            validate_safe_url("http://192.168.1.1/webhook")
+
+        with pytest.raises(ValueError, match="private IP"):
+            validate_safe_url("http://10.0.0.1/webhook")
+
+        with pytest.raises(ValueError, match="private IP"):
+            validate_safe_url("http://172.16.0.1/webhook")
+
+    def test_private_ip_allowed_with_flag(self) -> None:
+        """Test that private IPs are allowed with allow_private=True."""
+        # Note: These will fail DNS resolution in tests, so we skip actual validation
+        # In production, they would be validated properly
+
+    def test_cloud_metadata_always_blocked(self) -> None:
+        """Test that cloud metadata endpoints are always blocked."""
+        with pytest.raises(ValueError, match="SSRF blocked"):
+            validate_safe_url("http://169.254.169.254/latest/meta-data/")
+
+        # Even with allow_private=True
+        with pytest.raises(ValueError, match="SSRF blocked"):
+            validate_safe_url(
+                "http://169.254.169.254/latest/meta-data/",
+                allow_private=True,
+            )
+
+    def test_ipv6_mapped_ipv4_localhost_blocked(self) -> None:
+        """Test that IPv6-mapped IPv4 localhost is blocked."""
+        with pytest.raises(ValueError, match="SSRF blocked"):
+            validate_safe_url("http://[::ffff:127.0.0.1]:8080/webhook")
+
+    def test_ipv6_mapped_ipv4_cloud_metadata_blocked(self) -> None:
+        """Test that IPv6-mapped IPv4 cloud metadata is blocked."""
+        with pytest.raises(ValueError, match="SSRF blocked"):
+            validate_safe_url("http://[::ffff:169.254.169.254]/latest/meta-data/")
+
+    def test_invalid_scheme_blocked(self) -> None:
+        """Test that non-HTTP(S) schemes are blocked."""
+        with pytest.raises(ValueError, match="scheme"):
+            validate_safe_url("ftp://example.com/file")
+
+        with pytest.raises(ValueError, match="scheme"):
+            validate_safe_url("file:///etc/passwd")
+
+        with pytest.raises(ValueError, match="scheme"):
+            validate_safe_url("javascript:alert(1)")
+
+    def test_https_only_mode(self) -> None:
+        """Test that HTTP is blocked when allow_http=False."""
+        with pytest.raises(ValueError, match="scheme"):
+            validate_safe_url("http://example.com/webhook", allow_http=False)
+
+        # HTTPS should still work
+        url = "https://example.com/webhook"
+        result = validate_safe_url(url, allow_http=False)
+        assert result == url
+
+    def test_url_without_hostname(self) -> None:
+        """Test that URLs without hostname are rejected."""
+        with pytest.raises(ValueError, match="hostname"):
+            validate_safe_url("http:///path")
+
+    def test_dns_resolution_failure(self) -> None:
+        """Test handling of DNS resolution failures."""
+        with pytest.raises(ValueError, match="resolve"):
+            validate_safe_url("http://this-domain-definitely-does-not-exist-12345.com")
+
+    def test_testserver_allowed(self, monkeypatch: Any) -> None:
+        """Test that testserver hostname is allowed for test environments."""
+        # testserver is used by FastAPI/Starlette test clients
+        monkeypatch.setenv("LANGCHAIN_ENV", "local_test")
+        url = "http://testserver/webhook"
+        result = validate_safe_url(url)
+        assert result == url
+
+
+class TestIsSafeUrl:
+    """Tests for is_safe_url function (non-throwing version)."""
+
+    def test_safe_url_returns_true(self) -> None:
+        """Test that safe URLs return True."""
+        assert is_safe_url("https://example.com/webhook") is True
+        assert is_safe_url("http://hooks.slack.com/services/xxx") is True
+
+    def test_unsafe_url_returns_false(self) -> None:
+        """Test that unsafe URLs return False."""
+        assert is_safe_url("http://localhost:8080") is False
+        assert is_safe_url("http://127.0.0.1:8080") is False
+        assert is_safe_url("http://192.168.1.1") is False
+        assert is_safe_url("http://169.254.169.254") is False
+
+    def test_unsafe_url_safe_with_allow_private(self) -> None:
+        """Test that private URLs are safe with allow_private=True."""
+        assert is_safe_url("http://localhost:8080", allow_private=True) is True
+        assert is_safe_url("http://127.0.0.1:8080", allow_private=True) is True
+
+    def test_cloud_metadata_always_unsafe(self) -> None:
+        """Test that cloud metadata is always unsafe."""
+        assert is_safe_url("http://169.254.169.254") is False
+        assert is_safe_url("http://169.254.169.254", allow_private=True) is False
+
+
+class TestSSRFProtectedUrlType:
+    """Tests for SSRFProtectedUrl Pydantic type."""
+
+    def test_valid_url_accepted(self) -> None:
+        """Test that valid URLs are accepted by Pydantic schema."""
+
+        class WebhookSchema(BaseModel):
+            url: SSRFProtectedUrl
+
+        schema = WebhookSchema(url="https://hooks.slack.com/services/xxx")
+        assert str(schema.url).startswith("https://hooks.slack.com/")
+
+    def test_localhost_rejected(self) -> None:
+        """Test that localhost URLs are rejected by Pydantic schema."""
+
+        class WebhookSchema(BaseModel):
+            url: SSRFProtectedUrl
+
+        with pytest.raises(ValidationError):
+            WebhookSchema(url="http://localhost:8080")
+
+    def test_private_ip_rejected(self) -> None:
+        """Test that private IPs are rejected by Pydantic schema."""
+
+        class WebhookSchema(BaseModel):
+            url: SSRFProtectedUrl
+
+        with pytest.raises(ValidationError):
+            WebhookSchema(url="http://192.168.1.1")
+
+    def test_cloud_metadata_rejected(self) -> None:
+        """Test that cloud metadata is rejected by Pydantic schema."""
+
+        class WebhookSchema(BaseModel):
+            url: SSRFProtectedUrl
+
+        with pytest.raises(ValidationError):
+            WebhookSchema(url="http://169.254.169.254/latest/meta-data/")
+
+
+class TestSSRFProtectedUrlRelaxedType:
+    """Tests for SSRFProtectedUrlRelaxed Pydantic type."""
+
+    def test_localhost_accepted(self) -> None:
+        """Test that localhost URLs are accepted by relaxed schema."""
+
+        class WebhookSchema(BaseModel):
+            url: SSRFProtectedUrlRelaxed
+
+        schema = WebhookSchema(url="http://localhost:8080")
+        assert str(schema.url).startswith("http://localhost")
+
+    def test_cloud_metadata_still_rejected(self) -> None:
+        """Test that cloud metadata is still rejected by relaxed schema."""
+
+        class WebhookSchema(BaseModel):
+            url: SSRFProtectedUrlRelaxed
+
+        with pytest.raises(ValidationError):
+            WebhookSchema(url="http://169.254.169.254/latest/meta-data/")
+
+
+class TestRealWorldURLs:
+    """Tests with real-world webhook URLs."""
+
+    def test_slack_webhook(self) -> None:
+        """Test Slack webhook URL."""
+        url = (
+            "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX"
+        )
+        assert is_safe_url(url) is True
+
+    def test_discord_webhook(self) -> None:
+        """Test Discord webhook URL."""
+        url = "https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrstuvwxyz"
+        assert is_safe_url(url) is True
+
+    def test_webhook_site(self) -> None:
+        """Test webhook.site URL."""
+        url = "https://webhook.site/unique-id"
+        assert is_safe_url(url) is True
+
+    def test_ngrok_url(self) -> None:
+        """Test ngrok URL (should be safe as it's public)."""
+        url = "https://abc123.ngrok.io/webhook"
+        assert is_safe_url(url) is True

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -118,6 +118,7 @@ from langchain_openai.chat_models._compat import (
 )
 
 if TYPE_CHECKING:
+    import httpx
     from openai.types.responses import Response
 
 logger = logging.getLogger(__name__)
@@ -125,6 +126,19 @@ logger = logging.getLogger(__name__)
 # This SSL context is equivelent to the default `verify=True`.
 # https://www.python-httpx.org/advanced/ssl/#configuring-client-instances
 global_ssl_context = ssl.create_default_context(cafile=certifi.where())
+
+_ssrf_client: httpx.Client | None = None
+
+
+def _get_ssrf_safe_client() -> httpx.Client:
+    global _ssrf_client
+    if _ssrf_client is None:
+        from langchain_core._security._transport import ssrf_safe_client
+
+        _ssrf_client = ssrf_safe_client(
+            verify=global_ssl_context, follow_redirects=False
+        )
+    return _ssrf_client
 
 WellKnownTools = (
     "file_search",
@@ -3313,22 +3327,51 @@ def _url_to_size(image_source: str) -> Optional[tuple[int, int]]:
         )
         return None
     if _is_url(image_source):
+        import httpx
+
+        # Set reasonable limits to prevent resource exhaustion
+        # Timeout prevents indefinite hangs on slow/malicious servers
+        timeout = 5.0  # seconds
+        # Max size matches OpenAI's 50 MB payload limit
+        max_size = 50 * 1024 * 1024  # 50 MB
+
         try:
-            import httpx
-        except ImportError:
-            logger.info(
-                "Unable to count image tokens. To count image tokens please install "
-                "`pip install -U httpx`."
-            )
+            response = _get_ssrf_safe_client().get(image_source, timeout=timeout)
+            response.raise_for_status()
+
+            # Check response size before loading into memory
+            content_length = response.headers.get("content-length")
+            if content_length and int(content_length) > max_size:
+                logger.warning(
+                    "Image URL exceeds maximum size limit of %d bytes", max_size
+                )
+                return None
+
+            # Also check actual content size
+            if len(response.content) > max_size:
+                logger.warning(
+                    "Image URL exceeds maximum size limit of %d bytes", max_size
+                )
+                return None
+
+            with Image.open(BytesIO(response.content)) as img:
+                width, height = img.size
+            return width, height
+        except httpx.TimeoutException:
+            logger.warning("Image URL request timed out after %s seconds", timeout)
             return None
-        response = httpx.get(image_source)
-        response.raise_for_status()
-        width, height = Image.open(BytesIO(response.content)).size
-        return width, height
+        except httpx.HTTPStatusError as e:
+            logger.warning("Image URL returned HTTP error: %s", e)
+            return None
+        except Exception as e:
+            logger.warning("Failed to fetch or process image from URL: %s", e)
+            return None
+
     if _is_b64(image_source):
         _, encoded = image_source.split(",", 1)
         data = base64.b64decode(encoded)
-        width, height = Image.open(BytesIO(data)).size
+        with Image.open(BytesIO(data)) as img:
+            width, height = img.size
         return width, height
     return None
 


### PR DESCRIPTION
Fixes #37299

## Summary

Backports the upstream SSRF-protection chain to **v0.3** so that
`ChatOpenAI.get_num_tokens_from_messages` no longer makes unrestricted
HTTP requests when counting image tokens.

Addresses on v0.3 (no published 0.3.x patch exists for either):
- **CVE-2026-26013 / GHSA-2g6r-c272-w58r** — SSRF via `image_url` token counting
  in `ChatOpenAI.get_num_tokens_from_messages` (`_url_to_size` calling
  `httpx.get(url)` directly).
- **CVE-2026-41488 / GHSA-r7w7-9xr2-qq2r** — DNS-rebinding bypass of the
  earlier SSRF protection (master fix uses an SSRF-safe transport that
  pins the resolved IP and disables redirects).

Ports the final state of the upstream `_security` module (PRs #35143 →
#36768 → #36816) plus the openai partner fix (#36819) onto v0.3.

## Changes

- **`libs/core/langchain_core/_security/`** — new internal module:
  - `_exceptions.py`: `SSRFBlockedError`
  - `_policy.py`: DNS-aware policy with IPv4/IPv6 blocklists, link-local
    and cloud-metadata IP coverage, sync + async URL validation
  - `_transport.py`: `SSRFSafeTransport` / `SSRFSafeSyncTransport` that
    pin the resolved IP and set SNI; `ssrf_safe_client` / `ssrf_safe_async_client`
    helpers
  - `_ssrf_protection.py`: slim wrapper preserving the original 0.3
    internal `validate_safe_url` / `is_safe_url` surface
  - `__init__.py`: re-exports the public-internal surface
- **`libs/core/pyproject.toml`** — per-file ruff ignores for the new
  module + `ARG` ignore for `tests/**` (matches upstream).
- **`libs/core/tests/unit_tests/test_ssrf_protection.py`** + **`test_ssrf_policy_transport.py`** — 68 new unit tests, ported from upstream.
- **`libs/partners/openai/langchain_openai/chat_models/base.py`**:
  - New `_get_ssrf_safe_client()` lazily instantiates the SSRF-safe
    `httpx.Client` via `langchain_core._security._transport.ssrf_safe_client`
    with the existing `global_ssl_context` and `follow_redirects=False`.
  - `_url_to_size` rewritten to use that client with a 5 s timeout, a
    50 MB content-length / body cap, and explicit `httpx.TimeoutException`
    / `HTTPStatusError` / broad-`Exception` fallbacks that preserve the
    existing \"silently skip image counting on failure\" semantics.

### v0.3-only adjustments

The upstream files are taken verbatim from `master` except for two
small changes required because v0.3 core targets py39 (master targets
py310):

- `_policy.py` and `_ssrf_protection.py` get `from __future__ import annotations`
  so the PEP 604 `X | Y` annotations parse on py39.

No public-API changes. No version bumps. The openai partner does not
bump its `langchain-core` minimum: the import of the security module
is lazy and any `ImportError` falls through the existing broad
`except Exception` in `_url_to_size`, so older-core combinations
degrade to the same \"skip image token counting + warn\" behaviour
that already triggers when `pillow` / `httpx` are missing.

## Proof of life

\`\`\`
$ uv run --group test pytest tests/unit_tests/test_ssrf_protection.py tests/unit_tests/test_ssrf_policy_transport.py
....................................................................     [100%]
68 passed in 11.04s
\`\`\`

Full unit suites also clean:

\`\`\`
$ uv run --group test pytest libs/core/tests/unit_tests
1548 passed, 2 skipped, 10 xfailed, 2 xpassed, 100 warnings in 17.94s

$ OPENAI_API_KEY=dummy uv run --group test pytest libs/partners/openai/tests/unit_tests
266 passed, 5 xpassed, 25 warnings in 8.08s
\`\`\`

Lint:

\`\`\`
$ uv run --group lint ruff check libs/core/langchain_core/_security \\
                                  libs/core/tests/unit_tests/test_ssrf_protection.py \\
                                  libs/core/tests/unit_tests/test_ssrf_policy_transport.py \\
                                  libs/partners/openai/langchain_openai/chat_models/base.py
All checks passed!
\`\`\`

## Test plan

- [x] Port SSRF test files run green on v0.3 core (68 tests)
- [x] Full v0.3 core unit suite green (1548 tests)
- [x] Full v0.3 openai partner unit suite green (266 tests)
- [x] ruff clean on new + modified files
- [ ] Reviewer to confirm v0.3 release strategy (if a follow-up
      `langchain-openai` `langchain-core` minimum bump is desired)
