### PR TITLE
fix(mistralai): strip strict param from Mistral API request payload

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -103,6 +103,16 @@ def _get_default_model_profile(model_name: str) -> ModelProfile:
     return default.copy()
 
 
+def _sanitize_mistral_request_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Remove LangChain-level params that Mistral rejects at the API boundary."""
+    if "strict" not in payload:
+        return payload
+
+    sanitized_payload = payload.copy()
+    sanitized_payload.pop("strict")
+    return sanitized_payload
+
+
 def _create_retry_decorator(
     llm: ChatMistralAI,
     run_manager: AsyncCallbackManagerForLLMRun | CallbackManagerForLLMRun | None = None,
@@ -233,6 +243,7 @@ async def acompletion_with_retry(
     async def _completion_with_retry(**kwargs: Any) -> Any:
         if "stream" not in kwargs:
             kwargs["stream"] = False
+        kwargs = _sanitize_mistral_request_payload(kwargs)
         stream = kwargs["stream"]
         if stream:
             event_source = aconnect_sse(
@@ -618,6 +629,7 @@ class ChatMistralAI(BaseChatModel):
         def _completion_with_retry(**kwargs: Any) -> Any:
             if "stream" not in kwargs:
                 kwargs["stream"] = False
+            kwargs = _sanitize_mistral_request_payload(kwargs)
             stream = kwargs["stream"]
             if stream:
 

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -566,6 +566,57 @@ def test_retry_with_failure_then_success() -> None:
         assert call_count == 2, f"Expected 2 calls, but got {call_count}"
 
 
+def test_bind_tools_strict_not_forwarded_to_request_payload() -> None:
+    """`strict` from upstream structured-output bindings must not reach Mistral."""
+    chat = ChatMistralAI(model="test")
+    captured_payloads = []
+
+    def mock_post(*args: Any, **kwargs: Any) -> MagicMock:
+        captured_payloads.append(kwargs["json"])
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello!",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 1,
+                "completion_tokens": 1,
+                "total_tokens": 2,
+            },
+        }
+        return mock_response
+
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "MeetingAction",
+            "schema": {
+                "type": "object",
+                "properties": {"task": {"type": "string"}},
+                "required": ["task"],
+            },
+            "strict": True,
+        },
+    }
+
+    bound = chat.bind_tools([], strict=True, response_format=response_format)
+
+    with patch.object(chat.client, "post", side_effect=mock_post):
+        result = bound.invoke("Hello")
+
+    assert result.content == "Hello!"
+    assert len(captured_payloads) == 1
+    assert "strict" not in captured_payloads[0]
+    assert captured_payloads[0]["response_format"] == response_format
+
+
 def test_no_duplicate_tool_calls_when_multiple_tools() -> None:
     """
     Tests whether the conversion of an AIMessage with more than one tool call


### PR DESCRIPTION
Fixes #37290

Mistral's API does not support the `strict` parameter in chat completion 
requests, but it was being forwarded from `bind_tools`/`with_structured_output`, 
causing a 422 error. This fix strips `strict` before the API call and adds 
a regression test covering the affected path.