### PR TITLE
docs(qdrant): add await to async search example

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -167,7 +167,7 @@ class QdrantVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)


### PR DESCRIPTION
Fixes #37058

## Description

This updates the Qdrant async usage example so the `asimilarity_search(...)` call is awaited:

```python
# results = await vector_store.asimilarity_search(query="thud", k=1)
```

Without `await`, the example returns a coroutine instead of search results.

## Testing

- `git diff --check`
- Targeted Python assertion confirmed the old example is gone and the awaited example is present.

Full tests were not run because this is a docstring-only example change.
