### PR TITLE
fix(core): handle `NameError` in `_returns_runnable` when annotations are unresolvable

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -649,7 +649,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
 def _returns_runnable(attr: Any) -> bool:
     if not callable(attr):
         return False
-    return_type = typing.get_type_hints(attr).get("return")
+    try:
+        return_type = typing.get_type_hints(attr).get("return")
+    except (NameError, TypeError, AttributeError):
+        return False
     return bool(return_type and _is_runnable_type(return_type))
 
 

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -400,3 +400,22 @@ def test_fallbacks_getattr_runnable_output() -> None:
         for fallback in llm_with_fallbacks_with_tools.fallbacks
     )
     assert llm_with_fallbacks_with_tools.runnable.kwargs["tools"] == []
+
+
+def test_fallbacks_getattr_unresolvable_forward_ref() -> None:
+    """__getattr__ should not raise NameError when get_type_hints fails.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/36579.
+    Methods whose annotations contain unresolvable forward references (e.g. when
+    the method's module defines ``from __future__ import annotations`` and the
+    referenced name is not importable at runtime) used to propagate a NameError
+    from ``typing.get_type_hints``.  The fix wraps the call in a try/except so
+    that the attribute is treated as a non-Runnable-returning method.
+    """
+    from langchain_core.runnables.fallbacks import _returns_runnable
+
+    def _method_with_bad_annotation() -> "NonExistentClass":  # type: ignore[name-defined]  # noqa: F821
+        return None  # type: ignore[return-value]
+
+    # Should not raise NameError even though the annotation is unresolvable
+    assert _returns_runnable(_method_with_bad_annotation) is False


### PR DESCRIPTION
Closes #36579

---

`_returns_runnable` in `RunnableWithFallbacks` calls `typing.get_type_hints()` to inspect return annotations. When a callable has a forward reference that cannot be resolved in the current scope (e.g., an annotation defined in a different module or a string literal for a type that isn't imported), `get_type_hints()` raises `NameError`. This causes `getattr`-based attribute access on `RunnableWithFallbacks` to raise unexpectedly, instead of gracefully returning `False`.

The fix catches `NameError` (along with `TypeError` and `AttributeError` which can also be raised by `get_type_hints` in edge cases) and returns `False`, treating such callables as non-runnable.

A test is included that constructs a function with an unresolvable annotation and asserts `_returns_runnable` returns `False` without raising.