### PR TITLE
fix(langchain): remove rejected tool calls from `AIMessage` in HITL middleware

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -649,7 +649,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
 def _returns_runnable(attr: Any) -> bool:
     if not callable(attr):
         return False
-    return_type = typing.get_type_hints(attr).get("return")
+    try:
+        return_type = typing.get_type_hints(attr).get("return")
+    except (NameError, TypeError, AttributeError):
+        return False
     return bool(return_type and _is_runnable_type(return_type))
 
 

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -400,3 +400,22 @@ def test_fallbacks_getattr_runnable_output() -> None:
         for fallback in llm_with_fallbacks_with_tools.fallbacks
     )
     assert llm_with_fallbacks_with_tools.runnable.kwargs["tools"] == []
+
+
+def test_fallbacks_getattr_unresolvable_forward_ref() -> None:
+    """__getattr__ should not raise NameError when get_type_hints fails.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/36579.
+    Methods whose annotations contain unresolvable forward references (e.g. when
+    the method's module defines ``from __future__ import annotations`` and the
+    referenced name is not importable at runtime) used to propagate a NameError
+    from ``typing.get_type_hints``.  The fix wraps the call in a try/except so
+    that the attribute is treated as a non-Runnable-returning method.
+    """
+    from langchain_core.runnables.fallbacks import _returns_runnable
+
+    def _method_with_bad_annotation() -> "NonExistentClass":  # type: ignore[name-defined]  # noqa: F821
+        return None  # type: ignore[return-value]
+
+    # Should not raise NameError even though the annotation is unresolvable
+    assert _returns_runnable(_method_with_bad_annotation) is False

--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -292,7 +292,7 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
                 tool_call_id=tool_call["id"],
                 status="error",
             )
-            return tool_call, tool_message
+            return None, tool_message
         if decision["type"] == "respond" and "respond" in allowed_decisions:
             # Skip tool execution; the human answers on behalf of the tool.
             tool_message = ToolMessage(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -868,15 +868,14 @@ def test_human_in_the_loop_middleware_preserves_order_with_rejections() -> None:
         assert len(result["messages"]) == 2  # AI message + tool message for rejection
 
         updated_ai_message = result["messages"][0]
-        # tool_b is still in the list (with rejection handled via tool message)
-        assert len(updated_ai_message.tool_calls) == 5
+        # tool_b is removed from the list because it was rejected; ToolNode must not execute it
+        assert len(updated_ai_message.tool_calls) == 4
 
-        # Verify order maintained: A (auto) -> B (rejected) -> C (auto) -> D (approved) -> E (auto)
+        # Verify order maintained: A (auto) -> C (auto) -> D (approved) -> E (auto)
         assert updated_ai_message.tool_calls[0]["name"] == "tool_a"
-        assert updated_ai_message.tool_calls[1]["name"] == "tool_b"
-        assert updated_ai_message.tool_calls[2]["name"] == "tool_c"
-        assert updated_ai_message.tool_calls[3]["name"] == "tool_d"
-        assert updated_ai_message.tool_calls[4]["name"] == "tool_e"
+        assert updated_ai_message.tool_calls[1]["name"] == "tool_c"
+        assert updated_ai_message.tool_calls[2]["name"] == "tool_d"
+        assert updated_ai_message.tool_calls[3]["name"] == "tool_e"
 
         # Check rejection tool message
         tool_message = result["messages"][1]


### PR DESCRIPTION
Closes #37093

---

In `HumanInTheLoopMiddleware._process_decision`, when a human rejects a tool call the method returned `(tool_call, tool_message)` — preserving the original `ToolCall` in the revised list. This caused `ToolNode` to still execute the rejected tool despite the rejection, because the tool call remained on the `AIMessage`.

The fix returns `(None, tool_message)` for the `reject` branch, so the rejected tool call is excluded from `revised_tool_calls` and never passed to `ToolNode`.

The `respond` branch is intentionally left unchanged: it returns `(tool_call, tool_message)` because provider APIs require that every tool call ID appearing in an `AIMessage` has a corresponding `ToolMessage`.

The existing unit test for mixed decisions is updated to reflect the corrected behaviour: a rejected tool call no longer appears in the updated `AIMessage`.