### PR TITLE
release(core): 1.4.0

### DIFF
--- a/libs/core/langchain_core/version.py
+++ b/libs/core/langchain_core/version.py
@@ -1,3 +1,3 @@
 """langchain-core version information and utilities."""
 
-VERSION = "1.4.0a2"
+VERSION = "1.4.0"

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.4.0a2"
+version = "1.4.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langsmith>=0.3.45,<1.0.0",

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0a2"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Bumps `langchain-core` from `1.4.0a2` → `1.4.0` (GA).

