### PR TITLE
release(langchain): 1.3.0

### DIFF
--- a/libs/core/langchain_core/version.py
+++ b/libs/core/langchain_core/version.py
@@ -1,3 +1,3 @@
 """langchain-core version information and utilities."""
 
-VERSION = "1.4.0a2"
+VERSION = "1.4.0"

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.4.0a2"
+version = "1.4.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langsmith>=0.3.45,<1.0.0",

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -995,7 +995,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0a2"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/langchain_v1/langchain/__init__.py
+++ b/libs/langchain_v1/langchain/__init__.py
@@ -1,3 +1,3 @@
 """Main entrypoint into LangChain."""
 
-__version__ = "1.3.0a2"
+__version__ = "1.3.0"

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -21,10 +21,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.3.0a2"
+version = "1.3.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.0a2,<2.0.0",
+    "langchain-core>=1.4.0,<2.0.0",
     "langgraph>=1.2.0a5,<1.3.0",
     "pydantic>=2.7.4,<3.0.0",
 ]

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1920,7 +1920,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.0a2"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0a2"
+version = "1.4.0"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Bumps `langchain` from `1.3.0a2` → `1.3.0` (GA). Also bumps the `langchain-core` floor from `>=1.4.0a2` to `>=1.4.0` to match the GA core release.

Stacked on #37344. Once that merges, GitHub will auto-retarget this PR to \`v1.4\`.

_Disclaimer: prepared with AI-agent assistance._