### PR TITLE
feat(core)!: auto-assign UUID to BaseMessage.id at creation

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING, Any, cast, overload
 
 from pydantic import ConfigDict, Field
@@ -132,10 +133,22 @@ class BaseMessage(Serializable):
 
     """
 
-    id: str | None = Field(default=None, coerce_numbers_to_str=True)
-    """An optional unique identifier for the message.
+    id: str | None = Field(
+        default_factory=lambda: str(uuid.uuid4()),
+        coerce_numbers_to_str=True,
+    )
+    """A unique identifier for the message.
 
-    This should ideally be provided by the provider/model which created the message.
+    Auto-assigned as a UUID on creation when not provided. The id is used by
+    LangGraph's ``DeltaChannel`` reducer and other components to deduplicate
+    messages: a message written to a channel can be updated in-place on
+    subsequent writes because it carries a stable id from birth. Without an id
+    the deduplication logic cannot match a message to its prior version across
+    checkpoint serialization boundaries, causing duplicates.
+
+    The type is ``str | None`` rather than ``str`` so that existing serialized
+    messages without an ``id`` field deserialize cleanly (they get ``None``
+    back, not an error). New messages created at runtime always receive a UUID.
 
     """
 


### PR DESCRIPTION
## Summary

Change `BaseMessage.id` from `default=None` to `default_factory=lambda: str(uuid.uuid4())` so every message receives a stable, unique id the moment it is constructed.

## Why this is needed

This is the root fix for a class of bugs in LangGraph's `DeltaChannel` (and any similar write-replay mechanism).

**The problem:** LangGraph checkpointers serialize pending writes **before** `DeltaChannel.update()` runs. This means:

1. User sends `HumanMessage(content="...", id=None)`
2. `put_writes()` → serializes the write → stored as `id=None`
3. Later: `DeltaChannel.update([write])` → reducer assigns `id=<uuid_A>` in-memory
4. Eviction/update Command writes `tagged(id=<uuid_A>)` to state

On the next `invoke`, `replay_writes` replays stored writes:
- Stored write: `HumanMessage(id=None)` → reducer assigns fresh `id=<uuid_B>` where `B ≠ A`
- `tagged(id=<uuid_A>)` doesn't match anything in the index (only `uuid_B` is there)
- Both the original and the tagged version coexist as separate messages → duplicate HumanMessages in the model call

**The fix:** If the message already carries `id=<uuid_A>` when it is first created (before any serialization), the stored write has `id=<uuid_A>`, the Command's tagged message references `id=<uuid_A>`, and replay correctly updates in-place.

See the companion deepagents PR for context: https://github.com/langchain-ai/deepagents/pull/3357

## Breaking change

`HumanMessage(content="x") == HumanMessage(content="x")` is now `**False**` because auto-assigned UUIDs differ. Previously both had `id=None` and compared equal via Pydantic's default field comparison.

**129 tests in langchain-core fail** — all due to this equality change, not serialization or runtime behavior.

## Options for handling the equality change

The team should choose one of:

**Option A — Fix tests** (most semantically correct): Update failing tests to set explicit `id` values or compare fields other than `id`. Two independently-created messages *should* be distinct objects; equality was arguably already wrong.

**Option B — Override `__eq__` to exclude `id`** (least disruptive): Keep content-based equality. DeltaChannel dedup uses an id-keyed index dict, not `==`, so this doesn't affect the correctness of the fix. Downstream code continues to work without changes.

```python
def __eq__(self, other: object) -> bool:
    if not isinstance(other, self.__class__):
        return NotImplemented
    return self.model_dump(exclude={"id"}) == other.model_dump(exclude={"id"})
```

**Option C — Hybrid `__eq__`**: Use id for equality only when both messages have a non-None id; otherwise fall back to content comparison. Preserves backward compat for code that creates messages without explicit ids while making messages with ids compare correctly.

## Notes

- Explicitly passing `id=None` still gives `id=None`; `default_factory` only fires when `id` is not supplied at all. This means old serialized messages that deserialize to `id=None` (pre-change blobs) are handled gracefully.
- `RemoveMessage` and `BaseMessageChunk` both inherit this change.
- The `id` type stays `str | None` (not narrowed to `str`) for backward compat with deserialization of old blobs.