### PR TITLE
fix(langchain): propagate config to agent model calls

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1288,7 +1288,9 @@ def create_agent(
             )
         return request.model.bind(**request.model_settings), None
 
-    def _execute_model_sync(request: ModelRequest[ContextT]) -> ModelResponse:
+    def _execute_model_sync(
+        request: ModelRequest[ContextT], config: RunnableConfig
+    ) -> ModelResponse:
         """Execute model and return response.
 
         This is the core model execution logic wrapped by `wrap_model_call` handlers.
@@ -1301,7 +1303,7 @@ def create_agent(
         if request.system_message:
             messages = [request.system_message, *messages]
 
-        output = model_.invoke(messages)
+        output = model_.invoke(messages, config=config)
         if name:
             output.name = name
 
@@ -1315,7 +1317,11 @@ def create_agent(
             structured_response=structured_response,
         )
 
-    def model_node(state: AgentState[Any], runtime: Runtime[ContextT]) -> list[Command[Any]]:
+    def model_node(
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+        config: RunnableConfig,
+    ) -> list[Command[Any]]:
         """Sync model request handler with sequential middleware processing."""
         request = ModelRequest(
             model=model,
@@ -1328,14 +1334,19 @@ def create_agent(
             runtime=runtime,
         )
 
+        def execute_model_sync(request: ModelRequest[ContextT]) -> ModelResponse:
+            return _execute_model_sync(request, config)
+
         if wrap_model_call_handler is None:
-            model_response = _execute_model_sync(request)
+            model_response = execute_model_sync(request)
             return _build_commands(model_response)
 
-        result = wrap_model_call_handler(request, _execute_model_sync)
+        result = wrap_model_call_handler(request, execute_model_sync)
         return _build_commands(result.model_response, result.commands)
 
-    async def _execute_model_async(request: ModelRequest[ContextT]) -> ModelResponse:
+    async def _execute_model_async(
+        request: ModelRequest[ContextT], config: RunnableConfig
+    ) -> ModelResponse:
         """Execute model asynchronously and return response.
 
         This is the core async model execution logic wrapped by `wrap_model_call`
@@ -1349,7 +1360,7 @@ def create_agent(
         if request.system_message:
             messages = [request.system_message, *messages]
 
-        output = await model_.ainvoke(messages)
+        output = await model_.ainvoke(messages, config=config)
         if name:
             output.name = name
 
@@ -1363,7 +1374,11 @@ def create_agent(
             structured_response=structured_response,
         )
 
-    async def amodel_node(state: AgentState[Any], runtime: Runtime[ContextT]) -> list[Command[Any]]:
+    async def amodel_node(
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+        config: RunnableConfig,
+    ) -> list[Command[Any]]:
         """Async model request handler with sequential middleware processing."""
         request = ModelRequest(
             model=model,
@@ -1376,11 +1391,14 @@ def create_agent(
             runtime=runtime,
         )
 
+        async def execute_model_async(request: ModelRequest[ContextT]) -> ModelResponse:
+            return await _execute_model_async(request, config)
+
         if awrap_model_call_handler is None:
-            model_response = await _execute_model_async(request)
+            model_response = await execute_model_async(request)
             return _build_commands(model_response)
 
-        result = await awrap_model_call_handler(request, _execute_model_async)
+        result = await awrap_model_call_handler(request, execute_model_async)
         return _build_commands(result.model_response, result.commands)
 
     # Use sync or async based on model capabilities

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_model_config.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_model_config.py
@@ -1,0 +1,131 @@
+"""Tests for agent model invocation config propagation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.callbacks import AsyncCallbackHandler, BaseCallbackHandler
+from langchain_core.messages import BaseMessage, HumanMessage
+from pydantic import Field
+from typing_extensions import override
+
+from langchain.agents import create_agent
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import LanguageModelInput
+    from langchain_core.runnables import RunnableConfig
+
+
+class _ConfigCapturingModel(FakeToolCallingModel):
+    captured_configs: list[Any] = Field(default_factory=list, exclude=True)
+
+    @override
+    def invoke(
+        self,
+        input: LanguageModelInput,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> BaseMessage:
+        self.captured_configs.append(config)
+        return super().invoke(input, config=config, **kwargs)
+
+    @override
+    async def ainvoke(
+        self,
+        input: LanguageModelInput,
+        config: RunnableConfig | None = None,
+        **kwargs: Any,
+    ) -> BaseMessage:
+        self.captured_configs.append(config)
+        return await super().ainvoke(input, config=config, **kwargs)
+
+
+class _CallbackRecorder(BaseCallbackHandler):
+    starts: list[dict[str, Any]]
+
+    def __init__(self) -> None:
+        self.starts = []
+
+    @override
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        *,
+        metadata: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.starts.append({"metadata": metadata or {}, "messages": messages, "tags": tags or []})
+
+
+class _AsyncCallbackRecorder(AsyncCallbackHandler):
+    starts: list[dict[str, Any]]
+
+    def __init__(self) -> None:
+        self.starts = []
+
+    @override
+    async def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: list[list[BaseMessage]],
+        *,
+        metadata: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.starts.append({"metadata": metadata or {}, "messages": messages, "tags": tags or []})
+
+
+def test_agent_model_receives_config_and_callbacks() -> None:
+    """The agent model node should forward invocation config to the chat model."""
+    model = _ConfigCapturingModel()
+    handler = _CallbackRecorder()
+    agent = create_agent(model=model)
+
+    agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        config={
+            "callbacks": [handler],
+            "configurable": {"thread_id": "sync-thread"},
+            "metadata": {"test_case": "sync"},
+            "tags": ["agent-config"],
+        },
+    )
+
+    assert len(model.captured_configs) == 1
+    captured_config = model.captured_configs[0]
+    assert captured_config is not None
+    assert captured_config["configurable"]["thread_id"] == "sync-thread"
+
+    assert len(handler.starts) == 1
+    assert handler.starts[0]["metadata"]["test_case"] == "sync"
+    assert "agent-config" in handler.starts[0]["tags"]
+
+
+async def test_agent_model_receives_config_and_callbacks_async() -> None:
+    """The async agent model node should forward invocation config to the chat model."""
+    model = _ConfigCapturingModel()
+    handler = _AsyncCallbackRecorder()
+    agent = create_agent(model=model)
+
+    await agent.ainvoke(
+        {"messages": [HumanMessage("Hello")]},
+        config={
+            "callbacks": [handler],
+            "configurable": {"thread_id": "async-thread"},
+            "metadata": {"test_case": "async"},
+            "tags": ["agent-config-async"],
+        },
+    )
+
+    assert len(model.captured_configs) == 1
+    captured_config = model.captured_configs[0]
+    assert captured_config is not None
+    assert captured_config["configurable"]["thread_id"] == "async-thread"
+
+    assert len(handler.starts) == 1
+    assert handler.starts[0]["metadata"]["test_case"] == "async"
+    assert "agent-config-async" in handler.starts[0]["tags"]


### PR DESCRIPTION
Closes #36393

---

Agent model nodes run with `trace=False`, so their model invocation needs to receive the graph `RunnableConfig` directly...
