### PR TITLE
fix(langchain): omit tools field when empty in ProviderStrategy model binding

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1246,12 +1246,16 @@ def create_agent(
         if isinstance(effective_response_format, ProviderStrategy):
             # (Backward compatibility) Use OpenAI format structured output
             kwargs = effective_response_format.to_model_kwargs()
-            return (
-                request.model.bind_tools(
+            if final_tools:
+                bound_model = request.model.bind_tools(
                     final_tools, strict=True, **kwargs, **request.model_settings
-                ),
-                effective_response_format,
-            )
+                )
+            else:
+                # Omit `tools` entirely when the list is empty: the OpenAI spec
+                # (and OpenAI-compatible servers such as vLLM ≥ v0.20.0) reject
+                # requests that send `"tools": []`.
+                bound_model = request.model.bind(**kwargs, **request.model_settings)
+            return bound_model, effective_response_format
 
         if isinstance(effective_response_format, ToolStrategy):
             # Current implementation requires that tools used for structured output

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -787,6 +787,64 @@ class TestResponseFormatAsProviderStrategy:
         assert len(response["messages"]) == 4
 
 
+class TestResponseFormatAsProviderStrategyNoTools:
+    """Tests for ProviderStrategy when no user tools are supplied.
+
+    OpenAI and OpenAI-compatible servers (e.g. vLLM ≥ v0.20.0) reject requests
+    that include ``"tools": []`` — the field must be omitted entirely when there
+    are no tools.  These tests guard against the regression reported in
+    https://github.com/langchain-ai/langchain/issues/37184.
+    """
+
+    def test_no_tools_does_not_call_bind_tools(self) -> None:
+        """bind_tools must not be called when the tool list is empty.
+
+        FakeToolCallingModel.bind_tools raises ValueError for an empty list,
+        mirroring the behaviour of real OpenAI-compatible providers.  A
+        successful invocation here proves that the ProviderStrategy branch
+        falls back to model.bind() instead of model.bind_tools([]).
+        """
+        model = FakeToolCallingModel(structured_response=EXPECTED_WEATHER_PYDANTIC)
+
+        # No tools — this is the scenario that triggered the vLLM v0.20.0 error.
+        agent = create_agent(
+            model, [], response_format=ProviderStrategy(WeatherBaseModel)
+        )
+        response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+
+    def test_no_tools_bind_tools_not_invoked(self) -> None:
+        """bind_tools must never be invoked when final_tools is empty."""
+        model = FakeToolCallingModel(structured_response=EXPECTED_WEATHER_PYDANTIC)
+
+        with patch.object(
+            FakeToolCallingModel, "bind_tools", wraps=FakeToolCallingModel.bind_tools
+        ) as mock_bind_tools:
+            agent = create_agent(
+                model, [], response_format=ProviderStrategy(WeatherBaseModel)
+            )
+            agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        mock_bind_tools.assert_not_called()
+
+    def test_with_tools_still_works(self) -> None:
+        """Agents with tools + ProviderStrategy must still work correctly (no regression)."""
+        tool_calls = [
+            [{"args": {}, "id": "1", "name": "get_weather"}],
+        ]
+        model = FakeToolCallingModel(
+            tool_calls=tool_calls, structured_response=EXPECTED_WEATHER_PYDANTIC
+        )
+
+        agent = create_agent(
+            model, [get_weather], response_format=ProviderStrategy(WeatherBaseModel)
+        )
+        response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+
+
 class TestDynamicModelWithResponseFormat:
     """Test response_format with middleware that modifies the model."""
 


### PR DESCRIPTION
## Description

Fixes #37184

When `create_agent` is used with `response_format=ProviderStrategy(...)` and **no user tools are provided**, `_get_bound_model` was unconditionally calling `model.bind_tools([])` — forwarding an empty `tools` array to the provider.

The OpenAI API specification explicitly forbids this:

> `tools`: An optional list of tools the model may call. Currently, only functions are supported. A maximum of 128 functions are supported. **Use this parameter only if the array is non-empty.**

Starting with **vLLM v0.20.0** (and other spec-compliant OpenAI-compatible servers) this produces a hard failure:

```
ValueError: `tools` must not be an empty array.
Either provide at least one tool or omit the field entirely.
```

This breaks structured-output-only agents that legitimately have no tools — a valid and common pattern where a given execution path uses `response_format` for provider-native structured output without any tool calls.

## Root Cause

In `libs/langchain_v1/langchain/agents/factory.py`, the `ProviderStrategy` branch of `_get_bound_model` always called `bind_tools`:

```python
# Before — always sends tools=[], which breaks OpenAI-compatible providers
if isinstance(effective_response_format, ProviderStrategy):
    kwargs = effective_response_format.to_model_kwargs()
    return (
        request.model.bind_tools(
            final_tools, strict=True, **kwargs, **request.model_settings
        ),
        effective_response_format,
    )
```

## Fix

Guard the call so that `bind_tools` is only used when `final_tools` is non-empty. When the list is empty, fall back to `model.bind(...)`, which omits the `tools` field from the request entirely:

```python
# After — omits tools field when list is empty
if isinstance(effective_response_format, ProviderStrategy):
    kwargs = effective_response_format.to_model_kwargs()
    if final_tools:
        bound_model = request.model.bind_tools(
            final_tools, strict=True, **kwargs, **request.model_settings
        )
    else:
        # Omit `tools` entirely when the list is empty: the OpenAI spec
        # (and OpenAI-compatible servers such as vLLM ≥ v0.20.0) reject
        # requests that send `"tools": []`.
        bound_model = request.model.bind(**kwargs, **request.model_settings)
    return bound_model, effective_response_format
```

## Tests

Three new unit tests added to `TestResponseFormatAsProviderStrategyNoTools`:

| Test | What it verifies |
|---|---|
| `test_no_tools_does_not_call_bind_tools` | Agent with `ProviderStrategy` + no tools succeeds end-to-end (`FakeToolCallingModel.bind_tools` raises `ValueError` on empty list, so a clean pass proves `bind` was used instead) |
| `test_no_tools_bind_tools_not_invoked` | `bind_tools` is never called at all when tool list is empty (mock assertion) |
| `test_with_tools_still_works` | Existing behaviour unchanged — agents with tools + `ProviderStrategy` still produce correct structured output |

All existing `TestResponseFormatAsProviderStrategy` tests continue to pass.

## Related

- Upstream provider enforcement: vllm-project/vllm#39741