### PR TITLE
fix(langchain): sort glob_search results by modification time

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -170,6 +170,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             if not matching:
                 return "No files found"
 
+            matching.sort(key=lambda item: item[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
 


### PR DESCRIPTION
Fixes #37369 

```
sed -n '139p' libs/langchain_v1/langchain/agents/middleware/file_search.py 
            Returns matching file paths sorted by modification time.
```

This fixes glob_search so it returns matched files from newest to oldest, as documented.
Previously, matches were returned in the arbitrary order from Path.glob(). Now the collected results are sorted by modification timestamp before file paths are returned.
No public API changes. 

```
git diff master  libs/langchain_v1/langchain/agents/middleware/file_search.py
...
+            matching.sort(key=lambda item: item[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
````

Fix with tests here:
PR: https://github.com/langchain-ai/langchain/pull/37378