### PR TITLE
fix(ollama): use Ollama done_reason for stream finish_reason

### DIFF
--- a/libs/partners/ollama/langchain_ollama/llms.py
+++ b/libs/partners/ollama/langchain_ollama/llms.py
@@ -513,10 +513,11 @@ class OllamaLLM(BaseLLM):
                 chunk = GenerationChunk(
                     text=(stream_resp.get("response", "")),
                     generation_info={
-                        "finish_reason": self.stop,
                         **additional_kwargs,
                         **(
-                            dict(stream_resp) if stream_resp.get("done") is True else {}
+                            {**dict(stream_resp), "finish_reason": stream_resp.get("done_reason")}
+                            if stream_resp.get("done") is True
+                            else {}
                         ),
                     },
                 )
@@ -544,10 +545,11 @@ class OllamaLLM(BaseLLM):
                 chunk = GenerationChunk(
                     text=(stream_resp.get("response", "")),
                     generation_info={
-                        "finish_reason": self.stop,
                         **additional_kwargs,
                         **(
-                            dict(stream_resp) if stream_resp.get("done") is True else {}
+                            {**dict(stream_resp), "finish_reason": stream_resp.get("done_reason")}
+                            if stream_resp.get("done") is True
+                            else {}
                         ),
                     },
                 )


### PR DESCRIPTION
Fixes #37370

This fixes how `OllamaLLM._stream` and `_astream` populate `generation_info["finish_reason"]`.

Previously, both methods used `self.stop` as the finish reason for every streamed chunk. But `self.stop` contains the user-provided stop sequences, not the actual reason why the model finished generating.

This could lead to confusing or invalid metadata. For example, when `stop=["END"]` is set, `finish_reason` becomes `["END"]` instead of a string like `"stop"`. When no stop sequences are configured, `finish_reason` is `None` on every chunk, so downstream telemetry can lose the completion signal.

Ollama already provides the real finish reason as `done_reason` on the final streamed response. This change uses that value only when the stream is done, and leaves intermediate chunks without a finish reason.
The same fix is applied to both sync and async streaming paths.