### PR TITLE
ci: parse changed files as JSON

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -242,8 +242,42 @@ def _get_configs_for_multi_dirs(
     ]
 
 
+def _get_changed_files(args: list[str]) -> list[str]:
+    """Parse changed files from command-line arguments.
+
+    Args:
+        args: Either a legacy list of filename arguments or a single JSON array
+            produced by `Ana06/get-changed-files` with `format: json`.
+
+    Returns:
+        List of changed files.
+
+    Raises:
+        ValueError: If a single argument looks like JSON but is not a string array.
+    """
+    if len(args) != 1:
+        return args
+
+    value = args[0].strip()
+    if not value.startswith("[") or not value.endswith("]"):
+        return args
+
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as e:
+        msg = "Expected changed files JSON to be a list of strings."
+        raise ValueError(msg) from e
+
+    if not isinstance(parsed, list) or not all(
+        isinstance(file, str) for file in parsed
+    ):
+        msg = "Expected changed files JSON to be a list of strings."
+        raise ValueError(msg)
+    return parsed
+
+
 if __name__ == "__main__":
-    files = sys.argv[1:]
+    files = _get_changed_files(sys.argv[1:])
 
     dirs_to_run: Dict[str, set] = {
         "lint": set(),

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -54,11 +54,15 @@ jobs:
       - name: "📂 Get Changed Files"
         id: files
         uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
+        with:
+          format: json
       - name: "🔍 Analyze Changed Files & Generate Build Matrix"
         id: set-matrix
+        env:
+          ALL_CHANGED_FILES: ${{ steps.files.outputs.all }}
         run: |
           python -m pip install packaging requests
-          python .github/scripts/check_diff.py ${{ steps.files.outputs.all }} >> $GITHUB_OUTPUT
+          python .github/scripts/check_diff.py "$ALL_CHANGED_FILES" >> $GITHUB_OUTPUT
     outputs:
       lint: ${{ steps.set-matrix.outputs.lint }}
       test: ${{ steps.set-matrix.outputs.test }}

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -40,11 +40,15 @@ jobs:
       - name: "📂 Get Changed Files"
         id: files
         uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c # v2.3.0
+        with:
+          format: json
       - name: "🔍 Analyze Changed Files"
         id: set-matrix
+        env:
+          ALL_CHANGED_FILES: ${{ steps.files.outputs.all }}
         run: |
           python -m pip install packaging requests
-          python .github/scripts/check_diff.py ${{ steps.files.outputs.all }} >> $GITHUB_OUTPUT
+          python .github/scripts/check_diff.py "$ALL_CHANGED_FILES" >> $GITHUB_OUTPUT
     outputs:
       codspeed: ${{ steps.set-matrix.outputs.codspeed }}
 


### PR DESCRIPTION
Avoid interpolating changed file names directly into shell scripts when building CI matrices.