### PR TITLE
Bug(langchain): glob_search returns files in arbitrary order despite docstring promising mtime-desc sort

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -170,6 +170,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             if not matching:
                 return "No files found"
 
+            matching.sort(key=lambda entry: entry[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -1,5 +1,6 @@
 """Unit tests for file search middleware."""
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -209,6 +210,28 @@ class TestFilesystemGlobSearch:
         result = middleware.glob_search.func(pattern="*.py", path="/nonexistent")
 
         assert result == "No files found"
+
+    def test_glob_results_sorted_by_mtime_descending(self, tmp_path: Path) -> None:
+        """Glob results must be sorted by modification time, newest first."""
+        # mtimes deliberately uncorrelated with alphabetical or creation order
+        # so no filesystem traversal order accidentally yields the expected output.
+        for name, mtime in [
+            ("a.txt", 2_000_000.0),
+            ("b.txt", 4_000_000.0),
+            ("c.txt", 1_000_000.0),
+            ("d.txt", 3_000_000.0),
+        ]:
+            file_path = tmp_path / name
+            file_path.write_text("x", encoding="utf-8")
+            os.utime(file_path, (mtime, mtime))
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.txt")
+
+        assert result.splitlines() == ["/b.txt", "/d.txt", "/a.txt", "/c.txt"]
 
 
 class TestPathTraversalSecurity:


### PR DESCRIPTION
Fixes #37369 --- ## Description `FilesystemFileSearchMiddleware.glob_search` built `(virtual_path, modified_at)` tuples but never sorted them, so result order was whatever `Path.glob()` returned. The docstring promised "most recently modified first," but that contract was silently broken on most filesystems. ## What changed
- Sort matches by ISO timestamp in descending order before extracting paths in `glob_search`.
- Added a unit test that creates files with staggered modification times and asserts the returned order. ## Checklist
- [x] Linting/formatting run
- [x] All tests pass locally
- [x] Self-reviewed
- [ ] Documentation updated
- [ ] CI is green