### PR TITLE
fix(langchain): remove rejected tool calls from `AIMessage` in HITL m…

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -292,7 +292,7 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
                 tool_call_id=tool_call["id"],
                 status="error",
             )
-            return tool_call, tool_message
+            return None, tool_message
         if decision["type"] == "respond" and "respond" in allowed_decisions:
             # Skip tool execution; the human answers on behalf of the tool.
             tool_message = ToolMessage(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -316,11 +316,10 @@ def test_human_in_the_loop_middleware_multiple_tools_mixed_responses() -> None:
             len(result["messages"]) == 2
         )  # AI message with accepted tool call + tool message for rejected
 
-        # First message should be the AI message with both tool calls
+        # First message should be the AI message with only the approved tool call
         updated_ai_message = result["messages"][0]
-        assert len(updated_ai_message.tool_calls) == 2  # Both tool calls remain
+        assert len(updated_ai_message.tool_calls) == 1  # Only the approved tool call remains
         assert updated_ai_message.tool_calls[0]["name"] == "get_forecast"  # Accepted
-        assert updated_ai_message.tool_calls[1]["name"] == "get_temperature"  # Got response
 
         # Second message should be the tool message for the rejected tool call
         tool_message = result["messages"][1]
@@ -868,15 +867,14 @@ def test_human_in_the_loop_middleware_preserves_order_with_rejections() -> None:
         assert len(result["messages"]) == 2  # AI message + tool message for rejection
 
         updated_ai_message = result["messages"][0]
-        # tool_b is still in the list (with rejection handled via tool message)
-        assert len(updated_ai_message.tool_calls) == 5
+        # tool_b is removed from the list since it was rejected
+        assert len(updated_ai_message.tool_calls) == 4
 
-        # Verify order maintained: A (auto) -> B (rejected) -> C (auto) -> D (approved) -> E (auto)
+        # Verify order maintained: A (auto) -> C (auto) -> D (approved) -> E (auto)
         assert updated_ai_message.tool_calls[0]["name"] == "tool_a"
-        assert updated_ai_message.tool_calls[1]["name"] == "tool_b"
-        assert updated_ai_message.tool_calls[2]["name"] == "tool_c"
-        assert updated_ai_message.tool_calls[3]["name"] == "tool_d"
-        assert updated_ai_message.tool_calls[4]["name"] == "tool_e"
+        assert updated_ai_message.tool_calls[1]["name"] == "tool_c"
+        assert updated_ai_message.tool_calls[2]["name"] == "tool_d"
+        assert updated_ai_message.tool_calls[3]["name"] == "tool_e"
 
         # Check rejection tool message
         tool_message = result["messages"][1]


### PR DESCRIPTION
Fixes #37093

---

`HumanInTheLoopMiddleware` was incorrectly preserving rejected tool calls in the `AIMessage`'s `tool_calls` list. When a human reviewer rejected a tool via the `'reject'` decision, the tool call remained in the message, allowing LangGraph's `ToolNode` to execute it anyway on the next step.

The fix is a one-line change in `_process_decision`: for the `'reject'` decision type, return `None` as the tool_call instead of the tool_call itself. The existing guard in `after_model` (`if revised_tool_call is not None`) already filters out `None` values, so rejected calls are dropped from the reconstructed message while the rejection `ToolMessage` is preserved in the thread.

Two existing tests had incorrect assertions about expected tool call counts after rejection; these have been corrected to match the intended behavior where rejected tools no longer appear in the final message.

- 22/22 HITL-specific tests pass
- 801/801 total unit tests pass
- Linter clean

## Social handles
LinkedIn: https://www.linkedin.com/in/pkmishra70/
