### PR TITLE
fix(langchain): sort glob search results by modification time

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -170,6 +170,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             if not matching:
                 return "No files found"
 
+            matching.sort(key=lambda item: item[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -1,5 +1,6 @@
 """Unit tests for file search middleware."""
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -199,6 +200,49 @@ class TestFilesystemGlobSearch:
         result = middleware.glob_search.func(pattern="*.py")
 
         assert result == "No files found"
+
+    def test_glob_sorts_by_modification_time_descending(self, tmp_path: Path) -> None:
+        """Result list must be ordered most-recently-modified first."""
+        a_file = tmp_path / "a.py"
+        b_file = tmp_path / "b.py"
+        c_file = tmp_path / "c.py"
+        for f in (a_file, b_file, c_file):
+            f.write_text("content", encoding="utf-8")
+
+        # Stamp mtimes so alphabetical order (a, b, c) is opposite of mtime order.
+        os.utime(a_file, (1_000_000_000, 1_000_000_000))
+        os.utime(b_file, (1_000_000_500, 1_000_000_500))
+        os.utime(c_file, (1_000_001_000, 1_000_001_000))
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.py")
+
+        assert result.splitlines() == ["/c.py", "/b.py", "/a.py"]
+
+    def test_glob_sort_across_subdirectories(self, tmp_path: Path) -> None:
+        """Sort order must hold across files in different subdirectories."""
+        (tmp_path / "x").mkdir()
+        (tmp_path / "y").mkdir()
+        a_file = tmp_path / "x" / "a.py"
+        b_file = tmp_path / "y" / "b.py"
+        c_file = tmp_path / "x" / "c.py"
+        for f in (a_file, b_file, c_file):
+            f.write_text("content", encoding="utf-8")
+
+        os.utime(a_file, (1_000_000_000, 1_000_000_000))
+        os.utime(b_file, (1_000_000_500, 1_000_000_500))
+        os.utime(c_file, (1_000_001_000, 1_000_001_000))
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="**/*.py")
+
+        assert result.splitlines() == ["/x/c.py", "/y/b.py", "/x/a.py"]
 
     def test_glob_invalid_path(self, tmp_path: Path) -> None:
         """Test glob search with non-existent path."""


### PR DESCRIPTION
Fixes #37369 

```
sed -n '139p' libs/langchain_v1/langchain/agents/middleware/file_search.py 
            Returns matching file paths sorted by modification time.
```

This fixes glob_search so it returns matched files from newest to oldest, as documented.
Previously, matches were returned in the arbitrary order from Path.glob(). Now the collected results are sorted by modification timestamp before file paths are returned.
No public API changes. 

```
git diff master  libs/langchain_v1/langchain/agents/middleware/file_search.py
...
+            matching.sort(key=lambda item: item[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
````
 + tests