### PR TITLE
fix(langchain): glob_search returns files sorted by modification time

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -170,6 +170,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             if not matching:
                 return "No files found"
 
+            matching.sort(key=lambda item: item[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -210,6 +210,37 @@ class TestFilesystemGlobSearch:
 
         assert result == "No files found"
 
+    def test_glob_sorted_by_modification_time(self, tmp_path: Path) -> None:
+        """Test that glob results are sorted by modification time (newest first)."""
+        import time
+
+        # Create three files with distinct mtimes
+        file1 = tmp_path / "oldest.txt"
+        file1.write_text("content1", encoding="utf-8")
+        time.sleep(0.1)
+
+        file2 = tmp_path / "middle.txt"
+        file2.write_text("content2", encoding="utf-8")
+        time.sleep(0.1)
+
+        file3 = tmp_path / "newest.txt"
+        file3.write_text("content3", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.txt")
+
+        # Parse results
+        lines = result.strip().split("\n")
+        assert len(lines) == 3
+
+        # Verify order: newest first (descending by mtime)
+        assert lines[0] == "/newest.txt"
+        assert lines[1] == "/middle.txt"
+        assert lines[2] == "/oldest.txt"
+
 
 class TestPathTraversalSecurity:
     """Security tests for path traversal protection."""


### PR DESCRIPTION
Fixes #37369

## Summary
The `glob_search()` tool's docstring promises to return files sorted by modification time (newest first), but the implementation returns them in arbitrary order from `Path.glob()`.

**Changes:**
- Added sorting by modification timestamp before returning results
- Files are sorted in descending order (newest first) as documented
- Added comprehensive test to verify sorting behavior

## Why this works
- Files are collected as tuples: `(virtual_path, modified_at_iso_string)`
- ISO format timestamps sort correctly as strings
- Single-line fix: `matching.sort(key=lambda item: item[1], reverse=True)`

## Testing
- All 32 existing tests pass ✅
- New test `test_glob_sorted_by_modification_time` verifies sorting
- No breaking changes: only affects result ordering (already promised)

---

🤖 Generated with Claude Code