### PR TITLE
fix(text-splitters): skip invalid and unsafe HTML links

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -814,11 +814,22 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
             soup: Parsed HTML content using BeautifulSoup.
         """
         for a_tag in _find_all_tags(soup, name="a"):
-            a_href = a_tag.get("href", "")
+            a_href = a_tag.get("href", "").strip()
             a_text = a_tag.get_text(strip=True)
+
+            # Skip malformed or empty links
+            if not a_href or not a_text:
+                continue
+
+            # Skip javascript pseudo-links
+            if a_href.lower().startswith("javascript:"):
+                continue
+
             markdown_link = f"[{a_text}]({a_href})"
+
             wrapper = soup.new_tag("link-wrapper")
             wrapper.string = markdown_link
+
             a_tag.replace_with(NavigableString(markdown_link))
 
     def _filter_tags(self, soup: BeautifulSoup) -> None:

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1302,6 +1302,31 @@ def test_html_code_splitter() -> None:
         "<p>Some more text</p>\n            </div>",
     ]
 
+def test_html_semantic_preserving_splitter_skips_invalid_links() -> None:
+    """Test that invalid or unsafe links are skipped."""
+    html = """
+    <html>
+        <body>
+            <p><a href="">Empty Link</a></p>
+            <p><a href="javascript:void(0)">Bad Link</a></p>
+            <p><a href="https://example.com">Valid Link</a></p>
+        </body>
+    </html>
+    """
+
+    splitter = HTMLSemanticPreservingSplitter(
+        headers_to_split_on=[("h1", "Header 1")],
+        preserve_links=True,
+    )
+
+    docs = splitter.split_text(html)
+
+    combined_text = " ".join(doc.page_content for doc in docs)
+
+    assert "[Valid Link](https://example.com)" in combined_text
+    assert "javascript:void(0)" not in combined_text
+    assert "[]( )" not in combined_text
+
 
 def test_md_header_text_splitter_1() -> None:
     """Test markdown splitter by header: Case 1."""


### PR DESCRIPTION
Fixes #37423

Improves HTML link processing in `HTMLSemanticPreservingSplitter` by skipping malformed or unsafe links such as empty `href` values and `javascript:` pseudo-links.

Also adds a unit test to verify invalid links are ignored while valid links are preserved correctly.
