### PR TITLE
Feature/perl beast mode

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -807,6 +807,8 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "\nmy ",
                 "\nour ",
                 "\nlocal ",
+                # Split along the __END__ token
+                "\n__END__",
                 # Split by the normal type of lines
                 "\n\n",
                 "\n",

--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -788,6 +788,32 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "",
             ]
 
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "\nsub ",
+                # Split along package declarations
+                "\npackage ",
+                # Split along control flow statements
+                "\nif ",
+                "\nunless ",
+                "\nuntil ",
+                "\nwhile ",
+                "\nfor ",
+                "\nforeach ",
+                "\ndo ",
+                # Split along common built-ins and block keywords
+                "\nuse ",
+                "\nmy ",
+                "\nour ",
+                "\nlocal ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
+
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"
             raise ValueError(msg)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -764,6 +764,33 @@ Not a comment
     assert chunks == ["harry", "***\nbabylon is"]
 
 
+def test_perl_code_splitter() -> None:
+    splitter = RecursiveCharacterTextSplitter.from_language(
+        Language.PERL, chunk_size=30, chunk_overlap=0
+    )
+    code = """
+package MyModule;
+use strict;
+use warnings;
+
+sub hello {
+    my $name = shift;
+    print "Hello, $name!\n";
+}
+
+1;
+__END__
+This is some documentation.
+"""
+    chunks = splitter.split_text(code)
+    # Verify we get chunks and no error
+    assert len(chunks) > 0
+    # The chunk size 30 should force splits at logical boundaries
+    assert any("package MyModule;" in c for c in chunks)
+    assert any("sub hello" in c for c in chunks)
+    assert any("__END__" in c for c in chunks)
+
+
 def test_proto_file_splitter() -> None:
     splitter = RecursiveCharacterTextSplitter.from_language(
         Language.PROTO, chunk_size=CHUNK_SIZE, chunk_overlap=0


### PR DESCRIPTION
Description: Closes #37049

While Language.PERL existed in the enum, it was missing an implementation in get_separators_for_language. This PR adds comprehensive Perl support with:

Rich Separators: Includes sub, package, unless, until, local, and __END__.
Recursive Fallbacks: Standard fallbacks included to ensure the splitter never fails.
Unit Tested: Added test_perl_code_splitter to test_text_splitters.py.