### PR TITLE
fix(langchain): glob_search returns files in arbitrary order despite …

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -170,6 +170,8 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             if not matching:
                 return "No files found"
 
+            # Sort by modification time descending (most recently modified first)
+            matching.sort(key=lambda x: x[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
 


### PR DESCRIPTION
Description: Closes #37369

The docstring for glob_search explicitly states that results are returned sorted by modification time (most recently modified first). However, the implementation was returning paths in the arbitrary order provided by the glob iteration.

This PR applies a descending sort by modification time before returning the paths, ensuring the observed behavior matches the documented contract and provides more useful results for file-search tools.