### PR TITLE
docs(qdrant, chroma, core): fix missing await in asimilarity_search docstring examples

### DIFF
--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -132,7 +132,7 @@ class InMemoryVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud", k=1)
+        results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)

--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -271,7 +271,7 @@ class Chroma(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)

--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -167,7 +167,7 @@ class QdrantVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)


### PR DESCRIPTION
 Closes #37058

This PR fixes a recurring issue in asimilarity_search async docstring examples across several packages. The examples were missing the await keyword, which is misleading for users copy-pasting the snippets.

Affected packages fixed in this PR:

langchain-qdrant (QdrantVectorStore)
langchain-chroma (Chroma)
langchain-core (InMemoryVectorStore)