### PR TITLE
fix(core): prevent all LangSmith identity string fields from concatenating in merge_dicts

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -56,8 +56,21 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "should either occur once or have the same value across "
                 #             "all dicts."
                 #         )
+                # LangSmith identity fields are constant across all streaming chunks
+                # (set once by the provider, e.g. "amazon_bedrock", "openai").
+                # They must never be concatenated; skip if the value is identical.
+                _LANGSMITH_IDENTITY_KEYS = {
+                    "id",
+                    "output_version",
+                    "model_provider",
+                    # LangSmith tracing params — all identity / constant per request
+                    "ls_provider",
+                    "ls_model_name",
+                    "ls_model_type",
+                    "ls_integration",
+                }
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k in _LANGSMITH_IDENTITY_KEYS
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,36 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # LangSmith identity string fields must NOT be concatenated across chunks.
+        # Regression tests for github.com/langchain-ai/langchain/issues/36993.
+        # All these fields are constants emitted on every streaming chunk; they must
+        # be de-duplicated (last-wins / skip), never accumulated.
+        (
+            {"ls_provider": "amazon_bedrock"},
+            {"ls_provider": "amazon_bedrock"},
+            {"ls_provider": "amazon_bedrock"},
+        ),
+        (
+            {"ls_model_name": "anthropic.claude-3-5-sonnet"},
+            {"ls_model_name": "anthropic.claude-3-5-sonnet"},
+            {"ls_model_name": "anthropic.claude-3-5-sonnet"},
+        ),
+        (
+            {"ls_model_type": "chat"},
+            {"ls_model_type": "chat"},
+            {"ls_model_type": "chat"},
+        ),
+        (
+            {"ls_integration": "langchain-aws"},
+            {"ls_integration": "langchain-aws"},
+            {"ls_integration": "langchain-aws"},
+        ),
+        # Realistic multi-key streaming chunk scenario
+        (
+            {"ls_provider": "amazon_bedrock", "model_provider": "bedrock_converse"},
+            {"ls_provider": "amazon_bedrock", "model_provider": "bedrock_converse"},
+            {"ls_provider": "amazon_bedrock", "model_provider": "bedrock_converse"},
+        ),
     ],
 )
 def test_merge_dicts(


### PR DESCRIPTION
Closes #36993

While the initial issue report highlighted ls_provider, a deep audit of the LangSmithParams architecture revealed that several other identity fields were suffering from the same string-concatenation bug during streaming.

This PR extends the merge_dicts skip-concatenation guard to protect the following four fields, ensuring they are de-duplicated rather than accumulated:

ls_provider (e.g., "amazon_bedrock")
ls_model_name (e.g., "gpt-4o")
ls_model_type (e.g., "chat")
ls_integration (e.g., "langchain-aws")
Why this is a better fix: Simply fixing ls_provider would leave other tracing parameters vulnerable to the same payload bloat issue. This change ensures that any string-based identity field from LangSmith is handled safely across streaming chunks.

Changes:

Updated libs/core/langchain_core/utils/_merge.py with a robust _LANGSMITH_IDENTITY_KEYS set.
Added 5 new regression tests in test_utils.py covering individual field de-duplication and a realistic multi-key streaming scenario