### PR TITLE
fix(langchain): sort `glob_search` results by mtime descending

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -170,6 +170,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             if not matching:
                 return "No files found"
 
+            matching.sort(key=lambda item: item[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
 


### PR DESCRIPTION
Closes #37369

---

`glob_search` in `FilesystemFileSearchMiddleware` documents that it returns results "sorted by modification time (most recently modified first)", but the implementation returned matches in the arbitrary order from `Path.glob()`.

This adds a sort on the ISO-8601 modified-at timestamp (descending) before extracting file paths — matching the behavior already present in the Anthropic middleware variant (`_handle_glob_search` in `langchain_anthropic`).

No public API changes; the return type and format remain identical.

---

*This contribution was made with AI-agent assistance.*