### PR TITLE
fix(langchain): sort `glob_search` results by mtime descending

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -170,6 +170,8 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             if not matching:
                 return "No files found"
 
+            # Sort by modification time (most recently modified first)
+            matching.sort(key=lambda x: x[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -200,6 +200,30 @@ class TestFilesystemGlobSearch:
 
         assert result == "No files found"
 
+    def test_glob_sorts_by_mtime_descending(self, tmp_path: Path) -> None:
+        """Test that glob results are sorted by modification time descending."""
+        import time
+
+        # Create files with distinct modification times
+        old_file = tmp_path / "old.py"
+        old_file.write_text("old", encoding="utf-8")
+        # Ensure a measurable time difference
+        time.sleep(0.05)
+
+        new_file = tmp_path / "new.py"
+        new_file.write_text("new", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.py")
+
+        lines = result.split("\n")
+        # Most recently modified first
+        assert lines[0] == "/new.py"
+        assert lines[1] == "/old.py"
+
     def test_glob_invalid_path(self, tmp_path: Path) -> None:
         """Test glob search with non-existent path."""
         middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))


### PR DESCRIPTION
Closes #37369

---

`glob_search` docstring promises files are returned sorted by modification time (most recently modified first), but the implementation returned files in arbitrary filesystem order.

**Changes:**
- Added explicit `sort(key=lambda x: x[1], reverse=True)` on the `(path, mtime)` tuples before extracting file paths
- Added unit test `test_glob_sorts_by_mtime_descending` that creates files with distinct mtimes and verifies ordering

All 32 existing tests pass.

---
*AI-agent involvement: This contribution was developed with AI-agent assistance.*