### PR TITLE
fix(deepseek): preserve `reasoning_content` in multi-turn conversations

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -268,8 +268,12 @@ class ChatDeepSeek(BaseChatOpenAI):
         stop: list[str] | None = None,
         **kwargs: Any,
     ) -> dict:
+        # Convert input to messages before calling super, so we can map
+        # original AIMessage objects (with additional_kwargs) to their
+        # serialized dicts in the payload.
+        messages = self._convert_input(input_).to_messages()
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
-        for message in payload["messages"]:
+        for lc_message, message in zip(messages, payload["messages"]):
             if message["role"] == "tool" and isinstance(message["content"], list):
                 message["content"] = json.dumps(message["content"])
             elif message["role"] == "assistant" and isinstance(
@@ -283,6 +287,19 @@ class ChatDeepSeek(BaseChatOpenAI):
                     if isinstance(block, dict) and block.get("type") == "text"
                 ]
                 message["content"] = "".join(text_parts) if text_parts else ""
+
+            # Preserve reasoning_content from additional_kwargs so that
+            # DeepSeek reasoner models can use it in multi-turn and
+            # tool-calling flows.  The parent _convert_message_to_dict
+            # does not know about this non-standard field and silently
+            # drops it.
+            if (
+                isinstance(lc_message, AIMessage)
+                and "reasoning_content" in lc_message.additional_kwargs
+            ):
+                message["reasoning_content"] = lc_message.additional_kwargs[
+                    "reasoning_content"
+                ]
 
         # Azure-hosted DeepSeek does not support the dict/object form of
         # tool_choice (e.g. {"type": "function", "function": {"name": "..."}}).

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal
 from unittest.mock import MagicMock
 
-from langchain_core.messages import AIMessageChunk, ToolMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
 from openai import BaseModel
 from openai.types.chat import ChatCompletionMessage
@@ -252,6 +252,74 @@ class TestChatDeepSeekCustomUnit:
         tool_message = ToolMessage(content="test string", tool_call_id="test_id")
         payload = chat_model._get_request_payload([tool_message])
         assert payload["messages"][0]["content"] == "test string"
+
+    def test_get_request_payload_preserves_reasoning_content(self) -> None:
+        """Test that reasoning_content in AIMessage.additional_kwargs is preserved in the request payload."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(
+                content="Hi there!",
+                additional_kwargs={"reasoning_content": "Let me think about this..."},
+            ),
+            HumanMessage(content="What did you think about?"),
+        ]
+        payload = chat_model._get_request_payload(messages)
+        assistant_msg = payload["messages"][1]
+        assert assistant_msg["role"] == "assistant"
+        assert assistant_msg["content"] == "Hi there!"
+        assert assistant_msg["reasoning_content"] == "Let me think about this..."
+
+    def test_get_request_payload_preserves_reasoning_content_in_tool_flow(self) -> None:
+        """Test that reasoning_content is preserved in tool-calling flows."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+
+        messages = [
+            HumanMessage(content="What's the weather?"),
+            AIMessage(
+                content="",
+                additional_kwargs={
+                    "reasoning_content": "I need to call the weather tool.",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"location": "NYC"}',
+                            },
+                        }
+                    ],
+                },
+                tool_calls=[
+                    {
+                        "id": "call_1",
+                        "name": "get_weather",
+                        "args": {"location": "NYC"},
+                    }
+                ],
+            ),
+            ToolMessage(content='{"temp": 72}', tool_call_id="call_1"),
+        ]
+        payload = chat_model._get_request_payload(messages)
+        assistant_msg = payload["messages"][1]
+        assert assistant_msg["role"] == "assistant"
+        assert assistant_msg["reasoning_content"] == "I need to call the weather tool."
+
+    def test_get_request_payload_no_reasoning_content(self) -> None:
+        """Test that messages without reasoning_content are unaffected."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi there!"),
+        ]
+        payload = chat_model._get_request_payload(messages)
+        assistant_msg = payload["messages"][1]
+        assert assistant_msg["role"] == "assistant"
+        assert assistant_msg["content"] == "Hi there!"
+        assert "reasoning_content" not in assistant_msg
 
 
 class SampleTool(PydanticBaseModel):


### PR DESCRIPTION
Closes #37390

---

The parent `_convert_message_to_dict` does not know about the non-standard `reasoning_content` field in `AIMessage.additional_kwargs` and silently drops it when constructing the request payload. This breaks multi-turn and tool-calling flows with DeepSeek reasoner models (e.g. DeepSeek-R1) because the model loses its own chain-of-thought between turns.

**Fix:** Map original LangChain `AIMessage` objects to serialized payload dicts and inject `reasoning_content` back where present.

**Tests added:**
- `test_get_request_payload_preserves_reasoning_content` — basic multi-turn
- `test_get_request_payload_preserves_reasoning_content_in_tool_flow` — tool-calling scenario
- `test_get_request_payload_no_reasoning_content` — regression guard

All 29 tests pass (1 skipped).

---
*AI-agent involvement: This contribution was developed with AI-agent assistance.*