### PR TITLE
[codex] Read file search fallback as UTF-8

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -338,7 +338,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 continue
 
             try:
-                content = file_path.read_text()
+                content = file_path.read_text(encoding="utf-8")
             except (UnicodeDecodeError, PermissionError):
                 continue
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -74,6 +74,36 @@ class TestFilesystemGrepSearch:
         assert "/file3.txt" in result
         assert "/file2.py" not in result
 
+    def test_grep_python_fallback_reads_utf8_explicitly(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Search UTF-8 files without relying on the platform default encoding."""
+        file_path = tmp_path / "notes.md"
+        file_path.write_text("cafe\ncafé\n", encoding="utf-8")
+
+        original_read_text = Path.read_text
+
+        def read_text_with_cp1252_default(
+            self: Path,
+            encoding: str | None = None,
+            errors: str | None = None,
+        ) -> str:
+            return original_read_text(
+                self,
+                encoding=encoding or "cp1252",
+                errors=errors,
+            )
+
+        monkeypatch.setattr(Path, "read_text", read_text_with_cp1252_default)
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+        result = middleware.grep_search.func(pattern="café")
+
+        assert "/notes.md" in result
+
     def test_grep_with_include_filter(self, tmp_path: Path) -> None:
         """Test grep search with include pattern filter."""
         (tmp_path / "file1.py").write_text("def hello():\n    pass\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Make the FilesystemFileSearchMiddleware Python fallback read files with explicit UTF-8 encoding
- Add a regression test that simulates a non-UTF-8 platform default and searches UTF-8 content

Fixes #37438.

## Tests
- Attempted: `python3 -m pytest libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py -q`
- Blocked locally because this checkout's Python environment is missing `langchain_core` during pytest config parsing.