### PR TITLE
[codex] Lazy import GPT2 tokenizer dependency

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -38,14 +38,6 @@ from langchain_core.runnables import Runnable, RunnableSerializable
 if TYPE_CHECKING:
     from langchain_core.outputs import LLMResult
 
-try:
-    from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
-
-    _HAS_TRANSFORMERS = True
-except ImportError:
-    _HAS_TRANSFORMERS = False
-
-
 class LangSmithParams(TypedDict, total=False):
     """LangSmith parameters for tracing."""
 
@@ -86,13 +78,15 @@ def get_tokenizer() -> Any:
         The GPT-2 tokenizer instance.
 
     """
-    if not _HAS_TRANSFORMERS:
+    try:
+        from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
+    except ImportError as exc:
         msg = (
             "Could not import transformers python package. "
             "This is needed in order to calculate get_token_ids. "
             "Please install it with `pip install transformers`."
         )
-        raise ImportError(msg)
+        raise ImportError(msg) from exc
     # create a GPT-2 tokenizer instance
     return GPT2TokenizerFast.from_pretrained("gpt2")
 


### PR DESCRIPTION
## Summary
- Move the `transformers.GPT2TokenizerFast` import into `get_tokenizer()`
- Avoid importing `transformers` when importing base language model classes
- Preserve the existing ImportError guidance when tokenization is requested without `transformers` installed

Fixes #36835.

## Tests
- `python3 -m py_compile libs/core/langchain_core/language_models/base.py`
- Attempted: `python3 -m pytest libs/core/tests/unit_tests/language_models/test_imports.py -q`
- Pytest blocked locally because this checkout's Python environment is missing `langchain_core` during pytest config parsing.