### PR TITLE
[codex] Reject prompt loader symlink escapes

### DIFF
--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -45,6 +45,23 @@ def _validate_path(path: Path) -> None:
         raise ValueError(msg)
 
 
+def _resolve_safe_relative_path(path: Path) -> Path:
+    """Resolve a config path and reject symlink escapes outside the cwd."""
+    _validate_path(path)
+    resolved_path = path.resolve()
+    cwd = Path.cwd().resolve()
+    try:
+        resolved_path.relative_to(cwd)
+    except ValueError as exc:
+        msg = (
+            f"Path '{path}' resolves outside the current working directory. "
+            f"Symlinks that escape the working directory are not allowed when "
+            f"`allow_dangerous_paths=False`."
+        )
+        raise ValueError(msg) from exc
+    return resolved_path
+
+
 @deprecated(
     since="1.2.21",
     removal="2.0.0",
@@ -95,10 +112,11 @@ def _load_template(
         # Pop the template path from the config.
         template_path = Path(config.pop(f"{var_name}_path"))
         if not allow_dangerous_paths:
-            _validate_path(template_path)
-        # Resolve symlinks before checking the suffix so that a symlink named
-        # "exploit.txt" pointing to a non-.txt file is caught.
-        resolved_path = template_path.resolve()
+            resolved_path = _resolve_safe_relative_path(template_path)
+        else:
+            # Resolve symlinks before checking the suffix so that a symlink named
+            # "exploit.txt" pointing to a non-.txt file is caught.
+            resolved_path = template_path.resolve()
         # Load the template.
         if resolved_path.suffix == ".txt":
             template = resolved_path.read_text(encoding="utf-8")
@@ -116,7 +134,7 @@ def _load_examples(config: dict, *, allow_dangerous_paths: bool = False) -> dict
     elif isinstance(config["examples"], str):
         path = Path(config["examples"])
         if not allow_dangerous_paths:
-            _validate_path(path)
+            path = _resolve_safe_relative_path(path)
         with path.open(encoding="utf-8") as f:
             if path.suffix == ".json":
                 examples = json.load(f)
@@ -251,6 +269,8 @@ def _load_prompt_from_file(
     """Load prompt from file."""
     # Convert file to a Path object.
     file_path = Path(file)
+    if not allow_dangerous_paths and not file_path.is_absolute():
+        file_path = _resolve_safe_relative_path(file_path)
     # Load from either json or yaml.
     if file_path.suffix == ".json":
         with file_path.open(encoding=encoding) as f:

--- a/libs/core/tests/unit_tests/prompts/test_loading.py
+++ b/libs/core/tests/unit_tests/prompts/test_loading.py
@@ -162,6 +162,22 @@ def test_load_examples_allows_dangerous_paths_when_opted_in(tmp_path: Path) -> N
     assert result["examples"] == [{"input": "a", "output": "b"}]
 
 
+def test_load_examples_rejects_relative_symlink_escape(tmp_path: Path) -> None:
+    safe_dir = tmp_path / "safe"
+    outside_dir = tmp_path / "outside"
+    safe_dir.mkdir()
+    outside_dir.mkdir()
+    (outside_dir / "examples.json").write_text(
+        json.dumps([{"input": "TOP_SECRET", "output": "LEAKED"}])
+    )
+    (safe_dir / "examples.json").symlink_to(outside_dir / "examples.json")
+
+    with change_directory(safe_dir), pytest.raises(
+        ValueError, match="resolves outside the current working directory"
+    ):
+        _load_examples({"examples": "examples.json"})
+
+
 def test_load_prompt_from_config_rejects_absolute_template_path(
     tmp_path: Path,
 ) -> None:
@@ -204,6 +220,58 @@ def test_load_prompt_from_config_allows_dangerous_paths(tmp_path: Path) -> None:
         prompt = load_prompt_from_config(config, allow_dangerous_paths=True)
     assert isinstance(prompt, PromptTemplate)
     assert prompt.template == "SECRET"
+
+
+def test_load_prompt_from_config_rejects_relative_template_symlink_escape(
+    tmp_path: Path,
+) -> None:
+    safe_dir = tmp_path / "safe"
+    outside_dir = tmp_path / "outside"
+    safe_dir.mkdir()
+    outside_dir.mkdir()
+    (outside_dir / "secret.txt").write_text("EXTERNAL_TEMPLATE")
+    (safe_dir / "template.txt").symlink_to(outside_dir / "secret.txt")
+
+    config = {
+        "_type": "prompt",
+        "template_path": "template.txt",
+        "input_variables": [],
+    }
+
+    with (
+        change_directory(safe_dir),
+        suppress_langchain_deprecation_warning(),
+        pytest.raises(
+            ValueError, match="resolves outside the current working directory"
+        ),
+    ):
+        load_prompt_from_config(config)
+
+
+def test_load_prompt_rejects_relative_symlink_escape(tmp_path: Path) -> None:
+    safe_dir = tmp_path / "safe"
+    outside_dir = tmp_path / "outside"
+    safe_dir.mkdir()
+    outside_dir.mkdir()
+    (outside_dir / "prompt.json").write_text(
+        json.dumps(
+            {
+                "_type": "prompt",
+                "template": "external {value}",
+                "input_variables": ["value"],
+            }
+        )
+    )
+    (safe_dir / "prompt.json").symlink_to(outside_dir / "prompt.json")
+
+    with (
+        change_directory(safe_dir),
+        suppress_langchain_deprecation_warning(),
+        pytest.raises(
+            ValueError, match="resolves outside the current working directory"
+        ),
+    ):
+        load_prompt("prompt.json")
 
 
 def test_load_prompt_from_config_few_shot_rejects_traversal_examples() -> None:


### PR DESCRIPTION
## Summary
- Resolve relative prompt-loader paths before opening them when `allow_dangerous_paths=False`
- Reject symlinks that escape the current working directory for `template_path`, `examples`, and relative `load_prompt(...)` files
- Add regression tests for the three symlink escape flows from the issue

Fixes #36823.

## Tests
- `python3 -m py_compile libs/core/langchain_core/prompts/loading.py libs/core/tests/unit_tests/prompts/test_loading.py`
- Attempted: `python3 -m pytest libs/core/tests/unit_tests/prompts/test_loading.py -q -k 'symlink_escape or load_examples_rejects_relative_symlink_escape'`
- Pytest blocked locally because this checkout's Python environment is missing `langchain_core` during pytest config parsing.