### PR TITLE
BUG: Added Missing Targets to .PHONY

### DIFF
--- a/libs/core/Makefile
+++ b/libs/core/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests test_watch integration_tests help extended_tests check_version
+.PHONY: all benchmark check_imports check_version extended_tests format format_diff help integration_tests lint lint_diff lint_package lint_tests test test_profile test_watch tests type help
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/langchain/Makefile
+++ b/libs/langchain/Makefile
@@ -1,5 +1,4 @@
-.PHONY: all coverage test tests extended_tests test_watch test_watch_extended integration_tests check_imports lint format type lint_diff format_diff lint_package lint_tests help
-
+.PHONY: all check_imports coverage extended_tests format format_diff integration_tests lint lint_diff lint_package lint_tests test test_watch test_watch_extended tests type help
 # Default target executed when no arguments are given to make.
 all: help
 

--- a/libs/model-profiles/Makefile
+++ b/libs/model-profiles/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests refresh-profiles
+.PHONY: all benchmark check_imports format format_diff help integration_test integration_tests lint lint_diff lint_package lint_tests refresh-profiles test test_watch tests type
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/anthropic/Makefile
+++ b/libs/partners/anthropic/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch benchmark check_imports check_version help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/chroma/Makefile
+++ b/libs/partners/chroma/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/deepseek/Makefile
+++ b/libs/partners/deepseek/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/exa/Makefile
+++ b/libs/partners/exa/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/fireworks/Makefile
+++ b/libs/partners/fireworks/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/groq/Makefile
+++ b/libs/partners/groq/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/huggingface/Makefile
+++ b/libs/partners/huggingface/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/mistralai/Makefile
+++ b/libs/partners/mistralai/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/nomic/Makefile
+++ b/libs/partners/nomic/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/ollama/Makefile
+++ b/libs/partners/ollama/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_vcr test_watch benchmark check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/openrouter/Makefile
+++ b/libs/partners/openrouter/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/perplexity/Makefile
+++ b/libs/partners/perplexity/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/qdrant/Makefile
+++ b/libs/partners/qdrant/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_test integration_tests help
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/partners/xai/Makefile
+++ b/libs/partners/xai/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all format format_diff lint lint_diff lint_package lint_tests type test tests integration_test integration_tests test_watch check_imports help extended_tests
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/standard-tests/Makefile
+++ b/libs/standard-tests/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests integration_tests help extended_tests
+.PHONY: all integration_test integration_tests test tests lint format lint_diff format_diff lint_package lint_tests type check_imports help
 
 # Default target executed when no arguments are given to make.
 all: help

--- a/libs/text-splitters/Makefile
+++ b/libs/text-splitters/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint type test tests test_watch integration_tests help extended_tests
+.PHONY: all test tests integration_test integration_tests test_watch test_profile check_imports extended_tests lint lint_diff lint_package lint_tests type format format_diff help
 
 # Default target executed when no arguments are given to make.
 all: help


### PR DESCRIPTION
This PR fixes all the `Makefile` under `libs/` directory where `.PHONY` declaration have missing targets.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
LinkedIn: https://www.linkedin.com/in/sarowar-jahan-biswas/