### PR TITLE
fix(langchain): read grep fallback files as utf-8

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -338,7 +338,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 continue
 
             try:
-                content = file_path.read_text()
+                content = file_path.read_text(encoding="utf-8")
             except (UnicodeDecodeError, PermissionError):
                 continue
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -74,6 +74,28 @@ class TestFilesystemGrepSearch:
         assert "/file3.txt" in result
         assert "/file2.py" not in result
 
+    def test_grep_python_fallback_reads_utf8_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Find UTF-8 files even when the platform default is not UTF-8."""
+        (tmp_path / "notes.md").write_text("needle\u200d\n", encoding="utf-8")
+
+        original_read_text = Path.read_text
+
+        def fake_windows_read_text(self: Path, *args: Any, **kwargs: Any) -> str:
+            if not args and "encoding" not in kwargs:
+                kwargs["encoding"] = "cp1252"
+            return original_read_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "read_text", fake_windows_read_text)
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+        result = middleware.grep_search.func(pattern="needle")
+
+        assert "/notes.md" in result
+
     def test_grep_with_include_filter(self, tmp_path: Path) -> None:
         """Test grep search with include pattern filter."""
         (tmp_path / "file1.py").write_text("def hello():\n    pass\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- read files with explicit UTF-8 decoding in the Python grep_search fallback
- add a regression that simulates a non-UTF-8 platform default so valid UTF-8 files are still searched

Fixes #37438.

## Tests
- cd libs/langchain_v1 && uv run --group test pytest tests/unit_tests/agents/middleware/implementations/test_file_search.py -q
- cd libs/langchain_v1 && uv run --group lint ruff check langchain/agents/middleware/file_search.py tests/unit_tests/agents/middleware/implementations/test_file_search.py
- cd libs/langchain_v1 && uv run --group lint ruff format --check langchain/agents/middleware/file_search.py tests/unit_tests/agents/middleware/implementations/test_file_search.py