### PR TITLE
fix(chroma): normalize None metadata to empty dict in update_documents

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1231,7 +1231,7 @@ class Chroma(VectorStore):
             ValueError: If the embedding function is not provided.
         """
         text = [document.page_content for document in documents]
-        metadata = [document.metadata for document in documents]
+        metadata = [document.metadata if document.metadata is not None else {} for document in documents]
         if self._embedding_function is None:
             msg = "For update, you must specify an embedding function on creation."
             raise ValueError(


### PR DESCRIPTION
Closes #37452

---

When calling `update_document()` or `update_documents()` with a `Document` whose `metadata` attribute is `None` (e.g. `Document(page_content="foo")` without explicit metadata), the method passes `None` metadata entries straight through to the Chroma `_collection.update()` call, which raises `ValueError`.

This conflicts with the behavior of `add_documents()` which accepts documents without metadata.

Fix by normalizing `None` metadata to `{}` before passing to Chroma.