### PR TITLE
fix(ollama): use done_reason for finish_reason in streaming

### DIFF
--- a/libs/partners/ollama/langchain_ollama/llms.py
+++ b/libs/partners/ollama/langchain_ollama/llms.py
@@ -510,15 +510,16 @@ class OllamaLLM(BaseLLM):
                 if reasoning and (thinking_content := stream_resp.get("thinking")):
                     additional_kwargs["reasoning_content"] = thinking_content
 
+                done = stream_resp.get("done") is True
+                done_reason = stream_resp.get("done_reason")
+                generation_info: dict[str, Any] = {**additional_kwargs}
+                if done:
+                    generation_info["finish_reason"] = done_reason
+                    generation_info |= stream_resp
+
                 chunk = GenerationChunk(
                     text=(stream_resp.get("response", "")),
-                    generation_info={
-                        "finish_reason": self.stop,
-                        **additional_kwargs,
-                        **(
-                            dict(stream_resp) if stream_resp.get("done") is True else {}
-                        ),
-                    },
+                    generation_info=generation_info,
                 )
                 if run_manager:
                     run_manager.on_llm_new_token(
@@ -541,15 +542,16 @@ class OllamaLLM(BaseLLM):
                 if reasoning and (thinking_content := stream_resp.get("thinking")):
                     additional_kwargs["reasoning_content"] = thinking_content
 
+                done = stream_resp.get("done") is True
+                done_reason = stream_resp.get("done_reason")
+                generation_info: dict[str, Any] = {**additional_kwargs}
+                if done:
+                    generation_info["finish_reason"] = done_reason
+                    generation_info |= stream_resp
+
                 chunk = GenerationChunk(
                     text=(stream_resp.get("response", "")),
-                    generation_info={
-                        "finish_reason": self.stop,
-                        **additional_kwargs,
-                        **(
-                            dict(stream_resp) if stream_resp.get("done") is True else {}
-                        ),
-                    },
+                    generation_info=generation_info,
                 )
                 if run_manager:
                     await run_manager.on_llm_new_token(


### PR DESCRIPTION
Closes #37370

---

This fixes how `OllamaLLM._stream` and `_astream` populate `generation_info["finish_reason"]`.

Previously, both methods used `self.stop` as the finish reason for every streamed chunk. But `self.stop` contains the user-provided stop sequences, not the actual reason why the model finished generating.

This could lead to confusing or invalid metadata. For example, when `stop=["END"]` is set, `finish_reason` becomes `["END"]` instead of a string like `"stop"`. When no stop sequences are configured, `finish_reason` is `None` on every chunk, so downstream telemetry can lose the completion signal.

Ollama already provides the real finish reason as `done_reason` on the final streamed response. This change uses that value only when the stream is done, and leaves intermediate chunks without a finish reason.

The same fix is applied to both sync and async streaming paths.

Disclaimer: This PR was partially generated with the help of an AI agent.
