### PR TITLE
fix(deepseek): preserve reasoning_content in ChatDeepSeek messages

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -284,6 +284,24 @@ class ChatDeepSeek(BaseChatOpenAI):
                 ]
                 message["content"] = "".join(text_parts) if text_parts else ""
 
+            # Echo reasoning_content back to the API for multi-turn reasoning.
+            # DeepSeek's reasoner models require prior reasoning_content to be
+            # included on each request — see
+            # https://api-docs.deepseek.com/guides/reasoning_model
+            # _convert_message_to_dict does not include reasoning_content from
+            # additional_kwargs, so we need to inject it here.
+            if message.get("role") == "assistant" and "reasoning_content" not in message:
+                # Reach back into the original messages to find reasoning_content.
+                # We convert input_ to messages and match by index.
+                messages_list = self._convert_input(input_).to_messages()
+                idx = payload["messages"].index(message)
+                if idx < len(messages_list):
+                    orig_msg = messages_list[idx]
+                    if isinstance(orig_msg, AIMessage):
+                        rc = orig_msg.additional_kwargs.get("reasoning_content")
+                        if rc is not None:
+                            message["reasoning_content"] = rc
+
         # Azure-hosted DeepSeek does not support the dict/object form of
         # tool_choice (e.g. {"type": "function", "function": {"name": "..."}}).
         # It only accepts string values: "none", "auto", or "required".


### PR DESCRIPTION
Closes #37390

---

DeepSeek's reasoner models require the prior turn's `reasoning_content`
to be echoed back on each multi-turn request — see
https://api-docs.deepseek.com/guides/reasoning_model under "Multi-round
conversation" — and reject the call with HTTP 400 otherwise.

`ChatDeepSeek._create_chat_result` already captures
`reasoning_content` from API responses into
`AIMessage.additional_kwargs`, but the outbound path inherited from
`BaseChatOpenAI._get_request_payload` (via
`_convert_message_to_dict` in `langchain_openai.chat_models.base`)
drops it when serializing assistant messages back to the API.

Net effect: single-shot `invoke()` works fine. Any agent loop that
follows a model response with a tool result and then re-invokes the
model breaks on the second turn — including `create_react_agent` /
`create_agent` in LangGraph.

**Fix:** override `_get_request_payload` in `ChatDeepSeek` to mirror
`additional_kwargs["reasoning_content"]` onto outbound assistant
message dicts — symmetrical with the inbound capture already done in
`_create_chat_result`.

**Files changed:**

- `libs/partners/deepseek/langchain_deepseek/chat_models.py`: added
  reasoning_content echo in `_get_request_payload`

AI-agent involvement: this contribution was partially assisted by an
AI agent.
