### PR TITLE
fix(langchain): sort `glob_search` results by mtime (newest first)

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -170,6 +170,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             if not matching:
                 return "No files found"
 
+            matching.sort(key=lambda item: item[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -1,5 +1,6 @@
 """Unit tests for file search middleware."""
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -209,6 +210,33 @@ class TestFilesystemGlobSearch:
         result = middleware.glob_search.func(pattern="*.py", path="/nonexistent")
 
         assert result == "No files found"
+
+    def test_glob_results_sorted_by_mtime_desc(self, tmp_path: Path) -> None:
+        """Results must be ordered newest-first, as documented."""
+        # Create files in alphabetical order opposite to mtime order so the
+        # default Path.glob() ordering cannot coincidentally pass the assertion.
+        oldest = tmp_path / "a_oldest.txt"
+        middle = tmp_path / "b_middle.txt"
+        newest = tmp_path / "c_newest.txt"
+        for p in (oldest, middle, newest):
+            p.write_text("x", encoding="utf-8")
+
+        # Explicit mtimes (seconds since epoch) — deterministic, no sleeps.
+        os.utime(oldest, (1_000_000, 1_000_000))
+        os.utime(middle, (2_000_000, 2_000_000))
+        os.utime(newest, (3_000_000, 3_000_000))
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.txt")
+
+        assert result.splitlines() == [
+            "/c_newest.txt",
+            "/b_middle.txt",
+            "/a_oldest.txt",
+        ]
 
 
 class TestPathTraversalSecurity:

--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -284,24 +284,6 @@ class ChatDeepSeek(BaseChatOpenAI):
                 ]
                 message["content"] = "".join(text_parts) if text_parts else ""
 
-            # Echo reasoning_content back to the API for multi-turn reasoning.
-            # DeepSeek's reasoner models require prior reasoning_content to be
-            # included on each request — see
-            # https://api-docs.deepseek.com/guides/reasoning_model
-            # _convert_message_to_dict does not include reasoning_content from
-            # additional_kwargs, so we need to inject it here.
-            if message.get("role") == "assistant" and "reasoning_content" not in message:
-                # Reach back into the original messages to find reasoning_content.
-                # We convert input_ to messages and match by index.
-                messages_list = self._convert_input(input_).to_messages()
-                idx = payload["messages"].index(message)
-                if idx < len(messages_list):
-                    orig_msg = messages_list[idx]
-                    if isinstance(orig_msg, AIMessage):
-                        rc = orig_msg.additional_kwargs.get("reasoning_content")
-                        if rc is not None:
-                            message["reasoning_content"] = rc
-
         # Azure-hosted DeepSeek does not support the dict/object form of
         # tool_choice (e.g. {"type": "function", "function": {"name": "..."}}).
         # It only accepts string values: "none", "auto", or "required".

--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -284,6 +284,24 @@ class ChatDeepSeek(BaseChatOpenAI):
                 ]
                 message["content"] = "".join(text_parts) if text_parts else ""
 
+            # Echo reasoning_content back to the API for multi-turn reasoning.
+            # DeepSeek's reasoner models require prior reasoning_content to be
+            # included on each request — see
+            # https://api-docs.deepseek.com/guides/reasoning_model
+            # _convert_message_to_dict does not include reasoning_content from
+            # additional_kwargs, so we need to inject it here.
+            if message.get("role") == "assistant" and "reasoning_content" not in message:
+                # Reach back into the original messages to find reasoning_content.
+                # We convert input_ to messages and match by index.
+                messages_list = self._convert_input(input_).to_messages()
+                idx = payload["messages"].index(message)
+                if idx < len(messages_list):
+                    orig_msg = messages_list[idx]
+                    if isinstance(orig_msg, AIMessage):
+                        rc = orig_msg.additional_kwargs.get("reasoning_content")
+                        if rc is not None:
+                            message["reasoning_content"] = rc
+
         # Azure-hosted DeepSeek does not support the dict/object form of
         # tool_choice (e.g. {"type": "function", "function": {"name": "..."}}).
         # It only accepts string values: "none", "auto", or "required".


### PR DESCRIPTION
Closes #37369

---

The `glob_search` tool in `FilesystemFileSearchMiddleware` documents that
results are "sorted by modification time (most recently modified first)",
but the implementation was returning files in the arbitrary order provided
by `Path.glob()`.

This change adds a sort by modification timestamp (`modified_at`), in
descending order, immediately before extracting the file paths for the
return value. No public API changes.
