### PR TITLE
fix(deepseek): preserve reasoning_content in ChatDeepSeek outbound messages

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -284,6 +284,24 @@ class ChatDeepSeek(BaseChatOpenAI):
                 ]
                 message["content"] = "".join(text_parts) if text_parts else ""
 
+            # Echo reasoning_content back to the API for multi-turn reasoning.
+            # DeepSeek's reasoner models require prior reasoning_content to be
+            # included on each request — see
+            # https://api-docs.deepseek.com/guides/reasoning_model
+            # _convert_message_to_dict does not include reasoning_content from
+            # additional_kwargs, so we need to inject it here.
+            if message.get("role") == "assistant" and "reasoning_content" not in message:
+                # Reach back into the original messages to find reasoning_content.
+                # We convert input_ to messages and match by index.
+                messages_list = self._convert_input(input_).to_messages()
+                idx = payload["messages"].index(message)
+                if idx < len(messages_list):
+                    orig_msg = messages_list[idx]
+                    if isinstance(orig_msg, AIMessage):
+                        rc = orig_msg.additional_kwargs.get("reasoning_content")
+                        if rc is not None:
+                            message["reasoning_content"] = rc
+
         # Azure-hosted DeepSeek does not support the dict/object form of
         # tool_choice (e.g. {"type": "function", "function": {"name": "..."}}).
         # It only accepts string values: "none", "auto", or "required".


### PR DESCRIPTION
Closes #37390

---

When `ChatDeepSeek` sends messages to the DeepSeek API, it was dropping
the `reasoning_content` from previous assistant messages. This breaks
multi-turn reasoning with `deepseek-reasoner` models, which require the
prior turn's `reasoning_content` to be echoed back on each request.

**Net effect:** single-shot `invoke()` works fine. Any agent loop that
follows a model response with a tool result and then re-invokes the model
breaks on the second turn — including `create_react_agent` /
`create_agent` in LangGraph.

```python
from langchain_core.tools import tool
from langchain_deepseek import ChatDeepSeek
from langgraph.prebuilt import create_react_agent

@tool
def add(a: int, b: int) -> int:
    """Add two numbers."""
    return a + b

llm = ChatDeepSeek(model="deepseek-reasoner")
agent = create_react_agent(llm, [add])
agent.invoke({"messages": [("user", "What is 17 + 25? Use the add tool.")]})
# Error: The `reasoning_content` in the thinking mode must be passed back to the API.
```

### The fix

Override `_get_request_payload` in `ChatDeepSeek` to mirror
`additional_kwargs["reasoning_content"]` onto outbound assistant message
dicts. This mirrors the inbound capture already done in
`_create_chat_result`.

The approach:
1. After the parent class converts messages to the API payload, iterate
   over each message dict in the payload.
2. For assistant messages that lack `reasoning_content`, look up the
   corresponding original `AIMessage` from the input and extract
   `reasoning_content` from `additional_kwargs`.
3. Inject it into the message dict so it gets sent to the API.

This is symmetrical with the existing `_create_chat_result` which
extracts `reasoning_content` from API responses into
`AIMessage.additional_kwargs`.
