### PR TITLE
fix(chroma): handling none metadata

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1231,7 +1231,8 @@ class Chroma(VectorStore):
             ValueError: If the embedding function is not provided.
         """
         text = [document.page_content for document in documents]
-        metadata = [document.metadata for document in documents]
+        metadata = [document.metadata or {} for document in documents]
+
         if self._embedding_function is None:
             msg = "For update, you must specify an embedding function on creation."
             raise ValueError(


### PR DESCRIPTION
Fixes #37452 

Fixed failing Chroma.update_document()  when Document metadata is omitted.