### PR TITLE
fix(langchain): use UTF-8 encoding in `_python_search` `read_text()` call

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -338,7 +338,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 continue
 
             try:
-                content = file_path.read_text()
+                content = file_path.read_text(encoding="utf-8")
             except (UnicodeDecodeError, PermissionError):
                 continue
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -403,3 +403,17 @@ class TestGrepEdgeCases:
 
         # Large file should be skipped
         assert "/small.txt" in result
+
+    def test_grep_utf8_file_with_non_ascii_content(self, tmp_path: Path) -> None:
+        """Test that grep correctly reads UTF-8 files containing non-ASCII characters."""
+        (tmp_path / "utf8.md").write_bytes(
+            "# Héllo wörld\ncafé résumé\n".encode("utf-8")
+        )
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+        result = middleware.grep_search.func(pattern="café")
+
+        assert "/utf8.md" in result


### PR DESCRIPTION
Closes #37438

---

The Python fallback in `_python_search` called `read_text()` without an explicit encoding, causing it to use the platform default (commonly `cp1252` on Windows) and silently skip valid UTF-8 files that contain non-ASCII characters. The fix passes `encoding="utf-8"` explicitly to `read_text()`, ensuring consistent behavior across platforms. A new test (`test_grep_utf8_file_with_non_ascii_content`) verifies that files with non-ASCII UTF-8 content are found correctly by the fallback search.

_This contribution was made with the assistance of an automated AI agent._

Fixes #37438