### PR TITLE
fix(core): preserve message classes in `Serializable` envelopes

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -674,23 +674,23 @@ def _create_message_from_message_type(
 
 # Map of class names emitted in the `Serializable` constructor-envelope
 # (`{"lc": 1, "type": "constructor", "id": [..., "<ClassName>"],
-# "kwargs": {...}}`) to the message-type strings
-# `_create_message_from_message_type` accepts. Read by
-# `_convert_to_message`'s dict branch when unpacking that wire shape.
-# Kept as a hardcoded allowlist of strings rather than a class registry
-# lookup so dispatch never resolves to a class chosen by the caller.
-_LC_CONSTRUCTOR_NAME_TO_TYPE: dict[str, str] = {
-    "HumanMessage": "human",
-    "HumanMessageChunk": "human",
-    "AIMessage": "ai",
-    "AIMessageChunk": "ai",
-    "SystemMessage": "system",
-    "SystemMessageChunk": "system",
-    "FunctionMessage": "function",
-    "FunctionMessageChunk": "function",
-    "ToolMessage": "tool",
-    "ToolMessageChunk": "tool",
-    "RemoveMessage": "remove",
+# "kwargs": {...}}`) to message classes `_convert_to_message` can revive.
+# Kept as a hardcoded allowlist rather than a class registry lookup so
+# dispatch never resolves to a class chosen by the caller.
+_LC_CONSTRUCTOR_NAME_TO_MESSAGE_CLASS: dict[str, type[BaseMessage]] = {
+    "HumanMessage": HumanMessage,
+    "HumanMessageChunk": HumanMessageChunk,
+    "AIMessage": AIMessage,
+    "AIMessageChunk": AIMessageChunk,
+    "SystemMessage": SystemMessage,
+    "SystemMessageChunk": SystemMessageChunk,
+    "FunctionMessage": FunctionMessage,
+    "FunctionMessageChunk": FunctionMessageChunk,
+    "ToolMessage": ToolMessage,
+    "ToolMessageChunk": ToolMessageChunk,
+    "ChatMessage": ChatMessage,
+    "ChatMessageChunk": ChatMessageChunk,
+    "RemoveMessage": RemoveMessage,
 }
 
 
@@ -705,8 +705,7 @@ def _convert_to_message(message: MessageLikeRepresentation) -> BaseMessage:
     - dict: a message dict with role and content keys
     - dict: the `Serializable` constructor-envelope wire shape
       `{"lc": 1, "type": "constructor", "id": [..., "<ClassName>"],
-      "kwargs": {...}}` — unpacked structurally and routed through the
-      standard dict-with-type dispatch.
+      "kwargs": {...}}` — unpacked structurally via a message-class allowlist.
     - string: shorthand for (`'human'`, template); e.g., `'{user_input}'`
 
     Args:
@@ -733,11 +732,9 @@ def _convert_to_message(message: MessageLikeRepresentation) -> BaseMessage:
                 raise NotImplementedError(msg) from e
             message_ = _create_message_from_message_type(message_type_str, template)
     elif isinstance(message, dict):
-        # `Serializable` constructor-envelope wire shape. Detect structurally, map
-        # the class name to a known message-type string via a hardcoded
-        # allowlist, and recurse with the canonical
-        # `{"type": ..., **kwargs}` shape — no `load()`, no dynamic
-        # class instantiation.
+        # `Serializable` constructor-envelope wire shape. Detect structurally,
+        # then instantiate only a known message class via a hardcoded allowlist —
+        # no `load()`, no dynamic class resolution.
         if (
             message.get("lc") == 1
             and message.get("type") == "constructor"
@@ -745,9 +742,9 @@ def _convert_to_message(message: MessageLikeRepresentation) -> BaseMessage:
             and message["id"]
             and isinstance(message.get("kwargs"), dict)
         ):
-            mapped = _LC_CONSTRUCTOR_NAME_TO_TYPE.get(message["id"][-1])
-            if mapped is not None:
-                return _convert_to_message({"type": mapped, **message["kwargs"]})
+            message_cls = _LC_CONSTRUCTOR_NAME_TO_MESSAGE_CLASS.get(message["id"][-1])
+            if message_cls is not None:
+                return message_cls(**message["kwargs"])
 
         msg_kwargs = message.copy()
         try:

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -3,7 +3,7 @@ import json
 import math
 import re
 from collections.abc import Callable, Sequence
-from typing import Any, TypedDict
+from typing import Any, TypedDict, cast
 
 import pytest
 from typing_extensions import NotRequired, override
@@ -11,10 +11,13 @@ from typing_extensions import NotRequired, override
 from langchain_core.language_models.fake_chat_models import FakeChatModel
 from langchain_core.messages import (
     AIMessage,
+    AIMessageChunk,
     BaseMessage,
     ChatMessage,
+    ChatMessageChunk,
     FunctionMessage,
     HumanMessage,
+    HumanMessageChunk,
     SystemMessage,
     ToolCall,
     ToolMessage,
@@ -3028,7 +3031,7 @@ def test_convert_to_messages_lc_envelope_tool_with_artifact() -> None:
                 content="result body",
                 tool_call_id="tc-99",
                 status="success",
-                additional_kwargs={"artifact": {"extra": "payload"}},
+                artifact={"extra": "payload"},
             )
         ]
     )
@@ -3048,18 +3051,39 @@ def test_convert_to_messages_lc_envelope_function() -> None:
     assert revived.name == "get_answer"
 
 
-def test_convert_to_messages_lc_envelope_chunk_aliases_collapse_to_parent() -> None:
-    """Chunk class names route to their parent message-type strings.
-
-    `AIMessageChunk` / `HumanMessageChunk` envelopes share dispatch with
-    their parent classes, so clients submitting chunks see them revived
-    as the corresponding finalized message types.
-    """
+def test_convert_to_messages_lc_envelope_chunk_preserves_chunk_type() -> None:
     [revived] = convert_to_messages(
         [_lc_envelope("HumanMessageChunk", content="streaming chunk")]
     )
-    assert isinstance(revived, HumanMessage)
+    assert isinstance(revived, HumanMessageChunk)
     assert revived.content == "streaming chunk"
+
+
+def test_convert_to_messages_lc_envelope_accepts_actual_to_json_output() -> None:
+    messages = [
+        AIMessage(
+            content="thinking",
+            usage_metadata={"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+            invalid_tool_calls=[
+                {
+                    "name": "broken",
+                    "args": "{",
+                    "id": "bad-call",
+                    "error": "invalid JSON",
+                    "type": "invalid_tool_call",
+                }
+            ],
+        ),
+        AIMessageChunk(content="streaming chunk"),
+        ChatMessage(content="custom speaker", role="critic"),
+        ChatMessageChunk(content="custom speaker chunk", role="critic"),
+    ]
+
+    revived = convert_to_messages(
+        [cast("MessageLikeRepresentation", message.to_json()) for message in messages]
+    )
+
+    assert revived == messages
 
 
 def test_convert_to_messages_lc_envelope_unknown_class_falls_through() -> None:


### PR DESCRIPTION
Follow-up to #37456.

This preserves concrete message classes when `_convert_to_message` receives a `Serializable` constructor-envelope, so `to_json()` output round-trips for message chunks, `ChatMessage`, and message-specific fields.

AI-assisted contribution.