### PR TITLE
fix(core): cast return type of StructuredTool._injected_args_keys to frozenset[str]

### DIFF
--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -11,6 +11,7 @@ from typing import (
     Annotated,
     Any,
     Literal,
+    cast,
 )
 
 from pydantic import Field, SkipValidation
@@ -256,10 +257,13 @@ class StructuredTool(BaseTool):
         fn = self.func or self.coroutine
         if fn is None:
             return _EMPTY_SET
-        return frozenset(
-            k
-            for k, v in signature(fn).parameters.items()
-            if _is_injected_arg_type(v.annotation)
+        return cast(
+            frozenset[str],
+            frozenset(
+                k
+                for k, v in signature(fn).parameters.items()
+                if _is_injected_arg_type(v.annotation)
+            ),
         )
 
 


### PR DESCRIPTION
## Summary

Fixes #36221

**What is the bug?**

`StructuredTool._injected_args_keys` is declared to return `frozenset[str]`, but mypy infers the actual return type as `frozenset[Any]`.

The root cause is that `self.func` and `self.coroutine` are each typed as `Callable[..., Any] | None`, so after the `or` expression `fn` has type `Callable[..., Any]`. When `inspect.signature(fn).parameters.items()` is called on a value with a broad `Callable` type, mypy cannot narrow the key type to `str` and falls back to `Any`. The generator expression then yields `Any`, and `frozenset(...)` produces `frozenset[Any]`, which conflicts with the declared `frozenset[str]` return type.

**What is the fix?**

Add a `cast(frozenset[str], ...)` around the `frozenset(...)` return expression. This is the narrowest correct change: it tells mypy what the type actually is without altering any runtime behavior. The keys produced by `signature(...).parameters.items()` are always plain Python strings, so the cast is accurate.

`cast` was already imported from `typing` elsewhere in the codebase; this change adds it to the existing import list in `structured.py`.

**Scope**

Only two lines changed:
1. `cast` added to the `from typing import (...)` block.
2. The return statement in `_injected_args_keys` wrapped with `cast(frozenset[str], ...)`.

No runtime behavior is affected.