### PR TITLE
feat(core): add `&` operator as declarative shorthand for RunnableParallel

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -657,6 +657,31 @@ class Runnable(ABC, Generic[Input, Output]):
             A new `Runnable`.
         """
         return RunnableSequence(coerce_to_runnable(other), self)
+    def __and__(
+        self,
+        other: Runnable[Any, Any]
+        | Callable[[Any], Any]
+        | Mapping[str, Runnable[Any, Any] | Callable[[Any], Any] | Any],
+    ) -> RunnableSerializable[Input, dict[str, Any]]:
+        """Runnable ``&`` operator — creates a ``RunnableParallel``.
+
+        Both runnables receive the same input and their outputs
+        are returned as ``{"left": ..., "right": ...}``.
+
+        Example:
+            parallel = chain_a & chain_b
+            parallel.invoke(x)  # {"left": chain_a(x), "right": chain_b(x)}
+        """
+        return RunnableParallel(left=self, right=coerce_to_runnable(other))
+
+    def __rand__(
+        self,
+        other: Runnable[Any, Any]
+        | Callable[[Any], Any]
+        | Mapping[str, Runnable[Any, Any] | Callable[[Any], Any] | Any],
+    ) -> RunnableSerializable[Input, dict[str, Any]]:
+        """Reverse ``&`` operator for ``RunnableParallel``."""
+        return RunnableParallel(left=coerce_to_runnable(other), right=self)
 
     def pipe(
         self,

--- a/libs/core/tests/unit_tests/runnables/test_runnable_parallel_operator.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_parallel_operator.py
@@ -1,0 +1,53 @@
+"""Unit tests for the & operator shorthand for RunnableParallel."""
+
+import pytest
+from langchain_core.runnables import RunnableLambda, RunnableParallel
+
+double = RunnableLambda(lambda x: x * 2)
+triple = RunnableLambda(lambda x: x * 3)
+add_one = RunnableLambda(lambda x: x + 1)
+
+def test_and_returns_runnable_parallel():
+    result = double & triple
+    assert isinstance(result, RunnableParallel)
+
+def test_and_invoke_correct_output():
+    parallel = double & triple
+    output = parallel.invoke(5)
+    assert output == {"left": 10, "right": 15}
+
+def test_and_with_callable():
+    parallel = double & (lambda x: x + 100)
+    output = parallel.invoke(3)
+    assert output == {"left": 6, "right": 103}
+
+def test_rand_invoke_correct_output():
+    parallel = double.__rand__(triple)
+    output = parallel.invoke(5)
+    assert output == {"left": 15, "right": 10}
+
+def test_and_inside_pipe_sequence():
+    chain = add_one | (double & triple)
+    output = chain.invoke(4)
+    assert output == {"left": 10, "right": 15}
+
+def test_pipe_after_and():
+    sum_values = RunnableLambda(lambda d: d["left"] + d["right"])
+    chain = (double & triple) | sum_values
+    output = chain.invoke(5)
+    assert output == 25
+
+@pytest.mark.asyncio
+async def test_and_ainvoke():
+    parallel = double & triple
+    output = await parallel.ainvoke(5)
+    assert output == {"left": 10, "right": 15}
+
+def test_and_batch():
+    parallel = double & triple
+    outputs = parallel.batch([1, 2, 3])
+    assert outputs == [
+        {"left": 2, "right": 3},
+        {"left": 4, "right": 6},
+        {"left": 6, "right": 9},
+    ]


### PR DESCRIPTION
Fixes #37473

Adds `__and__` and `__rand__` dunder methods to the `Runnable` base class,
mirroring the existing `__or__` / `__ror__` pattern used for `RunnableSequence`.

The `|` operator already lets users compose sequential chains declaratively:
    chain = prompt | model | parser   # RunnableSequence

This PR adds an equivalent `&` operator for parallel composition:
    parallel = chain_a & chain_b      # RunnableParallel