### PR TITLE
fix(chroma): normalize missing metadata in update_documents

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1231,7 +1231,7 @@ class Chroma(VectorStore):
             ValueError: If the embedding function is not provided.
         """
         text = [document.page_content for document in documents]
-        metadata = [document.metadata for document in documents]
+        metadata = [document.metadata or {} for document in documents]
         if self._embedding_function is None:
             msg = "For update, you must specify an embedding function on creation."
             raise ValueError(

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -28,3 +28,32 @@ def test_similarity_search() -> None:
     output = docsearch.similarity_search("foo", k=1)
     docsearch.delete_collection()
     assert len(output) == 1
+
+
+def test_update_document_without_metadata() -> None:
+    """Test that update_document works when Document has no metadata."""
+    from langchain_core.documents import Document
+
+    embedding = FakeEmbeddings(size=10)
+
+    # Create collection and add a document with metadata
+    docsearch = Chroma.from_texts(
+        collection_name="test_update_no_metadata",
+        texts=["original content"],
+        embedding=embedding,
+        ids=["doc_1"],
+    )
+
+    # Update with a Document that has no metadata (the bug case)
+    docsearch.update_document(
+        document_id="doc_1",
+        document=Document(page_content="updated content"),
+    )
+
+    # Verify the update succeeded
+    output = docsearch.similarity_search("updated content", k=1)
+    assert len(output) == 1
+    assert output[0].page_content == "updated content"
+    assert output[0].metadata == {}
+
+    docsearch.delete_collection()


### PR DESCRIPTION
Closes #37452

---

When a Document has no explicit metadata, document.metadata returns None, which causes Chroma update API to raise ValueError.

This is inconsistent with add_documents, which handles missing metadata gracefully.

## Fix

Normalize metadata with or {} before forwarding to Chroma, matching the existing pattern used elsewhere in this module.

## Changes

- langchain_chroma/vectorstores.py: update_documents() normalizes document.metadata with or {}
- Added unit test test_update_document_without_metadata verifying the fix

---
*AI-agent involvement: This contribution was assisted by an AI coding agent.*