### PR TITLE
fix(langchain): clear stale structured responses

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -179,6 +179,8 @@ def _normalize_to_model_response(
 def _build_commands(
     model_response: ModelResponse,
     middleware_commands: list[Command[Any]] | None = None,
+    *,
+    clear_structured_response: bool = False,
 ) -> list[Command[Any]]:
     """Build a list of Commands from a model response and middleware commands.
 
@@ -190,6 +192,8 @@ def _build_commands(
             structured output.
         middleware_commands: Commands accumulated from middleware layers during
             composition (inner-first ordering).
+        clear_structured_response: Whether to clear a previous structured response
+            when this model response does not include a new one.
 
     Returns:
         List of ``Command`` objects ready to be returned from a model node.
@@ -198,6 +202,8 @@ def _build_commands(
 
     if model_response.structured_response is not None:
         state["structured_response"] = model_response.structured_response
+    elif clear_structured_response:
+        state["structured_response"] = None
 
     for cmd in middleware_commands or []:
         if cmd.goto:
@@ -1330,10 +1336,17 @@ def create_agent(
 
         if wrap_model_call_handler is None:
             model_response = _execute_model_sync(request)
-            return _build_commands(model_response)
+            return _build_commands(
+                model_response,
+                clear_structured_response=initial_response_format is not None,
+            )
 
         result = wrap_model_call_handler(request, _execute_model_sync)
-        return _build_commands(result.model_response, result.commands)
+        return _build_commands(
+            result.model_response,
+            result.commands,
+            clear_structured_response=initial_response_format is not None,
+        )
 
     async def _execute_model_async(request: ModelRequest[ContextT]) -> ModelResponse:
         """Execute model asynchronously and return response.
@@ -1378,10 +1391,17 @@ def create_agent(
 
         if awrap_model_call_handler is None:
             model_response = await _execute_model_async(request)
-            return _build_commands(model_response)
+            return _build_commands(
+                model_response,
+                clear_structured_response=initial_response_format is not None,
+            )
 
         result = await awrap_model_call_handler(request, _execute_model_async)
-        return _build_commands(result.model_response, result.commands)
+        return _build_commands(
+            result.model_response,
+            result.commands,
+            clear_structured_response=initial_response_format is not None,
+        )
 
     # Use sync or async based on model capabilities
     graph.add_node("model", RunnableCallable(model_node, amodel_node, trace=False))
@@ -1759,7 +1779,7 @@ def _make_model_to_tools_edge(
             return [Send("tools", [tool_call]) for tool_call in pending_tool_calls]
 
         # 5. If there is a structured response, exit the loop
-        if "structured_response" in state:
+        if state.get("structured_response") is not None:
             return end_destination
 
         # 6. AIMessage has tool calls, but there are no pending tool calls which suggests
@@ -1786,7 +1806,7 @@ def _make_model_to_model_edge(
             )
 
         # 2. Exit condition: A structured response was generated
-        if "structured_response" in state:
+        if state.get("structured_response") is not None:
             return end_destination
 
         # 3. Default: Continue the loop, there may have been an issue with structured

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -12,7 +12,8 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import HumanMessage
 from langchain_core.runnables import Runnable
-from pydantic import BaseModel, Field
+from langgraph.checkpoint.memory import InMemorySaver
+from pydantic import BaseModel, Field, field_validator
 from typing_extensions import TypedDict
 
 from langchain.agents import create_agent
@@ -71,6 +72,18 @@ weather_json_schema = {
 class LocationResponse(BaseModel):
     city: str = Field(description="The city name")
     country: str = Field(description="The country name")
+
+
+class ValidatedAnswer(BaseModel):
+    text: str
+
+    @field_validator("text")
+    @classmethod
+    def reject_bad(cls, value: str) -> str:
+        if value == "BAD":
+            msg = "bad sentinel"
+            raise ValueError(msg)
+        return value
 
 
 class LocationTypedDict(TypedDict):
@@ -231,6 +244,28 @@ class TestResponseFormatAsModel:
 
 
 class TestResponseFormatAsToolStrategy:
+    def test_checkpointed_retry_clears_stale_structured_response(self) -> None:
+        """Test retries don't reuse a previous turn's structured response."""
+        tool_calls = [
+            [{"name": "ValidatedAnswer", "id": "1", "args": {"text": "Hi"}}],
+            [{"name": "ValidatedAnswer", "id": "2", "args": {"text": "BAD"}}],
+            [{"name": "ValidatedAnswer", "id": "3", "args": {"text": "Bye"}}],
+        ]
+        model = FakeToolCallingModel(tool_calls=tool_calls)
+        agent = create_agent(
+            model,
+            [],
+            response_format=ToolStrategy(ValidatedAnswer, handle_errors=True),
+            checkpointer=InMemorySaver(),
+        )
+        config = {"configurable": {"thread_id": "structured-retry"}}
+
+        first_response = agent.invoke({"messages": [HumanMessage("say hi")]}, config=config)
+        second_response = agent.invoke({"messages": [HumanMessage("say bye")]}, config=config)
+
+        assert first_response["structured_response"] == ValidatedAnswer(text="Hi")
+        assert second_response["structured_response"] == ValidatedAnswer(text="Bye")
+
     def test_pydantic_model(self) -> None:
         """Test response_format as ToolStrategy with Pydantic model."""
         tool_calls = [


### PR DESCRIPTION
Fixes #36957

---

Structured-output agents now clear a previous `structured_response` when a later model call in the same checkpointed thread does not produce a fresh parsed response. This prevents retry paths from exiting early with a stale response from an earlier turn.

This changes the routing checks to treat only non-`None` structured responses as complete, and adds a regression test for a checkpointed `ToolStrategy` retry that first fails validation and then succeeds.

Verified with:
- `uv run --group test pytest tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_checkpointed_retry_clears_stale_structured_response -q`
- `uv run --group test pytest tests/unit_tests/agents/test_response_format.py -q`
- `uv run --group lint ruff check langchain/agents/factory.py tests/unit_tests/agents/test_response_format.py`
- `uv run --group lint ruff format --check langchain/agents/factory.py tests/unit_tests/agents/test_response_format.py`

Draft PR prepared with AI-agent assistance and manually validated against the focused unit tests above.