### PR TITLE
fix(chroma): handle null metadata in `update_documents`

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1231,7 +1231,7 @@ class Chroma(VectorStore):
             ValueError: If the embedding function is not provided.
         """
         text = [document.page_content for document in documents]
-        metadata = [document.metadata for document in documents]
+        metadata = [document.metadata or {} for document in documents]
         if self._embedding_function is None:
             msg = "For update, you must specify an embedding function on creation."
             raise ValueError(


### PR DESCRIPTION
Closes #37452

---

When `update_documents` receives `Document` objects without metadata (or with `metadata=None` set explicitly), the metadata list comprehension at line 1234 passes `None` values through to Chroma SDK methods. Chroma's `collection.update()` expects `dict` values, so it raises an error.

This fix uses a fallback to empty dict for falsy metadata values, matching the existing pattern in `add_texts` (line 631-633 of the same file) where missing metadata is padded with `{}`.

The fix is a one-line change: `document.metadata or {}` replaces `document.metadata`.

This contribution was developed with the assistance of an AI agent (Hermes Agent by Nous Research).