### PR TITLE
feat(exa): add integration header and instant search type

### DIFF
--- a/libs/partners/exa/langchain_exa/_utilities.py
+++ b/libs/partners/exa/langchain_exa/_utilities.py
@@ -3,7 +3,6 @@ import os  # type: ignore[import-not-found]
 from exa_py import Exa
 from langchain_core.utils import convert_to_secret_str
 
-
 _INTEGRATION_HEADER = "langchain-integration"
 
 

--- a/libs/partners/exa/langchain_exa/_utilities.py
+++ b/libs/partners/exa/langchain_exa/_utilities.py
@@ -4,14 +4,19 @@ from exa_py import Exa
 from langchain_core.utils import convert_to_secret_str
 
 
+_INTEGRATION_HEADER = "langchain-integration"
+
+
 def initialize_client(values: dict) -> dict:
     """Initialize the client."""
     exa_api_key = values.get("exa_api_key") or os.environ.get("EXA_API_KEY") or ""
     values["exa_api_key"] = convert_to_secret_str(exa_api_key)
-    args = {
+    args: dict = {
         "api_key": values["exa_api_key"].get_secret_value(),
     }
     if values.get("exa_base_url"):
         args["base_url"] = values["exa_base_url"]
-    values["client"] = Exa(**args)
+    client = Exa(**args)
+    client.headers["x-exa-integration"] = _INTEGRATION_HEADER
+    values["client"] = client
     return values

--- a/libs/partners/exa/langchain_exa/retrievers.py
+++ b/libs/partners/exa/langchain_exa/retrievers.py
@@ -56,7 +56,7 @@ class ExaSearchRetriever(BaseRetriever):
     use_autoprompt: bool | None = None
     """Whether to use autoprompt for the search."""
     type: str = "auto"
-    """The type of search, 'auto', 'deep', or 'fast'. Default: auto"""
+    """The type of search, 'auto', 'fast', 'instant', or 'deep'. Default: auto"""
     highlights: HighlightsContentsOptions | bool | None = None
     """Whether to set the page content to the highlights of the results."""
     text_contents_options: TextContentsOptions | dict[str, Any] | Literal[True] = True

--- a/libs/partners/exa/langchain_exa/tools.py
+++ b/libs/partners/exa/langchain_exa/tools.py
@@ -116,7 +116,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
         use_autoprompt: bool | None = None,  # noqa: FBT001
         livecrawl: Literal["always", "fallback", "never"] | None = None,
         summary: bool | dict[str, str] | None = None,  # noqa: FBT001
-        type: Literal["auto", "deep", "fast"] | None = None,  # noqa: A002
+        type: Literal["auto", "deep", "fast", "instant"] | None = None,  # noqa: A002
         run_manager: CallbackManagerForToolRun | None = None,
     ) -> list[dict] | str:
         # TODO: rename `type` to something else, as it is a reserved keyword
@@ -136,7 +136,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
             use_autoprompt: Whether to use autoprompt for the search.
             livecrawl: Option to crawl live webpages if content is not in the index. Options: "always", "fallback", "never"
             summary: Whether to include a summary of the content. Can be a boolean or a dict with a custom query.
-            type: The type of search, 'auto', 'deep', or 'fast'.
+            type: The type of search, 'auto', 'fast', 'instant', or 'deep'.
             run_manager: The run manager for callbacks.
 
         """  # noqa: E501


### PR DESCRIPTION
Fixes #37495

---

Adds `x-exa-integration: langchain-integration` header to all Exa API requests for usage tracking, and adds `instant` to the search type Literal alongside `auto`, `deep`, `fast`.

No breaking changes.