### PR TITLE
fix(ollama): trace invoke model override

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -1186,7 +1186,7 @@ class ChatOllama(BaseChatModel):
         params = self._get_invocation_params(stop=stop, **kwargs)
         ls_params = LangSmithParams(
             ls_provider="ollama",
-            ls_model_name=self.model,
+            ls_model_name=params.get("model", self.model),
             ls_model_type="chat",
             ls_temperature=params.get("temperature", self.temperature),
         )


### PR DESCRIPTION
If you override the model at invoke time — e.g. `chat.invoke(messages, model="llama3.2")` or `chat.bind(model="llama3.2")` - traces previously logged the model the `ChatOllama` instance was constructed with, not the one that ran. Tracing now reflects the runtime override, so dashboards, filters, and cost/latency breakdowns line up with what really executed.