### PR TITLE
fix(chroma): normalize None metadata in update_documents to prevent ValueError

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1231,7 +1231,7 @@ class Chroma(VectorStore):
             ValueError: If the embedding function is not provided.
         """
         text = [document.page_content for document in documents]
-        metadata = [document.metadata for document in documents]
+        metadata = [document.metadata or {} for document in documents]
         if self._embedding_function is None:
             msg = "For update, you must specify an embedding function on creation."
             raise ValueError(


### PR DESCRIPTION
### Description

Fixes #37452

When `update_document()` (or `update_documents()`) is called with a `Document` that has no explicit metadata (`document.metadata is None`), the method passes `None` entries to Chroma's `_collection.update()`, which raises:

```
ValueError: Expected metadata to be a non-empty dict, got 0 metadata attributes in update.
```

This is inconsistent with `add_documents()` / `add_texts()`, which handle missing metadata gracefully.

### Change

- Normalize `None` metadata to `{}` before passing to the Chroma update API:
  ```python
  # Before
  metadata = [document.metadata for document in documents]
  # After
  metadata = [document.metadata or {} for document in documents]
  ```

This one-line change makes `update_documents()` behave consistently with `add_texts()`, which already handles metadata defaults.

### Related

- The issue reporter suggested this exact fix in the bug report.
