### PR TITLE
ci(infra): harden Dependabot version-bound preservation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,14 @@ updates:
       - "/libs/langchain_v1/"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langchain-core"
+      - dependency-name: "langchain"
+      - dependency-name: "langchain-classic"
+      - dependency-name: "langchain-text-splitters"
+      - dependency-name: "langchain-tests"
+      - dependency-name: "langchain-model-profiles"
     groups:
       minor-and-patch:
         patterns:
@@ -61,6 +69,14 @@ updates:
       - "/libs/partners/xai/"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langchain-core"
+      - dependency-name: "langchain"
+      - dependency-name: "langchain-classic"
+      - dependency-name: "langchain-text-splitters"
+      - dependency-name: "langchain-tests"
+      - dependency-name: "langchain-model-profiles"
     groups:
       minor-and-patch:
         patterns:
@@ -81,6 +97,14 @@ updates:
       - "/libs/model-profiles/"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langchain-core"
+      - dependency-name: "langchain"
+      - dependency-name: "langchain-classic"
+      - dependency-name: "langchain-text-splitters"
+      - dependency-name: "langchain-tests"
+      - dependency-name: "langchain-model-profiles"
     groups:
       minor-and-patch:
         patterns:

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -51,7 +51,7 @@ typing = [
     "mypy>=1.19.1,<1.20.0",
     "types-pyyaml>=6.0.12.2,<7.0.0.0",
     "types-requests>=2.28.11.5,<3.0.0.0",
-    "langchain-text-splitters",
+    "langchain-text-splitters>=1.0.0,<2.0.0",
 ]
 dev = [
     "jupyter>=1.0.0,<2.0.0",
@@ -72,7 +72,7 @@ test = [
     "blockbuster>=1.5.18,<1.6.0",
     "numpy>=1.26.4; python_version<'3.13'",
     "numpy>=2.1.0; python_version>='3.13'",
-    "langchain-tests",
+    "langchain-tests>=1.0.0,<2.0.0",
     "pytest-benchmark",
     "pytest-codspeed",
 ]

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -84,9 +84,9 @@ test = [
     "requests-mock>=1.11.0,<2.0.0",
     "toml>=0.10.2,<1.0.0",
     "packaging>=24.2.0,<27.0.0",
-    "langchain-tests",
-    "langchain-core",
-    "langchain-text-splitters",
+    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-text-splitters>=1.0.0,<2.0.0",
     "langchain-openai",
 ]
 test_integration = [
@@ -94,8 +94,8 @@ test_integration = [
     "wrapt>=1.15.0,<3.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "cassio>=0.1.0,<1.0.0; python_version < '3.14'",
-    "langchain-core",
-    "langchain-text-splitters",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-text-splitters>=1.0.0,<2.0.0",
 ]
 lint = [
     "ruff>=0.15.0,<0.16.0",
@@ -113,16 +113,16 @@ typing = [
     "types-chardet>=5.0.4.6,<6.0.0.0",
     "numpy>=1.26.4; python_version < '3.13'",
     "numpy>=2.1.0; python_version >= '3.13'",
-    "langchain-core",
-    "langchain-text-splitters",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-text-splitters>=1.0.0,<2.0.0",
     "fastapi<1.0.0,>=0.116.1",
 ]
 dev = [
     "jupyter>=1.0.0,<2.0.0",
     "playwright>=1.28.0,<2.0.0",
     "setuptools>=67.6.1,<83.0.0",
-    "langchain-core",
-    "langchain-text-splitters",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-text-splitters>=1.0.0,<2.0.0",
 ]
 
 

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "syrupy>=5.0.0,<6.0.0",
     "toml>=0.10.2,<1.0.0",
     "blockbuster>=1.5.26,<1.6.0",
-    "langchain-tests",
+    "langchain-tests>=1.0.0,<2.0.0",
     "langchain-openai",
 ]
 lint = [
@@ -88,8 +88,8 @@ test_integration = [
     "wrapt>=1.15.0,<3.0.0",
     "python-dotenv>=1.0.0,<2.0.0",
     "langchainhub>=0.1.16,<1.0.0",
-    "langchain-core",
-    "langchain-text-splitters",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-text-splitters>=1.0.0,<2.0.0",
 ]
 
 [tool.uv]

--- a/libs/model-profiles/pyproject.toml
+++ b/libs/model-profiles/pyproject.toml
@@ -55,14 +55,14 @@ test = [
     "syrupy>=5.0.0,<6.0.0",
     "toml>=0.10.2,<1.0.0",
     "langchain[openai]>=1.0.2,<2.0.0",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
 ]
 
-test_integration = ["langchain-core"]
+test_integration = ["langchain-core>=1.4.0,<2.0.0"]
 
 lint = [
     "ruff>=0.15.0,<0.16.0",
-    "langchain",
+    "langchain>=1.0.0,<2.0.0",
 ]
 typing = [
     "mypy>=1.18.1,<1.20.0",

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.4.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "anthropic>=0.96.0,<1.0.0",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 
@@ -54,17 +54,17 @@ test = [
     "pytest-xdist>=3.8.0,<4.0.0",
     "vcrpy>=8.0.0,<9.0.0",
     "langgraph-prebuilt>=0.7.0a2",  # set explicitly until we have a stable version
-    "langchain-core",
-    "langchain-tests",
-    "langchain",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain>=1.0.0,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
-dev = ["langchain-core"]
-test_integration = ["requests>=2.32.3,<3.0.0", "langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
+test_integration = ["requests>=2.32.3,<3.0.0", "langchain-core>=1.4.0,<2.0.0"]
 typing = [
     "mypy>=1.17.1,<2.0.0",
     "types-requests>=2.31.0,<3.0.0",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
 ]
 
 

--- a/libs/partners/chroma/pyproject.toml
+++ b/libs/partners/chroma/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "numpy>=1.26.0; python_version < '3.13'",
     "numpy>=2.1.0; python_version >= '3.13'",
     "chromadb>=1.5.5,<2.0.0",
@@ -48,18 +48,18 @@ test = [
     "pytest-xdist>=3.6.1,<4.0.0",
     "freezegun>=1.2.2,<2.0.0",
     "syrupy>=5.0.0,<6.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 test_integration = []
 lint = [
     "ruff>=0.13.1,<0.14.0",
 ]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 typing = [
     "mypy>=1.10.0,<2.0.0",
     "types-requests>=2.31.0,<3.0.0",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
 ]
 
 

--- a/libs/partners/deepseek/pyproject.toml
+++ b/libs/partners/deepseek/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "langchain-openai>=1.1.0,<2.0.0",
 ]
 
@@ -45,7 +45,7 @@ test = [
     "pytest-watcher>=0.3.4,<1.0.0",
     "pytest-timeout>=2.3.1,<3.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
-    "langchain-tests",
+    "langchain-tests>=1.0.0,<2.0.0",
     "langchain-openai",
 ]
 test_integration = []

--- a/libs/partners/exa/pyproject.toml
+++ b/libs/partners/exa/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "exa-py>=1.0.8,<2.0.0"
 ]
 
@@ -46,15 +46,15 @@ test = [
     "pytest-xdist>=3.6.1,<4.0.0",
     "freezegun>=1.2.2,<2.0.0",
     "syrupy>=5.0.0,<6.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 test_integration = []
 typing = [
     "mypy>=1.10.0,<2.0.0",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
 ]
 
 

--- a/libs/partners/fireworks/pyproject.toml
+++ b/libs/partners/fireworks/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.3.1"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "fireworks-ai>=0.13.0,<1.0.0",
     "openai>=2.0.0,<3.0.0",
     "requests>=2.0.0,<3.0.0",
@@ -50,16 +50,16 @@ test = [
     "pytest-asyncio>=1.3.0,<2.0.0",
     "pytest-socket>=0.7.0,<1.0.0",
     "pytest-xdist>=3.8.0,<4.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 typing = [
     "mypy>=1.10.0,<2.0.0",
     "types-requests>=2.0.0,<3.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 
 [tool.uv]

--- a/libs/partners/groq/pyproject.toml
+++ b/libs/partners/groq/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "groq>=0.30.0,<1.0.0"
 ]
 
@@ -45,15 +45,15 @@ test = [
     "pytest-asyncio>=1.3.0,<2.0.0",
     "pytest-retry>=1.7.0,<1.8.0",
     "pytest-xdist>=3.6.1,<4.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
-dev = ["langchain-core"]
-test_integration = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
+test_integration = ["langchain-core>=1.4.0,<2.0.0"]
 typing = [
     "mypy>=1.10.0,<2.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 
 [tool.uv]

--- a/libs/partners/huggingface/pyproject.toml
+++ b/libs/partners/huggingface/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.2.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "tokenizers>=0.19.1,<1.0.0",
     "huggingface-hub>=0.33.4,<2.0.0",
 ]
@@ -56,20 +56,20 @@ test = [
     "scipy>=1.14.1,<2.0.0; python_version >= \"3.13\"",
     "transformers>=5.0.0,<6.0.0",
     "sentence-transformers>=5.2.0,<6.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
     "langchain-community",
-    "langchain",
+    "langchain>=1.0.0,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
 dev = [
     "ipykernel>=6.29.2,<7.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 test_integration = []
 typing = [
     "mypy>=1.10.0,<2.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 
 [tool.uv]

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -213,7 +213,9 @@ def test_bind_tools(chat_hugging_face: Any) -> None:
             "langchain_huggingface.chat_models.huggingface.convert_to_openai_tool",
             side_effect=lambda x: x,
         ),
-        patch("langchain_core.runnables.base.Runnable.bind") as mock_super_bind,
+        patch(
+            "langchain_core.language_models.chat_models.BaseChatModel.bind"
+        ) as mock_super_bind,
     ):
         chat_hugging_face.bind_tools(tools, tool_choice="auto")
         mock_super_bind.assert_called_once()

--- a/libs/partners/huggingface/uv.lock
+++ b/libs/partners/huggingface/uv.lock
@@ -964,7 +964,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.2.18"
+version = "1.3.1"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },
@@ -978,7 +978,6 @@ requires-dist = [
     { name = "langchain-aws", marker = "extra == 'aws'" },
     { name = "langchain-azure-ai", marker = "extra == 'azure-ai'" },
     { name = "langchain-baseten", marker = "extra == 'baseten'", specifier = ">=0.2.0" },
-    { name = "langchain-cohere", marker = "extra == 'cohere'" },
     { name = "langchain-community", marker = "extra == 'community'" },
     { name = "langchain-core", editable = "../../core" },
     { name = "langchain-deepseek", marker = "extra == 'deepseek'" },
@@ -993,10 +992,10 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.1.10,<1.2.0" },
+    { name = "langgraph", specifier = ">=1.2.0,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
-provides-extras = ["community", "anthropic", "openai", "azure-ai", "cohere", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
+provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
 
 [package.metadata.requires-dev]
 lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
@@ -1054,7 +1053,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.3.3"
+version = "1.4.0"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1071,7 +1070,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.10" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -1198,19 +1197,19 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.10"
+version = "0.0.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/c3/0d3911d3274f097040e92133f18a425980cd4085e72b6cd65add1f25327c/langchain_protocol-0.0.10.tar.gz", hash = "sha256:5bc530e0b350d3a15a3ab6889abb8132692a2c8a15eed536bce46624751acaaf", size = 6528, upload-time = "2026-04-23T17:31:34.212Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/6c89bc86b5494cfe29ee23420c398406cc147a09b5cf756e323070e358d7/langchain_protocol-0.0.10-py3-none-any.whl", hash = "sha256:040bb2ae966a06ffcd0051a1d1ca7e4926f12e951e83b07440cb80e0e8e12268", size = 6677, upload-time = "2026-04-23T17:31:33.367Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
 ]
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.7"
+version = "1.1.8"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },
@@ -1255,7 +1254,7 @@ typing = [
 
 [[package]]
 name = "langgraph"
-version = "1.1.10"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1265,35 +1264,35 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/b3/7dec224369c7938eb3227ff69542a0d0f517862a0d27945b8c395f2a781f/langgraph-1.1.10.tar.gz", hash = "sha256:3115beb58203283c98d8752a90c034f3432177d2979a1fe205f76e5f1b744500", size = 560685, upload-time = "2026-04-27T17:19:10.426Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/61/d5d25e783035aa307d289b37e082258a6061c0fb4caa4a284f3bf1e87169/langgraph-1.2.0.tar.gz", hash = "sha256:4a9baaf62afc5d5f63144a50095140a34b9aa9b7cea695d25326d564775348e7", size = 690248, upload-time = "2026-05-12T03:46:39.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/07/057dc1aa7991115fca53f1fa6573a7cc0dd296c05360c672cc67fdb6245b/langgraph-1.1.10-py3-none-any.whl", hash = "sha256:8a4f163f72f4401648d0c11b48ee906947d938ba8cf1f474540fe591534f0d17", size = 173750, upload-time = "2026-04-27T17:19:09.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e8/e3304ac0015c2bdb04ad9785e4ed65c788855ce7857ce6104dd2f5d322db/langgraph-1.2.0-py3-none-any.whl", hash = "sha256:03fd5895a8d4b70db1ff63ebc3bacead29dd20cd794a8b1a483e7ec9018f7a65", size = 234262, upload-time = "2026-05-12T03:46:37.971Z" },
 ]
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.0.0"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/76/55a18c59dedf39688d72c4b06af73a5e3ea0d1a01bc867b88fbf0659f203/langgraph_checkpoint-4.0.0.tar.gz", hash = "sha256:814d1bd050fac029476558d8e68d87bce9009a0262d04a2c14b918255954a624", size = 137320, upload-time = "2026-01-12T20:30:26.38Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/b4/6005c5dd88ad484fe6235d4c43a0d2cee7e91b08ad85a180985c2662df87/langgraph_checkpoint-4.1.0.tar.gz", hash = "sha256:e5bb304e30fc1363ac8fcb5f7dee5ca2185d77fe475b0d01de2c5f91324c2c21", size = 181942, upload-time = "2026-05-12T03:33:49.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/de/ddd53b7032e623f3c7bcdab2b44e8bf635e468f62e10e5ff1946f62c9356/langgraph_checkpoint-4.0.0-py3-none-any.whl", hash = "sha256:3fa9b2635a7c5ac28b338f631abf6a030c3b508b7b9ce17c22611513b589c784", size = 46329, upload-time = "2026-01-12T20:30:25.2Z" },
+    { url = "https://files.pythonhosted.org/packages/93/74/d3be2b41955e20ccd624dba5f6fe9d38dcee385ba470a6e13ed86732fc86/langgraph_checkpoint-4.1.0-py3-none-any.whl", hash = "sha256:8bc2a0466a20c38b865ce6671b42093fd5c041133f32351cae4222e0eeaf7fb5", size = 56047, upload-time = "2026-05-12T03:33:48.548Z" },
 ]
 
 [[package]]
 name = "langgraph-prebuilt"
-version = "1.0.13"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/a4/f8ac75fa7c503103f0cf7680944e28bbaaef74c19a8d163d7346869cc369/langgraph_prebuilt-1.0.13.tar.gz", hash = "sha256:ad219782a80e1718e7e7794de49e0ae307111d45cbcffab9a52725a66a609456", size = 172913, upload-time = "2026-04-30T01:48:15.742Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/ef/5ada0bef4013ef5ae53a0ca1de5736517f1076a54d313f156ca545ec65d5/langgraph_prebuilt-1.0.13-py3-none-any.whl", hash = "sha256:7055e9fad41fbd3593800aed0aea0a6e974b17f33ed51b80d3d3a031212dd7c0", size = 37214, upload-time = "2026-04-30T01:48:14.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
 ]
 
 [[package]]

--- a/libs/partners/mistralai/pyproject.toml
+++ b/libs/partners/mistralai/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.4"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "tokenizers>=0.15.1,<1.0.0",
     "httpx>=0.25.2,<1.0.0",
     "httpx-sse>=0.3.1,<1.0.0",
@@ -46,15 +46,15 @@ test = [
     "pytest-asyncio>=1.3.0,<2.0.0",
     "pytest-watcher>=0.3.4,<1.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 typing = [
     "mypy>=1.10.0,<2.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 
 [tool.uv]

--- a/libs/partners/nomic/pyproject.toml
+++ b/libs/partners/nomic/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "nomic>=3.5.3,<4.0.0",
     "pillow>=12.1.1,<13.0.0",
 ]
@@ -47,16 +47,16 @@ test = [
     "pytest-xdist>=3.6.1,<4.0.0",
     "freezegun>=1.2.2,<2.0.0",
     "syrupy>=5.0.0,<6.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]
 typing = [
     "mypy>=1.18.1,<1.19.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 
 [tool.uv]
 constraint-dependencies = ["pygments>=2.20.0"]  # CVE-2026-4539

--- a/libs/partners/ollama/pyproject.toml
+++ b/libs/partners/ollama/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.1.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "ollama>=0.6.1,<1.0.0",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
 ]
 
 [project.urls]
@@ -45,15 +45,15 @@ test = [
     "pytest-watcher>=0.4.3,<1.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
     "syrupy>=5.0.0,<6.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 typing = [
     "ty>=0.0.1,<1.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 
 [tool.uv]

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.2.1"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "openai>=2.26.0,<3.0.0",
     "tiktoken>=0.7.0,<1.0.0",
 ]
@@ -53,12 +53,12 @@ test = [
     "vcrpy>=8.0.0,<9.0.0",
     "numpy>=1.26.4; python_version<'3.13'",
     "numpy>=2.1.0; python_version>='3.13'",
-    "langchain",
-    "langchain-core",
-    "langchain-tests",
+    "langchain>=1.0.0,<2.0.0",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 test_integration = [
     "httpx>=0.27.0,<1.0.0",
     "pillow>=12.1.1,<13.0.0",
@@ -68,7 +68,7 @@ test_integration = [
 typing = [
     "mypy>=1.17.1,<2.0.0",
     "types-tqdm>=4.66.0.5,<5.0.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 
 [tool.uv.sources]

--- a/libs/partners/openrouter/pyproject.toml
+++ b/libs/partners/openrouter/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "0.2.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "openrouter>=0.7.11,<1.0.0",
 ]
 
@@ -45,11 +45,11 @@ test = [
     "pytest-watcher>=0.6.3,<1.0.0",
     "pytest-timeout>=2.4.0,<3.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
-    "langchain-tests",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.15.0,<0.16.0"]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 typing = ["mypy>=1.19.1,<2.0.0"]
 
 

--- a/libs/partners/perplexity/pyproject.toml
+++ b/libs/partners/perplexity/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.2.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "perplexityai>=0.32.0,<1.0.0",
 ]
 
@@ -49,11 +49,11 @@ test = [
     "pytest-retry>=1.7.0,<1.8.0",
     "pytest-socket>=0.6.0,<1.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 test_integration = [
     "httpx>=0.27.0,<1.0.0",
     "pillow>=12.1.1,<13.0.0",
@@ -61,7 +61,7 @@ test_integration = [
 typing = [
     "mypy>=1.10.0,<2.0.0",
     "types-tqdm>=4.66.0.5,<5.0.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 
 [tool.uv]

--- a/libs/partners/qdrant/pyproject.toml
+++ b/libs/partners/qdrant/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "qdrant-client>=1.15.1,<2.0.0",
     "pydantic>=2.7.4,<3.0.0",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
 ]
 
 [project.urls]
@@ -54,16 +54,16 @@ test = [
     "freezegun>=1.2.2,<2.0.0",
     "syrupy>=5.0.0,<6.0.0",
     "requests>=2.31.0,<3.0.0",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 typing = [
     "mypy>=1.10.0,<2.0.0",
     "simsimd>=6.0.0,<7.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 
 # CVE-2026-25990: pillow < 12.1.1 is vulnerable to out-of-bounds write when loading PSD images.

--- a/libs/partners/xai/pyproject.toml
+++ b/libs/partners/xai/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.2.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-openai>=1.1.7,<2.0.0",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
     "requests>=2.0.0,<3.0.0",
     "aiohttp>=3.9.1,<4.0.0",
 ]
@@ -51,17 +51,17 @@ test = [
     "freezegun>=1.2.2,<2.0.0",
     "syrupy>=5.0.0,<6.0.0",
     "langchain-openai",
-    "langchain-core",
-    "langchain-tests",
+    "langchain-core>=1.4.0,<2.0.0",
+    "langchain-tests>=1.0.0,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]
 typing = [
     "mypy>=1.10.0,<2.0.0",
     "types-requests>=2.0.0,<3.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
-dev = ["langchain-core"]
+dev = ["langchain-core>=1.4.0,<2.0.0"]
 
 [tool.uv]
 constraint-dependencies = ["pygments>=2.20.0"]  # CVE-2026-4539

--- a/libs/standard-tests/pyproject.toml
+++ b/libs/standard-tests/pyproject.toml
@@ -49,13 +49,13 @@ Slack = "https://www.langchain.com/join-community"
 Reddit = "https://www.reddit.com/r/LangChain/"
 
 [dependency-groups]
-test = ["langchain-core"]
+test = ["langchain-core>=1.4.0,<2.0.0"]
 test_integration = []
 lint = ["ruff>=0.15.0,<0.16.0"]
 typing = [
     "mypy>=1.19.1,<1.20.0",
     "types-pyyaml>=6.0.12.2,<7.0.0.0",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
 ]
 
 [tool.uv.sources]

--- a/libs/text-splitters/pyproject.toml
+++ b/libs/text-splitters/pyproject.toml
@@ -41,7 +41,7 @@ Reddit = "https://www.reddit.com/r/LangChain/"
 [dependency-groups]
 lint = [
     "ruff>=0.15.0,<0.16.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 typing = [
     "mypy>=1.19.1,<1.20.0",
@@ -52,7 +52,7 @@ typing = [
 ]
 dev = [
     "jupyter<2.0.0,>=1.0.0",
-    "langchain-core"
+    "langchain-core>=1.4.0,<2.0.0"
 ]
 test = [
     "pytest>=9.0.3,<10.0.0",
@@ -62,7 +62,7 @@ test = [
     "pytest-asyncio>=1.3.0,<2.0.0",
     "pytest-socket>=0.7.0,<1.0.0",
     "pytest-xdist<4.0.0,>=3.6.1",
-    "langchain-core",
+    "langchain-core>=1.4.0,<2.0.0",
 ]
 test_integration = [
     "spacy>=3.8.13,<4.0.0",


### PR DESCRIPTION
Dependabot has been stripping upper/lower bounds from internal `langchain-*` deps in partner `pyproject.toml` files (e.g. #37288 reduced `langchain-core>=1.3.2,<2.0.0` to bare `langchain-core`). Locks down the config so bumps preserve existing specifiers, and restores the bounds it already mangled across the monorepo.

## Changes
- Add `versioning-strategy: increase` to every `uv` ecosystem block in `.github/dependabot.yml` so future bumps move the lower bound in place instead of rewriting the constraint.
- Ignore workspace-internal packages (`langchain-core`, `langchain`, `langchain-classic`, `langchain-text-splitters`, `langchain-tests`, `langchain-model-profiles`) on every `uv` block — these are editable installs from local paths and their published constraints are hand-curated for release, not Dependabot's to bump.
- Restore stripped bounds across all `libs/` packages — runtime `dependencies` and every dep group (`test`, `dev`, `test_integration`, `typing`, `lint`) — to `>=1.4.0,<2.0.0` for `langchain-core` and `>=1.0.0,<2.0.0` for the other internal packages.