### PR TITLE
fix(openrouter): cache httpx clients to prevent per-instance connection leaks

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/_client_utils.py
+++ b/libs/partners/openrouter/langchain_openrouter/_client_utils.py
@@ -1,0 +1,167 @@
+"""Cached httpx client factories for langchain-openrouter.
+
+Mirrors the pattern from langchain-openai's ``_client_utils``
+(originally PR #32531) to avoid per-instance httpx client creation.
+
+Without this cache, each ``ChatOpenRouter(...)`` constructs a fresh
+``httpx.Client`` / ``httpx.AsyncClient`` pair. When instances are created
+per-request (LangGraph factory graphs, FastAPI DI, etc.), the discarded
+clients hold onto TLS connections until interpreter exit, causing linear
+socket growth and eventual resource exhaustion.  See
+``langchain-openai``'s ``_client_utils`` for the detailed analogue.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+import httpx
+
+
+class _SyncClientWrapper(httpx.Client):
+    """Wraps a sync httpx client for safe __del__ cleanup.
+
+    Borrowed from ``httpx``'s own ``DefaultHttpxClient`` pattern.
+    """
+
+    def __del__(self) -> None:
+        if self.is_closed:
+            return
+        try:
+            self.close()
+        except Exception:  # noqa: S110
+            pass
+
+
+class _AsyncClientWrapper(httpx.AsyncClient):
+    """Wraps an async httpx client for safe __del__ cleanup."""
+
+    def __del__(self) -> None:
+        if self.is_closed:
+            return
+        try:
+            import asyncio
+
+            asyncio.get_running_loop().create_task(self.aclose())
+        except Exception:  # noqa: S110
+            pass
+
+
+def _build_sync_client(
+    base_url: str | None,
+    timeout: Any,
+    headers: dict[str, str] | None = None,
+) -> _SyncClientWrapper:
+    """Build a sync httpx client with the given parameters."""
+    kwargs: dict[str, Any] = {"timeout": timeout, "follow_redirects": True}
+    if base_url:
+        kwargs["base_url"] = base_url
+    if headers:
+        kwargs["headers"] = headers
+    return _SyncClientWrapper(**kwargs)
+
+
+def _build_async_client(
+    base_url: str | None,
+    timeout: Any,
+    headers: dict[str, str] | None = None,
+) -> _AsyncClientWrapper:
+    """Build an async httpx client with the given parameters."""
+    kwargs: dict[str, Any] = {"timeout": timeout, "follow_redirects": True}
+    if base_url:
+        kwargs["base_url"] = base_url
+    if headers:
+        kwargs["headers"] = headers
+    return _AsyncClientWrapper(**kwargs)
+
+
+def _cache_key(
+    base_url: str | None,
+    timeout: Any,
+    headers_tuple: tuple[tuple[str, str], ...],
+) -> tuple[str | None, Any, tuple[tuple[str, str], ...]]:
+    """Build a stable hash cache key for client parameters."""
+    return (base_url, timeout, headers_tuple)
+
+
+@lru_cache
+def _cached_sync_client(
+    base_url: str | None,
+    timeout: Any,
+    headers_tuple: tuple[tuple[str, str], ...],
+) -> _SyncClientWrapper:
+    """Build a cached sync httpx client.
+
+    ``headers_tuple`` is used instead of ``dict`` because dicts are not
+    hashable and cannot be passed to ``@lru_cache``.
+    """
+    headers = dict(headers_tuple) if headers_tuple else None
+    return _build_sync_client(base_url, timeout, headers)
+
+
+@lru_cache
+def _cached_async_client(
+    base_url: str | None,
+    timeout: Any,
+    headers_tuple: tuple[tuple[str, str], ...],
+) -> _AsyncClientWrapper:
+    """Build a cached async httpx client."""
+    headers = dict(headers_tuple) if headers_tuple else None
+    return _build_async_client(base_url, timeout, headers)
+
+
+def get_default_httpx_client(
+    *,
+    base_url: str | None = None,
+    timeout: Any = httpx.USE_DEFAULT,
+    headers: dict[str, str] | None = None,
+) -> httpx.Client:
+    """Get or create a default sync httpx client.
+
+    Uses an LRU cache so that identically-configured callers share a single
+    connection pool.  Pass ``headers`` to include custom per-request headers
+    (e.g. OpenRouter attribution headers).
+
+    Args:
+        base_url: Optional base URL for the client.
+        timeout: Timeout configuration (default: httpx.USE_DEFAULT).
+        headers: Optional extra headers to include on every request.
+
+    Returns:
+        An httpx.Client instance (potentially shared).
+    """
+    headers_tuple = tuple(sorted(headers.items())) if headers else ()
+    try:
+        hash(timeout)
+    except TypeError:
+        # Unhashable timeout (e.g. httpx.Timeout with custom values) --
+        # fall through to an uncached build.
+        return _build_sync_client(base_url, timeout, headers)
+    return _cached_sync_client(base_url, timeout, headers_tuple)
+
+
+def get_default_async_httpx_client(
+    *,
+    base_url: str | None = None,
+    timeout: Any = httpx.USE_DEFAULT,
+    headers: dict[str, str] | None = None,
+) -> httpx.AsyncClient:
+    """Get or create a default async httpx client.
+
+    Same caching semantics as ``get_default_httpx_client``.
+
+    Args:
+        base_url: Optional base URL for the client.
+        timeout: Timeout configuration.
+        headers: Optional extra headers.
+
+    Returns:
+        An httpx.AsyncClient instance (potentially shared).
+    """
+    headers_tuple = tuple(sorted(headers.items())) if headers else ()
+    try:
+        hash(timeout)
+    except TypeError:
+        return _build_async_client(base_url, timeout, headers)
+    return _cached_async_client(base_url, timeout, headers_tuple)

--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import warnings
+
+import httpx
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from operator import itemgetter
 from typing import Any, Literal, cast
@@ -69,6 +71,10 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openrouter._client_utils import (
+    get_default_async_httpx_client,
+    get_default_httpx_client,
+)
 from langchain_openrouter.data._profiles import _PROFILES
 
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
@@ -141,6 +147,20 @@ class ChatOpenRouter(BaseChatModel):
 
     client: Any = Field(default=None, exclude=True)
     """Underlying SDK client (`openrouter.OpenRouter`)."""
+
+    http_client: Any = Field(default=None, exclude=True)
+    """Optional custom `httpx.Client` to use for sync requests.
+    
+    If not provided, a cached default client will be shared across all
+    instances with the same configuration.
+    """
+
+    http_async_client: Any = Field(default=None, exclude=True)
+    """Optional custom `httpx.AsyncClient` to use for async requests.
+    
+    If not provided, a cached default client will be shared across all
+    instances with the same configuration.
+    """
 
     openrouter_api_key: SecretStr | None = Field(
         alias="api_key",
@@ -386,17 +406,27 @@ class ChatOpenRouter(BaseChatModel):
             extra_headers["X-Title"] = self.app_title
         if self.app_categories:
             extra_headers["X-OpenRouter-Categories"] = ",".join(self.app_categories)
-        if extra_headers:
-            import httpx  # noqa: PLC0415
-
-            client_kwargs["client"] = httpx.Client(
-                headers=extra_headers, follow_redirects=True
+        # Use cached default httpx clients to avoid per-instance connection
+        # pool leaks.  Pass extra_headers so attribution data is included on
+        # every request without constructing a fresh client each time.
+        # If the user has supplied an explicit http_client / http_async_client,
+        # use those instead (matching ChatOpenAI's public surface).
+        client_kwargs["client"] = (
+            self.http_client
+            or get_default_httpx_client(
+                base_url=self.openrouter_api_base,
+                timeout=httpx.USE_DEFAULT if self.request_timeout is None else httpx.Timeout(timeout=self.request_timeout / 1000),
+                headers=extra_headers or None,
             )
-            client_kwargs["async_client"] = httpx.AsyncClient(
-                headers=extra_headers, follow_redirects=True
+        )
+        client_kwargs["async_client"] = (
+            self.http_async_client
+            or get_default_async_httpx_client(
+                base_url=self.openrouter_api_base,
+                timeout=httpx.USE_DEFAULT if self.request_timeout is None else httpx.Timeout(timeout=self.request_timeout / 1000),
+                headers=extra_headers or None,
             )
-        if self.request_timeout is not None:
-            client_kwargs["timeout_ms"] = self.request_timeout
+        )
         if self.max_retries > 0:
             client_kwargs["retry_config"] = RetryConfig(
                 strategy="backoff",


### PR DESCRIPTION
Closes #37498

---

Each `ChatOpenRouter(...)` instantiation constructs fresh `httpx.Client` / `httpx.AsyncClient` pairs. Under per-request instance patterns (LangGraph factory graphs, FastAPI DI, etc.), the discarded clients hold onto TLS connections until interpreter exit, causing linear socket growth and eventual resource exhaustion.

**Fix:** Adds a `_client_utils` module with `@lru_cache`-backed default httpx clients, mirroring the pattern from langchain-openai's `_client_utils` (PR #32531). When the user does not supply explicit `http_client` / `http_async_client`, a shared cached client is used instead of constructing a fresh one per instance.

**Changes:**
- New `langchain_openrouter/_client_utils.py`: cached `get_default_httpx_client()` / `get_default_async_httpx_client()` factories
- `chat_models.py`: use cached clients in `_build_client()`, expose `http_client` / `http_async_client` constructor kwargs

This PR was contributed by an AI agent (Hermes Agent by Nous Research).