### PR TITLE
feat(anthropic): add http_client and http_async_client fields to ChatAnthropic

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -915,6 +915,48 @@ class ChatAnthropic(BaseChatModel):
     default_headers: Mapping[str, str] | None = None
     """Headers to pass to the Anthropic clients, will be used for every API call."""
 
+    http_client: Any | None = Field(default=None, exclude=True)
+    """Custom httpx.Client instance to use for sync API calls.
+
+    Allows injecting custom transports (e.g. for intercepting/mutating requests).
+
+    Example::
+
+        import httpx
+        from langchain_anthropic import ChatAnthropic
+
+        class MyTransport(httpx.BaseTransport):
+            def handle_request(self, request):
+                ...  # mutate request
+                return self._inner.handle_request(request)
+
+        llm = ChatAnthropic(
+            model="claude-3-5-sonnet-latest",
+            http_client=httpx.Client(transport=MyTransport()),
+        )
+    """
+
+    http_async_client: Any | None = Field(default=None, exclude=True)
+    """Custom httpx.AsyncClient instance to use for async API calls.
+
+    Allows injecting custom transports (e.g. for intercepting/mutating requests).
+
+    Example::
+
+        import httpx
+        from langchain_anthropic import ChatAnthropic
+
+        class MyTransport(httpx.AsyncBaseTransport):
+            async def handle_async_request(self, request):
+                ...  # mutate request
+                return await self._inner.handle_async_request(request)
+
+        llm = ChatAnthropic(
+            model="claude-3-5-sonnet-latest",
+            http_async_client=httpx.AsyncClient(transport=MyTransport()),
+        )
+    """
+
     betas: list[str] | None = None
     """List of beta features to enable. If specified, invocations will be routed
     through `client.beta.messages.create`.
@@ -1139,12 +1181,15 @@ class ChatAnthropic(BaseChatModel):
     @cached_property
     def _client(self) -> anthropic.Client:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
-        if "timeout" in client_params:
-            http_client_params["timeout"] = client_params["timeout"]
-        if self.anthropic_proxy:
-            http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_httpx_client(**http_client_params)
+        if self.http_client is not None:
+            http_client = self.http_client
+        else:
+            http_client_params = {"base_url": client_params["base_url"]}
+            if "timeout" in client_params:
+                http_client_params["timeout"] = client_params["timeout"]
+            if self.anthropic_proxy:
+                http_client_params["anthropic_proxy"] = self.anthropic_proxy
+            http_client = _get_default_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,
@@ -1154,12 +1199,15 @@ class ChatAnthropic(BaseChatModel):
     @cached_property
     def _async_client(self) -> anthropic.AsyncClient:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
-        if "timeout" in client_params:
-            http_client_params["timeout"] = client_params["timeout"]
-        if self.anthropic_proxy:
-            http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_async_httpx_client(**http_client_params)
+        if self.http_async_client is not None:
+            http_client = self.http_async_client
+        else:
+            http_client_params = {"base_url": client_params["base_url"]}
+            if "timeout" in client_params:
+                http_client_params["timeout"] = client_params["timeout"]
+            if self.anthropic_proxy:
+                http_client_params["anthropic_proxy"] = self.anthropic_proxy
+            http_client = _get_default_async_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,


### PR DESCRIPTION
## Summary

Adds two public fields to `ChatAnthropic` that allow callers to inject custom `httpx` clients — and therefore custom transports — without subclassing or monkey-patching internals:

- `http_client: httpx.Client | None` — used for sync API calls
- `http_async_client: httpx.AsyncClient | None` — used for async API calls

When either field is set, the corresponding `_client` / `_async_client` cached property uses the provided client directly instead of creating one via the internal `_get_default_httpx_client` helpers. Both fields are `exclude=True` so they are not serialised into model snapshots.

This matches the existing pattern in `ChatOpenAI` and `ChatVertexAI`, and unblocks use-cases like:
- **Request interception / observability** — mutate or log tool descriptions / payloads at the transport layer before bytes leave the process
- **Custom retry/timeout policies** — wrap with a custom `httpx.BaseTransport`
- **Testing** — inject a transport that returns fixture responses without a live network

## Motivation

Tracked in two long-standing issues:
- Fixes #30146
- Fixes #35843

The previous behaviour silently moved `http_async_client` to `model_kwargs` (which ends up in the API request body, not the client constructor), so the transport was never wired — this PR makes both fields first-class.

## Usage

```python
import httpx
from langchain_anthropic import ChatAnthropic

class ToolDescriptionTransport(httpx.AsyncBaseTransport):
    def __init__(self):
        self._inner = httpx.AsyncHTTPTransport()

    async def handle_async_request(self, request):
        body = await request.aread()
        body = mutate_tool_descriptions(body)  # your logic here
        headers = {k: v for k, v in request.headers.items()
                   if k.lower() != "content-length"}
        headers["content-length"] = str(len(body))
        mutated = httpx.Request(
            method=request.method, url=request.url,
            headers=headers, content=body,
        )
        return await self._inner.handle_async_request(mutated)

transport = ToolDescriptionTransport()
llm = ChatAnthropic(
    model="claude-3-5-sonnet-latest",
    http_async_client=httpx.AsyncClient(transport=transport),
)
```

## Test plan

- [ ] Existing unit tests pass (`make test` in `libs/partners/anthropic/`)
- [ ] New fields appear in `ChatAnthropic.model_fields` and accept `httpx.Client` / `httpx.AsyncClient` instances
- [ ] When a custom client is passed, `_client` / `_async_client` use it (verified by checking `llm._async_client._transport` equals the injected transport)
- [ ] When no client is passed, behaviour is unchanged (falls back to `_get_default_httpx_client`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)