### PR TITLE
fix(text-splitters): skip invalid and unsafe HTML links in HTMLSemanticPreservingSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -815,8 +815,17 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
             soup: Parsed HTML content using BeautifulSoup.
         """
         for a_tag in _find_all_tags(soup, name="a"):
-            a_href = a_tag.get("href", "")
+            a_href = a_tag.get("href", "").strip()
             a_text = a_tag.get_text(strip=True)
+
+            # Skip malformed or empty links
+            if not a_href or not a_text:
+                continue
+
+            # Skip javascript pseudo-links
+            if a_href.lower().startswith("javascript:"):
+                continue
+
             markdown_link = f"[{a_text}]({a_href})"
             wrapper = soup.new_tag("link-wrapper")
             wrapper.string = markdown_link

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1303,6 +1303,32 @@ def test_html_code_splitter() -> None:
     ]
 
 
+def test_html_semantic_preserving_splitter_skips_invalid_links() -> None:
+    """Test that invalid or unsafe links are skipped."""
+    html = """
+    <html>
+        <body>
+            <p><a href="">Empty Link</a></p>
+            <p><a href="javascript:void(0)">Bad Link</a></p>
+            <p><a href="https://example.com">Valid Link</a></p>
+        </body>
+    </html>
+    """
+
+    splitter = HTMLSemanticPreservingSplitter(
+        headers_to_split_on=[("h1", "Header 1")],
+        preserve_links=True,
+    )
+
+    docs = splitter.split_text(html)
+
+    combined_text = " ".join(doc.page_content for doc in docs)
+
+    assert "[Valid Link](https://example.com)" in combined_text
+    assert "javascript:void(0)" not in combined_text
+    assert "[]( )" not in combined_text
+
+
 def test_md_header_text_splitter_1() -> None:
     """Test markdown splitter by header: Case 1."""
     markdown_document = (


### PR DESCRIPTION
## What

Skip malformed and unsafe HTML links in `HTMLSemanticPreservingSplitter` instead of converting them to invalid markdown links.

## Why

`HTMLSemanticPreservingSplitter._process_links()` was converting **all** `<a>` tags to markdown links, including:
- **Empty `href` values** — produced broken markdown like `[]( )`
- **`javascript:` pseudo-links** — produced potentially unsafe markdown links

These generated invalid markdown output and could pose a security risk with `javascript:` URIs.

## How

In `_process_links()`, added three guard conditions before creating the markdown link:
1. Skip if `href` is empty (after stripping whitespace)
2. Skip if link text is empty
3. Skip if `href` starts with `javascript:` (case-insensitive)

## Testing

Added `test_html_semantic_preserving_splitter_skips_invalid_links()` which verifies:
- Valid links are still converted to markdown
- `javascript:` pseudo-links are skipped
- Empty links are not rendered as broken markdown

Fixes #37423