### PR TITLE
fix: add explicit encoding="utf-8" to agent and chain save_path writers

### DIFF
--- a/libs/langchain/langchain_classic/agents/agent.py
+++ b/libs/langchain/langchain_classic/agents/agent.py
@@ -204,10 +204,10 @@ class BaseSingleActionAgent(BaseModel):
             raise NotImplementedError(msg)
 
         if save_path.suffix == ".json":
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 json.dump(agent_dict, f, indent=4)
         elif save_path.suffix.endswith((".yaml", ".yml")):
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 yaml.dump(agent_dict, f, default_flow_style=False)
         else:
             msg = f"{save_path} must be json or yaml"
@@ -344,10 +344,10 @@ class BaseMultiActionAgent(BaseModel):
         directory_path.mkdir(parents=True, exist_ok=True)
 
         if save_path.suffix == ".json":
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 json.dump(agent_dict, f, indent=4)
         elif save_path.suffix.endswith((".yaml", ".yml")):
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 yaml.dump(agent_dict, f, default_flow_style=False)
         else:
             msg = f"{save_path} must be json or yaml"

--- a/libs/langchain/langchain_classic/chains/base.py
+++ b/libs/langchain/langchain_classic/chains/base.py
@@ -787,10 +787,10 @@ class Chain(RunnableSerializable[dict[str, Any], dict[str, Any]], ABC):
         directory_path.mkdir(parents=True, exist_ok=True)
 
         if save_path.suffix == ".json":
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 json.dump(chain_dict, f, indent=4)
         elif save_path.suffix.endswith((".yaml", ".yml")):
-            with save_path.open("w") as f:
+            with save_path.open("w", encoding="utf-8") as f:
                 yaml.dump(chain_dict, f, default_flow_style=False)
         else:
             msg = f"{save_path} must be json or yaml"


### PR DESCRIPTION
Fixes #37577

## What

`Agent.save()` / `AgentExecutor.save()` in `langchain_classic/agents/agent.py` and `Chain.save()` in `langchain_classic/chains/base.py` write JSON or YAML serializations of agent/chain dicts via `Path.open("w")` without an explicit `encoding=` argument. Python falls back to `locale.getpreferredencoding()`, which is `cp1252` on Windows and `utf-8` on Linux/macOS.

Agent/chain dicts routinely contain non-ASCII content — prompts, descriptions, system messages, tool docstrings — so a chain saved on Linux and re-loaded on Windows (or vice versa) can produce `UnicodeDecodeError` or silently mangle characters when the prompt contains accented characters, mathematical notation, emoji, CJK, etc.

> Note: This is a re-open of #37566, which was closed automatically by the missing-issue-link bot before I had created the tracking issue. The tracking issue is now #37577.

## Why

- Reliability across Windows / Linux / macOS / Docker for saved agents and chains.
- PEP 597 recommends always specifying `encoding=` for text-mode opens.
- Eliminates `EncodingWarning` under `PYTHONWARNDEFAULTENCODING=1` (Python 3.10+).
- No behavior change on systems where the default is already utf-8.

## Changes

Added `encoding="utf-8"` to 6 `save_path.open("w")` call sites:

- `libs/langchain/langchain_classic/agents/agent.py` — 4 sites in `Agent.save()` and `AgentExecutor.save()` (JSON and YAML branches)
- `libs/langchain/langchain_classic/chains/base.py` — 2 sites in `Chain.save()` (JSON and YAML branches)

Total: 2 files, +6/-6 lines.

## Testing

Pure keyword-argument addition to existing `Path.open()` calls; no logic touched. Verified both files parse cleanly with `python -m py_compile`. The existing save/load round-trip tests for agents and chains continue to work because they execute on CI where the default encoding is already utf-8 — this just makes the contract explicit and portable to Windows.