### PR TITLE
feat(langchain): add `interrupt_mode` and `when` predicate to `HumanInTheLoopMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -7,6 +7,7 @@ from langchain.agents.middleware.file_search import FilesystemFileSearchMiddlewa
 from langchain.agents.middleware.human_in_the_loop import (
     HumanInTheLoopMiddleware,
     InterruptOnConfig,
+    ToolCallReviewRequest,
 )
 from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddleware
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
@@ -72,6 +73,7 @@ __all__ = [
     "TodoListMiddleware",
     "ToolCallLimitMiddleware",
     "ToolCallRequest",
+    "ToolCallReviewRequest",
     "ToolRetryMiddleware",
     "after_agent",
     "after_model",

--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -7,7 +7,6 @@ from langchain.agents.middleware.file_search import FilesystemFileSearchMiddlewa
 from langchain.agents.middleware.human_in_the_loop import (
     HumanInTheLoopMiddleware,
     InterruptOnConfig,
-    ToolCallReviewRequest,
 )
 from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddleware
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
@@ -73,7 +72,6 @@ __all__ = [
     "TodoListMiddleware",
     "ToolCallLimitMiddleware",
     "ToolCallRequest",
-    "ToolCallReviewRequest",
     "ToolRetryMiddleware",
     "after_agent",
     "after_model",

--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from langchain_core.messages import AIMessage, ToolCall, ToolMessage
 from langgraph.types import interrupt
@@ -186,21 +186,23 @@ class InterruptOnConfig(TypedDict):
     args_schema: NotRequired[dict[str, Any]]
     """JSON schema for the args associated with the action, if edits are allowed."""
 
-    when: NotRequired[Callable[[ToolCall, AgentState[Any], Runtime[Any]], bool]]
+    when: NotRequired[Callable[[ToolCallRequest], bool]]
     """Optional predicate controlling whether to interrupt for a given tool call.
 
-    Called with the tool call, current agent state, and runtime. When provided,
-    the interrupt only fires if this returns `True`. Works in both `"batch"` and
-    `"per_call"` modes.
+    Receives a `ToolCallRequest` and returns `True` to interrupt or `False` to
+    auto-approve. Works in both `"batch"` and `"per_call"` modes.
+
+    In `"batch"` mode the request is constructed with `tool=None` and
+    `runtime` set to the node-level `Runtime` (not a `ToolRuntime`), so
+    `request.runtime.tool_call_id` and `request.runtime.tools` are not available.
+    In `"per_call"` mode the full `ToolCallRequest` from `wrap_tool_call` is passed.
 
     Example:
         ```python
         # Only interrupt delete_file calls targeting /etc
         config = InterruptOnConfig(
             allowed_decisions=["approve", "reject"],
-            when=lambda tool_call, state, runtime: (
-                tool_call["args"].get("path", "").startswith("/etc")
-            ),
+            when=lambda req: req.tool_call["args"].get("path", "").startswith("/etc"),
         )
         ```
     """
@@ -283,8 +285,8 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         self,
         tool_call: ToolCall,
         config: InterruptOnConfig,
-        state: AgentState[Any],
-        runtime: Runtime[ContextT],
+        state: Any,
+        runtime: Any,
     ) -> tuple[ActionRequest, ReviewConfig]:
         """Create an ActionRequest and ReviewConfig for a tool call."""
         tool_name = tool_call["name"]
@@ -401,8 +403,15 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         for idx, tool_call in enumerate(last_ai_msg.tool_calls):
             if (config := self.interrupt_on.get(tool_call["name"])) is not None:
                 when = config.get("when")
-                if when is not None and not when(tool_call, state, runtime):
-                    continue
+                if when is not None:
+                    req = ToolCallRequest(
+                        tool_call=tool_call,
+                        tool=None,
+                        state=state,
+                        runtime=runtime,  # type: ignore[arg-type]
+                    )
+                    if not when(req):
+                        continue
                 action_request, review_config = self._create_action_and_config(
                     tool_call, config, state, runtime
                 )
@@ -495,18 +504,17 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         if self.interrupt_mode == "batch":
             return handler(request)
 
-        tool_call = cast("ToolCall", request.tool_call)
+        tool_call = request.tool_call
         config = self.interrupt_on.get(tool_call["name"])
         if config is None:
             return handler(request)
 
-        state = cast("AgentState[Any]", request.state)
         when = config.get("when")
-        if when is not None and not when(tool_call, state, request.runtime):
+        if when is not None and not when(request):
             return handler(request)
 
         action_request, review_config = self._create_action_and_config(
-            tool_call, config, state, request.runtime
+            tool_call, config, request.state, request.runtime
         )
         decision: Decision = interrupt(
             ToolCallReviewRequest(action_request=action_request, review_config=review_config)
@@ -542,18 +550,17 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         if self.interrupt_mode == "batch":
             return await handler(request)
 
-        tool_call = cast("ToolCall", request.tool_call)
+        tool_call = request.tool_call
         config = self.interrupt_on.get(tool_call["name"])
         if config is None:
             return await handler(request)
 
-        state = cast("AgentState[Any]", request.state)
         when = config.get("when")
-        if when is not None and not when(tool_call, state, request.runtime):
+        if when is not None and not when(request):
             return await handler(request)
 
         action_request, review_config = self._create_action_and_config(
-            tool_call, config, state, request.runtime
+            tool_call, config, request.state, request.runtime
         )
         decision: Decision = interrupt(
             ToolCallReviewRequest(action_request=action_request, review_config=review_config)

--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -260,8 +260,8 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         self,
         tool_call: ToolCall,
         config: InterruptOnConfig,
-        state: Any,
-        runtime: Any,
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
     ) -> tuple[ActionRequest, ReviewConfig]:
         """Create an ActionRequest and ReviewConfig for a tool call."""
         tool_name = tool_call["name"]
@@ -343,6 +343,39 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         )
         raise ValueError(msg)
 
+    def _should_interrupt(
+        self,
+        tool_call: ToolCall,
+        config: InterruptOnConfig,
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+    ) -> bool:
+        """Return False if the `when` predicate rejects this tool call, True otherwise."""
+        when = config.get("when")
+        if when is None:
+            return True
+        try:
+            runnable_config = get_config()
+        except RuntimeError:
+            runnable_config = {}
+        tool_runtime = ToolRuntime(
+            state=state,
+            context=runtime.context,
+            config=runnable_config,
+            stream_writer=runtime.stream_writer,
+            tool_call_id=tool_call["id"],
+            store=runtime.store,
+            execution_info=runtime.execution_info,
+            server_info=runtime.server_info,
+        )
+        req = ToolCallRequest(
+            tool_call=tool_call,
+            tool=None,
+            state=state,
+            runtime=tool_runtime,  # type: ignore[arg-type]
+        )
+        return when(req)
+
     def after_model(
         self, state: AgentState[Any], runtime: Runtime[ContextT]
     ) -> dict[str, Any] | None:
@@ -374,30 +407,8 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
 
         for idx, tool_call in enumerate(last_ai_msg.tool_calls):
             if (config := self.interrupt_on.get(tool_call["name"])) is not None:
-                when = config.get("when")
-                if when is not None:
-                    try:
-                        runnable_config = get_config()
-                    except RuntimeError:
-                        runnable_config = {}
-                    tool_runtime = ToolRuntime(
-                        state=state,
-                        context=runtime.context,
-                        config=runnable_config,
-                        stream_writer=runtime.stream_writer,
-                        tool_call_id=tool_call["id"],
-                        store=runtime.store,
-                        execution_info=runtime.execution_info,
-                        server_info=runtime.server_info,
-                    )
-                    req = ToolCallRequest(
-                        tool_call=tool_call,
-                        tool=None,
-                        state=state,
-                        runtime=tool_runtime,  # type: ignore[arg-type]
-                    )
-                    if not when(req):
-                        continue
+                if not self._should_interrupt(tool_call, config, state, runtime):
+                    continue
                 action_request, review_config = self._create_action_and_config(
                     tool_call, config, state, runtime
                 )

--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -1,9 +1,10 @@
 """Human in the loop middleware."""
 
-from typing import Any, Literal, Protocol
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
 from langchain_core.messages import AIMessage, ToolCall, ToolMessage
-from langgraph.runtime import Runtime
 from langgraph.types import interrupt
 from typing_extensions import NotRequired, TypedDict
 
@@ -13,7 +14,14 @@ from langchain.agents.middleware.types import (
     ContextT,
     ResponseT,
     StateT,
+    ToolCallRequest,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langgraph.runtime import Runtime
+    from langgraph.types import Command
 
 
 class Action(TypedDict):
@@ -178,6 +186,40 @@ class InterruptOnConfig(TypedDict):
     args_schema: NotRequired[dict[str, Any]]
     """JSON schema for the args associated with the action, if edits are allowed."""
 
+    when: NotRequired[Callable[[ToolCall, AgentState[Any], Runtime[Any]], bool]]
+    """Optional predicate controlling whether to interrupt for a given tool call.
+
+    Called with the tool call, current agent state, and runtime. When provided,
+    the interrupt only fires if this returns `True`. Works in both `"batch"` and
+    `"per_call"` modes.
+
+    Example:
+        ```python
+        # Only interrupt delete_file calls targeting /etc
+        config = InterruptOnConfig(
+            allowed_decisions=["approve", "reject"],
+            when=lambda tool_call, state, runtime: (
+                tool_call["args"].get("path", "").startswith("/etc")
+            ),
+        )
+        ```
+    """
+
+
+class ToolCallReviewRequest(TypedDict):
+    """Interrupt payload for a single tool call review (per-call HITL).
+
+    Used as the value passed to `interrupt()` when
+    `HumanInTheLoopMiddleware` is configured with `interrupt_mode="per_call"`.
+    Resume with a single `Decision` (not wrapped in `HITLResponse`).
+    """
+
+    action_request: ActionRequest
+    """The action being reviewed."""
+
+    review_config: ReviewConfig
+    """Review policy for this action."""
+
 
 class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
     """Human in the loop middleware."""
@@ -187,6 +229,7 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         interrupt_on: dict[str, bool | InterruptOnConfig],
         *,
         description_prefix: str = "Tool execution requires approval",
+        interrupt_mode: Literal["batch", "per_call"] = "batch",
     ) -> None:
         """Initialize the human in the loop middleware.
 
@@ -203,12 +246,24 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
 
                     The `InterruptOnConfig` can include a `description` field (`str` or
                     `Callable`) for custom formatting of the interrupt description.
+
+                    A `when` predicate can also be provided to dynamically control
+                    whether a tool call triggers an interrupt. Works in both modes.
             description_prefix: The prefix to use when constructing action requests.
 
                 This is used to provide context about the tool call and the action being
                 requested.
 
                 Not used if a tool has a `description` in its `InterruptOnConfig`.
+            interrupt_mode: Controls how interrupts are raised.
+
+                * `"batch"` (default): all tool calls requiring approval are collected
+                    into a single `HITLRequest` interrupt after the model responds.
+                    Resume with `HITLResponse(decisions=[...])`.
+                * `"per_call"`: one interrupt fires per tool call via `wrap_tool_call`.
+                    Interrupts may run in parallel for concurrent tool calls. Each
+                    interrupt payload is a `ToolCallReviewRequest`; resume with a single
+                    `Decision`.
         """
         super().__init__()
         resolved_configs: dict[str, InterruptOnConfig] = {}
@@ -222,6 +277,7 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
                 resolved_configs[tool_name] = tool_config
         self.interrupt_on = resolved_configs
         self.description_prefix = description_prefix
+        self.interrupt_mode = interrupt_mode
 
     def _create_action_and_config(
         self,
@@ -326,6 +382,9 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
             ValueError: If the number of human decisions does not match the number of
                 interrupted tool calls.
         """
+        if self.interrupt_mode == "per_call":
+            return None
+
         messages = state["messages"]
         if not messages:
             return None
@@ -341,6 +400,9 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
 
         for idx, tool_call in enumerate(last_ai_msg.tool_calls):
             if (config := self.interrupt_on.get(tool_call["name"])) is not None:
+                when = config.get("when")
+                if when is not None and not when(tool_call, state, runtime):
+                    continue
                 action_request, review_config = self._create_action_and_config(
                     tool_call, config, state, runtime
                 )
@@ -410,3 +472,100 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
             Updated message with the revised tool calls.
         """
         return self.after_model(state, runtime)
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Per-call HITL intercept. No-op passthrough in `"batch"` mode.
+
+        In `"per_call"` mode, raises one `interrupt()` per tool call with a
+        `ToolCallReviewRequest` payload. Resume with a single `Decision`.
+
+        Args:
+            request: Tool call request with the call dict, `BaseTool`, state, and
+                runtime.
+            handler: Callable that executes the tool.
+
+        Returns:
+            `ToolMessage` from the tool, or a synthetic `ToolMessage` for
+            `"reject"` / `"respond"` decisions.
+        """
+        if self.interrupt_mode == "batch":
+            return handler(request)
+
+        tool_call = cast("ToolCall", request.tool_call)
+        config = self.interrupt_on.get(tool_call["name"])
+        if config is None:
+            return handler(request)
+
+        state = cast("AgentState[Any]", request.state)
+        when = config.get("when")
+        if when is not None and not when(tool_call, state, request.runtime):
+            return handler(request)
+
+        action_request, review_config = self._create_action_and_config(
+            tool_call, config, state, request.runtime
+        )
+        decision: Decision = interrupt(
+            ToolCallReviewRequest(action_request=action_request, review_config=review_config)
+        )
+
+        revised_tool_call, tool_message = self._process_decision(decision, tool_call, config)
+        if tool_message is not None:
+            return tool_message
+
+        if revised_tool_call is None:
+            msg = f"_process_decision returned no tool call or message for '{tool_call['name']}'"
+            raise RuntimeError(msg)
+        if revised_tool_call != tool_call:
+            request = request.override(tool_call=revised_tool_call)
+        return handler(request)
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Async per-call HITL intercept. No-op passthrough in `"batch"` mode.
+
+        Args:
+            request: Tool call request with the call dict, `BaseTool`, state, and
+                runtime.
+            handler: Async callable that executes the tool.
+
+        Returns:
+            `ToolMessage` from the tool, or a synthetic `ToolMessage` for
+            `"reject"` / `"respond"` decisions.
+        """
+        if self.interrupt_mode == "batch":
+            return await handler(request)
+
+        tool_call = cast("ToolCall", request.tool_call)
+        config = self.interrupt_on.get(tool_call["name"])
+        if config is None:
+            return await handler(request)
+
+        state = cast("AgentState[Any]", request.state)
+        when = config.get("when")
+        if when is not None and not when(tool_call, state, request.runtime):
+            return await handler(request)
+
+        action_request, review_config = self._create_action_and_config(
+            tool_call, config, state, request.runtime
+        )
+        decision: Decision = interrupt(
+            ToolCallReviewRequest(action_request=action_request, review_config=review_config)
+        )
+
+        revised_tool_call, tool_message = self._process_decision(decision, tool_call, config)
+        if tool_message is not None:
+            return tool_message
+
+        if revised_tool_call is None:
+            msg = f"_process_decision returned no tool call or message for '{tool_call['name']}'"
+            raise RuntimeError(msg)
+        if revised_tool_call != tool_call:
+            request = request.override(tool_call=revised_tool_call)
+        return await handler(request)

--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from langchain_core.messages import AIMessage, ToolCall, ToolMessage
+from langgraph.config import get_config
+from langgraph.prebuilt.tool_node import ToolRuntime
 from langgraph.types import interrupt
 from typing_extensions import NotRequired, TypedDict
 
@@ -18,10 +20,9 @@ from langchain.agents.middleware.types import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Callable
 
     from langgraph.runtime import Runtime
-    from langgraph.types import Command
 
 
 class Action(TypedDict):
@@ -208,21 +209,6 @@ class InterruptOnConfig(TypedDict):
     """
 
 
-class ToolCallReviewRequest(TypedDict):
-    """Interrupt payload for a single tool call review (per-call HITL).
-
-    Used as the value passed to `interrupt()` when
-    `HumanInTheLoopMiddleware` is configured with `interrupt_mode="per_call"`.
-    Resume with a single `Decision` (not wrapped in `HITLResponse`).
-    """
-
-    action_request: ActionRequest
-    """The action being reviewed."""
-
-    review_config: ReviewConfig
-    """Review policy for this action."""
-
-
 class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
     """Human in the loop middleware."""
 
@@ -231,7 +217,6 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
         interrupt_on: dict[str, bool | InterruptOnConfig],
         *,
         description_prefix: str = "Tool execution requires approval",
-        interrupt_mode: Literal["batch", "per_call"] = "batch",
     ) -> None:
         """Initialize the human in the loop middleware.
 
@@ -250,22 +235,13 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
                     `Callable`) for custom formatting of the interrupt description.
 
                     A `when` predicate can also be provided to dynamically control
-                    whether a tool call triggers an interrupt. Works in both modes.
+                    whether a tool call triggers an interrupt.
             description_prefix: The prefix to use when constructing action requests.
 
                 This is used to provide context about the tool call and the action being
                 requested.
 
                 Not used if a tool has a `description` in its `InterruptOnConfig`.
-            interrupt_mode: Controls how interrupts are raised.
-
-                * `"batch"` (default): all tool calls requiring approval are collected
-                    into a single `HITLRequest` interrupt after the model responds.
-                    Resume with `HITLResponse(decisions=[...])`.
-                * `"per_call"`: one interrupt fires per tool call via `wrap_tool_call`.
-                    Interrupts may run in parallel for concurrent tool calls. Each
-                    interrupt payload is a `ToolCallReviewRequest`; resume with a single
-                    `Decision`.
         """
         super().__init__()
         resolved_configs: dict[str, InterruptOnConfig] = {}
@@ -279,7 +255,6 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
                 resolved_configs[tool_name] = tool_config
         self.interrupt_on = resolved_configs
         self.description_prefix = description_prefix
-        self.interrupt_mode = interrupt_mode
 
     def _create_action_and_config(
         self,
@@ -384,9 +359,6 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
             ValueError: If the number of human decisions does not match the number of
                 interrupted tool calls.
         """
-        if self.interrupt_mode == "per_call":
-            return None
-
         messages = state["messages"]
         if not messages:
             return None
@@ -404,11 +376,25 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
             if (config := self.interrupt_on.get(tool_call["name"])) is not None:
                 when = config.get("when")
                 if when is not None:
+                    try:
+                        runnable_config = get_config()
+                    except RuntimeError:
+                        runnable_config = {}
+                    tool_runtime = ToolRuntime(
+                        state=state,
+                        context=runtime.context,
+                        config=runnable_config,
+                        stream_writer=runtime.stream_writer,
+                        tool_call_id=tool_call["id"],
+                        store=runtime.store,
+                        execution_info=runtime.execution_info,
+                        server_info=runtime.server_info,
+                    )
                     req = ToolCallRequest(
                         tool_call=tool_call,
                         tool=None,
                         state=state,
-                        runtime=runtime,  # type: ignore[arg-type]
+                        runtime=tool_runtime,  # type: ignore[arg-type]
                     )
                     if not when(req):
                         continue
@@ -481,98 +467,3 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
             Updated message with the revised tool calls.
         """
         return self.after_model(state, runtime)
-
-    def wrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
-    ) -> ToolMessage | Command[Any]:
-        """Per-call HITL intercept. No-op passthrough in `"batch"` mode.
-
-        In `"per_call"` mode, raises one `interrupt()` per tool call with a
-        `ToolCallReviewRequest` payload. Resume with a single `Decision`.
-
-        Args:
-            request: Tool call request with the call dict, `BaseTool`, state, and
-                runtime.
-            handler: Callable that executes the tool.
-
-        Returns:
-            `ToolMessage` from the tool, or a synthetic `ToolMessage` for
-            `"reject"` / `"respond"` decisions.
-        """
-        if self.interrupt_mode == "batch":
-            return handler(request)
-
-        tool_call = request.tool_call
-        config = self.interrupt_on.get(tool_call["name"])
-        if config is None:
-            return handler(request)
-
-        when = config.get("when")
-        if when is not None and not when(request):
-            return handler(request)
-
-        action_request, review_config = self._create_action_and_config(
-            tool_call, config, request.state, request.runtime
-        )
-        decision: Decision = interrupt(
-            ToolCallReviewRequest(action_request=action_request, review_config=review_config)
-        )
-
-        revised_tool_call, tool_message = self._process_decision(decision, tool_call, config)
-        if tool_message is not None:
-            return tool_message
-
-        if revised_tool_call is None:
-            msg = f"_process_decision returned no tool call or message for '{tool_call['name']}'"
-            raise RuntimeError(msg)
-        if revised_tool_call != tool_call:
-            request = request.override(tool_call=revised_tool_call)
-        return handler(request)
-
-    async def awrap_tool_call(
-        self,
-        request: ToolCallRequest,
-        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
-    ) -> ToolMessage | Command[Any]:
-        """Async per-call HITL intercept. No-op passthrough in `"batch"` mode.
-
-        Args:
-            request: Tool call request with the call dict, `BaseTool`, state, and
-                runtime.
-            handler: Async callable that executes the tool.
-
-        Returns:
-            `ToolMessage` from the tool, or a synthetic `ToolMessage` for
-            `"reject"` / `"respond"` decisions.
-        """
-        if self.interrupt_mode == "batch":
-            return await handler(request)
-
-        tool_call = request.tool_call
-        config = self.interrupt_on.get(tool_call["name"])
-        if config is None:
-            return await handler(request)
-
-        when = config.get("when")
-        if when is not None and not when(request):
-            return await handler(request)
-
-        action_request, review_config = self._create_action_and_config(
-            tool_call, config, request.state, request.runtime
-        )
-        decision: Decision = interrupt(
-            ToolCallReviewRequest(action_request=action_request, review_config=review_config)
-        )
-
-        revised_tool_call, tool_message = self._process_decision(decision, tool_call, config)
-        if tool_message is not None:
-            return tool_message
-
-        if revised_tool_call is None:
-            msg = f"_process_decision returned no tool call or message for '{tool_call['name']}'"
-            raise RuntimeError(msg)
-        if revised_tool_call != tool_call:
-            request = request.override(tool_call=revised_tool_call)
-        return await handler(request)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -1,6 +1,6 @@
 import re
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
@@ -10,8 +10,28 @@ from langchain.agents.middleware import InterruptOnConfig
 from langchain.agents.middleware.human_in_the_loop import (
     Action,
     HumanInTheLoopMiddleware,
+    ToolCallReviewRequest,
 )
 from langchain.agents.middleware.types import AgentState
+
+
+def _make_request(
+    tool_call: dict[str, Any],
+    state: AgentState[Any] | None = None,
+    runtime: Runtime | None = None,
+) -> MagicMock:
+    """Build a mock ToolCallRequest for wrap_tool_call tests."""
+    req = MagicMock()
+    req.tool_call = tool_call
+    req.state = state or AgentState[Any](messages=[])
+    req.runtime = runtime or Runtime()
+
+    def _override(**kwargs: Any) -> MagicMock:
+        new_tc = kwargs.get("tool_call", tool_call)
+        return _make_request(new_tc, req.state, req.runtime)
+
+    req.override.side_effect = _override
+    return req
 
 
 def test_human_in_the_loop_middleware_initialization() -> None:
@@ -883,3 +903,315 @@ def test_human_in_the_loop_middleware_preserves_order_with_rejections() -> None:
         assert isinstance(tool_message, ToolMessage)
         assert tool_message.content == "Rejected tool B"
         assert tool_message.tool_call_id == "id_b"
+
+
+# ---------------------------------------------------------------------------
+# interrupt_mode="per_call" — wrap_tool_call behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_per_call_after_model_is_noop() -> None:
+    """after_model returns None in per_call mode regardless of pending tool calls."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={"test_tool": True},
+        interrupt_mode="per_call",
+    )
+    ai_message = AIMessage(
+        content="...",
+        tool_calls=[{"name": "test_tool", "args": {}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hi"), ai_message])
+    result = middleware.after_model(state, Runtime())
+    assert result is None
+
+
+def test_batch_mode_wrap_tool_call_passthrough() -> None:
+    """wrap_tool_call is a no-op passthrough in batch mode."""
+    middleware = HumanInTheLoopMiddleware(interrupt_on={"test_tool": True})
+    expected = ToolMessage(content="result", name="test_tool", tool_call_id="1")
+    handler = MagicMock(return_value=expected)
+    request = _make_request({"name": "test_tool", "args": {}, "id": "1"})
+
+    with patch("langchain.agents.middleware.human_in_the_loop.interrupt") as mock_interrupt:
+        result = middleware.wrap_tool_call(request, handler)
+        mock_interrupt.assert_not_called()
+
+    handler.assert_called_once_with(request)
+    assert result is expected
+
+
+def test_per_call_approve() -> None:
+    """Approve decision calls the handler unchanged."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={"test_tool": {"allowed_decisions": ["approve"]}},
+        interrupt_mode="per_call",
+    )
+    expected = ToolMessage(content="ok", name="test_tool", tool_call_id="1")
+    handler = MagicMock(return_value=expected)
+    request = _make_request({"name": "test_tool", "args": {"x": 1}, "id": "1"})
+
+    with patch(
+        "langchain.agents.middleware.human_in_the_loop.interrupt",
+        return_value={"type": "approve"},
+    ):
+        result = middleware.wrap_tool_call(request, handler)
+
+    handler.assert_called_once()
+    assert result is expected
+
+
+def test_per_call_edit() -> None:
+    """Edit decision calls handler with a modified request; original request is not mutated."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={"test_tool": {"allowed_decisions": ["edit"]}},
+        interrupt_mode="per_call",
+    )
+    expected = ToolMessage(content="ok", name="test_tool", tool_call_id="1")
+    handler = MagicMock(return_value=expected)
+    request = _make_request({"name": "test_tool", "args": {"x": 1}, "id": "1"})
+
+    edit_decision = {
+        "type": "edit",
+        "edited_action": Action(name="test_tool", args={"x": 99}),
+    }
+    with patch(
+        "langchain.agents.middleware.human_in_the_loop.interrupt",
+        return_value=edit_decision,
+    ):
+        result = middleware.wrap_tool_call(request, handler)
+
+    handler.assert_called_once()
+    called_request = handler.call_args[0][0]
+    assert called_request.tool_call["args"] == {"x": 99}
+    assert called_request.tool_call["id"] == "1"
+    assert result is expected
+
+
+def test_per_call_reject() -> None:
+    """Reject decision returns a synthetic error ToolMessage; handler is never called."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={"test_tool": {"allowed_decisions": ["reject"]}},
+        interrupt_mode="per_call",
+    )
+    handler = MagicMock()
+    request = _make_request({"name": "test_tool", "args": {}, "id": "1"})
+
+    with patch(
+        "langchain.agents.middleware.human_in_the_loop.interrupt",
+        return_value={"type": "reject", "message": "Not allowed"},
+    ):
+        result = middleware.wrap_tool_call(request, handler)
+
+    handler.assert_not_called()
+    assert isinstance(result, ToolMessage)
+    assert result.content == "Not allowed"
+    assert result.status == "error"
+    assert result.tool_call_id == "1"
+
+
+def test_per_call_respond() -> None:
+    """Respond decision returns a synthetic success ToolMessage; handler is never called."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={"ask_user": {"allowed_decisions": ["respond"]}},
+        interrupt_mode="per_call",
+    )
+    handler = MagicMock()
+    request = _make_request({"name": "ask_user", "args": {"q": "?"}, "id": "1"})
+
+    with patch(
+        "langchain.agents.middleware.human_in_the_loop.interrupt",
+        return_value={"type": "respond", "message": "My answer"},
+    ):
+        result = middleware.wrap_tool_call(request, handler)
+
+    handler.assert_not_called()
+    assert isinstance(result, ToolMessage)
+    assert result.content == "My answer"
+    assert result.status == "success"
+    assert result.tool_call_id == "1"
+
+
+def test_per_call_auto_approve_unknown_tool() -> None:
+    """Tool not in interrupt_on passes straight through without an interrupt."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={"known_tool": True},
+        interrupt_mode="per_call",
+    )
+    expected = ToolMessage(content="r", name="unknown_tool", tool_call_id="1")
+    handler = MagicMock(return_value=expected)
+    request = _make_request({"name": "unknown_tool", "args": {}, "id": "1"})
+
+    with patch("langchain.agents.middleware.human_in_the_loop.interrupt") as mock_interrupt:
+        result = middleware.wrap_tool_call(request, handler)
+        mock_interrupt.assert_not_called()
+
+    handler.assert_called_once_with(request)
+    assert result is expected
+
+
+def test_per_call_interrupt_payload_is_single_item() -> None:
+    """Interrupt payload is a ToolCallReviewRequest (not a batched HITLRequest)."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={"test_tool": {"allowed_decisions": ["approve"]}},
+        interrupt_mode="per_call",
+    )
+    handler = MagicMock(
+        return_value=ToolMessage(content="ok", name="test_tool", tool_call_id="1")
+    )
+    request = _make_request({"name": "test_tool", "args": {"x": 1}, "id": "1"})
+
+    captured: Any = None
+
+    def capture(payload: Any) -> Any:
+        nonlocal captured
+        captured = payload
+        return {"type": "approve"}
+
+    with patch("langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=capture):
+        middleware.wrap_tool_call(request, handler)
+
+    assert captured is not None
+    assert "action_request" in captured
+    assert "review_config" in captured
+    assert captured["action_request"]["name"] == "test_tool"
+    assert captured["review_config"]["allowed_decisions"] == ["approve"]
+    # Must NOT look like a batched HITLRequest
+    assert "action_requests" not in captured
+    assert "decisions" not in captured
+
+
+# ---------------------------------------------------------------------------
+# when predicate — batch and per_call modes
+# ---------------------------------------------------------------------------
+
+
+def test_when_predicate_batch_skips_interrupt_when_false() -> None:
+    """`when` returning False prevents the tool call from joining the batch interrupt."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "test_tool": InterruptOnConfig(
+                allowed_decisions=["approve"],
+                when=lambda tc, state, runtime: tc["args"].get("risky", False),
+            )
+        }
+    )
+    ai_message = AIMessage(
+        content="...",
+        tool_calls=[{"name": "test_tool", "args": {"risky": False}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hi"), ai_message])
+
+    with patch("langchain.agents.middleware.human_in_the_loop.interrupt") as mock_interrupt:
+        result = middleware.after_model(state, Runtime())
+        mock_interrupt.assert_not_called()
+
+    assert result is None
+
+
+def test_when_predicate_batch_fires_interrupt_when_true() -> None:
+    """`when` returning True allows the tool call to trigger the batch interrupt."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "test_tool": InterruptOnConfig(
+                allowed_decisions=["approve"],
+                when=lambda tc, state, runtime: tc["args"].get("risky", False),
+            )
+        }
+    )
+    ai_message = AIMessage(
+        content="...",
+        tool_calls=[{"name": "test_tool", "args": {"risky": True}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hi"), ai_message])
+
+    with patch(
+        "langchain.agents.middleware.human_in_the_loop.interrupt",
+        return_value={"decisions": [{"type": "approve"}]},
+    ):
+        result = middleware.after_model(state, Runtime())
+
+    assert result is not None
+
+
+def test_when_predicate_per_call_skips_interrupt_when_false() -> None:
+    """`when` returning False passes the call straight through in per_call mode."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "test_tool": InterruptOnConfig(
+                allowed_decisions=["approve"],
+                when=lambda tc, state, runtime: tc["args"].get("risky", False),
+            )
+        },
+        interrupt_mode="per_call",
+    )
+    expected = ToolMessage(content="ok", name="test_tool", tool_call_id="1")
+    handler = MagicMock(return_value=expected)
+    request = _make_request({"name": "test_tool", "args": {"risky": False}, "id": "1"})
+
+    with patch("langchain.agents.middleware.human_in_the_loop.interrupt") as mock_interrupt:
+        result = middleware.wrap_tool_call(request, handler)
+        mock_interrupt.assert_not_called()
+
+    handler.assert_called_once_with(request)
+    assert result is expected
+
+
+def test_when_predicate_per_call_fires_interrupt_when_true() -> None:
+    """`when` returning True triggers the interrupt in per_call mode."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "test_tool": InterruptOnConfig(
+                allowed_decisions=["approve"],
+                when=lambda tc, state, runtime: tc["args"].get("risky", False),
+            )
+        },
+        interrupt_mode="per_call",
+    )
+    expected = ToolMessage(content="ok", name="test_tool", tool_call_id="1")
+    handler = MagicMock(return_value=expected)
+    request = _make_request({"name": "test_tool", "args": {"risky": True}, "id": "1"})
+
+    with patch(
+        "langchain.agents.middleware.human_in_the_loop.interrupt",
+        return_value={"type": "approve"},
+    ):
+        result = middleware.wrap_tool_call(request, handler)
+
+    handler.assert_called_once()
+    assert result is expected
+
+
+def test_when_predicate_receives_correct_args() -> None:
+    """The when predicate receives (tool_call, state, runtime) with correct values."""
+    captured_args: list[Any] = []
+
+    def capture_when(tc: Any, state: Any, runtime: Any) -> bool:
+        captured_args.extend([tc, state, runtime])
+        return True
+
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "test_tool": InterruptOnConfig(
+                allowed_decisions=["approve"],
+                when=capture_when,
+            )
+        }
+    )
+    ai_message = AIMessage(
+        content="...",
+        tool_calls=[{"name": "test_tool", "args": {"val": 42}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hi"), ai_message])
+    runtime = Runtime()
+
+    with patch(
+        "langchain.agents.middleware.human_in_the_loop.interrupt",
+        return_value={"decisions": [{"type": "approve"}]},
+    ):
+        middleware.after_model(state, runtime)
+
+    tool_call_arg, state_arg, runtime_arg = captured_args
+    assert tool_call_arg["name"] == "test_tool"
+    assert tool_call_arg["args"] == {"val": 42}
+    assert state_arg is state
+    assert runtime_arg is runtime

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -10,9 +10,8 @@ from langchain.agents.middleware import InterruptOnConfig
 from langchain.agents.middleware.human_in_the_loop import (
     Action,
     HumanInTheLoopMiddleware,
-    ToolCallReviewRequest,
 )
-from langchain.agents.middleware.types import AgentState
+from langchain.agents.middleware.types import AgentState, ToolCallRequest
 
 
 def _make_request(
@@ -1055,9 +1054,7 @@ def test_per_call_interrupt_payload_is_single_item() -> None:
         interrupt_on={"test_tool": {"allowed_decisions": ["approve"]}},
         interrupt_mode="per_call",
     )
-    handler = MagicMock(
-        return_value=ToolMessage(content="ok", name="test_tool", tool_call_id="1")
-    )
+    handler = MagicMock(return_value=ToolMessage(content="ok", name="test_tool", tool_call_id="1"))
     request = _make_request({"name": "test_tool", "args": {"x": 1}, "id": "1"})
 
     captured: Any = None
@@ -1091,7 +1088,7 @@ def test_when_predicate_batch_skips_interrupt_when_false() -> None:
         interrupt_on={
             "test_tool": InterruptOnConfig(
                 allowed_decisions=["approve"],
-                when=lambda tc, state, runtime: tc["args"].get("risky", False),
+                when=lambda req: req.tool_call["args"].get("risky", False),
             )
         }
     )
@@ -1114,7 +1111,7 @@ def test_when_predicate_batch_fires_interrupt_when_true() -> None:
         interrupt_on={
             "test_tool": InterruptOnConfig(
                 allowed_decisions=["approve"],
-                when=lambda tc, state, runtime: tc["args"].get("risky", False),
+                when=lambda req: req.tool_call["args"].get("risky", False),
             )
         }
     )
@@ -1139,7 +1136,7 @@ def test_when_predicate_per_call_skips_interrupt_when_false() -> None:
         interrupt_on={
             "test_tool": InterruptOnConfig(
                 allowed_decisions=["approve"],
-                when=lambda tc, state, runtime: tc["args"].get("risky", False),
+                when=lambda req: req.tool_call["args"].get("risky", False),
             )
         },
         interrupt_mode="per_call",
@@ -1162,7 +1159,7 @@ def test_when_predicate_per_call_fires_interrupt_when_true() -> None:
         interrupt_on={
             "test_tool": InterruptOnConfig(
                 allowed_decisions=["approve"],
-                when=lambda tc, state, runtime: tc["args"].get("risky", False),
+                when=lambda req: req.tool_call["args"].get("risky", False),
             )
         },
         interrupt_mode="per_call",
@@ -1183,10 +1180,10 @@ def test_when_predicate_per_call_fires_interrupt_when_true() -> None:
 
 def test_when_predicate_receives_correct_args() -> None:
     """The when predicate receives (tool_call, state, runtime) with correct values."""
-    captured_args: list[Any] = []
+    captured: list[Any] = []
 
-    def capture_when(tc: Any, state: Any, runtime: Any) -> bool:
-        captured_args.extend([tc, state, runtime])
+    def capture_when(req: ToolCallRequest) -> bool:
+        captured.append(req)
         return True
 
     middleware = HumanInTheLoopMiddleware(
@@ -1210,8 +1207,9 @@ def test_when_predicate_receives_correct_args() -> None:
     ):
         middleware.after_model(state, runtime)
 
-    tool_call_arg, state_arg, runtime_arg = captured_args
-    assert tool_call_arg["name"] == "test_tool"
-    assert tool_call_arg["args"] == {"val": 42}
-    assert state_arg is state
-    assert runtime_arg is runtime
+    assert len(captured) == 1
+    req = captured[0]
+    assert req.tool_call["name"] == "test_tool"
+    assert req.tool_call["args"] == {"val": 42}
+    assert req.state is state
+    assert req.runtime is runtime

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -1,9 +1,10 @@
 import re
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, ToolCall, ToolMessage
+from langgraph.prebuilt.tool_node import ToolRuntime
 from langgraph.runtime import Runtime
 
 from langchain.agents.middleware import InterruptOnConfig
@@ -12,25 +13,6 @@ from langchain.agents.middleware.human_in_the_loop import (
     HumanInTheLoopMiddleware,
 )
 from langchain.agents.middleware.types import AgentState, ToolCallRequest
-
-
-def _make_request(
-    tool_call: dict[str, Any],
-    state: AgentState[Any] | None = None,
-    runtime: Runtime | None = None,
-) -> MagicMock:
-    """Build a mock ToolCallRequest for wrap_tool_call tests."""
-    req = MagicMock()
-    req.tool_call = tool_call
-    req.state = state or AgentState[Any](messages=[])
-    req.runtime = runtime or Runtime()
-
-    def _override(**kwargs: Any) -> MagicMock:
-        new_tc = kwargs.get("tool_call", tool_call)
-        return _make_request(new_tc, req.state, req.runtime)
-
-    req.override.side_effect = _override
-    return req
 
 
 def test_human_in_the_loop_middleware_initialization() -> None:
@@ -905,180 +887,7 @@ def test_human_in_the_loop_middleware_preserves_order_with_rejections() -> None:
 
 
 # ---------------------------------------------------------------------------
-# interrupt_mode="per_call" — wrap_tool_call behaviour
-# ---------------------------------------------------------------------------
-
-
-def test_per_call_after_model_is_noop() -> None:
-    """after_model returns None in per_call mode regardless of pending tool calls."""
-    middleware = HumanInTheLoopMiddleware(
-        interrupt_on={"test_tool": True},
-        interrupt_mode="per_call",
-    )
-    ai_message = AIMessage(
-        content="...",
-        tool_calls=[{"name": "test_tool", "args": {}, "id": "1"}],
-    )
-    state = AgentState[Any](messages=[HumanMessage(content="Hi"), ai_message])
-    result = middleware.after_model(state, Runtime())
-    assert result is None
-
-
-def test_batch_mode_wrap_tool_call_passthrough() -> None:
-    """wrap_tool_call is a no-op passthrough in batch mode."""
-    middleware = HumanInTheLoopMiddleware(interrupt_on={"test_tool": True})
-    expected = ToolMessage(content="result", name="test_tool", tool_call_id="1")
-    handler = MagicMock(return_value=expected)
-    request = _make_request({"name": "test_tool", "args": {}, "id": "1"})
-
-    with patch("langchain.agents.middleware.human_in_the_loop.interrupt") as mock_interrupt:
-        result = middleware.wrap_tool_call(request, handler)
-        mock_interrupt.assert_not_called()
-
-    handler.assert_called_once_with(request)
-    assert result is expected
-
-
-def test_per_call_approve() -> None:
-    """Approve decision calls the handler unchanged."""
-    middleware = HumanInTheLoopMiddleware(
-        interrupt_on={"test_tool": {"allowed_decisions": ["approve"]}},
-        interrupt_mode="per_call",
-    )
-    expected = ToolMessage(content="ok", name="test_tool", tool_call_id="1")
-    handler = MagicMock(return_value=expected)
-    request = _make_request({"name": "test_tool", "args": {"x": 1}, "id": "1"})
-
-    with patch(
-        "langchain.agents.middleware.human_in_the_loop.interrupt",
-        return_value={"type": "approve"},
-    ):
-        result = middleware.wrap_tool_call(request, handler)
-
-    handler.assert_called_once()
-    assert result is expected
-
-
-def test_per_call_edit() -> None:
-    """Edit decision calls handler with a modified request; original request is not mutated."""
-    middleware = HumanInTheLoopMiddleware(
-        interrupt_on={"test_tool": {"allowed_decisions": ["edit"]}},
-        interrupt_mode="per_call",
-    )
-    expected = ToolMessage(content="ok", name="test_tool", tool_call_id="1")
-    handler = MagicMock(return_value=expected)
-    request = _make_request({"name": "test_tool", "args": {"x": 1}, "id": "1"})
-
-    edit_decision = {
-        "type": "edit",
-        "edited_action": Action(name="test_tool", args={"x": 99}),
-    }
-    with patch(
-        "langchain.agents.middleware.human_in_the_loop.interrupt",
-        return_value=edit_decision,
-    ):
-        result = middleware.wrap_tool_call(request, handler)
-
-    handler.assert_called_once()
-    called_request = handler.call_args[0][0]
-    assert called_request.tool_call["args"] == {"x": 99}
-    assert called_request.tool_call["id"] == "1"
-    assert result is expected
-
-
-def test_per_call_reject() -> None:
-    """Reject decision returns a synthetic error ToolMessage; handler is never called."""
-    middleware = HumanInTheLoopMiddleware(
-        interrupt_on={"test_tool": {"allowed_decisions": ["reject"]}},
-        interrupt_mode="per_call",
-    )
-    handler = MagicMock()
-    request = _make_request({"name": "test_tool", "args": {}, "id": "1"})
-
-    with patch(
-        "langchain.agents.middleware.human_in_the_loop.interrupt",
-        return_value={"type": "reject", "message": "Not allowed"},
-    ):
-        result = middleware.wrap_tool_call(request, handler)
-
-    handler.assert_not_called()
-    assert isinstance(result, ToolMessage)
-    assert result.content == "Not allowed"
-    assert result.status == "error"
-    assert result.tool_call_id == "1"
-
-
-def test_per_call_respond() -> None:
-    """Respond decision returns a synthetic success ToolMessage; handler is never called."""
-    middleware = HumanInTheLoopMiddleware(
-        interrupt_on={"ask_user": {"allowed_decisions": ["respond"]}},
-        interrupt_mode="per_call",
-    )
-    handler = MagicMock()
-    request = _make_request({"name": "ask_user", "args": {"q": "?"}, "id": "1"})
-
-    with patch(
-        "langchain.agents.middleware.human_in_the_loop.interrupt",
-        return_value={"type": "respond", "message": "My answer"},
-    ):
-        result = middleware.wrap_tool_call(request, handler)
-
-    handler.assert_not_called()
-    assert isinstance(result, ToolMessage)
-    assert result.content == "My answer"
-    assert result.status == "success"
-    assert result.tool_call_id == "1"
-
-
-def test_per_call_auto_approve_unknown_tool() -> None:
-    """Tool not in interrupt_on passes straight through without an interrupt."""
-    middleware = HumanInTheLoopMiddleware(
-        interrupt_on={"known_tool": True},
-        interrupt_mode="per_call",
-    )
-    expected = ToolMessage(content="r", name="unknown_tool", tool_call_id="1")
-    handler = MagicMock(return_value=expected)
-    request = _make_request({"name": "unknown_tool", "args": {}, "id": "1"})
-
-    with patch("langchain.agents.middleware.human_in_the_loop.interrupt") as mock_interrupt:
-        result = middleware.wrap_tool_call(request, handler)
-        mock_interrupt.assert_not_called()
-
-    handler.assert_called_once_with(request)
-    assert result is expected
-
-
-def test_per_call_interrupt_payload_is_single_item() -> None:
-    """Interrupt payload is a ToolCallReviewRequest (not a batched HITLRequest)."""
-    middleware = HumanInTheLoopMiddleware(
-        interrupt_on={"test_tool": {"allowed_decisions": ["approve"]}},
-        interrupt_mode="per_call",
-    )
-    handler = MagicMock(return_value=ToolMessage(content="ok", name="test_tool", tool_call_id="1"))
-    request = _make_request({"name": "test_tool", "args": {"x": 1}, "id": "1"})
-
-    captured: Any = None
-
-    def capture(payload: Any) -> Any:
-        nonlocal captured
-        captured = payload
-        return {"type": "approve"}
-
-    with patch("langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=capture):
-        middleware.wrap_tool_call(request, handler)
-
-    assert captured is not None
-    assert "action_request" in captured
-    assert "review_config" in captured
-    assert captured["action_request"]["name"] == "test_tool"
-    assert captured["review_config"]["allowed_decisions"] == ["approve"]
-    # Must NOT look like a batched HITLRequest
-    assert "action_requests" not in captured
-    assert "decisions" not in captured
-
-
-# ---------------------------------------------------------------------------
-# when predicate — batch and per_call modes
+# when predicate
 # ---------------------------------------------------------------------------
 
 
@@ -1098,7 +907,10 @@ def test_when_predicate_batch_skips_interrupt_when_false() -> None:
     )
     state = AgentState[Any](messages=[HumanMessage(content="Hi"), ai_message])
 
-    with patch("langchain.agents.middleware.human_in_the_loop.interrupt") as mock_interrupt:
+    with (
+        patch("langchain.agents.middleware.human_in_the_loop.get_config", return_value={}),
+        patch("langchain.agents.middleware.human_in_the_loop.interrupt") as mock_interrupt,
+    ):
         result = middleware.after_model(state, Runtime())
         mock_interrupt.assert_not_called()
 
@@ -1121,65 +933,20 @@ def test_when_predicate_batch_fires_interrupt_when_true() -> None:
     )
     state = AgentState[Any](messages=[HumanMessage(content="Hi"), ai_message])
 
-    with patch(
-        "langchain.agents.middleware.human_in_the_loop.interrupt",
-        return_value={"decisions": [{"type": "approve"}]},
+    with (
+        patch("langchain.agents.middleware.human_in_the_loop.get_config", return_value={}),
+        patch(
+            "langchain.agents.middleware.human_in_the_loop.interrupt",
+            return_value={"decisions": [{"type": "approve"}]},
+        ),
     ):
         result = middleware.after_model(state, Runtime())
 
     assert result is not None
 
 
-def test_when_predicate_per_call_skips_interrupt_when_false() -> None:
-    """`when` returning False passes the call straight through in per_call mode."""
-    middleware = HumanInTheLoopMiddleware(
-        interrupt_on={
-            "test_tool": InterruptOnConfig(
-                allowed_decisions=["approve"],
-                when=lambda req: req.tool_call["args"].get("risky", False),
-            )
-        },
-        interrupt_mode="per_call",
-    )
-    expected = ToolMessage(content="ok", name="test_tool", tool_call_id="1")
-    handler = MagicMock(return_value=expected)
-    request = _make_request({"name": "test_tool", "args": {"risky": False}, "id": "1"})
-
-    with patch("langchain.agents.middleware.human_in_the_loop.interrupt") as mock_interrupt:
-        result = middleware.wrap_tool_call(request, handler)
-        mock_interrupt.assert_not_called()
-
-    handler.assert_called_once_with(request)
-    assert result is expected
-
-
-def test_when_predicate_per_call_fires_interrupt_when_true() -> None:
-    """`when` returning True triggers the interrupt in per_call mode."""
-    middleware = HumanInTheLoopMiddleware(
-        interrupt_on={
-            "test_tool": InterruptOnConfig(
-                allowed_decisions=["approve"],
-                when=lambda req: req.tool_call["args"].get("risky", False),
-            )
-        },
-        interrupt_mode="per_call",
-    )
-    expected = ToolMessage(content="ok", name="test_tool", tool_call_id="1")
-    handler = MagicMock(return_value=expected)
-    request = _make_request({"name": "test_tool", "args": {"risky": True}, "id": "1"})
-
-    with patch(
-        "langchain.agents.middleware.human_in_the_loop.interrupt",
-        return_value={"type": "approve"},
-    ):
-        result = middleware.wrap_tool_call(request, handler)
-
-    handler.assert_called_once()
-    assert result is expected
-
-
 def test_when_predicate_receives_correct_args() -> None:
-    """The when predicate receives (tool_call, state, runtime) with correct values."""
+    """The when predicate receives a ToolCallRequest with correct values and a ToolRuntime."""
     captured: list[Any] = []
 
     def capture_when(req: ToolCallRequest) -> bool:
@@ -1196,14 +963,17 @@ def test_when_predicate_receives_correct_args() -> None:
     )
     ai_message = AIMessage(
         content="...",
-        tool_calls=[{"name": "test_tool", "args": {"val": 42}, "id": "1"}],
+        tool_calls=[{"name": "test_tool", "args": {"val": 42}, "id": "tc-1"}],
     )
     state = AgentState[Any](messages=[HumanMessage(content="Hi"), ai_message])
     runtime = Runtime()
 
-    with patch(
-        "langchain.agents.middleware.human_in_the_loop.interrupt",
-        return_value={"decisions": [{"type": "approve"}]},
+    with (
+        patch("langchain.agents.middleware.human_in_the_loop.get_config", return_value={}),
+        patch(
+            "langchain.agents.middleware.human_in_the_loop.interrupt",
+            return_value={"decisions": [{"type": "approve"}]},
+        ),
     ):
         middleware.after_model(state, runtime)
 
@@ -1211,5 +981,10 @@ def test_when_predicate_receives_correct_args() -> None:
     req = captured[0]
     assert req.tool_call["name"] == "test_tool"
     assert req.tool_call["args"] == {"val": 42}
+    assert req.tool is None
     assert req.state is state
-    assert req.runtime is runtime
+    assert isinstance(req.runtime, ToolRuntime)
+    assert req.runtime.tool_call_id == "tc-1"
+    assert req.runtime.state is state
+    assert req.runtime.context is runtime.context
+    assert req.runtime.store is runtime.store


### PR DESCRIPTION
Adds an optional `when` predicate to `InterruptOnConfig`, allowing dynamic per-tool-call control over whether a HITL interrupt fires.

---

**`when` predicate in `InterruptOnConfig`**

```python
class InterruptOnConfig(TypedDict):
    allowed_decisions: list[DecisionType]
    description: NotRequired[str | _DescriptionFactory]
    args_schema: NotRequired[dict[str, Any]]
    when: NotRequired[Callable[[ToolCallRequest], bool]]  # new
```

When provided, `when` is called before adding a tool call to the batch interrupt. If it returns `False`, the call is auto-approved and excluded. If it returns `True` (or `when` is absent), existing behaviour is unchanged.

The predicate receives a `ToolCallRequest` with:
- `tool_call` — the raw tool call dict (name, args, id)
- `tool` — `None` (no `BaseTool` instance is available at the `after_model` stage)
- `state` — current agent state
- `runtime` — a `ToolRuntime` constructed from the node-level `Runtime`, with `tool_call_id` populated

Example:

```python
HumanInTheLoopMiddleware(
    interrupt_on={
        "delete_file": InterruptOnConfig(
            allowed_decisions=["approve", "reject"],
            when=lambda req: req.tool_call["args"].get("path", "").startswith("/etc"),
        )
    }
)
```

This change is fully backwards-compatible — `when` is `NotRequired` and existing configs without it behave identically.

> This PR was developed with AI-agent assistance.