### PR TITLE
fix: handle empty metadata in Chroma update_document

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1231,7 +1231,10 @@ class Chroma(VectorStore):
             ValueError: If the embedding function is not provided.
         """
         text = [document.page_content for document in documents]
-        metadata = [document.metadata for document in documents]
+        metadata = [
+            document.metadata if document.metadata else None
+            for document in documents
+        ]
         if self._embedding_function is None:
             msg = "For update, you must specify an embedding function on creation."
             raise ValueError(

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -1,3 +1,4 @@
+from langchain_core.documents import Document
 from langchain_core.embeddings.fake import (
     FakeEmbeddings,
 )
@@ -28,3 +29,31 @@ def test_similarity_search() -> None:
     output = docsearch.similarity_search("foo", k=1)
     docsearch.delete_collection()
     assert len(output) == 1
+
+
+def test_update_document_without_metadata() -> None:
+    """Test that update_document handles documents without explicit metadata.
+
+    Documents created without metadata have metadata={}, which Chroma's
+    update API rejects. The fix normalizes empty metadata to None before
+    passing it to Chroma.
+    """
+    embedding = FakeEmbeddings(size=10)
+    docsearch = Chroma.from_documents(
+        collection_name="test_collection",
+        documents=[Document(page_content="original", metadata={"page": "0"})],
+        embedding=embedding,
+        ids=["doc1"],
+    )
+
+    # Update with a Document that has no explicit metadata
+    # Document(page_content="...") defaults to metadata={}
+    docsearch.update_document(
+        document_id="doc1",
+        document=Document(page_content="updated"),
+    )
+
+    output = docsearch.similarity_search("updated", k=1)
+    docsearch.delete_collection()
+    assert len(output) == 1
+    assert output[0].page_content == "updated"


### PR DESCRIPTION
## What

Normalizes empty/falsy metadata to `None` before passing it to Chroma's `update` API in the `update_documents` method.

## Why

Fixes #37452. When a `Document` is created without explicit metadata, `Document.metadata` defaults to `{}`. Chroma's `update` API rejects empty metadata dicts with:

```
ValueError: Expected metadata to be a non-empty dict, got 0 metadata attributes in update.
```

This creates inconsistent behavior:
- `add_documents()` accepts `Document(page_content="...")` without issue
- `update_document()` rejects the same document unless `metadata={}` is explicitly provided

## How

Changed the metadata list comprehension in `update_documents` from:
```python
metadata = [document.metadata for document in documents]
```
to:
```python
metadata = [
    document.metadata if document.metadata else None
    for document in documents
]
```

Chroma's `validate_metadata()` (in `chromadb/api/types.py:1068`) explicitly skips validation for `None` metadata entries, while rejecting empty dicts. Passing `None` means "don't update metadata for this entry", which is the correct semantic for documents without metadata.

This approach is consistent with how `add_texts` handles empty metadata — it separates documents with metadata from those without, and only passes `metadatas=` to Chroma when there's actual metadata.

## Testing

- Added `test_update_document_without_metadata` that reproduces the exact failure scenario
- All 3 unit tests pass (2 existing + 1 new)

## Checklist
- [x] Follows existing code style
- [x] Tests pass locally
- [x] No breaking changes
- [x] Documentation updated if needed