### PR TITLE
fix(anthropic): decode text/* mime types to inline text instead of base64

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import copy
 import datetime
 import json
@@ -360,14 +362,33 @@ def _format_data_content_block(block: dict) -> dict:
                 },
             }
         elif "base64" in block or block.get("source_type") == "base64":
-            formatted_block = {
-                "type": "document",
-                "source": {
-                    "type": "base64",
-                    "media_type": block.get("mime_type") or "application/pdf",
-                    "data": block.get("base64") or block.get("data", ""),
-                },
-            }
+            mime_type = block.get("mime_type") or "application/pdf"
+            data = block.get("base64") or block.get("data", "")
+            if mime_type.startswith("text/") and mime_type != "application/pdf":
+                try:
+                    text = base64.b64decode(data).decode("utf-8")
+                    formatted_block = {
+                        "type": "document",
+                        "source": {"type": "text", "media_type": "text/plain", "data": text},
+                    }
+                except (binascii.Error, UnicodeDecodeError):
+                    formatted_block = {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": mime_type,
+                            "data": data,
+                        },
+                    }
+            else:
+                formatted_block = {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime_type,
+                        "data": data,
+                    },
+                }
         elif block.get("source_type") == "text":
             formatted_block = {
                 "type": "document",


### PR DESCRIPTION
## Summary

When `ChatAnthropic` receives a `HumanMessage` with a `Document` block using `mime_type: "text/csv"` (or any `text/*` type other than `application/pdf`), it was forwarding the `mime_type` verbatim into the `document.source.base64.media_type` field of the Anthropic API request.

Anthropic's API only accepts `application/pdf` for base64 document sources. For text formats (CSV, TXT, MD, etc.), it requires the content to be decoded to UTF-8 and sent as an inline `text` source document.

## Fix

In `libs/partners/anthropic/langchain_anthropic/chat_models.py`, the `_format_image_document_block()` method now:
1. Detects when `mime_type` starts with `text/` and is not `application/pdf`
2. Decodes the base64 content to UTF-8
3. Emits a `{"type": "document", "source": {"type": "text", "media_type": "text/plain", "data": text}}` block instead of a base64 block
4. Falls back to the original base64 behavior if decoding fails

This matches how `langchain-aws` / Bedrock Converse handles the same content types.

Closes #37576