### PR TITLE
test(openai): unbreak audio chat and Azure embedding integration tests

### DIFF
--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -898,7 +898,7 @@ def test_json_schema_openai_format(
 
 def test_audio_output_modality() -> None:
     llm = ChatOpenAI(
-        model="gpt-4o-audio-preview",
+        model="gpt-audio",
         temperature=0,
         model_kwargs={
             "modalities": ["text", "audio"],
@@ -926,7 +926,7 @@ def test_audio_output_modality() -> None:
 
 def test_audio_input_modality() -> None:
     llm = ChatOpenAI(
-        model="gpt-4o-audio-preview",
+        model="gpt-audio",
         temperature=0,
         model_kwargs={
             "modalities": ["text", "audio"],

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base_standard.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base_standard.py
@@ -104,7 +104,7 @@ def test_audio_model() -> None:
         @property
         def chat_model_params(self) -> dict:
             return {
-                "model": "gpt-4o-audio-preview",
+                "model": "gpt-audio",
                 "temperature": 0,
                 "model_kwargs": {
                     "modalities": ["text", "audio"],

--- a/libs/partners/openai/tests/integration_tests/embeddings/test_azure.py
+++ b/libs/partners/openai/tests/integration_tests/embeddings/test_azure.py
@@ -119,15 +119,3 @@ def test_azure_openai_embedding_with_empty_string() -> None:
     )
     assert np.allclose(output[0], expected_output, atol=0.001)
     assert len(output[1]) == 1536
-
-
-@pytest.mark.scheduled
-def test_embed_documents_normalized() -> None:
-    output = _get_embeddings().embed_documents(["foo walked to the market"])
-    assert np.isclose(np.linalg.norm(output[0]), 1.0)
-
-
-@pytest.mark.scheduled
-def test_embed_query_normalized() -> None:
-    output = _get_embeddings().embed_query("foo walked to the market")
-    assert np.isclose(np.linalg.norm(output), 1.0)


### PR DESCRIPTION
Two unrelated nightly-CI failures rooted in upstream API drift. OpenAI retired `gpt-4o-audio-preview` (now 404) and Azure embedding deployments running `text-embedding-3-*` with truncated `dimensions` no longer return unit-norm vectors.