### PR TITLE
test(standard-tests): allow extra content blocks in streaming assertions

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -853,7 +853,10 @@ class ChatModelIntegrationTests(ChatModelTests):
         assert isinstance(full, AIMessageChunk)
         assert full.content
         assert full.text
-        assert any(block["type"] == "text" for block in full.content_blocks)
+        # Exactly one text block — guards against merge bugs that would produce
+        # multiple adjacent text blocks in the aggregated result.
+        text_blocks = [b for b in full.content_blocks if b["type"] == "text"]
+        assert len(text_blocks) == 1
 
         # Verify chunk_position signaling
         last_chunk = chunks[-1]
@@ -903,7 +906,10 @@ class ChatModelIntegrationTests(ChatModelTests):
         assert isinstance(full, AIMessageChunk)
         assert full.content
         assert full.text
-        assert any(block["type"] == "text" for block in full.content_blocks)
+        # Exactly one text block — guards against merge bugs that would produce
+        # multiple adjacent text blocks in the aggregated result.
+        text_blocks = [b for b in full.content_blocks if b["type"] == "text"]
+        assert len(text_blocks) == 1
 
         # Verify chunk_position signaling
         last_chunk = chunks[-1]

--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -852,8 +852,8 @@ class ChatModelIntegrationTests(ChatModelTests):
         assert len(chunks) > 0
         assert isinstance(full, AIMessageChunk)
         assert full.content
-        assert len(full.content_blocks) == 1
-        assert full.content_blocks[0]["type"] == "text"
+        assert full.text
+        assert any(block["type"] == "text" for block in full.content_blocks)
 
         # Verify chunk_position signaling
         last_chunk = chunks[-1]
@@ -902,8 +902,8 @@ class ChatModelIntegrationTests(ChatModelTests):
         assert len(chunks) > 0
         assert isinstance(full, AIMessageChunk)
         assert full.content
-        assert len(full.content_blocks) == 1
-        assert full.content_blocks[0]["type"] == "text"
+        assert full.text
+        assert any(block["type"] == "text" for block in full.content_blocks)
 
         # Verify chunk_position signaling
         last_chunk = chunks[-1]
@@ -941,8 +941,8 @@ class ChatModelIntegrationTests(ChatModelTests):
         message = stream.output
         assert isinstance(message, AIMessage)
         assert message.content
-        assert len(message.content_blocks) == 1
-        assert message.content_blocks[0]["type"] == "text"
+        assert message.text
+        assert any(block["type"] == "text" for block in message.content_blocks)
         # `stream_events(version="v3")` always assembles content as v1 protocol blocks.
         assert message.response_metadata.get("output_version") == "v1"
 
@@ -972,8 +972,8 @@ class ChatModelIntegrationTests(ChatModelTests):
         message = await stream.output
         assert isinstance(message, AIMessage)
         assert message.content
-        assert len(message.content_blocks) == 1
-        assert message.content_blocks[0]["type"] == "text"
+        assert message.text
+        assert any(block["type"] == "text" for block in message.content_blocks)
         assert message.response_metadata.get("output_version") == "v1"
 
     def test_invoke_with_model_override(self, model: BaseChatModel) -> None:


### PR DESCRIPTION
Reasoning-emitting chat models return `[reasoning, text]` content blocks where vanilla models return `[text]`. The shared streaming integration tests asserted exactly one block, which fails when reasoning blocks are returned when streaming is otherwise correct.

Relaxed to assert text presence without touching the lifecycle, `chunk_position`, or `output_version` checks.