### PR TITLE
fix(anthropic): convert text/* base64 file blocks to text source

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -360,14 +360,39 @@ def _format_data_content_block(block: dict) -> dict:
                 },
             }
         elif "base64" in block or block.get("source_type") == "base64":
-            formatted_block = {
-                "type": "document",
-                "source": {
-                    "type": "base64",
-                    "media_type": block.get("mime_type") or "application/pdf",
-                    "data": block.get("base64") or block.get("data", ""),
-                },
-            }
+            mime_type = block.get("mime_type") or "application/pdf"
+            data = block.get("base64") or block.get("data", "")
+            if mime_type.startswith("text/") and mime_type != "application/pdf":
+                try:
+                    import base64 as b64mod
+
+                    text = b64mod.b64decode(data).decode("utf-8")
+                    formatted_block = {
+                        "type": "document",
+                        "source": {
+                            "type": "text",
+                            "media_type": "text/plain",
+                            "data": text,
+                        },
+                    }
+                except (ValueError, UnicodeDecodeError):
+                    formatted_block = {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": mime_type,
+                            "data": data,
+                        },
+                    }
+            else:
+                formatted_block = {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime_type,
+                        "data": data,
+                    },
+                }
         elif block.get("source_type") == "text":
             formatted_block = {
                 "type": "document",


### PR DESCRIPTION
Closes #37576

---

When a file block with base64 data has a text/* mime type (e.g. `text/csv`, `text/plain`), decode the base64 and use a text-source document block instead of forwarding it as base64. This is required because the Anthropic Messages API only accepts `application/pdf` for base64 document source.

**Changes:**
- In `convert_to_anthropic_blocks`, check the mime type of base64 file blocks
- If `text/*` (and not PDF), decode to UTF-8 and emit a `text`-source document block
- Falls back to base64 on decode errors
- PDF behavior unchanged

**Why:** Previously, any non-PDF text mime type (e.g. `text/csv`) was forwarded verbatim as `document.source.base64.media_type`, which Anthropic's API rejects with a 400 error. The correct approach per Anthropic's docs is to convert non-PDF text formats to plain text and inline them.