### PR TITLE
fix(anthropic): avoid mutating caller's tool_choice dict in bind_tools

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1822,7 +1822,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = dict(tool_choice)
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1398,6 +1398,28 @@ def test_anthropic_bind_tools_tool_choice() -> None:
     }
 
 
+def test_bind_tools_does_not_mutate_tool_choice_dict() -> None:
+    """Test that bind_tools does not mutate the caller's tool_choice dict."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    tool_choice = {"type": "tool", "name": "GetWeather"}
+    chat_model_with_tools = chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=tool_choice,
+        parallel_tool_calls=False,
+    )
+    # Original dict should not be mutated
+    assert tool_choice == {"type": "tool", "name": "GetWeather"}
+    # But the bound tools should have disable_parallel_tool_use
+    assert cast("RunnableBinding", chat_model_with_tools).kwargs["tool_choice"] == {
+        "type": "tool",
+        "name": "GetWeather",
+        "disable_parallel_tool_use": True,
+    }
+
+
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""
     # Test with betas parameter at initialization


### PR DESCRIPTION
Closes #37596

---

When ChatAnthropic.bind_tools receives tool_choice as a dict and parallel_tool_calls=False, it was storing the caller-provided dict directly in kwargs["tool_choice"], then adding disable_parallel_tool_use to it. This mutated the original dict passed by the caller.

Fix by making a shallow copy of the tool_choice dict before modifying it.

- libs/partners/anthropic/langchain_anthropic/chat_models.py: Changed kwargs["tool_choice"] = tool_choice to kwargs["tool_choice"] = dict(tool_choice) to avoid mutating the callers dict.
- libs/partners/anthropic/tests/unit_tests/test_chat_models.py: Added test_bind_tools_does_not_mutate_tool_choice_dict to verify the fix.