### PR TITLE
fix(anthropic): decode text/* base64 file blocks to inline text

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import copy
 import datetime
 import json
@@ -360,14 +361,30 @@ def _format_data_content_block(block: dict) -> dict:
                 },
             }
         elif "base64" in block or block.get("source_type") == "base64":
-            formatted_block = {
-                "type": "document",
-                "source": {
-                    "type": "base64",
-                    "media_type": block.get("mime_type") or "application/pdf",
-                    "data": block.get("base64") or block.get("data", ""),
-                },
-            }
+            mime_type = block.get("mime_type") or "application/pdf"
+            base64_data = block.get("base64") or block.get("data", "")
+            # For text/* mime types (but not application/pdf), decode the base64
+            # and send as inline text since Anthropic only accepts application/pdf
+            # for base64-encoded documents.
+            if mime_type.startswith("text/") and mime_type != "application/pdf":
+                decoded_data = base64.b64decode(base64_data).decode("utf-8")
+                formatted_block = {
+                    "type": "document",
+                    "source": {
+                        "type": "text",
+                        "media_type": mime_type,
+                        "data": decoded_data,
+                    },
+                }
+            else:
+                formatted_block = {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime_type,
+                        "data": base64_data,
+                    },
+                }
         elif block.get("source_type") == "text":
             formatted_block = {
                 "type": "document",

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1239,6 +1239,128 @@ def test__format_messages_with_citations() -> None:
     assert actual_messages == expected_messages
 
 
+def test__format_messages_with_text_base64_file_blocks() -> None:
+    """Test that text/* mime type base64 file blocks are decoded to inline text.
+
+    See https://github.com/langchain-ai/langchain/issues/37576
+    Anthropic only accepts application/pdf for base64-encoded documents.
+    For text/* mime types, the content should be decoded and sent as
+    source.type="text" instead of source.type="base64".
+    """
+    import base64
+
+    # Test text/csv with base64 encoding
+    csv_content = "name,age\nAlice,30\nBob,25"
+    csv_base64 = base64.b64encode(csv_content.encode("utf-8")).decode("utf-8")
+
+    messages = [
+        HumanMessage(
+            content=[
+                {
+                    "type": "text",
+                    "text": "Analyze this CSV data:",
+                },
+                {
+                    "type": "file",
+                    "source_type": "base64",
+                    "mime_type": "text/csv",
+                    "data": csv_base64,
+                },
+            ],
+        ),
+    ]
+    expected_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Analyze this CSV data:",
+                },
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "text",
+                        "media_type": "text/csv",
+                        "data": csv_content,
+                    },
+                },
+            ],
+        },
+    ]
+    actual_system, actual_messages = _format_messages(messages)
+    assert actual_system is None
+    assert actual_messages == expected_messages
+
+    # Test text/plain with base64 encoding
+    plain_content = "This is plain text content."
+    plain_base64 = base64.b64encode(plain_content.encode("utf-8")).decode("utf-8")
+
+    messages = [
+        HumanMessage(
+            content=[
+                {
+                    "type": "file",
+                    "mime_type": "text/plain",
+                    "base64": plain_base64,
+                },
+            ],
+        ),
+    ]
+    expected_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "text",
+                        "media_type": "text/plain",
+                        "data": plain_content,
+                    },
+                },
+            ],
+        },
+    ]
+    actual_system, actual_messages = _format_messages(messages)
+    assert actual_system is None
+    assert actual_messages == expected_messages
+
+    # Test that application/pdf still uses base64 (should NOT be decoded)
+    pdf_content = "dummy pdf content"
+    pdf_base64 = base64.b64encode(pdf_content.encode("utf-8")).decode("utf-8")
+
+    messages = [
+        HumanMessage(
+            content=[
+                {
+                    "type": "file",
+                    "mime_type": "application/pdf",
+                    "base64": pdf_base64,
+                },
+            ],
+        ),
+    ]
+    expected_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": "application/pdf",
+                        "data": pdf_base64,
+                    },
+                },
+            ],
+        },
+    ]
+    actual_system, actual_messages = _format_messages(messages)
+    assert actual_system is None
+    assert actual_messages == expected_messages
+
+
 def test__format_messages_openai_image_format() -> None:
     message = HumanMessage(
         content=[


### PR DESCRIPTION
Closes #37576

---

Anthropic only accepts `application/pdf` for base64-encoded document sources. For `text/*` mime types (e.g., `text/csv`, `text/plain`), the base64 data should be decoded and sent as an inline text source instead.

This changes the `_format_data_content_block` function to detect `text/*` mime types and decode the base64 data to UTF-8, then format as `source.type='text'` instead of `source.type='base64'`.

---

**Note:** This contribution was generated with AI agent assistance.