### PR TITLE
fix(deepseek): preserve `reasoning_content` in request payload

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -267,9 +267,16 @@ class ChatDeepSeek(BaseChatOpenAI):
         *,
         stop: list[str] | None = None,
         **kwargs: Any,
-    ) -> dict:
+    ) -> dict[str, Any]:
+        messages = self._convert_input(input_).to_messages()
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
-        for message in payload["messages"]:
+        payload_messages = payload["messages"]
+        for source, message in zip(messages, payload_messages, strict=True):
+            if isinstance(source, AIMessage):
+                reasoning_content = source.additional_kwargs.get("reasoning_content")
+                if isinstance(reasoning_content, str) and reasoning_content:
+                    message["reasoning_content"] = reasoning_content
+
             if message["role"] == "tool" and isinstance(message["content"], list):
                 message["content"] = json.dumps(message["content"])
             elif message["role"] == "assistant" and isinstance(

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal
 from unittest.mock import MagicMock
 
-from langchain_core.messages import AIMessageChunk, ToolMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
 from openai import BaseModel
 from openai.types.chat import ChatCompletionMessage
@@ -252,6 +252,43 @@ class TestChatDeepSeekCustomUnit:
         tool_message = ToolMessage(content="test string", tool_call_id="test_id")
         payload = chat_model._get_request_payload([tool_message])
         assert payload["messages"][0]["content"] == "test string"
+
+    def test_get_request_payload_includes_reasoning_content(self) -> None:
+        """Test that `AIMessage` reasoning content is included in the payload."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+        messages = [
+            HumanMessage(content="What is the weather?"),
+            AIMessage(
+                content="",
+                additional_kwargs={"reasoning_content": "I should call a tool."},
+                tool_calls=[
+                    {
+                        "name": "GetWeather",
+                        "args": {"location": "San Francisco, CA"},
+                        "id": "call_1",
+                    },
+                ],
+            ),
+            ToolMessage(content="sunny", tool_call_id="call_1"),
+        ]
+
+        payload = chat_model._get_request_payload(messages)
+
+        assert payload["messages"][1]["role"] == "assistant"
+        assert payload["messages"][1]["reasoning_content"] == "I should call a tool."
+
+    def test_get_request_payload_ignores_invalid_reasoning_content(self) -> None:
+        """Test that empty or non-string reasoning content is not included."""
+        chat_model = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("api_key"))
+        messages = [
+            AIMessage(content="", additional_kwargs={"reasoning_content": ""}),
+            AIMessage(content="", additional_kwargs={"reasoning_content": 1}),
+        ]
+
+        payload = chat_model._get_request_payload(messages)
+
+        assert "reasoning_content" not in payload["messages"][0]
+        assert "reasoning_content" not in payload["messages"][1]
 
 
 class SampleTool(PydanticBaseModel):


### PR DESCRIPTION
Fixes #34166

Preserve DeepSeek `reasoning_content` when building follow-up request payloads from `AIMessage`. This keeps reasoning/tool-call conversations from dropping the model's reasoning field.

Verified with: `uv run --group test pytest tests/unit_tests/test_chat_models.py -q`

Also verified in my own project with a real DeepSeek reasoning/tool-call conversation.