### PR TITLE
anthropic: decode base64 text file blocks

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -7,6 +7,8 @@ import datetime
 import json
 import re
 import warnings
+from base64 import b64decode
+from binascii import Error as BinasciiError
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from functools import cached_property
 from operator import itemgetter
@@ -360,14 +362,36 @@ def _format_data_content_block(block: dict) -> dict:
                 },
             }
         elif "base64" in block or block.get("source_type") == "base64":
-            formatted_block = {
-                "type": "document",
-                "source": {
-                    "type": "base64",
-                    "media_type": block.get("mime_type") or "application/pdf",
-                    "data": block.get("base64") or block.get("data", ""),
-                },
-            }
+            media_type = block.get("mime_type") or "application/pdf"
+            data = block.get("base64") or block.get("data", "")
+            if media_type.startswith("text/"):
+                try:
+                    formatted_block = {
+                        "type": "document",
+                        "source": {
+                            "type": "text",
+                            "media_type": "text/plain",
+                            "data": b64decode(data, validate=True).decode("utf-8"),
+                        },
+                    }
+                except (BinasciiError, UnicodeDecodeError):
+                    formatted_block = {
+                        "type": "document",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": data,
+                        },
+                    }
+            else:
+                formatted_block = {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": media_type,
+                        "data": data,
+                    },
+                }
         elif block.get("source_type") == "text":
             formatted_block = {
                 "type": "document",

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1106,6 +1106,47 @@ def test__format_messages_with_cache_control() -> None:
     ]
     assert actual_messages == expected_messages
 
+    # Test base64 text documents are decoded to Anthropic text-source documents.
+    messages = [
+        HumanMessage(
+            [
+                {
+                    "type": "text",
+                    "text": "Summarize this document:",
+                },
+                {
+                    "type": "file",
+                    "mime_type": "text/csv",
+                    "base64": "YSxiLGMKMSwyLDMK",
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+        ),
+    ]
+    actual_system, actual_messages = _format_messages(messages)
+    assert actual_system is None
+    expected_messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Summarize this document:",
+                },
+                {
+                    "type": "document",
+                    "source": {
+                        "type": "text",
+                        "media_type": "text/plain",
+                        "data": "a,b,c\n1,2,3\n",
+                    },
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+        },
+    ]
+    assert actual_messages == expected_messages
+
     # Also test file inputs
     ## Images
     for block in [


### PR DESCRIPTION
## Summary
- Convert base64 `type: "file"` blocks with `text/*` MIME types into Anthropic text-source document blocks.
- Keep PDF and other non-text base64 file behavior unchanged.
- Add a regression test for a base64 `text/csv` file block.

Fixes #37576.

## Testing
- `uv run --group test pytest tests/unit_tests/test_chat_models.py -k 'format_messages_with_cache_control or format_messages_with_citations' -q`
- `uv run --group lint ruff check langchain_anthropic/chat_models.py tests/unit_tests/test_chat_models.py`
