### PR TITLE
fix(anthropic): handle text file base64 blocks

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import copy
 import datetime
 import json
@@ -356,14 +357,26 @@ def _format_data_content_block(block: dict) -> dict:
                 },
             }
         elif "base64" in block or block.get("source_type") == "base64":
-            formatted_block = {
-                "type": "document",
-                "source": {
-                    "type": "base64",
-                    "media_type": block.get("mime_type") or "application/pdf",
-                    "data": block.get("base64") or block.get("data", ""),
-                },
-            }
+            media_type = block.get("mime_type") or "application/pdf"
+            data = block.get("base64") or block.get("data", "")
+            if media_type.startswith("text/"):
+                formatted_block = {
+                    "type": "document",
+                    "source": {
+                        "type": "text",
+                        "media_type": "text/plain",
+                        "data": base64.b64decode(data).decode("utf-8"),
+                    },
+                }
+            else:
+                formatted_block = {
+                    "type": "document",
+                    "source": {
+                        "type": "base64",
+                        "media_type": media_type,
+                        "data": data,
+                    },
+                }
         elif block.get("source_type") == "text":
             formatted_block = {
                 "type": "document",

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1191,6 +1191,28 @@ def test__format_messages_with_cache_control() -> None:
         assert actual_messages == expected_messages
 
 
+def test__format_messages_with_text_file_base64() -> None:
+    messages = [
+        HumanMessage(
+            [
+                {"type": "text", "text": "Summarize this document:"},
+                {"type": "file", "mime_type": "text/csv", "base64": "YSxiLGMKMSwyLDMK"},
+            ],
+        ),
+    ]
+
+    _, actual_messages = _format_messages(messages)
+
+    assert actual_messages[0]["content"][1] == {
+        "type": "document",
+        "source": {
+            "type": "text",
+            "media_type": "text/plain",
+            "data": "a,b,c\n1,2,3\n",
+        },
+    }
+
+
 def test__format_messages_with_citations() -> None:
     input_messages = [
         HumanMessage(


### PR DESCRIPTION
Decode standard text/* file blocks with base64 payloads into Anthropic text document sources instead of forwarding unsupported non-PDF media types as base64 documents. Adds a focused formatter regression test for text/csv input.

Fixes #37576

Verification:
- `uv run --group test pytest tests/unit_tests/test_chat_models.py -k 'format_messages_with_text_file_base64 or format_messages_with_cache_control' -q`
- `make format`
- `make lint`
- `make test`

This PR was prepared with AI assistance.
