### PR TITLE
fix(core): add float support to merge_dicts and merge_obj

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,7 +68,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to
@@ -201,6 +201,8 @@ def merge_obj(left: Any, right: Any) -> Any:
         return merge_lists(left, right)
     if left == right:
         return left
+    if isinstance(left, (int, float)):
+        return left + right
     msg = (
         f"Unable to merge {left=} and {right=}. Both must be of type str, dict, or "
         f"list, or else be two equal objects."

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,10 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # Float fields should be summed (e.g., logprobs, scores, costs)
+        ({"score": 0.5}, {"score": 0.3}, {"score": 0.8}),
+        ({"logprob": -1.2}, {"logprob": -0.5}, {"logprob": -1.7}),
+        ({"cost": 0.0}, {"cost": 0.001}, {"cost": 0.001}),
     ],
 )
 def test_merge_dicts(
@@ -478,6 +482,10 @@ def test_merge_lists_all_none() -> None:
         (42, 42, 42),
         (3.14, 3.14, 3.14),
         (True, True, True),
+        # Unequal numeric values should be summed
+        (10, 5, 15),
+        (0.5, 0.3, 0.8),
+        (-1.2, -0.5, -1.7),
     ],
 )
 def test_merge_obj(left: Any, right: Any, expected: Any) -> None:
@@ -494,10 +502,4 @@ def test_merge_obj_type_mismatch() -> None:
 def test_merge_obj_unmergeable_values() -> None:
     """Test `merge_obj` raises `ValueError` on unmergeable values."""
     with pytest.raises(ValueError, match="Unable to merge"):
-        merge_obj(1, 2)  # Different integers
-
-
-def test_merge_obj_tuple_raises() -> None:
-    """Test `merge_obj` raises `ValueError` for tuples."""
-    with pytest.raises(ValueError, match="Unable to merge"):
-        merge_obj((1, 2), (3, 4))
+        merge_obj((1, 2), (3, 4))  # Tuples are not supported


### PR DESCRIPTION
## Description

Fixes #31437

`merge_dicts()` handles `str`, `dict`, `list`, equal values, and `int` types — but not `float`. When two dicts contain the same key with unequal float values, the function falls through to the final `else` branch and raises a `TypeError`.

This affects streaming scenarios where LLM providers return float fields in `generation_info` or `additional_kwargs` (e.g., `logprob`, `score`, safety scores, cost fields). During chunk aggregation via `ChatGenerationChunk.__add__()` → `merge_dicts()`, these float fields cause the stream to crash.

Additionally, `merge_obj()` had the same gap — it didn't handle numeric types (`int` or `float`) for merging, despite `merge_dicts()` already supporting `int` since PR #16605.

## Changes

### `langchain_core/utils/_merge.py`
- `merge_dicts()`: changed `isinstance(merged[right_k], int)` to `isinstance(merged[right_k], (int, float))`
- `merge_obj()`: added `(int, float)` handling to sum numeric values instead of raising `ValueError`

### `tests/unit_tests/utils/test_utils.py`
- Added regression tests for float values in `merge_dicts` (score, logprob, cost)
- Added regression tests for numeric merging in `merge_obj`
- Updated `test_merge_obj_unmergeable_values` since `merge_obj(1, 2)` now correctly returns `3`

## Before / After

```python
from langchain_core.utils._merge import merge_dicts, merge_obj

# BEFORE
merge_dicts({"score": 0.5}, {"score": 0.3})  # ❌ TypeError
merge_obj(0.5, 0.3)                           # ❌ ValueError
merge_obj(1, 2)                               # ❌ ValueError

# AFTER
merge_dicts({"score": 0.5}, {"score": 0.3})  # ✅ {"score": 0.8}
merge_obj(0.5, 0.3)                           # ✅ 0.8
merge_obj(1, 2)                               # ✅ 3