### PR TITLE
fix(anthropic): copy `tool_choice` dict in `bind_tools` to avoid mutating caller input

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1822,7 +1822,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1398,6 +1398,30 @@ def test_anthropic_bind_tools_tool_choice() -> None:
     }
 
 
+def test_anthropic_bind_tools_does_not_mutate_tool_choice_dict() -> None:
+    """bind_tools must not mutate a caller-provided tool_choice dict.
+
+    When parallel_tool_calls is set, the method previously added
+    disable_parallel_tool_use directly onto the caller's dict object.
+    After the fix, a copy is made so the original remains unchanged.
+    """
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    tool_choice = {"type": "tool", "name": "GetWeather"}
+    original = tool_choice.copy()
+
+    chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=tool_choice,
+        parallel_tool_calls=False,
+    )
+
+    # The caller-provided dict must be unmodified.
+    assert tool_choice == original
+
+
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""
     # Test with betas parameter at initialization


### PR DESCRIPTION
Closes #37596

---

`ChatAnthropic.bind_tools` accepted a caller-provided `tool_choice` dict and stored a direct reference to it in `kwargs["tool_choice"]`. When `parallel_tool_calls` was also set, the method added `disable_parallel_tool_use` directly onto that same object, mutating the dict the caller originally passed in.

This meant that reusing the same `tool_choice` dict across multiple `bind_tools` calls could silently carry over `disable_parallel_tool_use` from a previous call — a subtle, hard-to-debug side effect.

The fix is a single `.copy()` call when storing the dict, so the method works on its own copy and leaves the caller's object untouched. A focused unit test covering the no-mutation behaviour is also added.