### PR TITLE
chore(infra): bump `langchain-tests` floor to 1.1.9

### DIFF
--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "blockbuster>=1.5.18,<1.6.0",
     "numpy>=1.26.4; python_version<'3.13'",
     "numpy>=2.1.0; python_version>='3.13'",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
     "pytest-benchmark",
     "pytest-codspeed",
 ]

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -84,7 +84,7 @@ test = [
     "requests-mock>=1.11.0,<2.0.0",
     "toml>=0.10.2,<1.0.0",
     "packaging>=24.2.0,<27.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
     "langchain-core>=1.4.0,<2.0.0",
     "langchain-text-splitters>=1.0.0,<2.0.0",
     "langchain-openai",

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "syrupy>=5.0.0,<6.0.0",
     "toml>=0.10.2,<1.0.0",
     "blockbuster>=1.5.26,<1.6.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
     "langchain-openai",
 ]
 lint = [

--- a/libs/partners/Makefile
+++ b/libs/partners/Makefile
@@ -1,0 +1,20 @@
+# Makefile for libs/partners/ directory
+# Contains targets that operate across all partner packages
+
+PARTNER_DIRS = anthropic chroma deepseek exa fireworks groq huggingface mistralai nomic ollama openai openrouter perplexity qdrant xai
+
+.PHONY: lock check-lock
+
+# Regenerate lockfiles for all partner packages
+lock:
+	@for dir in $(PARTNER_DIRS); do \
+		echo "=== Locking $$dir ==="; \
+		(cd $$dir && uv lock); \
+	done
+
+# Verify all lockfiles are up-to-date
+check-lock:
+	@for dir in $(PARTNER_DIRS); do \
+		echo "=== Checking $$dir ==="; \
+		(cd $$dir && uv lock --check) || exit 1; \
+	done

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -55,7 +55,7 @@ test = [
     "vcrpy>=8.0.0,<9.0.0",
     "langgraph-prebuilt>=0.7.0a2",  # set explicitly until we have a stable version
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
     "langchain>=1.0.0,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -734,7 +734,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/chroma/pyproject.toml
+++ b/libs/partners/chroma/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     "freezegun>=1.2.2,<2.0.0",
     "syrupy>=5.0.0,<6.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 test_integration = []
 lint = [

--- a/libs/partners/chroma/uv.lock
+++ b/libs/partners/chroma/uv.lock
@@ -898,7 +898,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/deepseek/pyproject.toml
+++ b/libs/partners/deepseek/pyproject.toml
@@ -45,7 +45,7 @@ test = [
     "pytest-watcher>=0.3.4,<1.0.0",
     "pytest-timeout>=2.3.1,<3.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
     "langchain-openai",
 ]
 test_integration = []

--- a/libs/partners/deepseek/uv.lock
+++ b/libs/partners/deepseek/uv.lock
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/exa/pyproject.toml
+++ b/libs/partners/exa/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "freezegun>=1.2.2,<2.0.0",
     "syrupy>=5.0.0,<6.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
 dev = ["langchain-core>=1.4.0,<2.0.0"]

--- a/libs/partners/exa/uv.lock
+++ b/libs/partners/exa/uv.lock
@@ -551,7 +551,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/fireworks/pyproject.toml
+++ b/libs/partners/fireworks/pyproject.toml
@@ -52,7 +52,7 @@ test = [
     "pytest-socket>=0.7.0,<1.0.0",
     "pytest-xdist>=3.8.0,<4.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]

--- a/libs/partners/fireworks/uv.lock
+++ b/libs/partners/fireworks/uv.lock
@@ -836,7 +836,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/groq/pyproject.toml
+++ b/libs/partners/groq/pyproject.toml
@@ -46,7 +46,7 @@ test = [
     "pytest-retry>=1.7.0,<1.8.0",
     "pytest-xdist>=3.6.1,<4.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
 dev = ["langchain-core>=1.4.0,<2.0.0"]

--- a/libs/partners/groq/uv.lock
+++ b/libs/partners/groq/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/huggingface/pyproject.toml
+++ b/libs/partners/huggingface/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "transformers>=5.0.0,<6.0.0",
     "sentence-transformers>=5.2.0,<6.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
     "langchain-community",
     "langchain>=1.0.0,<2.0.0",
 ]

--- a/libs/partners/huggingface/uv.lock
+++ b/libs/partners/huggingface/uv.lock
@@ -1209,7 +1209,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/mistralai/pyproject.toml
+++ b/libs/partners/mistralai/pyproject.toml
@@ -48,7 +48,7 @@ test = [
     "pytest-watcher>=0.3.4,<1.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]

--- a/libs/partners/mistralai/uv.lock
+++ b/libs/partners/mistralai/uv.lock
@@ -504,7 +504,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/nomic/pyproject.toml
+++ b/libs/partners/nomic/pyproject.toml
@@ -48,7 +48,7 @@ test = [
     "freezegun>=1.2.2,<2.0.0",
     "syrupy>=5.0.0,<6.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]

--- a/libs/partners/nomic/uv.lock
+++ b/libs/partners/nomic/uv.lock
@@ -519,7 +519,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/ollama/pyproject.toml
+++ b/libs/partners/ollama/pyproject.toml
@@ -46,7 +46,7 @@ test = [
     "pytest-xdist>=3.6.1,<4.0.0",
     "syrupy>=5.0.0,<6.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]

--- a/libs/partners/ollama/uv.lock
+++ b/libs/partners/ollama/uv.lock
@@ -439,7 +439,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -55,7 +55,7 @@ test = [
     "numpy>=2.1.0; python_version>='3.13'",
     "langchain>=1.0.0,<2.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
 dev = ["langchain-core>=1.4.0,<2.0.0"]

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -785,7 +785,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/openrouter/pyproject.toml
+++ b/libs/partners/openrouter/pyproject.toml
@@ -45,7 +45,7 @@ test = [
     "pytest-watcher>=0.6.3,<1.0.0",
     "pytest-timeout>=2.4.0,<3.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.15.0,<0.16.0"]

--- a/libs/partners/openrouter/uv.lock
+++ b/libs/partners/openrouter/uv.lock
@@ -470,7 +470,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/perplexity/pyproject.toml
+++ b/libs/partners/perplexity/pyproject.toml
@@ -50,7 +50,7 @@ test = [
     "pytest-socket>=0.6.0,<1.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 lint = ["ruff>=0.13.1,<0.14.0"]
 dev = ["langchain-core>=1.4.0,<2.0.0"]

--- a/libs/partners/perplexity/uv.lock
+++ b/libs/partners/perplexity/uv.lock
@@ -581,7 +581,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/qdrant/pyproject.toml
+++ b/libs/partners/qdrant/pyproject.toml
@@ -55,7 +55,7 @@ test = [
     "syrupy>=5.0.0,<6.0.0",
     "requests>=2.31.0,<3.0.0",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]

--- a/libs/partners/qdrant/uv.lock
+++ b/libs/partners/qdrant/uv.lock
@@ -677,7 +677,7 @@ typing = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },

--- a/libs/partners/xai/pyproject.toml
+++ b/libs/partners/xai/pyproject.toml
@@ -52,7 +52,7 @@ test = [
     "syrupy>=5.0.0,<6.0.0",
     "langchain-openai",
     "langchain-core>=1.4.0,<2.0.0",
-    "langchain-tests>=1.0.0,<2.0.0",
+    "langchain-tests>=1.1.9,<2.0.0",
 ]
 test_integration = []
 lint = ["ruff>=0.13.1,<0.14.0"]

--- a/libs/partners/xai/uv.lock
+++ b/libs/partners/xai/uv.lock
@@ -800,7 +800,7 @@ wheels = [
 
 [[package]]
 name = "langchain-tests"
-version = "1.1.8"
+version = "1.1.9"
 source = { editable = "../../standard-tests" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bumps the `langchain-tests` minimum across the monorepo from `1.0.0` to `1.1.9` and adds a partner-level `Makefile` so partner lockfiles can be regenerated in one command, matching the existing convention under `libs/`.