### PR TITLE
fix(anthropic): copy tool_choice dict in bind_tools to prevent caller mutation

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1859,9 +1859,10 @@ class ChatAnthropic(BaseChatModel):
         if parallel_tool_calls is not None:
             disable_parallel_tool_use = not parallel_tool_calls
             if "tool_choice" in kwargs:
-                kwargs["tool_choice"]["disable_parallel_tool_use"] = (
-                    disable_parallel_tool_use
-                )
+                kwargs["tool_choice"] = {
+                    **kwargs["tool_choice"],
+                    "disable_parallel_tool_use": disable_parallel_tool_use,
+                }
             else:
                 kwargs["tool_choice"] = {
                     "type": "auto",

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2966,6 +2966,25 @@ def test_bind_tools_keeps_forced_tool_choice_when_thinking_disabled() -> None:
     result = chat_model_disabled.bind_tools([GetWeather], tool_choice="any")
     assert cast("RunnableBinding", result).kwargs["tool_choice"] == {"type": "any"}
 
+def test_bind_tools_does_not_mutate_tool_choice_dict() -> None:
+    """bind_tools should not mutate a caller-provided tool_choice dict."""
+    chat_model = ChatAnthropic(
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    tool_choice = {"type": "tool", "name": "GetWeather"}
+    original = dict(tool_choice)
+
+    chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=tool_choice,
+        parallel_tool_calls=False,
+    )
+
+    assert tool_choice == original, (
+        f"bind_tools mutated caller-provided tool_choice: {tool_choice}"
+    )
+
 
 def test_thinking_in_params_recognizes_adaptive() -> None:
     """_thinking_in_params should recognize both enabled and adaptive types."""


### PR DESCRIPTION
Fixes #37596

## Problem
When `bind_tools` receives a `tool_choice` dict and `parallel_tool_calls` is set,
it was directly mutating the caller-provided dict by adding `disable_parallel_tool_use` to it.

This causes unexpected behavior when the same dict is reused across multiple calls —
the `disable_parallel_tool_use` key leaks into subsequent calls silently.

## Fix
Copy the `tool_choice` dict before adding `disable_parallel_tool_use`, using dict unpacking:

```python
kwargs["tool_choice"] = {
    **kwargs["tool_choice"],
    "disable_parallel_tool_use": disable_parallel_tool_use,
}
```

## Tests
Added `test_bind_tools_does_not_mutate_tool_choice_dict` to verify the caller's
original dict is not modified after calling `bind_tools`.