### PR TITLE
fix(standard-tests): recognize parametrize-nested xfails in override check

### DIFF
--- a/libs/standard-tests/langchain_tests/base.py
+++ b/libs/standard-tests/langchain_tests/base.py
@@ -46,10 +46,18 @@ class BaseStandardTests:
             m = getattr(self.__class__, method)
             if not hasattr(m, "pytestmark"):
                 return False
-            marks = m.pytestmark
-            return any(
-                mark.name == "xfail" and mark.kwargs.get("reason") for mark in marks
-            )
+            for mark in m.pytestmark:
+                if mark.name == "xfail" and mark.kwargs.get("reason"):
+                    return True
+                # Also accept xfail marks on individual `pytest.param` entries
+                # within a `parametrize` - supports xfailing only a subset of
+                # parametrized cases.
+                if mark.name == "parametrize" and len(mark.args) >= 2:
+                    for param in mark.args[1]:
+                        for inner in getattr(param, "marks", ()):
+                            if inner.name == "xfail" and inner.kwargs.get("reason"):
+                                return True
+            return False
 
         overridden_not_xfail = [
             method for method in overridden_tests if not is_xfail(method)


### PR DESCRIPTION
`test_no_overrides_DO_NOT_OVERRIDE` only treated an override as valid when the method itself carried an `@pytest.mark.xfail(reason=...)`. Overrides that re-parametrize a standard test and xfail only a subset of cases via `pytest.param(..., marks=pytest.mark.xfail(...))` were rejected.