### PR TITLE
fix(langchain): replace stale `ToolConfig` with `InterruptOnConfig` in docstring

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -152,7 +152,7 @@ class InterruptOnConfig(TypedDict):
     Example:
         ```python
         # Static string description
-        config = ToolConfig(
+        config = InterruptOnConfig(
             allowed_decisions=["approve", "reject"],
             description="Please review this tool execution"
         )


### PR DESCRIPTION
The `HumanInTheLoopMiddleware` docstring contains two example blocks. The first references `ToolConfig`, which is not defined anywhere in the package; the second (a few lines below) already uses the correct `InterruptOnConfig`. A user copy-pasting the first example would hit `NameError: name 'ToolConfig' is not defined`.

This looks like a stale name left behind during a rename. The fix swaps `ToolConfig` → `InterruptOnConfig` so both example blocks reference the actual class defined on the same module.

`grep -rn ToolConfig libs/langchain_v1/` confirms the only occurrence is this docstring.

> Note: this contribution was prepared with AI assistance.