### PR TITLE
fix: implement async _aget_relevant_documents for RePhraseQueryRetriever

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/re_phraser.py
+++ b/libs/langchain/langchain_classic/retrievers/re_phraser.py
@@ -89,4 +89,12 @@ class RePhraseQueryRetriever(BaseRetriever):
         *,
         run_manager: AsyncCallbackManagerForRetrieverRun,
     ) -> list[Document]:
-        raise NotImplementedError
+        re_phrased_question = await self.llm_chain.ainvoke(
+            query,
+            {"callbacks": run_manager.get_child()},
+        )
+        logger.info("Re-phrased question: %s", re_phrased_question)
+        return await self.retriever.ainvoke(
+            re_phrased_question,
+            config={"callbacks": run_manager.get_child()},
+        )

--- a/libs/langchain/tests/unit_tests/retrievers/test_re_phraser.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_re_phraser.py
@@ -1,0 +1,40 @@
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+from langchain_core.runnables import RunnableLambda
+
+from langchain_classic.retrievers.re_phraser import RePhraseQueryRetriever
+
+
+class _FakeRetriever(BaseRetriever):
+    def _get_relevant_documents(self, query: str, *, run_manager=None) -> list[Document]:
+        return [Document(page_content=f"relevant for: {query}")]
+
+    async def _aget_relevant_documents(
+        self, query: str, *, run_manager=None
+    ) -> list[Document]:
+        return [Document(page_content=f"relevant for: {query}")]
+
+
+def test_sync_invoke() -> None:
+    """Sync invoke rephrases the query and retrieves documents."""
+    chain = RunnableLambda(lambda q: "rephrased query")
+    retriever = RePhraseQueryRetriever(retriever=_FakeRetriever(), llm_chain=chain)
+
+    result = retriever.invoke("what is langchain?")
+
+    assert len(result) == 1
+    assert result[0].page_content == "relevant for: rephrased query"
+
+
+async def test_async_invoke() -> None:
+    """Async invoke rephrases the query and retrieves documents.
+
+    Regression test: _aget_relevant_documents used to raise NotImplementedError.
+    """
+    chain = RunnableLambda(lambda q: "rephrased query async")
+    retriever = RePhraseQueryRetriever(retriever=_FakeRetriever(), llm_chain=chain)
+
+    result = await retriever.ainvoke("what is langchain?")
+
+    assert len(result) == 1
+    assert result[0].page_content == "relevant for: rephrased query async"


### PR DESCRIPTION
Fixes #37619

---

`RePhraseQueryRetriever._aget_relevant_documents` was a stub that only raised
`NotImplementedError`, while the sync `_get_relevant_documents` had a full
implementation. This caused `ainvoke()` to crash at runtime for users in async
contexts.

`BaseRetriever.__init_subclass__` skips auto-generating an async fallback when
`_get_relevant_documents` accepts `run_manager` — but the async method was never
actually implemented.

**Changes:**
- Implement `_aget_relevant_documents` mirroring the sync version, using `ainvoke`
  for both the LLM chain and inner retriever
- Add unit tests covering sync and async invocation paths
