### PR TITLE
fix(anthropic): copy tool_choice dict in bind_tools to prevent caller mutation

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1859,9 +1859,11 @@ class ChatAnthropic(BaseChatModel):
         if parallel_tool_calls is not None:
             disable_parallel_tool_use = not parallel_tool_calls
             if "tool_choice" in kwargs:
-                kwargs["tool_choice"]["disable_parallel_tool_use"] = (
-                    disable_parallel_tool_use
-                )
+                # Copy the dict to avoid mutating the caller's object
+                kwargs["tool_choice"] = {
+                    **kwargs["tool_choice"],
+                    "disable_parallel_tool_use": disable_parallel_tool_use,
+                }
             else:
                 kwargs["tool_choice"] = {
                     "type": "auto",

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1398,6 +1398,28 @@ def test_anthropic_bind_tools_tool_choice() -> None:
     }
 
 
+def test_bind_tools_does_not_mutate_tool_choice_dict() -> None:
+    """bind_tools must not mutate a dict tool_choice passed by the caller."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    original_tool_choice: dict = {"type": "tool", "name": "GetWeather"}
+    # Take a snapshot so we can detect mutation
+    original_copy = dict(original_tool_choice)
+
+    chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=original_tool_choice,
+        parallel_tool_calls=False,
+    )
+
+    assert original_tool_choice == original_copy, (
+        "bind_tools mutated the caller-provided tool_choice dict; "
+        f"expected {original_copy!r}, got {original_tool_choice!r}"
+    )
+
+
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""
     # Test with betas parameter at initialization


### PR DESCRIPTION
## Problem

When `ChatAnthropic.bind_tools()` is called with a `dict` `tool_choice` **and** `parallel_tool_calls=False`, the method mutates the caller's dict in-place by writing `disable_parallel_tool_use` directly into the object:

```python
# before (libs/partners/anthropic/langchain_anthropic/chat_models.py ~L1862)
kwargs["tool_choice"]["disable_parallel_tool_use"] = disable_parallel_tool_use
```

`kwargs["tool_choice"]` is the same object as the dict the caller passed — so after `bind_tools` returns, the caller's dict has been silently modified. This violates the principle of least surprise for any caller that reuses the same `tool_choice` dict across multiple calls.

Minimal reproduction:

```python
from langchain_anthropic import ChatAnthropic

model = ChatAnthropic(model="claude-3-5-haiku-20241022")
tc = {"type": "tool", "name": "MyTool"}
snapshot = dict(tc)

model.bind_tools([...], tool_choice=tc, parallel_tool_calls=False)

assert tc == snapshot  # FAILS: tc now contains disable_parallel_tool_use=True
```

Closes #37596.

## Fix

Replace the in-place key assignment with a dict copy:

```python
kwargs["tool_choice"] = {
    **kwargs["tool_choice"],
    "disable_parallel_tool_use": disable_parallel_tool_use,
}
```

This creates a new dict, leaving the caller's object untouched.

## Changes

- `libs/partners/anthropic/langchain_anthropic/chat_models.py`: copy the dict before adding `disable_parallel_tool_use`
- `libs/partners/anthropic/tests/unit_tests/test_chat_models.py`: add `test_bind_tools_does_not_mutate_tool_choice_dict` which would have caught this regression