### PR TITLE
fix(chroma): allow empty or missing metadata in update_documents

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1231,7 +1231,12 @@ class Chroma(VectorStore):
             ValueError: If the embedding function is not provided.
         """
         text = [document.page_content for document in documents]
-        metadata = [document.metadata for document in documents]
+        # Normalize missing or empty metadata to None so that Chroma's update
+        # API doesn't raise a ValueError on empty dictionaries.
+        metadata = [
+            document.metadata if document.metadata else None
+            for document in documents
+        ]
         if self._embedding_function is None:
             msg = "For update, you must specify an embedding function on creation."
             raise ValueError(

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -28,3 +28,30 @@ def test_similarity_search() -> None:
     output = docsearch.similarity_search("foo", k=1)
     docsearch.delete_collection()
     assert len(output) == 1
+
+
+def test_update_document_empty_metadata() -> None:
+    """Test update_document with a document having empty or missing metadata."""
+    from langchain_core.documents import Document
+
+    texts = ["foo"]
+    docsearch = Chroma.from_texts(
+        collection_name="test_collection_update",
+        texts=texts,
+        embedding=FakeEmbeddings(size=10),
+    )
+    doc = Document(page_content="bar")
+    ids = docsearch.add_documents([doc], ids=["test_doc_1"])
+    assert ids == ["test_doc_1"]
+
+    updated_doc = Document(page_content="baz")
+    docsearch.update_documents(ids=["test_doc_1"], documents=[updated_doc])
+
+    results = docsearch.get(ids=["test_doc_1"])
+    docsearch.delete_collection()
+
+    assert results["ids"] == ["test_doc_1"]
+    assert results["documents"] == ["baz"]
+    assert results["metadatas"] in [[{}], [None], None]
+
+


### PR DESCRIPTION
Fixes #

In ChromaDB's update API, passing an empty dictionary `{}` for document metadata results in a strict validation `ValueError`. This PR normalizes empty or missing metadata entries to `None` inside `update_documents` to bypass this constraint, leaving existing metadata unaffected while updating other document fields.

Added a dedicated unit test `test_update_document_empty_metadata` using `Chroma.get` inside the partner package to verify the update and normalization behavior.

## Social handle
LinkedIn: https://www.linkedin.com/in/rajarajeswaran2001/
