### PR TITLE
fix(anthropic): `bind_tools` no longer mutates caller-provided `tool_choice` dict

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1822,7 +1822,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1398,6 +1398,22 @@ def test_anthropic_bind_tools_tool_choice() -> None:
     }
 
 
+def test_bind_tools_does_not_mutate_tool_choice_dict() -> None:
+    """bind_tools must not mutate the caller-provided tool_choice dict."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    tool_choice: dict = {"type": "tool", "name": "GetWeather"}
+    original = tool_choice.copy()
+
+    chat_model.bind_tools([GetWeather], tool_choice=tool_choice, parallel_tool_calls=False)
+
+    assert tool_choice == original, (
+        "bind_tools mutated the caller-provided tool_choice dict"
+    )
+
+
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""
     # Test with betas parameter at initialization


### PR DESCRIPTION
Closes #37596

---

When `tool_choice` is passed as a `dict` to `bind_tools`, it was stored by direct reference in `kwargs`. Later, if `parallel_tool_calls` was also set, the code mutated `kwargs["tool_choice"]` in place by adding `disable_parallel_tool_use` — silently corrupting the caller's original dict.

The fix is a one-line change: store a shallow copy (`tool_choice.copy()`) instead of the original reference. A unit test is added to prevent regression.