### PR TITLE
fix(anthropic): prevent bind_tools from mutating caller-provided tool_choice dict

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1822,7 +1822,9 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            # Shallow-copy so that later mutations (e.g. adding
+            # disable_parallel_tool_use) do not modify the caller's dict.
+            kwargs["tool_choice"] = dict(tool_choice)
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3209,3 +3209,62 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# Regression test for #37596 — bind_tools must not mutate caller's tool_choice
+# ---------------------------------------------------------------------------
+
+
+def test_bind_tools_does_not_mutate_caller_tool_choice_dict() -> None:
+    """bind_tools must not modify the caller-provided tool_choice dict in place.
+
+    Previously, when parallel_tool_calls=False was combined with a dict
+    tool_choice, the code would add 'disable_parallel_tool_use' directly to
+    the caller's dict object instead of a copy.
+    """
+    chat_model = ChatAnthropic(  # type: ignore[call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+
+    tool_choice = {"type": "tool", "name": "GetWeather"}
+    original_keys = set(tool_choice.keys())
+
+    chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=tool_choice,
+        parallel_tool_calls=False,
+    )
+
+    # The caller's dict must be unmodified
+    assert set(tool_choice.keys()) == original_keys, (
+        "bind_tools mutated the caller-provided tool_choice dict; "
+        f"unexpected key(s): {set(tool_choice.keys()) - original_keys}"
+    )
+    assert "disable_parallel_tool_use" not in tool_choice
+
+
+def test_bind_tools_tool_choice_in_bound_kwargs_has_disable_parallel() -> None:
+    """The bound kwargs (not the caller's dict) must carry disable_parallel_tool_use."""
+    from typing import cast
+
+    from langchain_core.runnables import RunnableBinding
+
+    chat_model = ChatAnthropic(  # type: ignore[call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+
+    tool_choice = {"type": "tool", "name": "GetWeather"}
+
+    bound = chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=tool_choice,
+        parallel_tool_calls=False,
+    )
+
+    bound_tc = cast(RunnableBinding, bound).kwargs["tool_choice"]
+    assert bound_tc["disable_parallel_tool_use"] is True
+    # And the original is still clean
+    assert "disable_parallel_tool_use" not in tool_choice


### PR DESCRIPTION
## Problem

`ChatAnthropic.bind_tools()` silently mutates the caller-provided `tool_choice`
dict when `parallel_tool_calls=False` is also passed:

```python
tool_choice = {"type": "tool", "name": "GetWeather"}

model.bind_tools(tools=[...], tool_choice=tool_choice, parallel_tool_calls=False)

print(tool_choice)
# {"type": "tool", "name": "GetWeather", "disable_parallel_tool_use": True}
#                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#                                         caller's dict was mutated!
```

### Root cause

In `bind_tools`, line 1825 assigns the caller's dict directly:
```python
kwargs["tool_choice"] = tool_choice   # same object reference
```

Later, line 1862 adds a key to what it thinks is its own local dict:
```python
kwargs["tool_choice"]["disable_parallel_tool_use"] = True  # mutates caller's obj
```

Because `kwargs["tool_choice"] is tool_choice`, this writes through to the
caller's original dict.

Reported in #37596.

## Fix

Make a shallow copy when storing a dict `tool_choice` so all downstream
mutations stay inside `bind_tools`:

```python
elif isinstance(tool_choice, dict):
    # Shallow-copy so that later mutations (e.g. adding
    # disable_parallel_tool_use) do not modify the caller's dict.
    kwargs["tool_choice"] = dict(tool_choice)
```

## Tests

Two new tests appended to
`libs/partners/anthropic/tests/unit_tests/test_chat_models.py`:

| Test | What it checks |
|---|---|
| `test_bind_tools_does_not_mutate_caller_tool_choice_dict` | caller's dict unchanged after `bind_tools` |
| `test_bind_tools_tool_choice_in_bound_kwargs_has_disable_parallel` | `disable_parallel_tool_use` IS present in the bound kwargs (i.e. feature still works) |

Fixes #37596