### PR TITLE
fix(chroma): normalize empty Document metadata in update_documents

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1231,7 +1231,14 @@ class Chroma(VectorStore):
             ValueError: If the embedding function is not provided.
         """
         text = [document.page_content for document in documents]
-        metadata = [document.metadata for document in documents]
+        # Normalise empty metadata dicts to None.  ChromaDB's update API rejects
+        # empty dicts with "Expected metadata to be a non-empty dict" — this
+        # matches the behaviour of add_documents(), which also skips empty metadata.
+        metadata = [document.metadata or None for document in documents]
+        # If every element is None, pass None for the whole list so chromadb skips
+        # the metadata update entirely (avoids "metadatas list length mismatch").
+        if all(m is None for m in metadata):
+            metadata = None  # type: ignore[assignment]
         if self._embedding_function is None:
             msg = "For update, you must specify an embedding function on creation."
             raise ValueError(


### PR DESCRIPTION
## Problem

`Chroma.update_document()` / `update_documents()` raises when a `Document` is
passed without explicit metadata (i.e. `metadata={}` — the default):

```python
vector_store.update_document(
    document_id="doc_1",
    document=Document(page_content="Updated document")  # metadata={}
)
# ValueError: Expected metadata to be a non-empty dict, got 0 metadata attributes in update.
```

`add_documents()` accepts the same `Document` without error, so the two methods
are inconsistent.

**Root cause**: `update_documents` passes `document.metadata` (which defaults to
`{}`) directly to the chromadb collection. Chromadb's update API rejects empty
dicts with the error above. `add_documents` already handles this by skipping
empty metadata before forwarding to chromadb.

Reported in #37452.

## Fix

Before forwarding to chromadb, normalize empty metadata dicts to `None`:

```python
metadata = [document.metadata or None for document in documents]
if all(m is None for m in metadata):
    metadata = None  # skip metadata update entirely
```

This matches chromadb's expectation (it accepts `None` to mean "no metadata
change") and mirrors how `add_documents` handles empty metadata.

Fixes #37452