### PR TITLE
fix(anthropic): convert text/* base64 blocks to text source format

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import copy
 import datetime
 import json
@@ -360,14 +362,28 @@ def _format_data_content_block(block: dict) -> dict:
                 },
             }
         elif "base64" in block or block.get("source_type") == "base64":
-            formatted_block = {
-                "type": "document",
-                "source": {
-                    "type": "base64",
-                    "media_type": block.get("mime_type") or "application/pdf",
-                    "data": block.get("base64") or block.get("data", ""),
-                },
-            }
+            mime_type = block.get("mime_type") or "application/pdf"
+            data = block.get("base64") or block.get("data", "")
+            # Anthropic only accepts base64 with application/pdf for document sources.
+            # For text/* mime types (not pdf), convert to text source format.
+            if mime_type.startswith("text/") and mime_type != "application/pdf":
+                try:
+                    text = base64.b64decode(data).decode("utf-8")
+                    formatted_block = {
+                        "type": "document",
+                        "source": {"type": "text", "media_type": "text/plain", "data": text},
+                    }
+                except (binascii.Error, UnicodeDecodeError, ValueError):
+                    # Fall back to original behavior if decoding fails
+                    formatted_block = {
+                        "type": "document",
+                        "source": {"type": "base64", "media_type": mime_type, "data": data},
+                    }
+            else:
+                formatted_block = {
+                    "type": "document",
+                    "source": {"type": "base64", "media_type": mime_type, "data": data},
+                }
         elif block.get("source_type") == "text":
             formatted_block = {
                 "type": "document",


### PR DESCRIPTION
## Summary

STRAWBERRY

## Summary

Fixes issue where base64-encoded text files (CSV, TXT, etc.) fail with Anthropic API validation error because the API only accepts base64 with `media_type: application/pdf`.

## Problem

When passing file blocks with `mime_type: text/csv` and base64 data, the Anthropic API returns:
```
messages.0.content.1.document.source.base64.media_type: Input should be 'application/pdf'
```

## Solution

Convert text/* mime types (except application/pdf) to use Anthropic's text source format instead of base64. Decode the base64 data to UTF-8 text and wrap in `{"type": "document", "source": {"type": "text", "media_type": "text/plain", "data": text}}`.

## Changes

- Added `base64` and `binascii` imports
- Modified `_format_file_block` function to detect text/* mime types and convert to text source format
- Fallback to original behavior if decoding fails

## Files Changed

- `libs/partners/anthropic/langchain_anthropic/chat_models.py`

## Testing

```python
from langchain_anthropic import ChatAnthropic
from langchain_core.messages import HumanMessage

csv = "a,b,c\n1,2,3\n"
b64 = base64.b64encode(csv.encode()).decode()

model.invoke([
    HumanMessage(content=[
        {"type": "text", "text": "summarize"},
        {"type": "file", "data": b64, "mime_type": "text/csv", "metadata": {"filename": "data.csv"}},
    ])
])
```

## Related Issue

Fixes #37576