### PR TITLE
fix(anthropic): convert text/* base64 blocks to text source format

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
 import copy
 import datetime
 import json
@@ -360,14 +362,28 @@ def _format_data_content_block(block: dict) -> dict:
                 },
             }
         elif "base64" in block or block.get("source_type") == "base64":
-            formatted_block = {
-                "type": "document",
-                "source": {
-                    "type": "base64",
-                    "media_type": block.get("mime_type") or "application/pdf",
-                    "data": block.get("base64") or block.get("data", ""),
-                },
-            }
+            mime_type = block.get("mime_type") or "application/pdf"
+            data = block.get("base64") or block.get("data", "")
+            # Anthropic only accepts base64 with application/pdf for document sources.
+            # For text/* mime types (not pdf), convert to text source format.
+            if mime_type.startswith("text/") and mime_type != "application/pdf":
+                try:
+                    text = base64.b64decode(data).decode("utf-8")
+                    formatted_block = {
+                        "type": "document",
+                        "source": {"type": "text", "media_type": "text/plain", "data": text},
+                    }
+                except (binascii.Error, UnicodeDecodeError, ValueError):
+                    # Fall back to original behavior if decoding fails
+                    formatted_block = {
+                        "type": "document",
+                        "source": {"type": "base64", "media_type": mime_type, "data": data},
+                    }
+            else:
+                formatted_block = {
+                    "type": "document",
+                    "source": {"type": "base64", "media_type": mime_type, "data": data},
+                }
         elif block.get("source_type") == "text":
             formatted_block = {
                 "type": "document",


### PR DESCRIPTION
## Summary

Fixes issue where base64-encoded text files (CSV, TXT, etc.) fail with Anthropic API validation error.

## Problem

When passing file blocks with `mime_type: text/csv` and base64 data, the Anthropic API returns:
```
messages.0.content.1.document.source.base64.media_type: Input should be 'application/pdf'
```

## Solution

Convert text/* mime types (except application/pdf) to use Anthropic's text source format instead of base64.

## Changes

- `libs/partners/anthropic/langchain_anthropic/chat_models.py`: Added base64/binascii imports and logic to convert text mime types to text source format

## Testing

```python
from langchain_anthropic import ChatAnthropic
model.invoke([HumanMessage(content=[
    {"type": "file", "data": b64, "mime_type": "text/csv"}
])])
```

Closes #37576