### PR TITLE
ci(infra): serialize integration test shards across runs

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -132,6 +132,13 @@ jobs:
     environment: "Scheduled testing"
     needs: [compute-matrix]
     timeout-minutes: 30
+    # Serialize same-package shards across workflow runs so a per-package
+    # manual dispatch doesn't race the scheduled "all libs" run against the
+    # same live API credentials. Keyed per (working-directory, python-version)
+    # so the 3.10/3.13 matrix legs within one run still execute in parallel.
+    concurrency:
+      group: integration-tests-${{ matrix.working-directory }}-${{ matrix.python-version }}
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Add job-level `concurrency` to the scheduled integration tests so per-package shards from overlapping workflow dispatches don't hit the same live API credentials at once — e.g. a manually triggered `anthropic` run colliding with the daily `all libs` run.