### PR TITLE
fix(core): add float support to merge_dicts()

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,7 +68,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to


### PR DESCRIPTION
Fixes #36011

---

The `merge_dicts()` function in `libs/core/langchain_core/utils/_merge.py` handles `str`, `dict`, `list`, equal values, and `int` types — but **not `float`**. When two dicts contain the same key with unequal `float` values (e.g., `logprob`, `score`, `safety_scores`), the function raises a `TypeError`.

This affects streaming scenarios where LLM providers return float fields in `generation_info` or `additional_kwargs`. During chunk aggregation via `ChatGenerationChunk.__add__()`, these float fields cause the stream to crash.

**Root cause:** Line 71 checks `isinstance(merged[right_k], int)` but omits `float`.

**Fix:** Changed to `isinstance(merged[right_k], (int, float))` to handle numeric values correctly, using the same last-wins strategy for temporal fields (`index`, `created`, `timestamp`) and sum accumulation for other numeric fields.

Note: This is an AI-assisted contribution.