### PR TITLE
fix(core): handle string data in Blob.as_bytes_io()

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f


### PR DESCRIPTION
Blob.as_bytes_io() raised NotImplementedError when the blob was created from string data via Blob.from_data(), even though as_bytes() and as_string() both handle strings correctly.

Fixes #36667

Added an elif branch for str data that encodes to bytes before wrapping in BytesIO, matching the existing pattern in as_bytes().

Verified manually:
- Blob.from_data('hello').as_bytes_io() now yields b'hello'
- Blob.from_data(b'world').as_bytes_io() still yields b'world' (unchanged)
- API consistency: as_string(), as_bytes(), and as_bytes_io() all agree on the same data