### PR TITLE
Add compatibility check for optimum-intel v2 IPEX removal

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface.py
@@ -74,7 +74,18 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
             raise ImportError(msg) from exc
 
         if self.model_kwargs.get("backend", "torch") == "ipex":
-            if not is_optimum_intel_available() or not is_ipex_available():
+            if not is_optimum_intel_available():
+                msg = f"Backend: ipex {IMPORT_ERROR.format('optimum[ipex]')}"
+                raise ImportError(msg)
+
+            if is_optimum_intel_version(">=", "2.0"):
+                msg = (
+                    "IPEX support has been removed in optimum-intel v2. "
+                    "Please downgrade optimum-intel or switch backend."
+                )
+                raise ImportError(msg)
+
+            if not is_ipex_available():
                 msg = f"Backend: ipex {IMPORT_ERROR.format('optimum[ipex]')}"
                 raise ImportError(msg)
 

--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -162,6 +162,13 @@ class HuggingFacePipeline(BaseLLM):
             if not is_optimum_intel_available():
                 raise ImportError(err_msg)
 
+            if backend == "ipex" and is_optimum_intel_version(">=", "2.0"):
+                msg = (
+                    "IPEX support has been removed in optimum-intel v2. "
+                    "Please downgrade optimum-intel or switch backend."
+                )
+                raise ImportError(msg)
+
             # TODO: upgrade _MIN_OPTIMUM_VERSION to 1.22 after release
             min_optimum_version = (
                 "1.22"

--- a/libs/partners/huggingface/tests/unit_tests/test_ipex_deprecation.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_ipex_deprecation.py
@@ -1,0 +1,120 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_huggingface import HuggingFaceEmbeddings, HuggingFacePipeline
+
+
+@patch("langchain_huggingface.llms.huggingface_pipeline.is_optimum_intel_available")
+@patch("langchain_huggingface.llms.huggingface_pipeline.is_optimum_intel_version")
+@patch("langchain_huggingface.llms.huggingface_pipeline.is_ipex_available")
+def test_huggingface_pipeline_ipex_unsupported_version(
+    mock_ipex_available: MagicMock,
+    mock_intel_version: MagicMock,
+    mock_intel_available: MagicMock,
+) -> None:
+    """Test optimum-intel >= 2.0 raises ImportError for pipeline."""
+    mock_intel_available.return_value = True
+    mock_intel_version.return_value = True  # >= 2.0 evaluates to True
+    mock_ipex_available.return_value = True
+
+    with pytest.raises(ImportError) as exc_info:
+        HuggingFacePipeline.from_model_id(
+            model_id="gpt2",
+            task="text-generation",
+            backend="ipex",
+        )
+    assert "IPEX support has been removed in optimum-intel v2" in str(exc_info.value)
+    assert "Please downgrade optimum-intel or switch backend." in str(exc_info.value)
+
+
+@patch("langchain_huggingface.llms.huggingface_pipeline.is_optimum_intel_available")
+@patch("langchain_huggingface.llms.huggingface_pipeline.is_optimum_intel_version")
+@patch("langchain_huggingface.llms.huggingface_pipeline.is_ipex_available")
+@patch("transformers.AutoTokenizer.from_pretrained")
+@patch("transformers.pipeline")
+def test_huggingface_pipeline_ipex_supported_version(
+    mock_pipeline: MagicMock,
+    mock_tokenizer: MagicMock,
+    mock_ipex_available: MagicMock,
+    mock_intel_version: MagicMock,
+    mock_intel_available: MagicMock,
+) -> None:
+    """Test optimum-intel < 2.0 succeeds for pipeline."""
+    mock_intel_available.return_value = True
+    # For >= 2.0, return False (meaning the version is < 2.0)
+    mock_intel_version.return_value = False
+    mock_ipex_available.return_value = True
+
+    mock_optimum_intel = MagicMock()
+    modules = {"optimum": MagicMock(), "optimum.intel": mock_optimum_intel}
+    with patch.dict("sys.modules", modules):
+        mock_tokenizer.return_value = MagicMock(pad_token_id=0)
+        mock_model = MagicMock()
+        mock_model.config.pad_token_id = 0
+
+        mock_from_pretrained = mock_optimum_intel.IPEXModelForCausalLM.from_pretrained
+        mock_from_pretrained.return_value = mock_model
+
+        mock_pipe = MagicMock()
+        mock_pipe.task = "text-generation"
+        mock_pipe.model = mock_model
+        mock_pipeline.return_value = mock_pipe
+
+        llm = HuggingFacePipeline.from_model_id(
+            model_id="gpt2",
+            task="text-generation",
+            backend="ipex",
+        )
+        assert llm.model_id == "gpt2"
+        mock_from_pretrained.assert_called_once()
+
+
+@patch("langchain_huggingface.embeddings.huggingface.is_optimum_intel_available")
+@patch("langchain_huggingface.embeddings.huggingface.is_optimum_intel_version")
+@patch("langchain_huggingface.embeddings.huggingface.is_ipex_available")
+def test_huggingface_embeddings_ipex_unsupported_version(
+    mock_ipex_available: MagicMock,
+    mock_intel_version: MagicMock,
+    mock_intel_available: MagicMock,
+) -> None:
+    """Test optimum-intel >= 2.0 raises ImportError for embeddings."""
+    mock_intel_available.return_value = True
+    mock_intel_version.return_value = True  # >= 2.0 evaluates to True
+    mock_ipex_available.return_value = True
+
+    with pytest.raises(ImportError) as exc_info:
+        HuggingFaceEmbeddings(
+            model_name="sentence-transformers/all-mpnet-base-v2",
+            model_kwargs={"backend": "ipex"},
+        )
+    assert "IPEX support has been removed in optimum-intel v2" in str(exc_info.value)
+    assert "Please downgrade optimum-intel or switch backend." in str(exc_info.value)
+
+
+@patch("langchain_huggingface.embeddings.huggingface.is_optimum_intel_available")
+@patch("langchain_huggingface.embeddings.huggingface.is_optimum_intel_version")
+@patch("langchain_huggingface.embeddings.huggingface.is_ipex_available")
+def test_huggingface_embeddings_ipex_supported_version(
+    mock_ipex_available: MagicMock,
+    mock_intel_version: MagicMock,
+    mock_intel_available: MagicMock,
+) -> None:
+    """Test optimum-intel < 2.0 succeeds for embeddings."""
+    mock_intel_available.return_value = True
+    # For >= 2.0, return False (meaning the version is < 2.0)
+    mock_intel_version.return_value = False
+    mock_ipex_available.return_value = True
+
+    mock_optimum_intel = MagicMock()
+    modules = {"optimum": MagicMock(), "optimum.intel": mock_optimum_intel}
+    with patch.dict("sys.modules", modules):
+        mock_client = MagicMock()
+        mock_optimum_intel.IPEXSentenceTransformer.return_value = mock_client
+
+        embeddings = HuggingFaceEmbeddings(
+            model_name="sentence-transformers/all-mpnet-base-v2",
+            model_kwargs={"backend": "ipex"},
+        )
+        assert embeddings.model_name == "sentence-transformers/all-mpnet-base-v2"
+        mock_optimum_intel.IPEXSentenceTransformer.assert_called_once()


### PR DESCRIPTION
# fix(huggingface): add compatibility check for optimum-intel v2 IPEX removal

## PR Description:

### Fixes #36765

This PR adds version validation for backend="ipex" in **HuggingFacePipeline**  and **HuggingFaceEmbeddings** when used with optimum-intel >= 2.0.

Since optimum-intel v2 removes IPEX-specific classes such as IPEXModelForCausalLM and IPEXSentenceTransformer, the change raises a clear ImportError instead of allowing runtime import failures. Existing behavior remains unchanged for supported versions < 2.0.

How I verified the changes:

- Ran unit tests for the new deprecation logic
- Verified supported versions continue normal execution
- Confirmed non-IPEX backends remain unaffected

### 

`LinkedIn:` https://linkedin.com/in/rahul-manchanda-3959b120a/