### PR TITLE
feat(text-splitters): inject custom chunk_splitter into HTMLSemanticPreservingSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
     from bs4.element import ResultSet
 
+    from langchain_text_splitters.base import TextSplitter
+
 try:
     import nltk
 
@@ -608,6 +610,27 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
             custom_handlers={"iframe": custom_iframe_extractor}
         )
         ```
+
+        To use a tokenizer-aware length function (or any other custom
+        `TextSplitter`) for further splitting oversize chunks, build the inner
+        splitter separately and pass it via `chunk_splitter`:
+
+        ```python
+        from langchain_text_splitters import (
+            HTMLSemanticPreservingSplitter,
+            RecursiveCharacterTextSplitter,
+        )
+
+        inner = RecursiveCharacterTextSplitter.from_huggingface_tokenizer(
+            tokenizer=qwen_tokenizer,
+            chunk_size=512,
+            chunk_overlap=32,
+        )
+        text_splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1"), ("h2", "Header 2")],
+            chunk_splitter=inner,
+        )
+        ```
     """  # noqa: D214
 
     def __init__(
@@ -631,6 +654,7 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
         denylist_tags: list[str] | None = None,
         preserve_parent_metadata: bool = False,
         keep_separator: bool | Literal["start", "end"] = True,
+        chunk_splitter: TextSplitter | None = None,
     ) -> None:
         """Initialize splitter.
 
@@ -665,10 +689,20 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
                 `transform_documents/atransform_documents()`.
             keep_separator: Whether separators should be at the beginning of a chunk, at
                 the end, or not at all.
+            chunk_splitter: Optional pre-built `TextSplitter` used to further split
+                chunks that exceed `max_chunk_size`. Use this to plug in a
+                tokenizer-aware splitter, e.g.
+                `RecursiveCharacterTextSplitter.from_huggingface_tokenizer(...)`.
+                Mutually exclusive with `max_chunk_size`, `chunk_overlap`,
+                `separators`, and `keep_separator` — when `chunk_splitter` is
+                provided, those arguments must be left at their defaults.
 
         Raises:
             ImportError: If BeautifulSoup or NLTK (when stopword removal is enabled)
                 is not installed.
+            ValueError: If `chunk_splitter` is provided together with any of
+                `max_chunk_size`, `chunk_overlap`, `separators`, or
+                `keep_separator` set to a non-default value.
         """
         if not _HAS_BS4:
             msg = (
@@ -678,7 +712,6 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
             raise ImportError(msg)
 
         self._headers_to_split_on = sorted(headers_to_split_on)
-        self._max_chunk_size = max_chunk_size
         self._elements_to_preserve = elements_to_preserve or []
         self._preserve_links = preserve_links
         self._preserve_images = preserve_images
@@ -703,7 +736,32 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
                 for tag in denylist_tags
                 if tag not in [header[0] for header in headers_to_split_on]
             ]
-        if separators:
+        if chunk_splitter is not None:
+            conflicting = [
+                name
+                for name, value, default in (
+                    ("max_chunk_size", max_chunk_size, 1000),
+                    ("chunk_overlap", chunk_overlap, 0),
+                    ("separators", separators, None),
+                    ("keep_separator", keep_separator, True),
+                )
+                if value != default
+            ]
+            if conflicting:
+                msg = (
+                    "`chunk_splitter` is mutually exclusive with "
+                    f"{', '.join(repr(c) for c in conflicting)}. "
+                    "Configure those options on the injected splitter instead."
+                )
+                raise ValueError(msg)
+            self._recursive_splitter = chunk_splitter
+            # `TextSplitter` exposes no public accessor; `_chunk_size` is the
+            # canonical place every subclass stores its size budget. Reading it
+            # here keeps the recurse-or-not gate aligned with the injected
+            # splitter's own configuration.
+            self._max_chunk_size = chunk_splitter._chunk_size  # noqa: SLF001
+        elif separators:
+            self._max_chunk_size = max_chunk_size
             self._recursive_splitter = RecursiveCharacterTextSplitter(
                 separators=separators,
                 keep_separator=keep_separator,
@@ -711,6 +769,7 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
                 chunk_overlap=chunk_overlap,
             )
         else:
+            self._max_chunk_size = max_chunk_size
             self._recursive_splitter = RecursiveCharacterTextSplitter(
                 keep_separator=keep_separator,
                 chunk_size=max_chunk_size,

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -4196,6 +4196,62 @@ def test_html_splitter_replacement_order() -> None:
     assert content == " ".join([f"Hello{i}" for i in range(1, 15)])
 
 
+@pytest.mark.requires("bs4")
+def test_html_splitter_with_injected_chunk_splitter() -> None:
+    """An injected `chunk_splitter` drives further splitting of oversize chunks."""
+    inner = RecursiveCharacterTextSplitter(
+        chunk_size=5,
+        chunk_overlap=0,
+        length_function=lambda s: len(s.split()),
+    )
+    html_content = (
+        "<h1>Section</h1>"
+        "<p>one two three four five six seven eight nine ten eleven twelve.</p>"
+    )
+    with suppress_langchain_beta_warning():
+        splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")],
+            chunk_splitter=inner,
+        )
+    documents = splitter.split_text(html_content)
+
+    assert len(documents) > 1
+    for doc in documents:
+        assert len(doc.page_content.split()) <= 5
+        assert doc.metadata == {"Header 1": "Section"}
+
+
+@pytest.mark.requires("bs4")
+def test_html_splitter_chunk_splitter_conflict_raises() -> None:
+    """Passing `chunk_splitter` alongside a non-default sizing arg is rejected."""
+    inner = RecursiveCharacterTextSplitter(chunk_size=10, chunk_overlap=0)
+    with (
+        suppress_langchain_beta_warning(),
+        pytest.raises(ValueError, match="mutually exclusive"),
+    ):
+        HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")],
+            max_chunk_size=500,
+            chunk_splitter=inner,
+        )
+
+
+@pytest.mark.requires("bs4")
+def test_html_splitter_default_chunk_splitter_behavior_unchanged() -> None:
+    """Without `chunk_splitter`, the default character-based path still applies."""
+    html_content = "<h1>Section</h1><p>" + ("word " * 200) + "</p>"
+    with suppress_langchain_beta_warning():
+        splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")],
+            max_chunk_size=100,
+            chunk_overlap=0,
+        )
+    documents = splitter.split_text(html_content)
+    assert len(documents) > 1
+    for doc in documents:
+        assert len(doc.page_content) <= 120
+
+
 def test_character_text_splitter_discard_regex_separator_on_merge() -> None:
     """Test that regex lookahead separator is not re-inserted when merging."""
     text = "SCE191 First chunk. SCE103 Second chunk."


### PR DESCRIPTION
Fixes #37358

---

Adds an optional `chunk_splitter` kwarg to `HTMLSemanticPreservingSplitter`, letting callers inject any pre-built `TextSplitter` (typically a `RecursiveCharacterTextSplitter` constructed via `from_huggingface_tokenizer` or `from_tiktoken_encoder`) to control how oversize chunks are further split. Previously the inner splitter was hardcoded with a character-length budget, so tokenizer-aware splitting required subclassing.

`chunk_splitter` is mutually exclusive with `max_chunk_size`, `chunk_overlap`, `separators`, and `keep_separator` — passing both raises `ValueError` to avoid silent disagreement between the wrapper's args and the injected splitter's own config. When `chunk_splitter` is supplied, the further-split gate uses the injected splitter's own `chunk_size`. Default construction is unchanged, so existing call sites are unaffected.

Disclaimer: drafted with assistance from an AI coding agent; all changes reviewed before submission.
