### PR TITLE
fix(langchain): align PII state hooks with recursive redaction

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/pii.py
+++ b/libs/langchain_v1/langchain/agents/middleware/pii.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
-from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langgraph.stream import StreamTransformer
 from typing_extensions import override
 
@@ -45,6 +45,106 @@ before any text is released downstream. 128 comfortably covers the built-in
 detectors (the credit-card regex tops out at 19 characters; URLs and emails
 are typically well under 100) while bounding first-token latency.
 """
+
+
+def _redact_tool_call_list(
+    calls: list[Any] | None, *, rule: ResolvedRedactionRule
+) -> tuple[list[Any], bool]:
+    """Walk a list of tool-call (or invalid-tool-call) dicts."""
+    if not calls:
+        return calls or [], False
+    new_calls: list[Any] = []
+    changed = False
+    for tc in calls:
+        if isinstance(tc, dict) and "args" in tc and tc["args"] is not None:
+            redacted = _redact_value(tc["args"], rule=rule)
+            if redacted != tc["args"]:
+                new_tc = dict(tc)
+                new_tc["args"] = redacted
+                new_calls.append(new_tc)
+                changed = True
+                continue
+        new_calls.append(tc)
+    return new_calls, changed
+
+
+def _redact_value(value: Any, *, rule: ResolvedRedactionRule) -> Any:
+    """Recursively redact PII in string leaves of a nested structure.
+
+    Returns a new value where every `str` leaf that contains PII has
+    been replaced (or emptied under `block`). Non-string leaves and
+    the structure itself are preserved.
+
+    `BaseMessage` payloads (typically `ToolMessage` from
+    `tool-finished.output`, or any message reached via the `values`
+    channel) return a fresh copy with `.content` redacted plus
+    `AIMessage.tool_calls[*].args` / `invalid_tool_calls[*].args`
+    walked. The original object stays intact for state-level
+    enforcers (`after_model`, `before_model` with
+    `apply_to_tool_results`) to act on independently.
+
+    Scope mirrors the pre-streaming state-level surfaces:
+    `.content` (string or list-of-content-blocks) and `tool_calls`
+    args. Other message attributes (`additional_kwargs`,
+    `response_metadata`, `ToolMessage.artifact`) are intentionally
+    not walked here — they aren't scrubbed in graph state by the
+    existing hooks, so scrubbing them on the wire would create
+    a wire/state divergence.
+    """
+    if isinstance(value, str):
+        if not value:
+            return value
+        matches = rule.detector(value)
+        if not matches:
+            return value
+        # `apply_strategy` raises `PIIDetectionError` under `block`
+        # — the run fails immediately rather than buffering until a
+        # state-level hook can raise.
+        return apply_strategy(value, matches, rule.strategy)
+    if isinstance(value, BaseMessage):
+        return _redact_base_message(value, rule=rule)
+    if isinstance(value, dict):
+        return {k: _redact_value(v, rule=rule) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(v, rule=rule) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(v, rule=rule) for v in value)
+    return value
+
+
+def _redact_base_message(value: BaseMessage, *, rule: ResolvedRedactionRule) -> BaseMessage:
+    """Return a fresh copy of `value` with PII-carrying surfaces redacted."""
+    update: dict[str, Any] = {}
+
+    content = value.content
+    if isinstance(content, str) and content:
+        matches = rule.detector(content)
+        if matches:
+            update["content"] = apply_strategy(content, matches, rule.strategy)
+    elif isinstance(content, list) and content:
+        # Structured content-blocks shape:
+        # `[{"type": "text", "text": "..."}, {"type": "tool_call", ...}, ...]`.
+        redacted_content = _redact_value(content, rule=rule)
+        if redacted_content != content:
+            update["content"] = redacted_content
+
+    # `AIMessage.tool_calls` and `.invalid_tool_calls` carry PII in
+    # `args` independently of `.content`. `tool_call.args` is a
+    # dict; `invalid_tool_call.args` is a raw JSON string —
+    # `_redact_value` handles both shapes via the recursion.
+    if isinstance(value, AIMessage):
+        new_tc_list, tc_changed = _redact_tool_call_list(value.tool_calls, rule=rule)
+        if tc_changed:
+            update["tool_calls"] = new_tc_list
+        new_inv_list, inv_changed = _redact_tool_call_list(
+            value.invalid_tool_calls, rule=rule
+        )
+        if inv_changed:
+            update["invalid_tool_calls"] = new_inv_list
+
+    if not update:
+        return value
+    return value.model_copy(update=update)
 
 
 class _PIIStreamTransformer(StreamTransformer):
@@ -218,104 +318,13 @@ class _PIIStreamTransformer(StreamTransformer):
             data["delta"] = self._redact_value(delta)
 
     def _redact_tool_call_list(self, calls: list[Any] | None) -> tuple[list[Any], bool]:
-        """Walk a list of tool-call (or invalid-tool-call) dicts.
-
-        Returns `(new_list, changed)`. Each element's `args` is run
-        through `_redact_value` regardless of its type — `tool_call.args`
-        is a dict, `invalid_tool_call.args` is a raw JSON string, and
-        `_redact_value` handles both shapes uniformly. If nothing
-        changed, returns the input list and `changed=False`.
-        """
-        if not calls:
-            return calls or [], False
-        new_calls: list[Any] = []
-        changed = False
-        for tc in calls:
-            if isinstance(tc, dict) and "args" in tc and tc["args"] is not None:
-                redacted = self._redact_value(tc["args"])
-                if redacted != tc["args"]:
-                    new_tc = dict(tc)
-                    new_tc["args"] = redacted
-                    new_calls.append(new_tc)
-                    changed = True
-                    continue
-            new_calls.append(tc)
-        return new_calls, changed
+        return _redact_tool_call_list(calls, rule=self._rule)
 
     def _redact_value(self, value: Any) -> Any:
-        """Recursively redact PII in string leaves of a nested structure.
-
-        Returns a new value where every `str` leaf that contains PII has
-        been replaced (or emptied under `block`). Non-string leaves and
-        the structure itself are preserved.
-
-        `BaseMessage` payloads (typically `ToolMessage` from
-        `tool-finished.output`, or any message reached via the `values`
-        channel) return a fresh copy with `.content` redacted plus
-        `AIMessage.tool_calls[*].args` / `invalid_tool_calls[*].args`
-        walked. The original object stays intact for state-level
-        enforcers (`after_model`, `before_model` with
-        `apply_to_tool_results`) to act on independently.
-
-        Scope mirrors the pre-streaming state-level surfaces:
-        `.content` (string or list-of-content-blocks) and `tool_calls`
-        args. Other message attributes (`additional_kwargs`,
-        `response_metadata`, `ToolMessage.artifact`) are intentionally
-        not walked here — they aren't scrubbed in graph state by the
-        existing hooks, so scrubbing them on the wire would create
-        a wire/state divergence.
-        """
-        if isinstance(value, str):
-            if not value:
-                return value
-            matches = self._rule.detector(value)
-            if not matches:
-                return value
-            # `apply_strategy` raises `PIIDetectionError` under `block`
-            # — the run fails immediately rather than buffering until a
-            # state-level hook can raise.
-            return apply_strategy(value, matches, self._rule.strategy)
-        if isinstance(value, BaseMessage):
-            return self._redact_base_message(value)
-        if isinstance(value, dict):
-            return {k: self._redact_value(v) for k, v in value.items()}
-        if isinstance(value, list):
-            return [self._redact_value(v) for v in value]
-        if isinstance(value, tuple):
-            return tuple(self._redact_value(v) for v in value)
-        return value
+        return _redact_value(value, rule=self._rule)
 
     def _redact_base_message(self, value: BaseMessage) -> BaseMessage:
-        """Return a fresh copy of `value` with PII-carrying surfaces redacted."""
-        update: dict[str, Any] = {}
-
-        content = value.content
-        if isinstance(content, str) and content:
-            matches = self._rule.detector(content)
-            if matches:
-                update["content"] = apply_strategy(content, matches, self._rule.strategy)
-        elif isinstance(content, list) and content:
-            # Structured content-blocks shape:
-            # `[{"type": "text", "text": "..."}, {"type": "tool_call", ...}, ...]`.
-            redacted_content = self._redact_value(content)
-            if redacted_content != content:
-                update["content"] = redacted_content
-
-        # `AIMessage.tool_calls` and `.invalid_tool_calls` carry PII in
-        # `args` independently of `.content`. `tool_call.args` is a
-        # dict; `invalid_tool_call.args` is a raw JSON string —
-        # `_redact_value` handles both shapes via the recursion.
-        if isinstance(value, AIMessage):
-            new_tc_list, tc_changed = self._redact_tool_call_list(value.tool_calls)
-            if tc_changed:
-                update["tool_calls"] = new_tc_list
-            new_inv_list, inv_changed = self._redact_tool_call_list(value.invalid_tool_calls)
-            if inv_changed:
-                update["invalid_tool_calls"] = new_inv_list
-
-        if not update:
-            return value
-        return value.model_copy(update=update)
+        return _redact_base_message(value, rule=self._rule)
 
     def _mutate_delta(self, payload: dict[str, Any], run_id: str) -> None:
         delta = payload.get("delta")
@@ -660,13 +669,8 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
         """Name of the middleware."""
         return f"{self.__class__.__name__}[{self.pii_type}]"
 
-    def _process_content(self, content: str) -> tuple[str, list[PIIMatch]]:
-        """Apply the configured redaction rule to the provided content."""
-        matches = self.detector(content)
-        if not matches:
-            return content, []
-        sanitized = apply_strategy(content, matches, self.strategy)
-        return sanitized, matches
+    def _redact_base_message(self, value: BaseMessage) -> BaseMessage:
+        return _redact_base_message(value, rule=self._resolved_rule)
 
     @hook_config(can_jump_to=["end"])
     @override
@@ -709,19 +713,10 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                     last_user_idx = i
                     break
 
-            if last_user_idx is not None and last_user_msg and last_user_msg.content:
-                # Detect PII in message content
-                content = str(last_user_msg.content)
-                new_content, matches = self._process_content(content)
-
-                if matches:
-                    updated_message: AnyMessage = HumanMessage(
-                        content=new_content,
-                        id=last_user_msg.id,
-                        name=last_user_msg.name,
-                    )
-
-                    new_messages[last_user_idx] = updated_message
+            if last_user_idx is not None and last_user_msg:
+                redacted = self._redact_base_message(last_user_msg)
+                if redacted is not last_user_msg:
+                    new_messages[last_user_idx] = redacted
                     any_modified = True
 
         # Check tool results if enabled
@@ -738,26 +733,10 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                 for i in range(last_ai_idx + 1, len(messages)):
                     msg = messages[i]
                     if isinstance(msg, ToolMessage):
-                        tool_msg = msg
-                        if not tool_msg.content:
-                            continue
-
-                        content = str(tool_msg.content)
-                        new_content, matches = self._process_content(content)
-
-                        if not matches:
-                            continue
-
-                        # Create updated tool message
-                        updated_message = ToolMessage(
-                            content=new_content,
-                            id=tool_msg.id,
-                            name=tool_msg.name,
-                            tool_call_id=tool_msg.tool_call_id,
-                        )
-
-                        new_messages[i] = updated_message
-                        any_modified = True
+                        redacted = self._redact_base_message(msg)
+                        if redacted is not msg:
+                            new_messages[i] = redacted
+                            any_modified = True
 
         if any_modified:
             return {"messages": new_messages}
@@ -821,27 +800,16 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                 last_ai_idx = i
                 break
 
-        if last_ai_idx is None or not last_ai_msg or not last_ai_msg.content:
+        if last_ai_idx is None or not last_ai_msg:
             return None
 
-        # Detect PII in message content
-        content = str(last_ai_msg.content)
-        new_content, matches = self._process_content(content)
-
-        if not matches:
+        redacted = self._redact_base_message(last_ai_msg)
+        if redacted is last_ai_msg:
             return None
-
-        # Create updated message
-        updated_message = AIMessage(
-            content=new_content,
-            id=last_ai_msg.id,
-            name=last_ai_msg.name,
-            tool_calls=last_ai_msg.tool_calls,
-        )
 
         # Return updated messages
         new_messages = list(messages)
-        new_messages[last_ai_idx] = updated_message
+        new_messages[last_ai_idx] = redacted
 
         return {"messages": new_messages}
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -401,6 +401,51 @@ class TestPIIMiddlewareIntegration:
         assert result is not None
         assert "[REDACTED_EMAIL]" in result["messages"][0].content
 
+    def test_after_model_redacts_tool_call_args_when_content_is_empty(self) -> None:
+        """Tool-call-only AI messages should still be scrubbed by `after_model`."""
+        middleware = PIIMiddleware(
+            "email", strategy="redact", apply_to_input=False, apply_to_output=True
+        )
+
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                ToolCall(
+                    name="send_email",
+                    args={"to": "alice@example.com"},
+                    id="call_123",
+                    type="tool_call",
+                )
+            ],
+        )
+        state = AgentState[Any](messages=[HumanMessage("hi"), msg])
+
+        result = middleware.after_model(state, Runtime())
+
+        assert result is not None
+        redacted = result["messages"][-1]
+        assert redacted.tool_calls[0]["args"] == {"to": "[REDACTED_EMAIL]"}
+        assert msg.tool_calls[0]["args"] == {"to": "alice@example.com"}
+
+    def test_before_model_preserves_structured_input_content(self) -> None:
+        """Structured human-message content should stay structured after redaction."""
+        middleware = PIIMiddleware(
+            "email", strategy="redact", apply_to_input=True, apply_to_output=False
+        )
+
+        msg = HumanMessage(
+            content=[{"type": "text", "text": "Reach me at alice@example.com"}]
+        )
+        state = AgentState[Any](messages=[msg])
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        redacted = result["messages"][0]
+        assert isinstance(redacted.content, list)
+        assert redacted.content[0]["text"] == "Reach me at [REDACTED_EMAIL]"
+        assert msg.content[0]["text"] == "Reach me at alice@example.com"
+
     def test_apply_to_both(self) -> None:
         """Test that middleware processes both input and output."""
         middleware = PIIMiddleware(
@@ -416,6 +461,25 @@ class TestPIIMiddlewareIntegration:
         state = AgentState[Any](messages=[AIMessage("My email is ai@example.com")])
         result = middleware.after_model(state, Runtime())
         assert result is not None
+
+    def test_after_model_preserves_structured_output_content(self) -> None:
+        """Structured AI-message content should stay structured after redaction."""
+        middleware = PIIMiddleware(
+            "email", strategy="redact", apply_to_input=False, apply_to_output=True
+        )
+
+        msg = AIMessage(
+            content=[{"type": "text", "text": "Reach me at ai@example.com"}]
+        )
+        state = AgentState[Any](messages=[msg])
+
+        result = middleware.after_model(state, Runtime())
+
+        assert result is not None
+        redacted = result["messages"][0]
+        assert isinstance(redacted.content, list)
+        assert redacted.content[0]["text"] == "Reach me at [REDACTED_EMAIL]"
+        assert msg.content[0]["text"] == "Reach me at ai@example.com"
 
     def test_no_pii_returns_none(self) -> None:
         """Test that middleware returns None when no PII detected."""
@@ -459,6 +523,36 @@ class TestPIIMiddlewareIntegration:
         assert isinstance(tool_msg, ToolMessage)
         assert "[REDACTED_EMAIL]" in tool_msg.content
         assert "john@example.com" not in tool_msg.content
+
+    def test_apply_to_tool_results_preserves_structured_content(self) -> None:
+        """Structured tool results should stay structured after redaction."""
+        middleware = PIIMiddleware(
+            "email", strategy="redact", apply_to_input=False, apply_to_tool_results=True
+        )
+
+        tool_msg = ToolMessage(
+            content=[{"type": "text", "text": "Found: john@example.com"}],
+            tool_call_id="call_123",
+        )
+        state = AgentState[Any](
+            messages=[
+                HumanMessage("Search for John"),
+                AIMessage(
+                    content="",
+                    tool_calls=[ToolCall(name="search", args={}, id="call_123", type="tool_call")],
+                ),
+                tool_msg,
+            ]
+        )
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        redacted = result["messages"][2]
+        assert isinstance(redacted, ToolMessage)
+        assert isinstance(redacted.content, list)
+        assert redacted.content[0]["text"] == "Found: [REDACTED_EMAIL]"
+        assert tool_msg.content[0]["text"] == "Found: john@example.com"
 
     def test_apply_to_tool_results_mask_strategy(self) -> None:
         """Test that mask strategy works for tool results."""


### PR DESCRIPTION
## Summary

This aligns `PIIMiddleware`'s state-level hooks with the recursive redaction semantics added for streaming and `values` snapshots.

Fixes #37659.

## What changed

- extracted shared recursive helpers for redacting message content and AI tool-call args
- routed `before_model` and `after_model` through the shared message redactor instead of `str(message.content)`-based reconstruction
- preserved structured content block shapes for human, tool, and AI messages on the state path
- redacted `AIMessage.tool_calls[*].args` even when the AI message has `content=""`
- added regression tests covering the empty-content tool-call case and structured content preservation on input, output, and tool results

## Root cause

`PIIMiddleware` originally implemented state-level redaction with manual hook logic. Later streaming work added a recursive message/value walker with broader and more accurate coverage, but the state hooks were left on the older path. That caused two behaviors to diverge:

- `after_model` skipped tool-call-only AI messages because it returned early when `content` was empty
- list-typed structured content was coerced through `str(...)`, corrupting message shape

## Impact

Non-streaming consumers now get the same redaction behavior that the recursive helper already provided on streaming and `values` surfaces, without broadening the PR into metadata or artifact redaction.

## Validation

- `uv run --directory libs/langchain_v1 --with ruff ruff check langchain/agents/middleware/pii.py tests/unit_tests/agents/middleware/implementations/test_pii.py`
- `uv run --directory libs/langchain_v1 --group test python -m pytest tests/unit_tests/agents/middleware/implementations/test_pii.py -q`
