### PR TITLE
fix(tests): correct router run name and remove redundant condition

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -2902,7 +2902,7 @@ def test_router_runnable(mocker: MockerFixture, snapshot: SnapshotAssertion) -> 
     parent_run = next(r for r in tracer.runs if r.parent_run_id is None)
     assert len(parent_run.child_runs) == 2
     router_run = parent_run.child_runs[1]
-    assert router_run.name == "RunnableSequence"  # TODO: should be RunnableRouter
+    assert router_run.name == "RunnableRouter"
     assert len(router_run.child_runs) == 2
 
 
@@ -3223,14 +3223,6 @@ def test_map_stream() -> None:
         {"llm": "i"},
         {"chat": _any_id_ai_message_chunk(content="i")},
     ]
-    if not (
-        # TODO: Rewrite properly the statement above
-        streamed_chunks[0] == {"llm": "i"}
-        or {"chat": _any_id_ai_message_chunk(content="i")}
-    ):
-        msg = f"Got an unexpected chunk: {streamed_chunks[0]}"
-        raise AssertionError(msg)
-
     assert len(streamed_chunks) == len(llm_res) + len(chat_res)
 
 


### PR DESCRIPTION
Was not a fix but a todo
    
    This PR corrects two small issues in test_runnable.py:
    
    - In test_router_runnable, the assertion checked for router_run.name == "RunnableSequence" but the expected value should be "RunnableRouter". The assertion is updated accordingly.
    - In test_map_stream_iterator_input, a redundant if block contained a logical bug (the second condition was not comparing streamed_chunks[0]). The entire block is removed because the preceding assertion already validates the condition, simplifying the test and removing the TODO.
        
    How to verify:
    bash
    make test
    
    All tests pass, including the affected ones:
    - libs/core/tests/unit_tests/runnables/test_runnable.py::test_router_runnable
    - libs/core/tests/unit_tests/runnables/test_runnable.py::test_map_stream_iterator_input