### PR TITLE
fix(langchain): preserve structured pii redaction in state hooks

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/pii.py
+++ b/libs/langchain_v1/langchain/agents/middleware/pii.py
@@ -166,6 +166,66 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
         sanitized = apply_strategy(content, matches, self.strategy)
         return sanitized, matches
 
+    def _process_value(self, value: Any) -> tuple[Any, list[PIIMatch]]:
+        """Recursively process strings while preserving structured content shapes."""
+        if isinstance(value, str):
+            return self._process_content(value)
+
+        if isinstance(value, list):
+            any_modified = False
+            all_matches: list[PIIMatch] = []
+            new_items = []
+            for item in value:
+                new_item, matches = self._process_value(item)
+                new_items.append(new_item)
+                if matches:
+                    any_modified = True
+                    all_matches.extend(matches)
+
+            if any_modified:
+                return new_items, all_matches
+            return value, []
+
+        if isinstance(value, dict):
+            any_modified = False
+            all_matches: list[PIIMatch] = []
+            new_dict = {}
+            for key, item in value.items():
+                new_item, matches = self._process_value(item)
+                new_dict[key] = new_item
+                if matches:
+                    any_modified = True
+                    all_matches.extend(matches)
+
+            if any_modified:
+                return new_dict, all_matches
+            return value, []
+
+        return value, []
+
+    def _process_tool_calls(
+        self,
+        tool_calls: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], list[PIIMatch]]:
+        """Process tool call args while preserving the rest of each tool call."""
+        any_modified = False
+        all_matches: list[PIIMatch] = []
+        new_tool_calls = []
+
+        for tool_call in tool_calls:
+            args = tool_call.get("args")
+            new_args, matches = self._process_value(args)
+            if matches:
+                any_modified = True
+                all_matches.extend(matches)
+                new_tool_calls.append({**tool_call, "args": new_args})
+            else:
+                new_tool_calls.append(tool_call)
+
+        if any_modified:
+            return new_tool_calls, all_matches
+        return tool_calls, []
+
     @hook_config(can_jump_to=["end"])
     @override
     def before_model(
@@ -208,15 +268,11 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                     break
 
             if last_user_idx is not None and last_user_msg and last_user_msg.content:
-                # Detect PII in message content
-                content = str(last_user_msg.content)
-                new_content, matches = self._process_content(content)
+                new_content, matches = self._process_value(last_user_msg.content)
 
                 if matches:
-                    updated_message: AnyMessage = HumanMessage(
-                        content=new_content,
-                        id=last_user_msg.id,
-                        name=last_user_msg.name,
+                    updated_message: AnyMessage = last_user_msg.model_copy(
+                        update={"content": new_content}
                     )
 
                     new_messages[last_user_idx] = updated_message
@@ -240,18 +296,13 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                         if not tool_msg.content:
                             continue
 
-                        content = str(tool_msg.content)
-                        new_content, matches = self._process_content(content)
+                        new_content, matches = self._process_value(tool_msg.content)
 
                         if not matches:
                             continue
 
-                        # Create updated tool message
-                        updated_message = ToolMessage(
-                            content=new_content,
-                            id=tool_msg.id,
-                            name=tool_msg.name,
-                            tool_call_id=tool_msg.tool_call_id,
+                        updated_message = tool_msg.model_copy(
+                            update={"content": new_content}
                         )
 
                         new_messages[i] = updated_message
@@ -319,22 +370,20 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                 last_ai_idx = i
                 break
 
-        if last_ai_idx is None or not last_ai_msg or not last_ai_msg.content:
+        if last_ai_idx is None or not last_ai_msg:
             return None
 
-        # Detect PII in message content
-        content = str(last_ai_msg.content)
-        new_content, matches = self._process_content(content)
+        new_content, content_matches = self._process_value(last_ai_msg.content)
+        new_tool_calls, tool_call_matches = self._process_tool_calls(last_ai_msg.tool_calls)
 
-        if not matches:
+        if not content_matches and not tool_call_matches:
             return None
 
-        # Create updated message
-        updated_message = AIMessage(
-            content=new_content,
-            id=last_ai_msg.id,
-            name=last_ai_msg.name,
-            tool_calls=last_ai_msg.tool_calls,
+        updated_message = last_ai_msg.model_copy(
+            update={
+                "content": new_content,
+                "tool_calls": new_tool_calls,
+            }
         )
 
         # Return updated messages

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -389,6 +389,89 @@ class TestPIIMiddlewareIntegration:
         assert result is not None
         assert "[REDACTED_EMAIL]" in result["messages"][0].content
 
+    def test_after_model_redacts_tool_call_args_without_content(self) -> None:
+        """Tool-call-only AI messages should still have args redacted."""
+        middleware = PIIMiddleware(
+            "email", strategy="redact", apply_to_input=False, apply_to_output=True
+        )
+
+        state = AgentState[Any](
+            messages=[
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            name="send_email",
+                            args={"to": "alice@example.com"},
+                            id="call_123",
+                            type="tool_call",
+                        )
+                    ],
+                )
+            ]
+        )
+
+        result = middleware.after_model(state, Runtime())
+
+        assert result is not None
+        message = result["messages"][0]
+        assert isinstance(message, AIMessage)
+        assert message.tool_calls[0]["args"] == {"to": "[REDACTED_EMAIL]"}
+
+    def test_before_model_preserves_structured_content_blocks(self) -> None:
+        """Structured content blocks should stay structured when redacted."""
+        middleware = PIIMiddleware("email", strategy="redact")
+
+        state = AgentState[Any](
+            messages=[
+                HumanMessage(
+                    content=[
+                        {"type": "text", "text": "Reach me at alice@example.com"}
+                    ]
+                )
+            ]
+        )
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        message = result["messages"][0]
+        assert isinstance(message, HumanMessage)
+        assert isinstance(message.content, list)
+        assert message.content[0]["text"] == "Reach me at [REDACTED_EMAIL]"
+
+    def test_before_model_preserves_structured_tool_results(self) -> None:
+        """Structured tool results should stay structured when redacted."""
+        middleware = PIIMiddleware(
+            "email", strategy="redact", apply_to_input=False, apply_to_tool_results=True
+        )
+
+        state = AgentState[Any](
+            messages=[
+                HumanMessage("Search for John"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        ToolCall(name="search", args={}, id="call_123", type="tool_call")
+                    ],
+                ),
+                ToolMessage(
+                    content=[
+                        {"type": "text", "text": "Found: john@example.com"}
+                    ],
+                    tool_call_id="call_123",
+                ),
+            ]
+        )
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        tool_msg = result["messages"][2]
+        assert isinstance(tool_msg, ToolMessage)
+        assert isinstance(tool_msg.content, list)
+        assert tool_msg.content[0]["text"] == "Found: [REDACTED_EMAIL]"
+
     def test_apply_to_both(self) -> None:
         """Test that middleware processes both input and output."""
         middleware = PIIMiddleware(


### PR DESCRIPTION
## Summary
- preserve structured `HumanMessage` and `ToolMessage` content during PII redaction in `before_model`
- redact tool call args in `after_model` even when the last `AIMessage` has empty `content`
- add regression coverage for structured content blocks, structured tool results, and tool-call-only AI messages

## Why
`PIIMiddleware` state hooks were coercing structured message content to strings, which corrupted block-based content in state. Separately, `after_model` returned early for tool-call-only AI messages, so tool call args containing PII were skipped entirely.

This patch keeps message shapes intact by redacting recursively within strings while preserving lists/dicts, and extends the output hook to process tool call args independently of `content`.

## Testing
- `python -m pytest -p pytest_asyncio.plugin -p pytest_mock -p syrupy -p pytest_recording.plugin tests/unit_tests/agents/middleware/implementations/test_pii.py -q`
- `python -m ruff check langchain/agents/middleware/pii.py tests/unit_tests/agents/middleware/implementations/test_pii.py`

## Review notes
- the recursive redaction helper only transforms nested strings and leaves non-string values unchanged
- tool call updates are limited to `args`; the rest of the tool call payload is preserved

AI assistance disclaimer: I used an AI coding assistant to help draft and validate this change, then reviewed and verified the final patch and test results locally.

Closes #37659