### PR TITLE
fix(text-splitters): regex separator pattern used as literal text when merging chunks

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -52,7 +52,13 @@ class CharacterTextSplitter(TextSplitter):
         #    - else -> re-insert literal separator
         merge_sep = ""
         if not (self._keep_separator or is_lookaround):
-            merge_sep = self._separator
+            if self._is_separator_regex:
+                # Use the actual matched text, not the raw regex pattern.
+                # Inserting the pattern string (e.g. r"\s") as literal text is wrong.
+                m = re.search(sep_pattern, text)
+                merge_sep = m.group(0) if m else ""
+            else:
+                merge_sep = self._separator
 
         # 5. Merge adjacent splits and return
         return self._merge_splits(splits, merge_sep)
@@ -127,7 +133,14 @@ class RecursiveCharacterTextSplitter(TextSplitter):
 
         # Now go merging things, recursively splitting longer texts.
         good_splits = []
-        separator_ = "" if self._keep_separator else separator
+        if self._keep_separator:
+            separator_ = ""
+        elif self._is_separator_regex:
+            # Use the actual text that matched the regex, not the pattern string itself.
+            m = re.search(separator_, text)
+            separator_ = m.group(0) if m else ""
+        else:
+            separator_ = separator
         for s in splits:
             if self._length_function(s) < self._chunk_size:
                 good_splits.append(s)


### PR DESCRIPTION
…ging chunks

Fixes #

---

<!-- Keep the `Fixes #xx` keyword at the very top and update the issue number — this auto-closes the issue on merge. Replace this comment with a 1-2 sentence description of your change. No `# Summary` header; the description is the summary. -->

## **Description:**

When `is_separator_regex=True` and `keep_separator=False`, both
`CharacterTextSplitter` and `RecursiveCharacterTextSplitter` were using
the raw regex pattern string (e.g. `r"\s"`) as the literal merge
separator when reassembling chunks. This resulted in the regex syntax
appearing verbatim in the output text (e.g. `"Hello\sworld"`) instead
of the actual matched character (e.g. `"Hello world"`).

**Root cause:** In `_split_text` (RecursiveCharacterTextSplitter) and
`split_text` (CharacterTextSplitter), the variable used for joining
chunks back together was set directly to `self._separator` / `separator`
without checking whether it was a regex pattern. When `is_separator_regex=True`,
that variable holds a regex string, not a literal character.

**Fix:** When `is_separator_regex=True` and `keep_separator=False`, use
`re.search()` to find what the pattern actually matched in the text, and
use that real matched string (e.g. `" "`) as the merge separator instead
of the raw pattern.

**Issue:** Fixes #23394

**Dependencies:** No new dependencies.

**Tests:**
- `CharacterTextSplitter` with `is_separator_regex=True`, `keep_separator=False` → no regex pattern in output ✅
- `RecursiveCharacterTextSplitter` same scenario ✅
- Chunk size boundary splitting still works correctly ✅
- Non-regex separators unchanged ✅
- `keep_separator=True` with regex unchanged ✅

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
LinkedIn: https://linkedin.com/in/hirad-dolatzadeh
