### PR TITLE
fix(core): use materialized sequence in VectorStore.add_texts with generator input

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -86,7 +86,7 @@ class VectorStore(ABC):
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             if ids is not None:
                 # For backward compatibility
@@ -226,7 +226,7 @@ class VectorStore(ABC):
 
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             return await self.aadd_documents(docs, **kwargs)
         return await run_in_executor(None, self.add_texts, texts, metadatas, **kwargs)

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -177,6 +177,13 @@ def test_default_add_texts(vs_class: type[VectorStore]) -> None:
         Document(id=ids_2[1], page_content="bar", metadata={"foo": "bar"}),
     ]
 
+    # Generator input should not be exhausted before documents are created
+    gen_ids = store.add_texts(text for text in ["alpha", "beta"])
+    assert store.get_by_ids(gen_ids) == [
+        Document(id=gen_ids[0], page_content="alpha"),
+        Document(id=gen_ids[1], page_content="beta"),
+    ]
+
 
 @pytest.mark.parametrize(
     "vs_class", [CustomAddTextsVectorstore, CustomAddDocumentsVectorstore]
@@ -233,6 +240,13 @@ async def test_default_aadd_texts(vs_class: type[VectorStore]) -> None:
     assert await store.aget_by_ids(ids_2) == [
         Document(id=ids_2[0], page_content="foo", metadata={"foo": "bar"}),
         Document(id=ids_2[1], page_content="bar", metadata={"foo": "bar"}),
+    ]
+
+    # Generator input should not be exhausted before documents are created
+    gen_ids = await store.aadd_texts(text for text in ["alpha", "beta"])
+    assert await store.aget_by_ids(gen_ids) == [
+        Document(id=gen_ids[0], page_content="alpha"),
+        Document(id=gen_ids[1], page_content="beta"),
     ]
 
 


### PR DESCRIPTION
Closes #37673

---

`VectorStore.add_texts` and `aadd_texts` both accept `Iterable[str]`, which
includes generators. Both methods guard against non-list/tuple inputs by
materializing the iterable first:

\`\`\`python
texts_: Sequence[str] = texts if isinstance(texts, (list, tuple)) else list(texts)
\`\`\`

However, the \`zip\` that builds the \`Document\` list used \`texts\` (the
original, now-exhausted generator) instead of \`texts_\`:

\`\`\`python
for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
\`\`\`

When a generator was passed, it was consumed by the materialization step and
the document list ended up empty — no documents were added and no error was
raised.

The fix replaces \`texts\` with \`texts_\` in the \`zip\` call in both \`add_texts\`
and \`aadd_texts\`. Regression tests cover generator input for both methods.

*This contribution was made with AI assistance.*