### PR TITLE
fix(core): serialize args_schema, func, and coroutine in model_dump JSON mode

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -31,6 +31,7 @@ from pydantic import (
     PydanticDeprecationWarning,
     SkipValidation,
     ValidationError,
+    field_serializer,
     validate_arguments,
 )
 from pydantic.fields import FieldInfo
@@ -402,6 +403,28 @@ ArgsSchema = TypeBaseModel | dict[str, Any]
 _EMPTY_SET: frozenset[str] = frozenset()
 
 
+def _serialize_callable_to_name(func: Callable | None) -> str | None:
+    """Serialize a callable to a stable, JSON-safe identifier string.
+
+    Used by JSON-only `field_serializer` decorators so that tools holding a
+    `func` or `coroutine` can be dumped with `model_dump(mode="json")`.
+
+    Args:
+        func: The callable to serialize, or `None`.
+
+    Returns:
+        A `"<module>.<qualname>"` string when those attributes are available,
+        the callable's `repr` as a fallback, or `None` if `func` is `None`.
+    """
+    if func is None:
+        return None
+    module = getattr(func, "__module__", None)
+    qualname = getattr(func, "__qualname__", None)
+    if module is not None and qualname is not None:
+        return f"{module}.{qualname}"
+    return repr(func)
+
+
 class BaseTool(RunnableSerializable[str | dict | ToolCall, Any]):
     """Base class for all LangChain tools.
 
@@ -553,6 +576,24 @@ class ChildTool(BaseTool):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
     )
+
+    @field_serializer("args_schema", when_used="json")
+    def _serialize_args_schema(
+        self, args_schema: ArgsSchema | None
+    ) -> dict[str, Any] | None:
+        """Serialize `args_schema` to a JSON schema dict for JSON dumps only.
+
+        This runs only for `model_dump(mode="json")` and `model_dump_json()`.
+        Python-mode `model_dump()` is unaffected and still returns the original
+        model class (or dict), preserving round-tripping and existing behavior.
+        """
+        if args_schema is None:
+            return None
+        if isinstance(args_schema, dict):
+            return args_schema
+        if issubclass(args_schema, BaseModelV1):
+            return args_schema.schema()
+        return args_schema.model_json_schema()
 
     @property
     def is_single_input(self) -> bool:

--- a/libs/core/langchain_core/tools/simple.py
+++ b/libs/core/langchain_core/tools/simple.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
 )
 
+from pydantic import field_serializer
 from typing_extensions import override
 
 # Cannot move to TYPE_CHECKING as _run/_arun parameter annotations are needed at runtime
@@ -22,6 +23,7 @@ from langchain_core.tools.base import (
     BaseTool,
     ToolException,
     _get_runnable_config_param,
+    _serialize_callable_to_name,
 )
 
 if TYPE_CHECKING:
@@ -38,6 +40,14 @@ class Tool(BaseTool):
 
     coroutine: Callable[..., Awaitable[str]] | None = None
     """The asynchronous version of the function."""
+
+    @field_serializer("func", "coroutine", when_used="json")
+    def _serialize_callables(self, func: Callable | None) -> str | None:
+        """Serialize callable fields to a name string for JSON dumps only.
+
+        Python-mode `model_dump()` is unaffected and still returns the callable.
+        """
+        return _serialize_callable_to_name(func)
 
     # --- Runnable ---
 

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -13,7 +13,7 @@ from typing import (
     Literal,
 )
 
-from pydantic import Field, SkipValidation
+from pydantic import Field, SkipValidation, field_serializer
 from typing_extensions import override
 
 # Cannot move to TYPE_CHECKING as _run/_arun parameter annotations are needed at runtime
@@ -29,6 +29,7 @@ from langchain_core.tools.base import (
     BaseTool,
     _get_runnable_config_param,
     _is_injected_arg_type,
+    _serialize_callable_to_name,
     create_schema_from_function,
 )
 from langchain_core.utils.pydantic import is_basemodel_subclass
@@ -52,6 +53,14 @@ class StructuredTool(BaseTool):
 
     coroutine: Callable[..., Awaitable[Any]] | None = None
     """The asynchronous version of the function."""
+
+    @field_serializer("func", "coroutine", when_used="json")
+    def _serialize_callables(self, func: Callable | None) -> str | None:
+        """Serialize callable fields to a name string for JSON dumps only.
+
+        Python-mode `model_dump()` is unaffected and still returns the callable.
+        """
+        return _serialize_callable_to_name(func)
 
     # --- Runnable ---
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3741,3 +3741,144 @@ def test_tool_invoke_returns_list_of_mixin() -> None:
     assert isinstance(result, list)
     assert len(result) == 3
     assert all(isinstance(m, ToolMessage) for m in result)
+
+
+def test_structured_tool_model_dump_json_mode() -> None:
+    """The issue repro: dumping a StructuredTool in JSON mode must not raise."""
+
+    class _Input(BaseModel):
+        x: str
+
+    def my_func(x: str) -> str:
+        return x
+
+    structured_tool = StructuredTool.from_function(
+        func=my_func, name="test", description="test", args_schema=_Input
+    )
+
+    dumped = structured_tool.model_dump(mode="json", exclude_none=True)
+
+    # args_schema is serialized to its JSON schema dict.
+    assert isinstance(dumped["args_schema"], dict)
+    assert dumped["args_schema"]["properties"]["x"]["type"] == "string"
+    # func is serialized to a stable name string.
+    assert isinstance(dumped["func"], str)
+    assert dumped["func"].endswith("my_func")
+
+    # model_dump_json works end to end and produces valid JSON.
+    parsed = json.loads(structured_tool.model_dump_json())
+    assert parsed["name"] == "test"
+
+
+def test_tool_model_dump_json_mode_with_coroutine() -> None:
+    """A Tool with a coroutine serializes cleanly in JSON mode."""
+
+    def my_func(x: str) -> str:
+        return x
+
+    async def my_coroutine(x: str) -> str:
+        return x
+
+    simple_tool = Tool(
+        name="test",
+        func=my_func,
+        description="test",
+        coroutine=my_coroutine,
+    )
+
+    dumped = simple_tool.model_dump(mode="json", exclude_none=True)
+
+    assert isinstance(dumped["func"], str)
+    assert dumped["func"].endswith("my_func")
+    assert isinstance(dumped["coroutine"], str)
+    assert dumped["coroutine"].endswith("my_coroutine")
+
+    # Ends to end through model_dump_json.
+    assert json.loads(simple_tool.model_dump_json())["name"] == "test"
+
+
+def test_structured_tool_model_dump_json_mode_with_coroutine() -> None:
+    """A StructuredTool with only a coroutine serializes cleanly in JSON mode."""
+
+    class _Input(BaseModel):
+        x: str
+
+    async def my_coroutine(x: str) -> str:
+        return x
+
+    structured_tool = StructuredTool.from_function(
+        func=None,
+        coroutine=my_coroutine,
+        name="test",
+        description="test",
+        args_schema=_Input,
+    )
+
+    dumped = structured_tool.model_dump(mode="json", exclude_none=True)
+
+    assert isinstance(dumped["args_schema"], dict)
+    assert isinstance(dumped["coroutine"], str)
+    assert dumped["coroutine"].endswith("my_coroutine")
+
+
+def test_tool_model_dump_json_mode_args_schema_dict() -> None:
+    """A dict args_schema passes through unchanged in JSON mode."""
+
+    def my_func(x: str) -> str:
+        return x
+
+    args_schema: dict = {
+        "type": "object",
+        "properties": {"x": {"type": "string"}},
+    }
+    simple_tool = Tool(
+        name="test",
+        func=my_func,
+        description="test",
+        args_schema=args_schema,
+    )
+
+    dumped = simple_tool.model_dump(mode="json", exclude_none=True)
+    assert dumped["args_schema"] == args_schema
+
+
+def test_tool_model_dump_json_mode_pydantic_v1_args_schema() -> None:
+    """A pydantic v1 args_schema is serialized via .schema() in JSON mode."""
+
+    class _InputV1(BaseModelV1):
+        x: str
+
+    def my_func(x: str) -> str:
+        return x
+
+    structured_tool = StructuredTool.from_function(
+        func=my_func, name="test", description="test", args_schema=_InputV1
+    )
+
+    dumped = structured_tool.model_dump(mode="json", exclude_none=True)
+    assert isinstance(dumped["args_schema"], dict)
+    assert dumped["args_schema"]["properties"]["x"]["type"] == "string"
+
+
+def test_tool_model_dump_python_mode_preserved() -> None:
+    """Python-mode model_dump must keep the real class and callable.
+
+    Only JSON mode is affected by the field serializers, so default dumps
+    continue to return the original objects for round-tripping.
+    """
+
+    class _Input(BaseModel):
+        x: str
+
+    def my_func(x: str) -> str:
+        return x
+
+    structured_tool = StructuredTool.from_function(
+        func=my_func, name="test", description="test", args_schema=_Input
+    )
+
+    dumped = structured_tool.model_dump()
+
+    # args_schema is still the model class, func is still the callable.
+    assert dumped["args_schema"] is _Input
+    assert dumped["func"] is my_func


### PR DESCRIPTION
Fixes #36517

---

Calling `model_dump(mode="json")` (or `model_dump_json()`) on a tool raised `PydanticSerializationError`. Three fields hold values that pydantic does not know how to JSON-serialize: `args_schema` is a pydantic model class or a JSON schema dict, and `func` and `coroutine` are callables. Pydantic could dump these in python mode but had no way to turn the model class or the callable into JSON.

The fix adds `field_serializer` decorators that are scoped with `when_used="json"`, so they only run for JSON serialization. For JSON dumps, `args_schema` is emitted as its JSON schema dict (`model_json_schema()` for pydantic v2 models, `.schema()` for v1 models, and dicts pass through unchanged), and `func`/`coroutine` become a stable `"<module>.<qualname>"` name string. Because the serializers are JSON-only, the default python-mode `model_dump()` is untouched and still returns the real class and the real callables, so existing behavior and round-tripping are preserved.

I added unit tests covering the original repro, a `Tool` and a `StructuredTool` with a coroutine, dict and pydantic v1 `args_schema`, and an explicit assertion that python-mode `model_dump()` still returns the class and callable.
