### PR TITLE
fix: implement async _aget_relevant_documents in RePhraseQueryRetriever

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/re_phraser.py
+++ b/libs/langchain/langchain_classic/retrievers/re_phraser.py
@@ -89,4 +89,21 @@ class RePhraseQueryRetriever(BaseRetriever):
         *,
         run_manager: AsyncCallbackManagerForRetrieverRun,
     ) -> list[Document]:
-        raise NotImplementedError
+        """Async implementation of _get_relevant_documents.
+
+        Args:
+            query: user question
+            run_manager: callback handler to use
+
+        Returns:
+            Relevant documents for re-phrased question
+        """
+        re_phrased_question = await self.llm_chain.ainvoke(
+            query,
+            {"callbacks": run_manager.get_child()},
+        )
+        logger.info("Re-phrased question: %s", re_phrased_question)
+        return await self.retriever.ainvoke(
+            re_phrased_question,
+            config={"callbacks": run_manager.get_child()},
+        )


### PR DESCRIPTION
## Description

Replaces the `raise NotImplementedError` stub in `RePhraseQueryRetriever._aget_relevant_documents` with a proper async implementation that mirrors the sync `_get_relevant_documents` method.

The async version uses `ainvoke` instead of `invoke` for both the LLM chain and retriever calls.

Fixes #37619

## Changes
- `libs/langchain/langchain_classic/retrievers/re_phraser.py`: Implemented async method using `await self.llm_chain.ainvoke()` and `await self.retriever.ainvoke()`