### PR TITLE
feat(core): add abstract TrustVerifier protocol for MCP server trust verification

### DIFF
--- a/libs/core/langchain_core/tools/__init__.py
+++ b/libs/core/langchain_core/tools/__init__.py
@@ -11,6 +11,13 @@ from typing import TYPE_CHECKING
 from langchain_core._import_utils import import_attr
 
 if TYPE_CHECKING:
+    from langchain_core.tools.mcp.trust import (
+        DominionObservatoryVerifier,
+        TrustFailureMode,
+        TrustScore,
+        TrustVerificationError,
+        TrustVerifier,
+    )
     from langchain_core.tools.base import (
         FILTERED_ARGS,
         ArgsSchema,
@@ -40,6 +47,7 @@ if TYPE_CHECKING:
     from langchain_core.tools.structured import StructuredTool
 
 __all__ = (
+    "DominionObservatoryVerifier",
     "FILTERED_ARGS",
     "ArgsSchema",
     "BaseTool",
@@ -52,6 +60,10 @@ __all__ = (
     "Tool",
     "ToolException",
     "ToolsRenderer",
+    "TrustFailureMode",
+    "TrustScore",
+    "TrustVerificationError",
+    "TrustVerifier",
     "_get_runnable_config_param",
     "convert_runnable_to_tool",
     "create_retriever_tool",
@@ -62,6 +74,11 @@ __all__ = (
 )
 
 _dynamic_imports = {
+    "DominionObservatoryVerifier": "mcp.trust",
+    "TrustFailureMode": "mcp.trust",
+    "TrustScore": "mcp.trust",
+    "TrustVerificationError": "mcp.trust",
+    "TrustVerifier": "mcp.trust",
     "FILTERED_ARGS": "base",
     "ArgsSchema": "base",
     "BaseTool": "base",

--- a/libs/core/langchain_core/tools/mcp/__init__.py
+++ b/libs/core/langchain_core/tools/mcp/__init__.py
@@ -1,0 +1,19 @@
+"""MCP (Model Context Protocol) tool utilities for langchain-core."""
+
+from __future__ import annotations
+
+from langchain_core.tools.mcp.trust import (
+    DominionObservatoryVerifier,
+    TrustFailureMode,
+    TrustScore,
+    TrustVerificationError,
+    TrustVerifier,
+)
+
+__all__ = (
+    "DominionObservatoryVerifier",
+    "TrustFailureMode",
+    "TrustScore",
+    "TrustVerificationError",
+    "TrustVerifier",
+)

--- a/libs/core/langchain_core/tools/mcp/trust.py
+++ b/libs/core/langchain_core/tools/mcp/trust.py
@@ -1,0 +1,255 @@
+"""Abstract TrustVerifier protocol and default implementation for MCP server trust."""
+
+from __future__ import annotations
+
+import abc
+import enum
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+
+class TrustVerificationError(Exception):
+    """Raised when an MCP server fails trust verification.
+
+    This can occur when the server's trust score is below the configured
+    threshold, or when the trust API is unreachable and the failure mode
+    is set to DENY.
+    """
+
+
+class TrustFailureMode(enum.Enum):
+    """Behavior when the trust verification API is unreachable.
+
+    Attributes:
+        ALLOW: Permit tool execution even when the API cannot be contacted.
+        DENY: Block tool execution when the API cannot be contacted.
+    """
+
+    ALLOW = "allow"
+    DENY = "deny"
+
+
+@dataclass
+class TrustScore:
+    """Trust assessment returned by a TrustVerifier for an MCP server.
+
+    Attributes:
+        trust_score: Numeric trust level in the range [0.0, 1.0], where
+            1.0 represents full trust and 0.0 represents no trust.
+        sla_grade: Qualitative grade label from the trust provider
+            (e.g. ``"A"``, ``"B"``, ``"F"``).
+    """
+
+    trust_score: float
+    sla_grade: str
+
+
+class TrustVerifier(abc.ABC):
+    """Abstract base class for MCP server trust verifiers.
+
+    Implementations check whether an MCP server is trustworthy before
+    tool execution proceeds. Both synchronous and asynchronous entry
+    points are required so callers can choose based on their runtime.
+
+    Example:
+        .. code-block:: python
+
+            class MyVerifier(TrustVerifier):
+                def verify(self, server_url: str) -> TrustScore:
+                    # custom logic
+                    return TrustScore(trust_score=0.9, sla_grade="A")
+
+                async def averify(self, server_url: str) -> TrustScore:
+                    return self.verify(server_url)
+    """
+
+    @abc.abstractmethod
+    def verify(self, server_url: str) -> TrustScore:
+        """Verify the trustworthiness of an MCP server synchronously.
+
+        Args:
+            server_url: The URL of the MCP server to verify.
+
+        Returns:
+            `TrustScore` describing the server's trust level.
+
+        Raises:
+            TrustVerificationError: If the server does not meet the
+                verifier's trust requirements.
+        """
+
+    @abc.abstractmethod
+    async def averify(self, server_url: str) -> TrustScore:
+        """Verify the trustworthiness of an MCP server asynchronously.
+
+        Args:
+            server_url: The URL of the MCP server to verify.
+
+        Returns:
+            `TrustScore` describing the server's trust level.
+
+        Raises:
+            TrustVerificationError: If the server does not meet the
+                verifier's trust requirements.
+        """
+
+
+class DominionObservatoryVerifier(TrustVerifier):
+    """Trust verifier backed by the Dominion Observatory public API.
+
+    Calls ``GET https://dominionobservatory.com/api/trust?url=<server_url>``
+    and returns a `TrustScore` from the response JSON. Results are cached
+    per server URL for `ttl` seconds to stay within the 50 queries/day
+    free-tier limit.
+
+    Example:
+        .. code-block:: python
+
+            verifier = DominionObservatoryVerifier(
+                trust_threshold=0.8,
+                trust_failure_mode=TrustFailureMode.DENY,
+                ttl=300,
+            )
+            score = verifier.verify("https://my-mcp-server.example.com")
+    """
+
+    _API_BASE = "https://dominionobservatory.com/api/trust"
+
+    def __init__(
+        self,
+        *,
+        trust_threshold: float = 0.7,
+        trust_failure_mode: TrustFailureMode = TrustFailureMode.DENY,
+        ttl: int = 300,
+    ) -> None:
+        """Initialize the Dominion Observatory verifier.
+
+        Args:
+            trust_threshold: Minimum `trust_score` required to pass
+                verification. Scores strictly below this value raise
+                `TrustVerificationError`.
+            trust_failure_mode: Behavior when the trust API is unreachable.
+                `ALLOW` permits execution; `DENY` raises `TrustVerificationError`.
+            ttl: Time-to-live in seconds for cached trust scores. Subsequent
+                calls for the same URL within this window skip the API request.
+        """
+        self.trust_threshold = trust_threshold
+        self.trust_failure_mode = trust_failure_mode
+        self.ttl = ttl
+        # Maps server_url -> (TrustScore, expiry_monotonic_timestamp)
+        self._cache: dict[str, tuple[TrustScore, float]] = {}
+
+    # ------------------------------------------------------------------ #
+    # Cache helpers
+    # ------------------------------------------------------------------ #
+
+    def _get_cached(self, server_url: str) -> TrustScore | None:
+        entry = self._cache.get(server_url)
+        if entry is None:
+            return None
+        score, expiry = entry
+        if time.monotonic() < expiry:
+            return score
+        del self._cache[server_url]
+        return None
+
+    def _set_cached(self, server_url: str, score: TrustScore) -> None:
+        self._cache[server_url] = (score, time.monotonic() + self.ttl)
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers
+    # ------------------------------------------------------------------ #
+
+    def _parse_response(self, data: dict[str, Any]) -> TrustScore:
+        return TrustScore(
+            trust_score=float(data["trust_score"]),
+            sla_grade=str(data["sla_grade"]),
+        )
+
+    def _check_threshold(self, score: TrustScore, server_url: str) -> None:
+        if score.trust_score < self.trust_threshold:
+            msg = (
+                f"MCP server '{server_url}' failed trust verification: "
+                f"score {score.trust_score:.2f} is below threshold "
+                f"{self.trust_threshold:.2f}"
+            )
+            raise TrustVerificationError(msg)
+
+    def _unreachable_score(self, server_url: str) -> TrustScore:
+        """Return a fallback score or raise, depending on trust_failure_mode."""
+        if self.trust_failure_mode is TrustFailureMode.ALLOW:
+            return TrustScore(trust_score=1.0, sla_grade="N/A")
+        msg = (
+            f"Trust API unreachable for '{server_url}'; "
+            "blocking tool execution per DENY failure mode"
+        )
+        raise TrustVerificationError(msg)
+
+    # ------------------------------------------------------------------ #
+    # Public interface
+    # ------------------------------------------------------------------ #
+
+    def verify(self, server_url: str) -> TrustScore:
+        """Verify trust for `server_url` synchronously, using cache when available.
+
+        Args:
+            server_url: The URL of the MCP server to verify.
+
+        Returns:
+            `TrustScore` with the server's `trust_score` and `sla_grade`.
+
+        Raises:
+            TrustVerificationError: If `trust_score` is below `trust_threshold`,
+                or if the API is unreachable and `trust_failure_mode` is `DENY`.
+        """
+        cached = self._get_cached(server_url)
+        if cached is not None:
+            self._check_threshold(cached, server_url)
+            return cached
+
+        try:
+            with httpx.Client(timeout=10.0) as client:
+                response = client.get(self._API_BASE, params={"url": server_url})
+                response.raise_for_status()
+                data: dict[str, Any] = response.json()
+        except Exception:
+            return self._unreachable_score(server_url)
+
+        score = self._parse_response(data)
+        self._set_cached(server_url, score)
+        self._check_threshold(score, server_url)
+        return score
+
+    async def averify(self, server_url: str) -> TrustScore:
+        """Verify trust for `server_url` asynchronously, using cache when available.
+
+        Args:
+            server_url: The URL of the MCP server to verify.
+
+        Returns:
+            `TrustScore` with the server's `trust_score` and `sla_grade`.
+
+        Raises:
+            TrustVerificationError: If `trust_score` is below `trust_threshold`,
+                or if the API is unreachable and `trust_failure_mode` is `DENY`.
+        """
+        cached = self._get_cached(server_url)
+        if cached is not None:
+            self._check_threshold(cached, server_url)
+            return cached
+
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.get(self._API_BASE, params={"url": server_url})
+                response.raise_for_status()
+                data: dict[str, Any] = response.json()
+        except Exception:
+            return self._unreachable_score(server_url)
+
+        score = self._parse_response(data)
+        self._set_cached(server_url, score)
+        self._check_threshold(score, server_url)
+        return score

--- a/libs/core/tests/unit_tests/tools/test_mcp_trust.py
+++ b/libs/core/tests/unit_tests/tools/test_mcp_trust.py
@@ -1,0 +1,314 @@
+"""Unit tests for MCP server trust verification."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from langchain_core.tools.mcp.trust import (
+    DominionObservatoryVerifier,
+    TrustFailureMode,
+    TrustScore,
+    TrustVerificationError,
+    TrustVerifier,
+)
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+_SERVER_URL = "https://mcp.example.com"
+_PASSING_RESPONSE = {"trust_score": 0.9, "sla_grade": "A"}
+_FAILING_RESPONSE = {"trust_score": 0.5, "sla_grade": "F"}
+
+
+def _make_httpx_response(data: dict[str, Any], status_code: int = 200) -> MagicMock:
+    """Build a mock httpx.Response."""
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = data
+    mock.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import httpx
+
+        mock.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=mock
+        )
+    return mock
+
+
+def _make_async_httpx_response(data: dict[str, Any], status_code: int = 200) -> MagicMock:
+    """Build a mock async httpx.Response."""
+    mock = _make_httpx_response(data, status_code)
+    return mock
+
+
+# --------------------------------------------------------------------------- #
+# Abstract protocol
+# --------------------------------------------------------------------------- #
+
+
+class TestTrustVerifierIsAbstract:
+    def test_cannot_instantiate_directly(self) -> None:
+        with pytest.raises(TypeError):
+            TrustVerifier()  # type: ignore[abstract]
+
+    def test_concrete_subclass_works(self) -> None:
+        class ConcreteVerifier(TrustVerifier):
+            def verify(self, server_url: str) -> TrustScore:
+                return TrustScore(trust_score=1.0, sla_grade="A")
+
+            async def averify(self, server_url: str) -> TrustScore:
+                return self.verify(server_url)
+
+        v = ConcreteVerifier()
+        score = v.verify(_SERVER_URL)
+        assert score.trust_score == 1.0
+        assert score.sla_grade == "A"
+
+
+# --------------------------------------------------------------------------- #
+# TrustScore dataclass
+# --------------------------------------------------------------------------- #
+
+
+class TestTrustScore:
+    def test_fields(self) -> None:
+        score = TrustScore(trust_score=0.85, sla_grade="B")
+        assert score.trust_score == 0.85
+        assert score.sla_grade == "B"
+
+    def test_equality(self) -> None:
+        assert TrustScore(0.9, "A") == TrustScore(0.9, "A")
+        assert TrustScore(0.9, "A") != TrustScore(0.8, "A")
+
+
+# --------------------------------------------------------------------------- #
+# DominionObservatoryVerifier — synchronous
+# --------------------------------------------------------------------------- #
+
+
+class TestDominionObservatoryVerifierSync:
+    def _verifier(self, **kwargs: Any) -> DominionObservatoryVerifier:
+        return DominionObservatoryVerifier(**kwargs)
+
+    def test_passes_when_score_above_threshold(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7)
+        response = _make_httpx_response(_PASSING_RESPONSE)
+        client_mock = MagicMock()
+        client_mock.__enter__ = MagicMock(return_value=client_mock)
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.return_value = response
+
+        with patch("httpx.Client", return_value=client_mock):
+            score = verifier.verify(_SERVER_URL)
+
+        assert score.trust_score == 0.9
+        assert score.sla_grade == "A"
+
+    def test_raises_when_score_below_threshold(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7)
+        response = _make_httpx_response(_FAILING_RESPONSE)
+        client_mock = MagicMock()
+        client_mock.__enter__ = MagicMock(return_value=client_mock)
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.return_value = response
+
+        with patch("httpx.Client", return_value=client_mock):
+            with pytest.raises(TrustVerificationError, match="below threshold"):
+                verifier.verify(_SERVER_URL)
+
+    def test_unreachable_allow_mode_passes(self) -> None:
+        verifier = self._verifier(trust_failure_mode=TrustFailureMode.ALLOW)
+        client_mock = MagicMock()
+        client_mock.__enter__ = MagicMock(return_value=client_mock)
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.side_effect = ConnectionError("unreachable")
+
+        with patch("httpx.Client", return_value=client_mock):
+            score = verifier.verify(_SERVER_URL)
+
+        assert score.trust_score == 1.0
+        assert score.sla_grade == "N/A"
+
+    def test_unreachable_deny_mode_raises(self) -> None:
+        verifier = self._verifier(trust_failure_mode=TrustFailureMode.DENY)
+        client_mock = MagicMock()
+        client_mock.__enter__ = MagicMock(return_value=client_mock)
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.side_effect = ConnectionError("unreachable")
+
+        with patch("httpx.Client", return_value=client_mock):
+            with pytest.raises(TrustVerificationError, match="DENY failure mode"):
+                verifier.verify(_SERVER_URL)
+
+    def test_ttl_cache_prevents_duplicate_api_calls(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7, ttl=300)
+        response = _make_httpx_response(_PASSING_RESPONSE)
+        client_mock = MagicMock()
+        client_mock.__enter__ = MagicMock(return_value=client_mock)
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.return_value = response
+
+        with patch("httpx.Client", return_value=client_mock):
+            verifier.verify(_SERVER_URL)
+            verifier.verify(_SERVER_URL)
+            verifier.verify(_SERVER_URL)
+
+        # API should only have been called once despite three verify() calls
+        assert client_mock.get.call_count == 1
+
+    def test_ttl_cache_expires_and_makes_fresh_call(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7, ttl=60)
+        response = _make_httpx_response(_PASSING_RESPONSE)
+        client_mock = MagicMock()
+        client_mock.__enter__ = MagicMock(return_value=client_mock)
+        client_mock.__exit__ = MagicMock(return_value=False)
+        client_mock.get.return_value = response
+
+        # Prime the cache with an already-expired entry
+        verifier._cache[_SERVER_URL] = (
+            TrustScore(trust_score=0.9, sla_grade="A"),
+            time.monotonic() - 1,  # expired one second ago
+        )
+
+        with patch("httpx.Client", return_value=client_mock):
+            verifier.verify(_SERVER_URL)
+
+        # Expired cache should trigger a fresh API call
+        assert client_mock.get.call_count == 1
+
+    def test_cache_hit_does_not_call_api(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7, ttl=300)
+
+        # Seed cache with a valid, non-expired entry
+        verifier._cache[_SERVER_URL] = (
+            TrustScore(trust_score=0.95, sla_grade="A+"),
+            time.monotonic() + 300,
+        )
+
+        client_mock = MagicMock()
+        with patch("httpx.Client", return_value=client_mock):
+            score = verifier.verify(_SERVER_URL)
+
+        client_mock.get.assert_not_called()
+        assert score.trust_score == 0.95
+
+
+# --------------------------------------------------------------------------- #
+# DominionObservatoryVerifier — asynchronous
+# --------------------------------------------------------------------------- #
+
+
+class TestDominionObservatoryVerifierAsync:
+    def _verifier(self, **kwargs: Any) -> DominionObservatoryVerifier:
+        return DominionObservatoryVerifier(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_passes_when_score_above_threshold(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7)
+        response = _make_async_httpx_response(_PASSING_RESPONSE)
+        async_client_mock = AsyncMock()
+        async_client_mock.__aenter__ = AsyncMock(return_value=async_client_mock)
+        async_client_mock.__aexit__ = AsyncMock(return_value=False)
+        async_client_mock.get = AsyncMock(return_value=response)
+
+        with patch("httpx.AsyncClient", return_value=async_client_mock):
+            score = await verifier.averify(_SERVER_URL)
+
+        assert score.trust_score == 0.9
+        assert score.sla_grade == "A"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_score_below_threshold(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7)
+        response = _make_async_httpx_response(_FAILING_RESPONSE)
+        async_client_mock = AsyncMock()
+        async_client_mock.__aenter__ = AsyncMock(return_value=async_client_mock)
+        async_client_mock.__aexit__ = AsyncMock(return_value=False)
+        async_client_mock.get = AsyncMock(return_value=response)
+
+        with patch("httpx.AsyncClient", return_value=async_client_mock):
+            with pytest.raises(TrustVerificationError, match="below threshold"):
+                await verifier.averify(_SERVER_URL)
+
+    @pytest.mark.asyncio
+    async def test_unreachable_allow_mode_passes(self) -> None:
+        verifier = self._verifier(trust_failure_mode=TrustFailureMode.ALLOW)
+        async_client_mock = AsyncMock()
+        async_client_mock.__aenter__ = AsyncMock(return_value=async_client_mock)
+        async_client_mock.__aexit__ = AsyncMock(return_value=False)
+        async_client_mock.get = AsyncMock(side_effect=ConnectionError("unreachable"))
+
+        with patch("httpx.AsyncClient", return_value=async_client_mock):
+            score = await verifier.averify(_SERVER_URL)
+
+        assert score.trust_score == 1.0
+        assert score.sla_grade == "N/A"
+
+    @pytest.mark.asyncio
+    async def test_unreachable_deny_mode_raises(self) -> None:
+        verifier = self._verifier(trust_failure_mode=TrustFailureMode.DENY)
+        async_client_mock = AsyncMock()
+        async_client_mock.__aenter__ = AsyncMock(return_value=async_client_mock)
+        async_client_mock.__aexit__ = AsyncMock(return_value=False)
+        async_client_mock.get = AsyncMock(side_effect=ConnectionError("unreachable"))
+
+        with patch("httpx.AsyncClient", return_value=async_client_mock):
+            with pytest.raises(TrustVerificationError, match="DENY failure mode"):
+                await verifier.averify(_SERVER_URL)
+
+    @pytest.mark.asyncio
+    async def test_ttl_cache_prevents_duplicate_api_calls(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7, ttl=300)
+        response = _make_async_httpx_response(_PASSING_RESPONSE)
+        async_client_mock = AsyncMock()
+        async_client_mock.__aenter__ = AsyncMock(return_value=async_client_mock)
+        async_client_mock.__aexit__ = AsyncMock(return_value=False)
+        async_client_mock.get = AsyncMock(return_value=response)
+
+        with patch("httpx.AsyncClient", return_value=async_client_mock):
+            await verifier.averify(_SERVER_URL)
+            await verifier.averify(_SERVER_URL)
+            await verifier.averify(_SERVER_URL)
+
+        assert async_client_mock.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_ttl_cache_expires_and_makes_fresh_call(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7, ttl=60)
+        response = _make_async_httpx_response(_PASSING_RESPONSE)
+        async_client_mock = AsyncMock()
+        async_client_mock.__aenter__ = AsyncMock(return_value=async_client_mock)
+        async_client_mock.__aexit__ = AsyncMock(return_value=False)
+        async_client_mock.get = AsyncMock(return_value=response)
+
+        # Seed cache with an expired entry
+        verifier._cache[_SERVER_URL] = (
+            TrustScore(trust_score=0.9, sla_grade="A"),
+            time.monotonic() - 1,
+        )
+
+        with patch("httpx.AsyncClient", return_value=async_client_mock):
+            await verifier.averify(_SERVER_URL)
+
+        assert async_client_mock.get.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_does_not_call_api(self) -> None:
+        verifier = self._verifier(trust_threshold=0.7, ttl=300)
+
+        verifier._cache[_SERVER_URL] = (
+            TrustScore(trust_score=0.95, sla_grade="A+"),
+            time.monotonic() + 300,
+        )
+
+        async_client_mock = AsyncMock()
+        with patch("httpx.AsyncClient", return_value=async_client_mock):
+            score = await verifier.averify(_SERVER_URL)
+
+        async_client_mock.get.assert_not_called()
+        assert score.trust_score == 0.95


### PR DESCRIPTION
Closes #37657

---

This PR adds a trust verification abstraction to `langchain-core` that allows any MCP integration to verify server trustworthiness before executing tools.

## New Public API

```python
from langchain_core.tools import (
    TrustVerifier,
    TrustVerificationError,
    TrustFailureMode,
    TrustScore,
    DominionObservatoryVerifier,
)

# Use the default Dominion Observatory verifier
verifier = DominionObservatoryVerifier(
    trust_threshold=0.7,
    trust_failure_mode=TrustFailureMode.DENY,
    ttl=300,
)

# Or implement your own
class MyVerifier(TrustVerifier):
    def verify(self, server_url: str) -> TrustScore:
        ...
    async def averify(self, server_url: str) -> TrustScore:
        ...
```

## Design Decisions

- **Abstract protocol in `langchain-core`** so any integration layer can use it without depending on a specific scoring backend
- **Pluggable** — `TrustVerifier` is an abstract base class, teams can bring their own scoring logic
- **Default implementation** ships with `DominionObservatoryVerifier` hitting `GET https://dominionobservatory.com/api/trust?url=<server_url>`
- **TTL cache** on trust scores per server URL to stay within the 50 queries/day free tier
- **`trust_failure_mode`** (`ALLOW` / `DENY`) controls behaviour when the trust API is unreachable
- **`httpx`** used for both sync and async HTTP calls, consistent with existing LangChain patterns

## Tests

18 unit tests covering:
- Score above/below threshold
- API unreachable with ALLOW and DENY modes
- TTL cache hit and expiry
- Async counterparts of all cases

## Related

A companion PR for the MCP integration layer is being prepared separately.

> This contribution was made with AI-agent assistance (Claude Code).

