### PR TITLE
fix(core): preserve non-ASCII chars in AIMessageChunk tool_call_chunks args

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -506,7 +506,7 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = [
                     create_tool_call_chunk(
                         name=tc["name"],
-                        args=json.dumps(tc["args"]),
+                        args=json.dumps(tc["args"], ensure_ascii=False),
                         id=tc["id"],
                         index=None,
                     )


### PR DESCRIPTION
## Problem
`AIMessageChunk` with non-ASCII tool arguments (CJK, emoji, accents) produces `tool_call_chunks[].args` with `\\uXXXX` escapes. The `tool_calls` field has clean dict values, but the chunk string does not ? same message, two representations, different content.

This breaks storage in langgraph checkpointers, LangSmith traces, and DB JSON columns where the escaped form is unreadable.

## Fix
Line 509 in `ai.py`: added `ensure_ascii=False` to `json.dumps(tc["args"])`.

Same fix was already applied in `utils.py:1810` (PR #34005). This was the only remaining outlier in the core messages module.

## Testing
Existing tests continue to pass. The non-ASCII tool args now round-trip correctly through `tool_call_chunks`.

Closes #37686