### PR TITLE
docs(core): fix a/an typo in `IsFunctionArgDict` docstring

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -209,7 +209,7 @@ class IsFunctionArgDict(ast.NodeVisitor):
     """Check if the first argument of a function is a dict."""
 
     def __init__(self) -> None:
-        """Create a IsFunctionArgDict visitor."""
+        """Create an `IsFunctionArgDict` visitor."""
         self.keys: set[str] = set()
 
     @override


### PR DESCRIPTION
Trivial grammar fix in the `__init__` docstring of `IsFunctionArgDict` (in `langchain_core.runnables.utils`). "Create a IsFunctionArgDict visitor" should use "an" since the following word starts with a vowel sound. Also wraps the class name in backticks per the repo's docstring style.

_Disclosure: this contribution was prepared with AI-agent assistance._