### PR TITLE
fix(core): preserve non-ASCII characters in tool_call_chunks args serialization

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -506,7 +506,7 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = [
                     create_tool_call_chunk(
                         name=tc["name"],
-                        args=json.dumps(tc["args"]),
+                        args=json.dumps(tc["args"], ensure_ascii=False),
                         id=tc["id"],
                         index=None,
                     )


### PR DESCRIPTION
## Description

Fixes non-ASCII characters (Chinese, Japanese, emoji, etc.) being escaped to `\uXXXX` sequences in `tool_call_chunks[].args` when `AIMessageChunk` is constructed with `tool_calls`.

## Problem

`json.dumps()` defaults to `ensure_ascii=True`, which escapes all non-ASCII characters. When `AIMessageChunk` serializes `tool_calls` into `tool_call_chunks`, the args string contains escaped sequences instead of the original characters.

```python
chunk = AIMessageChunk(
    content="",
    tool_calls=[{"name": "echo", "args": {"text": "你好", "emoji": "🚀"}, "id": "call_1", "type": "tool_call"}],
)
# Before: chunk.tool_call_chunks[0]["args"] == '{"text": "\\u4f60\\u597d", "emoji": "\\ud83d\\ude80"}'
# After:  chunk.tool_call_chunks[0]["args"] == '{"text": "你好", "emoji": "🚀"}'
```

## Fix

Add `ensure_ascii=False` to the `json.dumps()` call in `AIMessageChunk`'s validator, matching the existing convention at `libs/core/langchain_core/messages/utils.py:1810`.

## Related

Same class of bug as #34005 (closed). The convention is already established in this repo.

Fixes #37686