### PR TITLE
docs: fix minor documentation typos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,7 +284,7 @@ When adding a new partner package, update these files:
 
 ## GitHub Actions & Workflows
 
-This repository require actions to be pinned to a full-length commit SHA. Attempting to use a tag will fail. Use the `gh` cli to query. Verify tags are not annotated tag objects (which would need dereferencing).
+This repository requires actions to be pinned to a full-length commit SHA. Attempting to use a tag will fail. Use the `gh` cli to query. Verify tags are not annotated tag objects (which would need dereferencing).
 
 ## Additional resources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,7 @@ When adding a new partner package, update these files:
 
 ## GitHub Actions & Workflows
 
-This repository require actions to be pinned to a full-length commit SHA. Attempting to use a tag will fail. Use the `gh` cli to query. Verify tags are not annotated tag objects (which would need dereferencing).
+This repository requires actions to be pinned to a full-length commit SHA. Attempting to use a tag will fail. Use the `gh` cli to query. Verify tags are not annotated tag objects (which would need dereferencing).
 
 ## Additional resources
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 LangChain is a framework for building agents and LLM-powered applications. It helps you chain together interoperable components and third-party integrations to simplify AI application development — all while future-proofing decisions as the underlying technology evolves.
 
 > [!TIP]
-> Just getting started? Check out **[Deep Agents](http://docs.langchain.com/oss/python/deepagents/)** — a higher-level package built on LangChain for agents that have built-in capabilites for common usage patterns such as planning, subagents, file system usage, and more.
+> Just getting started? Check out **[Deep Agents](http://docs.langchain.com/oss/python/deepagents/)** — a higher-level package built on LangChain for agents that have built-in capabilities for common usage patterns such as planning, subagents, file system usage, and more.
 
 ## Quickstart
 


### PR DESCRIPTION

Fixes #36458

Minor documentation cleanup across three files to fix spelling and grammar issues:

- README.md: Fixed spelling typo `capabilites` -> `capabilities` in the first TIP section.
- CLAUDE.md: Fixed subject-verb agreement typo `require` -> `requires` under GitHub Actions.
- AGENTS.md: Fixed subject-verb agreement typo `require` -> `requires` under GitHub Actions.

No breaking changes, just a quick documentation maintenance fix. Thanks!
