### PR TITLE
partners[perplexity]: add X-Pplx-Integration attribution header

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/_utils.py
+++ b/libs/partners/perplexity/langchain_perplexity/_utils.py
@@ -1,8 +1,19 @@
 import os
+from importlib import metadata
 from typing import Any
 
 from langchain_core.utils import convert_to_secret_str
 from perplexity import Perplexity
+
+_INTEGRATION_HEADER = "X-Pplx-Integration"
+_INTEGRATION_NAME = "langchain"
+_PACKAGE_NAME = "langchain-perplexity"
+
+
+def get_integration_headers() -> dict[str, str]:
+    """Return the Perplexity attribution headers for this integration."""
+    package_version = metadata.version(_PACKAGE_NAME)
+    return {_INTEGRATION_HEADER: f"{_INTEGRATION_NAME}/{package_version}"}
 
 
 def initialize_client(values: dict[str, Any]) -> dict[str, Any]:
@@ -20,6 +31,8 @@ def initialize_client(values: dict[str, Any]) -> dict[str, Any]:
     )
 
     if not values.get("client"):
-        values["client"] = Perplexity(api_key=api_key)
+        values["client"] = Perplexity(
+            api_key=api_key, default_headers=get_integration_headers()
+        )
 
     return values

--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -49,6 +49,7 @@ from perplexity import AsyncPerplexity, Perplexity
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_perplexity._utils import get_integration_headers
 from langchain_perplexity.data._profiles import _PROFILES
 from langchain_perplexity.output_parsers import (
     ReasoningJsonOutputParser,
@@ -299,6 +300,7 @@ class ChatPerplexity(BaseChatModel):
 
         client_params: dict[str, Any] = {
             "api_key": pplx_api_key,
+            "default_headers": get_integration_headers(),
             "max_retries": self.max_retries,
         }
         if self.request_timeout is not None:

--- a/libs/partners/perplexity/langchain_perplexity/embeddings.py
+++ b/libs/partners/perplexity/langchain_perplexity/embeddings.py
@@ -12,6 +12,8 @@ from perplexity import AsyncPerplexity, Perplexity
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_perplexity._utils import get_integration_headers
+
 
 def _decode_int8_embedding(b64: str) -> list[float]:
     """Decode a `base64_int8`-encoded Perplexity embedding into a list of floats."""
@@ -117,6 +119,7 @@ class PerplexityEmbeddings(BaseModel, Embeddings):
         api_key = self.pplx_api_key.get_secret_value()
         client_params: dict[str, Any] = {
             "api_key": api_key,
+            "default_headers": get_integration_headers(),
             "max_retries": self.max_retries,
         }
         if self.request_timeout is not None:

--- a/libs/partners/perplexity/tests/unit_tests/test_attribution_headers.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_attribution_headers.py
@@ -1,0 +1,180 @@
+"""Unit tests for Perplexity attribution headers."""
+
+import base64
+import struct
+from importlib import metadata
+from typing import Any
+
+import httpx
+from perplexity import AsyncPerplexity as SDKAsyncPerplexity
+from perplexity import Perplexity as SDKPerplexity
+from pytest_mock import MockerFixture
+
+from langchain_perplexity import (
+    ChatPerplexity,
+    PerplexityEmbeddings,
+    PerplexitySearchResults,
+    PerplexitySearchRetriever,
+)
+
+_ATTRIBUTION_HEADER = "X-Pplx-Integration"
+_EXPECTED_ATTRIBUTION = f"langchain/{metadata.version('langchain-perplexity')}"
+
+
+def _encode_int8(values: list[int]) -> str:
+    raw = struct.pack(f"<{len(values)}b", *values)
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _make_response(request: httpx.Request) -> httpx.Response:
+    if request.url.path == "/chat/completions":
+        return httpx.Response(
+            200,
+            json={
+                "id": "chatcmpl-test",
+                "choices": [
+                    {
+                        "delta": {"content": "", "role": "assistant"},
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "message": {"content": "ok", "role": "assistant"},
+                    }
+                ],
+                "created": 0,
+                "model": "sonar",
+            },
+            request=request,
+        )
+    if request.url.path == "/v1/embeddings":
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "embedding": _encode_int8([1, 2, 3]),
+                        "index": 0,
+                        "object": "embedding",
+                    }
+                ],
+                "model": "pplx-embed-v1-4b",
+                "object": "list",
+            },
+            request=request,
+        )
+    if request.url.path == "/search":
+        return httpx.Response(
+            200,
+            json={
+                "id": "search-test",
+                "results": [
+                    {
+                        "date": "2026-01-01",
+                        "last_updated": "2026-01-02",
+                        "snippet": "Test snippet",
+                        "title": "Test title",
+                        "url": "https://example.com",
+                    }
+                ],
+            },
+            request=request,
+        )
+
+    return httpx.Response(404, request=request)
+
+
+def _patch_sync_client(
+    mocker: MockerFixture,
+    target: str,
+) -> list[httpx.Request]:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _make_response(request)
+
+    def make_client(**kwargs: Any) -> SDKPerplexity:
+        return SDKPerplexity(
+            **kwargs,
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+
+    mocker.patch(target, side_effect=make_client)
+    return requests
+
+
+def _patch_sync_and_async_clients(
+    mocker: MockerFixture,
+    *,
+    async_target: str,
+    sync_target: str,
+) -> list[httpx.Request]:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _make_response(request)
+
+    def make_client(**kwargs: Any) -> SDKPerplexity:
+        return SDKPerplexity(
+            **kwargs,
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+
+    def make_async_client(**kwargs: Any) -> SDKAsyncPerplexity:
+        return SDKAsyncPerplexity(
+            **kwargs,
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+
+    mocker.patch(sync_target, side_effect=make_client)
+    mocker.patch(async_target, side_effect=make_async_client)
+    return requests
+
+
+def _assert_attribution_header_sent(requests: list[httpx.Request]) -> None:
+    assert requests
+    assert requests[0].headers[_ATTRIBUTION_HEADER] == _EXPECTED_ATTRIBUTION
+
+
+def test_chat_sends_attribution_header(mocker: MockerFixture) -> None:
+    requests = _patch_sync_and_async_clients(
+        mocker,
+        sync_target="langchain_perplexity.chat_models.Perplexity",
+        async_target="langchain_perplexity.chat_models.AsyncPerplexity",
+    )
+
+    chat = ChatPerplexity(api_key="test", model="sonar")
+    chat.invoke("hello")
+
+    _assert_attribution_header_sent(requests)
+
+
+def test_embeddings_send_attribution_header(mocker: MockerFixture) -> None:
+    requests = _patch_sync_and_async_clients(
+        mocker,
+        sync_target="langchain_perplexity.embeddings.Perplexity",
+        async_target="langchain_perplexity.embeddings.AsyncPerplexity",
+    )
+
+    embeddings = PerplexityEmbeddings(pplx_api_key="test")
+    embeddings.embed_query("hello")
+
+    _assert_attribution_header_sent(requests)
+
+
+def test_search_retriever_sends_attribution_header(mocker: MockerFixture) -> None:
+    requests = _patch_sync_client(mocker, "langchain_perplexity._utils.Perplexity")
+
+    retriever = PerplexitySearchRetriever(pplx_api_key="test")
+    retriever.invoke("hello")
+
+    _assert_attribution_header_sent(requests)
+
+
+def test_search_tool_sends_attribution_header(mocker: MockerFixture) -> None:
+    requests = _patch_sync_client(mocker, "langchain_perplexity._utils.Perplexity")
+
+    tool = PerplexitySearchResults(pplx_api_key="test")
+    tool.invoke("hello")
+
+    _assert_attribution_header_sent(requests)


### PR DESCRIPTION
Adds the `X-Pplx-Integration: langchain/<package-version>` attribution header to outbound Perplexity API requests from the `langchain-perplexity` partner package.

This follows up on #37082, which added `PerplexityEmbeddings` without the attribution header. The header is now wired into the SDK client construction paths used by `ChatPerplexity`, `PerplexityEmbeddings`, and the shared search client used by the retriever and tool. This lets Perplexity attribute LangChain traffic through api-gateway while keeping the slug exactly `langchain` and reading the package version from `importlib.metadata.version("langchain-perplexity")`.

Unit coverage drives chat, embeddings, retriever, and tool requests through a mocked `httpx` transport and asserts the outbound header is present.

---
🤖 _Generated by [PSI](https://www.notion.so/perplexity-ai/HowTo-PSI-Perplexity-Super-Intelligence-29c6172b229b80d3a8ece89a6cfb6ae6)_
🧠 _Agent used: `codex`_