### PR TITLE
perf(text-splitters): use deque in experimental markdown splitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections import deque
 from typing import Any, TypedDict
 
 from langchain_core.documents import Document
@@ -389,10 +390,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
         self.current_chunk = Document(page_content="")
         self.current_header_stack.clear()
 
-        raw_lines = text.splitlines(keepends=True)
+        raw_lines = deque(text.splitlines(keepends=True))
 
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             header_match = self._match_header(raw_line)
             code_match = self._match_code(raw_line)
             horz_match = self._match_horz(raw_line)
@@ -439,10 +440,10 @@ class ExperimentalMarkdownSyntaxTextSplitter:
                 break
         self.current_header_stack.append((header_depth, header_text))
 
-    def _resolve_code_chunk(self, current_line: str, raw_lines: list[str]) -> str:
+    def _resolve_code_chunk(self, current_line: str, raw_lines: deque[str]) -> str:
         chunk = current_line
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.popleft()
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1971,6 +1971,28 @@ def test_experimental_markdown_syntax_text_splitter_split_lines() -> None:
     assert output == expected_output
 
 
+def test_experimental_markdown_syntax_text_splitter_handles_large_input() -> None:
+    """Test experimental markdown syntax splitter on large inputs.
+
+    This guards against accidentally reintroducing quadratic line consumption.
+    """
+    markdown_splitter = ExperimentalMarkdownSyntaxTextSplitter()
+    document = "# Header\n" + "".join(
+        f"Line {i}: some content here\n" for i in range(10_000)
+    )
+
+    output = markdown_splitter.split_text(document)
+
+    assert output == [
+        Document(
+            page_content="".join(
+                f"Line {i}: some content here\n" for i in range(10_000)
+            ),
+            metadata={"Header 1": "Header"},
+        )
+    ]
+
+
 EXPERIMENTAL_MARKDOWN_DOCUMENTS = [
     (
         "# My Header 1 From Document 1\n"


### PR DESCRIPTION
## Summary
- Replace `list.pop(0)` line consumption in `ExperimentalMarkdownSyntaxTextSplitter` with `deque.popleft()`
- Keep behavior unchanged for code-block parsing while making line consumption O(1)
- Add a large-input regression test covering 10k lines

Fixes #36488

## Tests
- `cd libs/text-splitters && uv run --group test pytest tests/unit_tests/test_text_splitters.py -k 'experimental_markdown_syntax_text_splitter'`\n- `cd libs/text-splitters && uv run --group lint ruff check langchain_text_splitters/markdown.py tests/unit_tests/test_text_splitters.py`