### PR TITLE
ci(infra): auto-remove `waiting-on-author` label on author reply

### DIFF
--- a/.github/workflows/remove_waiting_on_author.yml
+++ b/.github/workflows/remove_waiting_on_author.yml
@@ -1,0 +1,58 @@
+# Remove the `waiting-on-author` label from an issue or PR when the original
+# author replies. Fires on every issue/PR comment; the job's `if:` filter skips
+# runs unless the item is open, carries the label, and the commenter is the
+# original author (and not a bot).
+#
+# Uses the default GITHUB_TOKEN so the label-removal event does NOT re-trigger
+# other workflows. GitHub suppresses events created by the default GITHUB_TOKEN
+# within workflow runs to prevent infinite loops.
+
+name: Remove waiting-on-author on Author Reply
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  remove-label:
+    if: >-
+      github.event.issue.state == 'open' &&
+      contains(github.event.issue.labels.*.name, 'waiting-on-author') &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.comment.user.login == github.event.issue.user.login
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Remove waiting-on-author label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+            const author = context.payload.issue.user.login;
+
+            console.log(
+              `Author ${author} commented on #${issue_number} — removing waiting-on-author`,
+            );
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number,
+                name: 'waiting-on-author',
+              });
+            } catch (e) {
+              // 404: label not present (already removed or never applied).
+              if (e.status === 404) {
+                console.log('Label already absent — nothing to do');
+                return;
+              }
+              throw e;
+            }


### PR DESCRIPTION
Ports langchain-ai/deepagents#3626. Adds a workflow that clears the `waiting-on-author` label from an issue or PR as soon as the original author posts a follow-up comment, closing the manual loop where maintainers had to remember to strip the label after a reply landed.