### PR TITLE
feat(core): add subagent_name parameter to BaseTool

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -530,6 +530,20 @@ class ChildTool(BaseTool):
         ```
     """
 
+    subagent_name: str | Callable[[ToolCall], str] | None = None
+    """Declared name of the subagent this tool dispatches to, if any.
+
+    A static string declares a fixed dispatch target (one tool -> one subagent).
+    A callable resolves the name from the parsed `ToolCall` at dispatch time,
+    enabling registry-style dispatching (one tool -> many subagents based on
+    LLM-supplied args).
+
+    Read by `ToolNode` at dispatch time and surfaced on the wire as
+    `LifecyclePayload.graphName`. Purely declarative: the framework stamps the
+    resolved value into runtime config metadata; consumers project it onto
+    typed surfaces. Setting this does not change tool execution behavior.
+    """
+
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the tool.
 

--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -2,7 +2,7 @@
 
 import inspect
 from collections.abc import Callable
-from typing import Any, Literal, cast, get_type_hints, overload
+from typing import TYPE_CHECKING, Any, Literal, cast, get_type_hints, overload
 
 from pydantic import BaseModel, Field, create_model
 
@@ -11,6 +11,9 @@ from langchain_core.runnables import Runnable
 from langchain_core.tools.base import ArgsSchema, BaseTool
 from langchain_core.tools.simple import Tool
 from langchain_core.tools.structured import StructuredTool
+
+if TYPE_CHECKING:
+    from langchain_core.messages.tool import ToolCall
 
 
 @overload
@@ -24,6 +27,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    subagent_name: str | Callable[["ToolCall"], str] | None = None,
 ) -> Callable[[Callable | Runnable], BaseTool]: ...
 
 
@@ -40,6 +44,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    subagent_name: str | Callable[["ToolCall"], str] | None = None,
 ) -> BaseTool: ...
 
 
@@ -55,6 +60,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    subagent_name: str | Callable[["ToolCall"], str] | None = None,
 ) -> BaseTool: ...
 
 
@@ -70,6 +76,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    subagent_name: str | Callable[["ToolCall"], str] | None = None,
 ) -> Callable[[Callable | Runnable], BaseTool]: ...
 
 
@@ -85,6 +92,7 @@ def tool(
     parse_docstring: bool = False,
     error_on_invalid_docstring: bool = True,
     extras: dict[str, Any] | None = None,
+    subagent_name: str | Callable[["ToolCall"], str] | None = None,
 ) -> BaseTool | Callable[[Callable | Runnable], BaseTool]:
     """Convert Python functions and `Runnables` to LangChain tools.
 
@@ -150,6 +158,9 @@ def tool(
 
                 For example, Anthropic-specific fields like `cache_control`,
                 `defer_loading`, or `input_examples`.
+        subagent_name: Optional name of the subagent that should handle this tool call
+            (a static string), or a callable that resolves the subagent name from the
+            parsed `ToolCall` at dispatch time.
 
     Raises:
         ValueError: If too many positional arguments are provided (e.g. violating the
@@ -313,6 +324,7 @@ def tool(
                     parse_docstring=parse_docstring,
                     error_on_invalid_docstring=error_on_invalid_docstring,
                     extras=extras,
+                    subagent_name=subagent_name,
                 )
             # If someone doesn't want a schema applied, we must treat it as
             # a simple string->string function
@@ -322,7 +334,7 @@ def tool(
                     "description not provided and infer_schema is False."
                 )
                 raise ValueError(msg)
-            return Tool(
+            result = Tool(
                 name=tool_name,
                 func=func,
                 description=f"{tool_name} tool",
@@ -331,6 +343,8 @@ def tool(
                 response_format=response_format,
                 extras=extras,
             )
+            result.subagent_name = subagent_name
+            return result
 
         return _tool_factory
 

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -143,6 +143,7 @@ class StructuredTool(BaseTool):
         response_format: Literal["content", "content_and_artifact"] = "content",
         parse_docstring: bool = False,
         error_on_invalid_docstring: bool = False,
+        subagent_name: str | Callable[[ToolCall], str] | None = None,
         **kwargs: Any,
     ) -> StructuredTool:
         """Create tool from a given function.
@@ -171,6 +172,8 @@ class StructuredTool(BaseTool):
                 to parse parameter descriptions from Google Style function docstrings.
             error_on_invalid_docstring: if `parse_docstring` is provided, configure
                 whether to raise `ValueError` on invalid Google Style docstrings.
+            subagent_name: Name of the subagent this tool should route to (static
+                string or callable that resolves the name from the `ToolCall`).
             **kwargs: Additional arguments to pass to the tool
 
         Returns:
@@ -248,6 +251,7 @@ class StructuredTool(BaseTool):
             description=description_,
             return_direct=return_direct,
             response_format=response_format,
+            subagent_name=subagent_name,
             **kwargs,
         )
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3741,3 +3741,42 @@ def test_tool_invoke_returns_list_of_mixin() -> None:
     assert isinstance(result, list)
     assert len(result) == 3
     assert all(isinstance(m, ToolMessage) for m in result)
+
+
+# --- subagent_name attribute tests ---
+
+
+class _SubagentNameDummyTool(BaseTool):
+    """Minimal BaseTool subclass for subagent_name attribute tests."""
+
+    name: str = "dummy"
+    description: str = "A dummy tool used in subagent_name tests."
+
+    def _run(self, *args: Any, **kwargs: Any) -> str:
+        return "dummy result"
+
+
+def test_basetool_subagent_name_default_none() -> None:
+    tool = _SubagentNameDummyTool()
+    assert tool.subagent_name is None
+
+
+def test_basetool_subagent_name_accepts_static_string() -> None:
+    tool = _SubagentNameDummyTool(subagent_name="weather_agent")
+    assert tool.subagent_name == "weather_agent"
+
+
+def test_basetool_subagent_name_accepts_callable() -> None:
+    def resolver(call: ToolCall) -> str:
+        return str(call["args"]["subagent_type"])
+
+    tool = _SubagentNameDummyTool(subagent_name=resolver)
+    assert tool.subagent_name is resolver
+    fake_call: ToolCall = {
+        "name": "task",
+        "args": {"subagent_type": "researcher"},
+        "id": "id-1",
+        "type": "tool_call",
+    }
+    assert callable(tool.subagent_name)
+    assert tool.subagent_name(fake_call) == "researcher"

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3780,3 +3780,36 @@ def test_basetool_subagent_name_accepts_callable() -> None:
     }
     assert callable(tool.subagent_name)
     assert tool.subagent_name(fake_call) == "researcher"
+
+
+# --- @tool decorator subagent_name passthrough tests ---
+
+
+def test_tool_decorator_passes_subagent_name_static() -> None:
+    @tool("call_weather", subagent_name="weather_agent")
+    def call_weather(city: str) -> str:
+        """Call the weather agent."""
+        return f"weather in {city}"
+
+    assert call_weather.subagent_name == "weather_agent"
+
+
+def test_tool_decorator_passes_subagent_name_callable() -> None:
+    def resolver(call: ToolCall) -> str:
+        return str(call["args"]["target"])
+
+    @tool("dispatch", subagent_name=resolver)
+    def dispatch(target: str, query: str) -> str:
+        """Dispatch to a target."""
+        return f"dispatched to {target}: {query}"
+
+    assert dispatch.subagent_name is resolver
+
+
+def test_tool_decorator_subagent_name_defaults_to_none() -> None:
+    @tool("plain")
+    def plain(x: int) -> str:
+        """A tool with no subagent_name declared."""
+        return str(x)
+
+    assert plain.subagent_name is None

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3813,3 +3813,47 @@ def test_tool_decorator_subagent_name_defaults_to_none() -> None:
         return str(x)
 
     assert plain.subagent_name is None
+
+
+# --- StructuredTool.from_function subagent_name passthrough tests ---
+
+
+def test_structured_tool_from_function_passes_subagent_name_static() -> None:
+    def my_func(x: int) -> str:
+        return f"x={x}"
+
+    t = StructuredTool.from_function(
+        func=my_func,
+        name="my_func",
+        description="Test tool for subagent_name passthrough.",
+        subagent_name="x_agent",
+    )
+    assert t.subagent_name == "x_agent"
+
+
+def test_structured_tool_from_function_passes_subagent_name_callable() -> None:
+    def my_func(target: str) -> str:
+        return f"target={target}"
+
+    def resolver(call: ToolCall) -> str:
+        return str(call["args"]["target"])
+
+    t = StructuredTool.from_function(
+        func=my_func,
+        name="my_func",
+        description="Test tool for callable subagent_name.",
+        subagent_name=resolver,
+    )
+    assert t.subagent_name is resolver
+
+
+def test_structured_tool_from_function_subagent_name_defaults_to_none() -> None:
+    def my_func(x: int) -> str:
+        return str(x)
+
+    t = StructuredTool.from_function(
+        func=my_func,
+        name="my_func",
+        description="Plain tool.",
+    )
+    assert t.subagent_name is None


### PR DESCRIPTION
## Summary

Adds an optional `subagent_name: str | Callable[[ToolCall], str] | None` parameter to `BaseTool`, `@tool`, and `StructuredTool.from_function`. Pure attribute addition with no behavior change.

This is the first PR in a four-part series that lifts subagent identity into the framework so plain `create_agent` users get the streaming experience deepagents users have today (originating from langchain-ai/langgraph#7910). Standalone, this PR is safe: it adds an optional attribute that no current code reads. Subsequent PRs in langgraph and langchain will wire it into the dispatch path and surface it on the typed `run.subagents` projection.

## What this enables

Once the full series lands:

```python
@tool("call_weather", subagent_name="weather_agent")
def call_weather(city: str) -> str:
    return weather_agent.invoke(
        {"messages": [HumanMessage(f"Weather in {city}?")]}
    )["messages"][-1].text
```

The supervisor's `run.subgraphs` handle for this dispatch will be named `weather_agent` instead of `tools`, and the lifecycle event will carry the LLM tool_call_id as the cause anchor.

For dynamic dispatch (the deepagents `task` tool pattern), a callable resolves the name from the parsed `ToolCall` at dispatch time:

```python
@tool("task", subagent_name=lambda call: call["args"]["subagent_type"])
def task(description: str, subagent_type: str) -> str:
    return subagent_graphs[subagent_type].invoke(
        {"messages": [HumanMessage(description)]}
    )["messages"][-1].text
```

## What this PR contains

Three focused commits:

1. `b36d8ffaf7` — `BaseTool.subagent_name` field (the storage)
2. `df2b4cfdc4` — `@tool` decorator passes the value through (all overloads + impl)
3. `41d1c35270` — `StructuredTool.from_function` accepts the value (named parameter + propagation)

## Test plan

- [x] BaseTool stores the attribute; default `None`; accepts string; accepts callable.
- [x] `@tool` decorator passes value through (static + callable + default).
- [x] `StructuredTool.from_function` passes value through (static + callable + default).
- [x] Pre-existing tool tests unaffected (162 -> 171 with the 9 new tests).
- [x] Full langchain-core test suite passes (2047/2047 non-flake).
- [x] `make lint` clean.