### PR TITLE
fix(langchain-chroma): handle empty metadata in update_documents

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1239,34 +1239,62 @@ class Chroma(VectorStore):
             )
         embeddings = self._embedding_function.embed_documents(text)
 
-        if hasattr(
-            self._client,
-            "get_max_batch_size",
-        ) or hasattr(  # for Chroma 0.5.1 and above
-            self._client,
-            "max_batch_size",
-        ):  # for Chroma 0.4.10 and above
-            from chromadb.utils.batch_utils import create_batches
+        # Separate documents with non-empty metadata from those without.
+        # Chroma rejects empty dicts in the metadatas argument, so documents
+        # that have no metadata must be updated without the metadatas kwarg.
+        empty_ids = [idx for idx, m in enumerate(metadata) if not m]
+        non_empty_ids = [idx for idx, m in enumerate(metadata) if m]
 
-            for batch in create_batches(
-                api=self._client,
-                ids=ids,
-                metadatas=metadata,  # type: ignore[arg-type]
-                documents=text,
-                embeddings=embeddings,  # type: ignore[arg-type]
-            ):
-                self._collection.update(
-                    ids=batch[0],
-                    embeddings=batch[1],
-                    documents=batch[3],
-                    metadatas=batch[2],
-                )
-        else:
-            self._collection.update(
-                ids=ids,
-                embeddings=embeddings,  # type: ignore[arg-type]
-                documents=text,
-                metadatas=metadata,  # type: ignore[arg-type]
+        def _do_update(
+            batch_ids: list[str],
+            batch_text: list[str],
+            batch_embeddings: list,
+            batch_metadata: list[dict] | None,
+        ) -> None:
+            use_batches = hasattr(self._client, "get_max_batch_size") or hasattr(
+                self._client, "max_batch_size"
+            )
+            if use_batches:
+                from chromadb.utils.batch_utils import create_batches
+
+                for batch in create_batches(
+                    api=self._client,
+                    ids=batch_ids,
+                    metadatas=batch_metadata,  # type: ignore[arg-type]
+                    documents=batch_text,
+                    embeddings=batch_embeddings,  # type: ignore[arg-type]
+                ):
+                    update_kwargs: dict = {
+                        "ids": batch[0],
+                        "embeddings": batch[1],
+                        "documents": batch[3],
+                    }
+                    if batch[2] is not None:
+                        update_kwargs["metadatas"] = batch[2]
+                    self._collection.update(**update_kwargs)
+            else:
+                update_kwargs = {
+                    "ids": batch_ids,
+                    "embeddings": batch_embeddings,  # type: ignore[arg-type]
+                    "documents": batch_text,
+                }
+                if batch_metadata is not None:
+                    update_kwargs["metadatas"] = batch_metadata  # type: ignore[assignment]
+                self._collection.update(**update_kwargs)
+
+        if non_empty_ids:
+            _do_update(
+                batch_ids=[ids[i] for i in non_empty_ids],
+                batch_text=[text[i] for i in non_empty_ids],
+                batch_embeddings=[embeddings[i] for i in non_empty_ids],
+                batch_metadata=[metadata[i] for i in non_empty_ids],
+            )
+        if empty_ids:
+            _do_update(
+                batch_ids=[ids[i] for i in empty_ids],
+                batch_text=[text[i] for i in empty_ids],
+                batch_embeddings=[embeddings[i] for i in empty_ids],
+                batch_metadata=None,
             )
 
     @classmethod

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -1,3 +1,4 @@
+from langchain_core.documents import Document
 from langchain_core.embeddings.fake import (
     FakeEmbeddings,
 )
@@ -13,6 +14,65 @@ def test_initialization() -> None:
         texts=texts,
         embedding=FakeEmbeddings(size=10),
     )
+
+
+def test_update_document_without_metadata() -> None:
+    """Regression test for #37452.
+
+    update_document (and update_documents) must not raise when the Document
+    being updated has no metadata (i.e. metadata == {}).  Previously Chroma
+    rejected the empty dict with:
+
+        ValueError: Expected metadata to be a non-empty dict, got 0 metadata
+        attributes in update.
+    """
+    store = Chroma.from_documents(
+        collection_name="test_update_no_meta",
+        documents=[Document(page_content="original content")],
+        ids=["doc-1"],
+        embedding=FakeEmbeddings(size=10),
+    )
+    try:
+        # Should NOT raise even though Document has no metadata
+        store.update_document(
+            document_id="doc-1",
+            document=Document(page_content="updated content"),
+        )
+        results = store.similarity_search("updated content", k=1)
+        assert len(results) == 1
+        assert results[0].page_content == "updated content"
+    finally:
+        store.delete_collection()
+
+
+def test_update_documents_mixed_metadata() -> None:
+    """update_documents with a mix of empty and non-empty metadata must not raise."""
+    store = Chroma.from_documents(
+        collection_name="test_update_mixed_meta",
+        documents=[
+            Document(page_content="doc one", metadata={"key": "val"}),
+            Document(page_content="doc two"),
+        ],
+        ids=["doc-1", "doc-2"],
+        embedding=FakeEmbeddings(size=10),
+    )
+    try:
+        # Must NOT raise — this exercises the code path where some documents
+        # carry metadata and others don't.
+        store.update_documents(
+            ids=["doc-1", "doc-2"],
+            documents=[
+                Document(page_content="updated one", metadata={"key": "new-val"}),
+                Document(page_content="updated two"),  # no metadata
+            ],
+        )
+        # Verify both documents are retrievable (content was updated)
+        all_docs = store.get()
+        updated_contents = set(all_docs["documents"])
+        assert "updated one" in updated_contents
+        assert "updated two" in updated_contents
+    finally:
+        store.delete_collection()
 
 
 def test_similarity_search() -> None:


### PR DESCRIPTION
## Problem

`Chroma.update_document()` / `update_documents()` raise a `ValueError` when
the `Document` being updated has no metadata (empty `{}`):

```python
store.update_document(
    document_id="doc-1",
    document=Document(page_content="updated content"),  # no metadata
)
# ValueError: Expected metadata to be a non-empty dict,
#             got 0 metadata attributes in update.
```

This error comes from ChromaDB itself, which rejects empty metadata dicts in
`collection.update()`.  The same issue exists in `update_documents` when any
document in the batch has an empty metadata dict.

`add_texts` and `add_images` already handle this correctly by splitting
documents into those with non-empty metadata and those without, making two
separate upsert calls.  `update_documents` was missing this guard.

## Fix

Apply the same split-then-update pattern used in `add_texts`:

- Documents with non-empty metadata → `collection.update(..., metadatas=[...])`
- Documents with empty/no metadata → `collection.update(...)` without `metadatas`

The batching logic (for Chroma ≥ 0.4.10) is preserved within each group.

## Tests

Added two unit tests (no external API key required):

1. `test_update_document_without_metadata` — direct regression for the reported
   crash when updating a document that has no metadata.
2. `test_update_documents_mixed_metadata` — batch update where some documents
   have metadata and some don't; exercises the split-call code path.

Fixes #37452.