### PR TITLE
fix(core,openai): support Responses image file IDs

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -76,18 +76,26 @@ def convert_to_openai_data_block(
         The formatted content block.
     """
     if block["type"] == "image":
-        chat_completions_block = convert_to_openai_image_block(block)
-        if api == "responses":
-            formatted_block = {
-                "type": "input_image",
-                "image_url": chat_completions_block["image_url"]["url"],
-            }
-            if chat_completions_block["image_url"].get("detail"):
-                formatted_block["detail"] = chat_completions_block["image_url"][
-                    "detail"
-                ]
+        if api == "responses" and (
+            block.get("source_type") == "id" or "file_id" in block
+        ):
+            file_id = (
+                block["id"] if block.get("source_type") == "id" else block["file_id"]
+            )
+            formatted_block = {"type": "input_image", "file_id": file_id}
         else:
-            formatted_block = chat_completions_block
+            chat_completions_block = convert_to_openai_image_block(block)
+            if api == "responses":
+                formatted_block = {
+                    "type": "input_image",
+                    "image_url": chat_completions_block["image_url"]["url"],
+                }
+                if chat_completions_block["image_url"].get("detail"):
+                    formatted_block["detail"] = chat_completions_block["image_url"][
+                        "detail"
+                    ]
+            else:
+                formatted_block = chat_completions_block
 
     elif block["type"] == "file":
         if block.get("source_type") == "base64" or "base64" in block:

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -573,6 +573,25 @@ def test_convert_to_openai_data_block() -> None:
     result = convert_to_openai_data_block(block, api="responses")
     assert result == expected
 
+    # Image / file ID
+    block = {
+        "type": "image",
+        "file_id": "file-abc123",
+    }
+    expected = {"type": "input_image", "file_id": "file-abc123"}
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == expected
+
+    # Image / legacy ID
+    block = {
+        "type": "image",
+        "source_type": "id",
+        "id": "file-abc123",
+    }
+    expected = {"type": "input_image", "file_id": "file-abc123"}
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == expected
+
     # File / url
     block = {
         "type": "file",
@@ -603,3 +622,22 @@ def test_convert_to_openai_data_block() -> None:
     expected = {"type": "input_file", "file_id": "file-abc123"}
     result = convert_to_openai_data_block(block, api="responses")
     assert result == expected
+
+
+def test_convert_to_openai_data_block_image_file_id_uses_file_id() -> None:
+    block = types.create_image_block(file_id="file-abc123")
+
+    assert block["id"] != "file-abc123"
+    result = convert_to_openai_data_block(block, api="responses")
+
+    assert result == {"type": "input_image", "file_id": "file-abc123"}
+
+
+def test_convert_to_openai_data_block_image_file_id_chat_completions() -> None:
+    block = {
+        "type": "image",
+        "file_id": "file-abc123",
+    }
+
+    with pytest.raises(ValueError, match="Unsupported source type"):
+        convert_to_openai_data_block(block)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3640,6 +3640,21 @@ def test_context_overflow_error_backwards_compatibility() -> None:
     assert isinstance(exc_info.value, ContextOverflowError)
 
 
+def test_get_request_payload_responses_api_input_image_file_id() -> None:
+    llm = ChatOpenAI(model="gpt-5", api_key="test", use_responses_api=True)
+    payload = llm._get_request_payload(
+        [HumanMessage(content=[types.create_image_block(file_id="file-abc123")])]
+    )
+
+    assert payload["input"] == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_image", "file_id": "file-abc123"}],
+        }
+    ]
+
+
 def test_get_request_payload_responses_api_input_file_blocks_passthrough() -> None:
     llm = ChatOpenAI(model="gpt-5", use_responses_api=True)
     payload = llm._get_request_payload(


### PR DESCRIPTION
Fixes #37724

Support converting LangChain image content blocks with `file_id` into OpenAI Responses `input_image.file_id` payloads. This keeps Chat Completions behavior unchanged and adds focused regression coverage for the core translator and OpenAI request payload path.

Verified with focused core and langchain-openai pytest, touched-file ruff, py_compile, and git diff checks.

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/