### PR TITLE
fix(core,openai): support Responses image file_id blocks

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -76,18 +76,24 @@ def convert_to_openai_data_block(
         The formatted content block.
     """
     if block["type"] == "image":
-        chat_completions_block = convert_to_openai_image_block(block)
-        if api == "responses":
-            formatted_block = {
-                "type": "input_image",
-                "image_url": chat_completions_block["image_url"]["url"],
-            }
-            if chat_completions_block["image_url"].get("detail"):
-                formatted_block["detail"] = chat_completions_block["image_url"][
-                    "detail"
-                ]
+        if api == "responses" and (
+            block.get("source_type") == "id" or "file_id" in block
+        ):
+            file_id = block["id"] if "source_type" in block else block["file_id"]
+            formatted_block = {"type": "input_image", "file_id": file_id}
         else:
-            formatted_block = chat_completions_block
+            chat_completions_block = convert_to_openai_image_block(block)
+            if api == "responses":
+                formatted_block = {
+                    "type": "input_image",
+                    "image_url": chat_completions_block["image_url"]["url"],
+                }
+                if chat_completions_block["image_url"].get("detail"):
+                    formatted_block["detail"] = chat_completions_block["image_url"][
+                        "detail"
+                    ]
+            else:
+                formatted_block = chat_completions_block
 
     elif block["type"] == "file":
         if block.get("source_type") == "base64" or "base64" in block:

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -490,6 +490,14 @@ def test_convert_to_openai_data_block() -> None:
     result = convert_to_openai_data_block(block)
     assert result == expected
 
+    # Image / file ID
+    block = {
+        "type": "image",
+        "file_id": "file-abc123",
+    }
+    with pytest.raises(ValueError, match="Unsupported source type"):
+        convert_to_openai_data_block(block)
+
     # Image / base64
     block = {
         "type": "image",
@@ -557,6 +565,25 @@ def test_convert_to_openai_data_block() -> None:
         "url": "https://example.com/test.png",
     }
     expected = {"type": "input_image", "image_url": "https://example.com/test.png"}
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == expected
+
+    # Image / file ID
+    block = {
+        "type": "image",
+        "file_id": "file-abc123",
+    }
+    expected = {"type": "input_image", "file_id": "file-abc123"}
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == expected
+
+    # Image / legacy source_type=id
+    block = {
+        "type": "image",
+        "source_type": "id",
+        "id": "file-legacy123",
+    }
+    expected = {"type": "input_image", "file_id": "file-legacy123"}
     result = convert_to_openai_data_block(block, api="responses")
     assert result == expected
 


### PR DESCRIPTION
## Summary

Adds OpenAI Responses API support for image content blocks using `file_id`.

This updates the Responses conversion path in `convert_to_openai_data_block()` to support:

* modern image blocks with `file_id`
* legacy image blocks with `source_type == "id"`

Both now map to:

```python id="gwv8rq"
{
    "type": "input_image",
    "file_id": ...
}
```

when `api="responses"`.

## Notes

* Existing URL/base64 image handling remains unchanged.
* Chat Completions behavior is intentionally unchanged and still rejects image file IDs.

## Tests Added

* Responses API image `file_id` conversion
* Legacy `source_type="id"` conversion
* Chat Completions rejection behavior for image file IDs

Fixes #37724
