### PR TITLE
fix(langchain): validate `deprecated_kwargs` and avoid broad exception masking

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -80,6 +80,8 @@ Messages to summarize:
 _DEFAULT_MESSAGES_TO_KEEP = 20
 _DEFAULT_TRIM_TOKEN_LIMIT = 4000
 _DEFAULT_FALLBACK_MESSAGE_COUNT = 15
+_SUMMARY_RECOVERABLE_EXCEPTIONS = (ValueError, RuntimeError)
+_TRIM_RECOVERABLE_EXCEPTIONS = (TypeError, ValueError)
 
 # Some providers tag emitted messages with a `model_provider` string that differs from
 # their LangSmith `ls_provider`. The reported-token check below compares the two, so we
@@ -245,9 +247,10 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
 
                 Pass `None` to skip trimming entirely.
         """
-        # Handle deprecated parameters
-        if "max_tokens_before_summary" in deprecated_kwargs:
-            value = deprecated_kwargs["max_tokens_before_summary"]
+        # Handle deprecated parameters.
+        remaining_kwargs = dict(deprecated_kwargs)
+        if "max_tokens_before_summary" in remaining_kwargs:
+            value = remaining_kwargs.pop("max_tokens_before_summary")
             warnings.warn(
                 "max_tokens_before_summary is deprecated. Use trigger=('tokens', value) instead.",
                 DeprecationWarning,
@@ -256,8 +259,8 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             if trigger is None and value is not None:
                 trigger = ("tokens", value)
 
-        if "messages_to_keep" in deprecated_kwargs:
-            value = deprecated_kwargs["messages_to_keep"]
+        if "messages_to_keep" in remaining_kwargs:
+            value = remaining_kwargs.pop("messages_to_keep")
             warnings.warn(
                 "messages_to_keep is deprecated. Use keep=('messages', value) instead.",
                 DeprecationWarning,
@@ -265,6 +268,11 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             if keep == ("messages", _DEFAULT_MESSAGES_TO_KEEP):
                 keep = ("messages", value)
+
+        if remaining_kwargs:
+            unknown_kwargs = ", ".join(f"{key!r}" for key in sorted(remaining_kwargs))
+            msg = f"Unexpected keyword argument(s): {unknown_kwargs}"
+            raise TypeError(msg)
 
         super().__init__()
 
@@ -632,7 +640,7 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
                 config={"metadata": {"lc_source": "summarization"}},
             )
             return response.text.strip()
-        except Exception as e:
+        except _SUMMARY_RECOVERABLE_EXCEPTIONS as e:
             return f"Error generating summary: {e!s}"
 
     async def _acreate_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
@@ -658,7 +666,7 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
                 config={"metadata": {"lc_source": "summarization"}},
             )
             return response.text.strip()
-        except Exception as e:
+        except _SUMMARY_RECOVERABLE_EXCEPTIONS as e:
             return f"Error generating summary: {e!s}"
 
     def _trim_messages_for_summary(self, messages: list[AnyMessage]) -> list[AnyMessage]:
@@ -678,5 +686,5 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
                     include_system=True,
                 ),
             )
-        except Exception:
+        except _TRIM_RECOVERABLE_EXCEPTIONS:
             return messages[-_DEFAULT_FALLBACK_MESSAGE_COUNT:]

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -217,6 +217,37 @@ def test_summarization_middleware_summary_creation() -> None:
     summary = middleware_error._create_summary(messages)
     assert "Error generating summary: Model error" in summary
 
+    class BugModel(BaseChatModel):
+        @override
+        def invoke(
+            self,
+            input: LanguageModelInput,
+            config: RunnableConfig | None = None,
+            *,
+            stop: list[str] | None = None,
+            **kwargs: Any,
+        ) -> AIMessage:
+            msg = "Programming error"
+            raise TypeError(msg)
+
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="Summary"))])
+
+        @property
+        def _llm_type(self) -> str:
+            return "mock"
+
+    middleware_bug = SummarizationMiddleware(model=BugModel(), trigger=("tokens", 1000))
+    with pytest.raises(TypeError, match="Programming error"):
+        middleware_bug._create_summary(messages)
+
     # Test we raise warning if max_tokens_before_summary or messages_to_keep is specified
     with pytest.warns(DeprecationWarning, match="max_tokens_before_summary is deprecated"):
         SummarizationMiddleware(model=MockChatModel(), max_tokens_before_summary=500)
@@ -914,6 +945,40 @@ async def test_summarization_middleware_async_error_handling() -> None:
     assert "Error generating summary: Async model error" in summary
 
 
+async def test_summarization_middleware_async_reraises_non_recoverable_errors() -> None:
+    """Test async summary creation does not hide programming errors."""
+
+    class BugAsyncModel(BaseChatModel):
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content="Summary"))])
+
+        @override
+        async def _agenerate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: AsyncCallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            msg = "Async programming error"
+            raise TypeError(msg)
+
+        @property
+        def _llm_type(self) -> str:
+            return "mock"
+
+    middleware = SummarizationMiddleware(model=BugAsyncModel(), trigger=("messages", 5))
+    with pytest.raises(TypeError, match="Async programming error"):
+        await middleware._acreate_summary([HumanMessage(content="test")])
+
+
 def test_summarization_middleware_cutoff_at_boundary() -> None:
     """Test cutoff index determination at exact message boundaries."""
     middleware = SummarizationMiddleware(
@@ -945,6 +1010,27 @@ def test_summarization_middleware_deprecated_parameters_with_defaults() -> None:
             model=MockChatModel(), keep=("messages", 5), messages_to_keep=10
         )
     assert middleware.keep == ("messages", 5)
+
+
+def test_summarization_middleware_rejects_unknown_kwargs() -> None:
+    """Test that unexpected kwargs raise instead of being silently ignored."""
+    with pytest.raises(TypeError, match=r"Unexpected keyword argument\(s\): 'triger'"):
+        SummarizationMiddleware(model=MockChatModel(), triger=("tokens", 1000))
+
+
+def test_summarization_middleware_trim_reraises_non_recoverable_errors() -> None:
+    """Test that trim logic does not swallow programming errors."""
+    middleware = SummarizationMiddleware(model=MockChatModel(), trigger=("messages", 5))
+
+    def broken_token_counter(_: Iterable[MessageLikeRepresentation]) -> int:
+        msg = "counter wiring bug"
+        raise AttributeError(msg)
+
+    middleware.token_counter = broken_token_counter
+    messages: list[AnyMessage] = [HumanMessage(content=str(i)) for i in range(20)]
+
+    with pytest.raises(AttributeError, match="counter wiring bug"):
+        middleware._trim_messages_for_summary(messages)
 
 
 def test_summarization_middleware_fraction_trigger_with_no_profile() -> None:


### PR DESCRIPTION
This change fixes two behavior issues in `SummarizationMiddleware` that can hide mistakes at runtime.

`deprecated_kwargs` now accepts only the supported deprecated keys (`max_tokens_before_summary` and `messages_to_keep`). After processing those keys, any remaining unexpected kwargs raise `TypeError` so typos like `triger=` fail fast instead of becoming silent no-ops.

Exception handling in summary generation and trim fallback is now narrowed to recoverable runtime failures. Non-recoverable/programming errors are no longer swallowed, which helps surface real bugs during development and prevents masking incorrect integrations.

I added targeted unit coverage for:
- unknown kwargs raising `TypeError`
- sync/async summary paths re-raising non-recoverable errors
- trim fallback re-raising non-recoverable errors

Area that may benefit from extra reviewer attention: whether the chosen recoverable exception sets are strict enough for provider/runtime variability while still avoiding broad masking.

This PR was prepared with AI-agent assistance.