### PR TITLE
feat(langchain): project subagent runs onto typed `run.subagents` channel

### DIFF
--- a/libs/langchain_v1/langchain/agents/_subagent_transformer.py
+++ b/libs/langchain_v1/langchain/agents/_subagent_transformer.py
@@ -1,0 +1,203 @@
+"""Surface tools declaring `subagent_name` as typed `run.subagents` handles.
+
+Generalizes deepagents' SubagentTransformer to work with any tool that uses
+the `subagent_name=` parameter on `@tool` / `StructuredTool.from_function`.
+
+Reads the resolved name from `TaskPayload.metadata['subagent_name']` (stamped
+by langgraph's `ToolNode` at dispatch time). The base class
+`_TasksLifecycleBase._handle_task_start` already extracts `subagent_name` from
+metadata and populates `graph_name` and `cause` accordingly, so this
+transformer only needs to act on `_on_started` calls where `cause` is non-None
+(the discriminator for "this task was a subagent dispatch").
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from langgraph.stream.run_stream import (
+    AsyncSubgraphRunStream,
+    SubgraphRunStream,
+)
+from langgraph.stream.stream_channel import StreamChannel
+from langgraph.stream.transformers import (
+    LifecycleCause,
+    SubgraphStatus,
+    _TasksLifecycleBase,
+)
+
+if TYPE_CHECKING:
+    from langgraph.stream._mux import StreamMux
+    from langgraph.stream._types import ProtocolEvent
+
+logger = logging.getLogger(__name__)
+
+
+class SubagentRunStream(SubgraphRunStream):
+    """Typed sync handle for a declared subagent execution.
+
+    Surfaces on `run.subagents` when the dispatching tool has
+    `BaseTool.subagent_name` set (statically or via callable resolver).
+    """
+
+    @property
+    def name(self) -> str | None:
+        """Declared subagent name (alias of `graph_name`)."""
+        return self.graph_name
+
+    @property
+    def cause(self) -> dict[str, str] | None:
+        """Causation edge — the tool_call that triggered this subagent.
+
+        Returns `{"type": "toolCall", "tool_call_id": ...}` when a
+        trigger_call_id is set, else `None`.
+        """
+        if self.trigger_call_id is None:
+            return None
+        return {"type": "toolCall", "tool_call_id": self.trigger_call_id}
+
+
+class AsyncSubagentRunStream(AsyncSubgraphRunStream):
+    """Typed async handle for a declared subagent execution."""
+
+    @property
+    def name(self) -> str | None:
+        """Declared subagent name (alias of `graph_name`)."""
+        return self.graph_name
+
+    @property
+    def cause(self) -> dict[str, str] | None:
+        """Causation edge — the tool_call that triggered this subagent.
+
+        Returns `{"type": "toolCall", "tool_call_id": ...}` when a
+        trigger_call_id is set, else `None`.
+        """
+        if self.trigger_call_id is None:
+            return None
+        return {"type": "toolCall", "tool_call_id": self.trigger_call_id}
+
+
+class SubagentTransformer(_TasksLifecycleBase):
+    """Promote declared subagents into typed handles on `run.subagents`.
+
+    Watches `tasks` events at the configured scope. For each child task
+    whose `TaskPayload.metadata` contains a `subagent_name` (stamped by
+    `ToolNode` from `BaseTool.subagent_name`), builds a typed
+    `SubagentRunStream` handle and pushes it onto the `subagents` log.
+
+    The base class extracts `subagent_name` from metadata and passes it as
+    `graph_name` to `_on_started`. It also builds `cause` only when
+    `subagent_name` is present, so `cause is not None` is the discriminator
+    for subagent tasks vs. ordinary nested-graph dispatches.
+
+    Optionally filters to a declared set of subagent names via
+    `subagent_names`; when `None` (default), all dispatched subagents surface.
+    """
+
+    _native: ClassVar[bool] = True
+
+    def __init__(
+        self,
+        scope: tuple[str, ...] = (),
+        *,
+        subagent_names: frozenset[str] | None = None,
+    ) -> None:
+        super().__init__(scope)
+        self._names = subagent_names
+        self._log: StreamChannel[SubagentRunStream | AsyncSubagentRunStream] = StreamChannel()
+        self._handles: dict[tuple[str, ...], SubagentRunStream | AsyncSubagentRunStream] = {}
+        self._mux: StreamMux | None = None
+
+    def init(self) -> dict[str, Any]:
+        return {"subagents": self._log}
+
+    def _on_register(self, mux: StreamMux) -> None:
+        self._mux = mux
+
+    def _should_track(self, ns: tuple[str, ...]) -> bool:
+        depth = len(self.scope)
+        return len(ns) == depth + 1 and ns[:depth] == self.scope
+
+    def _on_started(
+        self,
+        ns: tuple[str, ...],
+        graph_name: str | None,
+        trigger_call_id: str | None,  # noqa: ARG002
+        *,
+        cause: LifecycleCause | None = None,
+    ) -> None:
+        # cause is only set by the base class when metadata.subagent_name was
+        # present — it is the discriminator for "this is a subagent dispatch."
+        if cause is None:
+            return
+        # graph_name carries the subagent_name extracted from metadata.
+        if not isinstance(graph_name, str) or not graph_name:
+            return
+        if self._names is not None and graph_name not in self._names:
+            return
+        if self._mux is None or ns in self._handles:
+            return
+        try:
+            child_mux = self._mux._make_child(ns)  # noqa: SLF001
+        except RuntimeError:
+            logger.debug("SubagentTransformer: could not create child mux for %s", ns)
+            return
+
+        # Extract tool_call_id from cause for the SubagentRunStream.cause property.
+        # cause is LifecycleCauseToolCall = {"type": "toolCall", "toolCallId": "..."}
+        tool_call_id: str | None = None
+        if isinstance(cause, dict):
+            raw = cause.get("toolCallId")
+            if isinstance(raw, str):
+                tool_call_id = raw
+
+        handle_cls = AsyncSubagentRunStream if child_mux.is_async else SubagentRunStream
+        handle = handle_cls(
+            mux=child_mux,
+            path=ns,
+            graph_name=graph_name,
+            trigger_call_id=tool_call_id,
+        )
+        self._handles[ns] = handle
+        self._log.push(handle)
+
+    def _on_terminal(
+        self,
+        ns: tuple[str, ...],
+        status: SubgraphStatus,
+        error: str | None,
+    ) -> None:
+        handle = self._handles.get(ns)
+        if handle is None or handle._seen_terminal:  # noqa: SLF001
+            return
+        handle.status = status
+        if error is not None and handle.error is None:
+            handle.error = error
+        handle._seen_terminal = True  # noqa: SLF001
+        if handle._mux is None or handle._mux._events._closed:  # noqa: SLF001
+            return
+        if status == "failed":
+            handle._mux.fail(RuntimeError(error or "Subagent failed"))  # noqa: SLF001
+        else:
+            handle._mux.close()  # noqa: SLF001
+
+    def _handle_for_event(
+        self, event: ProtocolEvent
+    ) -> SubagentRunStream | AsyncSubagentRunStream | None:
+        ns = tuple(event["params"]["namespace"])
+        depth = len(self.scope)
+        if len(ns) < depth + 1:
+            return None
+        handle = self._handles.get(ns[: depth + 1])
+        if handle is None or handle._mux is None or handle._mux._events._closed:  # noqa: SLF001
+            return None
+        return handle
+
+    def process(self, event: ProtocolEvent) -> bool:
+        keep = super().process(event)
+        handle = self._handle_for_event(event)
+        if handle is not None:
+            handle._observe_event(event)  # noqa: SLF001
+            handle._mux.push(event)  # noqa: SLF001
+        return keep

--- a/libs/langchain_v1/langchain/agents/_subagent_transformer.py
+++ b/libs/langchain_v1/langchain/agents/_subagent_transformer.py
@@ -1,14 +1,21 @@
-"""Surface tools declaring `subagent_name` as typed `run.subagents` handles.
+"""Surface nested named agents as typed `run.subagents` handles.
 
-Generalizes deepagents' SubagentTransformer to work with any tool that uses
-the `subagent_name=` parameter on `@tool` / `StructuredTool.from_function`.
+Detects subagents via the `lc_agent_name` transition that langgraph's base
+`_TasksLifecycleBase` now computes. `create_agent(name=...)` binds
+`lc_agent_name` into the run config; the base transformer records, per
+namespace, the `lc_agent_name` seen on each task start (first-write-wins).
 
-Reads the resolved name from `TaskPayload.metadata['subagent_name']`, which
-langgraph's `ToolNode` derives from `BaseTool.subagent_name` via the
-`pregel_dynamic_metadata` hook at task scheduling time. The metadata is
-projected onto the parent-scope `tasks` event for the tool dispatch; this
-transformer correlates that event to the child-scope `tasks` events emitted
-by the nested run that the tool spawns.
+A subagent boundary is a nested run whose `lc_agent_name` is set *and* differs
+from its parent namespace's `lc_agent_name`. Plain subgraphs inherit the
+parent's name (so they compare equal and are excluded); unnamed agents have
+`lc_agent_name == None` (also excluded). For genuine subagents the base also
+recovers the originating tool call and passes it through as a `cause`
+(`{"type": "toolCall", "tool_call_id": ...}`), joined from the parent task's
+pending tool calls.
+
+This transformer gates on that boundary and surfaces a typed handle on
+`run.subagents`, then forwards child-scope events into the handle's mux so the
+nested run can be consumed independently.
 """
 
 from __future__ import annotations
@@ -22,12 +29,12 @@ from langgraph.stream.run_stream import (
 )
 from langgraph.stream.stream_channel import StreamChannel
 from langgraph.stream.transformers import (
-    LifecycleCause,
     SubgraphStatus,
     _TasksLifecycleBase,
 )
 
 if TYPE_CHECKING:
+    from langchain_protocol.protocol import LifecycleCause
     from langgraph.stream._mux import StreamMux
     from langgraph.stream._types import ProtocolEvent
 
@@ -35,89 +42,104 @@ logger = logging.getLogger(__name__)
 
 
 class SubagentRunStream(SubgraphRunStream):
-    """Typed sync handle for a declared subagent execution.
+    """Typed sync handle for a nested named-agent execution.
 
-    Surfaces on `run.subagents` when the dispatching tool has
-    `BaseTool.subagent_name` set (statically or via callable resolver).
+    Surfaces on `run.subagents` when a nested run's `lc_agent_name` differs
+    from its parent's (i.e., a `create_agent(name=...)` dispatched from a tool).
     """
+
+    def __init__(
+        self,
+        mux: StreamMux,
+        *,
+        path: tuple[str, ...],
+        graph_name: str | None = None,
+        trigger_call_id: str | None = None,
+        cause: LifecycleCause | None = None,
+    ) -> None:
+        super().__init__(
+            mux,
+            path=path,
+            graph_name=graph_name,
+            trigger_call_id=trigger_call_id,
+        )
+        self._cause = cause
 
     @property
     def name(self) -> str | None:
-        """Declared subagent name (alias of `graph_name`)."""
+        """Subagent name (the nested run's `lc_agent_name`)."""
         return self.graph_name
 
     @property
-    def cause(self) -> dict[str, str] | None:
-        """Causation edge — the tool_call that triggered this subagent.
+    def cause(self) -> LifecycleCause | None:
+        """Causation edge — the tool call that triggered this subagent.
 
-        Returns `{"type": "toolCall", "tool_call_id": ...}` when a
-        trigger_call_id is set, else `None`.
+        Returns the `LifecycleCause` recovered by the base transformer (a
+        `{"type": "toolCall", "tool_call_id": ...}` dict) when the originating
+        tool call could be joined, else `None`.
         """
-        if self.trigger_call_id is None:
-            return None
-        return {"type": "toolCall", "tool_call_id": self.trigger_call_id}
+        return self._cause
 
 
 class AsyncSubagentRunStream(AsyncSubgraphRunStream):
-    """Typed async handle for a declared subagent execution."""
+    """Typed async handle for a nested named-agent execution."""
+
+    def __init__(
+        self,
+        mux: StreamMux,
+        *,
+        path: tuple[str, ...],
+        graph_name: str | None = None,
+        trigger_call_id: str | None = None,
+        cause: LifecycleCause | None = None,
+    ) -> None:
+        super().__init__(
+            mux,
+            path=path,
+            graph_name=graph_name,
+            trigger_call_id=trigger_call_id,
+        )
+        self._cause = cause
 
     @property
     def name(self) -> str | None:
-        """Declared subagent name (alias of `graph_name`)."""
+        """Subagent name (the nested run's `lc_agent_name`)."""
         return self.graph_name
 
     @property
-    def cause(self) -> dict[str, str] | None:
-        """Causation edge — the tool_call that triggered this subagent.
+    def cause(self) -> LifecycleCause | None:
+        """Causation edge — the tool call that triggered this subagent.
 
-        Returns `{"type": "toolCall", "tool_call_id": ...}` when a
-        trigger_call_id is set, else `None`.
+        Returns the `LifecycleCause` recovered by the base transformer (a
+        `{"type": "toolCall", "tool_call_id": ...}` dict) when the originating
+        tool call could be joined, else `None`.
         """
-        if self.trigger_call_id is None:
-            return None
-        return {"type": "toolCall", "tool_call_id": self.trigger_call_id}
+        return self._cause
 
 
 class SubagentTransformer(_TasksLifecycleBase):
-    """Promote declared subagents into typed handles on `run.subagents`.
+    """Promote nested named agents into typed handles on `run.subagents`.
 
-    The Pregel scheduler emits a `tasks` event at the *parent* namespace
-    when a node is scheduled, carrying the task's `id` and any metadata
-    set on its config. ToolNode's `pregel_dynamic_metadata` hook stamps
-    `subagent_name` and `tool_call_id` into that metadata when the
-    dispatched tool declares `BaseTool.subagent_name`.
+    The base `_TasksLifecycleBase` records each namespace's `lc_agent_name`
+    (set by `create_agent(name=...)`) and, on every task start, fires
+    `_on_started` with the resolved `graph_name` and a `cause` for genuine
+    subagent boundaries. This transformer gates on that boundary using the
+    inherited `_lc_by_ns` map: a nested run is a subagent when its
+    `lc_agent_name` is set and differs from its parent's. Plain subgraphs
+    (which inherit the parent's name) and unnamed agents (`None`) are excluded.
 
-    Nested runs spawned inside the tool (e.g., a subagent's Pregel
-    invocation) emit their own `tasks` events at a child namespace
-    that shares the parent task's id (segment shape `"<node>:<id>"`).
-
-    This transformer correlates the two: it stashes
-    `task_id -> (subagent_name, tool_call_id)` from parent-scope events,
-    and on the first matching child-scope event emits a typed handle on
-    `run.subagents`.
-
-    Optionally filters to a declared set of subagent names via
-    `subagent_names`; when `None` (default), all dispatched subagents
-    surface.
+    On the first matching task start it builds a child mux and emits a typed
+    handle on `run.subagents`, then forwards subsequent child-scope events into
+    that handle so the nested run can be consumed independently.
     """
 
     _native: ClassVar[bool] = True
 
-    def __init__(
-        self,
-        scope: tuple[str, ...] = (),
-        *,
-        subagent_names: frozenset[str] | None = None,
-    ) -> None:
+    def __init__(self, scope: tuple[str, ...] = ()) -> None:
         super().__init__(scope)
-        self._names = subagent_names
         self._log: StreamChannel[SubagentRunStream | AsyncSubagentRunStream] = StreamChannel()
         self._handles: dict[tuple[str, ...], SubagentRunStream | AsyncSubagentRunStream] = {}
         self._mux: StreamMux | None = None
-        # task_id -> {"subagent_name": ..., "tool_call_id": ...}, populated
-        # from parent-scope `tasks` events and consumed on the first matching
-        # child-scope task start.
-        self._pending: dict[str, dict[str, str]] = {}
 
     def init(self) -> dict[str, Any]:
         return {"subagents": self._log}
@@ -129,49 +151,20 @@ class SubagentTransformer(_TasksLifecycleBase):
         depth = len(self.scope)
         return len(ns) == depth + 1 and ns[:depth] == self.scope
 
-    def _capture_pending_from_parent(self, event: ProtocolEvent) -> None:
-        """Stash subagent metadata from a parent-scope task start.
-
-        Pregel emits a `tasks` event at this transformer's scope when a child
-        node is scheduled. The event's `data` carries the task `id` and the
-        `metadata` projected from the task config (which `ToolNode.pregel_dynamic_metadata`
-        populated with `subagent_name` and `tool_call_id`). Stash by id so the
-        corresponding child-scope event can pop it.
-        """
-        ns = tuple(event["params"]["namespace"])
-        if ns != self.scope:
-            return
-        data = event["params"]["data"]
-        if not isinstance(data, dict) or "result" in data:
-            return
-        task_id = data.get("id")
-        metadata = data.get("metadata") or {}
-        if not isinstance(task_id, str) or not isinstance(metadata, dict):
-            return
-        subagent_name = metadata.get("subagent_name")
-        if not isinstance(subagent_name, str) or not subagent_name:
-            return
-        tool_call_id = metadata.get("tool_call_id")
-        self._pending[task_id] = {
-            "subagent_name": subagent_name,
-            "tool_call_id": tool_call_id if isinstance(tool_call_id, str) else "",
-        }
-
     def _on_started(
         self,
         ns: tuple[str, ...],
-        graph_name: str | None,  # noqa: ARG002
+        graph_name: str | None,
         trigger_call_id: str | None,
         *,
-        cause: LifecycleCause | None = None,  # noqa: ARG002
+        cause: LifecycleCause | None = None,
     ) -> None:
-        if trigger_call_id is None:
-            return
-        info = self._pending.pop(trigger_call_id, None)
-        if info is None:
-            return
-        subagent_name = info["subagent_name"]
-        if self._names is not None and subagent_name not in self._names:
+        child_lc = self._lc_by_ns.get(ns)
+        parent_lc = self._lc_by_ns.get(ns[:-1])
+        # Surface only genuine subagents: a nested run whose lc_agent_name
+        # is set and differs from its parent's. Plain subgraphs inherit the
+        # parent's name (== parent); unnamed agents have None. Both excluded.
+        if child_lc is None or child_lc == parent_lc:
             return
         if self._mux is None or ns in self._handles:
             return
@@ -181,13 +174,13 @@ class SubagentTransformer(_TasksLifecycleBase):
             logger.debug("SubagentTransformer: could not create child mux for %s", ns)
             return
 
-        tool_call_id = info["tool_call_id"] or None
         handle_cls = AsyncSubagentRunStream if child_mux.is_async else SubagentRunStream
         handle = handle_cls(
             mux=child_mux,
             path=ns,
-            graph_name=subagent_name,
-            trigger_call_id=tool_call_id,
+            graph_name=graph_name,
+            trigger_call_id=trigger_call_id,
+            cause=cause,
         )
         self._handles[ns] = handle
         self._log.push(handle)
@@ -225,8 +218,6 @@ class SubagentTransformer(_TasksLifecycleBase):
         return handle
 
     def process(self, event: ProtocolEvent) -> bool:
-        if event.get("method") == "tasks":
-            self._capture_pending_from_parent(event)
         keep = super().process(event)
         handle = self._handle_for_event(event)
         if handle is not None:

--- a/libs/langchain_v1/langchain/agents/_subagent_transformer.py
+++ b/libs/langchain_v1/langchain/agents/_subagent_transformer.py
@@ -3,12 +3,12 @@
 Generalizes deepagents' SubagentTransformer to work with any tool that uses
 the `subagent_name=` parameter on `@tool` / `StructuredTool.from_function`.
 
-Reads the resolved name from `TaskPayload.metadata['subagent_name']` (stamped
-by langgraph's `ToolNode` at dispatch time). The base class
-`_TasksLifecycleBase._handle_task_start` already extracts `subagent_name` from
-metadata and populates `graph_name` and `cause` accordingly, so this
-transformer only needs to act on `_on_started` calls where `cause` is non-None
-(the discriminator for "this task was a subagent dispatch").
+Reads the resolved name from `TaskPayload.metadata['subagent_name']`, which
+langgraph's `ToolNode` derives from `BaseTool.subagent_name` via the
+`pregel_dynamic_metadata` hook at task scheduling time. The metadata is
+projected onto the parent-scope `tasks` event for the tool dispatch; this
+transformer correlates that event to the child-scope `tasks` events emitted
+by the nested run that the tool spawns.
 """
 
 from __future__ import annotations
@@ -81,18 +81,24 @@ class AsyncSubagentRunStream(AsyncSubgraphRunStream):
 class SubagentTransformer(_TasksLifecycleBase):
     """Promote declared subagents into typed handles on `run.subagents`.
 
-    Watches `tasks` events at the configured scope. For each child task
-    whose `TaskPayload.metadata` contains a `subagent_name` (stamped by
-    `ToolNode` from `BaseTool.subagent_name`), builds a typed
-    `SubagentRunStream` handle and pushes it onto the `subagents` log.
+    The Pregel scheduler emits a `tasks` event at the *parent* namespace
+    when a node is scheduled, carrying the task's `id` and any metadata
+    set on its config. ToolNode's `pregel_dynamic_metadata` hook stamps
+    `subagent_name` and `tool_call_id` into that metadata when the
+    dispatched tool declares `BaseTool.subagent_name`.
 
-    The base class extracts `subagent_name` from metadata and passes it as
-    `graph_name` to `_on_started`. It also builds `cause` only when
-    `subagent_name` is present, so `cause is not None` is the discriminator
-    for subagent tasks vs. ordinary nested-graph dispatches.
+    Nested runs spawned inside the tool (e.g., a subagent's Pregel
+    invocation) emit their own `tasks` events at a child namespace
+    that shares the parent task's id (segment shape `"<node>:<id>"`).
+
+    This transformer correlates the two: it stashes
+    `task_id -> (subagent_name, tool_call_id)` from parent-scope events,
+    and on the first matching child-scope event emits a typed handle on
+    `run.subagents`.
 
     Optionally filters to a declared set of subagent names via
-    `subagent_names`; when `None` (default), all dispatched subagents surface.
+    `subagent_names`; when `None` (default), all dispatched subagents
+    surface.
     """
 
     _native: ClassVar[bool] = True
@@ -108,6 +114,10 @@ class SubagentTransformer(_TasksLifecycleBase):
         self._log: StreamChannel[SubagentRunStream | AsyncSubagentRunStream] = StreamChannel()
         self._handles: dict[tuple[str, ...], SubagentRunStream | AsyncSubagentRunStream] = {}
         self._mux: StreamMux | None = None
+        # task_id -> {"subagent_name": ..., "tool_call_id": ...}, populated
+        # from parent-scope `tasks` events and consumed on the first matching
+        # child-scope task start.
+        self._pending: dict[str, dict[str, str]] = {}
 
     def init(self) -> dict[str, Any]:
         return {"subagents": self._log}
@@ -119,22 +129,49 @@ class SubagentTransformer(_TasksLifecycleBase):
         depth = len(self.scope)
         return len(ns) == depth + 1 and ns[:depth] == self.scope
 
+    def _capture_pending_from_parent(self, event: ProtocolEvent) -> None:
+        """Stash subagent metadata from a parent-scope task start.
+
+        Pregel emits a `tasks` event at this transformer's scope when a child
+        node is scheduled. The event's `data` carries the task `id` and the
+        `metadata` projected from the task config (which `ToolNode.pregel_dynamic_metadata`
+        populated with `subagent_name` and `tool_call_id`). Stash by id so the
+        corresponding child-scope event can pop it.
+        """
+        ns = tuple(event["params"]["namespace"])
+        if ns != self.scope:
+            return
+        data = event["params"]["data"]
+        if not isinstance(data, dict) or "result" in data:
+            return
+        task_id = data.get("id")
+        metadata = data.get("metadata") or {}
+        if not isinstance(task_id, str) or not isinstance(metadata, dict):
+            return
+        subagent_name = metadata.get("subagent_name")
+        if not isinstance(subagent_name, str) or not subagent_name:
+            return
+        tool_call_id = metadata.get("tool_call_id")
+        self._pending[task_id] = {
+            "subagent_name": subagent_name,
+            "tool_call_id": tool_call_id if isinstance(tool_call_id, str) else "",
+        }
+
     def _on_started(
         self,
         ns: tuple[str, ...],
-        graph_name: str | None,
-        trigger_call_id: str | None,  # noqa: ARG002
+        graph_name: str | None,  # noqa: ARG002
+        trigger_call_id: str | None,
         *,
-        cause: LifecycleCause | None = None,
+        cause: LifecycleCause | None = None,  # noqa: ARG002
     ) -> None:
-        # cause is only set by the base class when metadata.subagent_name was
-        # present — it is the discriminator for "this is a subagent dispatch."
-        if cause is None:
+        if trigger_call_id is None:
             return
-        # graph_name carries the subagent_name extracted from metadata.
-        if not isinstance(graph_name, str) or not graph_name:
+        info = self._pending.pop(trigger_call_id, None)
+        if info is None:
             return
-        if self._names is not None and graph_name not in self._names:
+        subagent_name = info["subagent_name"]
+        if self._names is not None and subagent_name not in self._names:
             return
         if self._mux is None or ns in self._handles:
             return
@@ -144,19 +181,12 @@ class SubagentTransformer(_TasksLifecycleBase):
             logger.debug("SubagentTransformer: could not create child mux for %s", ns)
             return
 
-        # Extract tool_call_id from cause for the SubagentRunStream.cause property.
-        # cause is LifecycleCauseToolCall = {"type": "toolCall", "toolCallId": "..."}
-        tool_call_id: str | None = None
-        if isinstance(cause, dict):
-            raw = cause.get("toolCallId")
-            if isinstance(raw, str):
-                tool_call_id = raw
-
+        tool_call_id = info["tool_call_id"] or None
         handle_cls = AsyncSubagentRunStream if child_mux.is_async else SubagentRunStream
         handle = handle_cls(
             mux=child_mux,
             path=ns,
-            graph_name=graph_name,
+            graph_name=subagent_name,
             trigger_call_id=tool_call_id,
         )
         self._handles[ns] = handle
@@ -195,6 +225,8 @@ class SubagentTransformer(_TasksLifecycleBase):
         return handle
 
     def process(self, event: ProtocolEvent) -> bool:
+        if event.get("method") == "tasks":
+            self._capture_pending_from_parent(event)
         keep = super().process(event)
         handle = self._handle_for_event(event)
         if handle is not None:

--- a/libs/langchain_v1/langchain/agents/_subagent_transformer.py
+++ b/libs/langchain_v1/langchain/agents/_subagent_transformer.py
@@ -124,9 +124,10 @@ class SubagentTransformer(_TasksLifecycleBase):
     (set by `create_agent(name=...)`) and, on every task start, fires
     `_on_started` with the resolved `graph_name` and a `cause` for genuine
     subagent boundaries. This transformer gates on that boundary using the
-    inherited `_lc_by_ns` map: a nested run is a subagent when its
-    `lc_agent_name` is set and differs from its parent's. Plain subgraphs
-    (which inherit the parent's name) and unnamed agents (`None`) are excluded.
+    inherited `_lc_by_ns` map: a nested run is a subagent when it carries an
+    `lc_agent_name`. Same-named nested agents (e.g. a subagent that invokes
+    itself) are surfaced; unnamed agents (`None`) are excluded. Trade-off: a
+    non-agent subgraph that inherited the parent's name will also surface.
 
     On the first matching task start it builds a child mux and emits a typed
     handle on `run.subagents`, then forwards subsequent child-scope events into
@@ -163,11 +164,13 @@ class SubagentTransformer(_TasksLifecycleBase):
         cause: LifecycleCause | None = None,
     ) -> None:
         child_lc = self._lc_by_ns.get(ns)
-        parent_lc = self._lc_by_ns.get(ns[:-1])
-        # Surface only genuine subagents: a nested run whose lc_agent_name
-        # is set and differs from its parent's. Plain subgraphs inherit the
-        # parent's name (== parent); unnamed agents have None. Both excluded.
-        if child_lc is None or child_lc == parent_lc:
+        # Surface any nested run carrying an lc_agent_name (set by create_agent).
+        # A same-named nested agent — e.g. a subagent that invokes itself —
+        # re-asserts its own name and is surfaced. Unnamed runs (None) are
+        # excluded. Trade-off: a non-agent subgraph that inherited the parent's
+        # name also surfaces; null lc_agent_name when invoking such a graph to
+        # exclude it.
+        if child_lc is None:
             return
         if self._mux is None or ns in self._handles:
             return

--- a/libs/langchain_v1/langchain/agents/_subagent_transformer.py
+++ b/libs/langchain_v1/langchain/agents/_subagent_transformer.py
@@ -134,6 +134,9 @@ class SubagentTransformer(_TasksLifecycleBase):
     """
 
     _native: ClassVar[bool] = True
+    # Overrides `aprocess` but also runs unchanged on the sync lane via
+    # `process`, so it must not be forced into an async-only run.
+    supports_sync: ClassVar[bool] = True
 
     def __init__(self, scope: tuple[str, ...] = ()) -> None:
         super().__init__(scope)
@@ -192,18 +195,61 @@ class SubagentTransformer(_TasksLifecycleBase):
         error: str | None,
     ) -> None:
         handle = self._handles.get(ns)
-        if handle is None or handle._seen_terminal:  # noqa: SLF001
+        if handle is None or not self._mark_terminal(handle, status, error):
             return
+        self._close_or_fail_handle(handle, status, error)
+
+    async def _aon_terminal(
+        self,
+        ns: tuple[str, ...],
+        status: SubgraphStatus,
+        error: str | None,
+    ) -> None:
+        handle = self._handles.get(ns)
+        if handle is None or not self._mark_terminal(handle, status, error):
+            return
+        await self._aclose_or_fail_handle(handle, status, error)
+
+    def _mark_terminal(
+        self,
+        handle: SubagentRunStream | AsyncSubagentRunStream,
+        status: SubgraphStatus,
+        error: str | None,
+    ) -> bool:
+        """Mark a handle terminal once. Returns True on the first transition."""
+        if handle._seen_terminal:  # noqa: SLF001
+            return False
         handle.status = status
         if error is not None and handle.error is None:
             handle.error = error
         handle._seen_terminal = True  # noqa: SLF001
+        return True
+
+    def _close_or_fail_handle(
+        self,
+        handle: SubagentRunStream | AsyncSubagentRunStream,
+        status: SubgraphStatus,
+        error: str | None,
+    ) -> None:
         if handle._mux is None or handle._mux._events._closed:  # noqa: SLF001
             return
         if status == "failed":
             handle._mux.fail(RuntimeError(error or "Subagent failed"))  # noqa: SLF001
         else:
             handle._mux.close()  # noqa: SLF001
+
+    async def _aclose_or_fail_handle(
+        self,
+        handle: SubagentRunStream | AsyncSubagentRunStream,
+        status: SubgraphStatus,
+        error: str | None,
+    ) -> None:
+        if handle._mux is None or handle._mux._events._closed:  # noqa: SLF001
+            return
+        if status == "failed":
+            await handle._mux.afail(RuntimeError(error or "Subagent failed"))  # noqa: SLF001
+        else:
+            await handle._mux.aclose()  # noqa: SLF001
 
     def _handle_for_event(
         self, event: ProtocolEvent
@@ -218,9 +264,38 @@ class SubagentTransformer(_TasksLifecycleBase):
         return handle
 
     def process(self, event: ProtocolEvent) -> bool:
+        # Run tasks bookkeeping first so a `started` handle exists by the
+        # time we forward the event into the child mini-mux.
         keep = super().process(event)
         handle = self._handle_for_event(event)
         if handle is not None:
             handle._observe_event(event)  # noqa: SLF001
             handle._mux.push(event)  # noqa: SLF001
+        return keep
+
+    async def aprocess(self, event: ProtocolEvent) -> bool:
+        # Async counterpart: repeat the tasks bookkeeping here and forward into
+        # the child mini-mux through its async lane so the subagent's own
+        # transformers are driven on the correct (async) lane instead of being
+        # double-driven via the sync `process`/`push` path.
+        if event["method"] == "tasks":
+            ns = tuple(event["params"]["namespace"])
+            data = event["params"]["data"]
+            if "result" in data:
+                for child_ns, status, error in self._pop_terminal_transitions(ns, data):
+                    await self._aon_terminal(child_ns, status, error)
+            else:
+                # Mirror the sync bookkeeping so the async lane observes parent
+                # identity / pending tool calls before discriminating a
+                # subagent boundary in `_handle_task_start` -> `_on_started`.
+                self._record_identity(ns, data)
+                self._record_pending_tool_calls(data)
+                self._handle_task_start(ns, data)
+            keep = False
+        else:
+            keep = True
+        handle = self._handle_for_event(event)
+        if handle is not None:
+            handle._observe_event(event)  # noqa: SLF001
+            await handle._mux.apush(event)  # noqa: SLF001
         return keep

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -28,6 +28,7 @@ from langgraph.types import Command, Send
 from langsmith import traceable
 from typing_extensions import NotRequired, Required, TypedDict
 
+from langchain.agents._subagent_transformer import SubagentTransformer
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
@@ -1677,6 +1678,7 @@ def create_agent(
         cache=cache,
         transformers=[
             ToolCallTransformer,
+            SubagentTransformer,
             *middleware_transformers,
             *(transformers or ()),
         ],

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -95,6 +95,13 @@ test_integration = [
 [tool.uv]
 constraint-dependencies = ["urllib3>=2.6.3", "pygments>=2.20.0"]
 
+[tool.uv.sources]
+langchain-core = { path = "../core", editable = true }
+langchain-tests = { path = "../standard-tests", editable = true }
+langchain-text-splitters = { path = "../text-splitters", editable = true }
+langchain-openai = { path = "../partners/openai", editable = true }
+langchain-anthropic = { path = "../partners/anthropic", editable = true }
+
 [tool.ruff]
 line-length = 100
 

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -96,7 +96,7 @@ test_integration = [
 constraint-dependencies = ["urllib3>=2.6.3", "pygments>=2.20.0"]
 
 [tool.uv.sources]
-langgraph = { git = "https://github.com/langchain-ai/langgraph", branch = "nh/subagent-name-langgraph", subdirectory = "libs/langgraph" }
+langgraph = { git = "https://github.com/langchain-ai/langgraph", rev = "577ee12cc90d4c1cdaed0eca1121b060153698f9", subdirectory = "libs/langgraph" }
 
 [tool.ruff]
 line-length = 100

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -25,7 +25,7 @@ version = "1.3.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.4.0,<2.0.0",
-    "langgraph>=1.2.2,<1.3.0",
+    "langgraph>=1.2.3,<1.3.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 
@@ -94,9 +94,6 @@ test_integration = [
 
 [tool.uv]
 constraint-dependencies = ["urllib3>=2.6.3", "pygments>=2.20.0"]
-
-[tool.uv.sources]
-langgraph = { git = "https://github.com/langchain-ai/langgraph", rev = "577ee12cc90d4c1cdaed0eca1121b060153698f9", subdirectory = "libs/langgraph" }
 
 [tool.ruff]
 line-length = 100

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -96,11 +96,7 @@ test_integration = [
 constraint-dependencies = ["urllib3>=2.6.3", "pygments>=2.20.0"]
 
 [tool.uv.sources]
-langchain-core = { path = "../core", editable = true }
-langchain-tests = { path = "../standard-tests", editable = true }
-langchain-text-splitters = { path = "../text-splitters", editable = true }
-langchain-openai = { path = "../partners/openai", editable = true }
-langchain-anthropic = { path = "../partners/anthropic", editable = true }
+langgraph = { git = "https://github.com/langchain-ai/langgraph", branch = "nh/subagent-name-langgraph", subdirectory = "libs/langgraph" }
 
 [tool.ruff]
 line-length = 100

--- a/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
@@ -1,11 +1,9 @@
 """Tests for langchain.agents._subagent_transformer.
 
-The transformer detects subagents via the `lc_agent_name` transition computed
-by langgraph's base `_TasksLifecycleBase`: a nested run whose `lc_agent_name`
-(set by `create_agent(name=...)`) differs from its parent's is surfaced as a
-typed `SubagentRunStream` handle on `run.subagents`. These tests drive a real
-supervisor `create_agent` that dispatches a nested `create_agent` from a tool,
-giving true end-to-end coverage.
+The transformer surfaces, on `run.subagents`, any nested run that carries an
+`lc_agent_name` (set by `create_agent(name=...)`), tracked via langgraph's base
+`_TasksLifecycleBase`. These tests drive a real supervisor `create_agent` that
+dispatches a nested `create_agent` from a tool, giving true end-to-end coverage.
 """
 
 from __future__ import annotations
@@ -119,8 +117,15 @@ def test_plain_tool_not_surfaced() -> None:
     assert handles == []
 
 
-def test_unnamed_inner_agent_not_surfaced() -> None:
-    """An inner `create_agent` without `name=` inherits the parent name, so excluded."""
+def test_unnamed_inner_agent_surfaces_with_inherited_name() -> None:
+    """An unnamed inner `create_agent` inherits the parent's name and surfaces.
+
+    This is the accepted trade-off of detecting subagents by "carries an
+    lc_agent_name": a nested run that didn't set its own name (an unnamed
+    `create_agent`, or a plain `StateGraph`) inherits the parent's name and is
+    surfaced under it. A caller can null `lc_agent_name` in the config it
+    invokes such a graph with to exclude it.
+    """
     inner_agent = create_agent(model=FakeToolCallingModel(tool_calls=[[]]))
 
     @tool("call_weather")
@@ -137,11 +142,51 @@ def test_unnamed_inner_agent_not_surfaced() -> None:
 
     run = supervisor.stream_events({"messages": [HumanMessage("weather?")]}, version="v3")
 
-    handles = list(run.subagents)
-    for _ in run:
-        pass
+    handles = []
+    for handle in run.subagents:
+        handles.append(handle)
+        for _ in handle:
+            pass
 
-    assert handles == []
+    assert len(handles) == 1
+    # Inherited the parent's name (the trade-off).
+    assert handles[0].name == "supervisor"
+
+
+def test_same_name_nested_agent_surfaced() -> None:
+    """A nested agent with the SAME name as its parent is still surfaced.
+
+    A subagent that dispatches a same-named agent (or invokes itself) re-asserts
+    its own `lc_agent_name`, so child lc == parent lc. The discriminator surfaces
+    any nested run that carries a name, so the same-named run is reported instead
+    of being folded into the parent (which the old `!= parent` rule did).
+    """
+    inner_agent = create_agent(model=FakeToolCallingModel(tool_calls=[[]]), name="weather_agent")
+
+    @tool("call_weather")
+    def call_weather(city: str) -> str:
+        """Call a same-named inner agent."""
+        result = inner_agent.invoke({"messages": [HumanMessage(f"weather in {city}")]})
+        return result["messages"][-1].text
+
+    # The parent agent shares the inner agent's name.
+    supervisor = create_agent(
+        model=_supervisor_model(),
+        tools=[call_weather],
+        name="weather_agent",
+    )
+
+    run = supervisor.stream_events({"messages": [HumanMessage("weather?")]}, version="v3")
+
+    handles = []
+    for handle in run.subagents:
+        handles.append(handle)
+        for _ in handle:
+            pass
+
+    assert len(handles) == 1
+    assert handles[0].name == "weather_agent"
+    assert handles[0].cause == {"type": "toolCall", "tool_call_id": "call_w"}
 
 
 def test_transformer_init_exposes_subagents_channel() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
@@ -59,6 +59,42 @@ def test_subagents_surfaces_named_subagent() -> None:
     assert handles[0].cause == {"type": "toolCall", "tool_call_id": "call_w"}
 
 
+async def test_subagents_surfaces_named_subagent_async() -> None:
+    """Async counterpart: the handle surfaces and reaches a terminal state.
+
+    Drives the run through `astream_events`, so events flow via the async
+    `aprocess`/`apush` lane and the child mini-mux is closed via `aclose`.
+    """
+    weather_agent = create_agent(model=FakeToolCallingModel(tool_calls=[[]]), name="weather_agent")
+
+    @tool("call_weather")
+    async def call_weather(city: str) -> str:
+        """Call the weather agent."""
+        result = await weather_agent.ainvoke({"messages": [HumanMessage(f"weather in {city}")]})
+        return result["messages"][-1].text
+
+    supervisor = create_agent(
+        model=_supervisor_model(),
+        tools=[call_weather],
+        name="supervisor",
+    )
+
+    run = await supervisor.astream_events({"messages": [HumanMessage("weather?")]}, version="v3")
+
+    handles = []
+    async for handle in run.subagents:
+        handles.append(handle)
+        # Drain the nested run so it completes.
+        async for _ in handle:
+            pass
+
+    assert len(handles) == 1
+    assert handles[0].name == "weather_agent"
+    assert handles[0].cause == {"type": "toolCall", "tool_call_id": "call_w"}
+    assert handles[0]._seen_terminal is True
+    assert handles[0].status == "completed"
+
+
 def test_plain_tool_not_surfaced() -> None:
     """A tool that returns a string (spawns no nested run) surfaces nothing."""
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
@@ -1,188 +1,142 @@
 """Tests for langchain.agents._subagent_transformer.
 
-The transformer reads TaskPayload.metadata.subagent_name (stamped by
-langgraph's ToolNode for tools with BaseTool.subagent_name declared)
-and builds typed SubagentRunStream handles on run.subagents.
+The transformer detects subagents via the `lc_agent_name` transition computed
+by langgraph's base `_TasksLifecycleBase`: a nested run whose `lc_agent_name`
+(set by `create_agent(name=...)`) differs from its parent's is surfaced as a
+typed `SubagentRunStream` handle on `run.subagents`. These tests drive a real
+supervisor `create_agent` that dispatches a nested `create_agent` from a tool,
+giving true end-to-end coverage.
 """
 
 from __future__ import annotations
 
+from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 from langgraph.prebuilt import ToolCallTransformer
 
 from langchain.agents import create_agent
-from langchain.agents._subagent_transformer import (
-    AsyncSubagentRunStream,
-    SubagentRunStream,
-    SubagentTransformer,
-)
+from langchain.agents._subagent_transformer import SubagentTransformer
 from tests.unit_tests.agents.model import FakeToolCallingModel
 
-# --- create_agent integration tests ---
+
+def _supervisor_model() -> FakeToolCallingModel:
+    """Supervisor emits one tool call (id `call_w`) then a final message."""
+    return FakeToolCallingModel(
+        tool_calls=[
+            [{"args": {"city": "SF"}, "id": "call_w", "name": "call_weather"}],
+            [],
+        ]
+    )
+
+
+def test_subagents_surfaces_named_subagent() -> None:
+    """A nested named `create_agent` dispatched from a tool surfaces a handle."""
+    weather_agent = create_agent(model=FakeToolCallingModel(tool_calls=[[]]), name="weather_agent")
+
+    @tool("call_weather")
+    def call_weather(city: str) -> str:
+        """Call the weather agent."""
+        result = weather_agent.invoke({"messages": [HumanMessage(f"weather in {city}")]})
+        return result["messages"][-1].text
+
+    supervisor = create_agent(
+        model=_supervisor_model(),
+        tools=[call_weather],
+        name="supervisor",
+    )
+
+    run = supervisor.stream_events({"messages": [HumanMessage("weather?")]}, version="v3")
+
+    handles = []
+    for handle in run.subagents:
+        handles.append(handle)
+        # Drain the nested run so it completes.
+        for _ in handle:
+            pass
+
+    assert len(handles) == 1
+    assert handles[0].name == "weather_agent"
+    assert handles[0].cause == {"type": "toolCall", "tool_call_id": "call_w"}
+
+
+def test_plain_tool_not_surfaced() -> None:
+    """A tool that returns a string (spawns no nested run) surfaces nothing."""
+
+    @tool("call_weather")
+    def call_weather(city: str) -> str:
+        """Return weather directly without invoking a subagent."""
+        return f"Sunny in {city}"
+
+    supervisor = create_agent(
+        model=_supervisor_model(),
+        tools=[call_weather],
+        name="supervisor",
+    )
+
+    run = supervisor.stream_events({"messages": [HumanMessage("weather?")]}, version="v3")
+
+    handles = list(run.subagents)
+    # Drain the main run to completion.
+    for _ in run:
+        pass
+
+    assert handles == []
+
+
+def test_unnamed_inner_agent_not_surfaced() -> None:
+    """An inner `create_agent` without `name=` inherits the parent name, so excluded."""
+    inner_agent = create_agent(model=FakeToolCallingModel(tool_calls=[[]]))
+
+    @tool("call_weather")
+    def call_weather(city: str) -> str:
+        """Call an unnamed inner agent."""
+        result = inner_agent.invoke({"messages": [HumanMessage(f"weather in {city}")]})
+        return result["messages"][-1].text
+
+    supervisor = create_agent(
+        model=_supervisor_model(),
+        tools=[call_weather],
+        name="supervisor",
+    )
+
+    run = supervisor.stream_events({"messages": [HumanMessage("weather?")]}, version="v3")
+
+    handles = list(run.subagents)
+    for _ in run:
+        pass
+
+    assert handles == []
 
 
 def test_transformer_init_exposes_subagents_channel() -> None:
+    """The transformer publishes a `subagents` channel from `init()`."""
     transformer = SubagentTransformer(scope=())
     state = transformer.init()
     assert "subagents" in state
 
 
-def test_subagent_run_stream_name_property() -> None:
-    handle = SubagentRunStream.__new__(SubagentRunStream)
-    handle.graph_name = "weather_agent"
-    handle.trigger_call_id = None
-    assert handle.name == "weather_agent"
-
-
-def test_subagent_run_stream_cause_with_tool_call_id() -> None:
-    handle = SubagentRunStream.__new__(SubagentRunStream)
-    handle.graph_name = "weather_agent"
-    handle.trigger_call_id = "call_xyz"
-    assert handle.cause == {"type": "toolCall", "tool_call_id": "call_xyz"}
-
-
-def test_subagent_run_stream_cause_without_tool_call_id() -> None:
-    handle = SubagentRunStream.__new__(SubagentRunStream)
-    handle.graph_name = "weather_agent"
-    handle.trigger_call_id = None
-    assert handle.cause is None
-
-
-def test_async_subagent_run_stream_name_and_cause() -> None:
-    handle = AsyncSubagentRunStream.__new__(AsyncSubagentRunStream)
-    handle.graph_name = "research_agent"
-    handle.trigger_call_id = "call_abc"
-    assert handle.name == "research_agent"
-    assert handle.cause == {"type": "toolCall", "tool_call_id": "call_abc"}
-
-
-def test_transformer_on_started_skips_when_no_cause() -> None:
-    """Tasks without cause (non-subagent dispatches) produce no handle."""
-    transformer = SubagentTransformer(scope=())
-    # Calling _on_started with cause=None should not add any handle.
-    transformer._on_started(("tools:abc123",), "tools", "abc123", cause=None)
-    assert len(transformer._handles) == 0
-
-
-def test_transformer_on_started_skips_when_no_graph_name() -> None:
-    """Tasks with cause but missing graph_name produce no handle."""
-    transformer = SubagentTransformer(scope=())
-    transformer._on_started(
-        ("tools:abc123",),
-        None,
-        "abc123",
-        cause={"type": "toolCall", "toolCallId": "call_1"},
-    )
-    assert len(transformer._handles) == 0
-
-
-def test_transformer_name_filter_excludes_undeclared() -> None:
-    """When subagent_names is set, names outside it are ignored."""
-    transformer = SubagentTransformer(scope=(), subagent_names=frozenset({"researcher"}))
-    transformer._on_started(
-        ("tools:abc123",),
-        "weather_agent",
-        "abc123",
-        cause={"type": "toolCall", "toolCallId": "call_1"},
-    )
-    assert len(transformer._handles) == 0
-
-
-def test_transformer_name_filter_accepts_declared() -> None:
-    """When subagent_names is set, declared names pass the filter (mux absent so no handle)."""
-    transformer = SubagentTransformer(scope=(), subagent_names=frozenset({"researcher"}))
-    # _mux is None so _make_child raises; the filter itself passes.
-    # We check that the guard after name-filter fires (RuntimeError from no mux)
-    # rather than silently returning at the name-filter step.
-    transformer._on_started(
-        ("tools:abc123",),
-        "researcher",
-        "abc123",
-        cause={"type": "toolCall", "toolCallId": "call_1"},
-    )
-    # No handle created (mux is None), but filter passed — no assertion error.
-    assert len(transformer._handles) == 0
-
-
-def test_transformer_none_filter_accepts_any_name() -> None:
-    """When subagent_names is None (default), any subagent_name is accepted."""
-    transformer = SubagentTransformer(scope=())
-    assert transformer._names is None
-    # With _mux=None we can't build a handle, but we verify the name filter
-    # didn't reject the call.
-    transformer._on_started(
-        ("tools:abc123",),
-        "arbitrary_agent",
-        "abc123",
-        cause={"type": "toolCall", "toolCallId": "call_1"},
-    )
-    assert len(transformer._handles) == 0
-
-
 def test_create_agent_registers_subagent_transformer() -> None:
-    """create_agent automatically registers SubagentTransformer in stream_transformers.
-
-    Verified by inspecting the compiled graph's stream_transformers tuple,
-    which is set by graph.compile(transformers=...) in the factory.
-    """
+    """`create_agent` registers `SubagentTransformer` in `stream_transformers`."""
 
     @tool("call_weather")
     def call_weather(city: str) -> str:
         """Call the weather agent."""
         return f"Sunny in {city}"
 
-    model = FakeToolCallingModel(tool_calls=[[]])
-    agent = create_agent(model=model, tools=[call_weather])
+    agent = create_agent(model=FakeToolCallingModel(tool_calls=[[]]), tools=[call_weather])
 
-    assert SubagentTransformer in agent.stream_transformers, (
-        "SubagentTransformer must be registered in compiled graph stream_transformers"
-    )
+    assert SubagentTransformer in agent.stream_transformers
 
 
 def test_create_agent_subagent_transformer_precedes_user_transformers() -> None:
-    """SubagentTransformer is registered before any user-supplied transformers.
-
-    Ensures SubagentTransformer processes events before user-provided transformers,
-    matching the ordering convention established by ToolCallTransformer.
-    """
+    """`ToolCallTransformer` precedes `SubagentTransformer` in registration order."""
 
     @tool("call_weather")
     def call_weather(city: str) -> str:
         """Call the weather agent."""
         return f"Sunny in {city}"
 
-    model = FakeToolCallingModel(tool_calls=[[]])
-    agent = create_agent(model=model, tools=[call_weather])
+    agent = create_agent(model=FakeToolCallingModel(tool_calls=[[]]), tools=[call_weather])
 
     transformers = list(agent.stream_transformers)
-    tool_call_idx = transformers.index(ToolCallTransformer)
-    subagent_idx = transformers.index(SubagentTransformer)
-    assert tool_call_idx < subagent_idx, (
-        "ToolCallTransformer must precede SubagentTransformer in stream_transformers"
-    )
-
-
-def test_create_agent_user_transformers_appended_after_subagent_transformer() -> None:
-    """User-supplied transformers are appended after SubagentTransformer.
-
-    Ensures that user-provided transformers=[] kwarg does not displace
-    SubagentTransformer.
-    """
-
-    class UserTransformer(SubagentTransformer):
-        """Sentinel subclass used only to verify ordering."""
-
-    @tool("call_weather")
-    def call_weather(city: str) -> str:
-        """Call the weather agent."""
-        return f"Sunny in {city}"
-
-    model = FakeToolCallingModel(tool_calls=[[]])
-    agent = create_agent(model=model, tools=[call_weather], transformers=[UserTransformer])
-
-    transformers = list(agent.stream_transformers)
-    assert SubagentTransformer in transformers, "SubagentTransformer must be present"
-    assert UserTransformer in transformers, "UserTransformer must be present"
-    subagent_idx = transformers.index(SubagentTransformer)
-    user_idx = transformers.index(UserTransformer)
-    assert subagent_idx < user_idx, "SubagentTransformer must precede user-supplied transformers"
+    assert transformers.index(ToolCallTransformer) < transformers.index(SubagentTransformer)

--- a/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
@@ -7,11 +7,18 @@ and builds typed SubagentRunStream handles on run.subagents.
 
 from __future__ import annotations
 
+from langchain_core.tools import tool
+from langgraph.prebuilt import ToolCallTransformer
+
+from langchain.agents import create_agent
 from langchain.agents._subagent_transformer import (
     AsyncSubagentRunStream,
     SubagentRunStream,
     SubagentTransformer,
 )
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+# --- create_agent integration tests ---
 
 
 def test_transformer_init_exposes_subagents_channel() -> None:
@@ -110,3 +117,72 @@ def test_transformer_none_filter_accepts_any_name() -> None:
         cause={"type": "toolCall", "toolCallId": "call_1"},
     )
     assert len(transformer._handles) == 0
+
+
+def test_create_agent_registers_subagent_transformer() -> None:
+    """create_agent automatically registers SubagentTransformer in stream_transformers.
+
+    Verified by inspecting the compiled graph's stream_transformers tuple,
+    which is set by graph.compile(transformers=...) in the factory.
+    """
+
+    @tool("call_weather")
+    def call_weather(city: str) -> str:
+        """Call the weather agent."""
+        return f"Sunny in {city}"
+
+    model = FakeToolCallingModel(tool_calls=[[]])
+    agent = create_agent(model=model, tools=[call_weather])
+
+    assert SubagentTransformer in agent.stream_transformers, (
+        "SubagentTransformer must be registered in compiled graph stream_transformers"
+    )
+
+
+def test_create_agent_subagent_transformer_precedes_user_transformers() -> None:
+    """SubagentTransformer is registered before any user-supplied transformers.
+
+    Ensures SubagentTransformer processes events before user-provided transformers,
+    matching the ordering convention established by ToolCallTransformer.
+    """
+
+    @tool("call_weather")
+    def call_weather(city: str) -> str:
+        """Call the weather agent."""
+        return f"Sunny in {city}"
+
+    model = FakeToolCallingModel(tool_calls=[[]])
+    agent = create_agent(model=model, tools=[call_weather])
+
+    transformers = list(agent.stream_transformers)
+    tool_call_idx = transformers.index(ToolCallTransformer)
+    subagent_idx = transformers.index(SubagentTransformer)
+    assert tool_call_idx < subagent_idx, (
+        "ToolCallTransformer must precede SubagentTransformer in stream_transformers"
+    )
+
+
+def test_create_agent_user_transformers_appended_after_subagent_transformer() -> None:
+    """User-supplied transformers are appended after SubagentTransformer.
+
+    Ensures that user-provided transformers=[] kwarg does not displace
+    SubagentTransformer.
+    """
+
+    class UserTransformer(SubagentTransformer):
+        """Sentinel subclass used only to verify ordering."""
+
+    @tool("call_weather")
+    def call_weather(city: str) -> str:
+        """Call the weather agent."""
+        return f"Sunny in {city}"
+
+    model = FakeToolCallingModel(tool_calls=[[]])
+    agent = create_agent(model=model, tools=[call_weather], transformers=[UserTransformer])
+
+    transformers = list(agent.stream_transformers)
+    assert SubagentTransformer in transformers, "SubagentTransformer must be present"
+    assert UserTransformer in transformers, "UserTransformer must be present"
+    subagent_idx = transformers.index(SubagentTransformer)
+    user_idx = transformers.index(UserTransformer)
+    assert subagent_idx < user_idx, "SubagentTransformer must precede user-supplied transformers"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
@@ -8,6 +8,9 @@ dispatches a nested `create_agent` from a tool, giving true end-to-end coverage.
 
 from __future__ import annotations
 
+import sys
+
+import pytest
 from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 from langgraph.prebuilt import ToolCallTransformer
@@ -57,6 +60,19 @@ def test_subagents_surfaces_named_subagent() -> None:
     assert handles[0].cause == {"type": "toolCall", "tool_call_id": "call_w"}
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason=(
+        "On Python <= 3.10, langchain-core does not automatically propagate "
+        "RunnableConfig into an async tool body (contextvar propagation across "
+        "`await` in tool execution requires 3.11+). Without it the nested "
+        "`ainvoke` is disconnected from the parent stream and never surfaces; "
+        "forwarding the parent config explicitly would instead overwrite the "
+        "subagent's bound `lc_agent_name` with the parent's. The async-lane "
+        "logic this test exercises is version-agnostic; the sync test covers "
+        "3.10."
+    ),
+)
 async def test_subagents_surfaces_named_subagent_async() -> None:
     """Async counterpart: the handle surfaces and reaches a terminal state.
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
@@ -1,0 +1,112 @@
+"""Tests for langchain.agents._subagent_transformer.
+
+The transformer reads TaskPayload.metadata.subagent_name (stamped by
+langgraph's ToolNode for tools with BaseTool.subagent_name declared)
+and builds typed SubagentRunStream handles on run.subagents.
+"""
+
+from __future__ import annotations
+
+from langchain.agents._subagent_transformer import (
+    AsyncSubagentRunStream,
+    SubagentRunStream,
+    SubagentTransformer,
+)
+
+
+def test_transformer_init_exposes_subagents_channel() -> None:
+    transformer = SubagentTransformer(scope=())
+    state = transformer.init()
+    assert "subagents" in state
+
+
+def test_subagent_run_stream_name_property() -> None:
+    handle = SubagentRunStream.__new__(SubagentRunStream)
+    handle.graph_name = "weather_agent"
+    handle.trigger_call_id = None
+    assert handle.name == "weather_agent"
+
+
+def test_subagent_run_stream_cause_with_tool_call_id() -> None:
+    handle = SubagentRunStream.__new__(SubagentRunStream)
+    handle.graph_name = "weather_agent"
+    handle.trigger_call_id = "call_xyz"
+    assert handle.cause == {"type": "toolCall", "tool_call_id": "call_xyz"}
+
+
+def test_subagent_run_stream_cause_without_tool_call_id() -> None:
+    handle = SubagentRunStream.__new__(SubagentRunStream)
+    handle.graph_name = "weather_agent"
+    handle.trigger_call_id = None
+    assert handle.cause is None
+
+
+def test_async_subagent_run_stream_name_and_cause() -> None:
+    handle = AsyncSubagentRunStream.__new__(AsyncSubagentRunStream)
+    handle.graph_name = "research_agent"
+    handle.trigger_call_id = "call_abc"
+    assert handle.name == "research_agent"
+    assert handle.cause == {"type": "toolCall", "tool_call_id": "call_abc"}
+
+
+def test_transformer_on_started_skips_when_no_cause() -> None:
+    """Tasks without cause (non-subagent dispatches) produce no handle."""
+    transformer = SubagentTransformer(scope=())
+    # Calling _on_started with cause=None should not add any handle.
+    transformer._on_started(("tools:abc123",), "tools", "abc123", cause=None)
+    assert len(transformer._handles) == 0
+
+
+def test_transformer_on_started_skips_when_no_graph_name() -> None:
+    """Tasks with cause but missing graph_name produce no handle."""
+    transformer = SubagentTransformer(scope=())
+    transformer._on_started(
+        ("tools:abc123",),
+        None,
+        "abc123",
+        cause={"type": "toolCall", "toolCallId": "call_1"},
+    )
+    assert len(transformer._handles) == 0
+
+
+def test_transformer_name_filter_excludes_undeclared() -> None:
+    """When subagent_names is set, names outside it are ignored."""
+    transformer = SubagentTransformer(scope=(), subagent_names=frozenset({"researcher"}))
+    transformer._on_started(
+        ("tools:abc123",),
+        "weather_agent",
+        "abc123",
+        cause={"type": "toolCall", "toolCallId": "call_1"},
+    )
+    assert len(transformer._handles) == 0
+
+
+def test_transformer_name_filter_accepts_declared() -> None:
+    """When subagent_names is set, declared names pass the filter (mux absent so no handle)."""
+    transformer = SubagentTransformer(scope=(), subagent_names=frozenset({"researcher"}))
+    # _mux is None so _make_child raises; the filter itself passes.
+    # We check that the guard after name-filter fires (RuntimeError from no mux)
+    # rather than silently returning at the name-filter step.
+    transformer._on_started(
+        ("tools:abc123",),
+        "researcher",
+        "abc123",
+        cause={"type": "toolCall", "toolCallId": "call_1"},
+    )
+    # No handle created (mux is None), but filter passed — no assertion error.
+    assert len(transformer._handles) == 0
+
+
+def test_transformer_none_filter_accepts_any_name() -> None:
+    """When subagent_names is None (default), any subagent_name is accepted."""
+    transformer = SubagentTransformer(scope=())
+    assert transformer._names is None
+    # With _mux=None we can't build a handle, but we verify the name filter
+    # didn't reject the call.
+    transformer._on_started(
+        ("tools:abc123",),
+        "arbitrary_agent",
+        "abc123",
+        cause={"type": "toolCall", "toolCallId": "call_1"},
+    )
+    assert len(transformer._handles) == 0

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2431,7 +2431,7 @@ wheels = [
 [[package]]
 name = "langgraph"
 version = "1.2.2"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph#8ef9a36d2eaca180cf13ece374f5e88c6d90b65d" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph#766a881c58c1eb5c9b0ad1205942f4c0ffe731e7" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2444,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "langgraph-checkpoint"
 version = "4.1.1"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&branch=nh%2Fsubagent-name-langgraph#8ef9a36d2eaca180cf13ece374f5e88c6d90b65d" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&branch=nh%2Fsubagent-name-langgraph#766a881c58c1eb5c9b0ad1205942f4c0ffe731e7" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
@@ -2453,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "langgraph-prebuilt"
 version = "1.1.0"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&branch=nh%2Fsubagent-name-langgraph#8ef9a36d2eaca180cf13ece374f5e88c6d90b65d" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&branch=nh%2Fsubagent-name-langgraph#766a881c58c1eb5c9b0ad1205942f4c0ffe731e7" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "langgraph-sdk"
 version = "0.3.15"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&branch=nh%2Fsubagent-name-langgraph#8ef9a36d2eaca180cf13ece374f5e88c6d90b65d" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&branch=nh%2Fsubagent-name-langgraph#766a881c58c1eb5c9b0ad1205942f4c0ffe731e7" }
 dependencies = [
     { name = "httpx" },
     { name = "langchain-core" },

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2025,7 +2025,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph" },
+    { name = "langgraph", git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -2435,7 +2435,7 @@ wheels = [
 [[package]]
 name = "langgraph"
 version = "1.2.2"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph#e3265ece45c868fb885bc11c97fed037b2761f01" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9#577ee12cc90d4c1cdaed0eca1121b060153698f9" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2448,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "langgraph-checkpoint"
 version = "4.1.1"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&branch=nh%2Fsubagent-name-langgraph#e3265ece45c868fb885bc11c97fed037b2761f01" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9#577ee12cc90d4c1cdaed0eca1121b060153698f9" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
@@ -2457,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "langgraph-prebuilt"
 version = "1.1.0"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&branch=nh%2Fsubagent-name-langgraph#e3265ece45c868fb885bc11c97fed037b2761f01" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9#577ee12cc90d4c1cdaed0eca1121b060153698f9" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2466,7 +2466,7 @@ dependencies = [
 [[package]]
 name = "langgraph-sdk"
 version = "0.4.0"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&branch=nh%2Fsubagent-name-langgraph#e3265ece45c868fb885bc11c97fed037b2761f01" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9#577ee12cc90d4c1cdaed0eca1121b060153698f9" }
 dependencies = [
     { name = "httpx" },
     { name = "langchain-core" },

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2025,7 +2025,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9" },
+    { name = "langgraph", specifier = ">=1.2.3,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -2434,8 +2434,8 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.2"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9#577ee12cc90d4c1cdaed0eca1121b060153698f9" }
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2444,35 +2444,51 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/55/e42f59b5e4cce75085f68abb77114c4d1152628157bd60c2587881bca559/langgraph-1.2.3.tar.gz", hash = "sha256:7f89cd5f0946fe29bd7ca048e2a84d3c14e7f652e38bb98e00f0ba8b7004b9d0", size = 718812, upload-time = "2026-06-01T18:55:54.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/9b/287f11be799f2f4dd289ab19d23788df22ac20ce884a010d0696f79016db/langgraph-1.2.3-py3-none-any.whl", hash = "sha256:22e6c89084adb3edb7855f6ffa692af3d75925f9c70deb43b86da14db1b02c78", size = 244841, upload-time = "2026-06-01T18:55:52.945Z" },
+]
 
 [[package]]
 name = "langgraph-checkpoint"
 version = "4.1.1"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9#577ee12cc90d4c1cdaed0eca1121b060153698f9" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
 ]
 
 [[package]]
 name = "langgraph-prebuilt"
 version = "1.1.0"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9#577ee12cc90d4c1cdaed0eca1121b060153698f9" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+]
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.4.0"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&rev=577ee12cc90d4c1cdaed0eca1121b060153698f9#577ee12cc90d4c1cdaed0eca1121b060153698f9" }
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "langchain-core" },
     { name = "langchain-protocol" },
     { name = "orjson" },
     { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload-time = "2026-06-01T17:51:18.849Z" },
 ]
 
 [[package]]

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2431,7 +2431,7 @@ wheels = [
 [[package]]
 name = "langgraph"
 version = "1.2.2"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph#1370fd6a4ae53da41e2fbb0e80b208ac65b8abf0" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph#8ef9a36d2eaca180cf13ece374f5e88c6d90b65d" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2444,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "langgraph-checkpoint"
 version = "4.1.1"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&branch=nh%2Fsubagent-name-langgraph#1370fd6a4ae53da41e2fbb0e80b208ac65b8abf0" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&branch=nh%2Fsubagent-name-langgraph#8ef9a36d2eaca180cf13ece374f5e88c6d90b65d" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
@@ -2453,7 +2453,7 @@ dependencies = [
 [[package]]
 name = "langgraph-prebuilt"
 version = "1.1.0"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&branch=nh%2Fsubagent-name-langgraph#1370fd6a4ae53da41e2fbb0e80b208ac65b8abf0" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&branch=nh%2Fsubagent-name-langgraph#8ef9a36d2eaca180cf13ece374f5e88c6d90b65d" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "langgraph-sdk"
 version = "0.3.15"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&branch=nh%2Fsubagent-name-langgraph#1370fd6a4ae53da41e2fbb0e80b208ac65b8abf0" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&branch=nh%2Fsubagent-name-langgraph#8ef9a36d2eaca180cf13ece374f5e88c6d90b65d" }
 dependencies = [
     { name = "httpx" },
     { name = "langchain-core" },

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1417,7 +1417,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1428,7 +1427,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1439,7 +1437,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1450,7 +1447,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1461,7 +1457,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -2012,12 +2007,12 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-anthropic", marker = "extra == 'anthropic'", editable = "../partners/anthropic" },
+    { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
     { name = "langchain-aws", marker = "extra == 'aws'" },
     { name = "langchain-azure-ai", marker = "extra == 'azure-ai'" },
     { name = "langchain-baseten", marker = "extra == 'baseten'", specifier = ">=0.2.0" },
     { name = "langchain-community", marker = "extra == 'community'" },
-    { name = "langchain-core", editable = "../core" },
+    { name = "langchain-core", specifier = ">=1.4.0,<2.0.0" },
     { name = "langchain-deepseek", marker = "extra == 'deepseek'" },
     { name = "langchain-fireworks", marker = "extra == 'fireworks'" },
     { name = "langchain-google-genai", marker = "extra == 'google-genai'" },
@@ -2026,11 +2021,11 @@ requires-dist = [
     { name = "langchain-huggingface", marker = "extra == 'huggingface'" },
     { name = "langchain-mistralai", marker = "extra == 'mistralai'" },
     { name = "langchain-ollama", marker = "extra == 'ollama'" },
-    { name = "langchain-openai", marker = "extra == 'openai'", editable = "../partners/openai" },
+    { name = "langchain-openai", marker = "extra == 'openai'" },
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.2.2,<1.3.0" },
+    { name = "langgraph", git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -2039,8 +2034,8 @@ provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-verte
 lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.26,<1.6.0" },
-    { name = "langchain-openai", editable = "../partners/openai" },
-    { name = "langchain-tests", editable = "../standard-tests" },
+    { name = "langchain-openai" },
+    { name = "langchain-tests", specifier = ">=1.1.9,<2.0.0" },
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6.0.0" },
@@ -2053,8 +2048,8 @@ test = [
     { name = "toml", specifier = ">=0.10.2,<1.0.0" },
 ]
 test-integration = [
-    { name = "langchain-core", editable = "../core" },
-    { name = "langchain-text-splitters", editable = "../text-splitters" },
+    { name = "langchain-core", specifier = ">=1.4.0,<2.0.0" },
+    { name = "langchain-text-splitters", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchainhub", specifier = ">=0.1.16,<1.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
     { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
@@ -2068,50 +2063,15 @@ typing = [
 [[package]]
 name = "langchain-anthropic"
 version = "1.4.3"
-source = { editable = "../partners/anthropic" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", specifier = ">=0.96.0,<1.0.0" },
-    { name = "langchain-core", editable = "../core" },
-    { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [{ name = "langchain-core", editable = "../core" }]
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
-test = [
-    { name = "blockbuster", specifier = ">=1.5.5,<1.6" },
-    { name = "defusedxml", specifier = ">=0.7.1,<1.0.0" },
-    { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
-    { name = "langchain", editable = "." },
-    { name = "langchain-core", editable = "../core" },
-    { name = "langchain-tests", editable = "../standard-tests" },
-    { name = "langgraph-prebuilt", specifier = ">=0.7.0a2" },
-    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
-    { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
-    { name = "pytest-retry", specifier = ">=1.7.0,<1.8.0" },
-    { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
-    { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },
-    { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
-    { name = "pytest-xdist", specifier = ">=3.8.0,<4.0.0" },
-    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
-]
-test-integration = [
-    { name = "langchain-core", editable = "../core" },
-    { name = "requests", specifier = ">=2.32.3,<3.0.0" },
-]
-typing = [
-    { name = "langchain-core", editable = "../core" },
-    { name = "mypy", specifier = ">=1.17.1,<2.0.0" },
-    { name = "types-requests", specifier = ">=2.31.0,<3.0.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/fa/e3/d2f9dec95602524b1cfb4be2747ba5bc38d32501b2a56cb4bcb76e80bb45/langchain_anthropic-1.4.3.tar.gz", hash = "sha256:f8a2442463c0629b1b3110eaeaa56fdbdc87df2a802f8c7f5ecf611eb4874ec8", size = 685219, upload-time = "2026-05-03T17:33:27.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/55/482a1968c95275e8be6d8c1e53b54f0f7be0b8b155ce1608c947a95cf543/langchain_anthropic-1.4.3-py3-none-any.whl", hash = "sha256:65466e0f2f95909a009708f2958e917dfdbfab79c612b4484a30866a85e1f291", size = 50389, upload-time = "2026-05-03T17:33:25.671Z" },
 ]
 
 [[package]]
@@ -2214,7 +2174,7 @@ wheels = [
 [[package]]
 name = "langchain-core"
 version = "1.4.0"
-source = { editable = "../core" }
+source = { git = "https://github.com/langchain-ai/langchain?subdirectory=libs%2Fcore&branch=nh%2Fbasetool-subagent-name#41d1c352709d3a22e192a185bf8632efab788d09" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
@@ -2225,52 +2185,6 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.14" },
-    { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
-    { name = "packaging", specifier = ">=23.2.0" },
-    { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
-    { name = "pyyaml", specifier = ">=5.3.0,<7.0.0" },
-    { name = "tenacity", specifier = ">=8.1.0,!=8.4.0,<10.0.0" },
-    { name = "typing-extensions", specifier = ">=4.7.0,<5.0.0" },
-    { name = "uuid-utils", specifier = ">=0.12.0,<1.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
-    { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
-    { name = "setuptools", specifier = ">=67.6.1,<83.0.0" },
-]
-lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
-test = [
-    { name = "blockbuster", specifier = ">=1.5.18,<1.6.0" },
-    { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
-    { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
-    { name = "langchain-tests", directory = "../standard-tests" },
-    { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },
-    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
-    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-codspeed" },
-    { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
-    { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
-    { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
-    { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
-    { name = "responses", specifier = ">=0.25.0,<1.0.0" },
-    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-]
-test-integration = []
-typing = [
-    { name = "langchain-text-splitters", directory = "../text-splitters" },
-    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
-    { name = "types-requests", specifier = ">=2.28.11.5,<3.0.0.0" },
 ]
 
 [[package]]
@@ -2399,51 +2313,15 @@ wheels = [
 [[package]]
 name = "langchain-openai"
 version = "1.2.2"
-source = { editable = "../partners/openai" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "langchain-core", editable = "../core" },
-    { name = "openai", specifier = ">=2.26.0,<3.0.0" },
-    { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [{ name = "langchain-core", editable = "../core" }]
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
-test = [
-    { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
-    { name = "langchain", editable = "." },
-    { name = "langchain-core", editable = "../core" },
-    { name = "langchain-tests", editable = "../standard-tests" },
-    { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },
-    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
-    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
-    { name = "pytest-cov", specifier = ">=4.1.0,<5.0.0" },
-    { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
-    { name = "pytest-retry", specifier = ">=1.7.0,<1.8.0" },
-    { name = "pytest-socket", specifier = ">=0.6.0,<1.0.0" },
-    { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
-    { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
-    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
-]
-test-integration = [
-    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
-    { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },
-    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
-    { name = "pillow", specifier = ">=12.1.1,<13.0.0" },
-]
-typing = [
-    { name = "langchain-core", editable = "../core" },
-    { name = "mypy", specifier = ">=1.17.1,<2.0.0" },
-    { name = "types-tqdm", specifier = ">=4.66.0.5,<5.0.0.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/f7/1b/c506c7f41156d3a6b4582b4c487f480001b8741deecc6e2d4931fdf4cf2c/langchain_openai-1.2.2.tar.gz", hash = "sha256:8698ffcee9a086e91ab6d207f0026181a03effcbf86bf9aee1808ee35af69dcc", size = 1147539, upload-time = "2026-05-21T22:08:31.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/8e/7406c99afacafc8c2ce0fa4152f9f8b9598c93ceb291959821abd053b982/langchain_openai-1.2.2-py3-none-any.whl", hash = "sha256:7da39a3c70cbafa93853456199e39a264dc70651be79b12ac49b4f6a448bce2d", size = 99631, upload-time = "2026-05-21T22:08:29.527Z" },
 ]
 
 [[package]]
@@ -2474,7 +2352,7 @@ wheels = [
 [[package]]
 name = "langchain-tests"
 version = "1.1.9"
-source = { editable = "../standard-tests" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "langchain-core" },
@@ -2489,77 +2367,21 @@ dependencies = [
     { name = "syrupy" },
     { name = "vcrpy" },
 ]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
-    { name = "langchain-core", editable = "../core" },
-    { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.2" },
-    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
-    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
-    { name = "pytest-benchmark" },
-    { name = "pytest-codspeed" },
-    { name = "pytest-recording" },
-    { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
-    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
-]
-
-[package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
-test = [{ name = "langchain-core", editable = "../core" }]
-test-integration = []
-typing = [
-    { name = "langchain-core", editable = "../core" },
-    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/94/0e/6eef4ddcc3503d40de4486abc923a48d5853a310d2b2752123e7a3c713b1/langchain_tests-1.1.9.tar.gz", hash = "sha256:a977a0c8f9a42ba2021a5ae59d468e4023f98a83818a3cb30e12c1dfab830203", size = 184443, upload-time = "2026-05-21T18:24:15.946Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/bb/ef5ccff7c22938e28716ecf3c4cc468082843df7f3b2214a931cfcaae98a/langchain_tests-1.1.9-py3-none-any.whl", hash = "sha256:f33e36e2015da437df2001ec6949b443de09dd37d021dea6160cf85912ccf05f", size = 66312, upload-time = "2026-05-21T18:24:14.387Z" },
 ]
 
 [[package]]
 name = "langchain-text-splitters"
 version = "1.1.2"
-source = { editable = "../text-splitters" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "langchain-core", editable = "../core" }]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
-    { name = "langchain-core", editable = "../core" },
-]
-lint = [
-    { name = "langchain-core", editable = "../core" },
-    { name = "ruff", specifier = ">=0.15.0,<0.16.0" },
-]
-test = [
-    { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
-    { name = "langchain-core", editable = "../core" },
-    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
-    { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
-    { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
-    { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
-    { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
-]
-test-integration = [
-    { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
-    { name = "nltk", specifier = ">=3.9.1,<4.0.0" },
-    { name = "sentence-transformers", specifier = ">=5.3.0,<6.0.0" },
-    { name = "spacy", specifier = ">=3.8.13,!=3.8.14,<4.0.0" },
-    { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
-    { name = "transformers", specifier = ">=4.51.3,<6.0.0" },
-]
-typing = [
-    { name = "beautifulsoup4", specifier = ">=4.13.5,<5.0.0" },
-    { name = "lxml-stubs", specifier = ">=0.5.1,<1.0.0" },
-    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
-    { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
-    { name = "types-requests", specifier = ">=2.31.0.20240218,<3.0.0.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/26/1ef06f56198d631296d646a6223de35bcc6cf9795ceb2442816bc963b84c/langchain_text_splitters-1.1.2-py3-none-any.whl", hash = "sha256:a2de0d799ff31886429fd6e2e0032df275b60ec817c19059a7b46181cc1c2f10", size = 35903, upload-time = "2026-04-16T14:20:38.243Z" },
 ]
 
 [[package]]
@@ -2609,7 +2431,7 @@ wheels = [
 [[package]]
 name = "langgraph"
 version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph#1370fd6a4ae53da41e2fbb0e80b208ac65b8abf0" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2618,48 +2440,35 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/5a/ffc12434ee8aecab830d58b4d204ddea45073eae7639c963310f671a5bf5/langgraph-1.2.2.tar.gz", hash = "sha256:f54a98458976b3ff0774683867df125fb52d8dbedeb2441d0b0656a51331cee5", size = 695730, upload-time = "2026-05-26T18:07:28.49Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/9b/b08d578bba73e25351152dfd3d6d21e81210a5fff1b6f26e56f33197c8f5/langgraph-1.2.2-py3-none-any.whl", hash = "sha256:0a851bf4ba5939c5474a2fd57e6b439b5315283e254e42943bd392c2d71a5e03", size = 236376, upload-time = "2026-05-26T18:07:26.577Z" },
-]
 
 [[package]]
 name = "langgraph-checkpoint"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
+version = "4.1.1"
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&branch=nh%2Fsubagent-name-langgraph#1370fd6a4ae53da41e2fbb0e80b208ac65b8abf0" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/02/b4/6005c5dd88ad484fe6235d4c43a0d2cee7e91b08ad85a180985c2662df87/langgraph_checkpoint-4.1.0.tar.gz", hash = "sha256:e5bb304e30fc1363ac8fcb5f7dee5ca2185d77fe475b0d01de2c5f91324c2c21", size = 181942, upload-time = "2026-05-12T03:33:49.888Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/74/d3be2b41955e20ccd624dba5f6fe9d38dcee385ba470a6e13ed86732fc86/langgraph_checkpoint-4.1.0-py3-none-any.whl", hash = "sha256:8bc2a0466a20c38b865ce6671b42093fd5c041133f32351cae4222e0eeaf7fb5", size = 56047, upload-time = "2026-05-12T03:33:48.548Z" },
 ]
 
 [[package]]
 name = "langgraph-prebuilt"
 version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&branch=nh%2Fsubagent-name-langgraph#1370fd6a4ae53da41e2fbb0e80b208ac65b8abf0" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
-]
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.3.3"
-source = { registry = "https://pypi.org/simple" }
+version = "0.3.15"
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&branch=nh%2Fsubagent-name-langgraph#1370fd6a4ae53da41e2fbb0e80b208ac65b8abf0" }
 dependencies = [
     { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
     { name = "orjson" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/0f/ed0634c222eed48a31ba48eab6881f94ad690d65e44fe7ca838240a260c1/langgraph_sdk-0.3.3.tar.gz", hash = "sha256:c34c3dce3b6848755eb61f0c94369d1ba04aceeb1b76015db1ea7362c544fb26", size = 130589, upload-time = "2026-01-13T00:30:43.894Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/be/4ad511bacfdd854afb12974f407cb30010dceb982dc20c55491867b34526/langgraph_sdk-0.3.3-py3-none-any.whl", hash = "sha256:a52ebaf09d91143e55378bb2d0b033ed98f57f48c9ad35c8f81493b88705fc7b", size = 67021, upload-time = "2026-01-13T00:30:42.264Z" },
+    { name = "websockets" },
 ]
 
 [[package]]

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2174,7 +2174,7 @@ wheels = [
 [[package]]
 name = "langchain-core"
 version = "1.4.0"
-source = { git = "https://github.com/langchain-ai/langchain?subdirectory=libs%2Fcore&branch=nh%2Fbasetool-subagent-name#41d1c352709d3a22e192a185bf8632efab788d09" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
@@ -2185,6 +2185,10 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
     { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
 ]
 
 [[package]]
@@ -2431,7 +2435,7 @@ wheels = [
 [[package]]
 name = "langgraph"
 version = "1.2.2"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph#766a881c58c1eb5c9b0ad1205942f4c0ffe731e7" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Flanggraph&branch=nh%2Fsubagent-name-langgraph#e3265ece45c868fb885bc11c97fed037b2761f01" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2444,7 +2448,7 @@ dependencies = [
 [[package]]
 name = "langgraph-checkpoint"
 version = "4.1.1"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&branch=nh%2Fsubagent-name-langgraph#766a881c58c1eb5c9b0ad1205942f4c0ffe731e7" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fcheckpoint&branch=nh%2Fsubagent-name-langgraph#e3265ece45c868fb885bc11c97fed037b2761f01" }
 dependencies = [
     { name = "langchain-core" },
     { name = "ormsgpack" },
@@ -2453,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "langgraph-prebuilt"
 version = "1.1.0"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&branch=nh%2Fsubagent-name-langgraph#766a881c58c1eb5c9b0ad1205942f4c0ffe731e7" }
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fprebuilt&branch=nh%2Fsubagent-name-langgraph#e3265ece45c868fb885bc11c97fed037b2761f01" }
 dependencies = [
     { name = "langchain-core" },
     { name = "langgraph-checkpoint" },
@@ -2461,8 +2465,8 @@ dependencies = [
 
 [[package]]
 name = "langgraph-sdk"
-version = "0.3.15"
-source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&branch=nh%2Fsubagent-name-langgraph#766a881c58c1eb5c9b0ad1205942f4c0ffe731e7" }
+version = "0.4.0"
+source = { git = "https://github.com/langchain-ai/langgraph?subdirectory=libs%2Fsdk-py&branch=nh%2Fsubagent-name-langgraph#e3265ece45c868fb885bc11c97fed037b2761f01" }
 dependencies = [
     { name = "httpx" },
     { name = "langchain-core" },

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2007,12 +2007,12 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "langchain-anthropic", marker = "extra == 'anthropic'" },
+    { name = "langchain-anthropic", marker = "extra == 'anthropic'", editable = "../partners/anthropic" },
     { name = "langchain-aws", marker = "extra == 'aws'" },
     { name = "langchain-azure-ai", marker = "extra == 'azure-ai'" },
     { name = "langchain-baseten", marker = "extra == 'baseten'", specifier = ">=0.2.0" },
     { name = "langchain-community", marker = "extra == 'community'" },
-    { name = "langchain-core", specifier = ">=1.4.0,<2.0.0" },
+    { name = "langchain-core", editable = "../core" },
     { name = "langchain-deepseek", marker = "extra == 'deepseek'" },
     { name = "langchain-fireworks", marker = "extra == 'fireworks'" },
     { name = "langchain-google-genai", marker = "extra == 'google-genai'" },
@@ -2021,7 +2021,7 @@ requires-dist = [
     { name = "langchain-huggingface", marker = "extra == 'huggingface'" },
     { name = "langchain-mistralai", marker = "extra == 'mistralai'" },
     { name = "langchain-ollama", marker = "extra == 'ollama'" },
-    { name = "langchain-openai", marker = "extra == 'openai'" },
+    { name = "langchain-openai", marker = "extra == 'openai'", editable = "../partners/openai" },
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
@@ -2034,8 +2034,8 @@ provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-verte
 lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.26,<1.6.0" },
-    { name = "langchain-openai" },
-    { name = "langchain-tests", specifier = ">=1.1.9,<2.0.0" },
+    { name = "langchain-openai", editable = "../partners/openai" },
+    { name = "langchain-tests", editable = "../standard-tests" },
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6.0.0" },
@@ -2048,8 +2048,8 @@ test = [
     { name = "toml", specifier = ">=0.10.2,<1.0.0" },
 ]
 test-integration = [
-    { name = "langchain-core", specifier = ">=1.4.0,<2.0.0" },
-    { name = "langchain-text-splitters", specifier = ">=1.0.0,<2.0.0" },
+    { name = "langchain-core", editable = "../core" },
+    { name = "langchain-text-splitters", editable = "../text-splitters" },
     { name = "langchainhub", specifier = ">=0.1.16,<1.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
     { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
@@ -2062,16 +2062,51 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.4.3"
-source = { registry = "https://pypi.org/simple" }
+version = "1.4.4"
+source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
     { name = "langchain-core" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/e3/d2f9dec95602524b1cfb4be2747ba5bc38d32501b2a56cb4bcb76e80bb45/langchain_anthropic-1.4.3.tar.gz", hash = "sha256:f8a2442463c0629b1b3110eaeaa56fdbdc87df2a802f8c7f5ecf611eb4874ec8", size = 685219, upload-time = "2026-05-03T17:33:27.118Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/55/482a1968c95275e8be6d8c1e53b54f0f7be0b8b155ce1608c947a95cf543/langchain_anthropic-1.4.3-py3-none-any.whl", hash = "sha256:65466e0f2f95909a009708f2958e917dfdbfab79c612b4484a30866a85e1f291", size = 50389, upload-time = "2026-05-03T17:33:25.671Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.96.0,<1.0.0" },
+    { name = "langchain-core", editable = "../core" },
+    { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "langchain-core", editable = "../core" }]
+lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
+test = [
+    { name = "blockbuster", specifier = ">=1.5.5,<1.6" },
+    { name = "defusedxml", specifier = ">=0.7.1,<1.0.0" },
+    { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
+    { name = "langchain", editable = "." },
+    { name = "langchain-core", editable = "../core" },
+    { name = "langchain-tests", editable = "../standard-tests" },
+    { name = "langgraph-prebuilt", specifier = ">=0.7.0a2" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
+    { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
+    { name = "pytest-retry", specifier = ">=1.7.0,<1.8.0" },
+    { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
+    { name = "pytest-timeout", specifier = ">=2.3.1,<3.0.0" },
+    { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0,<4.0.0" },
+    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
+    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
+]
+test-integration = [
+    { name = "langchain-core", editable = "../core" },
+    { name = "requests", specifier = ">=2.32.3,<3.0.0" },
+]
+typing = [
+    { name = "langchain-core", editable = "../core" },
+    { name = "mypy", specifier = ">=1.17.1,<2.0.0" },
+    { name = "types-requests", specifier = ">=2.31.0,<3.0.0" },
 ]
 
 [[package]]
@@ -2174,7 +2209,7 @@ wheels = [
 [[package]]
 name = "langchain-core"
 version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
@@ -2186,9 +2221,51 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
+    { name = "langchain-protocol", specifier = ">=0.0.14" },
+    { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
+    { name = "packaging", specifier = ">=23.2.0" },
+    { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
+    { name = "pyyaml", specifier = ">=5.3.0,<7.0.0" },
+    { name = "tenacity", specifier = ">=8.1.0,!=8.4.0,<10.0.0" },
+    { name = "typing-extensions", specifier = ">=4.7.0,<5.0.0" },
+    { name = "uuid-utils", specifier = ">=0.12.0,<1.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
+    { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
+    { name = "setuptools", specifier = ">=67.6.1,<83.0.0" },
+]
+lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
+test = [
+    { name = "blockbuster", specifier = ">=1.5.18,<1.6.0" },
+    { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
+    { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
+    { name = "langchain-tests", directory = "../standard-tests" },
+    { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },
+    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
+    { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
+    { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
+    { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
+    { name = "responses", specifier = ">=0.25.0,<1.0.0" },
+    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
+]
+test-integration = []
+typing = [
+    { name = "langchain-text-splitters", directory = "../text-splitters" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
+    { name = "types-requests", specifier = ">=2.28.11.5,<3.0.0.0" },
 ]
 
 [[package]]
@@ -2317,15 +2394,51 @@ wheels = [
 [[package]]
 name = "langchain-openai"
 version = "1.2.2"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/1b/c506c7f41156d3a6b4582b4c487f480001b8741deecc6e2d4931fdf4cf2c/langchain_openai-1.2.2.tar.gz", hash = "sha256:8698ffcee9a086e91ab6d207f0026181a03effcbf86bf9aee1808ee35af69dcc", size = 1147539, upload-time = "2026-05-21T22:08:31.123Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/8e/7406c99afacafc8c2ce0fa4152f9f8b9598c93ceb291959821abd053b982/langchain_openai-1.2.2-py3-none-any.whl", hash = "sha256:7da39a3c70cbafa93853456199e39a264dc70651be79b12ac49b4f6a448bce2d", size = 99631, upload-time = "2026-05-21T22:08:29.527Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "langchain-core", editable = "../core" },
+    { name = "openai", specifier = ">=2.26.0,<3.0.0" },
+    { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "langchain-core", editable = "../core" }]
+lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
+test = [
+    { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
+    { name = "langchain", editable = "." },
+    { name = "langchain-core", editable = "../core" },
+    { name = "langchain-tests", editable = "../standard-tests" },
+    { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },
+    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
+    { name = "pytest-cov", specifier = ">=4.1.0,<5.0.0" },
+    { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
+    { name = "pytest-retry", specifier = ">=1.7.0,<1.8.0" },
+    { name = "pytest-socket", specifier = ">=0.6.0,<1.0.0" },
+    { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
+    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
+    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
+]
+test-integration = [
+    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
+    { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.4" },
+    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
+    { name = "pillow", specifier = ">=12.1.1,<13.0.0" },
+]
+typing = [
+    { name = "langchain-core", editable = "../core" },
+    { name = "mypy", specifier = ">=1.17.1,<2.0.0" },
+    { name = "types-tqdm", specifier = ">=4.66.0.5,<5.0.0.0" },
 ]
 
 [[package]]
@@ -2356,7 +2469,7 @@ wheels = [
 [[package]]
 name = "langchain-tests"
 version = "1.1.9"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../standard-tests" }
 dependencies = [
     { name = "httpx" },
     { name = "langchain-core" },
@@ -2371,21 +2484,77 @@ dependencies = [
     { name = "syrupy" },
     { name = "vcrpy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/0e/6eef4ddcc3503d40de4486abc923a48d5853a310d2b2752123e7a3c713b1/langchain_tests-1.1.9.tar.gz", hash = "sha256:a977a0c8f9a42ba2021a5ae59d468e4023f98a83818a3cb30e12c1dfab830203", size = 184443, upload-time = "2026-05-21T18:24:15.946Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/bb/ef5ccff7c22938e28716ecf3c4cc468082843df7f3b2214a931cfcaae98a/langchain_tests-1.1.9-py3-none-any.whl", hash = "sha256:f33e36e2015da437df2001ec6949b443de09dd37d021dea6160cf85912ccf05f", size = 66312, upload-time = "2026-05-21T18:24:14.387Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.28.1,<1.0.0" },
+    { name = "langchain-core", editable = "../core" },
+    { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=1.26.2" },
+    { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
+    { name = "pytest-benchmark" },
+    { name = "pytest-codspeed" },
+    { name = "pytest-recording" },
+    { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
+    { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
+    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
+]
+
+[package.metadata.requires-dev]
+lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
+test = [{ name = "langchain-core", editable = "../core" }]
+test-integration = []
+typing = [
+    { name = "langchain-core", editable = "../core" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
 ]
 
 [[package]]
 name = "langchain-text-splitters"
 version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../text-splitters" }
 dependencies = [
     { name = "langchain-core" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/9f/6c545900fefb7b00ddfa3f16b80d61338a0ec68c31c5451eeeab99082760/langchain_text_splitters-1.1.2.tar.gz", hash = "sha256:782a723db0a4746ac91e251c7c1d57fd23636e4f38ed733074e28d7a86f41627", size = 293580, upload-time = "2026-04-16T14:20:39.162Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/26/1ef06f56198d631296d646a6223de35bcc6cf9795ceb2442816bc963b84c/langchain_text_splitters-1.1.2-py3-none-any.whl", hash = "sha256:a2de0d799ff31886429fd6e2e0032df275b60ec817c19059a7b46181cc1c2f10", size = 35903, upload-time = "2026-04-16T14:20:38.243Z" },
+
+[package.metadata]
+requires-dist = [{ name = "langchain-core", editable = "../core" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
+    { name = "langchain-core", editable = "../core" },
+]
+lint = [
+    { name = "langchain-core", editable = "../core" },
+    { name = "ruff", specifier = ">=0.15.0,<0.16.0" },
+]
+test = [
+    { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
+    { name = "langchain-core", editable = "../core" },
+    { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
+    { name = "pytest-mock", specifier = ">=3.10.0,<4.0.0" },
+    { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
+    { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
+]
+test-integration = [
+    { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
+    { name = "nltk", specifier = ">=3.9.1,<4.0.0" },
+    { name = "sentence-transformers", specifier = ">=5.3.0,<6.0.0" },
+    { name = "spacy", specifier = ">=3.8.13,!=3.8.14,<4.0.0" },
+    { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
+    { name = "transformers", specifier = ">=4.51.3,<6.0.0" },
+]
+typing = [
+    { name = "beautifulsoup4", specifier = ">=4.13.5,<5.0.0" },
+    { name = "lxml-stubs", specifier = ">=0.5.1,<1.0.0" },
+    { name = "mypy", specifier = ">=1.19.1,<1.20.0" },
+    { name = "tiktoken", specifier = ">=0.8.0,<1.0.0" },
+    { name = "types-requests", specifier = ">=2.31.0.20240218,<3.0.0.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a typed `run.subagents` projection that surfaces named subagents dispatched from tools, with no tool annotation required.

A subagent is a nested `create_agent` run whose `lc_agent_name` differs from its parent's. The langgraph stream transformers (langchain-ai/langgraph#7928) detect that boundary and pass the resolved name and the triggering tool call to the transformer; `SubagentTransformer` promotes those into typed `SubagentRunStream` handles (exposing `name` and `cause`) on `run.subagents`, registered automatically by `create_agent`. Both sync (`stream_events`) and async (`astream_events`) lanes are supported.

This reworks an earlier approach that added a `subagent_name` parameter to tools — no langchain-core change is needed (langchain-ai/langchain#37721 is closed). The `cause` type is imported from `langchain-protocol` rather than redefined.

Note: `langgraph` is temporarily pinned (git, branch `nh/subagent-name-langgraph`) to pick up #7928's reshape; this must be replaced with a released version constraint before merge, once langgraph ships with #7928. Depends on #7928.