### PR TITLE
fix(core): resolve SSRF bypass in `validate_safe_url` via strict hostname allowlist

### DIFF
--- a/libs/core/langchain_core/_security/_policy.py
+++ b/libs/core/langchain_core/_security/_policy.py
@@ -228,7 +228,10 @@ def validate_hostname(hostname: str, policy: SSRFPolicy) -> None:
 def _effective_allowed_hosts(policy: SSRFPolicy) -> frozenset[str]:
     """Return allowed_hosts, augmented for local environments."""
     extra: set[str] = set()
-    if os.environ.get("LANGCHAIN_ENV", "").startswith("local"):
+    # SECURITY: use exact match — startswith("local") was too broad and
+    # matched unintended values like "local_staging".
+    _LOCAL_ENVS = frozenset({"local", "local_test"})
+    if os.environ.get("LANGCHAIN_ENV", "") in _LOCAL_ENVS:
         extra.update({"localhost", "testserver"})
     if extra:
         return policy.allowed_hosts | frozenset(extra)

--- a/libs/core/langchain_core/_security/_ssrf_protection.py
+++ b/libs/core/langchain_core/_security/_ssrf_protection.py
@@ -65,11 +65,13 @@ def validate_safe_url(
     parsed = urlparse(url_str)
     hostname = parsed.hostname or ""
 
-    # Test-environment bypass (preserved from original implementation)
+    # Test-environment bypass — strict hostname allowlist only.
+    # SECURITY: never use prefix/substring matching here; only exact matches
+    # to prevent attacker-controlled hostnames from bypassing validation.
+    _TEST_HOSTNAMES = frozenset({"testserver", "testserver.local"})
     if (
         os.environ.get("LANGCHAIN_ENV") == "local_test"
-        and hostname.startswith("test")
-        and "server" in hostname
+        and hostname.lower() in _TEST_HOSTNAMES
     ):
         return url_str
 

--- a/libs/core/tests/unit_tests/test_ssrf_bypass_regression.py
+++ b/libs/core/tests/unit_tests/test_ssrf_bypass_regression.py
@@ -1,0 +1,105 @@
+"""Regression tests for SSRF bypass vulnerability (#37297).
+
+These tests verify that the test-environment bypass in validate_safe_url
+only allows exact known test hostnames, and that the
+_effective_allowed_hosts function only augments for exact local env values.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from langchain_core._security._policy import _effective_allowed_hosts, SSRFPolicy
+from langchain_core._security._ssrf_protection import validate_safe_url
+
+
+class TestSSRFBypassRegression:
+    """Regression tests for #37297 — SSRF bypass via crafted hostname."""
+
+    def test_attacker_hostname_blocked_in_local_test(self) -> None:
+        """Attacker-controlled hostname must NOT bypass validation."""
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "local_test"}):
+            with pytest.raises(ValueError):
+                validate_safe_url("http://test.attacker.server.com/exfil")
+
+    def test_attacker_hostname_with_test_prefix_blocked(self) -> None:
+        """Any hostname starting with 'test' should not auto-bypass."""
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "local_test"}):
+            with pytest.raises(ValueError):
+                validate_safe_url("http://testevil.server.com/steal")
+
+    def test_legitimate_testserver_allowed(self) -> None:
+        """The legitimate testserver hostname should still be allowed."""
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "local_test"}):
+            result = validate_safe_url("http://testserver/api/v1")
+            assert result == "http://testserver/api/v1"
+
+    def test_legitimate_testserver_local_allowed(self) -> None:
+        """testserver.local should be allowed in local_test env."""
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "local_test"}):
+            result = validate_safe_url("http://testserver.local/api/v1")
+            assert result == "http://testserver.local/api/v1"
+
+    def test_bypass_not_active_in_production(self) -> None:
+        """Test bypass must not activate in production environment."""
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "production"}):
+            with pytest.raises(ValueError):
+                validate_safe_url("http://testserver/api/v1")
+
+    def test_bypass_case_insensitive(self) -> None:
+        """Hostname matching should be case-insensitive."""
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "local_test"}):
+            result = validate_safe_url("http://TESTSERVER/api/v1")
+            assert result == "http://TESTSERVER/api/v1"
+
+
+class TestEffectiveAllowedHostsRegression:
+    """Regression tests for _effective_allowed_hosts env check."""
+
+    def test_exact_local_env_allowed(self) -> None:
+        """LANGCHAIN_ENV='local' should augment allowed hosts."""
+        policy = SSRFPolicy()
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "local"}):
+            hosts = _effective_allowed_hosts(policy)
+            assert "localhost" in hosts
+            assert "testserver" in hosts
+
+    def test_exact_local_test_env_allowed(self) -> None:
+        """LANGCHAIN_ENV='local_test' should augment allowed hosts."""
+        policy = SSRFPolicy()
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "local_test"}):
+            hosts = _effective_allowed_hosts(policy)
+            assert "localhost" in hosts
+            assert "testserver" in hosts
+
+    def test_local_staging_not_allowed(self) -> None:
+        """LANGCHAIN_ENV='local_staging' should NOT augment hosts."""
+        policy = SSRFPolicy()
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "local_staging"}):
+            hosts = _effective_allowed_hosts(policy)
+            assert "localhost" not in hosts
+            assert "testserver" not in hosts
+
+    def test_localized_not_allowed(self) -> None:
+        """LANGCHAIN_ENV='localized' should NOT augment hosts."""
+        policy = SSRFPolicy()
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "localized"}):
+            hosts = _effective_allowed_hosts(policy)
+            assert "localhost" not in hosts
+
+    def test_production_not_allowed(self) -> None:
+        """LANGCHAIN_ENV='production' should NOT augment hosts."""
+        policy = SSRFPolicy()
+        with patch.dict(os.environ, {"LANGCHAIN_ENV": "production"}):
+            hosts = _effective_allowed_hosts(policy)
+            assert "localhost" not in hosts
+            assert "testserver" not in hosts
+
+    def test_empty_env_not_allowed(self) -> None:
+        """Empty LANGCHAIN_ENV should NOT augment hosts."""
+        policy = SSRFPolicy()
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("LANGCHAIN_ENV", None)
+            hosts = _effective_allowed_hosts(policy)
+            assert "localhost" not in hosts


### PR DESCRIPTION
Fixes #37297

---

The test-environment bypass in `validate_safe_url` used overly permissive prefix/substring matching (`hostname.startswith('test')` and `'server' in hostname`), allowing attacker-controlled hostnames like `test.attacker.server.com` to bypass all SSRF validation when `LANGCHAIN_ENV=local_test` is set.

This PR replaces the pattern-based check with a strict hostname allowlist (`testserver`, `testserver.local`). Additionally, `_effective_allowed_hosts` in `_policy.py` used `startswith('local')` which matched unintended env values like `local_staging` — fixed to exact match against `{'local', 'local_test'}`.

**Changes:**
- `_ssrf_protection.py`: Replace prefix/substring hostname bypass with `frozenset` exact-match allowlist
- `_policy.py`: Replace `startswith('local')` with exact env value match
- New: 12 regression tests covering attacker hostnames, legitimate test hostnames, case-insensitivity, and env value boundaries

All 28 existing `test_ssrf_protection.py` tests continue to pass — zero regressions.

cc @eyurtsev @ccurme

*This PR was developed with AI agent assistance.*

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/