### PR TITLE
fix(langchain-classic): align EnsembleRetriever.arank_fusion normalization with rank_fusion

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -291,10 +291,16 @@ class EnsembleRetriever(BaseRetriever):
             ],
         )
 
-        # Enforce that retrieved docs are Documents for each list in retriever_docs
+        # Enforce that retrieved docs are Documents for each list in retriever_docs.
+        # Use the same normalization as rank_fusion (sync): only wrap bare strings;
+        # non-string, non-Document items are passed through unchanged so that the
+        # behaviour is identical regardless of which code path is used.
+        # Wrapping arbitrary objects unconditionally (the old behaviour) caused a
+        # pydantic ValidationError when page_content was not a str (e.g. int).
+        # See https://github.com/langchain-ai/langchain/issues/37736
         for i in range(len(retriever_docs)):
             retriever_docs[i] = [
-                Document(page_content=doc) if not isinstance(doc, Document) else doc
+                Document(page_content=cast("str", doc)) if isinstance(doc, str) else doc  # type: ignore[unreachable]
                 for doc in retriever_docs[i]
             ]
 

--- a/libs/langchain/tests/unit_tests/retrievers/test_ensemble.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_ensemble.py
@@ -1,4 +1,9 @@
-from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
+import asyncio
+
+from langchain_core.callbacks.manager import (
+    AsyncCallbackManagerForRetrieverRun,
+    CallbackManagerForRetrieverRun,
+)
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
 from typing_extensions import override
@@ -18,6 +23,28 @@ class MockRetriever(BaseRetriever):
     ) -> list[Document]:
         """Return the documents."""
         return self.docs
+
+
+class WeirdRetriever(BaseRetriever):
+    """Retriever that returns non-Document items (mimics misbehaved custom retrievers)."""
+
+    @override
+    def _get_relevant_documents(
+        self,
+        query: str,
+        *,
+        run_manager: CallbackManagerForRetrieverRun | None = None,
+    ) -> list:  # type: ignore[override]
+        return [42]
+
+    @override
+    async def _aget_relevant_documents(
+        self,
+        query: str,
+        *,
+        run_manager: AsyncCallbackManagerForRetrieverRun | None = None,
+    ) -> list:  # type: ignore[override]
+        return [42]
 
 
 def test_invoke() -> None:
@@ -92,3 +119,50 @@ def test_invoke() -> None:
     # Additionally, the document with page_content "b" will be ranked 1st.
     assert len(ranked_documents) == 3
     assert ranked_documents[0].page_content == "b"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for https://github.com/langchain-ai/langchain/issues/37736
+# arank_fusion must use the same normalization logic as rank_fusion so that
+# both paths behave identically when retrievers return non-Document items.
+# ---------------------------------------------------------------------------
+
+
+def test_arank_fusion_raises_same_error_as_rank_fusion_for_non_documents() -> None:
+    """Both sync and async paths should raise the same error for non-Document items.
+
+    Before the fix, arank_fusion tried ``Document(page_content=42)`` which
+    Pydantic rejected with a ValidationError. The sync path instead passed
+    non-Document items through, eventually raising AttributeError inside
+    weighted_reciprocal_rank.  The pydantic ValidationError was the wrong
+    error — callers expect consistent behaviour across both paths.
+    """
+    import pytest
+
+    ensemble = EnsembleRetriever(retrievers=[WeirdRetriever()], weights=[1.0])
+
+    sync_exc: type[Exception] | None = None
+    async_exc: type[Exception] | None = None
+
+    try:
+        ensemble.invoke("test")
+    except Exception as e:
+        sync_exc = type(e)
+
+    try:
+        asyncio.run(ensemble.ainvoke("test"))
+    except Exception as e:
+        async_exc = type(e)
+
+    # Both paths must raise (or both must not raise), and the exception type must match.
+    # Crucially, the async path must NOT raise a pydantic ValidationError when the
+    # sync path would raise something else (AttributeError).
+    from pydantic import ValidationError
+
+    assert async_exc is not ValidationError, (
+        "arank_fusion raised ValidationError but rank_fusion did not; "
+        "the async path must use the same normalization as the sync path."
+    )
+    assert sync_exc == async_exc, (
+        f"sync raised {sync_exc}, async raised {async_exc}; both paths must be consistent"
+    )


### PR DESCRIPTION
## Summary

Fixes #37736 — `EnsembleRetriever.arank_fusion` raised a pydantic `ValidationError` for non-string, non-Document items while the synchronous `rank_fusion` passed them through unchanged.

## Root cause

`arank_fusion` wrapped every non-`Document` item unconditionally:

```python
# before (arank_fusion)
Document(page_content=doc) if not isinstance(doc, Document) else doc
```

When `doc` is an integer (e.g., `42`), Pydantic rejects `Document(page_content=42)` with `ValidationError: value is not a valid string`.

The synchronous `rank_fusion` only wraps bare `str` values:

```python
# rank_fusion (unchanged)
Document(page_content=cast("str", doc)) if isinstance(doc, str) else doc
```

## Fix

Apply the same str-only wrapping in `arank_fusion`:

```python
# after (arank_fusion)
Document(page_content=cast("str", doc)) if isinstance(doc, str) else doc
```

Both paths now behave identically regardless of what a retriever returns.

## Tests

Added `test_arank_fusion_raises_same_error_as_rank_fusion_for_non_documents` to `tests/unit_tests/retrievers/test_ensemble.py`. The test:

1. Exercises both sync and async paths with a retriever returning an integer
2. Asserts the async path does **not** raise `ValidationError` when the sync path does not
3. Asserts both paths raise the same exception type (consistency guarantee)