### PR TITLE
fix(chroma): block path traversal in `Chroma.encode_image` and fix generator exhaustion in `add_texts`

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
 )
 
 import chromadb
@@ -483,10 +484,46 @@ class Chroma(VectorStore):
             **kwargs,
         )
 
+    _SUPPORTED_IMAGE_EXTENSIONS: ClassVar[frozenset[str]] = frozenset(
+        {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".webp", ".tiff", ".tif", ".svg"}
+    )
+
     @staticmethod
     def encode_image(uri: str) -> str:
-        """Get base64 string from image URI."""
-        with Path(uri).open("rb") as image_file:
+        """Get base64 string from image URI.
+
+        Args:
+            uri: File path to the image.
+
+        Returns:
+            Base64-encoded string of the image contents.
+
+        Raises:
+            ValueError: If the URI contains path traversal sequences or
+                points to a non-image file.
+        """
+        raw_path = Path(uri)
+
+        # Block path traversal
+        if ".." in raw_path.parts:
+            msg = (
+                f"Path traversal detected in image URI: {uri!r}. "
+                "URIs must not contain '..' components."
+            )
+            raise ValueError(msg)
+
+        resolved = raw_path.resolve()
+
+        # Validate file extension
+        if resolved.suffix.lower() not in Chroma._SUPPORTED_IMAGE_EXTENSIONS:
+            msg = (
+                f"Unsupported image file extension {resolved.suffix!r} in URI: "
+                f"{uri!r}. Supported extensions: "
+                f"{', '.join(sorted(Chroma._SUPPORTED_IMAGE_EXTENSIONS))}"
+            )
+            raise ValueError(msg)
+
+        with resolved.open("rb") as image_file:
             return base64.b64encode(image_file.read()).decode("utf-8")
 
     def fork(self, new_name: str) -> Chroma:
@@ -616,13 +653,15 @@ class Chroma(VectorStore):
         Raises:
             ValueError: When metadata is incorrect.
         """
+        # Materialize generators/iterables early to prevent exhaustion during
+        # ID generation below.
+        texts = list(texts)
         if ids is None:
             ids = [str(uuid.uuid4()) for _ in texts]
         else:
             ids = [id_ if id_ is not None else str(uuid.uuid4()) for id_ in ids]
 
         embeddings = None
-        texts = list(texts)
         if self._embedding_function is not None:
             embeddings = self._embedding_function.embed_documents(texts)
         if metadatas:

--- a/libs/partners/chroma/tests/unit_tests/test_encode_image_regression.py
+++ b/libs/partners/chroma/tests/unit_tests/test_encode_image_regression.py
@@ -1,0 +1,93 @@
+"""Regression tests for path traversal in Chroma.encode_image() (#37296).
+
+These tests verify that encode_image rejects path traversal sequences
+and non-image file extensions.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from langchain_chroma.vectorstores import Chroma
+
+
+class TestEncodeImagePathTraversal:
+    """Regression tests for #37296 — path traversal via unsanitized URI."""
+
+    def test_path_traversal_with_double_dots_blocked(self) -> None:
+        """URIs containing '..' must be rejected."""
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            Chroma.encode_image("../../../../etc/passwd")
+
+    def test_path_traversal_relative_blocked(self) -> None:
+        """Relative paths with '..' must be rejected."""
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            Chroma.encode_image("../../../secret.png")
+
+    def test_path_traversal_mixed_separators_blocked(self) -> None:
+        """Mixed path separators with '..' must be rejected."""
+        with pytest.raises(ValueError, match="Path traversal detected"):
+            Chroma.encode_image("images/../../etc/shadow")
+
+    def test_non_image_extension_blocked(self) -> None:
+        """Non-image file extensions must be rejected."""
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"not an image")
+            f.flush()
+            with pytest.raises(ValueError, match="Unsupported image file extension"):
+                Chroma.encode_image(f.name)
+
+    def test_no_extension_blocked(self) -> None:
+        """Files without extensions must be rejected."""
+        with tempfile.NamedTemporaryFile(suffix="", delete=False) as f:
+            f.write(b"not an image")
+            f.flush()
+            with pytest.raises(ValueError, match="Unsupported image file extension"):
+                Chroma.encode_image(f.name)
+
+    def test_valid_png_accepted(self) -> None:
+        """A legitimate .png file should be accepted."""
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            f.write(b"\x89PNG\r\n\x1a\n")  # PNG header
+            f.flush()
+            result = Chroma.encode_image(f.name)
+            assert isinstance(result, str)
+            assert len(result) > 0
+
+    def test_valid_jpg_accepted(self) -> None:
+        """A legitimate .jpg file should be accepted."""
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+            f.write(b"\xff\xd8\xff\xe0")  # JPEG header
+            f.flush()
+            result = Chroma.encode_image(f.name)
+            assert isinstance(result, str)
+
+    def test_valid_webp_accepted(self) -> None:
+        """A legitimate .webp file should be accepted."""
+        with tempfile.NamedTemporaryFile(suffix=".webp", delete=False) as f:
+            f.write(b"RIFF\x00\x00\x00\x00WEBP")
+            f.flush()
+            result = Chroma.encode_image(f.name)
+            assert isinstance(result, str)
+
+    def test_case_insensitive_extension(self) -> None:
+        """Extension check should be case-insensitive."""
+        with tempfile.NamedTemporaryFile(suffix=".PNG", delete=False) as f:
+            f.write(b"\x89PNG\r\n\x1a\n")
+            f.flush()
+            result = Chroma.encode_image(f.name)
+            assert isinstance(result, str)
+
+    def test_passwd_file_blocked(self) -> None:
+        """Explicit /etc/passwd path must be rejected."""
+        with pytest.raises(ValueError):
+            Chroma.encode_image("/etc/passwd")
+
+    def test_python_source_blocked(self) -> None:
+        """Python source files must be rejected."""
+        with tempfile.NamedTemporaryFile(suffix=".py", delete=False) as f:
+            f.write(b"import os")
+            f.flush()
+            with pytest.raises(ValueError, match="Unsupported image file extension"):
+                Chroma.encode_image(f.name)


### PR DESCRIPTION
Fixes #37296
Fixes #37673

---

Two related fixes in `langchain-chroma`:

**1. Path traversal in `encode_image()` (security)**

`Chroma.encode_image()` passed user-supplied URIs directly to `Path(uri).open('rb')` without any validation. An attacker could read arbitrary files via `add_images(uris=['../../../../etc/passwd'])`, which would be base64-encoded and returned through the embeddings pipeline.

Fix: reject URIs containing `..` path components and validate the file extension against a known set of image formats (`.png`, `.jpg`, `.jpeg`, `.gif`, `.bmp`, `.webp`, `.tiff`, `.tif`, `.svg`).

**2. Generator exhaustion in `add_texts()`**

When `texts` was a generator, iterating it for UUID generation (`[str(uuid.uuid4()) for _ in texts]`) consumed it entirely, leaving `list(texts)` on the next line with an empty iterator.

Fix: materialize the generator with `texts = list(texts)` before ID generation.

**Tests:** 11 new regression tests covering traversal sequences, non-image extensions, and legitimate image files.

cc @ccurme @mdrxy

*This PR was developed with AI agent assistance.*

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/