### PR TITLE
fix(langchain-anthropic): copy tool_choice dict in bind_tools to prevent caller mutation

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1822,7 +1822,10 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            # Copy the dict so that subsequent mutations (e.g. injecting
+            # "disable_parallel_tool_use") do not modify the caller's object.
+            # See https://github.com/langchain-ai/langchain/issues/37596
+            kwargs["tool_choice"] = dict(tool_choice)
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3209,3 +3209,38 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for https://github.com/langchain-ai/langchain/issues/37596
+# ChatAnthropic.bind_tools must not mutate a caller-provided tool_choice dict.
+# ---------------------------------------------------------------------------
+
+
+def test_bind_tools_does_not_mutate_tool_choice_dict() -> None:
+    """bind_tools with parallel_tool_calls=False must not modify the caller's dict.
+
+    When parallel_tool_calls is False, the old code did:
+        kwargs["tool_choice"]["disable_parallel_tool_use"] = True
+    where kwargs["tool_choice"] was the exact same object as the caller's
+    tool_choice dict — mutating it in place.
+    """
+    chat_model = ChatAnthropic(  # type: ignore[call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+
+    original_tool_choice = {"type": "tool", "name": "GetWeather"}
+    # Keep a copy to compare against after the call
+    expected = dict(original_tool_choice)
+
+    chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=original_tool_choice,
+        parallel_tool_calls=False,
+    )
+
+    assert original_tool_choice == expected, (
+        "bind_tools must not mutate the caller-provided tool_choice dict; "
+        f"expected {expected!r}, got {original_tool_choice!r}"
+    )


### PR DESCRIPTION
## Summary

Fixes #37596 — `ChatAnthropic.bind_tools` with `parallel_tool_calls=False` modified the caller's `tool_choice` dict in place.

## Root cause

```python
# bind_tools, before the fix
elif isinstance(tool_choice, dict):
    kwargs["tool_choice"] = tool_choice   # same object reference

# ...later...
if parallel_tool_calls is not None:
    kwargs["tool_choice"]["disable_parallel_tool_use"] = not parallel_tool_calls
    # ^^^ mutates the caller's dict!
```

`kwargs["tool_choice"]` pointed to the exact same dict the caller passed in, so the `"disable_parallel_tool_use"` injection silently modified the caller's variable.

## Fix

Shallow-copy the dict at the assignment site:

```python
elif isinstance(tool_choice, dict):
    kwargs["tool_choice"] = dict(tool_choice)  # copy — caller's object is never touched
```

## Tests

Added `test_bind_tools_does_not_mutate_tool_choice_dict` in `tests/unit_tests/test_chat_models.py`. The test passes the original dict through `bind_tools(..., parallel_tool_calls=False)` and asserts the dict is unchanged afterwards.