### PR TITLE
fix(anthropic): prevent `bind_tools` from mutating caller's `tool_choice` dict

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1822,7 +1822,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):


### PR DESCRIPTION
Fixes #37596

---

`ChatAnthropic.bind_tools()` assigned the caller-provided `tool_choice` dict directly to `kwargs` by reference. When `parallel_tool_calls` was subsequently set, the code mutated `kwargs['tool_choice']` in-place, which also mutated the caller's original dict — a surprising side effect.

Fix: copy the dict on assignment (`tool_choice.copy()`).

cc @ccurme @mdrxy

*This PR was developed with AI agent assistance.*