### PR TITLE
fix(core): preserve non-ASCII characters in `AIMessageChunk` tool_call_chunks

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -506,7 +506,7 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = [
                     create_tool_call_chunk(
                         name=tc["name"],
-                        args=json.dumps(tc["args"]),
+                        args=json.dumps(tc["args"], ensure_ascii=False),
                         id=tc["id"],
                         index=None,
                     )


### PR DESCRIPTION
Fixes #37686

---

`AIMessageChunk.init_tool_calls()` serializes `tool_calls` args back to `tool_call_chunks` using `json.dumps(tc['args'])`. Python's default `ensure_ascii=True` escapes non-ASCII characters (Chinese, Japanese, Korean, emoji, etc.) into `\uXXXX` sequences, corrupting the original text through the round-trip.

Fix: use `json.dumps(tc['args'], ensure_ascii=False)` to preserve the original Unicode characters.

cc @eyurtsev

*This PR was developed with AI agent assistance.*