### PR TITLE
fix(core): use ensure_ascii=False when building tool_call_chunks from tool_calls

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -506,7 +506,11 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = [
                     create_tool_call_chunk(
                         name=tc["name"],
-                        args=json.dumps(tc["args"]),
+                        # ensure_ascii=False preserves non-ASCII characters
+                        # (e.g. CJK, emoji) in tool-call arguments rather than
+                        # escaping them to \uXXXX sequences.
+                        # See https://github.com/langchain-ai/langchain/issues/37686
+                        args=json.dumps(tc["args"], ensure_ascii=False),
                         id=tc["id"],
                         index=None,
                     )

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1427,3 +1427,39 @@ def test_text_accessor() -> None:
     assert empty_msg.text == ""
     assert empty_msg.text == ""
     assert str(empty_msg.text) == str(empty_msg.text)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for https://github.com/langchain-ai/langchain/issues/37686
+# AIMessageChunk.tool_call_chunks must preserve non-ASCII characters in args.
+# ---------------------------------------------------------------------------
+
+
+def test_ai_message_chunk_tool_call_chunks_preserve_non_ascii() -> None:
+    """tool_call_chunks[].args must preserve non-ASCII characters verbatim.
+
+    The validator that populates tool_call_chunks from tool_calls previously
+    used json.dumps(tc["args"]) which defaults to ensure_ascii=True.  That
+    caused CJK and emoji characters to be escaped to \\uXXXX sequences,
+    making chunk.tool_call_chunks[0]["args"] != json.dumps(chunk.tool_calls[0]["args"]).
+    """
+    chunk = AIMessageChunk(
+        content="",
+        tool_calls=[
+            {
+                "name": "echo",
+                "args": {"text": "你好", "emoji": "🚀"},
+                "id": "call_1",
+                "type": "tool_call",
+            }
+        ],
+    )
+
+    args_str = chunk.tool_call_chunks[0]["args"]
+    assert args_str is not None
+    assert "你好" in args_str, (
+        f"Non-ASCII text '你好' was escaped in tool_call_chunks args: {args_str!r}"
+    )
+    assert "🚀" in args_str, (
+        f"Emoji '🚀' was escaped in tool_call_chunks args: {args_str!r}"
+    )


### PR DESCRIPTION
## Summary

Fixes #37686 — `AIMessageChunk.tool_call_chunks[].args` silently escaped non-ASCII characters (CJK, emoji, etc.) to `\uXXXX` sequences when populated from `tool_calls`.

## Root cause

The validator in `ai.py` that builds `tool_call_chunks` from `tool_calls` used:

```python
args=json.dumps(tc["args"])   # ensure_ascii=True by default
```

Non-ASCII characters were escaped: `"你好"` → `"你好"`. The same codebase already uses `ensure_ascii=False` in `utils.py` for the equivalent serialization path, making `ai.py` an outlier.

## Fix

```python
args=json.dumps(tc["args"], ensure_ascii=False)
```

One-line change, consistent with the existing convention in `messages/utils.py`.

## Tests

Added `test_ai_message_chunk_tool_call_chunks_preserve_non_ascii` in `tests/unit_tests/test_messages.py`. Verifies that CJK text (`你好`) and emoji (`🚀`) in tool-call args round-trip through `tool_call_chunks` without being escaped.