### PR TITLE
fix(langchain): implement async `_aget_relevant_documents` in `RePhraseQueryRetriever`

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/re_phraser.py
+++ b/libs/langchain/langchain_classic/retrievers/re_phraser.py
@@ -89,4 +89,21 @@ class RePhraseQueryRetriever(BaseRetriever):
         *,
         run_manager: AsyncCallbackManagerForRetrieverRun,
     ) -> list[Document]:
-        raise NotImplementedError
+        """Async get relevant documents given a user question.
+
+        Args:
+            query: user question
+            run_manager: callback handler to use
+
+        Returns:
+            Relevant documents for re-phrased question
+        """
+        re_phrased_question = await self.llm_chain.ainvoke(
+            query,
+            {"callbacks": run_manager.get_child()},
+        )
+        logger.info("Re-phrased question: %s", re_phrased_question)
+        return await self.retriever.ainvoke(
+            re_phrased_question,
+            config={"callbacks": run_manager.get_child()},
+        )


### PR DESCRIPTION
Fixes #37619

---

`RePhraseQueryRetriever._aget_relevant_documents()` raised `NotImplementedError`, forcing all async callers to fall back to sync-in-executor. This broke async workflows that depend on native async retrieval.

Fix: implement the async method by delegating to `self.llm_chain.ainvoke()` and `self.retriever.ainvoke()`, mirroring the sync implementation's pattern of re-phrasing the query before retrieval.

cc @eyurtsev

*This PR was developed with AI agent assistance.*