### PR TITLE
fix(core): use ensure_ascii=False in AIMessageChunk.tool_call_chunks serializer

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -506,7 +506,11 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = [
                     create_tool_call_chunk(
                         name=tc["name"],
-                        args=json.dumps(tc["args"]),
+                        # ensure_ascii=False preserves non-ASCII characters
+                        # (e.g. CJK, emoji) in tool-call arguments rather than
+                        # escaping them to \uXXXX sequences.
+                        # See https://github.com/langchain-ai/langchain/issues/37686
+                        args=json.dumps(tc["args"], ensure_ascii=False),
                         id=tc["id"],
                         index=None,
                     )

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1427,3 +1427,39 @@ def test_text_accessor() -> None:
     assert empty_msg.text == ""
     assert empty_msg.text == ""
     assert str(empty_msg.text) == str(empty_msg.text)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for https://github.com/langchain-ai/langchain/issues/37686
+# AIMessageChunk.tool_call_chunks must preserve non-ASCII characters in args.
+# ---------------------------------------------------------------------------
+
+
+def test_ai_message_chunk_tool_call_chunks_preserve_non_ascii() -> None:
+    """tool_call_chunks[].args must preserve non-ASCII characters verbatim.
+
+    The validator that populates tool_call_chunks from tool_calls previously
+    used json.dumps(tc["args"]) which defaults to ensure_ascii=True.  That
+    caused CJK and emoji characters to be escaped to \\uXXXX sequences,
+    making chunk.tool_call_chunks[0]["args"] != json.dumps(chunk.tool_calls[0]["args"]).
+    """
+    chunk = AIMessageChunk(
+        content="",
+        tool_calls=[
+            {
+                "name": "echo",
+                "args": {"text": "你好", "emoji": "🚀"},
+                "id": "call_1",
+                "type": "tool_call",
+            }
+        ],
+    )
+
+    args_str = chunk.tool_call_chunks[0]["args"]
+    assert args_str is not None
+    assert "你好" in args_str, (
+        f"Non-ASCII text '你好' was escaped in tool_call_chunks args: {args_str!r}"
+    )
+    assert "🚀" in args_str, (
+        f"Emoji '🚀' was escaped in tool_call_chunks args: {args_str!r}"
+    )


### PR DESCRIPTION
## Description

When `AIMessageChunk` is constructed from a `ToolCall` list (the common
path taken by all chat model integrations), it serialises each call's
`args` dict with `json.dumps()`.  The default `ensure_ascii=True`
escapes every non-ASCII code-point to its `\uXXXX` escape sequence.

That means tool-call arguments containing CJK characters, emoji, or any
other non-ASCII text come out looking like:

```python
# Before fix
chunk.tool_call_chunks[0]["args"]
# '{"city": "\\u5317\\u4eac"}'   ← 北京 instead of 北京
```

Downstream code that immediately calls `json.loads()` gets the right
value back, but anything that logs, displays, or streams the raw
`AIMessageChunk` sees garbled `\uXXXX` sequences instead of the
original Unicode characters.

## Fix

Pass `ensure_ascii=False` to `json.dumps()`:

```python
args=json.dumps(tc["args"], ensure_ascii=False),
```

This is a single-character change; it preserves all existing behaviour
for ASCII-only inputs.

## Tests

Added a regression test in `libs/core/tests/unit_tests/test_messages.py`
that verifies CJK characters survive the round-trip.

Fixes #37686