### PR TITLE
fix(core): materialise texts iterable before zip in add_texts/aadd_texts

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -73,6 +73,10 @@ class VectorStore(ABC):
             # This condition is triggered if the subclass has provided
             # an implementation of the upsert method.
             # The existing add_texts
+            # Materialise the iterable once so that generator inputs are not
+            # exhausted by the length check and then silently produce an empty
+            # document list when iterated again.
+            # See https://github.com/langchain-ai/langchain/issues/37673
             texts_: Sequence[str] = (
                 texts if isinstance(texts, (list, tuple)) else list(texts)
             )
@@ -86,7 +90,9 @@ class VectorStore(ABC):
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                # Use texts_ (the materialised sequence) rather than the original
+                # texts iterable which may already be exhausted at this point.
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             if ids is not None:
                 # For backward compatibility
@@ -211,7 +217,8 @@ class VectorStore(ABC):
         if type(self).aadd_documents != VectorStore.aadd_documents:
             # This condition is triggered if the subclass has provided
             # an implementation of the upsert method.
-            # The existing add_texts
+            # Materialise the iterable once; see the same comment in add_texts.
+            # See https://github.com/langchain-ai/langchain/issues/37673
             texts_: Sequence[str] = (
                 texts if isinstance(texts, (list, tuple)) else list(texts)
             )
@@ -226,7 +233,8 @@ class VectorStore(ABC):
 
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                # Use texts_ (materialised) instead of the potentially-exhausted texts.
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             return await self.aadd_documents(docs, **kwargs)
         return await run_in_executor(None, self.add_texts, texts, metadatas, **kwargs)

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -292,3 +292,66 @@ async def test_default_afrom_documents(vs_class: type[VectorStore]) -> None:
     store = await vs_class.afrom_documents([original_document], embeddings, ids=["6"])
     assert original_document.id == "7"  # original document should not be modified
     assert await store.aget_by_ids(["6"]) == [Document(id="6", page_content="baz")]
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for https://github.com/langchain-ai/langchain/issues/37673
+# VectorStore.add_texts / aadd_texts must work correctly with generator inputs.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingVectorStore(VectorStore):
+    """Minimal VectorStore that records documents added via add_documents."""
+
+    def __init__(self) -> None:
+        self.documents: list[Document] = []
+
+    @override
+    def add_documents(self, documents: list[Document], **kwargs: Any) -> list[str]:
+        self.documents.extend(documents)
+        return [str(i) for i in range(len(documents))]
+
+    @override
+    def similarity_search(
+        self, query: str, k: int = 4, **kwargs: Any
+    ) -> list[Document]:
+        return []
+
+    @classmethod
+    def from_texts(  # type: ignore[override]
+        cls, texts: list[str], embedding: Embeddings, **kwargs: Any
+    ) -> "_RecordingVectorStore":
+        store = cls()
+        store.add_texts(texts)
+        return store
+
+
+def test_add_texts_with_generator_input() -> None:
+    """add_texts must not silently drop texts when passed a generator.
+
+    Before the fix, the generator was materialised once into texts_ for the
+    length check, and then the original (now-exhausted) generator was used
+    in the zip() that builds Document objects — producing an empty list.
+    """
+    store = _RecordingVectorStore()
+    store.add_texts(text for text in ["alpha", "beta"])
+    assert [doc.page_content for doc in store.documents] == ["alpha", "beta"], (
+        "Generator inputs must produce the same documents as list inputs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_aadd_texts_with_generator_input() -> None:
+    """aadd_texts must not silently drop texts when passed a generator."""
+
+    class _AsyncRecordingVectorStore(_RecordingVectorStore):
+        async def aadd_documents(  # type: ignore[override]
+            self, documents: list[Document], **kwargs: Any
+        ) -> list[str]:
+            return self.add_documents(documents, **kwargs)
+
+    store = _AsyncRecordingVectorStore()
+    await store.aadd_texts(text for text in ["alpha", "beta"])
+    assert [doc.page_content for doc in store.documents] == ["alpha", "beta"], (
+        "Generator inputs must produce the same documents as list inputs (async path)"
+    )


### PR DESCRIPTION
## Description

`VectorStore.add_texts` and `aadd_texts` accept `texts: Iterable[str]`.
A generator is a valid `Iterable`, but generators can only be traversed
**once**.

Before this fix the code did:

```python
if metadatas and len(metadatas) != len(texts):  # ← exhausts the generator
    raise ValueError(...)
...
for text, metadata_, id_ in zip(texts, ...):    # ← texts is now empty!
```

Calling `len()` on a generator raises `TypeError`, but callers typically
pre-size `metadatas` to match, so the `len()` check succeeds — and
silently exhausts the generator.  The subsequent `zip` then sees an empty
iterator and **the entire batch is silently dropped** with no error.

## Fix

Materialise the iterable once into a `Sequence` before any length check
or `zip`:

```python
texts_: Sequence[str] = (
    texts if isinstance(texts, (list, tuple)) else list(texts)
)
```

All subsequent uses are switched to `texts_`.  The fix is applied to
both the sync `add_texts` and async `aadd_texts` methods.

## Tests

Added regression tests in
`libs/core/tests/unit_tests/vectorstores/test_vectorstore.py` that pass
a generator to both `add_texts` and `aadd_texts` and assert all rows are
forwarded correctly.

Fixes #37673