### PR TITLE
fix(core): preserve generator inputs in `VectorStore.add_texts`

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -86,7 +86,7 @@ class VectorStore(ABC):
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             if ids is not None:
                 # For backward compatibility
@@ -226,7 +226,7 @@ class VectorStore(ABC):
 
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             return await self.aadd_documents(docs, **kwargs)
         return await run_in_executor(None, self.add_texts, texts, metadatas, **kwargs)

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -178,6 +178,23 @@ def test_default_add_texts(vs_class: type[VectorStore]) -> None:
     ]
 
 
+def test_default_add_texts_accepts_generator_input() -> None:
+    """Test that the default implementation materializes one-shot iterables once."""
+    store = CustomAddDocumentsVectorstore()
+
+    ids = store.add_texts(
+        (text for text in ["alpha", "beta"]),
+        metadatas=[{"rank": 1}, {"rank": 2}],
+        ids=["10", "11"],
+    )
+
+    assert ids == ["10", "11"]
+    assert store.get_by_ids(ids) == [
+        Document(id="10", page_content="alpha", metadata={"rank": 1}),
+        Document(id="11", page_content="beta", metadata={"rank": 2}),
+    ]
+
+
 @pytest.mark.parametrize(
     "vs_class", [CustomAddTextsVectorstore, CustomAddDocumentsVectorstore]
 )
@@ -233,6 +250,23 @@ async def test_default_aadd_texts(vs_class: type[VectorStore]) -> None:
     assert await store.aget_by_ids(ids_2) == [
         Document(id=ids_2[0], page_content="foo", metadata={"foo": "bar"}),
         Document(id=ids_2[1], page_content="bar", metadata={"foo": "bar"}),
+    ]
+
+
+async def test_default_aadd_texts_accepts_generator_input() -> None:
+    """Test that the async default implementation preserves generator contents."""
+    store = CustomAddDocumentsVectorstore()
+
+    ids = await store.aadd_texts(
+        (text for text in ["alpha", "beta"]),
+        metadatas=[{"rank": 1}, {"rank": 2}],
+        ids=["10", "11"],
+    )
+
+    assert ids == ["10", "11"]
+    assert await store.aget_by_ids(ids) == [
+        Document(id="10", page_content="alpha", metadata={"rank": 1}),
+        Document(id="11", page_content="beta", metadata={"rank": 2}),
     ]
 
 


### PR DESCRIPTION
Closes #37673

---

`VectorStore.add_texts` and `VectorStore.aadd_texts` already materialize one-shot iterables into `texts_` so they can validate `metadatas` length, but both methods were still constructing `Document` objects from the original `texts` iterable. For generator inputs that meant the iterable was exhausted before document creation, so the default `add_documents` delegation received an empty document list.

This keeps the fix intentionally narrow: both default implementations now build documents from the materialized `texts_` sequence, so validation and document construction read the same values exactly once.

I also added sync and async regression coverage for generator inputs, including `ids` and `metadatas`, to make sure the default delegation path preserves both content and alignment.

AI-agent disclaimer: this pull request was prepared with the help of an AI coding agent and reviewed before submission.
