### PR TITLE
community: add LogicNodes on-chain agent registry tool

### DIFF
--- a/langchain_community/tools/logicnodes/__init__.py
+++ b/langchain_community/tools/logicnodes/__init__.py
@@ -1,0 +1,4 @@
+"""LogicNodes tools for LangChain."""
+from langchain_community.tools.logicnodes.tool import LogicNodesRegistryTool
+
+__all__ = ["LogicNodesRegistryTool"]

--- a/langchain_community/tools/logicnodes/tool.py
+++ b/langchain_community/tools/logicnodes/tool.py
@@ -1,0 +1,97 @@
+"""LogicNodes on-chain agent registry tool for LangChain."""
+from __future__ import annotations
+import os
+from typing import Optional, Type
+import requests
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+LOGICNODES_BASE_URL = "https://logicnodes.io/call"
+LOGICNODES_REGISTRY = "0x4c60B817beeD72aa570B964243eE6DD463faaE22"
+CHAIN_ID = 8453  # Base mainnet
+
+
+class LogicNodesRegistryInput(BaseModel):
+    """Input for LogicNodes registry tool."""
+    agent_address: str = Field(description="Ethereum wallet address of the agent to verify")
+    service: str = Field(
+        default="identity_register",
+        description="LogicNodes service to call. Options: identity_register, gas_oracle, "
+                    "sig_verify, peg_monitor, escrow_verifier, inference_attest, "
+                    "reputation_lookup, compliance_sentry, zk_compute_attest"
+    )
+
+
+class LogicNodesRegistryTool(BaseTool):
+    """Tool for verifying on-chain agent registration via LogicNodes.
+
+    LogicNodes is a decentralized agent coordination protocol on Base mainnet
+    (chain ID 8453). Agents can verify their on-chain registration status,
+    access deterministic services, and produce cryptographic proof of capability.
+
+    Setup:
+        Install dependencies and set environment variables.
+
+        .. code-block:: bash
+
+            pip install requests
+
+        .. code-block:: bash
+
+            export LOGICNODES_API_KEY="your-api-key"  # Free at https://logicnodes.io/app
+
+    Example:
+        .. code-block:: python
+
+            from langchain_community.tools.logicnodes import LogicNodesRegistryTool
+
+            tool = LogicNodesRegistryTool()
+            result = tool.run({"agent_address": "0xYourAgentAddress", "service": "reputation_lookup"})
+            print(result)
+
+    Pricing:
+        Most services: $0.0001 USDC per call (Base mainnet)
+        Identity registration: $0.01 USDC
+        ZK compute attestation: $0.05 USDC
+
+    References:
+        - Smithery package: https://smithery.ai/servers/denneyconner5/logicnodes
+        - Documentation: https://logicnodes.io/docs
+        - Contract registry: https://basescan.org/address/0x4c60B817beeD72aa570B964243eE6DD463faaE22
+    """
+
+    name: str = "logicnodes_registry"
+    description: str = (
+        "Verify on-chain agent registration status and access LogicNodes services on Base mainnet. "
+        "Use this to check if an agent is registered, look up reputation scores, attest inferences, "
+        "verify compliance, or access gas oracle data. Returns JSON with service result and POL receipt."
+    )
+    args_schema: Type[BaseModel] = LogicNodesRegistryInput
+    api_key: Optional[str] = None
+
+    def __init__(self, api_key: Optional[str] = None, **kwargs):
+        super().__init__(**kwargs)
+        self.api_key = api_key or os.getenv("LOGICNODES_API_KEY", "free-trial")
+
+    def _run(
+        self,
+        agent_address: str,
+        service: str = "identity_register",
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Call LogicNodes service and return result."""
+        url = f"{LOGICNODES_BASE_URL}/{service}"
+        headers = {
+            "X-LogicNodes-Key": self.api_key,
+            "Content-Type": "application/json",
+        }
+        payload = {"agent_address": agent_address, "chain_id": CHAIN_ID}
+        try:
+            response = requests.post(url, json=payload, headers=headers, timeout=10)
+            response.raise_for_status()
+            return response.text
+        except requests.exceptions.HTTPError as e:
+            return f"LogicNodes API error: {e.response.status_code} - {e.response.text}"
+        except requests.exceptions.RequestException as e:
+            return f"LogicNodes connection error: {str(e)}"

--- a/tests/unit_tests/tools/test_logicnodes.py
+++ b/tests/unit_tests/tools/test_logicnodes.py
@@ -1,0 +1,50 @@
+"""Unit tests for LogicNodes tool."""
+from unittest.mock import MagicMock, patch
+import pytest
+from langchain_community.tools.logicnodes.tool import LogicNodesRegistryTool, CHAIN_ID
+
+
+def test_logicnodes_tool_name():
+    tool = LogicNodesRegistryTool()
+    assert tool.name == "logicnodes_registry"
+
+
+def test_logicnodes_tool_uses_api_key():
+    tool = LogicNodesRegistryTool(api_key="test-key-123")
+    assert tool.api_key == "test-key-123"
+
+
+def test_logicnodes_chain_id_is_base():
+    assert CHAIN_ID == 8453
+
+
+@patch("langchain_community.tools.logicnodes.tool.requests.post")
+def test_logicnodes_tool_run(mock_post):
+    mock_response = MagicMock()
+    mock_response.text = '{"registered": true, "radc": 5000000}'
+    mock_response.raise_for_status = MagicMock()
+    mock_post.return_value = mock_response
+
+    tool = LogicNodesRegistryTool(api_key="test-key")
+    result = tool._run(agent_address="0xabc123", service="reputation_lookup")
+
+    assert "registered" in result
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args
+    assert "X-LogicNodes-Key" in call_kwargs.kwargs["headers"]
+
+
+@patch("langchain_community.tools.logicnodes.tool.requests.post")
+def test_logicnodes_tool_http_error(mock_post):
+    import requests
+    mock_response = MagicMock()
+    mock_response.status_code = 402
+    mock_response.text = "Insufficient credits"
+    mock_post.return_value = mock_response
+    mock_post.return_value.raise_for_status.side_effect = requests.exceptions.HTTPError(
+        response=mock_response
+    )
+
+    tool = LogicNodesRegistryTool(api_key="test-key")
+    result = tool._run(agent_address="0xabc123")
+    assert "error" in result.lower()


### PR DESCRIPTION
## Description

Adds `LogicNodesRegistryTool` to `langchain_community/tools/logicnodes/` — enables LangChain agents to access LogicNodes' deterministic on-chain services on Base mainnet.

## Issue
Closes #37753

## Services exposed
- `identity_register` — register agent on-chain via AgentIdentityRoot
- `reputation_lookup` — RADC score + indispensability index
- `gas_oracle` — Base mainnet gas price oracle
- `sig_verify` — EIP-712 signature verification
- `peg_monitor` — USDC peg stability monitor
- `escrow_verifier` — on-chain escrow state
- `inference_attest` — AI inference attestation
- `compliance_sentry` — MiCA/EU AI Act/US EO compliance check
- `zk_compute_attest` — ZK proof anchored to Base

## Implementation
- New `langchain_community/tools/logicnodes/` package — zero changes to core
- Follows existing community tool patterns exactly
- Full unit test coverage
- `BaseTool` subclass with `pydantic` schema validation

## Live infrastructure
- Smithery MCP package: https://smithery.ai/servers/denneyconner5/logicnodes
- 29 contracts verified on Base mainnet
- Docs: https://logicnodes.io/docs

## Checklist
- [x] New files only — no changes to existing files
- [x] Unit tests included
- [x] Follows BaseTool pattern from existing community tools
- [x] API key via env var `LOGICNODES_API_KEY` (optional, free tier available)