### PR TITLE
RFC: track anthropic service tier and geo tokens

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2324,18 +2324,32 @@ def _create_usage_metadata(
     if inference_geo is None:
         inference_geo = getattr(anthropic_usage, "inference_geo", None)
 
-    # Only break tokens out by tier when the tier carries a non-default pricing
-    # multiplier. `standard` is the default rate; `priority` is ~1.5x; `batch`
-    # is half-price.
+    # Only break tokens out when the value carries a non-default pricing
+    # multiplier. `standard`/`global` are default rates; `priority` is ~1.5x;
+    # `batch` is half-price; `us` is 1.1x on every category.
     if service_tier not in {"priority", "batch"}:
         service_tier = None
-    tier_prefix = f"{service_tier}_" if service_tier else ""
+    if inference_geo != "us":
+        inference_geo = None
+
+    # Build a combined prefix that encodes geo and tier together. When set, every
+    # bucket in input_token_details / output_token_details is renamed with this
+    # prefix so the cost engine can read the multiplier off the key while the
+    # buckets stay mutually exclusive (their values sum to input_tokens /
+    # output_tokens).
+    prefix_parts: list[str] = []
+    if inference_geo:
+        prefix_parts.append(f"inference_geo_{inference_geo}")
+    if service_tier:
+        prefix_parts.append(service_tier)
+    bare_prefix = "_".join(prefix_parts)
+    key_prefix = f"{bare_prefix}_" if bare_prefix else ""
 
     input_token_details: dict = {
-        f"{tier_prefix}cache_read": getattr(
+        f"{key_prefix}cache_read": getattr(
             anthropic_usage, "cache_read_input_tokens", None
         ),
-        f"{tier_prefix}cache_creation": getattr(
+        f"{key_prefix}cache_creation": getattr(
             anthropic_usage, "cache_creation_input_tokens", None
         ),
     }
@@ -2352,19 +2366,19 @@ def _create_usage_metadata(
             cache_creation = cache_creation.model_dump()
         for k in cache_creation_keys:
             specific_cache_creation_tokens += cache_creation.get(k, 0)
-            input_token_details[f"{tier_prefix}{k}"] = cache_creation.get(k)
+            input_token_details[f"{key_prefix}{k}"] = cache_creation.get(k)
         if not isinstance(specific_cache_creation_tokens, int):
             specific_cache_creation_tokens = 0
         if specific_cache_creation_tokens > 0:
             # Remove generic key to avoid double counting cache creation tokens
-            input_token_details[f"{tier_prefix}cache_creation"] = 0
+            input_token_details[f"{key_prefix}cache_creation"] = 0
 
     # Calculate total input tokens: Anthropic's `input_tokens` excludes cached tokens,
     # so we need to add them back to get the true total input token count
-    cache_read_total = input_token_details[f"{tier_prefix}cache_read"] or 0
+    cache_read_total = input_token_details[f"{key_prefix}cache_read"] or 0
     cache_creation_total = (
         specific_cache_creation_tokens
-        or input_token_details[f"{tier_prefix}cache_creation"]
+        or input_token_details[f"{key_prefix}cache_creation"]
         or 0
     )
     input_tokens = base_non_cache_input + cache_read_total + cache_creation_total
@@ -2372,17 +2386,13 @@ def _create_usage_metadata(
 
     output_token_details: dict = {}
 
-    if service_tier is not None:
-        # Mirror OpenAI: the bare tier key tracks tokens billed at tier rates that
-        # aren't already covered by a cache breakdown.
-        input_token_details[service_tier] = base_non_cache_input
-        output_token_details[service_tier] = output_tokens
-
-    # US-only inference applies a 1.1x multiplier to every token category, so the
-    # full input/output totals are the count subject to the multiplier.
-    if inference_geo == "us":
-        input_token_details["us"] = input_tokens
-        output_token_details["us"] = output_tokens
+    if bare_prefix:
+        # Non-cache base input gets a bare bucket so all input_token_details keys
+        # together partition input_tokens. Same for output_tokens — Anthropic
+        # doesn't currently split output further (no reasoning sub-bucket), so
+        # the bare bucket equals output_tokens.
+        input_token_details[bare_prefix] = base_non_cache_input
+        output_token_details[bare_prefix] = output_tokens
 
     output_details_filtered = {
         k: v for k, v in output_token_details.items() if v is not None

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -35,7 +35,11 @@ from langchain_core.messages import (
     is_data_content_block,
 )
 from langchain_core.messages import content as types
-from langchain_core.messages.ai import InputTokenDetails, UsageMetadata
+from langchain_core.messages.ai import (
+    InputTokenDetails,
+    OutputTokenDetails,
+    UsageMetadata,
+)
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
 from langchain_core.output_parsers import (
     JsonOutputKeyToolsParser,
@@ -1392,12 +1396,14 @@ class ChatAnthropic(BaseChatModel):
                 and not _compact_in_params(payload)
             )
             block_start_event = None
+            stream_state: dict = {}
             for event in stream:
                 msg, block_start_event = self._make_message_chunk_from_anthropic_event(
                     event,
                     stream_usage=stream_usage,
                     coerce_content_to_string=coerce_content_to_string,
                     block_start_event=block_start_event,
+                    stream_state=stream_state,
                 )
                 if msg is not None:
                     chunk = ChatGenerationChunk(message=msg)
@@ -1429,12 +1435,14 @@ class ChatAnthropic(BaseChatModel):
                 and not _compact_in_params(payload)
             )
             block_start_event = None
+            stream_state: dict = {}
             async for event in stream:
                 msg, block_start_event = self._make_message_chunk_from_anthropic_event(
                     event,
                     stream_usage=stream_usage,
                     coerce_content_to_string=coerce_content_to_string,
                     block_start_event=block_start_event,
+                    stream_state=stream_state,
                 )
                 if msg is not None:
                     chunk = ChatGenerationChunk(message=msg)
@@ -1451,6 +1459,7 @@ class ChatAnthropic(BaseChatModel):
         stream_usage: bool = True,
         coerce_content_to_string: bool,
         block_start_event: anthropic.types.RawMessageStreamEvent | None = None,
+        stream_state: dict | None = None,
     ) -> tuple[AIMessageChunk | None, anthropic.types.RawMessageStreamEvent | None]:
         """Convert Anthropic streaming event to `AIMessageChunk`.
 
@@ -1464,6 +1473,10 @@ class ChatAnthropic(BaseChatModel):
                 content like tool calls and citations are maintained.
             block_start_event: Previous content block start event, used for tracking
                 tool use blocks and maintaining context across related events.
+            stream_state: Mutable per-stream dict used to carry information that
+                only appears once (e.g. `service_tier`, `inference_geo` on
+                `message_start.message.usage`) so the final `message_delta` chunk
+                can attach it to `usage_metadata` and `response_metadata`.
 
         Returns:
             Tuple with
@@ -1487,6 +1500,21 @@ class ChatAnthropic(BaseChatModel):
                 response_metadata: dict[str, Any] = {"model_name": event.message.model}
             else:
                 response_metadata = {}
+
+            # `service_tier` and `inference_geo` only appear on the full `Usage`
+            # object delivered with `message_start`; the streaming `MessageDeltaUsage`
+            # doesn't carry them. Stash on stream_state so the final `message_delta`
+            # chunk can surface them via response_metadata + usage_metadata. We
+            # avoid putting them on the message_start chunk's response_metadata
+            # because string fields concatenate when AIMessageChunks merge.
+            start_usage = getattr(event.message, "usage", None)
+            start_service_tier = getattr(start_usage, "service_tier", None)
+            start_inference_geo = getattr(start_usage, "inference_geo", None)
+            if stream_state is not None:
+                if isinstance(start_service_tier, str):
+                    stream_state["service_tier"] = start_service_tier
+                if isinstance(start_inference_geo, str):
+                    stream_state["inference_geo"] = start_inference_geo
 
             message_chunk = AIMessageChunk(
                 content="" if coerce_content_to_string else [],
@@ -1600,11 +1628,21 @@ class ChatAnthropic(BaseChatModel):
 
         # Process final usage metadata and completion info
         elif event.type == "message_delta" and stream_usage:
-            usage_metadata = _create_usage_metadata(event.usage)
+            tier_from_start = (stream_state or {}).get("service_tier")
+            geo_from_start = (stream_state or {}).get("inference_geo")
+            usage_metadata = _create_usage_metadata(
+                event.usage,
+                service_tier=tier_from_start,
+                inference_geo=geo_from_start,
+            )
             response_metadata = {
                 "stop_reason": event.delta.stop_reason,
                 "stop_sequence": event.delta.stop_sequence,
             }
+            if tier_from_start:
+                response_metadata["service_tier"] = tier_from_start
+            if geo_from_start:
+                response_metadata["inference_geo"] = geo_from_start
             if context_management := getattr(event, "context_management", None):
                 response_metadata["context_management"] = (
                     context_management.model_dump()
@@ -1666,6 +1704,13 @@ class ChatAnthropic(BaseChatModel):
         response_metadata = {"model_provider": "anthropic"}
         if "model" in llm_output and "model_name" not in llm_output:
             llm_output["model_name"] = llm_output["model"]
+        usage_obj = getattr(data, "usage", None)
+        service_tier = getattr(usage_obj, "service_tier", None)
+        inference_geo = getattr(usage_obj, "inference_geo", None)
+        if isinstance(service_tier, str):
+            response_metadata["service_tier"] = service_tier
+        if isinstance(inference_geo, str):
+            response_metadata["inference_geo"] = inference_geo
         if (
             len(content) == 1
             and content[0]["type"] == "text"
@@ -2252,16 +2297,47 @@ def _convert_to_anthropic_output_config_format(schema: dict | type) -> dict[str,
     return {"type": "json_schema", "schema": json_schema}
 
 
-def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
+def _create_usage_metadata(
+    anthropic_usage: BaseModel,
+    *,
+    service_tier: str | None = None,
+    inference_geo: str | None = None,
+) -> UsageMetadata:
     """Create LangChain `UsageMetadata` from Anthropic `Usage` data.
 
     Note:
         Anthropic's `input_tokens` excludes cached tokens, so we manually add
         `cache_read` and `cache_creation` tokens to get the true total.
+
+    Args:
+        anthropic_usage: The Anthropic `Usage` / `MessageDeltaUsage` object.
+        service_tier: Override for `anthropic_usage.service_tier`. Streaming chunks
+            (`MessageDeltaUsage`) don't carry this field, so it must be threaded
+            from the `message_start` event.
+        inference_geo: Override for `anthropic_usage.inference_geo`. Same streaming
+            caveat as `service_tier`.
     """
+    base_non_cache_input = getattr(anthropic_usage, "input_tokens", 0) or 0
+
+    if service_tier is None:
+        service_tier = getattr(anthropic_usage, "service_tier", None)
+    if inference_geo is None:
+        inference_geo = getattr(anthropic_usage, "inference_geo", None)
+
+    # Only break tokens out by tier when the tier carries a non-default pricing
+    # multiplier. `standard` is the default rate; `priority` is ~1.5x; `batch`
+    # is half-price.
+    if service_tier not in {"priority", "batch"}:
+        service_tier = None
+    tier_prefix = f"{service_tier}_" if service_tier else ""
+
     input_token_details: dict = {
-        "cache_read": getattr(anthropic_usage, "cache_read_input_tokens", None),
-        "cache_creation": getattr(anthropic_usage, "cache_creation_input_tokens", None),
+        f"{tier_prefix}cache_read": getattr(
+            anthropic_usage, "cache_read_input_tokens", None
+        ),
+        f"{tier_prefix}cache_creation": getattr(
+            anthropic_usage, "cache_creation_input_tokens", None
+        ),
     }
 
     # Add cache TTL information if provided (5-minute and 1-hour ephemeral cache)
@@ -2276,25 +2352,42 @@ def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
             cache_creation = cache_creation.model_dump()
         for k in cache_creation_keys:
             specific_cache_creation_tokens += cache_creation.get(k, 0)
-            input_token_details[k] = cache_creation.get(k)
+            input_token_details[f"{tier_prefix}{k}"] = cache_creation.get(k)
         if not isinstance(specific_cache_creation_tokens, int):
             specific_cache_creation_tokens = 0
         if specific_cache_creation_tokens > 0:
             # Remove generic key to avoid double counting cache creation tokens
-            input_token_details["cache_creation"] = 0
+            input_token_details[f"{tier_prefix}cache_creation"] = 0
 
     # Calculate total input tokens: Anthropic's `input_tokens` excludes cached tokens,
     # so we need to add them back to get the true total input token count
-    input_tokens = (
-        (getattr(anthropic_usage, "input_tokens", 0) or 0)  # Base input tokens
-        + (input_token_details["cache_read"] or 0)  # Tokens read from cache
-        + (
-            specific_cache_creation_tokens or input_token_details["cache_creation"] or 0
-        )  # Tokens used to create cache
+    cache_read_total = input_token_details[f"{tier_prefix}cache_read"] or 0
+    cache_creation_total = (
+        specific_cache_creation_tokens
+        or input_token_details[f"{tier_prefix}cache_creation"]
+        or 0
     )
+    input_tokens = base_non_cache_input + cache_read_total + cache_creation_total
     output_tokens = getattr(anthropic_usage, "output_tokens", 0) or 0
 
-    return UsageMetadata(
+    output_token_details: dict = {}
+
+    if service_tier is not None:
+        # Mirror OpenAI: the bare tier key tracks tokens billed at tier rates that
+        # aren't already covered by a cache breakdown.
+        input_token_details[service_tier] = base_non_cache_input
+        output_token_details[service_tier] = output_tokens
+
+    # US-only inference applies a 1.1x multiplier to every token category, so the
+    # full input/output totals are the count subject to the multiplier.
+    if inference_geo == "us":
+        input_token_details["us"] = input_tokens
+        output_token_details["us"] = output_tokens
+
+    output_details_filtered = {
+        k: v for k, v in output_token_details.items() if v is not None
+    }
+    metadata: UsageMetadata = UsageMetadata(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=input_tokens + output_tokens,
@@ -2302,3 +2395,6 @@ def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
             **{k: v for k, v in input_token_details.items() if v is not None},
         ),
     )
+    if output_details_filtered:
+        metadata["output_token_details"] = OutputTokenDetails(**output_details_filtered)
+    return metadata

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1520,6 +1520,115 @@ def test_usage_metadata_standardization() -> None:
     assert result["total_tokens"] == 0
 
 
+def test_usage_metadata_service_tier_and_inference_geo() -> None:
+    """`service_tier` and `inference_geo` should drive token-detail breakdowns
+    so downstream pricing can apply Anthropic's priority and US-only multipliers.
+    """
+
+    class UsageStandard(BaseModel):
+        input_tokens: int = 80
+        output_tokens: int = 20
+        cache_read_input_tokens: int = 5
+        cache_creation_input_tokens: int = 3
+        service_tier: str = "standard"
+        inference_geo: str = "global"
+
+    # standard tier + global geo: no extra keys, behaves like a vanilla response.
+    result = _create_usage_metadata(UsageStandard())
+    details = dict(result.get("input_token_details") or {})
+    assert details == {"cache_read": 5, "cache_creation": 3}
+    assert not result.get("output_token_details")
+
+    # priority tier: cache keys get prefixed, bare `priority` = non-cache input.
+    class UsagePriority(BaseModel):
+        input_tokens: int = 80
+        output_tokens: int = 20
+        cache_read_input_tokens: int = 5
+        cache_creation_input_tokens: int = 3
+        service_tier: str = "priority"
+        inference_geo: str = "global"
+
+    result = _create_usage_metadata(UsagePriority())
+    details = dict(result.get("input_token_details") or {})
+    assert details["priority_cache_read"] == 5
+    assert details["priority_cache_creation"] == 3
+    assert details["priority"] == 80  # non-cache input
+    assert "cache_read" not in details
+    assert "cache_creation" not in details
+    assert dict(result.get("output_token_details") or {}) == {"priority": 20}
+    assert result["input_tokens"] == 88  # 80 + 5 + 3
+
+    # batch tier behaves the same as priority (different multiplier downstream).
+    class UsageBatch(BaseModel):
+        input_tokens: int = 80
+        output_tokens: int = 20
+        service_tier: str = "batch"
+
+    result = _create_usage_metadata(UsageBatch())
+    details = dict(result.get("input_token_details") or {})
+    assert details["batch"] == 80
+    assert dict(result.get("output_token_details") or {}) == {"batch": 20}
+
+    # inference_geo='us': 1.1x applies to all categories, so the bare `us` key
+    # carries the full input/output totals.
+    class UsageUS(BaseModel):
+        input_tokens: int = 80
+        output_tokens: int = 20
+        cache_read_input_tokens: int = 5
+        cache_creation_input_tokens: int = 3
+        service_tier: str = "standard"
+        inference_geo: str = "us"
+
+    result = _create_usage_metadata(UsageUS())
+    details = dict(result.get("input_token_details") or {})
+    assert details["us"] == 88  # full input total incl. cache
+    assert details["cache_read"] == 5
+    assert details["cache_creation"] == 3
+    assert dict(result.get("output_token_details") or {}) == {"us": 20}
+
+    # Priority + US: both keys present, tier-prefixed cache keys + `us` total.
+    class UsagePriorityUS(BaseModel):
+        input_tokens: int = 80
+        output_tokens: int = 20
+        cache_read_input_tokens: int = 5
+        cache_creation_input_tokens: int = 3
+        service_tier: str = "priority"
+        inference_geo: str = "us"
+
+    result = _create_usage_metadata(UsagePriorityUS())
+    details = dict(result.get("input_token_details") or {})
+    assert details["priority_cache_read"] == 5
+    assert details["priority_cache_creation"] == 3
+    assert details["priority"] == 80
+    assert details["us"] == 88
+    out_details = dict(result.get("output_token_details") or {})
+    assert out_details == {"priority": 20, "us": 20}
+
+    # 'not_available' inference_geo (older models) is a no-op.
+    class UsageGeoUnavailable(BaseModel):
+        input_tokens: int = 10
+        output_tokens: int = 5
+        service_tier: str = "standard"
+        inference_geo: str = "not_available"
+
+    result = _create_usage_metadata(UsageGeoUnavailable())
+    assert not result.get("output_token_details")
+    assert "us" not in dict(result.get("input_token_details") or {})
+
+    # Explicit overrides win over the values on the usage object — used by the
+    # streaming path to inject service_tier/inference_geo from message_start.
+    class UsageBareDelta(BaseModel):
+        input_tokens: int = 80
+        output_tokens: int = 20
+
+    result = _create_usage_metadata(
+        UsageBareDelta(), service_tier="priority", inference_geo="us"
+    )
+    details = dict(result.get("input_token_details") or {})
+    assert details["priority"] == 80
+    assert details["us"] == 80
+
+
 def test_usage_metadata_cache_creation_ttl() -> None:
     """Test _create_usage_metadata with granular cache_creation TTL fields."""
 
@@ -2041,6 +2150,83 @@ def test_streaming_cache_token_reporting() -> None:
     assert delta_chunk.usage_metadata["input_tokens"] == 135
     assert delta_chunk.usage_metadata["output_tokens"] == 50
     assert delta_chunk.usage_metadata["total_tokens"] == 185
+
+
+def test_streaming_service_tier_and_inference_geo_propagation() -> None:
+    """`service_tier` and `inference_geo` only ship on the `message_start` Usage
+    object, so the stream loop must stash them for the final `message_delta`
+    chunk.
+    """
+    from unittest.mock import MagicMock
+
+    from anthropic.types import MessageDeltaUsage
+
+    mock_message = MagicMock()
+    mock_message.model = MODEL_NAME
+    mock_message.usage.input_tokens = 100
+    mock_message.usage.output_tokens = 0
+    mock_message.usage.cache_read_input_tokens = 25
+    mock_message.usage.cache_creation_input_tokens = 0
+    mock_message.usage.cache_creation = None
+    mock_message.usage.service_tier = "priority"
+    mock_message.usage.inference_geo = "us"
+
+    message_start_event = MagicMock()
+    message_start_event.type = "message_start"
+    message_start_event.message = mock_message
+
+    mock_delta_usage = MessageDeltaUsage(
+        output_tokens=50,
+        input_tokens=100,
+        cache_read_input_tokens=25,
+        cache_creation_input_tokens=0,
+    )
+    mock_delta = MagicMock()
+    mock_delta.stop_reason = "end_turn"
+    mock_delta.stop_sequence = None
+    mock_delta.container = None
+
+    message_delta_event = MagicMock()
+    message_delta_event.type = "message_delta"
+    message_delta_event.usage = mock_delta_usage
+    message_delta_event.delta = mock_delta
+    message_delta_event.context_management = None
+
+    llm = ChatAnthropic(model=MODEL_NAME)  # type: ignore[call-arg]
+    stream_state: dict = {}
+
+    start_chunk, _ = llm._make_message_chunk_from_anthropic_event(
+        message_start_event,
+        stream_usage=True,
+        coerce_content_to_string=True,
+        block_start_event=None,
+        stream_state=stream_state,
+    )
+    assert start_chunk is not None
+    # message_start stashes on stream_state but doesn't emit on response_metadata,
+    # because string response_metadata fields concatenate during chunk merging.
+    assert "service_tier" not in start_chunk.response_metadata
+    assert "inference_geo" not in start_chunk.response_metadata
+    assert stream_state == {"service_tier": "priority", "inference_geo": "us"}
+
+    delta_chunk, _ = llm._make_message_chunk_from_anthropic_event(
+        message_delta_event,
+        stream_usage=True,
+        coerce_content_to_string=True,
+        block_start_event=None,
+        stream_state=stream_state,
+    )
+    assert delta_chunk is not None
+    assert delta_chunk.usage_metadata is not None
+    input_details = delta_chunk.usage_metadata["input_token_details"]
+    assert input_details["priority_cache_read"] == 25
+    assert input_details["priority"] == 100  # non-cache input
+    assert input_details["us"] == 125  # total input subject to 1.1x
+    output_details = delta_chunk.usage_metadata.get("output_token_details") or {}
+    assert output_details["priority"] == 50
+    assert output_details["us"] == 50
+    assert delta_chunk.response_metadata["service_tier"] == "priority"
+    assert delta_chunk.response_metadata["inference_geo"] == "us"
 
 
 def test_strict_tool_use() -> None:

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1523,6 +1523,10 @@ def test_usage_metadata_standardization() -> None:
 def test_usage_metadata_service_tier_and_inference_geo() -> None:
     """`service_tier` and `inference_geo` should drive token-detail breakdowns
     so downstream pricing can apply Anthropic's priority and US-only multipliers.
+
+    `input_token_details` keys must stay mutually exclusive: their values sum
+    to `input_tokens`, with the cost engine reading the multiplier off the key
+    prefix (`inference_geo_us_`, `priority_`, `batch_`, or a combination).
     """
 
     class UsageStandard(BaseModel):
@@ -1534,12 +1538,15 @@ def test_usage_metadata_service_tier_and_inference_geo() -> None:
         inference_geo: str = "global"
 
     # standard tier + global geo: no extra keys, behaves like a vanilla response.
+    # No bare non-cache key (the non-cache portion stays implicit, matching legacy
+    # behavior on default-priced requests).
     result = _create_usage_metadata(UsageStandard())
     details = dict(result.get("input_token_details") or {})
     assert details == {"cache_read": 5, "cache_creation": 3}
     assert not result.get("output_token_details")
 
-    # priority tier: cache keys get prefixed, bare `priority` = non-cache input.
+    # priority tier alone: keys are prefixed with `priority_`, bare `priority`
+    # holds non-cache input. Mutually exclusive: keys sum to input_tokens.
     class UsagePriority(BaseModel):
         input_tokens: int = 80
         output_tokens: int = 20
@@ -1550,15 +1557,16 @@ def test_usage_metadata_service_tier_and_inference_geo() -> None:
 
     result = _create_usage_metadata(UsagePriority())
     details = dict(result.get("input_token_details") or {})
-    assert details["priority_cache_read"] == 5
-    assert details["priority_cache_creation"] == 3
-    assert details["priority"] == 80  # non-cache input
-    assert "cache_read" not in details
-    assert "cache_creation" not in details
+    assert details == {
+        "priority_cache_read": 5,
+        "priority_cache_creation": 3,
+        "priority": 80,
+    }
+    assert sum(details.values()) == result["input_tokens"]
     assert dict(result.get("output_token_details") or {}) == {"priority": 20}
-    assert result["input_tokens"] == 88  # 80 + 5 + 3
 
-    # batch tier behaves the same as priority (different multiplier downstream).
+    # batch tier alone: prefixed with `batch_`, bare `batch` = non-cache input.
+    # cache fields absent on the usage object (None) are filtered out of details.
     class UsageBatch(BaseModel):
         input_tokens: int = 80
         output_tokens: int = 20
@@ -1566,11 +1574,11 @@ def test_usage_metadata_service_tier_and_inference_geo() -> None:
 
     result = _create_usage_metadata(UsageBatch())
     details = dict(result.get("input_token_details") or {})
-    assert details["batch"] == 80
+    assert details == {"batch": 80}
     assert dict(result.get("output_token_details") or {}) == {"batch": 20}
 
-    # inference_geo='us': 1.1x applies to all categories, so the bare `us` key
-    # carries the full input/output totals.
+    # inference_geo='us' alone (standard tier): every key prefixed with
+    # `inference_geo_us_`, bare `inference_geo_us` for non-cache input.
     class UsageUS(BaseModel):
         input_tokens: int = 80
         output_tokens: int = 20
@@ -1581,12 +1589,15 @@ def test_usage_metadata_service_tier_and_inference_geo() -> None:
 
     result = _create_usage_metadata(UsageUS())
     details = dict(result.get("input_token_details") or {})
-    assert details["us"] == 88  # full input total incl. cache
-    assert details["cache_read"] == 5
-    assert details["cache_creation"] == 3
-    assert dict(result.get("output_token_details") or {}) == {"us": 20}
+    assert details == {
+        "inference_geo_us_cache_read": 5,
+        "inference_geo_us_cache_creation": 3,
+        "inference_geo_us": 80,
+    }
+    assert sum(details.values()) == result["input_tokens"]
+    assert dict(result.get("output_token_details") or {}) == {"inference_geo_us": 20}
 
-    # Priority + US: both keys present, tier-prefixed cache keys + `us` total.
+    # priority + us: both multipliers encoded in the prefix.
     class UsagePriorityUS(BaseModel):
         input_tokens: int = 80
         output_tokens: int = 20
@@ -1597,23 +1608,28 @@ def test_usage_metadata_service_tier_and_inference_geo() -> None:
 
     result = _create_usage_metadata(UsagePriorityUS())
     details = dict(result.get("input_token_details") or {})
-    assert details["priority_cache_read"] == 5
-    assert details["priority_cache_creation"] == 3
-    assert details["priority"] == 80
-    assert details["us"] == 88
-    out_details = dict(result.get("output_token_details") or {})
-    assert out_details == {"priority": 20, "us": 20}
+    assert details == {
+        "inference_geo_us_priority_cache_read": 5,
+        "inference_geo_us_priority_cache_creation": 3,
+        "inference_geo_us_priority": 80,
+    }
+    assert sum(details.values()) == result["input_tokens"]
+    assert dict(result.get("output_token_details") or {}) == {
+        "inference_geo_us_priority": 20
+    }
 
-    # 'not_available' inference_geo (older models) is a no-op.
+    # 'not_available' inference_geo (older models) is a no-op; same for `global`.
     class UsageGeoUnavailable(BaseModel):
         input_tokens: int = 10
         output_tokens: int = 5
+        cache_read_input_tokens: int = 2
         service_tier: str = "standard"
         inference_geo: str = "not_available"
 
     result = _create_usage_metadata(UsageGeoUnavailable())
+    details = dict(result.get("input_token_details") or {})
+    assert details == {"cache_read": 2}
     assert not result.get("output_token_details")
-    assert "us" not in dict(result.get("input_token_details") or {})
 
     # Explicit overrides win over the values on the usage object — used by the
     # streaming path to inject service_tier/inference_geo from message_start.
@@ -1625,8 +1641,8 @@ def test_usage_metadata_service_tier_and_inference_geo() -> None:
         UsageBareDelta(), service_tier="priority", inference_geo="us"
     )
     details = dict(result.get("input_token_details") or {})
-    assert details["priority"] == 80
-    assert details["us"] == 80
+    assert details == {"inference_geo_us_priority": 80}
+    assert sum(details.values()) == result["input_tokens"]
 
 
 def test_usage_metadata_cache_creation_ttl() -> None:
@@ -2219,12 +2235,15 @@ def test_streaming_service_tier_and_inference_geo_propagation() -> None:
     assert delta_chunk is not None
     assert delta_chunk.usage_metadata is not None
     input_details = delta_chunk.usage_metadata["input_token_details"]
-    assert input_details["priority_cache_read"] == 25
-    assert input_details["priority"] == 100  # non-cache input
-    assert input_details["us"] == 125  # total input subject to 1.1x
+    assert input_details == {
+        "inference_geo_us_priority_cache_read": 25,
+        "inference_geo_us_priority_cache_creation": 0,
+        "inference_geo_us_priority": 100,
+    }
+    # Buckets stay mutually exclusive: they sum to input_tokens.
+    assert sum(input_details.values()) == delta_chunk.usage_metadata["input_tokens"]
     output_details = delta_chunk.usage_metadata.get("output_token_details") or {}
-    assert output_details["priority"] == 50
-    assert output_details["us"] == 50
+    assert output_details == {"inference_geo_us_priority": 50}
     assert delta_chunk.response_metadata["service_tier"] == "priority"
     assert delta_chunk.response_metadata["inference_geo"] == "us"
 


### PR DESCRIPTION
pretty ugly, not sure if there's a better approach

'Mirrors langchain-openai's `service_tier` pattern in `ChatAnthropic` so downstream tooling (pricing engines, dashboards) can see Anthropic's priority-tier (~1.5x) and US-only inference (1.1x) multipliers in `usage_metadata` instead of digging through provider-specific fields.

The Anthropic API exposes two response fields that affect billing:
- `usage.service_tier` — `standard` / `priority` / `batch`
- `usage.inference_geo` — `global` / `us` / `not_available` (Claude 4.6+ only)

Both are echoed into `response_metadata`. For `input_token_details` / `output_token_details`, every bucket is renamed with a combined prefix that encodes the active multipliers, so buckets stay mutually exclusive (sum equals `input_tokens` / `output_tokens`) and a flat-lookup cost engine can read the multiplier off the key:

| service_tier | inference_geo | input_token_details keys |
|---|---|---|
| standard | global | `cache_read`, `cache_creation` (non-cache implicit) |
| priority | global | `priority_cache_read`, `priority_cache_creation`, `priority` |
| batch | global | `batch_cache_read`, `batch_cache_creation`, `batch` |
| standard | us | `inference_geo_us_cache_read`, `inference_geo_us_cache_creation`, `inference_geo_us` |
| priority | us | `inference_geo_us_priority_cache_read`, `inference_geo_us_priority_cache_creation`, `inference_geo_us_priority` |

Default `standard + global` is unchanged.

Streaming: `service_tier` and `inference_geo` only ship on the `message_start.message.usage` object (the streaming `MessageDeltaUsage` doesn't carry them), so they're stashed in a per-stream state dict on `message_start` and re-emitted on the final `message_delta` chunk. Emitting only on the delta avoids string concatenation during `AIMessageChunk` merging.

## Release Note

`ChatAnthropic.usage_metadata` now surfaces `service_tier` and `inference_geo` token breakdowns so cost tracking can apply Anthropic's priority-tier and US-only inference multipliers.

## Test Plan

- [x] Unit tests cover every (service_tier, inference_geo) combination and assert `sum(input_token_details.values()) == input_tokens`
- [x] Streaming propagation test (message_start → message_delta) asserts the state-threaded prefix appears in usage_metadata + response_metadata
- [x] Live API sanity check on `claude-sonnet-4-6` with `inference_geo="us"` (non-streaming + streaming) confirms expected keys
