### PR TITLE
fix(core): forward input_token_details and output_token_details in _to_protocol_usage

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -497,7 +497,14 @@ def _to_protocol_usage(usage: dict[str, Any] | None) -> UsageInfo | None:
     if usage is None:
         return None
     result: dict[str, Any] = {}
-    for key in ("input_tokens", "output_tokens", "total_tokens", "cached_tokens"):
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cached_tokens",
+        "input_token_details",
+        "output_token_details",
+    ):
         if key in usage:
             result[key] = usage[key]
     return cast("UsageInfo", result) if result else None


### PR DESCRIPTION
## Description

Fixes `input_token_details` (containing `cache_read` and `cache_creation` counts) being silently dropped in the v3 streaming events path, making cache token tracking impossible.

## Problem

`_to_protocol_usage()` in `_compat_bridge.py` only forwards 4 keys to the protocol `UsageInfo` shape:
- `input_tokens`
- `output_tokens`
- `total_tokens`
- `cached_tokens`

It drops `input_token_details` and `output_token_details`, so providers that return cache breakdowns (e.g., ChatBedrockConverse with prompt caching) have their detail data lost in the `message-finish` event.

## Fix

Add `"input_token_details"` and `"output_token_details"` to the key forwarding list.

## Reproduction (from issue)

```python
# usage_metadata with cache details:
{"input_tokens": 100, "output_tokens": 10, "total_tokens": 110,
 "input_token_details": {"cache_read": 90, "cache_creation": 5}}

# Before fix: message-finish event only has input_tokens/output_tokens/total_tokens
# After fix: input_token_details preserved in message-finish event
```

Fixes #37761