### PR TITLE
docs(langchain): fix duplicate-word typos in `langchain_classic` API docs and test message

### DIFF
--- a/libs/langchain/langchain_classic/chains/api/news_docs.py
+++ b/libs/langchain/langchain_classic/chains/api/news_docs.py
@@ -18,7 +18,7 @@ Response object
     status | string | If the request was successful or not. Options: ok, error. In the case of error a code and message property will be populated.
     totalResults | int | The total number of results available for your request.
     articles | array[article] | The results of the request.
-    source | object | The identifier id and a display name name for the source this article came from.
+    source | object | The identifier id and a display name for the source this article came from.
     author | string | The author of the article
     title | string | The headline or title of the article.
     description | string | A description or snippet from the article.

--- a/libs/langchain/langchain_classic/chains/api/open_meteo_docs.py
+++ b/libs/langchain/langchain_classic/chains/api/open_meteo_docs.py
@@ -9,7 +9,7 @@ hourly	String array	No		A list of weather variables which should be returned. Va
 daily	String array	No		A list of daily weather variable aggregations which should be returned. Values can be comma separated, or multiple &daily= parameter in the URL can be used. If daily weather variables are specified, parameter timezone is required.
 current_weather	Bool	No	false	Include current weather conditions in the JSON output.
 temperature_unit	String	No	celsius	If fahrenheit is set, all temperature values are converted to Fahrenheit.
-windspeed_unit	String	No	kmh	Other wind speed speed units: ms, mph and kn
+windspeed_unit	String	No	kmh	Other wind speed units: ms, mph and kn
 precipitation_unit	String	No	mm	Other precipitation amount units: inch
 timeformat	String	No	iso8601	If format unixtime is selected, all time values are returned in UNIX epoch time in seconds. Please note that all timestamp are in GMT+0! For daily values with unix timestamps, please apply utc_offset_seconds again to get the correct date.
 timezone	String	No	GMT	If timezone is set, all timestamps are returned as local-time and data is returned starting at 00:00 local-time. Any time zone name from the time zone database is supported. If auto is set as a time zone, the coordinates will be automatically resolved to the local time zone.

--- a/libs/langchain/tests/unit_tests/test_imports.py
+++ b/libs/langchain/tests/unit_tests/test_imports.py
@@ -102,7 +102,7 @@ def test_no_more_changes_to_proxy_community() -> None:
     assert hash_ == evil_magic_number, (
         "If you're triggering this test, you're likely adding a new import "
         "to the langchain package that is importing something from "
-        "langchain_community. This test is meant to catch such such imports "
+        "langchain_community. This test is meant to catch such imports "
         "as they are officially DEPRECATED. Please do not add any new imports "
         "from langchain_community to the langchain package. "
     )


### PR DESCRIPTION
Three accidental duplicate-word typos in `langchain_classic`, all in user-visible or LLM-facing text:

- **Open-Meteo API description** — the string read `Other wind speed speed units: ms, mph and kn`; the duplicate `speed` is removed. This string is injected into LLM prompts via `APIChain.from_llm_and_api_docs`, so the typo previously reached the model on every Open-Meteo chain call.

- **News API description** — the string read `a display name name for the source this article came from`; the duplicate `name` is removed. Same prompt-injection path as above.

- **Imports test assertion** — the failure message read `catch such such imports`; the duplicate `such` is removed.

Pure text fixes — no behavior change beyond cleaner prompts for the two `*_docs.py` strings.

> AI-agent involvement: I used an automated duplicate-word scanner to surface these and reviewed each match manually before fixing.
