### PR TITLE
fix(core): forward input_token_details and output_token_details in _to_protocol_usage

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -500,6 +500,9 @@ def _to_protocol_usage(usage: dict[str, Any] | None) -> UsageInfo | None:
     for key in ("input_tokens", "output_tokens", "total_tokens", "cached_tokens"):
         if key in usage:
             result[key] = usage[key]
+    for detail_key in ("input_token_details", "output_token_details"):
+        if detail_key in usage and isinstance(usage[detail_key], dict):
+            result[detail_key] = usage[detail_key]
     return cast("UsageInfo", result) if result else None
 
 

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -120,6 +120,109 @@ def test_to_protocol_usage_none() -> None:
     assert _to_protocol_usage(None) is None
 
 
+def test_to_protocol_usage_forwards_input_token_details() -> None:
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "total_tokens": 110,
+        "input_token_details": {"cache_read": 90, "cache_creation": 5},
+    }
+    result = _to_protocol_usage(usage)
+    assert result is not None
+    assert result["input_token_details"] == {"cache_read": 90, "cache_creation": 5}
+
+
+def test_to_protocol_usage_forwards_output_token_details() -> None:
+    usage = {
+        "input_tokens": 50,
+        "output_tokens": 20,
+        "total_tokens": 70,
+        "output_token_details": {"reasoning": 15},
+    }
+    result = _to_protocol_usage(usage)
+    assert result is not None
+    assert result["output_token_details"] == {"reasoning": 15}
+
+
+def test_to_protocol_usage_ignores_non_dict_token_details() -> None:
+    """Non-dict values for token detail keys are silently skipped."""
+    usage = {
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "total_tokens": 15,
+        "input_token_details": "not-a-dict",
+    }
+    result = _to_protocol_usage(usage)
+    assert result is not None
+    assert "input_token_details" not in result
+
+
+def test_chunks_to_events_propagates_token_details_in_finish() -> None:
+    """Token detail dicts survive the streaming path to message-finish."""
+    chunks = [
+        ChatGenerationChunk(
+            message=AIMessageChunk(content="Hello", id="msg-cache"),
+        ),
+        ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="",
+                id="msg-cache",
+                usage_metadata={
+                    "input_tokens": 100,
+                    "output_tokens": 10,
+                    "total_tokens": 110,
+                    "input_token_details": {
+                        "cache_read": 90,
+                        "cache_creation": 5,
+                    },
+                    "output_token_details": {"reasoning": 8},
+                },
+            ),
+        ),
+    ]
+
+    events = list(chunks_to_events(iter(chunks), message_id="msg-cache"))
+    finish = next(e for e in events if e["event"] == "message-finish")
+    usage: dict[str, Any] = finish["usage"]
+    assert usage["input_tokens"] == 100
+    assert usage["output_tokens"] == 10
+    assert usage["input_token_details"] == {"cache_read": 90, "cache_creation": 5}
+    assert usage["output_token_details"] == {"reasoning": 8}
+
+
+@pytest.mark.asyncio
+async def test_achunks_to_events_propagates_token_details_in_finish() -> None:
+    """Async twin: token detail dicts survive to message-finish."""
+    chunks = [
+        ChatGenerationChunk(
+            message=AIMessageChunk(content="Hi", id="msg-async-cache"),
+        ),
+        ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="",
+                id="msg-async-cache",
+                usage_metadata={
+                    "input_tokens": 200,
+                    "output_tokens": 25,
+                    "total_tokens": 225,
+                    "input_token_details": {"cache_read": 180},
+                },
+            ),
+        ),
+    ]
+
+    events = [
+        event
+        async for event in achunks_to_events(
+            _aiter_chunks(chunks), message_id="msg-async-cache"
+        )
+    ]
+    finish = next(e for e in events if e["event"] == "message-finish")
+    usage: dict[str, Any] = finish["usage"]
+    assert usage["input_tokens"] == 200
+    assert usage["input_token_details"] == {"cache_read": 180}
+
+
 # ---------------------------------------------------------------------------
 # chunks_to_events: streaming lifecycle
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #37761

---

Forward `input_token_details` and `output_token_details` dicts from accumulated usage to the `message-finish` protocol event in `_to_protocol_usage()`. These detail dicts (containing `cache_creation_input_tokens`, `cache_read_input_tokens`, and `reasoning_tokens`) were correctly accumulated by `_accumulate_usage()` but silently dropped when building the protocol event, making prompt cache token tracking impossible in the v3 streaming path.

The fix adds a 3-line forwarding loop that checks for dict-typed detail keys and includes them in the output, mirroring the guard pattern already used in `_accumulate_usage`.

5 new unit tests covering: individual detail key forwarding, non-dict guard, and end-to-end sync/async streaming verification.

This PR was developed with assistance from an AI coding agent.