### PR TITLE
fix(core): correct typo in `Visitor._validate_func` error message

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
Fixes #36701

---

The error message in `Visitor._validate_func` for disallowed operators incorrectly says "Allowed comparators" instead of "Allowed operators". One-word fix: `comparators` → `operators`.