### PR TITLE
test(core): add regression tests for EvaluationResult.feedback_config (#31802)

### DIFF
--- a/libs/core/tests/unit_tests/test_evaluation_feedback_config.py
+++ b/libs/core/tests/unit_tests/test_evaluation_feedback_config.py
@@ -1,0 +1,89 @@
+"""Regression test for langchain-ai/langchain#31802.
+
+Verify that EvaluationResult.feedback_config preserves dict fields
+and does not silently drop unknown or partial dict keys.
+
+The EvaluationResult class is defined in the langsmith package.
+This test ensures langchain_core's usage of it preserves dict data.
+
+Background: In older langsmith versions, Pydantic's TypedDict validation
+on Union[FeedbackConfig, dict] would silently strip unknown keys from
+dicts passed to feedback_config. The fix is in langsmith-sdk PR #2718.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langsmith.evaluation.evaluator import EvaluationResult
+
+
+class TestEvaluationResultFeedbackConfig:
+    """Tests for EvaluationResult.feedback_config dict preservation.
+
+    See: https://github.com/langchain-ai/langchain/issues/31802
+    See: https://github.com/langchain-ai/langsmith-sdk/pull/2718
+    """
+
+    def test_feedback_config_preserves_unknown_keys(self) -> None:
+        """Unknown dict keys should be preserved, not silently dropped."""
+        config: dict[str, Any] = {
+            "custom_key": "custom_value",
+            "another_key": 123,
+        }
+        result = EvaluationResult(
+            key="test",
+            score=1.0,
+            feedback_config=config,
+        )
+        assert result.feedback_config is not None
+        assert result.feedback_config["custom_key"] == "custom_value"
+        assert result.feedback_config["another_key"] == 123
+
+    def test_feedback_config_preserves_mixed_keys(self) -> None:
+        """Known FeedbackConfig keys mixed with unknown keys should all be preserved."""
+        config: dict[str, Any] = {
+            "type": "continuous",
+            "min": 0,
+            "max": 1,
+            "custom_key": "custom_value",
+        }
+        result = EvaluationResult(
+            key="test",
+            score=1.0,
+            feedback_config=config,
+        )
+        assert result.feedback_config is not None
+        assert result.feedback_config["type"] == "continuous"
+        assert result.feedback_config["min"] == 0
+        assert result.feedback_config["max"] == 1
+        assert result.feedback_config["custom_key"] == "custom_value"
+
+    def test_feedback_config_empty_dict(self) -> None:
+        """An empty dict should be preserved as-is."""
+        result = EvaluationResult(
+            key="test",
+            score=1.0,
+            feedback_config={},
+        )
+        assert result.feedback_config == {}
+
+    def test_feedback_config_none_default(self) -> None:
+        """When not provided, feedback_config should be None."""
+        result = EvaluationResult(key="test", score=1.0)
+        assert result.feedback_config is None
+
+    def test_feedback_config_nested_dict(self) -> None:
+        """Nested dict structures should be preserved."""
+        config: dict[str, Any] = {
+            "nested": {"a": 1, "b": [2, 3]},
+            "flat": "value",
+        }
+        result = EvaluationResult(
+            key="test",
+            score=1.0,
+            feedback_config=config,
+        )
+        assert result.feedback_config is not None
+        assert result.feedback_config["nested"] == {"a": 1, "b": [2, 3]}
+        assert result.feedback_config["flat"] == "value"


### PR DESCRIPTION
Closes #31802

---

## Problem

`EvaluationResult.feedback_config` silently drops unknown or partial dict fields. When a user passes `{"custom_key": "value"}` to `feedback_config`, the data is discarded without error or warning, despite the type hint accepting `dict`.

The root cause is in the langsmith package: older versions used `Optional[Union[FeedbackConfig, dict]]` where Pydantic's TypedDict validation would silently strip unknown keys. This has been fixed in langsmith-sdk PR #2718 by changing the type to `Optional[dict]`.

## What this PR adds

Regression tests to ensure `EvaluationResult.feedback_config` correctly preserves dict data, including:

- Unknown/custom dict keys
- Mixed known + unknown keys
- Empty dicts
- `None` default behavior
- Nested dict structures

These tests validate the fix from langsmith-sdk and prevent future regressions in langchain_core's usage of `EvaluationResult`.

## Tests

5 new unit tests in `libs/core/tests/unit_tests/test_evaluation_feedback_config.py`, all passing.

> Disclaimer: This contribution was assisted by an AI agent (Hermes Agent).