### PR TITLE
test(huggingface): add standard unit tests for ChatHuggingFace

### DIFF
--- a/libs/partners/huggingface/tests/unit_tests/test_standard.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_standard.py
@@ -1,0 +1,29 @@
+"""Standard LangChain interface tests."""
+
+from typing import Any
+
+import pytest
+from langchain_core.language_models import BaseChatModel
+from langchain_tests.unit_tests import ChatModelUnitTests
+
+from langchain_huggingface import ChatHuggingFace, HuggingFaceEndpoint
+
+
+class TestHuggingFaceChatModelUnit(ChatModelUnitTests):
+    @property
+    def chat_model_class(self) -> type[BaseChatModel]:
+        return ChatHuggingFace
+
+    @property
+    def chat_model_params(self) -> dict:
+        llm = HuggingFaceEndpoint(  # type: ignore[call-arg]
+            repo_id="meta-llama/Llama-3.3-70B-Instruct",
+            task="conversational",
+            provider="together",
+            temperature=0,
+        )
+        return {"llm": llm}
+
+    @pytest.fixture
+    def model(self, request: Any) -> BaseChatModel:
+        return self.chat_model_class(**self.chat_model_params)  # type: ignore[call-arg]


### PR DESCRIPTION
Description
Fixes #37785
Adds missing `test_standard.py` to `unit_tests` for `langchain-huggingface`.
The integration tests already have `test_standard.py` but the unit tests folder was missing it. This PR adds `ChatModelUnitTests` coverage for `ChatHuggingFace` consistent with other partner packages.
## Issue
Closes #(no issue — gap identified by comparing partner package test coverage)
## Dependencies
None
## Tests
- Added `tests/unit_tests/test_standard.py` inheriting from `ChatModelUnitTests`