### PR TITLE
test(ollama): add standard unit tests for ChatOllama

### DIFF
--- a/libs/partners/ollama/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/ollama/tests/unit_tests/test_chat_models.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, BaseMessage, ChatMessage, HumanMessage
-from langchain_tests.unit_tests import ChatModelUnitTests
 
 from langchain_ollama.chat_models import (
     ChatOllama,
@@ -23,16 +22,6 @@ MODEL_NAME = "llama3.1"
 dummy_raw_tool_call = {
     "function": {"name": "test_func", "arguments": ""},
 }
-
-
-class TestChatOllama(ChatModelUnitTests):
-    @property
-    def chat_model_class(self) -> type[ChatOllama]:
-        return ChatOllama
-
-    @property
-    def chat_model_params(self) -> dict:
-        return {"model": MODEL_NAME}
 
 
 def test__parse_arguments_from_tool_call() -> None:

--- a/libs/partners/ollama/tests/unit_tests/test_standard.py
+++ b/libs/partners/ollama/tests/unit_tests/test_standard.py
@@ -1,0 +1,16 @@
+"""Standard LangChain interface tests."""
+
+from langchain_core.language_models import BaseChatModel
+from langchain_tests.unit_tests import ChatModelUnitTests
+
+from langchain_ollama import ChatOllama
+
+
+class TestOllamaStandard(ChatModelUnitTests):
+    @property
+    def chat_model_class(self) -> type[BaseChatModel]:
+        return ChatOllama
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {"model": "llama3.1"}


### PR DESCRIPTION
Fixes #37786

Adds the missing `tests/unit_tests/test_standard.py` for `ChatOllama` in the `langchain-ollama` package and cleans up the leftover ChatModelUnitTests import and usages in test_chat_models.py.
The test follows the existing standard test pattern used by other partner packages and validates `ChatOllama` against the shared `ChatModelUnitTests` suite.

Verification:

- Ran the new standard unit tests locally.
- Verified the test file follows the same structure as other partner integrations.
- Ran formatting and linting checks successfully.

Social handles:
LinkedIn: https://www.linkedin.com/in/prince-samuel-kyeremanteng-941956165/
