### PR TITLE
fix(langchain-classic): align arank_fusion isinstance check with rank_fusion

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -294,7 +294,7 @@ class EnsembleRetriever(BaseRetriever):
         # Enforce that retrieved docs are Documents for each list in retriever_docs
         for i in range(len(retriever_docs)):
             retriever_docs[i] = [
-                Document(page_content=doc) if not isinstance(doc, Document) else doc
+                Document(page_content=cast("str", doc)) if isinstance(doc, str) else doc  # type: ignore[unreachable]
                 for doc in retriever_docs[i]
             ]
 


### PR DESCRIPTION
## Bug

`arank_fusion` uses `not isinstance(doc, Document)` to decide whether to wrap a value in `Document(page_content=...)`, while the synchronous `rank_fusion` uses `isinstance(doc, str)`. These conditions are not equivalent.

## Root cause

When a retriever returns a value that is neither a `str` nor a `Document` (e.g. an `int` in tests, or a custom object), the async path calls `Document(page_content=<non-str>)`, which Pydantic rejects with a `ValidationError`. The sync path passes the value through unchanged.

**Affected lines:**
- `libs/langchain/langchain_classic/retrievers/ensemble.py`, `arank_fusion`, line ~297

```python
# Before (async) — wraps everything that is not a Document:
Document(page_content=doc) if not isinstance(doc, Document) else doc

# After (async) — matches rank_fusion exactly:
Document(page_content=cast("str", doc)) if isinstance(doc, str) else doc
```

## Why this fix is correct

`rank_fusion` (sync) has used `isinstance(doc, str)` since the method was introduced. Wrapping bare strings in `Document` is the only intended normalization; non-string, non-Document values are passed through so callers can decide how to handle them. Using `not isinstance(doc, Document)` was an accidental divergence that makes the async path stricter than the sync path and causes `ValidationError` for any non-string value.

Closes #37736