### PR TITLE
fix(huggingface): use PydanticOutputParser for Pydantic schemas in with_structured_output

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,7 +47,7 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
     make_invalid_tool_call,
@@ -1188,7 +1188,10 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+            else:
+                output_parser = JsonOutputParser()  # type: ignore[arg-type]
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1197,7 +1200,10 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+            else:
+                output_parser = JsonOutputParser()  # type: ignore[arg-type]
         else:
             msg = (
                 f"Unrecognized method argument. Expected one of 'function_calling' or "


### PR DESCRIPTION
## Summary

Fixes #32197.

`ChatHuggingFace.with_structured_output` accepts Pydantic model classes as `schema`, but when `method='json_schema'` or `method='json_mode'`, the output parser was always `JsonOutputParser()`, which returns a plain `dict` rather than a typed Pydantic instance.

This PR uses `PydanticOutputParser(pydantic_object=schema)` when `is_pydantic_schema` is True for both `json_schema` and `json_mode` methods, consistent with the documented behaviour and with other LangChain chat-model integrations (e.g. `ChatOpenAI`).

## Changes

`libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py`:
- Import `PydanticOutputParser` alongside `JsonOutputParser`
- In `json_schema` branch: use `PydanticOutputParser` when `is_pydantic_schema`
- In `json_mode` branch: use `PydanticOutputParser` when `is_pydantic_schema`

## Before / After

```python
from pydantic import BaseModel

class Joke(BaseModel):
    setup: str
    punchline: str

llm = ChatHuggingFace(...)
structured = llm.with_structured_output(Joke, method="json_mode")
result = structured.invoke("Tell me a joke")

# Before: result is a dict {"setup": ..., "punchline": ...}
# After:  result is a Joke instance
assert isinstance(result, Joke)
```

## Test plan

- [ ] Run existing tests: `pytest libs/partners/huggingface/tests/ -k structured`
- [ ] Verify `with_structured_output(SomePydanticModel, method="json_mode")` returns a typed instance
- [ ] Verify `with_structured_output(SomePydanticModel, method="json_schema")` returns a typed instance
- [ ] Verify plain dict schema still returns dict (no regression)