### PR TITLE
fix(core): preserve non-ASCII characters in AIMessageChunk tool_call_chunks

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -506,7 +506,7 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = [
                     create_tool_call_chunk(
                         name=tc["name"],
-                        args=json.dumps(tc["args"]),
+                        args=json.dumps(tc["args"], ensure_ascii=False),
                         id=tc["id"],
                         index=None,
                     )

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -502,3 +502,19 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+
+def test_aimessagechunk_tool_call_chunks_non_ascii_roundtrip() -> None:
+    """Non-ASCII characters in tool args must round-trip through tool_call_chunks.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/37686
+    """
+    chunk = AIMessageChunk(
+        content="",
+        tool_calls=[
+            create_tool_call(name="echo", args={"text": "你好", "emoji": "🚀"}, id="call_1")
+        ],
+    )
+    assert chunk.tool_call_chunks
+    assert "你好" in chunk.tool_call_chunks[0]["args"]
+    assert "🚀" in chunk.tool_call_chunks[0]["args"]


### PR DESCRIPTION
Closes #37686

---

 serialized tool args with `json.dumps(tc['args'])`, which defaults to `ensure_ascii=True`. This caused CJK characters, emoji, and other non-ASCII content in tool arguments to be escaped as \uXXXX sequences when round-tripped through `tool_call_chunks`.

The fix adds `ensure_ascii=False` to match the existing convention used elsewhere in the same module (e.g. line 222, 470) and in `messages/utils.py`.

A unit test verifies that non-ASCII characters survive the round-trip.

*This contribution was prepared with assistance from an AI agent.*