### PR TITLE
fix(core): correct typo in error message for invalid operators

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
Closes #36701

---

In `Visitor._validate_func`, the error message for an invalid operator incorrectly refers to "allowed comparators" instead of "allowed operators". This was a copy-paste error from the comparator branch below it.

The fix replaces "comparators" with "operators" in the error message string for the operator validation path. The comparator validation path further below was already correct.

This contribution was assisted by an AI agent.
