### PR TITLE
Fixes/exa api update

### DIFF
--- a/libs/partners/exa/langchain_exa/_utilities.py
+++ b/libs/partners/exa/langchain_exa/_utilities.py
@@ -3,6 +3,9 @@ import os  # type: ignore[import-not-found]
 from exa_py import Exa
 from langchain_core.utils import convert_to_secret_str
 
+EXA_INTEGRATION_HEADER = "x-exa-integration"
+EXA_INTEGRATION_NAME = "langchain-integration"
+
 
 def initialize_client(values: dict) -> dict:
     """Initialize the client."""
@@ -14,4 +17,5 @@ def initialize_client(values: dict) -> dict:
     if values.get("exa_base_url"):
         args["base_url"] = values["exa_base_url"]
     values["client"] = Exa(**args)
+    values["client"].headers[EXA_INTEGRATION_HEADER] = EXA_INTEGRATION_NAME
     return values

--- a/libs/partners/exa/langchain_exa/retrievers.py
+++ b/libs/partners/exa/langchain_exa/retrievers.py
@@ -55,7 +55,7 @@ class ExaSearchRetriever(BaseRetriever):
     """The end date for when the document was published (in YYYY-MM-DD format)."""
     use_autoprompt: bool | None = None
     """Whether to use autoprompt for the search."""
-    type: str = "auto"
+    type: Literal["auto", "deep", "fast"] = "auto"
     """The type of search, 'auto', 'deep', or 'fast'. Default: auto"""
     highlights: HighlightsContentsOptions | bool | None = None
     """Whether to set the page content to the highlights of the results."""

--- a/libs/partners/exa/tests/unit_tests/test_standard.py
+++ b/libs/partners/exa/tests/unit_tests/test_standard.py
@@ -28,3 +28,10 @@ def test_exa_clients_include_integration_header() -> None:
 
     for client in clients:
         assert client.headers[EXA_INTEGRATION_HEADER] == EXA_INTEGRATION_NAME
+
+
+def test_exa_retriever_search_type_values() -> None:
+    """Test ExaSearchRetriever supports current search type values."""
+    for search_type in ("auto", "deep", "fast"):
+        retriever = ExaSearchRetriever(type=search_type)
+        assert retriever.type == search_type

--- a/libs/partners/exa/tests/unit_tests/test_standard.py
+++ b/libs/partners/exa/tests/unit_tests/test_standard.py
@@ -3,7 +3,8 @@
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture  # type: ignore[import-untyped]
 
-from langchain_exa import ExaSearchRetriever
+from langchain_exa import ExaFindSimilarResults, ExaSearchResults, ExaSearchRetriever
+from langchain_exa._utilities import EXA_INTEGRATION_HEADER, EXA_INTEGRATION_NAME
 
 
 @pytest.mark.benchmark
@@ -15,3 +16,15 @@ def test_exa_retriever_init_time(benchmark: BenchmarkFixture) -> None:
             ExaSearchRetriever()
 
     benchmark(_init_exa_retriever)
+
+
+def test_exa_clients_include_integration_header() -> None:
+    """Test Exa clients include the LangChain integration header."""
+    clients = [
+        ExaSearchRetriever().client,
+        ExaSearchResults().client,
+        ExaFindSimilarResults().client,
+    ]
+
+    for client in clients:
+        assert client.headers[EXA_INTEGRATION_HEADER] == EXA_INTEGRATION_NAME


### PR DESCRIPTION
Fixes #37701

Updates the Exa partner integration to align with the latest Exa API specification by adding the x-exa-integration: langchain-integration header to Exa client requests and updating ExaSearchRetriever.type to use Literal["auto", "deep", "fast"].

Also adds unit tests covering integration header initialization and the new retriever search type values. No breaking changes or function signature changes were introduced.

How I verified
Ran git diff --check
Verified updated retriever type values through unit tests in test_standard.py
Confirmed integration header is added during Exa client initialization