### PR TITLE
fix(ollama): preserve int/float/bool primitives in tool call argument parsing

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -192,7 +192,7 @@ def _parse_arguments_from_tool_call(
                 parsed_value = _parse_json_string(
                     value, skip=True, raw_tool_call=raw_tool_call
                 )
-                if isinstance(parsed_value, (dict, list)):
+                if isinstance(parsed_value, (dict, list, int, float, bool)):
                     parsed_arguments[key] = parsed_value
                 else:
                     parsed_arguments[key] = value

--- a/libs/partners/ollama/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/ollama/tests/unit_tests/test_chat_models.py
@@ -1164,3 +1164,51 @@ def test_multimodal_message_content_has_no_leading_newline() -> None:
     ollama_messages = model._convert_messages_to_ollama_messages([message])
 
     assert ollama_messages[0]["content"] == "Extract all text from this image."
+
+def test_parse_arguments_preserves_int_from_string():
+    """
+    Regression test: llama3.2:1b returns numeric args as strings.
+    Fixes https://github.com/langchain-ai/langchain/issues/30145
+    """
+    from langchain_ollama.chat_models import _parse_arguments_from_tool_call
+
+    raw_tool_call = {
+        "function": {
+            "name": "multiply",
+            "arguments": {"a": "12", "b": "8"}
+        }
+    }
+    result = _parse_arguments_from_tool_call(raw_tool_call)
+    assert result["a"] == 12
+    assert result["b"] == 8
+    assert isinstance(result["a"], int)
+    assert isinstance(result["b"], int)
+
+
+def test_parse_arguments_preserves_float_from_string():
+    from langchain_ollama.chat_models import _parse_arguments_from_tool_call
+
+    raw_tool_call = {
+        "function": {
+            "name": "calculate",
+            "arguments": {"price": "9.99"}
+        }
+    }
+    result = _parse_arguments_from_tool_call(raw_tool_call)
+    assert isinstance(result["price"], float)
+    assert result["price"] == 9.99
+
+
+def test_parse_arguments_preserves_genuine_string():
+    """Non-numeric strings must stay as strings."""
+    from langchain_ollama.chat_models import _parse_arguments_from_tool_call
+
+    raw_tool_call = {
+        "function": {
+            "name": "search",
+            "arguments": {"query": "hello world"}
+        }
+    }
+    result = _parse_arguments_from_tool_call(raw_tool_call)
+    assert isinstance(result["query"], str)
+    assert result["query"] == "hello world"


### PR DESCRIPTION
## Description
Fixes #30145

### Problem
When small models (e.g. `llama3.2:1b`) return numeric tool call 
arguments as strings, `_parse_arguments_from_tool_call` correctly 
parses them via `_parse_json_string` but then discards the result:

    parsed_value = _parse_json_string("12") → 12 (int) ✅
    isinstance(12, (dict, list))            → False
    stores original "12" string             → ❌

### Fix
Added `int, float, bool` to the isinstance check so parsed 
primitives are preserved instead of dropped.

### Evidence
Tested across llama3.2:1b, qwen2.5:0.5b, qwen2.5:1.5b, qwen2.5:3b.

Before: {'a': '12', 'b': '8'}  ← strings
After:  {'a': 12,  'b': 8}     ← correct ints