### PR TITLE
fix(core): add VideoContentBlock support in OpenAI block translator

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -145,6 +145,23 @@ def convert_to_openai_data_block(
         else:
             error_msg = "Key base64 is required for audio blocks."
             raise ValueError(error_msg)
+
+    elif block["type"] == "video":
+        if "url" in block:
+            formatted_block = {
+                "type": "video_url",
+                "video_url": {"url": block["url"]},
+            }
+        elif "base64" in block or block.get("source_type") == "base64":
+            base64_data = block["data"] if "source_type" in block else block["base64"]
+            mime_type = block.get("mime_type", "video/mp4")
+            formatted_block = {
+                "type": "video_url",
+                "video_url": {"url": f"data:{mime_type};base64,{base64_data}"},
+            }
+        else:
+            error_msg = "Keys url or base64 are required for video blocks."
+            raise ValueError(error_msg)
     else:
         error_msg = f"Block of type {block['type']} is not supported."
         raise ValueError(error_msg)


### PR DESCRIPTION
Fixes #37770

---

The `convert_to_openai_data_block` function did not handle `video` content blocks, causing a `ValueError: Block of type video is not supported` when users tried to send video content through OpenAI-compatible APIs.

This change adds `video` type handling that converts `VideoContentBlock` to OpenAI's `video_url` format, supporting both URL-based and base64-encoded videos. This aligns with how the OpenRouter integration already handles video blocks.

Changes:
- URL-based videos: `{type: "video_url", video_url: {url}}`
- Base64 videos: data URI with configurable mime_type (defaults to video/mp4)

*This contribution was made with assistance from an AI agent.*