### PR TITLE
fix(langchain): redact PII state hooks recursively

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/pii.py
+++ b/libs/langchain_v1/langchain/agents/middleware/pii.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
-from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langgraph.stream import StreamTransformer
 from typing_extensions import override
 
@@ -47,7 +47,113 @@ are typically well under 100) while bounding first-token latency.
 """
 
 
-class _PIIStreamTransformer(StreamTransformer):
+class _PIIRedactor:
+    """Shared recursive redaction helpers for state and stream surfaces."""
+
+    _rule: ResolvedRedactionRule
+
+    def _redact_tool_call_list(self, calls: list[Any] | None) -> tuple[list[Any], bool]:
+        """Walk a list of tool-call (or invalid-tool-call) dicts.
+
+        Returns `(new_list, changed)`. Each element's `args` is run
+        through `_redact_value` regardless of its type — `tool_call.args`
+        is a dict, `invalid_tool_call.args` is a raw JSON string, and
+        `_redact_value` handles both shapes uniformly. If nothing
+        changed, returns the input list and `changed=False`.
+        """
+        if not calls:
+            return calls or [], False
+        new_calls: list[Any] = []
+        changed = False
+        for tc in calls:
+            if isinstance(tc, dict) and "args" in tc and tc["args"] is not None:
+                redacted = self._redact_value(tc["args"])
+                if redacted != tc["args"]:
+                    new_tc = dict(tc)
+                    new_tc["args"] = redacted
+                    new_calls.append(new_tc)
+                    changed = True
+                    continue
+            new_calls.append(tc)
+        return new_calls, changed
+
+    def _redact_value(self, value: Any) -> Any:
+        """Recursively redact PII in string leaves of a nested structure.
+
+        Returns a new value where every `str` leaf that contains PII has
+        been replaced (or emptied under `block`). Non-string leaves and
+        the structure itself are preserved.
+
+        `BaseMessage` payloads (typically `ToolMessage` from
+        `tool-finished.output`, or any message reached via the `values`
+        channel) return a fresh copy with `.content` redacted plus
+        `AIMessage.tool_calls[*].args` / `invalid_tool_calls[*].args`
+        walked. The original object stays intact for state-level
+        enforcers (`after_model`, `before_model` with
+        `apply_to_tool_results`) to act on independently.
+
+        Scope mirrors the pre-streaming state-level surfaces:
+        `.content` (string or list-of-content-blocks) and `tool_calls`
+        args. Other message attributes (`additional_kwargs`,
+        `response_metadata`, `ToolMessage.artifact`) are intentionally
+        not walked here — they aren't scrubbed in graph state by the
+        existing hooks, so scrubbing them on the wire would create
+        a wire/state divergence.
+        """
+        if isinstance(value, str):
+            if not value:
+                return value
+            matches = self._rule.detector(value)
+            if not matches:
+                return value
+            # `apply_strategy` raises `PIIDetectionError` under `block`
+            # — the run fails immediately rather than buffering until a
+            # state-level hook can raise.
+            return apply_strategy(value, matches, self._rule.strategy)
+        if isinstance(value, BaseMessage):
+            return self._redact_base_message(value)
+        if isinstance(value, dict):
+            return {k: self._redact_value(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._redact_value(v) for v in value]
+        if isinstance(value, tuple):
+            return tuple(self._redact_value(v) for v in value)
+        return value
+
+    def _redact_base_message(self, value: BaseMessage) -> BaseMessage:
+        """Return a fresh copy of `value` with PII-carrying surfaces redacted."""
+        update: dict[str, Any] = {}
+
+        content = value.content
+        if isinstance(content, str) and content:
+            matches = self._rule.detector(content)
+            if matches:
+                update["content"] = apply_strategy(content, matches, self._rule.strategy)
+        elif isinstance(content, list) and content:
+            # Structured content-blocks shape:
+            # `[{"type": "text", "text": "..."}, {"type": "tool_call", ...}, ...]`.
+            redacted_content = self._redact_value(content)
+            if redacted_content != content:
+                update["content"] = redacted_content
+
+        # `AIMessage.tool_calls` and `.invalid_tool_calls` carry PII in
+        # `args` independently of `.content`. `tool_call.args` is a
+        # dict; `invalid_tool_call.args` is a raw JSON string —
+        # `_redact_value` handles both shapes via the recursion.
+        if isinstance(value, AIMessage):
+            new_tc_list, tc_changed = self._redact_tool_call_list(value.tool_calls)
+            if tc_changed:
+                update["tool_calls"] = new_tc_list
+            new_inv_list, inv_changed = self._redact_tool_call_list(value.invalid_tool_calls)
+            if inv_changed:
+                update["invalid_tool_calls"] = new_inv_list
+
+        if not update:
+            return value
+        return value.model_copy(update=update)
+
+
+class _PIIStreamTransformer(_PIIRedactor, StreamTransformer):
     """Mutates `content-block-delta` text on `messages` events in flight.
 
     Runs before built-in stream transformers so the redacted text is what
@@ -216,106 +322,6 @@ class _PIIStreamTransformer(StreamTransformer):
             data["delta"] = combined[:emit_end]
         elif isinstance(delta, (dict, list)):
             data["delta"] = self._redact_value(delta)
-
-    def _redact_tool_call_list(self, calls: list[Any] | None) -> tuple[list[Any], bool]:
-        """Walk a list of tool-call (or invalid-tool-call) dicts.
-
-        Returns `(new_list, changed)`. Each element's `args` is run
-        through `_redact_value` regardless of its type — `tool_call.args`
-        is a dict, `invalid_tool_call.args` is a raw JSON string, and
-        `_redact_value` handles both shapes uniformly. If nothing
-        changed, returns the input list and `changed=False`.
-        """
-        if not calls:
-            return calls or [], False
-        new_calls: list[Any] = []
-        changed = False
-        for tc in calls:
-            if isinstance(tc, dict) and "args" in tc and tc["args"] is not None:
-                redacted = self._redact_value(tc["args"])
-                if redacted != tc["args"]:
-                    new_tc = dict(tc)
-                    new_tc["args"] = redacted
-                    new_calls.append(new_tc)
-                    changed = True
-                    continue
-            new_calls.append(tc)
-        return new_calls, changed
-
-    def _redact_value(self, value: Any) -> Any:
-        """Recursively redact PII in string leaves of a nested structure.
-
-        Returns a new value where every `str` leaf that contains PII has
-        been replaced (or emptied under `block`). Non-string leaves and
-        the structure itself are preserved.
-
-        `BaseMessage` payloads (typically `ToolMessage` from
-        `tool-finished.output`, or any message reached via the `values`
-        channel) return a fresh copy with `.content` redacted plus
-        `AIMessage.tool_calls[*].args` / `invalid_tool_calls[*].args`
-        walked. The original object stays intact for state-level
-        enforcers (`after_model`, `before_model` with
-        `apply_to_tool_results`) to act on independently.
-
-        Scope mirrors the pre-streaming state-level surfaces:
-        `.content` (string or list-of-content-blocks) and `tool_calls`
-        args. Other message attributes (`additional_kwargs`,
-        `response_metadata`, `ToolMessage.artifact`) are intentionally
-        not walked here — they aren't scrubbed in graph state by the
-        existing hooks, so scrubbing them on the wire would create
-        a wire/state divergence.
-        """
-        if isinstance(value, str):
-            if not value:
-                return value
-            matches = self._rule.detector(value)
-            if not matches:
-                return value
-            # `apply_strategy` raises `PIIDetectionError` under `block`
-            # — the run fails immediately rather than buffering until a
-            # state-level hook can raise.
-            return apply_strategy(value, matches, self._rule.strategy)
-        if isinstance(value, BaseMessage):
-            return self._redact_base_message(value)
-        if isinstance(value, dict):
-            return {k: self._redact_value(v) for k, v in value.items()}
-        if isinstance(value, list):
-            return [self._redact_value(v) for v in value]
-        if isinstance(value, tuple):
-            return tuple(self._redact_value(v) for v in value)
-        return value
-
-    def _redact_base_message(self, value: BaseMessage) -> BaseMessage:
-        """Return a fresh copy of `value` with PII-carrying surfaces redacted."""
-        update: dict[str, Any] = {}
-
-        content = value.content
-        if isinstance(content, str) and content:
-            matches = self._rule.detector(content)
-            if matches:
-                update["content"] = apply_strategy(content, matches, self._rule.strategy)
-        elif isinstance(content, list) and content:
-            # Structured content-blocks shape:
-            # `[{"type": "text", "text": "..."}, {"type": "tool_call", ...}, ...]`.
-            redacted_content = self._redact_value(content)
-            if redacted_content != content:
-                update["content"] = redacted_content
-
-        # `AIMessage.tool_calls` and `.invalid_tool_calls` carry PII in
-        # `args` independently of `.content`. `tool_call.args` is a
-        # dict; `invalid_tool_call.args` is a raw JSON string —
-        # `_redact_value` handles both shapes via the recursion.
-        if isinstance(value, AIMessage):
-            new_tc_list, tc_changed = self._redact_tool_call_list(value.tool_calls)
-            if tc_changed:
-                update["tool_calls"] = new_tc_list
-            new_inv_list, inv_changed = self._redact_tool_call_list(value.invalid_tool_calls)
-            if inv_changed:
-                update["invalid_tool_calls"] = new_inv_list
-
-        if not update:
-            return value
-        return value.model_copy(update=update)
 
     def _mutate_delta(self, payload: dict[str, Any], run_id: str) -> None:
         delta = payload.get("delta")
@@ -489,7 +495,7 @@ class _PIIStreamTransformer(StreamTransformer):
         self._tool_buffers.clear()
 
 
-class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
+class PIIMiddleware(_PIIRedactor, AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
     """Detect and handle Personally Identifiable Information (PII) in conversations.
 
     This middleware detects common PII types and applies configurable strategies
@@ -631,6 +637,7 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
             strategy=strategy,
             detector=detector,
         ).resolve()
+        self._rule = self._resolved_rule
         self.pii_type = self._resolved_rule.pii_type
         self.strategy = self._resolved_rule.strategy
         self.detector = self._resolved_rule.detector
@@ -659,14 +666,6 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
     def name(self) -> str:
         """Name of the middleware."""
         return f"{self.__class__.__name__}[{self.pii_type}]"
-
-    def _process_content(self, content: str) -> tuple[str, list[PIIMatch]]:
-        """Apply the configured redaction rule to the provided content."""
-        matches = self.detector(content)
-        if not matches:
-            return content, []
-        sanitized = apply_strategy(content, matches, self.strategy)
-        return sanitized, matches
 
     @hook_config(can_jump_to=["end"])
     @override
@@ -709,19 +708,12 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                     last_user_idx = i
                     break
 
-            if last_user_idx is not None and last_user_msg and last_user_msg.content:
-                # Detect PII in message content
-                content = str(last_user_msg.content)
-                new_content, matches = self._process_content(content)
-
-                if matches:
-                    updated_message: AnyMessage = HumanMessage(
-                        content=new_content,
-                        id=last_user_msg.id,
-                        name=last_user_msg.name,
-                    )
-
-                    new_messages[last_user_idx] = updated_message
+            if last_user_idx is not None and last_user_msg:
+                updated_user_message = cast(
+                    "HumanMessage", self._redact_base_message(last_user_msg)
+                )
+                if updated_user_message is not last_user_msg:
+                    new_messages[last_user_idx] = updated_user_message
                     any_modified = True
 
         # Check tool results if enabled
@@ -738,26 +730,10 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                 for i in range(last_ai_idx + 1, len(messages)):
                     msg = messages[i]
                     if isinstance(msg, ToolMessage):
-                        tool_msg = msg
-                        if not tool_msg.content:
-                            continue
-
-                        content = str(tool_msg.content)
-                        new_content, matches = self._process_content(content)
-
-                        if not matches:
-                            continue
-
-                        # Create updated tool message
-                        updated_message = ToolMessage(
-                            content=new_content,
-                            id=tool_msg.id,
-                            name=tool_msg.name,
-                            tool_call_id=tool_msg.tool_call_id,
-                        )
-
-                        new_messages[i] = updated_message
-                        any_modified = True
+                        updated_tool_message = cast("ToolMessage", self._redact_base_message(msg))
+                        if updated_tool_message is not msg:
+                            new_messages[i] = updated_tool_message
+                            any_modified = True
 
         if any_modified:
             return {"messages": new_messages}
@@ -821,27 +797,16 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                 last_ai_idx = i
                 break
 
-        if last_ai_idx is None or not last_ai_msg or not last_ai_msg.content:
+        if last_ai_idx is None or not last_ai_msg:
             return None
 
-        # Detect PII in message content
-        content = str(last_ai_msg.content)
-        new_content, matches = self._process_content(content)
-
-        if not matches:
+        updated_ai_message = cast("AIMessage", self._redact_base_message(last_ai_msg))
+        if updated_ai_message is last_ai_msg:
             return None
-
-        # Create updated message
-        updated_message = AIMessage(
-            content=new_content,
-            id=last_ai_msg.id,
-            name=last_ai_msg.name,
-            tool_calls=last_ai_msg.tool_calls,
-        )
 
         # Return updated messages
         new_messages = list(messages)
-        new_messages[last_ai_idx] = updated_message
+        new_messages[last_ai_idx] = updated_ai_message
 
         return {"messages": new_messages}
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -401,6 +401,50 @@ class TestPIIMiddlewareIntegration:
         assert result is not None
         assert "[REDACTED_EMAIL]" in result["messages"][0].content
 
+    def test_apply_to_input_preserves_structured_content(self) -> None:
+        """State hook redacts structured message content without stringifying it."""
+        middleware = PIIMiddleware("email", strategy="redact", apply_to_input=True)
+        state = AgentState[Any](
+            messages=[
+                HumanMessage(content=[{"type": "text", "text": "Reach me at alice@example.com"}])
+            ]
+        )
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        content = result["messages"][0].content
+        assert isinstance(content, list)
+        assert content == [{"type": "text", "text": "Reach me at [REDACTED_EMAIL]"}]
+
+    def test_apply_to_output_redacts_tool_call_args_without_content(self) -> None:
+        """State hook redacts tool-call args even when AI message content is empty."""
+        middleware = PIIMiddleware("email", strategy="redact", apply_to_output=True)
+        state = AgentState[Any](
+            messages=[
+                HumanMessage("hi"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        ToolCall(
+                            name="send_email",
+                            args={"to": "alice@example.com"},
+                            id="call_123",
+                            type="tool_call",
+                        )
+                    ],
+                ),
+            ]
+        )
+
+        result = middleware.after_model(state, Runtime())
+
+        assert result is not None
+        ai_msg = result["messages"][1]
+        assert isinstance(ai_msg, AIMessage)
+        assert ai_msg.content == ""
+        assert ai_msg.tool_calls[0]["args"] == {"to": "[REDACTED_EMAIL]"}
+
     def test_apply_to_both(self) -> None:
         """Test that middleware processes both input and output."""
         middleware = PIIMiddleware(


### PR DESCRIPTION
Closes #37659

---

`PIIMiddleware` state hooks had drifted from the recursive redaction path used by streamed values. `before_model` still stringified structured message content, and `after_model` skipped tool-call-only `AIMessage`s when `content` was empty.

This refactors the recursive message redaction helpers into a shared private redactor used by both the stream transformer and the state-level middleware hooks. The hooks keep their existing scope: last user message, tool messages after the last AI message, and the last AI message. They now preserve structured content shape and redact `tool_calls[*].args` consistently.

Added regression coverage for structured input content and empty-content AI tool-call args, alongside the existing full PII middleware test file.

AI-agent involvement: this contribution was prepared with AI-agent assistance and verified locally before submission.
