### PR TITLE
docs(langchain): fix typo "capabilites" → "capabilities" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 LangChain is a framework for building agents and LLM-powered applications. It helps you chain together interoperable components and third-party integrations to simplify AI application development — all while future-proofing decisions as the underlying technology evolves.
 
 > [!TIP]
-> Just getting started? Check out **[Deep Agents](http://docs.langchain.com/oss/python/deepagents/)** — a higher-level package built on LangChain for agents that have built-in capabilites for common usage patterns such as planning, subagents, file system usage, and more.
+> Just getting started? Check out **[Deep Agents](http://docs.langchain.com/oss/python/deepagents/)** — a higher-level package built on LangChain for agents that have built-in capabilities for common usage patterns such as planning, subagents, file system usage, and more.
 
 ## Quickstart
 


### PR DESCRIPTION
Fixed a spelling typo in the README.

   "capabilites" → "capabilities" in the Deep Agents tip section.