### PR TITLE
feat(openai): Added support for video block conversion

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -55,6 +55,45 @@ def convert_to_openai_image_block(block: dict[str, Any]) -> dict:
     raise ValueError(error_message)
 
 
+def convert_to_openai_video_block(block: dict[str, Any]) -> dict:
+    """Convert `VideoContentBlock` to format expected by OpenAI Chat Completions.
+
+    Args:
+        block: The video content block to convert.
+
+    Raises:
+        ValueError: If required keys are missing.
+        ValueError: If source type is unsupported.
+
+    Returns:
+        The formatted image content block.
+    """
+    if "url" in block:
+        return {
+            "type": "video_url",
+            "video_url": {
+                "url": block["url"],
+            },
+        }
+    if "base64" in block or block.get("source_type") == "base64":
+        if "mime_type" not in block:
+            error_message = "mime_type key is required for base64 data."
+            raise ValueError(error_message)
+        mime_type = block["mime_type"]
+        base64_data = block["data"] if "data" in block else block["base64"]
+        return {
+            "type": "video_url",
+            "video_url": {
+                "url": f"data:{mime_type};base64,{base64_data}",
+            },
+        }
+    if "file_id" in block or block.get("source_type") == "id":
+        file_id = block["id"] if "source_type" in block else block["file_id"]
+        return {"type": "video", "video": file_id}
+    error_message = "Unsupported source type. Only 'url' and 'base64' and 'file_id' are supported."
+    raise ValueError(error_message)
+
+
 def convert_to_openai_data_block(
     block: dict, api: Literal["chat/completions", "responses"] = "chat/completions"
 ) -> dict:
@@ -88,6 +127,21 @@ def convert_to_openai_data_block(
                 ]
         else:
             formatted_block = chat_completions_block
+
+    elif block["type"] == "video":
+        chat_completions_block = convert_to_openai_video_block(block)
+        print(chat_completions_block)
+        if api == "responses" and chat_completions_block.get("video_url"):
+            formatted_block = {
+                "type": "input_video",
+                "video_url": chat_completions_block["video_url"]["url"],
+            }
+            if chat_completions_block["video_url"].get("detail"):
+                formatted_block["detail"] = chat_completions_block["video_url"]["detail"]
+        else:
+            formatted_block = chat_completions_block
+        if extras := block.get("extras"):
+            formatted_block.update(extras)
 
     elif block["type"] == "file":
         if block.get("source_type") == "base64" or "base64" in block:

--- a/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_openai.py
@@ -503,6 +503,55 @@ def test_convert_to_openai_data_block() -> None:
     result = convert_to_openai_data_block(block)
     assert result == expected
 
+    # Video / url
+    block = {
+        "type": "video",
+        "url": "https://example.com/test.mp4",
+        "extras":{
+            "fps":2
+        }
+    }
+    expected = {
+        "type": "video_url",
+        "video_url": {"url": "https://example.com/test.mp4"},
+        "fps": 2
+    }
+    result = convert_to_openai_data_block(block)
+    assert result == expected
+
+    # Video / file_id
+    block = {
+        "type": "video",
+        "file_id": "/test.mp4",
+        "extras": {
+            "fps": 2
+        }
+    }
+    expected = {
+        "type": "video",
+        "video": "/test.mp4",
+        "fps": 2
+    }
+    result = convert_to_openai_data_block(block)
+    assert result == expected
+
+    # Image / base64
+    block = {
+        "type": "video",
+        "base64": "<base64 string>",
+        "mime_type": "video/mp4",
+        "extras": {
+            "fps": 2
+        }
+    }
+    expected = {
+        "type": "video_url",
+        "video_url": {"url": "data:video/mp4;base64,<base64 string>"},
+        "fps": 2
+    }
+    result = convert_to_openai_data_block(block)
+    assert result == expected
+
     # File / url
     block = {
         "type": "file",
@@ -569,6 +618,55 @@ def test_convert_to_openai_data_block() -> None:
     expected = {
         "type": "input_image",
         "image_url": "data:image/png;base64,<base64 string>",
+    }
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == expected
+
+    # Video / url
+    block = {
+        "type": "video",
+        "url": "https://example.com/test.mp4",
+        "extras": {
+            "fps": 2
+        }
+    }
+    expected = {
+        "type": "input_video",
+        "video_url": "https://example.com/test.mp4",
+        "fps": 2
+    }
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == expected
+
+    # Video / file_id
+    block = {
+        "type": "video",
+        "file_id": "/test.mp4",
+        "extras": {
+            "fps": 2
+        }
+    }
+    expected = {
+        "type": "video",
+        "video": "/test.mp4",
+        "fps": 2
+    }
+    result = convert_to_openai_data_block(block, api="responses")
+    assert result == expected
+
+    # Image / base64
+    block = {
+        "type": "video",
+        "base64": "<base64 string>",
+        "mime_type": "video/mp4",
+        "extras": {
+            "fps": 2
+        }
+    }
+    expected = {
+        "type": "input_video",
+        "video_url": "data:video/mp4;base64,<base64 string>",
+        "fps": 2
     }
     result = convert_to_openai_data_block(block, api="responses")
     assert result == expected


### PR DESCRIPTION
Fixes #37770
VideoContentBlock ValueError: Block of type video is not supported
convert_to_openai_data_block VideoContentBlock has not been implemented

feat(openai): Added support for video block conversion

Implemented the convert_to_openai_video_block function to handle video content block conversion
Supported multiple video source types including URL, base64 encoding, and file ID
Added complete processing logic for video block types
Implemented video block formatting under API response mode
Expanded test cases to cover various video source scenarios
Added support for passing through the extras field