### PR TITLE
fix(text-splitters): preserve nested media source URLs

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -773,6 +773,19 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
             transformed.extend(splits)
         return transformed
 
+    @staticmethod
+    def _get_media_src(tag: Tag) -> str:
+        src = tag.get("src", "")
+        if isinstance(src, str) and src:
+            return src
+
+        source_tag = tag.find("source", src=True)
+        if isinstance(source_tag, Tag):
+            source_src = source_tag.get("src", "")
+            if isinstance(source_src, str):
+                return source_src
+        return ""
+
     def _process_media(self, soup: BeautifulSoup) -> None:
         """Processes the media elements.
 
@@ -792,7 +805,7 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
 
         if self._preserve_videos:
             for video_tag in _find_all_tags(soup, name="video"):
-                video_src = video_tag.get("src", "")
+                video_src = self._get_media_src(video_tag)
                 markdown_video = f"![video:{video_src}]({video_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_video
@@ -800,7 +813,7 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
 
         if self._preserve_audio:
             for audio_tag in _find_all_tags(soup, name="audio"):
-                audio_src = audio_tag.get("src", "")
+                audio_src = self._get_media_src(audio_tag)
                 markdown_audio = f"![audio:{audio_src}]({audio_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_audio

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3975,6 +3975,42 @@ def test_html_splitter_with_media_preservation() -> None:
 
 
 @pytest.mark.requires("bs4")
+def test_html_splitter_with_nested_media_sources() -> None:
+    """Test HTML splitter preserves media URLs from nested source tags."""
+    html_content = """
+    <h1>Section 1</h1>
+    <p>This is a video:</p>
+    <video controls>
+        <source src="http://example.com/video.mp4" type="video/mp4" />
+    </video>
+    <p>This is audio:</p>
+    <audio controls>
+        <source src="http://example.com/audio.mp3" type="audio/mpeg" />
+    </audio>
+    """
+    with suppress_langchain_beta_warning():
+        splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")],
+            preserve_videos=True,
+            preserve_audio=True,
+            max_chunk_size=1000,
+        )
+    documents = splitter.split_text(html_content)
+
+    expected = [
+        Document(
+            page_content="This is a video: ![video:http://example.com/video.mp4]"
+            "(http://example.com/video.mp4) "
+            "This is audio: ![audio:http://example.com/audio.mp3]"
+            "(http://example.com/audio.mp3)",
+            metadata={"Header 1": "Section 1"},
+        ),
+    ]
+
+    assert documents == expected
+
+
+@pytest.mark.requires("bs4")
 def test_html_splitter_keep_separator_true() -> None:
     """Test HTML splitting with keep_separator=True."""
     html_content = """


### PR DESCRIPTION
Fixes #37826

`HTMLSemanticPreservingSplitter` now falls back to the first nested `<source src="...">` when preserving `<video>` and `<audio>` tags without a direct `src`. This keeps the existing direct-`src` behavior while avoiding empty media links for common HTML media markup.

Verified with:

- `uv run --no-sync pytest tests/unit_tests/test_text_splitters.py -k 'html_splitter_with_media_preservation or html_splitter_with_nested_media_sources'`
- `uv run --no-sync pytest tests/unit_tests/test_text_splitters.py -k 'HTMLSemanticPreservingSplitter or html_splitter'`
- `uv run --no-sync pytest tests/unit_tests/test_text_splitters.py`
- `uv run --no-sync python -m py_compile langchain_text_splitters/html.py tests/unit_tests/test_text_splitters.py`
- `uv run --group lint ruff check langchain_text_splitters/html.py tests/unit_tests/test_text_splitters.py`
- `uv run --group lint ruff format langchain_text_splitters/html.py tests/unit_tests/test_text_splitters.py --diff`
- `git diff --check -- libs/text-splitters/langchain_text_splitters/html.py libs/text-splitters/tests/unit_tests/test_text_splitters.py`