### PR TITLE
fix: preserve generator inputs in VectorStore.add_texts

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -86,7 +86,7 @@ class VectorStore(ABC):
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             if ids is not None:
                 # For backward compatibility
@@ -226,7 +226,7 @@ class VectorStore(ABC):
 
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             return await self.aadd_documents(docs, **kwargs)
         return await run_in_executor(None, self.add_texts, texts, metadatas, **kwargs)

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -236,6 +236,29 @@ async def test_default_aadd_texts(vs_class: type[VectorStore]) -> None:
     ]
 
 
+
+def test_default_add_texts_accepts_generator() -> None:
+    store = CustomAddDocumentsVectorstore()
+
+    ids_ = store.add_texts((text for text in ["alpha", "beta"]))
+
+    assert len(ids_) == 2
+    assert store.get_by_ids(ids_) == [
+        Document(id=ids_[0], page_content="alpha"),
+        Document(id=ids_[1], page_content="beta"),
+    ]
+
+
+async def test_default_aadd_texts_accepts_generator() -> None:
+    store = CustomAddDocumentsVectorstore()
+
+    ids_ = await store.aadd_texts((text for text in ["alpha", "beta"]))
+
+    assert len(ids_) == 2
+    assert await store.aget_by_ids(ids_) == [
+        Document(id=ids_[0], page_content="alpha"),
+        Document(id=ids_[1], page_content="beta"),
+    ]
 @pytest.mark.parametrize(
     "vs_class", [CustomAddTextsVectorstore, CustomAddDocumentsVectorstore]
 )


### PR DESCRIPTION
Fixes #37673.

### Summary
- build `Document` objects from the materialized `texts_` sequence in default `add_texts` and `aadd_texts`
- add sync and async regression coverage for generator inputs

### Tests
- Not run locally; patch created through the GitHub API.