### PR TITLE
fix: tolerate malformed raw tool calls

### DIFF
--- a/libs/core/langchain_core/messages/tool.py
+++ b/libs/core/langchain_core/messages/tool.py
@@ -362,9 +362,35 @@ def default_tool_parser(
     for raw_tool_call in raw_tool_calls:
         if "function" not in raw_tool_call:
             continue
-        function_name = raw_tool_call["function"]["name"]
+        function = raw_tool_call["function"]
+        if not isinstance(function, dict):
+            invalid_tool_calls.append(
+                invalid_tool_call(
+                    name=None,
+                    args=None,
+                    id=raw_tool_call.get("id"),
+                    error=None,
+                )
+            )
+            continue
+
+        function_name = function.get("name")
+        if not isinstance(function_name, str):
+            function_name = None
+        function_arguments = function.get("arguments")
+        if not isinstance(function_arguments, str):
+            invalid_tool_calls.append(
+                invalid_tool_call(
+                    name=function_name,
+                    args=None,
+                    id=raw_tool_call.get("id"),
+                    error=None,
+                )
+            )
+            continue
+
         try:
-            function_args = json.loads(raw_tool_call["function"]["arguments"])
+            function_args = json.loads(function_arguments)
             parsed = tool_call(
                 name=function_name or "",
                 args=function_args or {},
@@ -375,7 +401,7 @@ def default_tool_parser(
             invalid_tool_calls.append(
                 invalid_tool_call(
                     name=function_name,
-                    args=raw_tool_call["function"]["arguments"],
+                    args=function_arguments,
                     id=raw_tool_call.get("id"),
                     error=None,
                 )
@@ -394,12 +420,17 @@ def default_tool_chunk_parser(raw_tool_calls: list[dict]) -> list[ToolCallChunk]
     """
     tool_call_chunks = []
     for tool_call in raw_tool_calls:
-        if "function" not in tool_call:
+        function = tool_call.get("function")
+        if isinstance(function, dict):
+            function_args = function.get("arguments")
+            function_name = function.get("name")
+        else:
             function_args = None
             function_name = None
-        else:
-            function_args = tool_call["function"]["arguments"]
-            function_name = tool_call["function"]["name"]
+        if not isinstance(function_args, str):
+            function_args = None
+        if not isinstance(function_name, str):
+            function_name = None
         parsed = tool_call_chunk(
             name=function_name,
             args=function_args,

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -30,6 +30,7 @@ from langchain_core.messages import (
     messages_to_dict,
 )
 from langchain_core.messages.content import KNOWN_BLOCK_TYPES, ContentBlock
+from langchain_core.messages.tool import default_tool_chunk_parser, default_tool_parser
 from langchain_core.messages.tool import invalid_tool_call as create_invalid_tool_call
 from langchain_core.messages.tool import tool_call as create_tool_call
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
@@ -487,6 +488,51 @@ def test_message_chunk_to_message() -> None:
     assert AIMessageChunk(**chunk.model_dump()) == chunk
 
 
+def test_default_tool_parser_keeps_valid_calls_with_malformed_function() -> None:
+    tool_calls, invalid_tool_calls = default_tool_parser(
+        [
+            {"id": "bad-function", "function": None},
+            {
+                "id": "valid",
+                "function": {"name": "search", "arguments": '{"query": "docs"}'},
+            },
+            {"id": "missing-arguments", "function": {"name": "search"}},
+            {"id": "bad-json", "function": {"name": "search", "arguments": "{"}},
+        ]
+    )
+
+    assert tool_calls == [
+        create_tool_call(name="search", args={"query": "docs"}, id="valid")
+    ]
+    assert invalid_tool_calls == [
+        create_invalid_tool_call(name=None, args=None, id="bad-function", error=None),
+        create_invalid_tool_call(
+            name="search", args=None, id="missing-arguments", error=None
+        ),
+        create_invalid_tool_call(name="search", args="{", id="bad-json", error=None),
+    ]
+
+
+def test_default_tool_chunk_parser_handles_malformed_function() -> None:
+    assert default_tool_chunk_parser(
+        [
+            {"id": "bad-function", "index": 0, "function": None},
+            {
+                "id": "valid",
+                "index": 1,
+                "function": {"name": "search", "arguments": "{}"},
+            },
+            {
+                "id": "bad-arguments",
+                "index": 2,
+                "function": {"name": "search", "arguments": {"query": "docs"}},
+            },
+        ]
+    ) == [
+        create_tool_call_chunk(name=None, args=None, id="bad-function", index=0),
+        create_tool_call_chunk(name="search", args="{}", id="valid", index=1),
+        create_tool_call_chunk(name="search", args=None, id="bad-arguments", index=2),
+    ]
 def test_tool_calls_merge() -> None:
     chunks: list[dict] = [
         {"content": ""},


### PR DESCRIPTION
Fixes #36679.

### Summary
- validate raw `function` payloads before indexing into them
- classify malformed function payloads as invalid tool calls without dropping later valid calls
- make chunk parsing tolerate malformed `function` payloads as best-effort chunks

### Tests
- Not run locally; patch created through the GitHub API.