### PR TITLE
fix(openai): strip __api_exclude__ fields when dumping Responses API output items

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4381,6 +4381,28 @@ def _pop_index_and_sub_index(block: dict) -> dict:
     return new_block
 
 
+def _dump_for_content_block(obj: BaseModel) -> dict:
+    """Dump an OpenAI Responses API output item to a dict suitable for use as
+    a LangChain content block.
+
+    Honors the OpenAI SDK's ``__api_exclude__`` class attribute (e.g. set on
+    ``ParsedResponseFunctionToolCall`` for ``parsed_arguments``) so that
+    client-side-only fields do not leak into ``AIMessage.content`` and, on the
+    next turn, into the request body sent back to the Responses API. Without
+    this, the endpoint rejects follow-up requests with
+    ``BadRequestError: Unknown parameter: 'input[N].parsed_arguments'``.
+
+    The OpenAI Python SDK applies the same convention when serializing models
+    for transport (see ``openai/_utils/_transform.py``); this helper mirrors it
+    for the content-block dump path.
+    """
+    return obj.model_dump(
+        exclude_none=True,
+        mode="json",
+        exclude=getattr(obj, "__api_exclude__", None),
+    )
+
+
 def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
     """Construct the input for the OpenAI Responses API."""
     input_ = []
@@ -4658,7 +4680,7 @@ def _construct_lc_result_from_responses_api(
                         refusal_block["phase"] = phase
                     content_blocks.append(refusal_block)
         elif output.type == "function_call":
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            content_blocks.append(_dump_for_content_block(output))
             try:
                 args = json.loads(output.arguments, strict=False)
                 error = None
@@ -4683,7 +4705,7 @@ def _construct_lc_result_from_responses_api(
                 }
                 invalid_tool_calls.append(tool_call)
         elif output.type == "custom_tool_call":
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            content_blocks.append(_dump_for_content_block(output))
             tool_call = {
                 "type": "tool_call",
                 "name": output.name,
@@ -4705,7 +4727,7 @@ def _construct_lc_result_from_responses_api(
             "tool_search_call",
             "tool_search_output",
         ):
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            content_blocks.append(_dump_for_content_block(output))
 
     # Workaround for parsing structured output in the streaming case.
     #    from openai import OpenAI

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -37,6 +37,7 @@ from langchain_core.tracers.base import BaseTracer
 from langchain_core.tracers.schemas import Run
 from openai.types.responses import ResponseOutputMessage, ResponseReasoningItem
 from openai.types.responses.response import IncompleteDetails, Response
+from openai.types.responses.parsed_response import ParsedResponseFunctionToolCall
 from openai.types.responses.response_error import ResponseError
 from openai.types.responses.response_file_search_tool_call import (
     ResponseFileSearchToolCall,
@@ -1766,6 +1767,64 @@ def test__construct_lc_result_from_responses_api_function_call_valid_json() -> N
             "call_id": "call_123",
         }
     ]
+
+
+def test__construct_lc_result_from_responses_api_function_call_strips_parsed_arguments() -> None:
+    """``ParsedResponseFunctionToolCall.parsed_arguments`` must not leak into
+    ``AIMessage.content`` content blocks.
+
+    The OpenAI SDK marks ``parsed_arguments`` as a client-side-only field via
+    ``__api_exclude__ = {"parsed_arguments"}``. If the field reaches
+    ``AIMessage.content`` it will be re-sent on the next turn via
+    ``_construct_responses_api_input`` and the Responses endpoint rejects the
+    request with::
+
+        BadRequestError: Unknown parameter: 'input[N].parsed_arguments'.
+
+    Regression test for that round-trip break.
+    """
+    response = Response(
+        id="resp_parsed",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ParsedResponseFunctionToolCall(
+                type="function_call",
+                id="func_parsed",
+                call_id="call_parsed",
+                name="get_weather",
+                arguments='{"location": "New York", "unit": "celsius"}',
+                parsed_arguments={"location": "New York", "unit": "celsius"},
+            )
+        ],
+    )
+
+    # responses/v1 — content blocks must not carry ``parsed_arguments``.
+    result = _construct_lc_result_from_responses_api(response)
+    msg = cast(AIMessage, result.generations[0].message)
+    assert isinstance(msg.content, list)
+    assert len(msg.content) == 1
+    block = msg.content[0]
+    assert isinstance(block, dict)
+    assert block["type"] == "function_call"
+    assert block["call_id"] == "call_parsed"
+    assert block["name"] == "get_weather"
+    assert block["arguments"] == '{"location": "New York", "unit": "celsius"}'
+    assert "parsed_arguments" not in block, (
+        "parsed_arguments leaked into the content block; it would be rejected by "
+        "the Responses API on the next turn (`Unknown parameter: 'input[N]."
+        "parsed_arguments'`)."
+    )
+
+    # The standardized ``tool_calls`` field is still populated.
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0]["name"] == "get_weather"
+    assert msg.tool_calls[0]["id"] == "call_parsed"
+    assert msg.tool_calls[0]["args"] == {"location": "New York", "unit": "celsius"}
 
 
 def test__construct_lc_result_from_responses_api_function_call_invalid_json() -> None:


### PR DESCRIPTION
Fixes #37836

## Description
  
  When `ChatOpenAI` is used against the Responses API with `output_version="responses/v1"` together with structured output and tool bindings (e.g. `with_structured_output(method="json_schema", strict=True,
  include_raw=True, tools=...)`), the second turn of a ReAct-style loop fails with:

  ```
  openai.BadRequestError: Error code: 400 - {
    'error': {
      'message': "Unknown parameter: 'input[N].parsed_arguments'.",
      'type': 'invalid_request_error',
      'param': 'input[N].parsed_arguments',
      'code': 'unknown_parameter'
    }
  }
  ```
  
  ## Root cause

  `_construct_lc_result_from_responses_api` builds `AIMessage.content` content blocks for each output item by calling `output.model_dump(exclude_none=True, mode="json")` (at three sites around lines 4661, 4686, 4708 in
  `base.py`).

  When the request used `text_format` (structured output via `responses.parse()`), the SDK returns `ParsedResponseFunctionToolCall` instances whose `parsed_arguments` field carries the already-parsed Python object. The
  SDK marks this field as client-side-only via:

  ```python
  # openai/types/responses/parsed_response.py
  class ParsedResponseFunctionToolCall(ResponseFunctionToolCall):
      parsed_arguments: object = None
      __api_exclude__ = {"parsed_arguments"}
  ```

  The OpenAI Python SDK honors `__api_exclude__` itself when serializing models for transport (`openai/_utils/_transform.py:221`):

  ```python
  return model_dump(data, exclude_unset=True, mode="json",
                    exclude=getattr(data, "__api_exclude__", None))
  ```

  `langchain-openai`'s plain `model_dump(exclude_none=True, mode="json")` doesn't follow that convention, so `parsed_arguments` lands inside the AIMessage content block. On the next turn,
  `_construct_responses_api_input` routes the block through `_pop_index_and_sub_index` (which only strips `index`) and re-sends it as an `input` item. OpenAI rejects the request.

  ## Fix

  Introduce a small helper next to `_pop_index_and_sub_index` that mirrors the OpenAI SDK's convention, and use it at the three sites in `_construct_lc_result_from_responses_api` that dump SDK output items into
  LangChain content blocks (`function_call`, `custom_tool_call`, and the reasoning / web_search_call / file_search_call / … group):

  ```python
  def _dump_for_content_block(obj: BaseModel) -> dict:
      return obj.model_dump(
          exclude_none=True,
          mode="json",
          exclude=getattr(obj, "__api_exclude__", None),
      )
  ```
  
  The behavior is unchanged for any output type that doesn't declare `__api_exclude__` (i.e., the existing test surface stays green — verified: 13 of 13 `test__construct_lc_result_from_responses_api_*` tests still
  pass). It only differs for items that do — currently only `ParsedResponseFunctionToolCall`, but future SDK additions automatically benefit.

  The streaming-side `model_dump` sites (around lines 4867, 4963, 4971, 4996) follow the same pattern and are good follow-up candidates, but are out of scope here to keep this PR focused. They don't currently exhibit
  the bug because no `__api_exclude__`-bearing type flows through them yet.

  ## Minimal repro

  ```python
  from langchain_openai import ChatOpenAI
  from langchain_core.tools import tool
  from pydantic import BaseModel

  class Answer(BaseModel):
      response: str

  @tool
  def now() -> str:
      """Return current time."""
      return "12:00"

  llm = ChatOpenAI(model="gpt-4o-mini", output_version="responses/v1")
  runnable = llm.with_structured_output(
      Answer, method="json_schema", strict=True, include_raw=True, tools=[now]
  )
  
  # Turn 1: succeeds, AI requests the tool.
  m1 = runnable.invoke("What time is it?")

  # Turn 2: re-sends the AIMessage; fails with parsed_arguments BadRequestError.
  runnable.invoke([
      ("user", "What time is it?"),
      m1["raw"],
      ("tool", "12:00"),
  ])
  ```

  ## Test added

  `libs/partners/openai/tests/unit_tests/chat_models/test_base.py`: `test__construct_lc_result_from_responses_api_function_call_strips_parsed_arguments`. Constructs a `Response` carrying a
  `ParsedResponseFunctionToolCall` with `parsed_arguments` populated and asserts that the resulting AIMessage's `content` blocks do not include the field.

  ## References

  - Currently-tracking issue (filed against the OpenAI SDK repo by mistake): https://github.com/openai/openai-python/issues/2720
  - Same-shape PR for the Chat Completions path: #35543 (*avoid PydanticSerializationUnexpectedValue for structured output*)
  - OpenAI SDK declaration of the field: `openai/types/responses/parsed_response.py:67-70`
  - OpenAI SDK's own honoring of `__api_exclude__`: `openai/_utils/_transform.py:221`
