### PR TITLE
fix: handle missing trailing newline in ShellSession._collect_output

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -265,8 +265,11 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
-                _, _, status = data.partition(" ")
+            if source == "stdout" and marker in data:
+                marker_idx = data.index(marker)
+                if marker_idx > 0:
+                    collected.append(data[:marker_idx])
+                _, _, status = data[marker_idx + len(marker):].partition(" ")
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.
                 # The stderr reader thread runs independently, so output might


### PR DESCRIPTION
## What breaks

`ShellSession._collect_output` uses `readline()` to read stdout and detects completion with `data.startswith(marker)`. When a command's last output line has no trailing newline (e.g. `head`, `cat`, `grep` on a minified single-line JSON file), `readline()` blocks until the next newline arrives — which only comes from the marker's own `printf` call. The result is that both are returned in a single `readline()` read:

`{"key":"value"}__LC_SHELL_DONE__abc123 0\n`

The `startswith(marker)` check fails, the loop receives nothing further, and the command times out after the full `command_timeout` (default 30s).

Fixes #37837

## Fix

Change `data.startswith(marker)` to `marker in data` and extract any content before the marker:

```python
if source == "stdout" and marker in data:
    marker_idx = data.index(marker)
    if marker_idx > 0:
        collected.append(data[:marker_idx])
    _, _, status = data[marker_idx + len(marker):].partition(" ")
    exit_code = self._safe_int(status.strip())
```