### PR TITLE
fix: handle marker embedded in output when no trailing newline

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -265,8 +265,11 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
-                _, _, status = data.partition(" ")
+            if source == "stdout" and marker in data:
+                marker_idx = data.index(marker)
+                if marker_idx > 0:
+                    collected.append(data[:marker_idx])
+                _, _, status = data[marker_idx + len(marker) :].partition(" ")
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.
                 # The stderr reader thread runs independently, so output might


### PR DESCRIPTION
### Fixes #37837

ShellSession._collect_output uses readline() to read stdout and detects completion with data.startswith(marker). When output has no trailing newline, readline() returns the output + marker merged. startswith(marker) fails, and the command times out.

Fix: use `marker in data` instead of `data.startswith(marker)`. Extract preceding output before parsing exit code.