### PR TITLE
fix(langchain): detect done-marker merged with unterminated output line

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -265,8 +265,18 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
-                _, _, status = data.partition(" ")
+            if source == "stdout" and marker in data:
+                # The marker is emitted by a `printf` that supplies its own
+                # newline. When a command's final output line has no trailing
+                # newline, `readline()` returns that output merged with the
+                # marker on a single line, so the marker can appear mid-line
+                # rather than at the very start. Preserve any real output that
+                # precedes the marker before extracting the exit status.
+                marker_index = data.index(marker)
+                if marker_index > 0:
+                    collected.append(data[:marker_index])
+                remainder = data[marker_index + len(marker) :]
+                _, _, status = remainder.partition(" ")
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.
                 # The stderr reader thread runs independently, so output might

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -107,6 +107,39 @@ def test_timeout_returns_error(tmp_path: Path) -> None:
         middleware.after_agent(state, runtime)
 
 
+def test_output_without_trailing_newline_does_not_time_out(tmp_path: Path) -> None:
+    """Regression test for a command whose final output line lacks a newline.
+
+    The done-marker is emitted by a ``printf`` that supplies its own newline, so
+    when a command's last line of output has no trailing newline the reader's
+    ``readline()`` returns that output merged with the marker on a single line.
+    Completion detection must recognize the marker mid-line rather than only at
+    the very start, otherwise the marker is never matched and the command times
+    out. See https://github.com/langchain-ai/langchain/issues/37837.
+    """
+    policy = HostExecutionPolicy(command_timeout=5.0)
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=policy)
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+        start = time.monotonic()
+        # `printf` (no `\n` in the format string) emits output without a trailing newline.
+        result = middleware._run_shell_tool(
+            resources, {"command": 'printf \'{"key":"value"}\''}, tool_call_id=None
+        )
+        elapsed = time.monotonic() - start
+        assert isinstance(result, str)
+        assert elapsed < policy.command_timeout
+        assert "timed out" not in result.lower()
+        assert '{"key":"value"}' in result
+    finally:
+        middleware.after_agent(state, runtime)
+
+
 def test_redaction_policy_applies(tmp_path: Path) -> None:
     middleware = ShellToolMiddleware(
         workspace_root=tmp_path / "workspace",


### PR DESCRIPTION
Fixes #37837

---

`ShellSession._collect_output` detects command completion by checking `data.startswith(marker)` on lines read from the shell's stdout. The done-marker is written by a `printf` that supplies its own trailing newline, while the reader thread uses `readline()`, which only returns once a newline is seen.

When a command's final line of output has no trailing newline — common for `printf`, `head`, `cat`, or `grep` on a single-line/minified file — the missing newline only arrives from the marker's own `printf`. As a result `readline()` returns the command output and the marker concatenated on one line (e.g. `{"key":"value"}__LC_SHELL_DONE__<hex> 0\n`). The `startswith` check then fails, no further line ever arrives, and the command times out after the full `command_timeout` (30 s by default).

This changes detection to look for the marker anywhere in the line. Any real output preceding the marker is preserved as normal stdout, and the exit status is parsed from the remainder after the marker. When the marker arrives on its own line (the common case), behavior is unchanged.

Added a regression test that runs a command whose output lacks a trailing newline and asserts it completes promptly instead of timing out.

---

*Disclaimer: this contribution was prepared with the assistance of an AI agent and reviewed by the submitter.*
