### PR TITLE
fix(langchain): prevent ShellSession output collection timeout without trailing newline

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -265,8 +265,11 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
-                _, _, status = data.partition(" ")
+            if source == "stdout" and marker in data:
+                marker_idx = data.index(marker)
+                if marker_idx > 0:
+                    collected.append(data[:marker_idx])
+                _, _, status = data[marker_idx + len(marker):].partition(" ")
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.
                 # The stderr reader thread runs independently, so output might


### PR DESCRIPTION
Fixes #37837

Update `ShellSession._collect_output` to correctly handle command output that does not end with a newline. Previously, the output collection logic could wait until timeout even when the command had already completed, causing unnecessary delays and failures for valid command output.

Added tests covering commands that emit output both with and without a trailing newline to verify consistent behavior.

```
$ make format
[ "." = "" ] || uv run --all-groups ruff format .
Using CPython 3.13.3
Creating virtual environment at: .venv
      Built langchain-openai @ file:///home/{hidden-path}/test/ghiander/langchain/libs/partners/openai
      Built langchain-tests @ file:///home/{hidden-path}/test/ghiander/langchain/libs/standard-tests
      Built langchain-core @ file:///home/{hidden-path}/test/ghiander/langchain/libs/core
      Built langchain-text-splitters @ file:///home/{hidden-path}/test/ghiander/langchain/libs/text-splitters
      Built langchain @ file:///home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1
      Built forbiddenfruit==0.1.4
      Built tiktoken==0.12.0
      Built numpy==2.3.4
Installed 82 packages in 60ms
1 file reformatted, 120 files left unchanged
[ "." = "" ] || uv run --all-groups ruff check --fix .
All checks passed!
```

```
$ make lint
[ "." = "" ] || uv run --all-groups ruff check .
All checks passed!
[ "." = "" ] || uv run --all-groups ruff format . --diff
121 files already formatted
[ "." = "" ] || mkdir -p .mypy_cache && uv run --all-groups mypy . --cache-dir .mypy_cache
Success: no issues found in 74 source files
```

```
$ make test
make start_services && LANGGRAPH_TEST_FAST=0 uv run --no-sync --active --group test pytest -n auto  --benchmark-disable --disable-socket --allow-unix-socket tests/unit_tests/ --cov-report term-missing:skip-covered --snapshot-update; \
EXIT_CODE=$?; \
make stop_services; \
exit $EXIT_CODE
make[1]: Entering directory `/home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1'
docker-compose -f tests/unit_tests/agents/compose-postgres.yml -f tests/unit_tests/agents/compose-redis.yml up -V --force-recreate --wait --remove-orphans
make[1]: Leaving directory `/home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1'
============================= test session starts ==============================
platform linux -- Python 3.13.3, pytest-9.0.3, pluggy-1.6.0 -- /home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1/.venv/bin/python
codspeed: 4.2.0 (disabled, mode: walltime, callgraph: enabled, timer_resolution: 1.0ns)
cachedir: .pytest_cache
benchmark: 5.2.3 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1
configfile: pyproject.toml
plugins: socket-0.7.0, asyncio-1.3.0, benchmark-5.2.3, cov-7.0.0, xdist-3.8.0, syrupy-5.1.0, recording-0.13.4, mock-3.15.1, langsmith-0.8.0, codspeed-4.2.0, langchain-tests-1.1.9, anyio-4.11.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
created: 8/8 workers
8 workers [884 items]

scheduling tests via LoadScheduling

tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_empty_handlers_returns_none 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_chaining 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_execution[before-False] 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_conditional_dynamic_tool[True] 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_multiple_decorated_middleware 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_inner_command_propagated_through_composition 
[gw0] [  0%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_empty_handlers_returns_none 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestBasicWrapModelCall::test_counting_middleware 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_can_jump_to_integration 
tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_single_handler_returns_unchanged 
[gw4] [  0%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_chaining 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_sync_only_middleware_works_on_sync_path 
[gw0] [  0%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_single_handler_returns_unchanged 
tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_two_handlers_basic_composition 
[gw0] [  0%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_two_handlers_basic_composition 
tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_two_handlers_with_commands 
[gw0] [  0%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_two_handlers_with_commands 
tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_three_handlers_composition 
[gw6] [  0%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_multiple_decorated_middleware 
[gw5] [  0%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestBasicWrapModelCall::test_counting_middleware 
[gw0] [  0%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_three_handlers_composition 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRetryLogic::test_simple_retry_on_error 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_with_custom_state_schema 
tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_inner_handler_retry 
[gw6] [  1%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_with_custom_state_schema 
[gw0] [  1%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_inner_handler_retry 
tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_error_to_success_conversion 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_with_tools_parameter 
[gw0] [  1%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_error_to_success_conversion 
tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_request_modification 
[gw4] [  1%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_sync_only_middleware_works_on_sync_path 
[gw7] [  1%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_inner_command_propagated_through_composition 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_sync_only_middleware_raises_on_async_path 
[gw0] [  1%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_request_modification 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_non_reducer_key_conflict_raises 
[gw6] [  1%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_with_tools_parameter 
tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_composition_preserves_state_and_runtime 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_parentheses_optional 
[gw6] [  1%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_parentheses_optional 
[gw0] [  1%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_composition_preserves_state_and_runtime 
tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_multiple_yields_in_retry_loop 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_preserves_function_name 
[gw6] [  2%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_preserves_function_name 
[gw0] [  2%] PASSED tests/unit_tests/agents/middleware/core/test_composition.py::TestChainModelCallHandlers::test_multiple_yields_in_retry_loop 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_mixed_with_class_middleware 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_before_model_decorator 
[gw0] [  2%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_before_model_decorator 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_after_model_decorator 
[gw5] [  2%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRetryLogic::test_simple_retry_on_error 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRetryLogic::test_max_retries 
[gw0] [  2%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_after_model_decorator 
[gw6] [  2%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_mixed_with_class_middleware 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_on_model_call_decorator 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_complex_retry_logic 
[gw0] [  2%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_on_model_call_decorator 
[gw7] [  2%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_non_reducer_key_conflict_raises 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_all_decorators_integration 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_inner_state_preserved_when_outer_has_no_conflict 
[gw7] [  2%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_inner_state_preserved_when_outer_has_no_conflict 
[gw6] [  3%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_complex_retry_logic 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_inner_command_retry_safe 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_request_modification 
[gw0] [  3%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_all_decorators_integration 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_decorators_use_function_names_as_default 
[gw6] [  3%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_request_modification 
[gw0] [  3%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_decorators_use_function_names_as_default 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestAsyncWrapModelCall::test_async_model_with_middleware 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_hook_config_decorator_on_class_method 
[gw5] [  3%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRetryLogic::test_max_retries 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRetryLogic::test_no_retry_propagates_error 
[gw0] [  3%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_hook_config_decorator_on_class_method 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_can_jump_to_with_before_model_decorator 
[gw0] [  3%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_can_jump_to_with_before_model_decorator 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_can_jump_to_with_after_model_decorator 
[gw0] [  3%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_can_jump_to_with_after_model_decorator 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_can_jump_to_integration 
[gw5] [  3%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRetryLogic::test_no_retry_propagates_error 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRetryLogic::test_max_attempts_limit 
[gw0] [  4%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_can_jump_to_integration 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_before_model_decorator 
[gw0] [  4%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_before_model_decorator 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_after_model_decorator 
[gw0] [  4%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_after_model_decorator 
[gw5] [  4%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRetryLogic::test_max_attempts_limit 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_on_model_call_decorator 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestResponseRewriting::test_uppercase_response 
[gw7] [  4%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_inner_command_retry_safe 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_decorator_returns_wrap_result 
[gw0] [  4%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_on_model_call_decorator 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_mixed_sync_async_decorators 
[gw0] [  4%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_mixed_sync_async_decorators 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_decorators_integration 
[gw5] [  4%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestResponseRewriting::test_uppercase_response 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestResponseRewriting::test_prefix_response 
[gw7] [  4%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_decorator_returns_wrap_result 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_structured_response_preserved 
[gw5] [  5%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestResponseRewriting::test_prefix_response 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestResponseRewriting::test_multi_stage_transformation 
[gw7] [  5%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_structured_response_preserved 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncComposition::test_async_inner_command_propagated 
[gw5] [  5%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestResponseRewriting::test_multi_stage_transformation 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestErrorHandling::test_convert_error_to_response 
[gw5] [  5%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestErrorHandling::test_convert_error_to_response 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestErrorHandling::test_selective_error_handling 
[gw5] [  5%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestErrorHandling::test_selective_error_handling 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestErrorHandling::test_error_handling_with_success_path 
[gw5] [  5%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestErrorHandling::test_error_handling_with_success_path 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestShortCircuit::test_cache_short_circuit 
[gw5] [  5%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestShortCircuit::test_cache_short_circuit 
[gw2] [  5%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_conditional_dynamic_tool[True] 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRequestModification::test_add_system_prompt 
[gw4] [  5%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_sync_only_middleware_raises_on_async_path 
[gw1] [  6%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_can_jump_to_integration 
[gw5] [  6%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestRequestModification::test_add_system_prompt 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_async_only_middleware_works_on_async_path 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_get_can_jump_to_no_false_positives 
[gw1] [  6%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_get_can_jump_to_no_false_positives 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestStateAndRuntime::test_access_state_in_middleware 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_get_can_jump_to_only_overridden_methods 
[gw1] [  6%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_get_can_jump_to_only_overridden_methods 
[gw3] [  6%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_execution[before-False] 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_middleware_with_can_jump_to_graph_snapshot 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_execution[before-True] 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_chained_middleware[False] 
[gw5] [  6%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestStateAndRuntime::test_access_state_in_middleware 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestStateAndRuntime::test_retry_with_state_tracking 
[gw6] [  6%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestAsyncWrapModelCall::test_async_model_with_middleware 
[gw2] [  6%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_chained_middleware[False] 
[gw4] [  7%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_async_only_middleware_works_on_async_path 
[gw5] [  7%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestStateAndRuntime::test_retry_with_state_tracking 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_chained_middleware[True] 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_two_middleware_composition 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestAsyncWrapModelCall::test_async_retry 
[gw1] [  7%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_middleware_with_can_jump_to_graph_snapshot 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_async_only_middleware_raises_on_sync_path 
[gw3] [  7%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_execution[before-True] 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_decorator 
[gw5] [  7%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_two_middleware_composition 
[gw1] [  7%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_decorator 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_three_middleware_composition 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_uses_state 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_execution[after-False] 
[gw1] [  7%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_uses_state 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_integration 
[gw6] [  7%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestAsyncWrapModelCall::test_async_retry 
[gw5] [  7%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_three_middleware_composition 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_retry_with_logging 
[gw4] [  8%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_async_only_middleware_raises_on_sync_path 
[gw1] [  8%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_integration 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_both_sync_and_async_middleware_uses_appropriate_path 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_dynamic_prompt_decorator 
[gw1] [  8%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_dynamic_prompt_decorator 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_dynamic_prompt_integration 
[gw2] [  8%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_chained_middleware[True] 
[gw5] [  8%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_retry_with_logging 
[gw0] [  8%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_decorators_integration 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestAsyncWrapModelCall::test_decorator_with_async_agent 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_multiple_transformations 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_mixed_sync_async_decorators_integration 
[gw1] [  8%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_dynamic_prompt_integration 
[gw6] [  8%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestAsyncWrapModelCall::test_decorator_with_async_agent 
[gw3] [  8%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_execution[after-False] 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_execution[after-True] 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestSyncAsyncInterop::test_sync_invoke_with_only_async_middleware_raises_error 
[gw5] [  9%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_multiple_transformations 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_retry_outer_transform_inner 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_overwrites_system_prompt 
[gw1] [  9%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_overwrites_system_prompt 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_multiple_in_sequence 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[memory] 
[gw6] [  9%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestSyncAsyncInterop::test_sync_invoke_with_only_async_middleware_raises_error 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestSyncAsyncInterop::test_sync_invoke_with_mixed_middleware 
[gw5] [  9%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_retry_outer_transform_inner 
[gw1] [  9%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_dynamic_prompt_multiple_in_sequence 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_middle_retry_middleware 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_dynamic_prompt_skipped_on_sync_invoke 
[gw4] [  9%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_both_sync_and_async_middleware_uses_appropriate_path 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_both_sync_and_async_middleware_uses_appropriate_path_async 
[gw6] [  9%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestSyncAsyncInterop::test_sync_invoke_with_mixed_middleware 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestEdgeCases::test_middleware_modifies_request 
[gw3] [  9%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_execution[after-True] 
[gw1] [  9%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_dynamic_prompt_skipped_on_sync_invoke 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_sync_dynamic_prompt_on_async_invoke 
[gw0] [ 10%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_mixed_sync_async_decorators_integration 
[gw7] [ 10%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncComposition::test_async_inner_command_propagated 
[gw6] [ 10%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestEdgeCases::test_middleware_modifies_request 
[gw5] [ 10%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestMiddlewareComposition::test_middle_retry_middleware 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_with_class_inheritance[before-False] 
[gw4] [ 10%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_both_sync_and_async_middleware_uses_appropriate_path_async 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_basic_decorator_usage 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestEdgeCases::test_multiple_yields_retry_different_models 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_mixed_middleware_composition_async_path_fails_with_sync_only 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncComposition::test_async_both_commands_additive_messages 
[gw5] [ 10%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_basic_decorator_usage 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_with_custom_name 
[gw3] [ 10%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_with_class_inheritance[before-False] 
[gw5] [ 10%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_with_custom_name 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_with_class_inheritance[before-True] 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_retry_logic 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_before_model_preserves_can_jump_to 
[gw1] [ 10%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_sync_dynamic_prompt_on_async_invoke 
[gw0] [ 11%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_before_model_preserves_can_jump_to 
tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_after_model_preserves_can_jump_to 
[gw4] [ 11%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_mixed_middleware_composition_async_path_fails_with_sync_only 
[gw0] [ 11%] PASSED tests/unit_tests/agents/middleware/core/test_decorators.py::test_async_after_model_preserves_can_jump_to 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_mixed_middleware_composition_sync_path_with_async_only_fails 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_three_levels_composition 
[gw7] [ 11%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncComposition::test_async_both_commands_additive_messages 
[gw6] [ 11%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestEdgeCases::test_multiple_yields_retry_different_models 
tests/unit_tests/agents/middleware/core/test_diagram.py::test_create_agent_diagram 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBasicCommand::test_command_messages_added_alongside_model_messages 
[gw2] [ 11%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[memory] 
[gw5] [ 11%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_retry_logic 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_response_rewriting 
[gw6] [ 11%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBasicCommand::test_command_messages_added_alongside_model_messages 
[gw5] [ 11%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_response_rewriting 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBasicCommand::test_command_with_extra_messages_and_model_response 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_error_handling 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[sqlite] 
[gw3] [ 12%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_with_class_inheritance[before-True] 
[gw6] [ 12%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBasicCommand::test_command_with_extra_messages_and_model_response 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncComposition::test_async_inner_command_retry_safe 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBasicCommand::test_command_structured_response_conflicts_with_model_response 
[gw5] [ 12%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_error_handling 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_with_state_access 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_with_class_inheritance[after-False] 
[gw5] [ 12%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestWrapModelCallDecorator::test_decorator_with_state_access 
[gw6] [ 12%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBasicCommand::test_command_structured_response_conflicts_with_model_response 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBasicCommand::test_command_with_custom_state_field 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestMatchIncludePattern::test_match_pattern_invalid_expansion 
[gw3] [ 12%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_with_class_inheritance[after-False] 
[gw5] [ 12%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestMatchIncludePattern::test_match_pattern_invalid_expansion 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_with_class_inheritance[after-True] 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestGrepEdgeCases::test_grep_with_special_chars_in_pattern 
[gw0] [ 12%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_three_levels_composition 
[gw6] [ 13%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBasicCommand::test_command_with_custom_state_field 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_outer_intercepts_inner 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCustomStateField::test_custom_field_via_state_schema 
[gw3] [ 13%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentMiddlewareHooks::test_hook_with_class_inheritance[after-True] 
[gw4] [ 13%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_mixed_middleware_composition_sync_path_with_async_only_fails 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_decorator_sync_only_works_both_paths 
[gw6] [ 13%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCustomStateField::test_custom_field_via_state_schema 
[gw5] [ 13%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestGrepEdgeCases::test_grep_with_special_chars_in_pattern 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestGrepEdgeCases::test_grep_case_insensitive 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_execution_order[False] 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCustomStateField::test_no_command 
[gw7] [ 13%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncComposition::test_async_inner_command_retry_safe 
[gw5] [ 13%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestGrepEdgeCases::test_grep_case_insensitive 
[gw6] [ 13%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCustomStateField::test_no_command 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestGrepEdgeCases::test_grep_with_large_file_skipping 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBackwardsCompatibility::test_model_response_return_unchanged 
[gw2] [ 13%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[sqlite] 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[postgres] 
[gw6] [ 14%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBackwardsCompatibility::test_model_response_return_unchanged 
[gw1] [ 14%] PASSED tests/unit_tests/agents/middleware/core/test_diagram.py::test_create_agent_diagram 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandGotoDisallowed::test_command_goto_raises_not_implemented 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBackwardsCompatibility::test_ai_message_return_unchanged 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[with_static_tools-False] 
[gw0] [ 14%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_outer_intercepts_inner 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_inner_short_circuits 
[gw7] [ 14%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandGotoDisallowed::test_command_goto_raises_not_implemented 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandGotoDisallowed::test_async_command_goto_raises_not_implemented 
[gw6] [ 14%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBackwardsCompatibility::test_ai_message_return_unchanged 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBackwardsCompatibility::test_no_middleware_unchanged 
[gw4] [ 14%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_decorator_sync_only_works_both_paths 
[gw6] [ 14%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestBackwardsCompatibility::test_no_middleware_unchanged 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_decorator_sync_only_raises_on_async_path 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncExtendedModelResponse::test_async_command_adds_messages 
[gw5] [ 14%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestGrepEdgeCases::test_grep_with_large_file_skipping 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_initialization 
[gw5] [ 14%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_initialization 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_no_interrupts_needed 
[gw3] [ 15%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_execution_order[False] 
[gw5] [ 15%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_no_interrupts_needed 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_execution_order[True] 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_single_tool_accept 
[gw7] [ 15%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandGotoDisallowed::test_async_command_goto_raises_not_implemented 
[gw6] [ 15%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncExtendedModelResponse::test_async_command_adds_messages 
[gw5] [ 15%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_single_tool_accept 
[gw2] [ 15%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[postgres] 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_single_tool_edit 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[postgres_pipe] 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandResumeDisallowed::test_command_resume_raises_not_implemented 
[gw5] [ 15%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_single_tool_edit 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_single_tool_response 
[gw7] [ 15%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandResumeDisallowed::test_command_resume_raises_not_implemented 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandResumeDisallowed::test_async_command_resume_raises_not_implemented 
[gw5] [ 15%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_single_tool_response 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_single_tool_respond 
[gw5] [ 16%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_single_tool_respond 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_respond_disallowed 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncExtendedModelResponse::test_async_decorator_command 
[gw5] [ 16%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_respond_disallowed 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_mixed_with_respond 
[gw0] [ 16%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_inner_short_circuits 
[gw5] [ 16%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_mixed_with_respond 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_true_allows_respond 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_mixed_passthrough_and_intercepting 
[gw5] [ 16%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_true_allows_respond 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_multiple_tools_mixed_responses 
[gw5] [ 16%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_multiple_tools_mixed_responses 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_multiple_tools_edit_responses 
[gw5] [ 16%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_multiple_tools_edit_responses 
[gw1] [ 16%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[with_static_tools-False] 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_edit_with_modified_args 
[gw5] [ 16%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_edit_with_modified_args 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_unknown_response_type 
[gw7] [ 17%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandResumeDisallowed::test_async_command_resume_raises_not_implemented 
[gw5] [ 17%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_unknown_response_type 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_disallowed_action 
[gw4] [ 17%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_decorator_sync_only_raises_on_async_path 
[gw5] [ 17%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_disallowed_action 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_decorator_async_only_works_async_path 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_mixed_auto_approved_and_interrupt 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[with_static_tools-True] 
[gw5] [ 17%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_mixed_auto_approved_and_interrupt 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_interrupt_request_structure 
[gw3] [ 17%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_execution_order[True] 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_state_passthrough 
[gw5] [ 17%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_interrupt_request_structure 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_boolean_configs 
[gw2] [ 17%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[postgres_pipe] 
[gw5] [ 17%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_boolean_configs 
[gw0] [ 18%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_mixed_passthrough_and_intercepting 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_uses_function_name_as_default 
[gw0] [ 18%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_uses_function_name_as_default 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_caching_pattern 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_jitter_variation 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[postgres_pool] 
[gw5] [ 18%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_jitter_variation 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_async_working_model 
[gw3] [ 18%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_state_passthrough 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_multiple_middleware_instances 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandGraphDisallowed::test_command_graph_raises_not_implemented 
[gw6] [ 18%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestAsyncExtendedModelResponse::test_async_decorator_command 
[gw7] [ 18%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandGraphDisallowed::test_command_graph_raises_not_implemented 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_outer_command_messages_added_alongside_model 
tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandGraphDisallowed::test_async_command_graph_raises_not_implemented 
[gw3] [ 18%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_multiple_middleware_instances 
[gw4] [ 18%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_decorator_async_only_works_async_path 
tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_agent_hooks_run_once_with_multiple_model_calls 
tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_decorator_async_only_raises_on_sync_path 
[gw1] [ 19%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[with_static_tools-True] 
[gw0] [ 19%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_caching_pattern 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_monitoring_pattern 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[without_static_tools-False] 
[gw6] [ 19%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestComposition::test_outer_command_messages_added_alongside_model 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_no_matches 
[gw7] [ 19%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py::TestCommandGraphDisallowed::test_async_command_graph_raises_not_implemented 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_basic_passthrough 
[gw6] [ 19%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_no_matches 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_basic_pattern 
[gw0] [ 19%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_monitoring_pattern 
tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_no_edit_when_below_trigger 
[gw2] [ 19%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_invoke[postgres_pool] 
[gw0] [ 19%] PASSED tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_no_edit_when_below_trigger 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[memory] 
tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_clear_tool_outputs_and_inputs 
[gw4] [ 19%] PASSED tests/unit_tests/agents/middleware/core/test_sync_async_wrappers.py::TestSyncAsyncMiddlewareComposition::test_decorator_async_only_raises_on_sync_path 
tests/unit_tests/agents/middleware/core/test_tools.py::test_model_request_tools_are_base_tools 
[gw0] [ 20%] PASSED tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_clear_tool_outputs_and_inputs 
tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_respects_keep_last_tool_results 
[gw6] [ 20%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_basic_pattern 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_recursive_pattern 
[gw0] [ 20%] PASSED tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_respects_keep_last_tool_results 
tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_exclude_tools_prevents_clearing 
[gw1] [ 20%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[without_static_tools-False] 
[gw0] [ 20%] PASSED tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_exclude_tools_prevents_clearing 
tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_no_edit_when_below_trigger_async 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[without_static_tools-True] 
[gw0] [ 20%] PASSED tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_no_edit_when_below_trigger_async 
[gw4] [ 20%] PASSED tests/unit_tests/agents/middleware/core/test_tools.py::test_model_request_tools_are_base_tools 
tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_clear_tool_outputs_and_inputs_async 
tests/unit_tests/agents/middleware/core/test_tools.py::test_middleware_can_modify_tools 
[gw6] [ 20%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_recursive_pattern 
[gw0] [ 20%] PASSED tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_clear_tool_outputs_and_inputs_async 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_with_subdirectory_path 
tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_respects_keep_last_tool_results_async 
[gw3] [ 21%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::TestAgentHooksCombined::test_agent_hooks_run_once_with_multiple_model_calls 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_single_attribute 
[gw0] [ 21%] PASSED tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_respects_keep_last_tool_results_async 
[gw7] [ 21%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_basic_passthrough 
tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_exclude_tools_prevents_clearing_async 
[gw3] [ 21%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_single_attribute 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_multiple_attributes 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_logging 
[gw0] [ 21%] PASSED tests/unit_tests/agents/middleware/implementations/test_context_editing.py::test_exclude_tools_prevents_clearing_async 
[gw3] [ 21%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_multiple_attributes 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_messages 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_invalid_include_pattern 
[gw3] [ 21%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_messages 
[gw6] [ 21%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_with_subdirectory_path 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_model_settings 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_no_matches 
[gw3] [ 21%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_model_settings 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_with_none_value 
[gw3] [ 22%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_with_none_value 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_preserves_identity_of_unchanged_objects 
[gw2] [ 22%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[memory] 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[sqlite] 
[gw3] [ 22%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_preserves_identity_of_unchanged_objects 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_chaining 
[gw4] [ 22%] PASSED tests/unit_tests/agents/middleware/core/test_tools.py::test_middleware_can_modify_tools 
[gw0] [ 22%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_invalid_include_pattern 
tests/unit_tests/agents/middleware/core/test_tools.py::test_unknown_tool_raises_error 
[gw3] [ 22%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_chaining 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_ripgrep_command_uses_literal_pattern 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_raises_on_both_system_prompt_and_system_message 
[gw3] [ 22%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_raises_on_both_system_prompt_and_system_message 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_system_prompt_backward_compatibility 
[gw3] [ 22%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestModelRequestOverride::test_override_system_prompt_backward_compatibility 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_tool_call 
[gw6] [ 22%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_no_matches 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_invalid_path 
[gw1] [ 23%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[without_static_tools-True] 
[gw7] [ 23%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_logging 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_modify_args 
[gw3] [ 23%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_tool_call 
[gw0] [ 23%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_ripgrep_command_uses_literal_pattern 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[with_none_tools-False] 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_state 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_basic_search_python_fallback 
[gw4] [ 23%] PASSED tests/unit_tests/agents/middleware/core/test_tools.py::test_unknown_tool_raises_error 
tests/unit_tests/agents/middleware/core/test_tools.py::test_middleware_can_add_and_remove_tools 
[gw3] [ 23%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_state 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_multiple_attributes 
[gw6] [ 23%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_invalid_path 
[gw2] [ 23%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[sqlite] 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[postgres] 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_results_sorted_by_mtime_desc 
[gw0] [ 23%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_basic_search_python_fallback 
[gw3] [ 24%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_multiple_attributes 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_with_copy_pattern 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_with_include_filter 
[gw3] [ 24%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_with_copy_pattern 
tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_preserves_identity 
[gw4] [ 24%] PASSED tests/unit_tests/agents/middleware/core/test_tools.py::test_middleware_can_add_and_remove_tools 
tests/unit_tests/agents/middleware/core/test_tools.py::test_empty_tools_list_is_valid 
[gw3] [ 24%] PASSED tests/unit_tests/agents/middleware/core/test_overrides.py::TestToolCallRequestOverride::test_override_preserves_identity 
[gw6] [ 24%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGlobSearch::test_glob_results_sorted_by_mtime_desc 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMaskStrategy::test_mask_ip 
[gw7] [ 24%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_modify_args 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_access_state 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_path_traversal_with_double_dots 
[gw3] [ 24%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMaskStrategy::test_mask_ip 
[gw0] [ 24%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_with_include_filter 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestHashStrategy::test_hash_email 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_output_mode_content 
[gw3] [ 25%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestHashStrategy::test_hash_email 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestHashStrategy::test_hash_is_deterministic 
[gw3] [ 25%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestHashStrategy::test_hash_is_deterministic 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestBlockStrategy::test_block_raises_exception 
[gw3] [ 25%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestBlockStrategy::test_block_raises_exception 
[gw4] [ 25%] PASSED tests/unit_tests/agents/middleware/core/test_tools.py::test_empty_tools_list_is_valid 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestBlockStrategy::test_block_with_multiple_matches 
tests/unit_tests/agents/middleware/core/test_tools.py::test_tools_preserved_across_multiple_middleware 
[gw3] [ 25%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestBlockStrategy::test_block_with_multiple_matches 
[gw6] [ 25%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_path_traversal_with_double_dots 
[gw1] [ 25%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[with_none_tools-False] 
[gw0] [ 25%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_output_mode_content 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_input_only 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_path_traversal_with_absolute_path 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_output_mode_count 
[gw3] [ 25%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_input_only 
[gw7] [ 26%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_access_state 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_access_runtime 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_output_only 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[with_none_tools-True] 
[gw3] [ 26%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_output_only 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_both 
[gw2] [ 26%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[postgres] 
[gw3] [ 26%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_both 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_no_pii_returns_none 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[postgres_pipe] 
[gw6] [ 26%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_path_traversal_with_absolute_path 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_path_traversal_with_symlink 
[gw3] [ 26%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_no_pii_returns_none 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_empty_messages 
[gw3] [ 26%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_empty_messages 
[gw4] [ 26%] PASSED tests/unit_tests/agents/middleware/core/test_tools.py::test_tools_preserved_across_multiple_middleware 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_tool_results 
[gw1] [ 26%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_basic[with_none_tools-True] 
tests/unit_tests/agents/middleware/core/test_tools.py::test_middleware_with_additional_tools 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_multiple_dynamic_tools_with_static[False] 
[gw3] [ 27%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_tool_results 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_tool_results_mask_strategy 
[gw3] [ 27%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_tool_results_mask_strategy 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_tool_results_block_strategy 
[gw0] [ 27%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_output_mode_count 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_invalid_regex_pattern 
[gw6] [ 27%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_path_traversal_with_symlink 
[gw3] [ 27%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_apply_to_tool_results_block_strategy 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_validate_path_blocks_tilde 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_with_agent 
[gw7] [ 27%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_access_runtime 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_retry_on_error 
[gw2] [ 27%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[postgres_pipe] 
[gw4] [ 27%] PASSED tests/unit_tests/agents/middleware/core/test_tools.py::test_middleware_with_additional_tools 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[postgres_pool] 
tests/unit_tests/agents/middleware/core/test_tools.py::test_tool_node_not_accepted 
[gw5] [ 27%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_async_working_model 
[gw0] [ 28%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestFilesystemGrepSearch::test_grep_invalid_regex_pattern 
[gw6] [ 28%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_validate_path_blocks_tilde 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_unknown_builtin_type_raises_error 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_grep_path_traversal_protection 
[gw4] [ 28%] PASSED tests/unit_tests/agents/middleware/core/test_tools.py::test_tool_node_not_accepted 
[gw0] [ 28%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_unknown_builtin_type_raises_error 
[gw1] [ 28%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_multiple_dynamic_tools_with_static[False] 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_type_without_detector_raises_error 
tests/unit_tests/agents/middleware/core/test_transformers.py::test_middleware_transformer_registered_on_compiled_graph 
[gw3] [ 28%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIMiddlewareIntegration::test_with_agent 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_multiple_dynamic_tools_with_static[True] 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_regex_detector 
[gw0] [ 28%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_type_without_detector_raises_error 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMultipleMiddleware::test_sequential_application 
[gw3] [ 28%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_regex_detector 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_callable_detector 
[gw0] [ 28%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMultipleMiddleware::test_sequential_application 
[gw6] [ 29%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestPathTraversalSecurity::test_grep_path_traversal_protection 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMultipleMiddleware::test_multiple_pii_middleware_with_create_agent 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_basic_brace_expansion 
[gw3] [ 29%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_callable_detector 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_callable_detector_with_text_key_hash 
[gw6] [ 29%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_basic_brace_expansion 
[gw3] [ 29%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_callable_detector_with_text_key_hash 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_nested_braces 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_callable_detector_with_text_key_mask 
[gw6] [ 29%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_nested_braces 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_async_failing_model 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_invalid_braces[*.py}] 
[gw3] [ 29%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCustomDetector::test_custom_callable_detector_with_text_key_mask 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_finished_clears_per_tool_buffer 
[gw6] [ 29%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_invalid_braces[*.py}] 
[gw3] [ 29%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_finished_clears_per_tool_buffer 
[gw7] [ 29%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_retry_on_error 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_short_circuit 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_output_delta_block_strategy_raises 
[gw3] [ 30%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_output_delta_block_strategy_raises 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_call_args_block_strategy_raises 
[gw3] [ 30%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_call_args_block_strategy_raises 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_pii_fully_inside_one_delta_is_redacted_on_finalize 
[gw2] [ 30%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_jump[postgres_pool] 
tests/unit_tests/agents/middleware/core/test_framework.py::test_simple_agent_graph 
[gw1] [ 30%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_multiple_dynamic_tools_with_static[True] 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_invalid_braces[*.{}] 
[gw6] [ 30%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_invalid_braces[*.{}] 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_invalid_braces[*.{py] 
[gw6] [ 30%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestExpandIncludePatterns::test_expand_patterns_invalid_braces[*.{py] 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestValidateIncludePattern::test_validate_invalid_patterns[] 
[gw3] [ 30%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_pii_fully_inside_one_delta_is_redacted_on_finalize 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_pii_split_across_deltas_is_caught 
[gw6] [ 30%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestValidateIncludePattern::test_validate_invalid_patterns[] 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestValidateIncludePattern::test_validate_invalid_patterns[*.py\x00] 
[gw3] [ 30%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_pii_split_across_deltas_is_caught 
[gw7] [ 31%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_short_circuit 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_pii_straddling_lookback_boundary_is_caught 
[gw6] [ 31%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestValidateIncludePattern::test_validate_invalid_patterns[*.py\x00] 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestValidateIncludePattern::test_validate_invalid_patterns[*.py\n] 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_response_modification 
[gw3] [ 31%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_pii_straddling_lookback_boundary_is_caught 
[gw4] [ 31%] PASSED tests/unit_tests/agents/middleware/core/test_transformers.py::test_middleware_transformer_registered_on_compiled_graph 
tests/unit_tests/agents/middleware/core/test_transformers.py::test_middleware_and_user_transformers_compose_in_order 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_credit_card_split_across_whitespace_is_caught 
[gw6] [ 31%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestValidateIncludePattern::test_validate_invalid_patterns[*.py\n] 
tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestMatchIncludePattern::test_match_pattern_with_braces 
[gw2] [ 31%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_simple_agent_graph 
[gw3] [ 31%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_credit_card_split_across_whitespace_is_caught 
[gw6] [ 31%] PASSED tests/unit_tests/agents/middleware/implementations/test_file_search.py::TestMatchIncludePattern::test_match_pattern_with_braces 
tests/unit_tests/agents/middleware/core/test_framework.py::test_agent_graph_with_jump_to_end_as_after_agent 
[gw0] [ 32%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMultipleMiddleware::test_multiple_pii_middleware_with_create_agent 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_no_transformer_when_neither_output_nor_tool_results_apply 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_block_raises_on_tool_call_args_under_block 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_without_handler_raises_error[with_static_tools-False] 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMultipleMiddleware::test_custom_detector_for_multiple_types 
[gw4] [ 32%] PASSED tests/unit_tests/agents/middleware/core/test_transformers.py::test_middleware_and_user_transformers_compose_in_order 
[gw3] [ 32%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_no_transformer_when_neither_output_nor_tool_results_apply 
tests/unit_tests/agents/middleware/core/test_transformers.py::test_transformers_from_multiple_middleware_preserve_middleware_order 
[gw0] [ 32%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMultipleMiddleware::test_custom_detector_for_multiple_types 
[gw6] [ 32%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_block_raises_on_tool_call_args_under_block 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_nested_strings 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_legacy_payload_redacts_tool_call_args 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_transformer_installed_for_tool_results_only 
[gw3] [ 32%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_transformer_installed_for_tool_results_only 
[gw6] [ 32%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_legacy_payload_redacts_tool_call_args 
[gw0] [ 32%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_nested_strings 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_block_strategy_installs_buffering_stream_transformer 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_legacy_payload_block_raises_when_tool_call_has_pii 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_block_strategy_raises 
[gw3] [ 32%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_block_strategy_installs_buffering_stream_transformer 
[gw6] [ 33%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_legacy_payload_block_raises_when_tool_call_has_pii 
[gw0] [ 33%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_block_strategy_raises 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_passthrough_for_clean_input 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_legacy_payload_redacts_tool_message_content 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_block_strategy_raises_on_first_pii_detection 
[gw4] [ 33%] PASSED tests/unit_tests/agents/middleware/core/test_transformers.py::test_transformers_from_multiple_middleware_preserve_middleware_order 
[gw6] [ 33%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_legacy_payload_redacts_tool_message_content 
tests/unit_tests/agents/middleware/core/test_transformers.py::test_middleware_without_transformers_does_not_affect_registry 
[gw0] [ 33%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_passthrough_for_clean_input 
[gw3] [ 33%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_block_strategy_raises_on_first_pii_detection 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tools_in_required_stream_modes 
[gw2] [ 33%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_agent_graph_with_jump_to_end_as_after_agent 
[gw1] [ 33%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_without_handler_raises_error[with_static_tools-False] 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_block_strategy_releases_full_text_at_finalize_when_clean 
[gw5] [ 33%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_async_failing_model 
tests/unit_tests/agents/middleware/core/test_framework.py::test_on_model_call 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_structured_message_content 
[gw0] [ 34%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_structured_message_content 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_ai_message_tool_calls 
[gw3] [ 34%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_block_strategy_releases_full_text_at_finalize_when_clean 
[gw6] [ 34%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tools_in_required_stream_modes 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_process_tools_event_passes_through 
[gw6] [ 34%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_process_tools_event_passes_through 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_block_redacts_full_text_even_if_stream_redaction_partial 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_without_handler_raises_error[with_static_tools-True] 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_started_string_input_redacted 
[gw0] [ 34%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_ai_message_tool_calls 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_both_content_and_tool_calls 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_async_succeeds_after_retries 
[gw3] [ 34%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_block_redacts_full_text_even_if_stream_redaction_partial 
[gw6] [ 34%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_started_string_input_redacted 
[gw0] [ 34%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_both_content_and_tool_calls 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_reasoning_delta_uses_lookback 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_started_list_input_redacted 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_buffers_isolated_by_run_id 
[gw7] [ 34%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_response_modification 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_multiple_middleware_composition 
[gw2] [ 35%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_on_model_call 
[gw0] [ 35%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_reasoning_delta_uses_lookback 
tests/unit_tests/agents/middleware/core/test_framework.py::test_tools_to_model_edge_with_structured_and_regular_tool_calls 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_reasoning_delta_block_strategy_raises 
[gw6] [ 35%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_started_list_input_redacted 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_drop_run_does_not_sweep_tool_buffers 
[gw3] [ 35%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_buffers_isolated_by_run_id 
[gw0] [ 35%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_reasoning_delta_block_strategy_raises 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_call_args_short_args_withheld_during_streaming 
[gw6] [ 35%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_drop_run_does_not_sweep_tool_buffers 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_message_finish_drops_buffers 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_invalid_tool_call_redacts_string_args 
[gw0] [ 35%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_call_args_short_args_withheld_during_streaming 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_call_args_long_args_emit_safe_prefix 
[gw3] [ 35%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_message_finish_drops_buffers 
[gw6] [ 35%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_invalid_tool_call_redacts_string_args 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_clears_all_state 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_invalid_tool_calls 
[gw0] [ 36%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_call_args_long_args_emit_safe_prefix 
[gw4] [ 36%] PASSED tests/unit_tests/agents/middleware/core/test_transformers.py::test_middleware_without_transformers_does_not_affect_registry 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_call_args_partial_pii_across_chunks_withheld 
[gw3] [ 36%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_clears_all_state 
[gw6] [ 36%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_redact_value_walks_invalid_tool_calls 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_long_pii_exceeding_lookback_still_caught_on_finalize 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_started_input_is_redacted 
[gw0] [ 36%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_call_args_partial_pii_across_chunks_withheld 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestBasicWrapModelCall::test_passthrough_middleware 
[gw3] [ 36%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_long_pii_exceeding_lookback_still_caught_on_finalize 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_block_redacts_tool_call_args 
[gw6] [ 36%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_started_input_is_redacted 
[gw1] [ 36%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_without_handler_raises_error[with_static_tools-True] 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_output_delta_string_uses_lookback 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_data_delta_passes_through_untouched 
[gw0] [ 36%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_finalize_block_redacts_tool_call_args 
[gw6] [ 37%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_output_delta_string_uses_lookback 
[gw3] [ 37%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_data_delta_passes_through_untouched 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_respects_process_group_flag 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_without_handler_raises_error[without_static_tools-False] 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_output_delta_dict_walks_strings 
[gw4] [ 37%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestBasicWrapModelCall::test_passthrough_middleware 
tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestBasicWrapModelCall::test_logging_middleware 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_transformer_registered_before_messages_transformer_on_agent 
[gw6] [ 37%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_output_delta_dict_walks_strings 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_finished_output_redacted 
[gw0] [ 37%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_respects_process_group_flag 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_falls_back_to_rlimit_data 
[gw6] [ 37%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_finished_output_redacted 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_error_message_redacted 
[gw4] [ 37%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_model_call.py::TestBasicWrapModelCall::test_logging_middleware 
[gw0] [ 37%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_falls_back_to_rlimit_data 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_version_number_not_detected 
[gw6] [ 38%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_tool_error_message_redacted 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_spawns_codex_cli 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_read_only_and_user 
[gw0] [ 38%] SKIPPED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_spawns_codex_cli 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_auto_platform_linux 
[gw0] [ 38%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_auto_platform_linux 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_auto_platform_macos 
[gw0] [ 38%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_auto_platform_macos 
[gw6] [ 38%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_read_only_and_user 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_resolve_missing_binary 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_resolve_missing_binary 
[gw2] [ 38%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_tools_to_model_edge_with_structured_and_regular_tool_calls 
tests/unit_tests/agents/middleware/core/test_framework.py::test_public_private_state_for_custom_middleware 
[gw0] [ 38%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_resolve_missing_binary 
[gw7] [ 38%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_multiple_middleware_composition 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_multiple_tools 
[gw6] [ 38%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_resolve_missing_binary 
[gw3] [ 39%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamTransformer::test_transformer_registered_before_messages_transformer_on_agent 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_auto_platform_failure 
[gw2] [ 39%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_public_private_state_for_custom_middleware 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_executes_command_and_persists_state 
[gw0] [ 39%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_auto_platform_failure 
tests/unit_tests/agents/middleware/core/test_framework.py::test_runtime_injected_into_middleware 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_formats_override_values 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_streamed_messages_projection_is_redacted 
[gw0] [ 39%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_formats_override_values 
[gw5] [ 39%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_async_succeeds_after_retries 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_sorts_config_overrides 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_async_backoff_timing 
[gw0] [ 39%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_codex_policy_sorts_config_overrides 
[gw1] [ 39%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_without_handler_raises_error[without_static_tools-False] 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_spawns_docker_run 
[gw4] [ 39%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_version_number_not_detected 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_no_ip 
[gw2] [ 39%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_runtime_injected_into_middleware 
tests/unit_tests/agents/middleware/core/test_framework.py::test_injected_state_in_middleware_agent 
[gw0] [ 40%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_spawns_docker_run 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_without_handler_raises_error[without_static_tools-True] 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_rejects_cpu_limit 
[gw4] [ 40%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_no_ip 
[gw0] [ 40%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_rejects_cpu_limit 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_detect_mac_with_colons 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_validates_memory 
[gw0] [ 40%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_validates_memory 
[gw4] [ 40%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_detect_mac_with_colons 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_skips_mount_for_temp_workspace 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_detect_mac_with_dashes 
[gw0] [ 40%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_skips_mount_for_temp_workspace 
[gw1] [ 40%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_dynamic_tool_without_handler_raises_error[without_static_tools-True] 
[gw4] [ 40%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_detect_mac_with_dashes 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_detect_lowercase_mac 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_validates_cpus 
[gw0] [ 40%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_validates_cpus 
[gw4] [ 41%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_detect_lowercase_mac 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_validates_user 
[gw7] [ 41%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_multiple_tools 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_with_custom_name 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_no_mac 
[gw7] [ 41%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_with_custom_name 
[gw3] [ 41%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_streamed_messages_projection_is_redacted 
tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_with_tools_parameter 
[gw0] [ 41%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_docker_policy_validates_user 
[gw4] [ 41%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_no_mac 
tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_conditional_dynamic_tool[False] 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_get_or_create_resources_creates_when_missing 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_partial_mac_not_detected 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_main_event_log_carries_redacted_deltas 
[gw4] [ 41%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMACAddressDetection::test_partial_mac_not_detected 
[gw2] [ 41%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_injected_state_in_middleware_agent 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_http_url 
[gw7] [ 41%] PASSED tests/unit_tests/agents/middleware/core/test_wrap_tool_call.py::test_wrap_tool_call_with_tools_parameter 
tests/unit_tests/agents/middleware/core/test_framework.py::test_jump_to_is_ephemeral 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_model_fallback_middleware_exhausted_with_agent 
[gw4] [ 42%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_http_url 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_https_url 
[gw4] [ 42%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_https_url 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_www_url 
[gw0] [ 42%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_get_or_create_resources_creates_when_missing 
[gw4] [ 42%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_www_url 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_bare_domain_with_path 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_get_or_create_resources_reuses_existing 
[gw2] [ 42%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_jump_to_is_ephemeral 
[gw4] [ 42%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_bare_domain_with_path 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_multiple_urls 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_sync_invoke_with_only_async_middleware_raises_error 
[gw1] [ 42%] PASSED tests/unit_tests/agents/middleware/core/test_dynamic_tools.py::test_conditional_dynamic_tool[False] 
[gw7] [ 42%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_model_fallback_middleware_exhausted_with_agent 
[gw4] [ 42%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_detect_multiple_urls 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_model_fallback_middleware_initialization 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_no_url 
[gw7] [ 43%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_model_fallback_middleware_initialization 
[gw4] [ 43%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_no_url 
[gw0] [ 43%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_get_or_create_resources_reuses_existing 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_model_request_is_frozen 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_sequence_mismatch 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_bare_domain_without_path_not_detected 
[gw2] [ 43%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_sync_invoke_with_only_async_middleware_raises_error 
[gw1] [ 43%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_sequence_mismatch 
[gw7] [ 43%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_model_request_is_frozen 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_description_as_callable 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_sync_invoke_with_mixed_middleware 
[gw3] [ 43%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_main_event_log_carries_redacted_deltas 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_initialization_defaults 
[gw4] [ 43%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestURLDetection::test_bare_domain_without_path_not_detected 
[gw7] [ 44%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_initialization_defaults 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_initialization_custom 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestRedactStrategy::test_redact_email 
[gw1] [ 44%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_description_as_callable 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_preserves_tool_call_order 
[gw7] [ 44%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_initialization_custom 
tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_first_attempt_invalid 
[gw4] [ 44%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestRedactStrategy::test_redact_email 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_invalid_max_retries 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestRedactStrategy::test_redact_multiple_pii 
[gw1] [ 44%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_preserves_tool_call_order 
[gw7] [ 44%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_invalid_max_retries 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_invalid_initial_delay 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_preserves_order_with_edits 
[gw4] [ 44%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestRedactStrategy::test_redact_multiple_pii 
[gw2] [ 44%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_sync_invoke_with_mixed_middleware 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMaskStrategy::test_mask_email 
[gw7] [ 44%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_invalid_initial_delay 
[gw1] [ 45%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_preserves_order_with_edits 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_async_invoke 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_invalid_max_delay 
[gw4] [ 45%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMaskStrategy::test_mask_email 
tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_preserves_order_with_rejections 
[gw0] [ 45%] PASSED tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_first_attempt_invalid 
tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_exceeds_max_retries 
[gw7] [ 45%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_invalid_max_delay 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMaskStrategy::test_mask_credit_card 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_invalid_backoff_factor 
[gw1] [ 45%] PASSED tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py::test_human_in_the_loop_middleware_preserves_order_with_rejections 
tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_middleware_unit_functionality 
[gw4] [ 45%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestMaskStrategy::test_mask_credit_card 
[gw7] [ 45%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_invalid_backoff_factor 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_working_model_no_retry_needed 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_multiple_triggers 
[gw1] [ 45%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_middleware_unit_functionality 
tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_thread_limit_with_create_agent 
[gw4] [ 45%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_multiple_triggers 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_profile_edge_cases 
[gw0] [ 46%] PASSED tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_exceeds_max_retries 
[gw7] [ 46%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_working_model_no_retry_needed 
tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_succeeds_first_attempt 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_failing_model_returns_message 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_block_strategy_emits_no_pii_and_run_raises 
[gw2] [ 46%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_async_invoke 
[gw0] [ 46%] PASSED tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_succeeds_first_attempt 
tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_validation_error 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_async_invoke_multiple_middleware 
[gw4] [ 46%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_profile_edge_cases 
[gw1] [ 46%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_thread_limit_with_create_agent 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_trim_messages_error_fallback 
tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_run_limit_with_create_agent 
[gw4] [ 46%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_trim_messages_error_fallback 
[gw3] [ 46%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_block_strategy_emits_no_pii_and_run_raises 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_binary_search_edge_cases 
[gw4] [ 46%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_binary_search_edge_cases 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_tool_call_args_redacted_end_to_end 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_find_safe_cutoff_point 
[gw4] [ 47%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_find_safe_cutoff_point 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_find_safe_cutoff_point_orphan_tool 
[gw2] [ 47%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_async_invoke_multiple_middleware 
[gw4] [ 47%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_find_safe_cutoff_point_orphan_tool 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_async_jump 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_cutoff_moves_backward_to_include_ai_message 
[gw0] [ 47%] PASSED tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_validation_error 
[gw4] [ 47%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_cutoff_moves_backward_to_include_ai_message 
tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_zero_retries 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_zero_and_negative_target_tokens 
[gw4] [ 47%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_zero_and_negative_target_tokens 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_async_error_handling 
[gw1] [ 47%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_run_limit_with_create_agent 
tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_middleware_initialization_validation 
[gw1] [ 47%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_middleware_initialization_validation 
[gw4] [ 47%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_async_error_handling 
[gw2] [ 48%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_async_jump 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_cutoff_at_boundary 
tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_exception_error_message 
[gw7] [ 48%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_failing_model_returns_message 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_failing_model_raises 
[gw0] [ 48%] PASSED tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_zero_retries 
tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_mixed_sync_async_middleware_async_invoke 
[gw1] [ 48%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_exception_error_message 
tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_preserves_messages 
tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_run_limit_resets_between_invocations 
[gw4] [ 48%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_cutoff_at_boundary 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_deprecated_parameters_with_defaults 
[gw4] [ 48%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_deprecated_parameters_with_defaults 
[gw3] [ 48%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_tool_call_args_redacted_end_to_end 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_fraction_trigger_with_no_profile 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_tool_output_redacted_end_to_end 
[gw4] [ 48%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_fraction_trigger_with_no_profile 
[gw2] [ 48%] PASSED tests/unit_tests/agents/middleware/core/test_framework.py::test_create_agent_mixed_sync_async_middleware_async_invoke 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_adjust_token_counts 
[gw0] [ 49%] PASSED tests/unit_tests/agents/middleware/implementations/test_structured_output_retry.py::test_structured_output_retry_preserves_messages 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_tool_message_formatting_with_id 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_initialization 
[gw4] [ 49%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_adjust_token_counts 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_execution[todos2-Updated todo list to [{'content': 'Task 1', 'status': 'pending'}, {'content': 'Task 2', 'status': 'in_progress'}]] 
[gw0] [ 49%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_initialization 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_no_summarization_cases 
[gw4] [ 49%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_execution[todos2-Updated todo list to [{'content': 'Task 1', 'status': 'pending'}, {'content': 'Task 2', 'status': 'in_progress'}]] 
[gw0] [ 49%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_no_summarization_cases 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_helper_methods 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_execution[todos3-Updated todo list to [{'content': 'Task 1', 'status': 'pending'}, {'content': 'Task 2', 'status': 'in_progress'}, {'content': 'Task 3', 'status': 'completed'}]] 
[gw0] [ 49%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_helper_methods 
[gw4] [ 49%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_execution[todos3-Updated todo list to [{'content': 'Task 1', 'status': 'pending'}, {'content': 'Task 2', 'status': 'in_progress'}, {'content': 'Task 3', 'status': 'completed'}]] 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_summary_creation 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_validation_errors[invalid_todos0] 
[gw4] [ 49%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_validation_errors[invalid_todos0] 
[gw1] [ 50%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_call_limit.py::test_run_limit_resets_between_invocations 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_validation_errors[invalid_todos1] 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_primary_model_succeeds 
[gw4] [ 50%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_validation_errors[invalid_todos1] 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_agent_creation_with_middleware 
[gw0] [ 50%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_summary_creation 
[gw1] [ 50%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_primary_model_succeeds 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_trim_limit_none_keeps_all_messages 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_fallback_on_primary_failure 
[gw0] [ 50%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_trim_limit_none_keeps_all_messages 
[gw7] [ 50%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_failing_model_raises 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_custom_failure_formatter 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_profile_inference_triggers_summary 
[gw3] [ 50%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_tool_output_redacted_end_to_end 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_block_raises_on_tool_output_pii 
[gw0] [ 50%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_profile_inference_triggers_summary 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_default_prompts 
[gw1] [ 50%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_fallback_on_primary_failure 
[gw6] [ 51%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_executes_command_and_persists_state 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_multiple_fallbacks 
[gw0] [ 51%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_default_prompts 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_restart_resets_session_environment 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_adds_system_prompt_when_none_exists 
[gw0] [ 51%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_adds_system_prompt_when_none_exists 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_appends_to_existing_system_prompt 
[gw0] [ 51%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_appends_to_existing_system_prompt 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_on_model_call[Original prompt-Original prompt\n\n## `write_todos`] 
[gw1] [ 51%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_multiple_fallbacks 
[gw0] [ 51%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_on_model_call[Original prompt-Original prompt\n\n## `write_todos`] 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_all_models_fail 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_on_model_call[None-## `write_todos`] 
[gw0] [ 51%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_on_model_call[None-## `write_todos`] 
[gw7] [ 51%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_custom_failure_formatter 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_custom_system_prompt 
[gw4] [ 51%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_agent_creation_with_middleware 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_custom_system_prompt_in_agent 
[gw0] [ 52%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_custom_system_prompt 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_custom_system_prompt 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_succeeds_after_retries 
[gw0] [ 52%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_custom_system_prompt 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_custom_tool_description 
[gw1] [ 52%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_all_models_fail 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_primary_model_succeeds_async 
[gw0] [ 52%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_custom_tool_description 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_custom_tool_description 
[gw0] [ 52%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_custom_tool_description 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_custom_system_prompt_and_tool_description 
[gw1] [ 52%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_primary_model_succeeds_async 
[gw0] [ 52%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_custom_system_prompt_and_tool_description 
[gw3] [ 52%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_block_raises_on_tool_output_pii 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_execution[todos0-Updated todo list to []] 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_fallback_on_primary_failure_async 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_block_fails_all_projections_cleanly 
[gw0] [ 52%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_execution[todos0-Updated todo list to []] 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_execution[todos1-Updated todo list to [{'content': 'Task 1', 'status': 'pending'}]] 
[gw0] [ 53%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_write_todos_tool_execution[todos1-Updated todo list to [{'content': 'Task 1', 'status': 'pending'}]] 
[gw4] [ 53%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_custom_system_prompt_in_agent 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_emulates_specified_tool_by_name 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_adds_system_prompt_when_none_exists_async 
[gw1] [ 53%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_fallback_on_primary_failure_async 
[gw4] [ 53%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_adds_system_prompt_when_none_exists_async 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_appends_to_existing_system_prompt_async 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_multiple_fallbacks_async 
[gw2] [ 53%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_tool_message_formatting_with_id 
[gw4] [ 53%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_appends_to_existing_system_prompt_async 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_custom_system_prompt_async 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_nonzero_exit_code_returns_error 
[gw4] [ 53%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_custom_system_prompt_async 
[gw0] [ 53%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_emulates_specified_tool_by_name 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_parallel_write_todos_calls_rejected 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_emulates_specified_tool_by_instance 
[gw4] [ 53%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_parallel_write_todos_calls_rejected 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_parallel_write_todos_with_other_tools 
[gw1] [ 54%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_multiple_fallbacks_async 
[gw4] [ 54%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_parallel_write_todos_with_other_tools 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_single_write_todos_call_allowed 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_all_models_fail_async 
[gw4] [ 54%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_single_write_todos_call_allowed 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_agent_creation_with_middleware_async 
[gw7] [ 54%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_succeeds_after_retries 
[gw1] [ 54%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_all_models_fail_async 
[gw0] [ 54%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_emulates_specified_tool_by_instance 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_non_emulated_tools_execute_normally 
tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_model_fallback_middleware_with_agent 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_specific_exceptions 
[gw7] [ 54%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_specific_exceptions 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_custom_exception_filter 
[gw0] [ 54%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_non_emulated_tools_execute_normally 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_empty_tools_to_emulate_does_nothing 
[gw1] [ 54%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_fallback.py::test_model_fallback_middleware_with_agent 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_multiple_middleware_instances 
[gw4] [ 55%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_agent_creation_with_middleware_async 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_parallel_write_todos_calls_rejected_async 
[gw4] [ 55%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_parallel_write_todos_calls_rejected_async 
[gw0] [ 55%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_empty_tools_to_emulate_does_nothing 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_parallel_write_todos_with_other_tools_async 
[gw3] [ 55%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_block_fails_all_projections_cleanly 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_none_tools_emulates_all 
[gw4] [ 55%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_parallel_write_todos_with_other_tools_async 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_subgraph_redaction_via_create_agent_in_tool 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_single_write_todos_call_allowed_async 
[gw7] [ 55%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_custom_exception_filter 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_backoff_timing 
[gw4] [ 55%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_single_write_todos_call_allowed_async 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_handler_called_with_modified_request_async 
[gw2] [ 55%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_nonzero_exit_code_returns_error 
[gw4] [ 55%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_handler_called_with_modified_request_async 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_truncation_by_bytes 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_initialization_validation 
[gw4] [ 56%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_initialization_validation 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_name_property 
[gw0] [ 56%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorBasic::test_none_tools_emulates_all 
[gw4] [ 56%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_name_property 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorMultipleTools::test_emulate_multiple_tools 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_unit_functionality 
[gw4] [ 56%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_unit_functionality 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_end_behavior_with_unrelated_parallel_tool_calls 
[gw4] [ 56%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_end_behavior_with_unrelated_parallel_tool_calls 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_with_specific_tool 
[gw4] [ 56%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_with_specific_tool 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_error_behavior 
[gw4] [ 56%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_middleware_error_behavior 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_invalid_initial_delay 
[gw6] [ 56%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_restart_resets_session_environment 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_truncation_indicator_present 
[gw4] [ 57%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_invalid_initial_delay 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_invalid_max_delay 
[gw4] [ 57%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_invalid_max_delay 
[gw0] [ 57%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorMultipleTools::test_emulate_multiple_tools 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorMultipleTools::test_mixed_emulated_and_real_tools 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_invalid_backoff_factor 
[gw4] [ 57%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_invalid_backoff_factor 
[gw1] [ 57%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_multiple_middleware_instances 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_run_limit_with_multiple_human_messages 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_working_tool_no_retry_needed 
[gw3] [ 57%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestPIIStreamingEndToEnd::test_subgraph_redaction_via_create_agent_in_tool 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_validations 
[gw3] [ 57%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_validations 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_requires_resource_for_limits 
[gw0] [ 57%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorMultipleTools::test_mixed_emulated_and_real_tools 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorModelConfiguration::test_custom_model_string 
[gw3] [ 57%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_requires_resource_for_limits 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_applies_prlimit 
[gw0] [ 58%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorModelConfiguration::test_custom_model_string 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorModelConfiguration::test_custom_model_instance 
[gw4] [ 58%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_working_tool_no_retry_needed 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_failing_tool_returns_message 
[gw3] [ 58%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_applies_prlimit 
tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_uses_preexec_on_macos 
[gw3] [ 58%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py::test_host_policy_uses_preexec_on_macos 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_token_retention_preserves_ai_tool_pairs 
[gw3] [ 58%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_token_retention_preserves_ai_tool_pairs 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_missing_profile 
[gw3] [ 58%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_missing_profile 
[gw1] [ 58%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_run_limit_with_multiple_human_messages 
[gw0] [ 58%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorModelConfiguration::test_custom_model_instance 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorModelConfiguration::test_default_model_used_when_none 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_full_workflow 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_exception_error_messages 
[gw3] [ 58%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_full_workflow 
[gw0] [ 59%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorModelConfiguration::test_default_model_used_when_none 
[gw1] [ 59%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_exception_error_messages 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_emulates_specified_tool_by_name 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_limit_reached_but_not_exceeded 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_full_workflow_async 
[gw1] [ 59%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_limit_reached_but_not_exceeded 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_exit_behavior_continue 
[gw3] [ 59%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_full_workflow_async 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_keep_messages 
[gw3] [ 59%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_keep_messages 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value0-Fractional trigger values must be between 0 and 1] 
[gw3] [ 59%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value0-Fractional trigger values must be between 0 and 1] 
[gw0] [ 59%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_emulates_specified_tool_by_name 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value1-Fractional trigger values must be between 0 and 1] 
[gw2] [ 59%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_truncation_by_bytes 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_startup_command_failure 
[gw3] [ 59%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value1-Fractional trigger values must be between 0 and 1] 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[keep-param_value2-Fractional keep values must be between 0 and 1] 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_emulates_specified_tool_by_instance 
[gw3] [ 60%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[keep-param_value2-Fractional keep values must be between 0 and 1] 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value3-trigger thresholds must be greater than 0] 
[gw3] [ 60%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value3-trigger thresholds must be greater than 0] 
[gw6] [ 60%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_truncation_indicator_present 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value4-trigger thresholds must be greater than 0] 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_timeout_returns_error 
[gw3] [ 60%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value4-trigger thresholds must be greater than 0] 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[keep-param_value5-keep thresholds must be greater than 0] 
[gw3] [ 60%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[keep-param_value5-keep thresholds must be greater than 0] 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value6-Unsupported context size type] 
[gw3] [ 60%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[trigger-param_value6-Unsupported context size type] 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[keep-param_value7-Unsupported context size type] 
[gw0] [ 60%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_emulates_specified_tool_by_instance 
[gw3] [ 60%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_validation_edge_cases[keep-param_value7-Unsupported context size type] 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_non_emulated_tools_execute_normally 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestMaxToolsLimiting::test_no_max_tools_uses_all_selected 
[gw4] [ 60%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_failing_tool_returns_message 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_failing_tool_raises 
[gw0] [ 61%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_non_emulated_tools_execute_normally 
[gw1] [ 61%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_exit_behavior_continue 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_none_tools_emulates_all 
[gw3] [ 61%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestMaxToolsLimiting::test_no_max_tools_uses_all_selected 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_thread_count_excludes_blocked_run_calls 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestAlwaysInclude::test_always_include_tools_present 
[gw1] [ 61%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_thread_count_excludes_blocked_run_calls 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_unified_error_messages 
[gw1] [ 61%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_unified_error_messages 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_end_behavior_creates_artificial_messages 
[gw0] [ 61%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_none_tools_emulates_all 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_emulate_multiple_tools 
[gw3] [ 61%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestAlwaysInclude::test_always_include_tools_present 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestAlwaysInclude::test_always_include_not_counted_against_max 
[gw0] [ 61%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_emulate_multiple_tools 
[gw3] [ 61%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestAlwaysInclude::test_always_include_not_counted_against_max 
tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_mixed_emulated_and_real_tools 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestAlwaysInclude::test_multiple_always_include_tools 
[gw4] [ 62%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_failing_tool_raises 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_custom_failure_formatter 
[gw1] [ 62%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_end_behavior_creates_artificial_messages 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_parallel_tool_calls_with_limit_continue_mode 
[gw3] [ 62%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestAlwaysInclude::test_multiple_always_include_tools 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestDuplicateAndInvalidTools::test_duplicate_tool_selection_deduplicated 
[gw0] [ 62%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_emulator.py::TestLLMToolEmulatorAsync::test_async_mixed_emulated_and_real_tools 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_initialization_defaults 
[gw0] [ 62%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_initialization_defaults 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_initialization_custom 
[gw0] [ 62%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_initialization_custom 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_initialization_with_base_tools 
[gw0] [ 62%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_initialization_with_base_tools 
[gw3] [ 62%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestDuplicateAndInvalidTools::test_duplicate_tool_selection_deduplicated 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_initialization_with_mixed_tools 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestDuplicateAndInvalidTools::test_max_tools_with_duplicates 
[gw0] [ 63%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_initialization_with_mixed_tools 
[gw1] [ 63%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_parallel_tool_calls_with_limit_continue_mode 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_invalid_max_retries 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_parallel_tool_calls_with_limit_end_mode 
[gw4] [ 63%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_custom_failure_formatter 
[gw0] [ 63%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_invalid_max_retries 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_succeeds_after_retries 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_3_explicit_none 
[gw0] [ 63%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_3_explicit_none 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_4_specific_context 
[gw3] [ 63%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestDuplicateAndInvalidTools::test_max_tools_with_duplicates 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestEdgeCases::test_empty_tools_list_raises_error 
[gw3] [ 63%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestEdgeCases::test_empty_tools_list_raises_error 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_1_unparameterized 
[gw0] [ 63%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_4_specific_context 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_5_decorator 
[gw1] [ 63%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_parallel_tool_calls_with_limit_end_mode 
tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_parallel_mixed_tool_calls_with_specific_tool_limit 
[gw3] [ 64%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_1_unparameterized 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_2_two_params 
[gw0] [ 64%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_5_decorator 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_6_async 
[gw3] [ 64%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_2_two_params 
tests/unit_tests/agents/middleware_typing/test_middleware_type_errors.py::test_backwards_compat_with_context_schema 
[gw0] [ 64%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_6_async 
[gw3] [ 64%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_type_errors.py::test_backwards_compat_with_context_schema 
tests/unit_tests/agents/middleware_typing/test_middleware_type_errors.py::test_mismatched_response_format 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_7_model_response_unparameterized 
[gw3] [ 64%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_type_errors.py::test_mismatched_response_format 
[gw1] [ 64%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py::test_parallel_mixed_tool_calls_with_specific_tool_limit 
[gw0] [ 64%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_old_pattern_7_model_response_unparameterized 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_no_context_schema 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_zero_retries 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_multiple_old_style_middlewares 
[gw3] [ 64%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_no_context_schema 
[gw4] [ 65%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_succeeds_after_retries 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_with_user_context 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_specific_tools_only 
[gw0] [ 65%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_multiple_old_style_middlewares 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_model_response_backwards_compat 
[gw3] [ 65%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_with_user_context 
[gw0] [ 65%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_model_response_backwards_compat 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_with_session_context 
tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_model_request_backwards_compat 
[gw1] [ 65%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_zero_retries 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_multiple_middleware_composition 
[gw0] [ 65%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_backwards_compat.py::test_model_request_backwards_compat 
tests/unit_tests/agents/middleware_typing/test_middleware_type_errors.py::test_mismatched_context_schema 
[gw3] [ 65%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_with_session_context 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_with_flexible_middleware 
[gw0] [ 65%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_type_errors.py::test_mismatched_context_schema 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_async_middleware_with_context 
[gw3] [ 65%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_with_flexible_middleware 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_with_response_middleware 
[gw1] [ 66%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_multiple_middleware_composition 
[gw0] [ 66%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_async_middleware_with_context 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_deprecated_raise_keyword 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_async_middleware_with_response 
[gw1] [ 66%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_deprecated_raise_keyword 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_deprecated_return_message_keyword 
[gw3] [ 66%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_with_response_middleware 
[gw1] [ 66%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_deprecated_return_message_keyword 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_fully_typed 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_deprecated_raise_behavior 
[gw0] [ 66%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_async_middleware_with_response 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_request_preserves_context_type 
[gw0] [ 66%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_request_preserves_context_type 
[gw3] [ 66%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_create_agent_fully_typed 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_request_backwards_compatible 
tests/unit_tests/agents/test_agent_name.py::test_agent_name_set_on_ai_message 
[gw0] [ 66%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_request_backwards_compatible 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_request_explicit_none 
[gw0] [ 67%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_request_explicit_none 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_response_with_response_type 
[gw3] [ 67%] PASSED tests/unit_tests/agents/test_agent_name.py::test_agent_name_set_on_ai_message 
[gw0] [ 67%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_response_with_response_type 
tests/unit_tests/agents/test_agent_name.py::test_agent_name_not_set_when_none 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_response_without_structured 
[gw0] [ 67%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_response_without_structured 
tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_response_backwards_compatible 
[gw0] [ 67%] PASSED tests/unit_tests/agents/middleware_typing/test_middleware_typing.py::test_model_response_backwards_compatible 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_caller_transformers_appended_not_replaced 
[gw3] [ 67%] PASSED tests/unit_tests/agents/test_agent_name.py::test_agent_name_not_set_when_none 
[gw4] [ 67%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_specific_tools_only 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_specific_tools_with_base_tool 
tests/unit_tests/agents/test_agent_name.py::test_agent_name_on_multiple_iterations 
[gw3] [ 67%] PASSED tests/unit_tests/agents/test_agent_name.py::test_agent_name_on_multiple_iterations 
tests/unit_tests/agents/test_agent_name.py::test_agent_name_async 
[gw0] [ 67%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_caller_transformers_appended_not_replaced 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_tool_error_sets_error_field 
[gw3] [ 68%] PASSED tests/unit_tests/agents/test_agent_name.py::test_agent_name_async 
tests/unit_tests/agents/test_agent_name.py::test_agent_name_async_multiple_iterations 
[gw1] [ 68%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_deprecated_raise_behavior 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_deprecated_return_message_behavior 
[gw0] [ 68%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_tool_error_sets_error_field 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_inner_agent_tool_calls_via_subgraph 
[gw3] [ 68%] PASSED tests/unit_tests/agents/test_agent_name.py::test_agent_name_async_multiple_iterations 
tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_in_stream_metadata 
[gw4] [ 68%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_specific_tools_with_base_tool 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_specific_exceptions 
[gw3] [ 68%] PASSED tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_in_stream_metadata 
tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_not_in_stream_metadata_when_name_not_provided 
[gw0] [ 68%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_inner_agent_tool_calls_via_subgraph 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Async::test_astream_returns_async_agent_run_stream 
[gw3] [ 68%] PASSED tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_not_in_stream_metadata_when_name_not_provided 
tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_in_stream_metadata_multiple_iterations 
[gw3] [ 69%] PASSED tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_in_stream_metadata_multiple_iterations 
tests/unit_tests/agents/test_create_agent_tool_validation.py::test_create_agent_error_content_with_multiple_params 
[gw1] [ 69%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_deprecated_return_message_behavior 
[gw0] [ 69%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Async::test_astream_returns_async_agent_run_stream 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestLLMToolSelectorBasic::test_sync_basic_selection 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Async::test_async_tool_deltas_flow 
[gw0] [ 69%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Async::test_async_tool_deltas_flow 
[gw1] [ 69%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestLLMToolSelectorBasic::test_sync_basic_selection 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestLLMToolSelectorBasic::test_async_basic_selection 
tests/unit_tests/agents/test_create_agent_tool_validation.py::test_tool_invocation_error_excludes_injected_state 
[gw3] [ 69%] PASSED tests/unit_tests/agents/test_create_agent_tool_validation.py::test_create_agent_error_content_with_multiple_params 
tests/unit_tests/agents/test_create_agent_tool_validation.py::test_create_agent_error_only_model_controllable_params 
[gw4] [ 69%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_specific_exceptions 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_custom_exception_filter 
[gw1] [ 69%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestLLMToolSelectorBasic::test_async_basic_selection 
tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestMaxToolsLimiting::test_max_tools_limits_selection 
[gw0] [ 69%] PASSED tests/unit_tests/agents/test_create_agent_tool_validation.py::test_tool_invocation_error_excludes_injected_state 
tests/unit_tests/agents/test_create_agent_tool_validation.py::test_tool_invocation_error_excludes_injected_state_async 
[gw3] [ 70%] PASSED tests/unit_tests/agents/test_create_agent_tool_validation.py::test_create_agent_error_only_model_controllable_params 
tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_normal 
[gw3] [ 70%] PASSED tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_normal 
tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_multiple_ai 
[gw1] [ 70%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_selection.py::TestMaxToolsLimiting::test_max_tools_limits_selection 
[gw3] [ 70%] PASSED tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_multiple_ai 
tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_in_astream_metadata 
tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_no_ai_message 
[gw3] [ 70%] PASSED tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_no_ai_message 
tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_empty_list 
[gw3] [ 70%] PASSED tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_empty_list 
tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_only_human_messages 
[gw4] [ 70%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_custom_exception_filter 
[gw3] [ 70%] PASSED tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_only_human_messages 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_backoff_timing 
[gw1] [ 70%] PASSED tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_in_astream_metadata 
[gw0] [ 71%] PASSED tests/unit_tests/agents/test_create_agent_tool_validation.py::test_tool_invocation_error_excludes_injected_state_async 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_with_custom_state 
tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_not_in_astream_metadata_when_name_not_provided 
tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_ai_without_tool_calls 
[gw0] [ 71%] PASSED tests/unit_tests/agents/test_fetch_last_ai_and_tool_messages.py::test_fetch_last_ai_and_tool_messages_ai_without_tool_calls 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_basic_injection 
[gw1] [ 71%] PASSED tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_not_in_astream_metadata_when_name_not_provided 
tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_in_astream_metadata_multiple_iterations 
[gw1] [ 71%] PASSED tests/unit_tests/agents/test_agent_name.py::test_lc_agent_name_in_astream_metadata_multiple_iterations 
[gw3] [ 71%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_with_custom_state 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_no_runtime_parameter 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_stream_returns_agent_run_stream 
[gw0] [ 71%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_basic_injection 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_async_injection 
[gw1] [ 71%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_stream_returns_agent_run_stream 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_tool_calls_populated_without_opt_in 
[gw3] [ 71%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_no_runtime_parameter 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_parallel_execution 
[gw1] [ 71%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_tool_calls_populated_without_opt_in 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_tool_output_deltas_flow_through 
[gw0] [ 72%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_async_injection 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_state_access 
[gw1] [ 72%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_tool_output_deltas_flow_through 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_no_tools_run_is_still_usable 
[gw0] [ 72%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_state_access 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_with_store 
[gw1] [ 72%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_no_tools_run_is_still_usable 
[gw5] [ 72%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_async_backoff_timing 
tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_messages_projection_present 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_zero_retries 
[gw5] [ 72%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_zero_retries 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_multiple_middleware_composition 
[gw1] [ 72%] PASSED tests/unit_tests/agents/test_agent_streaming.py::TestAgentStreamV3Sync::test_messages_projection_present 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_combined_injected_state_runtime_store 
[gw3] [ 72%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_parallel_execution 
[gw5] [ 72%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_multiple_middleware_composition 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_error_handling 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestEmailDetection::test_detect_valid_email 
[gw5] [ 73%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestEmailDetection::test_detect_valid_email 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestEmailDetection::test_detect_multiple_emails 
[gw5] [ 73%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestEmailDetection::test_detect_multiple_emails 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestEmailDetection::test_no_email 
[gw0] [ 73%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_with_store 
[gw5] [ 73%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestEmailDetection::test_no_email 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_with_multiple_tools 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestEmailDetection::test_invalid_email_format 
[gw5] [ 73%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestEmailDetection::test_invalid_email_format 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_detect_valid_credit_card 
[gw1] [ 73%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_combined_injected_state_runtime_store 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_combined_injected_state_runtime_store_async 
[gw5] [ 73%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_detect_valid_credit_card 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_detect_credit_card_with_spaces 
[gw5] [ 73%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_detect_credit_card_with_spaces 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_detect_credit_card_with_dashes 
[gw5] [ 73%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_detect_credit_card_with_dashes 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_invalid_luhn_not_detected 
[gw5] [ 74%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_invalid_luhn_not_detected 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_no_credit_card 
[gw5] [ 74%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestCreditCardDetection::test_no_credit_card 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_detect_valid_ipv4 
[gw5] [ 74%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_detect_valid_ipv4 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_detect_multiple_ips 
[gw5] [ 74%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_detect_multiple_ips 
[gw1] [ 74%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_combined_injected_state_runtime_store_async 
tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_invalid_ip_not_detected 
tests/unit_tests/agents/test_kwargs_tool_runtime_injection.py::test_config_and_runtime_not_injected_to_kwargs 
[gw5] [ 74%] PASSED tests/unit_tests/agents/middleware/implementations/test_pii.py::TestIPDetection::test_invalid_ip_not_detected 
[gw3] [ 74%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_error_handling 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_retry_with_custom_string_message 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_with_middleware 
[gw5] [ 74%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_retry_with_custom_string_message 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_validation_error_with_invalid_response 
[gw0] [ 75%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_with_multiple_tools 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_config_access 
[gw1] [ 75%] PASSED tests/unit_tests/agents/test_kwargs_tool_runtime_injection.py::test_config_and_runtime_not_injected_to_kwargs 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_pydantic_model 
[gw5] [ 75%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_validation_error_with_invalid_response 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_pydantic_model 
[gw1] [ 75%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_pydantic_model 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_dataclass 
[gw3] [ 75%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_with_middleware 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_type_hints 
[gw5] [ 75%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_pydantic_model 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_validation_error_with_invalid_response 
[gw1] [ 75%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_dataclass 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_typed_dict 
[gw0] [ 75%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_config_access 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_autostrategy_with_anonymous_json_schema 
[gw0] [ 75%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_autostrategy_with_anonymous_json_schema 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_pydantic_model 
[gw1] [ 76%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_typed_dict 
[gw5] [ 76%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_validation_error_with_invalid_response 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_json_schema 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_dataclass 
[gw3] [ 76%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_type_hints 
tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_name_based_injection 
[gw1] [ 76%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsModel::test_json_schema 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_json_schema 
[gw0] [ 76%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_pydantic_model 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_dataclass 
[gw5] [ 76%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_dataclass 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_typed_dict 
[gw3] [ 76%] PASSED tests/unit_tests/agents/test_injected_runtime_create_agent.py::test_tool_runtime_name_based_injection 
[gw1] [ 76%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_json_schema 
tests/unit_tests/agents/test_response_format.py::TestDynamicModelWithResponseFormat::test_middleware_model_swap_provider_to_tool_strategy 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_union_of_types 
[gw0] [ 76%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_dataclass 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_typed_dict 
[gw5] [ 77%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsProviderStrategy::test_typed_dict 
tests/unit_tests/agents/test_response_format.py::TestSupportsProviderStrategy::test_blocks_gemini_latest_aliases[gemini-flash-lite-latest] 
[gw1] [ 77%] PASSED tests/unit_tests/agents/test_response_format.py::TestDynamicModelWithResponseFormat::test_middleware_model_swap_provider_to_tool_strategy 
tests/unit_tests/agents/test_response_format.py::test_union_of_types 
[gw5] [ 77%] PASSED tests/unit_tests/agents/test_response_format.py::TestSupportsProviderStrategy::test_blocks_gemini_latest_aliases[gemini-flash-lite-latest] 
tests/unit_tests/agents/test_response_format_integration.py::test_inference_to_native_output[False] 
[gw0] [ 77%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_typed_dict 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_json_schema 
[gw1] [ 77%] PASSED tests/unit_tests/agents/test_response_format.py::test_union_of_types 
[gw3] [ 77%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_union_of_types 
tests/unit_tests/agents/test_response_format.py::TestSupportsProviderStrategy::test_blocks_gemini_v2_with_tools 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_multiple_structured_outputs_error_without_retry 
[gw1] [ 77%] PASSED tests/unit_tests/agents/test_response_format.py::TestSupportsProviderStrategy::test_blocks_gemini_v2_with_tools 
[gw3] [ 77%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_multiple_structured_outputs_error_without_retry 
tests/unit_tests/agents/test_response_format.py::TestSupportsProviderStrategy::test_allows_gemini_v3_with_tools 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_multiple_structured_outputs_with_retry 
[gw0] [ 77%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_json_schema 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_union_of_json_schemas 
[gw1] [ 78%] PASSED tests/unit_tests/agents/test_response_format.py::TestSupportsProviderStrategy::test_allows_gemini_v3_with_tools 
tests/unit_tests/agents/test_response_format.py::TestSupportsProviderStrategy::test_blocks_gemini_latest_aliases[gemini-flash-latest] 
[gw3] [ 78%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_multiple_structured_outputs_with_retry 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_structured_output_parsing_error_without_retry 
[gw1] [ 78%] PASSED tests/unit_tests/agents/test_response_format.py::TestSupportsProviderStrategy::test_blocks_gemini_latest_aliases[gemini-flash-latest] 
tests/unit_tests/agents/test_responses.py::TestProviderStrategy::test_strict 
[gw1] [ 78%] PASSED tests/unit_tests/agents/test_responses.py::TestProviderStrategy::test_strict 
[gw3] [ 78%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_structured_output_parsing_error_without_retry 
tests/unit_tests/agents/test_responses.py::TestProviderStrategy::test_to_model_kwargs 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_structured_output_parsing_error_with_retry 
[gw1] [ 78%] PASSED tests/unit_tests/agents/test_responses.py::TestProviderStrategy::test_to_model_kwargs 
tests/unit_tests/agents/test_responses.py::TestProviderStrategy::test_to_model_kwargs_strict 
[gw1] [ 78%] PASSED tests/unit_tests/agents/test_responses.py::TestProviderStrategy::test_to_model_kwargs_strict 
tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_basic 
[gw1] [ 78%] PASSED tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_basic 
[gw3] [ 78%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_structured_output_parsing_error_with_retry 
tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_with_custom_name 
tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_retry_with_custom_function 
[gw1] [ 79%] PASSED tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_with_custom_name 
[gw0] [ 79%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_union_of_json_schemas 
tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_from_schema_spec_basic 
tests/unit_tests/agents/test_response_format_integration.py::test_strict_mode[True] 
[gw1] [ 79%] PASSED tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_from_schema_spec_basic 
tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_parse_payload_pydantic_success 
[gw1] [ 79%] PASSED tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_parse_payload_pydantic_success 
tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_parse_payload_pydantic_validation_error 
[gw3] [ 79%] PASSED tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_retry_with_custom_function 
tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_with_custom_description 
[gw1] [ 79%] PASSED tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_parse_payload_pydantic_validation_error 
tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_parse_payload_pydantic_json_error 
[gw3] [ 79%] PASSED tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_with_custom_description 
tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_with_model_docstring 
[gw1] [ 79%] PASSED tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_parse_payload_pydantic_json_error 
tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_parse_content_list 
[gw3] [ 79%] PASSED tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_with_model_docstring 
tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_empty_docstring 
[gw1] [ 80%] PASSED tests/unit_tests/agents/test_responses.py::TestProviderStrategyBinding::test_parse_content_list 
tests/unit_tests/agents/test_responses.py::TestEdgeCases::test_single_schema 
[gw3] [ 80%] PASSED tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_from_schema_spec_empty_docstring 
tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_parse_payload_pydantic_success 
[gw1] [ 80%] PASSED tests/unit_tests/agents/test_responses.py::TestEdgeCases::test_single_schema 
tests/unit_tests/agents/test_responses.py::TestEdgeCases::test_empty_docstring_model 
[gw3] [ 80%] PASSED tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_parse_payload_pydantic_success 
tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_parse_payload_pydantic_validation_error 
[gw1] [ 80%] PASSED tests/unit_tests/agents/test_responses.py::TestEdgeCases::test_empty_docstring_model 
tests/unit_tests/agents/test_responses_spec.py::test_responses_integration_matrix[updated structured response] 
[gw1] [ 80%] SKIPPED tests/unit_tests/agents/test_responses_spec.py::test_responses_integration_matrix[updated structured response] 
[gw3] [ 80%] PASSED tests/unit_tests/agents/test_responses.py::TestOutputToolBinding::test_parse_payload_pydantic_validation_error 
tests/unit_tests/agents/test_responses_spec.py::test_responses_integration_matrix[asking for information that does not fit into the response format] 
[gw1] [ 80%] SKIPPED tests/unit_tests/agents/test_responses_spec.py::test_responses_integration_matrix[asking for information that does not fit into the response format] 
tests/unit_tests/agents/test_return_direct_graph.py::test_agent_graph_without_return_direct_tools 
tests/unit_tests/agents/test_return_direct_graph.py::test_agent_graph_with_return_direct_tool 
[gw1] [ 80%] PASSED tests/unit_tests/agents/test_return_direct_graph.py::test_agent_graph_without_return_direct_tools 
[gw3] [ 81%] PASSED tests/unit_tests/agents/test_return_direct_graph.py::test_agent_graph_with_return_direct_tool 
tests/unit_tests/agents/test_return_direct_spec.py::test_return_direct_integration_matrix[Scenario: YES return_direct, YES response_format] 
[gw1] [ 81%] SKIPPED tests/unit_tests/agents/test_return_direct_spec.py::test_return_direct_integration_matrix[Scenario: YES return_direct, YES response_format] 
tests/unit_tests/agents/test_return_direct_graph.py::test_agent_graph_with_mixed_tools 
tests/unit_tests/agents/test_state_schema.py::test_state_schema_single_custom_field 
[gw1] [ 81%] PASSED tests/unit_tests/agents/test_state_schema.py::test_state_schema_single_custom_field 
tests/unit_tests/agents/test_state_schema.py::test_state_schema_multiple_custom_fields 
[gw3] [ 81%] PASSED tests/unit_tests/agents/test_return_direct_graph.py::test_agent_graph_with_mixed_tools 
tests/unit_tests/agents/test_return_direct_spec.py::test_return_direct_integration_matrix[Scenario: NO return_direct, NO response_format] 
[gw3] [ 81%] SKIPPED tests/unit_tests/agents/test_return_direct_spec.py::test_return_direct_integration_matrix[Scenario: NO return_direct, NO response_format] 
tests/unit_tests/agents/test_return_direct_spec.py::test_return_direct_integration_matrix[Scenario: NO return_direct, YES response_format] 
[gw3] [ 81%] SKIPPED tests/unit_tests/agents/test_return_direct_spec.py::test_return_direct_integration_matrix[Scenario: NO return_direct, YES response_format] 
tests/unit_tests/agents/test_return_direct_spec.py::test_return_direct_integration_matrix[Scenario: YES return_direct, NO response_format] 
[gw3] [ 81%] SKIPPED tests/unit_tests/agents/test_return_direct_spec.py::test_return_direct_integration_matrix[Scenario: YES return_direct, NO response_format] 
tests/unit_tests/agents/test_state_schema.py::test_last_schema_wins_for_conflicting_field 
[gw3] [ 81%] PASSED tests/unit_tests/agents/test_state_schema.py::test_last_schema_wins_for_conflicting_field 
tests/unit_tests/agents/test_state_schema.py::test_get_schema_type_hints_cache_hits_for_reused_schema 
[gw3] [ 82%] PASSED tests/unit_tests/agents/test_state_schema.py::test_get_schema_type_hints_cache_hits_for_reused_schema 
[gw1] [ 82%] PASSED tests/unit_tests/agents/test_state_schema.py::test_state_schema_multiple_custom_fields 
tests/unit_tests/agents/test_state_schema.py::test_get_schema_type_hints_cache_accepts_distinct_local_schema_types 
tests/unit_tests/agents/test_state_schema.py::test_state_schema_with_tool_runtime 
[gw3] [ 82%] PASSED tests/unit_tests/agents/test_state_schema.py::test_get_schema_type_hints_cache_accepts_distinct_local_schema_types 
tests/unit_tests/agents/test_subagent_streaming.py::test_subagent_updates_emitted_when_streaming_with_subgraphs 
[gw7] [ 82%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_backoff_timing 
[gw1] [ 82%] PASSED tests/unit_tests/agents/test_state_schema.py::test_state_schema_with_tool_runtime 
[gw3] [ 82%] PASSED tests/unit_tests/agents/test_subagent_streaming.py::test_subagent_updates_emitted_when_streaming_with_subgraphs 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_constant_backoff 
tests/unit_tests/agents/test_state_schema.py::test_state_schema_with_middleware 
tests/unit_tests/agents/test_subagent_streaming.py::test_subagent_updates_emitted_when_astreaming_with_subgraphs 
[gw1] [ 82%] PASSED tests/unit_tests/agents/test_state_schema.py::test_state_schema_with_middleware 
tests/unit_tests/agents/test_state_schema.py::test_state_schema_none_uses_default 
[gw3] [ 82%] PASSED tests/unit_tests/agents/test_subagent_streaming.py::test_subagent_updates_emitted_when_astreaming_with_subgraphs 
[gw1] [ 82%] PASSED tests/unit_tests/agents/test_state_schema.py::test_state_schema_none_uses_default 
tests/unit_tests/agents/test_state_schema.py::test_state_schema_async 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_create_with_various_system_inputs[system_message0-None-expected_msg0-You are helpful] 
[gw3] [ 83%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_create_with_various_system_inputs[system_message0-None-expected_msg0-You are helpful] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_create_with_various_system_inputs[None-None-None-None] 
[gw3] [ 83%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_create_with_various_system_inputs[None-None-None-None] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_create_with_various_system_inputs[None-You are helpful-expected_msg2-You are helpful] 
[gw3] [ 83%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_create_with_various_system_inputs[None-You are helpful-expected_msg2-You are helpful] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_system_prompt_property_with_list_content 
[gw3] [ 83%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_system_prompt_property_with_list_content 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_override_methods[system_message-New] 
[gw3] [ 83%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_override_methods[system_message-New] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_override_methods[system_prompt-New prompt] 
[gw1] [ 83%] PASSED tests/unit_tests/agents/test_state_schema.py::test_state_schema_async 
[gw3] [ 83%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_override_methods[system_prompt-New prompt] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_override_system_prompt_to_none 
tests/unit_tests/agents/test_state_schema.py::test_state_schema_with_private_state_field 
[gw3] [ 83%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_override_system_prompt_to_none 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_cannot_set_both_system_prompt_and_system_message[constructor] 
[gw3] [ 83%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_cannot_set_both_system_prompt_and_system_message[constructor] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_cannot_set_both_system_prompt_and_system_message[override] 
[gw3] [ 84%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_cannot_set_both_system_prompt_and_system_message[override] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_setattr_system_prompt_deprecated[New prompt-False] 
[gw3] [ 84%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_setattr_system_prompt_deprecated[New prompt-False] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_setattr_system_prompt_deprecated[None-True] 
[gw3] [ 84%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_setattr_system_prompt_deprecated[None-True] 
tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[system_message] 
[gw3] [ 84%] PASSED tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[system_message] 
tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[system_message_with_metadata] 
[gw3] [ 84%] PASSED tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[system_message_with_metadata] 
[gw1] [ 84%] PASSED tests/unit_tests/agents/test_state_schema.py::test_state_schema_with_private_state_field 
tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[system_message_with_complex_content] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_system_message_with_complex_content 
[gw1] [ 84%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_system_message_with_complex_content 
[gw3] [ 84%] PASSED tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[system_message_with_complex_content] 
tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_multiple_overrides_with_system_message 
tests/unit_tests/agents/test_system_message.py::TestSystemMessageUpdateViaMiddleware::test_middleware_can_set_initial_system_message 
[gw1] [ 84%] PASSED tests/unit_tests/agents/test_system_message.py::TestModelRequestSystemMessage::test_multiple_overrides_with_system_message 
tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[none] 
[gw3] [ 85%] PASSED tests/unit_tests/agents/test_system_message.py::TestSystemMessageUpdateViaMiddleware::test_middleware_can_set_initial_system_message 
tests/unit_tests/agents/test_system_message.py::TestSystemMessageUpdateViaMiddleware::test_middleware_can_update_via_system_message_object 
[gw3] [ 85%] PASSED tests/unit_tests/agents/test_system_message.py::TestSystemMessageUpdateViaMiddleware::test_middleware_can_update_via_system_message_object 
tests/unit_tests/agents/test_system_message.py::TestMultipleMiddlewareChaining::test_multiple_middleware_can_chain_modifications 
[gw1] [ 85%] PASSED tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[none] 
tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[string] 
[gw3] [ 85%] PASSED tests/unit_tests/agents/test_system_message.py::TestMultipleMiddlewareChaining::test_multiple_middleware_can_chain_modifications 
tests/unit_tests/agents/test_system_message.py::TestMultipleMiddlewareChaining::test_middleware_can_mix_string_and_system_message_updates 
[gw3] [ 85%] PASSED tests/unit_tests/agents/test_system_message.py::TestMultipleMiddlewareChaining::test_middleware_can_mix_string_and_system_message_updates 
[gw1] [ 85%] PASSED tests/unit_tests/agents/test_system_message.py::TestCreateAgentSystemMessage::test_create_agent_with_various_system_prompts[string] 
tests/unit_tests/agents/test_system_message.py::TestMetadataMerging::test_metadata_merge_across_updates[response_metadata] 
tests/unit_tests/agents/test_system_message.py::TestCacheControlPreservation::test_middleware_can_add_cache_control 
[gw3] [ 85%] PASSED tests/unit_tests/agents/test_system_message.py::TestMetadataMerging::test_metadata_merge_across_updates[response_metadata] 
[gw1] [ 85%] PASSED tests/unit_tests/agents/test_system_message.py::TestCacheControlPreservation::test_middleware_can_add_cache_control 
tests/unit_tests/agents/test_system_message.py::TestDynamicSystemPromptMiddleware::test_middleware_can_return_system_message 
tests/unit_tests/agents/test_system_message.py::TestCacheControlPreservation::test_cache_control_preserved_across_middleware 
[gw1] [ 85%] PASSED tests/unit_tests/agents/test_system_message.py::TestCacheControlPreservation::test_cache_control_preserved_across_middleware 
[gw3] [ 86%] PASSED tests/unit_tests/agents/test_system_message.py::TestDynamicSystemPromptMiddleware::test_middleware_can_return_system_message 
tests/unit_tests/agents/test_system_message.py::TestMetadataMerging::test_metadata_merge_across_updates[additional_kwargs] 
tests/unit_tests/agents/test_system_message.py::TestDynamicSystemPromptMiddleware::test_middleware_can_use_system_message_with_metadata 
[gw3] [ 86%] PASSED tests/unit_tests/agents/test_system_message.py::TestDynamicSystemPromptMiddleware::test_middleware_can_use_system_message_with_metadata 
[gw1] [ 86%] PASSED tests/unit_tests/agents/test_system_message.py::TestMetadataMerging::test_metadata_merge_across_updates[additional_kwargs] 
tests/unit_tests/agents/test_system_message.py::TestDynamicSystemPromptMiddleware::test_middleware_handles_none_system_message 
tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_middleware_preserves_system_message_metadata 
[gw1] [ 86%] PASSED tests/unit_tests/agents/test_system_message.py::TestDynamicSystemPromptMiddleware::test_middleware_handles_none_system_message 
[gw3] [ 86%] PASSED tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_middleware_preserves_system_message_metadata 
tests/unit_tests/agents/test_system_message.py::TestDynamicSystemPromptMiddleware::test_middleware_with_content_blocks 
tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_backward_compatibility_with_string_system_prompt 
[gw1] [ 86%] PASSED tests/unit_tests/agents/test_system_message.py::TestDynamicSystemPromptMiddleware::test_middleware_with_content_blocks 
[gw3] [ 86%] PASSED tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_backward_compatibility_with_string_system_prompt 
tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_multiple_middleware_can_modify_system_message 
tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_middleware_can_switch_between_formats[system_message] 
[gw1] [ 86%] PASSED tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_multiple_middleware_can_modify_system_message 
[gw3] [ 86%] PASSED tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_middleware_can_switch_between_formats[system_message] 
tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_middleware_can_switch_between_formats[string] 
tests/unit_tests/agents/test_system_message.py::TestEdgeCasesAndErrorHandling::test_system_message_content_variations[empty_content] 
[gw1] [ 87%] PASSED tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_middleware_can_switch_between_formats[string] 
[gw3] [ 87%] PASSED tests/unit_tests/agents/test_system_message.py::TestEdgeCasesAndErrorHandling::test_system_message_content_variations[empty_content] 
tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_middleware_can_switch_between_formats[none] 
tests/unit_tests/agents/test_system_message.py::TestEdgeCasesAndErrorHandling::test_system_message_content_variations[multiple_blocks] 
[gw1] [ 87%] PASSED tests/unit_tests/agents/test_system_message.py::TestSystemMessageMiddlewareIntegration::test_middleware_can_switch_between_formats[none] 
[gw3] [ 87%] PASSED tests/unit_tests/agents/test_system_message.py::TestEdgeCasesAndErrorHandling::test_system_message_content_variations[multiple_blocks] 
tests/unit_tests/agents/test_system_message.py::TestEdgeCasesAndErrorHandling::test_reset_system_prompt_to_none 
tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model[gpt-4o-openai] 
[gw3] [ 87%] SKIPPED tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model[gpt-4o-openai] 
[gw1] [ 87%] PASSED tests/unit_tests/agents/test_system_message.py::TestEdgeCasesAndErrorHandling::test_reset_system_prompt_to_none 
tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model[claude-opus-4-1-anthropic] 
[gw3] [ 87%] SKIPPED tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model[claude-opus-4-1-anthropic] 
tests/unit_tests/chat_models/test_chat_models.py::test_all_imports 
tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model[accounts/fireworks/models/mixtral-8x7b-instruct-fireworks] 
[gw3] [ 87%] SKIPPED tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model[accounts/fireworks/models/mixtral-8x7b-instruct-fireworks] 
tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model[mixtral-8x7b-32768-groq] 
[gw3] [ 88%] SKIPPED tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model[mixtral-8x7b-32768-groq] 
[gw1] [ 88%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_all_imports 
tests/unit_tests/chat_models/test_chat_models.py::test_init_unknown_provider 
tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model_rejects_model_object 
[gw3] [ 88%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_init_unknown_provider 
[gw1] [ 88%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_init_chat_model_rejects_model_object 
tests/unit_tests/chat_models/test_chat_models.py::test_supported_providers_is_sorted 
tests/unit_tests/chat_models/test_chat_models.py::test_init_missing_dep 
[gw3] [ 88%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_supported_providers_is_sorted 
[gw1] [ 88%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_init_missing_dep 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gpt-4o-openai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[o3-mini-openai] 
[gw1] [ 88%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[o3-mini-openai] 
[gw3] [ 88%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gpt-4o-openai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[chatgpt-4o-latest-openai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[o1-mini-openai] 
[gw1] [ 88%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[chatgpt-4o-latest-openai] 
[gw3] [ 89%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[o1-mini-openai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[text-davinci-003-openai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[claude-3-haiku-20240307-anthropic] 
[gw1] [ 89%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[text-davinci-003-openai] 
[gw3] [ 89%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[claude-3-haiku-20240307-anthropic] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[command-r-plus-cohere] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[accounts/fireworks/models/mixtral-8x7b-instruct-fireworks] 
[gw1] [ 89%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[command-r-plus-cohere] 
[gw3] [ 89%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[accounts/fireworks/models/mixtral-8x7b-instruct-fireworks] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[Accounts/Fireworks/models/mixtral-8x7b-instruct-fireworks] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gemini-1.5-pro-google_vertexai] 
[gw1] [ 89%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[Accounts/Fireworks/models/mixtral-8x7b-instruct-fireworks] 
[gw3] [ 89%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gemini-1.5-pro-google_vertexai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gemini-2.5-pro-google_vertexai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gemini-3.1-pro-preview-google_vertexai] 
[gw1] [ 89%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gemini-2.5-pro-google_vertexai] 
[gw3] [ 89%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gemini-3.1-pro-preview-google_vertexai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[Amazon.Titan-Text-Express-v1-bedrock] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[amazon.titan-text-express-v1-bedrock] 
[gw3] [ 90%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[Amazon.Titan-Text-Express-v1-bedrock] 
[gw1] [ 90%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[amazon.titan-text-express-v1-bedrock] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[anthropic.claude-v2-bedrock] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[Anthropic.Claude-V2-bedrock] 
[gw3] [ 90%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[anthropic.claude-v2-bedrock] 
[gw1] [ 90%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[Anthropic.Claude-V2-bedrock] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[mistral-small-mistralai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[mixtral-8x7b-mistralai] 
[gw3] [ 90%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[mistral-small-mistralai] 
[gw1] [ 90%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[mixtral-8x7b-mistralai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[grok-beta-xai] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[deepseek-v3-deepseek] 
[gw1] [ 90%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[grok-beta-xai] 
[gw3] [ 90%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[deepseek-v3-deepseek] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[sonar-small-perplexity] 
tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[solar-pro-upstage] 
[gw1] [ 90%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[sonar-small-perplexity] 
[gw3] [ 91%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[solar-pro-upstage] 
tests/unit_tests/chat_models/test_chat_models.py::test_configurable 
tests/unit_tests/chat_models/test_chat_models.py::test_configurable_with_default 
[gw3] [ 91%] SKIPPED tests/unit_tests/chat_models/test_chat_models.py::test_configurable_with_default 
tests/unit_tests/embeddings/test_base.py::test_parse_model_string[bedrock:amazon.titan-embed-text-v1-bedrock-amazon.titan-embed-text-v1] 
[gw3] [ 91%] PASSED tests/unit_tests/embeddings/test_base.py::test_parse_model_string[bedrock:amazon.titan-embed-text-v1-bedrock-amazon.titan-embed-text-v1] 
tests/unit_tests/embeddings/test_base.py::test_parse_model_string[huggingface:BAAI/bge-base-en:v1.5-huggingface-BAAI/bge-base-en:v1.5] 
[gw3] [ 91%] PASSED tests/unit_tests/embeddings/test_base.py::test_parse_model_string[huggingface:BAAI/bge-base-en:v1.5-huggingface-BAAI/bge-base-en:v1.5] 
tests/unit_tests/embeddings/test_base.py::test_parse_model_string[google_genai:gemini-embedding-001-google_genai-gemini-embedding-001] 
[gw3] [ 91%] PASSED tests/unit_tests/embeddings/test_base.py::test_parse_model_string[google_genai:gemini-embedding-001-google_genai-gemini-embedding-001] 
tests/unit_tests/embeddings/test_base.py::test_parse_model_string_errors 
[gw3] [ 91%] PASSED tests/unit_tests/embeddings/test_base.py::test_parse_model_string_errors 
tests/unit_tests/embeddings/test_base.py::test_infer_model_and_provider 
[gw3] [ 91%] PASSED tests/unit_tests/embeddings/test_base.py::test_infer_model_and_provider 
tests/unit_tests/embeddings/test_base.py::test_infer_model_and_provider_errors 
[gw3] [ 91%] PASSED tests/unit_tests/embeddings/test_base.py::test_infer_model_and_provider_errors 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[azure_ai] 
[gw3] [ 91%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[azure_ai] 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[azure_openai] 
[gw3] [ 92%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[azure_openai] 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[bedrock] 
[gw3] [ 92%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[bedrock] 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[cohere] 
[gw3] [ 92%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[cohere] 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[google_genai] 
[gw3] [ 92%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[google_genai] 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[google_vertexai] 
[gw3] [ 92%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[google_vertexai] 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[huggingface] 
[gw3] [ 92%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[huggingface] 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[mistralai] 
[gw3] [ 92%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[mistralai] 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[ollama] 
[gw3] [ 92%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[ollama] 
tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[openai] 
[gw3] [ 92%] PASSED tests/unit_tests/embeddings/test_base.py::test_supported_providers_package_names[openai] 
tests/unit_tests/embeddings/test_base.py::test_is_sorted 
[gw3] [ 93%] PASSED tests/unit_tests/embeddings/test_base.py::test_is_sorted 
tests/unit_tests/embeddings/test_imports.py::test_all_imports 
[gw3] [ 93%] PASSED tests/unit_tests/embeddings/test_imports.py::test_all_imports 
tests/unit_tests/test_dependencies.py::test_required_dependencies 
[gw7] [ 93%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_constant_backoff 
tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_max_delay_cap 
[gw3] [ 93%] PASSED tests/unit_tests/test_dependencies.py::test_required_dependencies 
[gw7] [ 93%] PASSED tests/unit_tests/agents/middleware/implementations/test_model_retry.py::test_model_retry_max_delay_cap 
tests/unit_tests/test_imports.py::test_import_all 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_many_parallel_tool_calls_safety 
[gw7] [ 93%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_many_parallel_tool_calls_safety 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_before_model_uses_unscaled_tokens_for_cutoff 
[gw3] [ 93%] PASSED tests/unit_tests/test_imports.py::test_import_all 
[gw7] [ 93%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_before_model_uses_unscaled_tokens_for_cutoff 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_find_safe_cutoff_preserves_ai_tool_pair 
tests/unit_tests/test_imports.py::test_import_all_using_dir 
[gw7] [ 94%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_find_safe_cutoff_preserves_ai_tool_pair 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_cutoff_at_start_of_tool_sequence 
[gw3] [ 94%] PASSED tests/unit_tests/test_imports.py::test_import_all_using_dir 
[gw7] [ 94%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_cutoff_at_start_of_tool_sequence 
tests/unit_tests/test_pytest_config.py::test_socket_disabled 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_create_summary_uses_get_buffer_string_format 
[gw7] [ 94%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_create_summary_uses_get_buffer_string_format 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_usage_metadata_trigger 
[gw3] [ 94%] PASSED tests/unit_tests/test_pytest_config.py::test_socket_disabled 
[gw7] [ 94%] SKIPPED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_usage_metadata_trigger 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_provider_matches 
tests/unit_tests/test_version.py::test_version_matches_pyproject 
[gw7] [ 94%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_provider_matches 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_reported_tokens_trigger_for_bedrock_converse 
[gw3] [ 94%] PASSED tests/unit_tests/test_version.py::test_version_matches_pyproject 
[gw7] [ 94%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_reported_tokens_trigger_for_bedrock_converse 
tests/unit_tests/tools/test_imports.py::test_all_imports 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_create_summary_passes_lc_source_metadata[sync] 
[gw3] [ 95%] PASSED tests/unit_tests/tools/test_imports.py::test_all_imports 
[gw7] [ 95%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_create_summary_passes_lc_source_metadata[sync] 
tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_create_summary_passes_lc_source_metadata[async] 
[gw7] [ 95%] PASSED tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_create_summary_passes_lc_source_metadata[async] 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_initialization 
[gw7] [ 95%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_todo_middleware_initialization 
tests/unit_tests/agents/middleware/implementations/test_todo.py::test_has_write_todos_tool 
[gw7] [ 95%] PASSED tests/unit_tests/agents/middleware/implementations/test_todo.py::test_has_write_todos_tool 
[gw2] [ 95%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_startup_command_failure 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shutdown_command_failure_logged 
[gw5] [ 95%] PASSED tests/unit_tests/agents/test_response_format_integration.py::test_inference_to_native_output[False] 
tests/unit_tests/agents/test_response_format_integration.py::test_inference_to_native_output[True] 
[gw4] [ 95%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_backoff_timing 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_constant_backoff 
[gw1] [ 95%] PASSED tests/unit_tests/chat_models/test_chat_models.py::test_configurable 
tests/unit_tests/embeddings/test_base.py::test_parse_model_string[openai:text-embedding-3-small-openai-text-embedding-3-small] 
[gw1] [ 96%] PASSED tests/unit_tests/embeddings/test_base.py::test_parse_model_string[openai:text-embedding-3-small-openai-text-embedding-3-small] 
[gw4] [ 96%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_constant_backoff 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_max_delay_cap 
[gw4] [ 96%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_max_delay_cap 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_jitter_variation 
[gw4] [ 96%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_jitter_variation 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_async_working_tool 
[gw0] [ 96%] PASSED tests/unit_tests/agents/test_response_format_integration.py::test_strict_mode[True] 
tests/unit_tests/agents/test_responses.py::TestToolStrategy::test_basic_creation 
[gw0] [ 96%] PASSED tests/unit_tests/agents/test_responses.py::TestToolStrategy::test_basic_creation 
tests/unit_tests/agents/test_responses.py::TestToolStrategy::test_multiple_schemas 
[gw0] [ 96%] PASSED tests/unit_tests/agents/test_responses.py::TestToolStrategy::test_multiple_schemas 
tests/unit_tests/agents/test_responses.py::TestToolStrategy::test_schema_with_tool_message_content 
[gw0] [ 96%] PASSED tests/unit_tests/agents/test_responses.py::TestToolStrategy::test_schema_with_tool_message_content 
tests/unit_tests/agents/test_responses.py::TestProviderStrategy::test_basic_creation 
[gw4] [ 96%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_async_working_tool 
[gw0] [ 97%] PASSED tests/unit_tests/agents/test_responses.py::TestProviderStrategy::test_basic_creation 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_async_failing_tool 
[gw5] [ 97%] PASSED tests/unit_tests/agents/test_response_format_integration.py::test_inference_to_native_output[True] 
tests/unit_tests/agents/test_response_format_integration.py::test_inference_to_tool_output[False] 
[gw4] [ 97%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_async_failing_tool 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_async_succeeds_after_retries 
[gw5] [ 97%] PASSED tests/unit_tests/agents/test_response_format_integration.py::test_inference_to_tool_output[False] 
tests/unit_tests/agents/test_response_format_integration.py::test_inference_to_tool_output[True] 
[gw4] [ 97%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_async_succeeds_after_retries 
tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_async_backoff_timing 
[gw5] [ 97%] PASSED tests/unit_tests/agents/test_response_format_integration.py::test_inference_to_tool_output[True] 
tests/unit_tests/agents/test_response_format_integration.py::test_strict_mode[False] 
[gw5] [ 97%] PASSED tests/unit_tests/agents/test_response_format_integration.py::test_strict_mode[False] 
[gw2] [ 97%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shutdown_command_failure_logged 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shutdown_command_timeout_logged 
[gw6] [ 97%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_timeout_returns_error 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_redaction_policy_applies 
[gw6] [ 98%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_redaction_policy_applies 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_startup_and_shutdown_commands 
[gw4] [ 98%] PASSED tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_async_backoff_timing 
[gw6] [ 98%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_startup_and_shutdown_commands 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_session_resources_finalizer_cleans_up 
[gw6] [ 98%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_session_resources_finalizer_cleans_up 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shell_tool_input_validation 
[gw6] [ 98%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shell_tool_input_validation 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_shell_command_empty 
[gw6] [ 98%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_shell_command_empty 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_env_non_string_keys 
[gw6] [ 98%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_env_non_string_keys 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_env_coercion 
[gw6] [ 98%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_env_coercion 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shell_tool_missing_command_string 
[gw6] [ 98%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shell_tool_missing_command_string 
[gw2] [ 99%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shutdown_command_timeout_logged 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_empty_output_replaced_with_no_output 
[gw2] [ 99%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_empty_output_replaced_with_no_output 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_stderr_output_labeling 
[gw2] [ 99%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_stderr_output_labeling 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_commands_string_tuple_list[echo test-expected0] 
[gw2] [ 99%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_commands_string_tuple_list[echo test-expected0] 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_commands_string_tuple_list[startup_commands1-expected1] 
[gw2] [ 99%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_commands_string_tuple_list[startup_commands1-expected1] 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_commands_string_tuple_list[startup_commands2-expected2] 
[gw2] [ 99%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_commands_string_tuple_list[startup_commands2-expected2] 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_commands_string_tuple_list[None-expected3] 
[gw2] [ 99%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_normalize_commands_string_tuple_list[None-expected3] 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_async_methods_delegate_to_sync 
[gw2] [ 99%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_async_methods_delegate_to_sync 
tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shell_middleware_resumable_after_interrupt 
[gw2] [100%] PASSED tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shell_middleware_resumable_after_interrupt 

=============================== warnings summary ===============================
tests/unit_tests/agents/test_responses_spec.py:49
tests/unit_tests/agents/test_responses_spec.py:49
tests/unit_tests/agents/test_responses_spec.py:49
tests/unit_tests/agents/test_responses_spec.py:49
tests/unit_tests/agents/test_responses_spec.py:49
tests/unit_tests/agents/test_responses_spec.py:49
tests/unit_tests/agents/test_responses_spec.py:49
tests/unit_tests/agents/test_responses_spec.py:49
  /home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1/tests/unit_tests/agents/test_responses_spec.py:49: PytestCollectionWarning: cannot collect test class 'TestCase' because it has a __init__ constructor (from: tests/unit_tests/agents/test_responses_spec.py)
    class TestCase(BaseSchema):

tests/unit_tests/agents/test_return_direct_spec.py:35
tests/unit_tests/agents/test_return_direct_spec.py:35
tests/unit_tests/agents/test_return_direct_spec.py:35
tests/unit_tests/agents/test_return_direct_spec.py:35
tests/unit_tests/agents/test_return_direct_spec.py:35
tests/unit_tests/agents/test_return_direct_spec.py:35
tests/unit_tests/agents/test_return_direct_spec.py:35
tests/unit_tests/agents/test_return_direct_spec.py:35
  /home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1/tests/unit_tests/agents/test_return_direct_spec.py:35: PytestCollectionWarning: cannot collect test class 'TestCase' because it has a __init__ constructor (from: tests/unit_tests/agents/test_return_direct_spec.py)
    class TestCase(BaseSchema):

tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_profile_edge_cases
  /home/{hidden-path}/test/ghiander/langchain/libs/core/langchain_core/language_models/chat_models.py:429: UserWarning: Unrecognized keys in model profile: ['other_field']. This may indicate a version mismatch between langchain-core and your provider package. Consider upgrading langchain-core.
    _warn_unknown_profile_keys(self.profile)

tests/unit_tests/agents/middleware/implementations/test_summarization.py::test_summarization_middleware_full_workflow
  /home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py:409: DeprecationWarning: max_tokens_before_summary is deprecated. Use trigger=('tokens', value) instead.
    middleware = SummarizationMiddleware(

tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gemini-1.5-pro-google_vertexai]
  /home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1/.venv/lib/python3.13/site-packages/pluggy/_manager.py:120: DeprecationWarning: Inferred `model_provider='google_vertexai'` from 'gemini-1.5-pro'. This default will change to 'google_genai' in the next major release.To keep current behavior, pass `model_provider='google_vertexai'` (or use the prefix form, e.g. 'google_vertexai:gemini-1.5-pro'); for AI Studio / Gemini API, use 'google_genai' instead.
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)

tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gemini-3.1-pro-preview-google_vertexai]
  /home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1/.venv/lib/python3.13/site-packages/pluggy/_manager.py:120: DeprecationWarning: Inferred `model_provider='google_vertexai'` from 'gemini-3.1-pro-preview'. This default will change to 'google_genai' in the next major release.To keep current behavior, pass `model_provider='google_vertexai'` (or use the prefix form, e.g. 'google_vertexai:gemini-3.1-pro-preview'); for AI Studio / Gemini API, use 'google_genai' instead.
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)

tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider[gemini-2.5-pro-google_vertexai]
  /home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1/.venv/lib/python3.13/site-packages/pluggy/_manager.py:120: DeprecationWarning: Inferred `model_provider='google_vertexai'` from 'gemini-2.5-pro'. This default will change to 'google_genai' in the next major release.To keep current behavior, pass `model_provider='google_vertexai'` (or use the prefix form, e.g. 'google_vertexai:gemini-2.5-pro'); for AI Studio / Gemini API, use 'google_genai' instead.
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= slowest 5 durations ==============================
2.02s call     tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shutdown_command_timeout_logged
2.02s call     tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_timeout_returns_error
1.01s call     tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_startup_command_failure
1.01s call     tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_shutdown_command_failure_logged
0.72s call     tests/unit_tests/agents/middleware/implementations/test_tool_retry.py::test_tool_retry_async_backoff_timing
================ 871 passed, 13 skipped, 21 warnings in 10.58s =================
make[1]: Entering directory `/home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1'
docker-compose -f tests/unit_tests/agents/compose-postgres.yml -f tests/unit_tests/agents/compose-redis.yml down -v
make[1]: Leaving directory `/home/{hidden-path}/test/ghiander/langchain/libs/langchain_v1'
```

4. How did you verify your code works?
Using the same script I proposed to reproduce the issue
```
import time
from pathlib import Path

from langchain.agents.middleware._execution import HostExecutionPolicy
from langchain.agents.middleware.shell_tool import ShellSession

WORKSPACE = Path(__file__).parent / "scratch" / "reprod"
WORKSPACE.mkdir(parents=True, exist_ok=True)

WITH_NEWLINE = WORKSPACE / "with_newline.json"
NO_NEWLINE = WORKSPACE / "no_newline.json"

WITH_NEWLINE.write_text('{"k":"v"}\n')   # normal file
NO_NEWLINE.write_bytes(b'{"k":"v"}')     # no trailing newline — triggers the bug

policy = HostExecutionPolicy(command_timeout=5)
session = ShellSession(
    workspace=WORKSPACE,
    policy=policy,
    command=("/bin/bash",),
    environment={},
)
session.start()

for label, path in [("with newline   ", WITH_NEWLINE), ("without newline", NO_NEWLINE)]:
    t0 = time.monotonic()
    result = session.execute(f"head -n 1 {path}", timeout=policy.command_timeout)
    elapsed = time.monotonic() - t0

    status = "TIMEOUT" if result.timed_out else "OK"
    print(f"[{status}] {label}  output={result.output!r}  exit={result.exit_code}  {elapsed:.2f}s")

session.stop(policy.termination_timeout)
```

## Social handles (optional)
LinkedIn: https://www.linkedin.com/in/ghiandonigianmarco/
