### PR TITLE
chore(langchain): bump `langgraph` to 1.2.4

### DIFF
--- a/libs/langchain_v1/langchain/agents/_subagent_transformer.py
+++ b/libs/langchain_v1/langchain/agents/_subagent_transformer.py
@@ -9,9 +9,9 @@ A subagent boundary is a nested run whose `lc_agent_name` is set *and* differs
 from its parent namespace's `lc_agent_name`. Plain subgraphs inherit the
 parent's name (so they compare equal and are excluded); unnamed agents have
 `lc_agent_name == None` (also excluded). For genuine subagents the base also
-recovers the originating tool call and passes it through as a `cause`
-(`{"type": "toolCall", "tool_call_id": ...}`), joined from the parent task's
-pending tool calls.
+recovers the originating tool call and exposes it as a `cause`
+(`{"type": "toolCall", "tool_call_id": ...}`) via `self._pending_cause`, joined
+from the parent task's pending tool calls.
 
 This transformer gates on that boundary and surfaces a typed handle on
 `run.subagents`, then forwards child-scope events into the handle's mux so the
@@ -160,9 +160,12 @@ class SubagentTransformer(_TasksLifecycleBase):
         ns: tuple[str, ...],
         graph_name: str | None,
         trigger_call_id: str | None,
-        *,
-        cause: LifecycleCause | None = None,
     ) -> None:
+        # langgraph >=1.2.4 delivers the triggering `cause` via the base's
+        # `self._pending_cause` instance state rather than an `_on_started`
+        # keyword argument, so overrides predating `cause` keep working. Read it
+        # here to surface the originating tool call on the handle.
+        cause = self._pending_cause
         child_lc = self._lc_by_ns.get(ns)
         # Surface any nested run carrying an lc_agent_name (set by create_agent).
         # A same-named nested agent — e.g. a subagent that invokes itself —

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -25,7 +25,7 @@ version = "1.3.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.4.0,<2.0.0",
-    "langgraph>=1.2.2,<1.3.0",
+    "langgraph>=1.2.4,<1.3.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2025,7 +2025,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.2.3,<1.3.0" },
+    { name = "langgraph", specifier = ">=1.2.4,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -2603,7 +2603,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.3"
+version = "1.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2613,9 +2613,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/55/e42f59b5e4cce75085f68abb77114c4d1152628157bd60c2587881bca559/langgraph-1.2.3.tar.gz", hash = "sha256:7f89cd5f0946fe29bd7ca048e2a84d3c14e7f652e38bb98e00f0ba8b7004b9d0", size = 718812, upload-time = "2026-06-01T18:55:54.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/43/dac5a2621c1e57f8eb7f0703f6f6fe34a5caf62f8f0fb4d2bb395bb454ea/langgraph-1.2.4.tar.gz", hash = "sha256:5df076973a2d23efb13eceb279d1e5b46feebcbbeded0a86a2ef669abd9e4399", size = 720374, upload-time = "2026-06-02T17:07:37.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/9b/287f11be799f2f4dd289ab19d23788df22ac20ce884a010d0696f79016db/langgraph-1.2.3-py3-none-any.whl", hash = "sha256:22e6c89084adb3edb7855f6ffa692af3d75925f9c70deb43b86da14db1b02c78", size = 244841, upload-time = "2026-06-01T18:55:52.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/9e/31ca236104966d7bb14ea9e93cfd73350aea8c41008ddf057b65794ed10d/langgraph-1.2.4-py3-none-any.whl", hash = "sha256:ffe3e1e31dce28907640f82525858470f293506d2b272d07ea3b3ce97974b067", size = 245402, upload-time = "2026-06-02T17:07:35.977Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Raises the minimum `langgraph` requirement from `>=1.2.2` to `>=1.2.4`
- Re-resolves the lockfile off the now-yanked 1.2.3 onto 1.2.4
- Migrates `SubagentTransformer` to the 1.2.4 stream-transformer contract

langgraph 1.2.3 was yanked ("unintended merging strategy regression"), and 1.2.4 changes how the base `_TasksLifecycleBase` hands the triggering `cause` to its `_on_started` hook: it no longer passes `cause` as a keyword argument and instead exposes it via the `_pending_cause` instance attribute, so overrides predating `cause` keep working. Our `_on_started` override still declared a `cause` keyword and therefore silently received `None`, dropping the originating tool-call `cause` on every `run.subagents` handle. It now reads `_pending_cause`. The existing `test_subagent_transformer` regression tests cover the restored behavior.