### PR TITLE
feat(langchain): add "max_stalled_iterations" to "AgentExecutor" to detect stuck loops 

### DIFF
--- a/libs/langchain/langchain_classic/agents/agent.py
+++ b/libs/langchain/langchain_classic/agents/agent.py
@@ -1054,6 +1054,15 @@ class AgentExecutor(Chain):
     """How to trim the intermediate steps before returning them.
     Defaults to -1, which means no trimming.
     """
+    max_stalled_iterations: int | None = None
+    """Maximum number of consecutive steps that share the same tool name,
+    tool input, and observation before the loop is considered stuck and
+    terminated early via `early_stopping_method`.
+
+    A value of `None` (the default) disables the check entirely.
+    The minimum meaningful value is 2; lower positive values are treated as
+    disabled.
+    """
 
     @classmethod
     def from_agent_and_tools(
@@ -1236,6 +1245,36 @@ class AgentExecutor(Chain):
         if self.max_iterations is not None and iterations >= self.max_iterations:
             return False
         return self.max_execution_time is None or time_elapsed < self.max_execution_time
+
+    def _is_stuck_in_loop(
+        self, intermediate_steps: list[tuple[AgentAction, str]]
+    ) -> bool:
+        """Detect whether the agent is stuck repeating the same action with no progress.
+
+        Returns `True` when the last `max_stalled_iterations` steps all share
+        the same tool name, tool input, and observation, indicating the agent is
+        not making progress.
+
+        Args:
+            intermediate_steps: The history of `(AgentAction, observation)`
+                pairs accumulated so far.
+
+        Returns:
+            `True` when a no-progress loop is detected, `False` otherwise.
+        """
+        if not self.max_stalled_iterations or self.max_stalled_iterations < 2:
+            return False
+        n = self.max_stalled_iterations
+        if len(intermediate_steps) < n:
+            return False
+        last_n = intermediate_steps[-n:]
+        first_action, first_obs = last_n[0]
+        return all(
+            action.tool == first_action.tool
+            and action.tool_input == first_action.tool_input
+            and obs == first_obs
+            for action, obs in last_n[1:]
+        )
 
     def _return(
         self,
@@ -1612,6 +1651,8 @@ class AgentExecutor(Chain):
                         intermediate_steps,
                         run_manager=run_manager,
                     )
+            if self._is_stuck_in_loop(intermediate_steps):
+                break
             iterations += 1
             time_elapsed = time.time() - start_time
         output = self._action_agent.return_stopped_response(
@@ -1669,6 +1710,8 @@ class AgentExecutor(Chain):
                                 run_manager=run_manager,
                             )
 
+                    if self._is_stuck_in_loop(intermediate_steps):
+                        break
                     iterations += 1
                     time_elapsed = time.time() - start_time
                 output = self._action_agent.return_stopped_response(

--- a/libs/langchain/langchain_classic/agents/agent.py
+++ b/libs/langchain/langchain_classic/agents/agent.py
@@ -1262,18 +1262,18 @@ class AgentExecutor(Chain):
         Returns:
             `True` when a no-progress loop is detected, `False` otherwise.
         """
-        if not self.max_stalled_iterations or self.max_stalled_iterations < 2:
+        if not self.max_stalled_iterations or self.max_stalled_iterations < 2:  # noqa: PLR2004
             return False
-        n = self.max_stalled_iterations
-        if len(intermediate_steps) < n:
+        window = self.max_stalled_iterations
+        if len(intermediate_steps) < window:
             return False
-        last_n = intermediate_steps[-n:]
-        first_action, first_obs = last_n[0]
+        recent_steps = intermediate_steps[-window:]
+        first_action, first_obs = recent_steps[0]
         return all(
             action.tool == first_action.tool
             and action.tool_input == first_action.tool_input
             and obs == first_obs
-            for action, obs in last_n[1:]
+            for action, obs in recent_steps[1:]
         )
 
     def _return(

--- a/libs/langchain/langchain_classic/agents/agent_iterator.py
+++ b/libs/langchain/langchain_classic/agents/agent_iterator.py
@@ -227,6 +227,10 @@ class AgentExecutorIterator:
                 # if final output reached, stop iteration
                 if is_final:
                     return
+                # _should_continue only tracks count and time, not content-level stalling
+                if self.agent_executor._is_stuck_in_loop(self.intermediate_steps):  # noqa: SLF001
+                    yield self._stop(run_manager)
+                    return
         except BaseException as e:
             run_manager.on_chain_error(e)
             raise
@@ -304,6 +308,10 @@ class AgentExecutorIterator:
                         yield output
                     # if final output reached, stop iteration
                     if is_final:
+                        return
+                    # _should_continue only tracks count and time, not content-level stalling
+                    if self.agent_executor._is_stuck_in_loop(self.intermediate_steps):  # noqa: SLF001
+                        yield await self._astop(run_manager)
                         return
         except (TimeoutError, asyncio.TimeoutError):
             yield await self._astop(run_manager)

--- a/libs/langchain/tests/unit_tests/agents/test_agent.py
+++ b/libs/langchain/tests/unit_tests/agents/test_agent.py
@@ -1327,3 +1327,140 @@ async def test_openai_agent_tools_agent() -> None:
             " ",
             "bed.",
         ]
+
+
+def _make_stuck_agent(max_stalled_iterations: int | None, **kwargs: Any) -> AgentExecutor:
+    """Return an AgentExecutor whose LLM always requests the same Search call.
+
+    Args:
+        max_stalled_iterations: Passed directly to `AgentExecutor`.
+        **kwargs: Additional keyword arguments forwarded to `initialize_agent`.
+    """
+    repeated_action = "I'm stuck\nAction: Search\nAction Input: bad_query"
+    fake_llm = FakeListLLM(
+        cache=False,
+        responses=[repeated_action] * 20,
+    )
+    tools = [
+        Tool(
+            name="Search",
+            func=lambda x: "Error: invalid input",
+            description="Useful for searching",
+        ),
+    ]
+    return initialize_agent(
+        tools,
+        fake_llm,
+        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+        verbose=False,
+        max_stalled_iterations=max_stalled_iterations,
+        **kwargs,
+    )
+
+
+def test_is_stuck_in_loop_disabled_when_none() -> None:
+    """Guard is off by default (max_stalled_iterations=None)."""
+    agent = _make_stuck_agent(max_stalled_iterations=None, max_iterations=5)
+    assert not agent._is_stuck_in_loop([])
+
+
+def test_is_stuck_in_loop_disabled_for_low_values() -> None:
+    """Values below 2 are treated as disabled."""
+    agent = _make_stuck_agent(max_stalled_iterations=1)
+    action = AgentAction(tool="Search", tool_input="bad_query", log="")
+    steps = [(action, "Error: invalid input")]
+    assert not agent._is_stuck_in_loop(steps)
+
+
+def test_is_stuck_in_loop_not_enough_steps() -> None:
+    """Returns False when fewer steps than threshold have been taken."""
+    agent = _make_stuck_agent(max_stalled_iterations=3)
+    action = AgentAction(tool="Search", tool_input="bad_query", log="")
+    steps = [(action, "Error: invalid input"), (action, "Error: invalid input")]
+    assert not agent._is_stuck_in_loop(steps)
+
+
+def test_is_stuck_in_loop_detected() -> None:
+    """Returns True when the last N steps are all identical."""
+    agent = _make_stuck_agent(max_stalled_iterations=3)
+    action = AgentAction(tool="Search", tool_input="bad_query", log="")
+    steps = [(action, "Error: invalid input")] * 3
+    assert agent._is_stuck_in_loop(steps)
+
+
+def test_is_stuck_in_loop_different_observations() -> None:
+    """Returns False when observations differ across steps."""
+    agent = _make_stuck_agent(max_stalled_iterations=3)
+    action = AgentAction(tool="Search", tool_input="bad_query", log="")
+    steps = [
+        (action, "Error: invalid input"),
+        (action, "Error: different message"),
+        (action, "Error: invalid input"),
+    ]
+    assert not agent._is_stuck_in_loop(steps)
+
+
+def test_is_stuck_in_loop_different_inputs() -> None:
+    """Returns False when tool inputs differ across steps."""
+    agent = _make_stuck_agent(max_stalled_iterations=3)
+    steps = [
+        (AgentAction(tool="Search", tool_input="query_a", log=""), "Error"),
+        (AgentAction(tool="Search", tool_input="query_b", log=""), "Error"),
+        (AgentAction(tool="Search", tool_input="query_a", log=""), "Error"),
+    ]
+    assert not agent._is_stuck_in_loop(steps)
+
+
+def test_agent_stops_on_stalled_loop() -> None:
+    """Agent terminates early when max_stalled_iterations is reached."""
+    agent = _make_stuck_agent(max_stalled_iterations=3, max_iterations=20)
+    output = agent.run("do something")
+    assert output == "Agent stopped due to iteration limit or time limit."
+
+
+def test_agent_stalled_loop_returns_intermediate_steps() -> None:
+    """Intermediate steps are returned when the stalled-loop guard fires."""
+    agent = _make_stuck_agent(
+        max_stalled_iterations=3,
+        max_iterations=20,
+        return_intermediate_steps=True,
+    )
+    result = agent({"input": "do something"})
+    assert "intermediate_steps" in result
+    assert len(result["intermediate_steps"]) == 3
+
+
+def test_agent_no_false_positive_on_different_steps() -> None:
+    """Guard does not fire when each step is different."""
+    responses = [
+        "Thinking\nAction: Search\nAction Input: query_1",
+        "Thinking\nAction: Search\nAction Input: query_2",
+        "Thinking\nAction: Search\nAction Input: query_3",
+        "Oh well\nFinal Answer: done",
+    ]
+    fake_llm = FakeListLLM(cache=False, responses=responses)
+    tools = [
+        Tool(name="Search", func=lambda x: f"Result for {x}", description="Search")
+    ]
+    agent = initialize_agent(
+        tools,
+        fake_llm,
+        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+        verbose=False,
+        max_stalled_iterations=3,
+    )
+    output = agent.run("find something")
+    assert output == "done"
+
+
+async def _run_async_stuck_agent(max_stalled_iterations: int) -> str:
+    agent = _make_stuck_agent(
+        max_stalled_iterations=max_stalled_iterations, max_iterations=20
+    )
+    return await agent.arun("do something")
+
+
+def test_agent_async_stops_on_stalled_loop() -> None:
+    """Async path also terminates early when max_stalled_iterations is reached."""
+    output = asyncio.run(_run_async_stuck_agent(max_stalled_iterations=3))
+    assert output == "Agent stopped due to iteration limit or time limit."


### PR DESCRIPTION
Closes #36139

  ---

  `AgentExecutor` already guards against runaway agents with `max_iterations` and `max_execution_time`, but neither can tell an agent that's making progress apart from one stuck repeating the exact same action. When that happens the agent runs until it hits its iteration limit, wasting time and tokens even though it isn't getting anywhere. This adds a simple, opt-in way to catch that and stop early.

  The new `max_stalled_iterations` parameter on `AgentExecutor` looks at the most recent steps through a helper called `_is_stuck_in_loop`, and if they all share the same tool name, tool input, and observation, it treats the run as stuck and hands off to the existing `early_stopping_method`. The check is wired into the sync loop, the async loop, and both paths of `AgentExecutorIterator`. It's fully opt-in, since the default of `None` turns it off and values below `2` are treated as off.