### PR TITLE
fix(langchain): use `astream` in `_execute_model_async` to trigger `on_llm_new_token` callbacks

### DIFF
--- a/libs/core/langchain_core/language_models/fake_chat_models.py
+++ b/libs/core/langchain_core/language_models/fake_chat_models.py
@@ -314,6 +314,22 @@ class GenericFakeChatModel(BaseChatModel):
                     run_manager.on_llm_new_token(token, chunk=chunk)
                 yield chunk
 
+        if message.tool_calls or message.invalid_tool_calls:
+            # Yield a single chunk carrying tool calls when there is no text
+            # content and no additional_kwargs (OpenAI-style tool call responses).
+            chunk = ChatGenerationChunk(
+                message=AIMessageChunk(
+                    id=message.id,
+                    content="",
+                    tool_calls=message.tool_calls,
+                    invalid_tool_calls=message.invalid_tool_calls,
+                    chunk_position="last",
+                )
+            )
+            if run_manager:
+                run_manager.on_llm_new_token("", chunk=chunk)
+            yield chunk
+
         if message.additional_kwargs:
             for key, value in message.additional_kwargs.items():
                 # We should further break down the additional kwargs into chunks

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, AnyMessage, SystemMessage, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.constants import END, START
@@ -1348,8 +1348,33 @@ def create_agent(
         if request.system_message:
             messages = [request.system_message, *messages]
 
-        output = await model_.ainvoke(messages)
-        if name:
+        # Use astream instead of ainvoke to trigger on_llm_new_token callbacks
+        # for token-by-token streaming. astream falls back to ainvoke internally
+        # when the model doesn't support streaming.
+        output = None
+        async for chunk in model_.astream(messages):
+            output = chunk if output is None else output + chunk
+
+        if output is None:
+            output = await model_.ainvoke(messages)
+
+        # Convert AIMessageChunk to AIMessage so the v3 streaming MessagesTransformer
+        # processes it correctly (it explicitly ignores AIMessageChunk payloads).
+        # Use id=None so LangGraph assigns a fresh ID; the chunk ID was already
+        # added to StreamMessagesHandlerV2's "seen" set by on_llm_end, which would
+        # cause on_chain_end to deduplicate and skip the final AIMessage.
+        if isinstance(output, AIMessageChunk):
+            output = AIMessage(
+                content=output.content,
+                id=None,
+                name=name or output.name,
+                additional_kwargs=output.additional_kwargs,
+                response_metadata=output.response_metadata,
+                tool_calls=output.tool_calls,
+                invalid_tool_calls=output.invalid_tool_calls,
+                usage_metadata=output.usage_metadata,
+            )
+        elif name:
             output.name = name
 
         # Handle model output to get messages and structured_response

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_model_call.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_model_call.py
@@ -1408,18 +1408,18 @@ class TestAsyncWrapModelCall:
 
         class AsyncFailOnceThenSucceed(GenericFakeChatModel):
             @override
-            async def _agenerate(
+            def _generate(
                 self,
                 messages: list[BaseMessage],
                 stop: list[str] | None = None,
-                run_manager: AsyncCallbackManagerForLLMRun | None = None,
+                run_manager: CallbackManagerForLLMRun | None = None,
                 **kwargs: Any,
             ) -> ChatResult:
                 call_count["value"] += 1
                 if call_count["value"] == 1:
                     msg = "First async call fails"
                     raise ValueError(msg)
-                return await super()._agenerate(messages, **kwargs)
+                return super()._generate(messages, **kwargs)
 
         class RetryMiddleware(AgentMiddleware):
             async def awrap_model_call(


### PR DESCRIPTION
Closes #37869

---

`_execute_model_async` called `ainvoke` directly, which never fires `on_llm_new_token` for user-attached streaming callback handlers. This means users who register a `StreamingStdOutCallbackHandler` (or any v1 callback that implements `on_llm_new_token`) on their agent would never receive token-by-token events during async execution.

**Fix in `langchain`:** Switch `_execute_model_async` from `ainvoke` to `astream`, accumulating the chunks into a final response. When the model does not implement streaming, `astream` falls back to `ainvoke` internally, so non-streaming models are unaffected.

After accumulating all chunks, the resulting `AIMessageChunk` is converted to a plain `AIMessage` (with `id=None`) before being placed in the graph state. This is necessary because `StreamMessagesHandlerV2` (used by `astream_events(version="v3")`) adds the chunk's ID to its "seen" deduplication set during `on_llm_end`. Without the ID reset, `on_chain_end` would skip re-emitting the message, breaking the `run.messages` projection for v3 streaming callers.

**Fix in `langchain-core`:** `GenericFakeChatModel._stream` previously yielded zero chunks for messages with tool calls but no text content (e.g. `AIMessage(content="", tool_calls=[...])`). This caused `BaseChatModel._astream` to raise `"No generation chunks were returned"` when streaming such responses. Added a tail chunk that carries the tool calls, consistent with how real model streaming works.

The fix requires updating one existing async retry test that overrode `_agenerate` — since `astream` now goes through `_stream → _generate`, the override must target `_generate` instead.

> AI-assisted contribution via Claude Code.