### PR TITLE
fix(openai): exclude parsed response tool call fields

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4381,6 +4381,15 @@ def _pop_index_and_sub_index(block: dict) -> dict:
     return new_block
 
 
+def _dump_response_item_for_content_block(item: BaseModel) -> dict:
+    """Dump Responses API output item fields that can be round-tripped."""
+    return item.model_dump(
+        exclude_none=True,
+        mode="json",
+        exclude=getattr(item, "__api_exclude__", None),
+    )
+
+
 def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
     """Construct the input for the OpenAI Responses API."""
     input_ = []
@@ -4658,7 +4667,7 @@ def _construct_lc_result_from_responses_api(
                         refusal_block["phase"] = phase
                     content_blocks.append(refusal_block)
         elif output.type == "function_call":
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            content_blocks.append(_dump_response_item_for_content_block(output))
             try:
                 args = json.loads(output.arguments, strict=False)
                 error = None
@@ -4683,7 +4692,7 @@ def _construct_lc_result_from_responses_api(
                 }
                 invalid_tool_calls.append(tool_call)
         elif output.type == "custom_tool_call":
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            content_blocks.append(_dump_response_item_for_content_block(output))
             tool_call = {
                 "type": "tool_call",
                 "name": output.name,
@@ -4705,7 +4714,7 @@ def _construct_lc_result_from_responses_api(
             "tool_search_call",
             "tool_search_output",
         ):
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            content_blocks.append(_dump_response_item_for_content_block(output))
 
     # Workaround for parsing structured output in the streaming case.
     #    from openai import OpenAI

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -36,6 +36,7 @@ from langchain_core.runnables.base import RunnableBinding, RunnableSequence
 from langchain_core.tracers.base import BaseTracer
 from langchain_core.tracers.schemas import Run
 from openai.types.responses import ResponseOutputMessage, ResponseReasoningItem
+from openai.types.responses.parsed_response import ParsedResponseFunctionToolCall
 from openai.types.responses.response import IncompleteDetails, Response
 from openai.types.responses.response_error import ResponseError
 from openai.types.responses.response_file_search_tool_call import (
@@ -1758,6 +1759,61 @@ def test__construct_lc_result_from_responses_api_function_call_valid_json() -> N
     msg = cast(AIMessage, result.generations[0].message)
     assert msg.tool_calls
     assert msg.content == [
+        {
+            "type": "function_call",
+            "id": "func_123",
+            "name": "get_weather",
+            "arguments": '{"location": "New York", "unit": "celsius"}',
+            "call_id": "call_123",
+        }
+    ]
+
+
+def test__construct_lc_result_from_responses_api_parsed_function_call() -> None:
+    """Test parsed tool calls do not leak SDK-only fields into content."""
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ParsedResponseFunctionToolCall(
+                type="function_call",
+                id="func_123",
+                call_id="call_123",
+                name="get_weather",
+                arguments='{"location": "New York", "unit": "celsius"}',
+                parsed_arguments={"location": "New York", "unit": "celsius"},
+            )
+        ],
+    )
+
+    result = _construct_lc_result_from_responses_api(response)
+
+    msg = cast(AIMessage, result.generations[0].message)
+    assert msg.content == [
+        {
+            "type": "function_call",
+            "id": "func_123",
+            "name": "get_weather",
+            "arguments": '{"location": "New York", "unit": "celsius"}',
+            "call_id": "call_123",
+        }
+    ]
+    assert msg.tool_calls == [
+        {
+            "type": "tool_call",
+            "name": "get_weather",
+            "args": {"location": "New York", "unit": "celsius"},
+            "id": "call_123",
+        }
+    ]
+
+    input_ = _construct_responses_api_input([msg])
+    assert input_ == [
         {
             "type": "function_call",
             "id": "func_123",


### PR DESCRIPTION
## Summary
- use OpenAI SDK API exclusions when dumping Responses output items into AIMessage content blocks
- prevent parsed_arguments from being serialized into AIMessage content and sent back on the next Responses API turn
- keep tool call arguments, name, id, and call_id available for normal LangChain tool call handling

Fixes #37836

## Tests
- /tmp/langchain-37836-venv/bin/python -m pytest -q -o addopts='' /root/pr-work/langchain-37836/libs/partners/openai/tests/unit_tests/chat_models/test_base.py::test__construct_lc_result_from_responses_api_function_call_valid_json /root/pr-work/langchain-37836/libs/partners/openai/tests/unit_tests/chat_models/test_base.py::test__construct_lc_result_from_responses_api_parsed_function_call