### PR TITLE
fix(agents): detect shell marker after unterminated output

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -251,6 +251,32 @@ class ShellSession:
         exit_code: int | None = None
         timed_out = False
 
+        def append_output(source: str, data: str) -> None:
+            nonlocal total_lines, total_bytes, truncated_by_lines, truncated_by_bytes
+
+            total_lines += 1
+            encoded = data.encode("utf-8", "replace")
+            total_bytes += len(encoded)
+
+            if total_lines > self._policy.max_output_lines:
+                truncated_by_lines = True
+                return
+
+            if (
+                self._policy.max_output_bytes is not None
+                and total_bytes > self._policy.max_output_bytes
+            ):
+                truncated_by_bytes = True
+                return
+
+            if source == "stderr":
+                stripped = data.rstrip("\n")
+                collected.append(f"[stderr] {stripped}")
+                if data.endswith("\n"):
+                    collected.append("\n")
+            else:
+                collected.append(data)
+
         while True:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -265,8 +291,11 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
-                _, _, status = data.partition(" ")
+            if source == "stdout" and marker in data:
+                output_before_marker, _, marker_output = data.partition(marker)
+                if output_before_marker:
+                    append_output(source, output_before_marker)
+                _, _, status = marker_output.partition(" ")
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.
                 # The stderr reader thread runs independently, so output might
@@ -274,28 +303,7 @@ class ShellSession:
                 self._drain_remaining_stderr(collected, deadline)
                 break
 
-            total_lines += 1
-            encoded = data.encode("utf-8", "replace")
-            total_bytes += len(encoded)
-
-            if total_lines > self._policy.max_output_lines:
-                truncated_by_lines = True
-                continue
-
-            if (
-                self._policy.max_output_bytes is not None
-                and total_bytes > self._policy.max_output_bytes
-            ):
-                truncated_by_bytes = True
-                continue
-
-            if source == "stderr":
-                stripped = data.rstrip("\n")
-                collected.append(f"[stderr] {stripped}")
-                if data.endswith("\n"):
-                    collected.append("\n")
-            else:
-                collected.append(data)
+            append_output(source, data)
 
         if timed_out:
             LOGGER.warning(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -107,6 +107,37 @@ def test_timeout_returns_error(tmp_path: Path) -> None:
         middleware.after_agent(state, runtime)
 
 
+def test_command_output_without_trailing_newline_completes(tmp_path: Path) -> None:
+    policy = HostExecutionPolicy(command_timeout=0.5)
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace", execution_policy=policy)
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+
+        result = middleware._run_shell_tool(
+            resources,
+            {"command": "printf 'no trailing newline'"},
+            tool_call_id="test-id",
+        )
+
+        assert isinstance(result, ToolMessage)
+        assert result.status == "success"
+        assert result.content == "no trailing newline"
+        assert result.artifact["timed_out"] is False
+        assert result.artifact["exit_code"] == 0
+
+        next_result = middleware._run_shell_tool(
+            resources, {"command": "echo still-running"}, tool_call_id=None
+        )
+        assert "still-running" in next_result
+    finally:
+        middleware.after_agent(state, runtime)
+
+
 def test_redaction_policy_applies(tmp_path: Path) -> None:
     middleware = ShellToolMiddleware(
         workspace_root=tmp_path / "workspace",


### PR DESCRIPTION
## Summary
- detect the shell done marker when it appears after unterminated stdout in the same buffer
- preserve stdout before the marker instead of treating the command as timed out
- keep existing stderr draining, timeout, and truncation handling intact

Fixes #37837

## Tests
- .venv/bin/python -m pytest tests/unit_tests/agents/middleware/implementations/test_shell_tool.py::test_command_output_without_trailing_newline_completes tests/unit_tests/agents/middleware/implementations/test_shell_tool.py -q