### PR TITLE
fix(text-splitters): preserve URLs from nested source tags in video/a…

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -793,6 +793,11 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
         if self._preserve_videos:
             for video_tag in _find_all_tags(soup, name="video"):
                 video_src = video_tag.get("src", "")
+                if not video_src:
+                    source_tags = video_tag.find_all("source")
+                    video_src = ", ".join(
+                        s.get("src", "") for s in source_tags if s.get("src")
+                    )
                 markdown_video = f"![video:{video_src}]({video_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_video
@@ -801,6 +806,11 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
         if self._preserve_audio:
             for audio_tag in _find_all_tags(soup, name="audio"):
                 audio_src = audio_tag.get("src", "")
+                if not audio_src:
+                    source_tags = audio_tag.find_all("source")
+                    audio_src = ", ".join(
+                        s.get("src", "") for s in source_tags if s.get("src")
+                    )
                 markdown_audio = f"![audio:{audio_src}]({audio_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_audio

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3975,6 +3975,48 @@ def test_html_splitter_with_media_preservation() -> None:
 
 
 @pytest.mark.requires("bs4")
+def test_html_splitter_with_media_source_tags() -> None:
+    """Test HTML splitter preserves URLs from nested source tags in video/audio."""
+    html_content = """
+    <h1>Media</h1>
+    <p>Watch:</p>
+    <video controls>
+        <source src="https://example.com/video.mp4" type="video/mp4" />
+        <source src="https://example.com/video.webm" type="video/webm" />
+    </video>
+    <p>Listen:</p>
+    <audio controls>
+        <source src="https://example.com/audio.mp3" type="audio/mpeg" />
+        <source src="https://example.com/audio.ogg" type="audio/ogg" />
+    </audio>
+    """
+    with suppress_langchain_beta_warning():
+        splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")],
+            preserve_videos=True,
+            preserve_audio=True,
+            max_chunk_size=1000,
+        )
+    documents = splitter.split_text(html_content)
+
+    expected = [
+        Document(
+            page_content=(
+                "Watch: "
+                "![video:https://example.com/video.mp4, https://example.com/video.webm]"
+                "(https://example.com/video.mp4, https://example.com/video.webm) "
+                "Listen: "
+                "![audio:https://example.com/audio.mp3, https://example.com/audio.ogg]"
+                "(https://example.com/audio.mp3, https://example.com/audio.ogg)"
+            ),
+            metadata={"Header 1": "Media"},
+        ),
+    ]
+
+    assert documents == expected
+
+
+@pytest.mark.requires("bs4")
 def test_html_splitter_keep_separator_true() -> None:
     """Test HTML splitting with keep_separator=True."""
     html_content = """


### PR DESCRIPTION
 Fixes #37826

  ### Problem

  `_process_media` only reads `src` directly on `<video>` and `<audio>` tags, but in practice most HTML uses nested
  `<source>` children for format fallbacks (mp4 + webm etc). When there's no direct `src`, the whole thing gets replaced
  with `![video:]()` and all the URLs just vanish.

  The root cause is `video_tag.get("src", "")` returns empty when the actual URLs live on child `<source>` elements.

  ### Solution

  When the parent has no `src`, we now fall back to collecting from child `<source>` tags. Multiple sources get joined
  with commas since they represent different format options.

  This could also be handled by only taking the first `<source>`, but I think preserving all of them is more useful
  since the splitter doesn't know which format the user actually needs.

  ### Testing

  - Added `test_html_splitter_with_media_source_tags` covering the nested `<source>` pattern for both video and audio
  - All 33 existing HTML splitter tests pass