### PR TITLE
feat(agents): `AgentRuntime` fields + `_build_runtime` hook for middleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1020,10 +1020,13 @@ def create_agent(  # noqa: PLR0915
 
     def model_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
-        # Wrap runtime with agent name
+        # Create flat AgentRuntime with all runtime properties
         agent_runtime = AgentRuntime(
             agent_name=name or "LangGraph",
-            runtime=runtime,
+            context=runtime.context,
+            store=runtime.store,
+            stream_writer=runtime.stream_writer,
+            previous=runtime.previous,
         )
 
         request = ModelRequest(
@@ -1079,10 +1082,13 @@ def create_agent(  # noqa: PLR0915
 
     async def amodel_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Async model request handler with sequential middleware processing."""
-        # Wrap runtime with agent name
+        # Create flat AgentRuntime with all runtime properties
         agent_runtime = AgentRuntime(
             agent_name=name or "LangGraph",
-            runtime=runtime,
+            context=runtime.context,
+            store=runtime.store,
+            stream_writer=runtime.stream_writer,
+            previous=runtime.previous,
         )
 
         request = ModelRequest(
@@ -1128,21 +1134,26 @@ def create_agent(  # noqa: PLR0915
             async def async_wrapper(state, runtime: Runtime[ContextT]):
                 agent_runtime = AgentRuntime(
                     agent_name=name or "LangGraph",
-                    runtime=runtime,
+                    context=runtime.context,
+                    store=runtime.store,
+                    stream_writer=runtime.stream_writer,
+                    previous=runtime.previous,
                 )
                 return await hook_fn(state, agent_runtime)
 
             return async_wrapper
-        else:
 
-            def sync_wrapper(state, runtime: Runtime[ContextT]):
-                agent_runtime = AgentRuntime(
-                    agent_name=name or "LangGraph",
-                    runtime=runtime,
-                )
-                return hook_fn(state, agent_runtime)
+        def sync_wrapper(state, runtime: Runtime[ContextT]):
+            agent_runtime = AgentRuntime(
+                agent_name=name or "LangGraph",
+                context=runtime.context,
+                store=runtime.store,
+                stream_writer=runtime.stream_writer,
+                previous=runtime.previous,
+            )
+            return hook_fn(state, agent_runtime)
 
-            return sync_wrapper
+        return sync_wrapper
 
     # Add middleware nodes
     for m in middleware:

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -520,6 +520,7 @@ def create_agent(  # noqa: PLR0915
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache | None = None,
+    backend: object | None = None,
 ) -> CompiledStateGraph[
     AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]
 ]:
@@ -714,35 +715,40 @@ def create_agent(  # noqa: PLR0915
         _agent_model_name = model.model
 
     # Wrappers that convert the LangGraph Runtime into an AgentRuntime before
-    # dispatching to each middleware hook. Middleware may further enrich the
-    # runtime by overriding _build_runtime (private, not a public extension point).
-    def _wrap_hook(hook, mw):
+    # dispatching to each middleware hook. _build_runtime calls are accumulated
+    # across all middlewares in order, so a subpackage that prepends a specialised
+    # middleware can inject an enriched runtime subclass for all hooks downstream.
+    def _accumulate_runtime(ar: AgentRuntime[ContextT]) -> AgentRuntime[ContextT]:
+        for mw in middleware:
+            ar = mw._build_runtime(ar)
+        return ar
+
+    def _build_hook_runtime(runtime: Runtime[ContextT]) -> AgentRuntime[ContextT]:
+        return _accumulate_runtime(
+            AgentRuntime.from_runtime(
+                name or "agent",
+                runtime,
+                model_name=_agent_model_name,
+                tools=default_tools,
+                backend=backend,
+            )
+        )
+
+    def _wrap_hook(hook):
         if hook is None:
             return None
 
         def _wrapped(state: AgentState, runtime: Runtime[ContextT]):
-            agent_runtime = AgentRuntime.from_runtime(
-                name or "agent",
-                runtime,
-                model_name=_agent_model_name,
-                tools=default_tools,
-            )
-            return hook(state, mw._build_runtime(agent_runtime))
+            return hook(state, _build_hook_runtime(runtime))
 
         return _wrapped
 
-    def _wrap_async_hook(hook, mw):
+    def _wrap_async_hook(hook):
         if hook is None:
             return None
 
         async def _wrapped(state: AgentState, runtime: Runtime[ContextT]):
-            agent_runtime = AgentRuntime.from_runtime(
-                name or "agent",
-                runtime,
-                model_name=_agent_model_name,
-                tools=default_tools,
-            )
-            return await hook(state, mw._build_runtime(agent_runtime))
+            return await hook(state, _build_hook_runtime(runtime))
 
         return _wrapped
 
@@ -1061,16 +1067,18 @@ def create_agent(  # noqa: PLR0915
 
     def model_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
-        # Create flat AgentRuntime with all runtime properties
-        agent_runtime = AgentRuntime.from_runtime(
-            name or "agent",
-            runtime,
-            model_name=_agent_model_name,
-            model=model if isinstance(model, BaseChatModel) else None,
-            system_prompt=system_prompt,
-            tools=default_tools,
-            tool_choice=None,
-            response_format=initial_response_format,
+        agent_runtime = _accumulate_runtime(
+            AgentRuntime.from_runtime(
+                name or "agent",
+                runtime,
+                model_name=_agent_model_name,
+                model=model if isinstance(model, BaseChatModel) else None,
+                system_prompt=system_prompt,
+                tools=default_tools,
+                tool_choice=None,
+                response_format=initial_response_format,
+                backend=backend,
+            )
         )
         request = ModelRequest.from_runtime(agent_runtime, messages=state["messages"], state=state)
 
@@ -1116,16 +1124,18 @@ def create_agent(  # noqa: PLR0915
 
     async def amodel_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Async model request handler with sequential middleware processing."""
-        # Create flat AgentRuntime with all runtime properties
-        agent_runtime = AgentRuntime.from_runtime(
-            name or "agent",
-            runtime,
-            model_name=_agent_model_name,
-            model=model if isinstance(model, BaseChatModel) else None,
-            system_prompt=system_prompt,
-            tools=default_tools,
-            tool_choice=None,
-            response_format=initial_response_format,
+        agent_runtime = _accumulate_runtime(
+            AgentRuntime.from_runtime(
+                name or "agent",
+                runtime,
+                model_name=_agent_model_name,
+                model=model if isinstance(model, BaseChatModel) else None,
+                system_prompt=system_prompt,
+                tools=default_tools,
+                tool_choice=None,
+                response_format=initial_response_format,
+                backend=backend,
+            )
         )
         request = ModelRequest.from_runtime(agent_runtime, messages=state["messages"], state=state)
 
@@ -1157,10 +1167,10 @@ def create_agent(  # noqa: PLR0915
             or m.__class__.abefore_agent is not AgentMiddleware.abefore_agent
         ):
             sync_before_agent = _wrap_hook(
-                m.before_agent if m.__class__.before_agent is not AgentMiddleware.before_agent else None, m
+                m.before_agent if m.__class__.before_agent is not AgentMiddleware.before_agent else None
             )
             async_before_agent = _wrap_async_hook(
-                m.abefore_agent if m.__class__.abefore_agent is not AgentMiddleware.abefore_agent else None, m
+                m.abefore_agent if m.__class__.abefore_agent is not AgentMiddleware.abefore_agent else None
             )
             before_agent_node = RunnableCallable(sync_before_agent, async_before_agent, trace=False)
             graph.add_node(
@@ -1172,10 +1182,10 @@ def create_agent(  # noqa: PLR0915
             or m.__class__.abefore_model is not AgentMiddleware.abefore_model
         ):
             sync_before = _wrap_hook(
-                m.before_model if m.__class__.before_model is not AgentMiddleware.before_model else None, m
+                m.before_model if m.__class__.before_model is not AgentMiddleware.before_model else None
             )
             async_before = _wrap_async_hook(
-                m.abefore_model if m.__class__.abefore_model is not AgentMiddleware.abefore_model else None, m
+                m.abefore_model if m.__class__.abefore_model is not AgentMiddleware.abefore_model else None
             )
             before_node = RunnableCallable(sync_before, async_before, trace=False)
             graph.add_node(
@@ -1187,10 +1197,10 @@ def create_agent(  # noqa: PLR0915
             or m.__class__.aafter_model is not AgentMiddleware.aafter_model
         ):
             sync_after = _wrap_hook(
-                m.after_model if m.__class__.after_model is not AgentMiddleware.after_model else None, m
+                m.after_model if m.__class__.after_model is not AgentMiddleware.after_model else None
             )
             async_after = _wrap_async_hook(
-                m.aafter_model if m.__class__.aafter_model is not AgentMiddleware.aafter_model else None, m
+                m.aafter_model if m.__class__.aafter_model is not AgentMiddleware.aafter_model else None
             )
             after_node = RunnableCallable(sync_after, async_after, trace=False)
             graph.add_node(f"{m.name}.after_model", after_node, input_schema=resolved_state_schema)
@@ -1200,10 +1210,10 @@ def create_agent(  # noqa: PLR0915
             or m.__class__.aafter_agent is not AgentMiddleware.aafter_agent
         ):
             sync_after_agent = _wrap_hook(
-                m.after_agent if m.__class__.after_agent is not AgentMiddleware.after_agent else None, m
+                m.after_agent if m.__class__.after_agent is not AgentMiddleware.after_agent else None
             )
             async_after_agent = _wrap_async_hook(
-                m.aafter_agent if m.__class__.aafter_agent is not AgentMiddleware.aafter_agent else None, m
+                m.aafter_agent if m.__class__.aafter_agent is not AgentMiddleware.aafter_agent else None
             )
             after_agent_node = RunnableCallable(sync_after_agent, async_after_agent, trace=False)
             graph.add_node(

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1062,18 +1062,17 @@ def create_agent(  # noqa: PLR0915
     def model_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
         # Create flat AgentRuntime with all runtime properties
-        agent_runtime = AgentRuntime.from_runtime(name or "agent", runtime, model_name=_agent_model_name, tools=default_tools)
-
-        request = ModelRequest(
-            model=model,
-            tools=default_tools,
+        agent_runtime = AgentRuntime.from_runtime(
+            name or "agent",
+            runtime,
+            model_name=_agent_model_name,
+            model=model if isinstance(model, BaseChatModel) else None,
             system_prompt=system_prompt,
-            response_format=initial_response_format,
-            messages=state["messages"],
+            tools=default_tools,
             tool_choice=None,
-            state=state,
-            runtime=agent_runtime,
+            response_format=initial_response_format,
         )
+        request = ModelRequest.from_runtime(agent_runtime, messages=state["messages"], state=state)
 
         if wrap_model_call_handler is None:
             # No handlers - execute directly
@@ -1118,18 +1117,17 @@ def create_agent(  # noqa: PLR0915
     async def amodel_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Async model request handler with sequential middleware processing."""
         # Create flat AgentRuntime with all runtime properties
-        agent_runtime = AgentRuntime.from_runtime(name or "agent", runtime, model_name=_agent_model_name, tools=default_tools)
-
-        request = ModelRequest(
-            model=model,
-            tools=default_tools,
+        agent_runtime = AgentRuntime.from_runtime(
+            name or "agent",
+            runtime,
+            model_name=_agent_model_name,
+            model=model if isinstance(model, BaseChatModel) else None,
             system_prompt=system_prompt,
-            response_format=initial_response_format,
-            messages=state["messages"],
+            tools=default_tools,
             tool_choice=None,
-            state=state,
-            runtime=agent_runtime,
+            response_format=initial_response_format,
         )
+        request = ModelRequest.from_runtime(agent_runtime, messages=state["messages"], state=state)
 
         if awrap_model_call_handler is None:
             # No async handlers - execute directly

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -520,7 +520,6 @@ def create_agent(  # noqa: PLR0915
     debug: bool = False,
     name: str | None = None,
     cache: BaseCache | None = None,
-    backend: object | None = None,
 ) -> CompiledStateGraph[
     AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]
 ]:
@@ -730,7 +729,6 @@ def create_agent(  # noqa: PLR0915
                 runtime,
                 model_name=_agent_model_name,
                 tools=default_tools,
-                backend=backend,
             )
         )
 
@@ -1077,7 +1075,6 @@ def create_agent(  # noqa: PLR0915
                 tools=default_tools,
                 tool_choice=None,
                 response_format=initial_response_format,
-                backend=backend,
             )
         )
         request = ModelRequest.from_runtime(agent_runtime, messages=state["messages"], state=state)

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -704,6 +704,48 @@ def create_agent(  # noqa: PLR0915
     else:
         default_tools = list(built_in_tools)
 
+    # Derive model_name for AgentRuntime (best-effort; None for dynamic callables)
+    _agent_model_name: str | None = None
+    if isinstance(model, str):
+        _agent_model_name = model
+    elif hasattr(model, "model_name"):
+        _agent_model_name = model.model_name
+    elif hasattr(model, "model"):
+        _agent_model_name = model.model
+
+    # Wrappers that convert the LangGraph Runtime into an AgentRuntime before
+    # dispatching to each middleware hook. Middleware may further enrich the
+    # runtime by overriding _build_runtime (private, not a public extension point).
+    def _wrap_hook(hook, mw):
+        if hook is None:
+            return None
+
+        def _wrapped(state: AgentState, runtime: Runtime[ContextT]):
+            agent_runtime = AgentRuntime.from_runtime(
+                name or "agent",
+                runtime,
+                model_name=_agent_model_name,
+                tools=default_tools,
+            )
+            return hook(state, mw._build_runtime(agent_runtime))
+
+        return _wrapped
+
+    def _wrap_async_hook(hook, mw):
+        if hook is None:
+            return None
+
+        async def _wrapped(state: AgentState, runtime: Runtime[ContextT]):
+            agent_runtime = AgentRuntime.from_runtime(
+                name or "agent",
+                runtime,
+                model_name=_agent_model_name,
+                tools=default_tools,
+            )
+            return await hook(state, mw._build_runtime(agent_runtime))
+
+        return _wrapped
+
     # validate middleware
     assert len({m.name for m in middleware}) == len(middleware), (  # noqa: S101
         "Please remove duplicate middleware instances."
@@ -1020,7 +1062,7 @@ def create_agent(  # noqa: PLR0915
     def model_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Sync model request handler with sequential middleware processing."""
         # Create flat AgentRuntime with all runtime properties
-        agent_runtime = AgentRuntime.from_runtime(name or "agent", runtime)
+        agent_runtime = AgentRuntime.from_runtime(name or "agent", runtime, model_name=_agent_model_name, tools=default_tools)
 
         request = ModelRequest(
             model=model,
@@ -1076,7 +1118,7 @@ def create_agent(  # noqa: PLR0915
     async def amodel_node(state: AgentState, runtime: Runtime[ContextT]) -> dict[str, Any]:
         """Async model request handler with sequential middleware processing."""
         # Create flat AgentRuntime with all runtime properties
-        agent_runtime = AgentRuntime.from_runtime(name or "agent", runtime)
+        agent_runtime = AgentRuntime.from_runtime(name or "agent", runtime, model_name=_agent_model_name, tools=default_tools)
 
         request = ModelRequest(
             model=model,
@@ -1116,17 +1158,11 @@ def create_agent(  # noqa: PLR0915
             m.__class__.before_agent is not AgentMiddleware.before_agent
             or m.__class__.abefore_agent is not AgentMiddleware.abefore_agent
         ):
-            # Use RunnableCallable to support both sync and async
-            # Pass None for sync if not overridden to avoid signature conflicts
-            sync_before_agent = (
-                m.before_agent
-                if m.__class__.before_agent is not AgentMiddleware.before_agent
-                else None
+            sync_before_agent = _wrap_hook(
+                m.before_agent if m.__class__.before_agent is not AgentMiddleware.before_agent else None, m
             )
-            async_before_agent = (
-                m.abefore_agent
-                if m.__class__.abefore_agent is not AgentMiddleware.abefore_agent
-                else None
+            async_before_agent = _wrap_async_hook(
+                m.abefore_agent if m.__class__.abefore_agent is not AgentMiddleware.abefore_agent else None, m
             )
             before_agent_node = RunnableCallable(sync_before_agent, async_before_agent, trace=False)
             graph.add_node(
@@ -1137,17 +1173,11 @@ def create_agent(  # noqa: PLR0915
             m.__class__.before_model is not AgentMiddleware.before_model
             or m.__class__.abefore_model is not AgentMiddleware.abefore_model
         ):
-            # Use RunnableCallable to support both sync and async
-            # Pass None for sync if not overridden to avoid signature conflicts
-            sync_before = (
-                m.before_model
-                if m.__class__.before_model is not AgentMiddleware.before_model
-                else None
+            sync_before = _wrap_hook(
+                m.before_model if m.__class__.before_model is not AgentMiddleware.before_model else None, m
             )
-            async_before = (
-                m.abefore_model
-                if m.__class__.abefore_model is not AgentMiddleware.abefore_model
-                else None
+            async_before = _wrap_async_hook(
+                m.abefore_model if m.__class__.abefore_model is not AgentMiddleware.abefore_model else None, m
             )
             before_node = RunnableCallable(sync_before, async_before, trace=False)
             graph.add_node(
@@ -1158,17 +1188,11 @@ def create_agent(  # noqa: PLR0915
             m.__class__.after_model is not AgentMiddleware.after_model
             or m.__class__.aafter_model is not AgentMiddleware.aafter_model
         ):
-            # Use RunnableCallable to support both sync and async
-            # Pass None for sync if not overridden to avoid signature conflicts
-            sync_after = (
-                m.after_model
-                if m.__class__.after_model is not AgentMiddleware.after_model
-                else None
+            sync_after = _wrap_hook(
+                m.after_model if m.__class__.after_model is not AgentMiddleware.after_model else None, m
             )
-            async_after = (
-                m.aafter_model
-                if m.__class__.aafter_model is not AgentMiddleware.aafter_model
-                else None
+            async_after = _wrap_async_hook(
+                m.aafter_model if m.__class__.aafter_model is not AgentMiddleware.aafter_model else None, m
             )
             after_node = RunnableCallable(sync_after, async_after, trace=False)
             graph.add_node(f"{m.name}.after_model", after_node, input_schema=resolved_state_schema)
@@ -1177,17 +1201,11 @@ def create_agent(  # noqa: PLR0915
             m.__class__.after_agent is not AgentMiddleware.after_agent
             or m.__class__.aafter_agent is not AgentMiddleware.aafter_agent
         ):
-            # Use RunnableCallable to support both sync and async
-            # Pass None for sync if not overridden to avoid signature conflicts
-            sync_after_agent = (
-                m.after_agent
-                if m.__class__.after_agent is not AgentMiddleware.after_agent
-                else None
+            sync_after_agent = _wrap_hook(
+                m.after_agent if m.__class__.after_agent is not AgentMiddleware.after_agent else None, m
             )
-            async_after_agent = (
-                m.aafter_agent
-                if m.__class__.aafter_agent is not AgentMiddleware.aafter_agent
-                else None
+            async_after_agent = _wrap_async_hook(
+                m.aafter_agent if m.__class__.aafter_agent is not AgentMiddleware.aafter_agent else None, m
             )
             after_agent_node = RunnableCallable(sync_after_agent, async_after_agent, trace=False)
             graph.add_node(

--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -32,6 +32,7 @@ from .tool_retry import ToolRetryMiddleware
 from .tool_selection import LLMToolSelectorMiddleware
 from .types import (
     AgentMiddleware,
+    AgentRuntime,
     AgentState,
     ModelRequest,
     ModelResponse,
@@ -47,6 +48,7 @@ from .types import (
 
 __all__ = [
     "AgentMiddleware",
+    "AgentRuntime",
     "AgentState",
     "ClearToolUsesEdit",
     "CodexSandboxExecutionPolicy",

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -100,11 +100,6 @@ class AgentRuntime(Runtime[ContextT]):
     model_settings: dict[str, Any] = field(default_factory=dict)
     """Additional model-specific settings."""
 
-    backend: object | None = field(default=None)
-    """Opaque backend object injected by subpackages (e.g. deepagents).
-    Typed as ``object`` at this layer; subpackages narrow the type via
-    ``AgentMiddleware._build_runtime``."""
-
     @classmethod
     def from_runtime(
         cls,
@@ -118,7 +113,6 @@ class AgentRuntime(Runtime[ContextT]):
         tools: list[BaseTool | dict] | None = None,
         response_format: ResponseFormat | None = None,
         model_settings: dict[str, Any] | None = None,
-        backend: object | None = None,
     ) -> AgentRuntime[ContextT]:
         """Construct an AgentRuntime from a base LangGraph Runtime."""
         inherited = {f.name: getattr(runtime, f.name) for f in dc_fields(Runtime)}
@@ -132,7 +126,6 @@ class AgentRuntime(Runtime[ContextT]):
             tools=tools or [],
             response_format=response_format,
             model_settings=model_settings or {},
-            backend=backend,
         )
 
 

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -9,6 +9,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    ClassVar,
     Generic,
     Literal,
     Protocol,
@@ -66,25 +67,39 @@ ResponseT = TypeVar("ResponseT")
 class AgentRuntime(Runtime[ContextT]):
     """Agent-scoped runtime injected into all middleware hook nodes.
 
-    Extends LangGraph's `Runtime` with agent-level fields populated by
-    `create_agent` at wire time. Middleware that needs additional fields
-    (e.g. a resolved backend) can override the private `_build_runtime`
-    hook on `AgentMiddleware` to return a richer subclass.
+    Extends LangGraph's `Runtime` with all agent-level fields needed for
+    a model invocation. Populated by `create_agent` at node-dispatch time.
+    `ModelRequest` is constructed from an `AgentRuntime` via
+    `ModelRequest.from_runtime`; `ModelRequest.override` keeps both in sync.
 
-    Attributes:
-        agent_name: Name passed to `create_agent(name=...)`.
-        model_name: Model identifier, if statically known at wire time.
-        tools: Tools registered with the agent.
+    Middleware that needs additional fields (e.g. a resolved backend) can
+    override the private `_build_runtime` hook on `AgentMiddleware` to return
+    a richer subclass — this is not a public extension point.
     """
 
     agent_name: str = field(default="agent")
-    """The name of the currently executing agent."""
+    """Name passed to `create_agent(name=...)`."""
 
     model_name: str | None = field(default=None)
-    """Model identifier, if statically known at wire time."""
+    """Model identifier string, if statically known at wire time."""
 
-    tools: list[BaseTool] = field(default_factory=list)
+    model: BaseChatModel | None = field(default=None)
+    """Resolved model instance, if not a dynamic callable."""
+
+    system_prompt: str | None = field(default=None)
+    """System prompt for the agent."""
+
+    tool_choice: Any | None = field(default=None)
+    """Tool selection configuration."""
+
+    tools: list[BaseTool | dict] = field(default_factory=list)
     """Tools registered with the agent."""
+
+    response_format: ResponseFormat | None = field(default=None)
+    """Structured output format, if configured."""
+
+    model_settings: dict[str, Any] = field(default_factory=dict)
+    """Additional model-specific settings."""
 
     @classmethod
     def from_runtime(
@@ -93,9 +108,14 @@ class AgentRuntime(Runtime[ContextT]):
         runtime: Runtime[ContextT],
         *,
         model_name: str | None = None,
-        tools: list[BaseTool] | None = None,
+        model: BaseChatModel | None = None,
+        system_prompt: str | None = None,
+        tool_choice: Any | None = None,
+        tools: list[BaseTool | dict] | None = None,
+        response_format: ResponseFormat | None = None,
+        model_settings: dict[str, Any] | None = None,
     ) -> AgentRuntime[ContextT]:
-        """Construct an AgentRuntime from a base Runtime."""
+        """Construct an AgentRuntime from a base LangGraph Runtime."""
         return cls(
             context=runtime.context,
             store=runtime.store,
@@ -103,7 +123,12 @@ class AgentRuntime(Runtime[ContextT]):
             previous=runtime.previous,
             agent_name=name,
             model_name=model_name,
+            model=model,
+            system_prompt=system_prompt,
+            tool_choice=tool_choice,
             tools=tools or [],
+            response_format=response_format,
+            model_settings=model_settings or {},
         )
 
 
@@ -149,6 +174,32 @@ class ModelRequest:
     runtime: AgentRuntime[ContextT]  # type: ignore[valid-type]
     model_settings: dict[str, Any] = field(default_factory=dict)
 
+    # Fields shared with AgentRuntime — kept in sync by override().
+    _RUNTIME_FIELDS: ClassVar[frozenset[str]] = frozenset(
+        {"model", "system_prompt", "tool_choice", "tools", "response_format", "model_settings"}
+    )
+
+    @classmethod
+    def from_runtime(
+        cls,
+        runtime: AgentRuntime[ContextT],  # type: ignore[valid-type]
+        *,
+        messages: list[AnyMessage],
+        state: AgentState,
+    ) -> ModelRequest:
+        """Construct a ModelRequest from an AgentRuntime, messages, and state."""
+        return cls(
+            model=runtime.model,  # type: ignore[arg-type]
+            system_prompt=runtime.system_prompt,
+            messages=messages,
+            tool_choice=runtime.tool_choice,
+            tools=runtime.tools,
+            response_format=runtime.response_format,
+            state=state,
+            runtime=runtime,
+            model_settings=runtime.model_settings,
+        )
+
     def override(self, **overrides: Unpack[_ModelRequestOverrides]) -> ModelRequest:
         """Replace the request with a new request with the given overrides.
 
@@ -177,7 +228,13 @@ class ModelRequest:
             new_request = request.override(system_prompt="New instructions", tool_choice="auto")
             ```
         """
-        return replace(self, **overrides)
+        runtime_overrides = {k: v for k, v in overrides.items() if k in self._RUNTIME_FIELDS}
+        new_runtime = (
+            replace(self.runtime, **runtime_overrides)
+            if runtime_overrides and self.runtime is not None
+            else self.runtime
+        )
+        return replace(self, runtime=new_runtime, **overrides)
 
 
 @dataclass

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields as dc_fields, replace
 from inspect import iscoroutinefunction
 from typing import (
     TYPE_CHECKING,
@@ -116,11 +116,9 @@ class AgentRuntime(Runtime[ContextT]):
         model_settings: dict[str, Any] | None = None,
     ) -> AgentRuntime[ContextT]:
         """Construct an AgentRuntime from a base LangGraph Runtime."""
+        inherited = {f.name: getattr(runtime, f.name) for f in dc_fields(Runtime)}
         return cls(
-            context=runtime.context,
-            store=runtime.store,
-            stream_writer=runtime.stream_writer,
-            previous=runtime.previous,
+            **inherited,
             agent_name=name,
             model_name=model_name,
             model=model,

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -28,14 +28,14 @@ from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, ToolMess
 from langgraph.channels.ephemeral_value import EphemeralValue
 from langgraph.graph.message import add_messages
 from langgraph.store.base import BaseStore  # noqa: TC002
-from langgraph.types import Command, StreamWriter  # noqa: TC002
+from langgraph.runtime import Runtime
+from langgraph.types import Command, StreamWriter, _DC_KWARGS  # noqa: TC002
 from langgraph.typing import ContextT
 from typing_extensions import NotRequired, Required, TypedDict, TypeVar, Unpack
 
 if TYPE_CHECKING:
     from langchain_core.language_models.chat_models import BaseChatModel
     from langchain_core.tools import BaseTool
-    from langgraph.runtime import Runtime
 
     from langchain.agents.structured_output import ResponseFormat
 
@@ -62,65 +62,26 @@ JumpTo = Literal["tools", "model", "end"]
 ResponseT = TypeVar("ResponseT")
 
 
-@dataclass
-class AgentRuntime(Generic[ContextT]):
-    """Runtime context for agent execution, extending LangGraph's Runtime.
+@dataclass(**_DC_KWARGS)
+class AgentRuntime(Runtime[ContextT]):
+    """Agent-scoped runtime injected into all middleware hook nodes.
 
-    This class provides agent-specific execution context to middleware, including
-    the name of the currently executing graph and all Runtime properties flattened
-    for convenient access.
-
-    The AgentRuntime follows the same pattern as ToolRuntime, providing a flat
-    structure with all runtime properties directly accessible.
+    Extends LangGraph's `Runtime` with agent-level fields populated by
+    `create_agent` at wire time. Middleware that needs additional fields
+    (e.g. a resolved backend) can override the private `_build_runtime`
+    hook on `AgentMiddleware` to return a richer subclass.
 
     Attributes:
-        agent_name: The name of the currently executing graph/agent. This is the
-            name passed to `create_agent(name=...)` or defaults to "LangGraph".
-        context: Static context for the graph run (e.g., `user_id`, `db_conn`).
-        store: Store for persistence and memory, if configured.
-        stream_writer: Function for writing to the custom stream.
-        previous: The previous return value for the given thread (functional API only).
-
-    Example:
-        ```python
-        from langchain.agents.middleware import wrap_model_call, AgentRuntime
-        from langchain.agents.middleware.types import ModelRequest, ModelResponse
-
-
-        @wrap_model_call
-        def log_agent_name(
-            request: ModelRequest,
-            handler: Callable[[ModelRequest], ModelResponse],
-        ) -> ModelResponse:
-            '''Log which agent is making the model call.'''
-            agent_name = request.runtime.agent_name
-            print(f"Agent '{agent_name}' is calling the model")
-
-            # Access runtime context directly (flattened)
-            user_id = request.runtime.context.get("user_id")
-            print(f"User: {user_id}")
-
-            return handler(request)
-        ```
+        agent_name: Name passed to `create_agent(name=...)`.
+        model_name: Model identifier, if statically known at wire time.
+        tools: Tools registered with the agent.
     """
 
-    agent_name: str
-    """The name of the currently executing graph/agent."""
-
-    context: ContextT = field(default=None)  # type: ignore[assignment]
-    """Static context for the graph run, like `user_id`, `db_conn`, etc."""
-
-    store: BaseStore | None = field(default=None)
-    """Store for the graph run, enabling persistence and memory."""
-
-    stream_writer: StreamWriter = field(default=None)  # type: ignore[assignment]
-    """Function that writes to the custom stream."""
-
-    previous: Any = field(default=None)
-    """The previous return value for the given thread."""
+    agent_name: str = field(default="agent")
+    """The name of the currently executing agent."""
 
     model_name: str | None = field(default=None)
-    """Name of the model being used, if statically known."""
+    """Model identifier, if statically known at wire time."""
 
     tools: list[BaseTool] = field(default_factory=list)
     """Tools registered with the agent."""
@@ -134,13 +95,13 @@ class AgentRuntime(Generic[ContextT]):
         model_name: str | None = None,
         tools: list[BaseTool] | None = None,
     ) -> AgentRuntime[ContextT]:
-        """Create an AgentRuntime from a Runtime."""
-        return AgentRuntime[ContextT](
-            agent_name=name,
+        """Construct an AgentRuntime from a base Runtime."""
+        return cls(
             context=runtime.context,
             store=runtime.store,
             stream_writer=runtime.stream_writer,
             previous=runtime.previous,
+            agent_name=name,
             model_name=model_name,
             tools=tools or [],
         )

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -9,7 +9,6 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
-    ClassVar,
     Generic,
     Literal,
     Protocol,
@@ -101,6 +100,11 @@ class AgentRuntime(Runtime[ContextT]):
     model_settings: dict[str, Any] = field(default_factory=dict)
     """Additional model-specific settings."""
 
+    backend: object | None = field(default=None)
+    """Opaque backend object injected by subpackages (e.g. deepagents).
+    Typed as ``object`` at this layer; subpackages narrow the type via
+    ``AgentMiddleware._build_runtime``."""
+
     @classmethod
     def from_runtime(
         cls,
@@ -114,6 +118,7 @@ class AgentRuntime(Runtime[ContextT]):
         tools: list[BaseTool | dict] | None = None,
         response_format: ResponseFormat | None = None,
         model_settings: dict[str, Any] | None = None,
+        backend: object | None = None,
     ) -> AgentRuntime[ContextT]:
         """Construct an AgentRuntime from a base LangGraph Runtime."""
         inherited = {f.name: getattr(runtime, f.name) for f in dc_fields(Runtime)}
@@ -127,6 +132,7 @@ class AgentRuntime(Runtime[ContextT]):
             tools=tools or [],
             response_format=response_format,
             model_settings=model_settings or {},
+            backend=backend,
         )
 
 
@@ -146,36 +152,47 @@ class _ModelRequestOverrides(TypedDict, total=False):
 class ModelRequest:
     """Model request information for the agent.
 
-    This dataclass contains all the information needed for a model invocation,
-    including the model, messages, tools, and runtime context.
+    Owns only the fields that are unique to a single model invocation
+    (``messages``, ``state``, ``runtime``).  All other fields (``model``,
+    ``system_prompt``, ``tools``, etc.) are properties that read directly
+    from ``runtime``, so there is no duplication with ``AgentRuntime``.
 
     Attributes:
-        model: The chat model to invoke.
-        system_prompt: Optional system prompt to prepend to messages.
         messages: List of conversation messages (excluding system prompt).
-        tool_choice: Tool selection configuration for the model.
-        tools: Available tools for the model to use.
-        response_format: Structured output format specification.
         state: Complete agent state at the time of model invocation.
-        runtime: Agent runtime context including agent name and underlying
-            LangGraph Runtime with context, store, and stream_writer.
-        model_settings: Additional model-specific settings.
+        runtime: Agent runtime context — carries model, tools, system_prompt,
+            and all other invocation settings.
     """
 
-    model: BaseChatModel
-    system_prompt: str | None
-    messages: list[AnyMessage]  # excluding system prompt
-    tool_choice: Any | None
-    tools: list[BaseTool | dict]
-    response_format: ResponseFormat | None
+    messages: list[AnyMessage]
     state: AgentState
     runtime: AgentRuntime[ContextT]  # type: ignore[valid-type]
-    model_settings: dict[str, Any] = field(default_factory=dict)
 
-    # Fields shared with AgentRuntime — kept in sync by override().
-    _RUNTIME_FIELDS: ClassVar[frozenset[str]] = frozenset(
-        {"model", "system_prompt", "tool_choice", "tools", "response_format", "model_settings"}
-    )
+    # --- properties delegating to runtime ---
+
+    @property
+    def model(self) -> BaseChatModel:
+        return self.runtime.model  # type: ignore[return-value]
+
+    @property
+    def system_prompt(self) -> str | None:
+        return self.runtime.system_prompt
+
+    @property
+    def tool_choice(self) -> Any | None:
+        return self.runtime.tool_choice
+
+    @property
+    def tools(self) -> list[BaseTool | dict]:
+        return self.runtime.tools
+
+    @property
+    def response_format(self) -> ResponseFormat | None:
+        return self.runtime.response_format
+
+    @property
+    def model_settings(self) -> dict[str, Any]:
+        return self.runtime.model_settings
 
     @classmethod
     def from_runtime(
@@ -186,53 +203,32 @@ class ModelRequest:
         state: AgentState,
     ) -> ModelRequest:
         """Construct a ModelRequest from an AgentRuntime, messages, and state."""
-        return cls(
-            model=runtime.model,  # type: ignore[arg-type]
-            system_prompt=runtime.system_prompt,
-            messages=messages,
-            tool_choice=runtime.tool_choice,
-            tools=runtime.tools,
-            response_format=runtime.response_format,
-            state=state,
-            runtime=runtime,
-            model_settings=runtime.model_settings,
-        )
+        return cls(messages=messages, state=state, runtime=runtime)
 
     def override(self, **overrides: Unpack[_ModelRequestOverrides]) -> ModelRequest:
-        """Replace the request with a new request with the given overrides.
+        """Return a new ModelRequest with the given overrides applied.
 
-        Returns a new `ModelRequest` instance with the specified attributes replaced.
-        This follows an immutable pattern, leaving the original request unchanged.
+        Fields shared with ``AgentRuntime`` (``model``, ``system_prompt``,
+        ``tools``, etc.) are applied to the runtime via ``dataclasses.replace``.
+        ``messages`` and ``state`` are applied directly to the request.
 
         Args:
-            **overrides: Keyword arguments for attributes to override. Supported keys:
-                - model: BaseChatModel instance
-                - system_prompt: Optional system prompt string
-                - messages: List of messages
-                - tool_choice: Tool choice configuration
-                - tools: List of available tools
-                - response_format: Response format specification
-                - model_settings: Additional model settings
+            **overrides: Keyword arguments for attributes to override.
 
         Returns:
-            New ModelRequest instance with specified overrides applied.
+            New ``ModelRequest`` instance with overrides applied.
 
         Examples:
             ```python
-            # Create a new request with different model
             new_request = request.override(model=different_model)
-
-            # Override multiple attributes
             new_request = request.override(system_prompt="New instructions", tool_choice="auto")
             ```
         """
-        runtime_overrides = {k: v for k, v in overrides.items() if k in self._RUNTIME_FIELDS}
-        new_runtime = (
-            replace(self.runtime, **runtime_overrides)
-            if runtime_overrides and self.runtime is not None
-            else self.runtime
-        )
-        return replace(self, runtime=new_runtime, **overrides)
+        _runtime_fields = {"model", "system_prompt", "tool_choice", "tools", "response_format", "model_settings"}
+        runtime_overrides = {k: v for k, v in overrides.items() if k in _runtime_fields}
+        request_overrides = {k: v for k, v in overrides.items() if k not in _runtime_fields}
+        new_runtime = replace(self.runtime, **runtime_overrides) if runtime_overrides else self.runtime
+        return replace(self, runtime=new_runtime, **request_overrides)
 
 
 @dataclass
@@ -328,12 +324,16 @@ class AgentMiddleware(Generic[StateT, ContextT]):
         return self.__class__.__name__
 
     def _build_runtime(self, runtime: AgentRuntime[ContextT]) -> AgentRuntime[ContextT]:
-        """Enrich AgentRuntime before it is passed to hook methods.
+        """Enrich the AgentRuntime before it is passed to hook methods.
 
-        Called by the agent factory for every hook node (before_agent, before_model,
-        after_model, after_agent). The default is identity. Subpackages that need
-        extra fields on the runtime (e.g. a resolved backend) override this privately
-        — it is not a public extension point for end-user middleware.
+        Called by the agent factory once per hook dispatch, with calls accumulated
+        across all middlewares in order. The result of each middleware's
+        ``_build_runtime`` is passed as input to the next, so a subpackage that
+        prepends a specialised middleware (e.g. ``BackendMiddleware``) can inject
+        a typed subclass that all subsequent middlewares receive.
+
+        The default implementation is the identity. Override to return an enriched
+        subclass — for example, one that carries a resolved backend.
         """
         return runtime
 

--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "AgentMiddleware",
+    "AgentRuntime",
     "AgentState",
     "ContextT",
     "ModelRequest",
@@ -118,8 +119,21 @@ class AgentRuntime(Generic[ContextT]):
     previous: Any = field(default=None)
     """The previous return value for the given thread."""
 
+    model_name: str | None = field(default=None)
+    """Name of the model being used, if statically known."""
+
+    tools: list[BaseTool] = field(default_factory=list)
+    """Tools registered with the agent."""
+
     @classmethod
-    def from_runtime(cls, name: str, runtime: Runtime[ContextT]) -> AgentRuntime[ContextT]:
+    def from_runtime(
+        cls,
+        name: str,
+        runtime: Runtime[ContextT],
+        *,
+        model_name: str | None = None,
+        tools: list[BaseTool] | None = None,
+    ) -> AgentRuntime[ContextT]:
         """Create an AgentRuntime from a Runtime."""
         return AgentRuntime[ContextT](
             agent_name=name,
@@ -127,6 +141,8 @@ class AgentRuntime(Generic[ContextT]):
             store=runtime.store,
             stream_writer=runtime.stream_writer,
             previous=runtime.previous,
+            model_name=model_name,
+            tools=tools or [],
         )
 
 
@@ -294,6 +310,16 @@ class AgentMiddleware(Generic[StateT, ContextT]):
         Defaults to the class name, but can be overridden for custom naming.
         """
         return self.__class__.__name__
+
+    def _build_runtime(self, runtime: AgentRuntime[ContextT]) -> AgentRuntime[ContextT]:
+        """Enrich AgentRuntime before it is passed to hook methods.
+
+        Called by the agent factory for every hook node (before_agent, before_model,
+        after_model, after_agent). The default is identity. Subpackages that need
+        extra fields on the runtime (e.g. a resolved backend) override this privately
+        — it is not a public extension point for end-user middleware.
+        """
+        return runtime
 
     def before_agent(self, state: StateT, runtime: Runtime[ContextT]) -> dict[str, Any] | None:
         """Logic to run before the agent execution starts."""

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
@@ -1,0 +1,296 @@
+"""Tests for AgentRuntime functionality in middleware."""
+
+from dataclasses import dataclass
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.runtime import Runtime
+from langgraph.store.memory import InMemoryStore
+
+from langchain.agents import create_agent
+from langchain.agents.middleware import (
+    AgentRuntime,
+    before_agent,
+    before_model,
+    wrap_model_call,
+)
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+
+
+@dataclass
+class Context:
+    """Test context for agent runtime."""
+
+    user_id: str
+    session_id: str
+
+
+@pytest.fixture
+def fake_chat_model():
+    """Fixture providing a fake chat model for testing."""
+    return GenericFakeChatModel(messages=iter([AIMessage(content="test response")]))
+
+
+def test_agent_runtime_structure():
+    """Test that AgentRuntime has correct structure."""
+    @dataclass
+    class LocalContext:
+        user_id: str
+
+    runtime = Runtime(
+        context=LocalContext(user_id="test_user"),
+        store=None,
+    )
+
+    agent_runtime = AgentRuntime(
+        agent_name="TestAgent",
+        runtime=runtime,
+    )
+
+    assert agent_runtime.agent_name == "TestAgent"
+    assert agent_runtime.runtime == runtime
+    assert agent_runtime.runtime.context.user_id == "test_user"
+
+
+def test_agent_runtime_in_before_agent_hook(fake_chat_model):
+    """Test that AgentRuntime is correctly passed to before_agent hooks."""
+    captured_agent_name = None
+    captured_context = None
+
+    @before_agent
+    def capture_runtime(state, runtime: AgentRuntime):
+        nonlocal captured_agent_name, captured_context
+        captured_agent_name = runtime.agent_name
+        captured_context = runtime.runtime.context
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[capture_runtime],
+        name="MyTestAgent",
+        context_schema=Context,
+    )
+
+    agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        context=Context(user_id="user123", session_id="session456"),
+    )
+
+    assert captured_agent_name == "MyTestAgent"
+    assert captured_context.user_id == "user123"
+    assert captured_context.session_id == "session456"
+
+
+def test_agent_runtime_in_before_model_hook(fake_chat_model):
+    """Test that AgentRuntime is correctly passed to before_model hooks."""
+    captured_agent_name = None
+    captured_context = None
+
+    @before_model
+    def capture_runtime(state, runtime: AgentRuntime):
+        nonlocal captured_agent_name, captured_context
+        captured_agent_name = runtime.agent_name
+        captured_context = runtime.runtime.context
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[capture_runtime],
+        name="AnotherAgent",
+        context_schema=Context,
+    )
+
+    agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        context=Context(user_id="user456", session_id="session789"),
+    )
+
+    assert captured_agent_name == "AnotherAgent"
+    assert captured_context.user_id == "user456"
+    assert captured_context.session_id == "session789"
+
+
+def test_agent_runtime_in_wrap_model_call(fake_chat_model):
+    """Test that AgentRuntime is accessible via ModelRequest in wrap_model_call."""
+    captured_agent_name = None
+    captured_context = None
+
+    @wrap_model_call
+    def capture_from_request(request: ModelRequest, handler):
+        nonlocal captured_agent_name, captured_context
+        captured_agent_name = request.runtime.agent_name
+        captured_context = request.runtime.runtime.context
+        return handler(request)
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[capture_from_request],
+        name="WrapAgent",
+        context_schema=Context,
+    )
+
+    agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        context=Context(user_id="user789", session_id="session123"),
+    )
+
+    assert captured_agent_name == "WrapAgent"
+    assert captured_context.user_id == "user789"
+    assert captured_context.session_id == "session123"
+
+
+def test_agent_runtime_default_name(fake_chat_model):
+    """Test that AgentRuntime uses default name when not specified."""
+    captured_agent_name = None
+
+    @before_agent
+    def capture_name(state, runtime: AgentRuntime):
+        nonlocal captured_agent_name
+        captured_agent_name = runtime.agent_name
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[capture_name],
+        # name not specified - should default to "LangGraph"
+    )
+
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    assert captured_agent_name == "LangGraph"
+
+
+def test_agent_runtime_with_store(fake_chat_model):
+    """Test that AgentRuntime provides access to store through underlying runtime."""
+    store = InMemoryStore()
+    store.put(("test",), "key1", {"value": "test_data"})
+
+    captured_store_value = None
+
+    @before_agent
+    def access_store(state, runtime: AgentRuntime):
+        nonlocal captured_store_value
+        if runtime.runtime.store:
+            item = runtime.runtime.store.get(("test",), "key1")
+            if item:
+                captured_store_value = item.value
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[access_store],
+        name="StoreAgent",
+        store=store,
+    )
+
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    assert captured_store_value == {"value": "test_data"}
+
+
+async def test_agent_runtime_async_hooks(fake_chat_model):
+    """Test that AgentRuntime works with async middleware hooks."""
+    captured_agent_name = None
+
+    @before_agent
+    async def async_capture(state, runtime: AgentRuntime):
+        nonlocal captured_agent_name
+        captured_agent_name = runtime.agent_name
+        return None
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[async_capture],
+        name="AsyncAgent",
+    )
+
+    await agent.ainvoke({"messages": [HumanMessage("Hello")]})
+
+    assert captured_agent_name == "AsyncAgent"
+
+
+def test_agent_runtime_multiple_middleware(fake_chat_model):
+    """Test that all middleware receive correct AgentRuntime."""
+    captured_names = []
+
+    @before_agent(name="first")
+    def first_middleware(state, runtime: AgentRuntime):
+        captured_names.append(("first_before_agent", runtime.agent_name))
+        return None
+
+    @before_model(name="second")
+    def second_middleware(state, runtime: AgentRuntime):
+        captured_names.append(("second_before_model", runtime.agent_name))
+        return None
+
+    @wrap_model_call(name="third")
+    def third_middleware(request: ModelRequest, handler):
+        captured_names.append(("third_wrap_model", request.runtime.agent_name))
+        return handler(request)
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[first_middleware, second_middleware, third_middleware],
+        name="MultiMiddlewareAgent",
+    )
+
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    assert len(captured_names) == 3
+    assert all(name == "MultiMiddlewareAgent" for _, name in captured_names)
+    assert captured_names[0][0] == "first_before_agent"
+    assert captured_names[1][0] == "second_before_model"
+    assert captured_names[2][0] == "third_wrap_model"
+
+
+def test_model_request_runtime_field_type():
+    """Test that ModelRequest.runtime field has correct type."""
+    from langchain.agents.middleware.types import ModelRequest
+
+    # Check that the runtime field is AgentRuntime, not Runtime
+    annotations = ModelRequest.__annotations__
+    runtime_annotation = str(annotations["runtime"])
+
+    # Should contain AgentRuntime
+    assert "AgentRuntime" in runtime_annotation
+
+
+def test_agent_runtime_access_pattern(fake_chat_model):
+    """Test the recommended pattern for accessing agent name and context."""
+
+    @wrap_model_call
+    def middleware_using_runtime(request: ModelRequest, handler):
+        # Access agent name directly
+        agent_name = request.runtime.agent_name
+
+        # Access underlying runtime for context, store, etc.
+        user_id = request.runtime.runtime.context.user_id if request.runtime.runtime.context else None
+        store = request.runtime.runtime.store
+
+        assert agent_name == "PatternTestAgent"
+        assert user_id == "pattern_user"
+        assert store is not None
+
+        return handler(request)
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[middleware_using_runtime],
+        name="PatternTestAgent",
+        context_schema=Context,
+        store=InMemoryStore(),
+    )
+
+    agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        context=Context(user_id="pattern_user", session_id="pattern_session"),
+    )

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
@@ -1,22 +1,16 @@
-"""Tests for wrap_model_call and awrap_model_call functionality."""
-
-from dataclasses import dataclass
+"""Tests for AgentRuntime access via wrap_model_call middleware."""
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.tools import tool
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import wrap_model_call
-from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain.agents.middleware.types import ModelRequest
+from langchain.tools import ToolRuntime
 
-
-@dataclass
-class Context:
-    """Test context for agent runtime."""
-
-    user_id: str
-    session_id: str
+from .model import FakeToolCallingModel
 
 
 @pytest.fixture
@@ -25,312 +19,90 @@ def fake_chat_model():
     return GenericFakeChatModel(messages=iter([AIMessage(content="test response")]))
 
 
-def test_wrap_model_call_basic(fake_chat_model):
-    """Test basic wrap_model_call functionality."""
-    call_count = 0
+def test_agent_name_accessible_in_middleware(fake_chat_model):
+    """Test that agent name can be accessed via middleware."""
+    captured_agent_name = None
 
     @wrap_model_call
-    def count_calls(request: ModelRequest, handler):
-        nonlocal call_count
-        call_count += 1
+    def capture_agent_name(request: ModelRequest, handler):
+        nonlocal captured_agent_name
+        captured_agent_name = request.runtime.agent_name
         return handler(request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[count_calls],
+        middleware=[capture_agent_name],
         name="TestAgent",
     )
 
     agent.invoke({"messages": [HumanMessage("Hello")]})
-    assert call_count == 1
+    assert captured_agent_name == "TestAgent"
 
 
-def test_wrap_model_call_access_runtime(fake_chat_model):
-    """Test accessing AgentRuntime via ModelRequest in wrap_model_call."""
-    captured_agent_name = None
-    captured_context = None
+def test_nested_agent_name_accessible_in_tool():
+    """Test that nested agent's name is accessible when agent is used in a tool."""
+    # Track which agent names were captured
+    captured_agent_names = []
 
     @wrap_model_call
-    def capture_from_request(request: ModelRequest, handler):
-        nonlocal captured_agent_name, captured_context
-        captured_agent_name = request.runtime.agent_name
-        captured_context = request.runtime.context
+    def capture_agent_name(request: ModelRequest, handler):
+        captured_agent_names.append(request.runtime.agent_name)
         return handler(request)
 
-    agent = create_agent(
-        fake_chat_model,
+    # Create a nested agent that will be called from within a tool
+    nested_agent = create_agent(
+        FakeToolCallingModel(),
         tools=[],
-        middleware=[capture_from_request],
-        name="RuntimeAgent",
-        context_schema=Context,
+        middleware=[capture_agent_name],
+        name="NestedAgent",
     )
 
-    agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="user123", session_id="session456"),
+    # Create a tool that invokes the nested agent
+    @tool
+    def call_nested_agent(query: str, runtime: ToolRuntime) -> str:
+        """Tool that calls a nested agent."""
+        result = nested_agent.invoke({"messages": [HumanMessage(query)]})
+        return result["messages"][-1].content
+
+    # Create outer agent that uses the tool
+    outer_agent = create_agent(
+        FakeToolCallingModel(
+            tool_calls=[
+                [{"name": "call_nested_agent", "args": {"query": "test"}, "id": "1"}],
+                [],
+            ]
+        ),
+        tools=[call_nested_agent],
+        middleware=[capture_agent_name],
+        name="OuterAgent",
     )
 
-    assert captured_agent_name == "RuntimeAgent"
-    assert captured_context.user_id == "user123"
-    assert captured_context.session_id == "session456"
+    # Invoke the outer agent, which should call the tool, which calls the nested agent
+    outer_agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    # Both agents should have captured their names
+    assert "OuterAgent" in captured_agent_names
+    assert "NestedAgent" in captured_agent_names
 
 
-def test_wrap_model_call_modify_request(fake_chat_model):
-    """Test modifying the model request in wrap_model_call."""
-    modified_messages = []
-
-    @wrap_model_call
-    def modify_request(request: ModelRequest, handler):
-        # Add a system prompt
-        modified_request = request.override(system_prompt="You are a helpful assistant")
-        modified_messages.append(modified_request.system_prompt)
-        return handler(modified_request)
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[modify_request],
-        name="ModifyAgent",
-    )
-
-    agent.invoke({"messages": [HumanMessage("Hello")]})
-    assert modified_messages[0] == "You are a helpful assistant"
-
-
-def test_wrap_model_call_modify_response(fake_chat_model):
-    """Test modifying the model response in wrap_model_call."""
-
-    @wrap_model_call
-    def modify_response(request: ModelRequest, handler):
-        response = handler(request)
-        # Modify the response content
-        original_msg = response.result[0]
-        modified_msg = AIMessage(
-            content=f"[MODIFIED] {original_msg.content}",
-            id=original_msg.id,
-        )
-        return ModelResponse(
-            result=[modified_msg],
-            structured_response=response.structured_response,
-        )
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[modify_response],
-        name="ModifyResponseAgent",
-    )
-
-    result = agent.invoke({"messages": [HumanMessage("Hello")]})
-    assert result["messages"][-1].content == "[MODIFIED] test response"
-
-
-def test_wrap_model_call_retry_logic(fake_chat_model):
-    """Test retry logic in wrap_model_call."""
-    attempt_count = 0
-    model_call_count = 0
-
-    @wrap_model_call
-    def retry_on_error(request: ModelRequest, handler):
-        nonlocal attempt_count, model_call_count
-        max_retries = 3
-        last_error = None
-
-        for attempt in range(max_retries):
-            attempt_count += 1
-            try:
-                # Simulate failure on first two attempts
-                model_call_count += 1
-                if model_call_count < 3:
-                    raise ValueError("Simulated failure")
-                return handler(request)
-            except ValueError as e:
-                last_error = e
-                if attempt == max_retries - 1:
-                    raise
-
-        raise last_error  # Should never reach here
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[retry_on_error],
-        name="RetryAgent",
-    )
-
-    result = agent.invoke({"messages": [HumanMessage("Hello")]})
-    assert attempt_count == 3
-    # The model response should be from fake_chat_model
-    assert result["messages"][-1].content == "test response"
-
-
-def test_wrap_model_call_short_circuit(fake_chat_model):
-    """Test short-circuiting model call in wrap_model_call."""
-    handler_called = False
-
-    @wrap_model_call
-    def short_circuit(request: ModelRequest, handler):
-        nonlocal handler_called
-        # Check if we should short-circuit
-        if len(request.messages) > 0 and "bypass" in request.messages[-1].content:
-            # Return cached response without calling handler
-            return AIMessage(content="Cached response")
-
-        handler_called = True
-        return handler(request)
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[short_circuit],
-        name="ShortCircuitAgent",
-    )
-
-    result = agent.invoke({"messages": [HumanMessage("bypass")]})
-    assert not handler_called
-    assert result["messages"][-1].content == "Cached response"
-
-
-def test_wrap_model_call_multiple_middleware(fake_chat_model):
-    """Test composing multiple wrap_model_call middleware."""
-    execution_order = []
-
-    @wrap_model_call(name="first")
-    def first_middleware(request: ModelRequest, handler):
-        execution_order.append("first_before")
-        response = handler(request)
-        execution_order.append("first_after")
-        return response
-
-    @wrap_model_call(name="second")
-    def second_middleware(request: ModelRequest, handler):
-        execution_order.append("second_before")
-        response = handler(request)
-        execution_order.append("second_after")
-        return response
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[first_middleware, second_middleware],
-        name="MultiWrapAgent",
-    )
-
-    agent.invoke({"messages": [HumanMessage("Hello")]})
-
-    # Middleware should compose as: first -> second -> model -> second -> first
-    assert execution_order == [
-        "first_before",
-        "second_before",
-        "second_after",
-        "first_after",
-    ]
-
-
-async def test_awrap_model_call_basic(fake_chat_model):
-    """Test basic awrap_model_call functionality."""
-    call_count = 0
-
-    @wrap_model_call
-    async def count_calls_async(request: ModelRequest, handler):
-        nonlocal call_count
-        call_count += 1
-        return await handler(request)
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[count_calls_async],
-        name="AsyncTestAgent",
-    )
-
-    await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-    assert call_count == 1
-
-
-async def test_awrap_model_call_access_runtime(fake_chat_model):
-    """Test accessing AgentRuntime in async wrap_model_call."""
+async def test_agent_name_accessible_in_async_middleware():
+    """Test that agent name can be accessed in async middleware."""
     captured_agent_name = None
 
     @wrap_model_call
-    async def capture_async(request: ModelRequest, handler):
+    async def capture_agent_name_async(request: ModelRequest, handler):
         nonlocal captured_agent_name
         captured_agent_name = request.runtime.agent_name
         return await handler(request)
 
+    fake_model = GenericFakeChatModel(messages=iter([AIMessage(content="async response")]))
     agent = create_agent(
-        fake_chat_model,
+        fake_model,
         tools=[],
-        middleware=[capture_async],
-        name="AsyncRuntimeAgent",
+        middleware=[capture_agent_name_async],
+        name="AsyncAgent",
     )
 
     await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-    assert captured_agent_name == "AsyncRuntimeAgent"
-
-
-async def test_awrap_model_call_retry_logic(fake_chat_model):
-    """Test async retry logic in awrap_model_call."""
-    attempt_count = 0
-    model_call_count = 0
-
-    @wrap_model_call
-    async def async_retry_on_error(request: ModelRequest, handler):
-        nonlocal attempt_count, model_call_count
-        max_retries = 3
-        last_error = None
-
-        for attempt in range(max_retries):
-            attempt_count += 1
-            try:
-                # Simulate failure on first two attempts
-                model_call_count += 1
-                if model_call_count < 3:
-                    raise ValueError("Simulated async failure")
-                return await handler(request)
-            except ValueError as e:
-                last_error = e
-                if attempt == max_retries - 1:
-                    raise
-
-        raise last_error  # Should never reach here
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[async_retry_on_error],
-        name="AsyncRetryAgent",
-    )
-
-    result = await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-    assert attempt_count == 3
-    # The model response should be from fake_chat_model
-    assert result["messages"][-1].content == "test response"
-
-
-async def test_awrap_model_call_modify_response(fake_chat_model):
-    """Test modifying response in async wrap_model_call."""
-
-    @wrap_model_call
-    async def async_modify_response(request: ModelRequest, handler):
-        response = await handler(request)
-        original_msg = response.result[0]
-        modified_msg = AIMessage(
-            content=f"[ASYNC MODIFIED] {original_msg.content}",
-            id=original_msg.id,
-        )
-        return ModelResponse(
-            result=[modified_msg],
-            structured_response=response.structured_response,
-        )
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[async_modify_response],
-        name="AsyncModifyAgent",
-    )
-
-    result = await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-    assert result["messages"][-1].content == "[ASYNC MODIFIED] test response"
+    assert captured_agent_name == "AsyncAgent"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_runtime.py
@@ -1,20 +1,13 @@
-"""Tests for AgentRuntime functionality in middleware."""
+"""Tests for wrap_model_call and awrap_model_call functionality."""
 
 from dataclasses import dataclass
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage
-from langgraph.runtime import Runtime
-from langgraph.store.memory import InMemoryStore
 
 from langchain.agents import create_agent
-from langchain.agents.middleware import (
-    AgentRuntime,
-    before_agent,
-    before_model,
-    wrap_model_call,
-)
+from langchain.agents.middleware import wrap_model_call
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 
 
@@ -32,90 +25,29 @@ def fake_chat_model():
     return GenericFakeChatModel(messages=iter([AIMessage(content="test response")]))
 
 
-def test_agent_runtime_structure():
-    """Test that AgentRuntime has correct structure."""
+def test_wrap_model_call_basic(fake_chat_model):
+    """Test basic wrap_model_call functionality."""
+    call_count = 0
 
-    @dataclass
-    class LocalContext:
-        user_id: str
-
-    context = LocalContext(user_id="test_user")
-    agent_runtime = AgentRuntime(
-        agent_name="TestAgent",
-        context=context,
-        store=None,
-        stream_writer=None,
-        previous=None,
-    )
-
-    assert agent_runtime.agent_name == "TestAgent"
-    assert agent_runtime.context == context
-    assert agent_runtime.context.user_id == "test_user"
-    assert agent_runtime.store is None
-
-
-def test_agent_runtime_in_before_agent_hook(fake_chat_model):
-    """Test that AgentRuntime is correctly passed to before_agent hooks."""
-    captured_agent_name = None
-    captured_context = None
-
-    @before_agent
-    def capture_runtime(state, runtime: AgentRuntime):
-        nonlocal captured_agent_name, captured_context
-        captured_agent_name = runtime.agent_name
-        captured_context = runtime.context
-        return None
+    @wrap_model_call
+    def count_calls(request: ModelRequest, handler):
+        nonlocal call_count
+        call_count += 1
+        return handler(request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[capture_runtime],
-        name="MyTestAgent",
-        context_schema=Context,
+        middleware=[count_calls],
+        name="TestAgent",
     )
 
-    agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="user123", session_id="session456"),
-    )
-
-    assert captured_agent_name == "MyTestAgent"
-    assert captured_context.user_id == "user123"
-    assert captured_context.session_id == "session456"
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert call_count == 1
 
 
-def test_agent_runtime_in_before_model_hook(fake_chat_model):
-    """Test that AgentRuntime is correctly passed to before_model hooks."""
-    captured_agent_name = None
-    captured_context = None
-
-    @before_model
-    def capture_runtime(state, runtime: AgentRuntime):
-        nonlocal captured_agent_name, captured_context
-        captured_agent_name = runtime.agent_name
-        captured_context = runtime.context
-        return None
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[capture_runtime],
-        name="AnotherAgent",
-        context_schema=Context,
-    )
-
-    agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="user456", session_id="session789"),
-    )
-
-    assert captured_agent_name == "AnotherAgent"
-    assert captured_context.user_id == "user456"
-    assert captured_context.session_id == "session789"
-
-
-def test_agent_runtime_in_wrap_model_call(fake_chat_model):
-    """Test that AgentRuntime is accessible via ModelRequest in wrap_model_call."""
+def test_wrap_model_call_access_runtime(fake_chat_model):
+    """Test accessing AgentRuntime via ModelRequest in wrap_model_call."""
     captured_agent_name = None
     captured_context = None
 
@@ -130,168 +62,275 @@ def test_agent_runtime_in_wrap_model_call(fake_chat_model):
         fake_chat_model,
         tools=[],
         middleware=[capture_from_request],
-        name="WrapAgent",
+        name="RuntimeAgent",
         context_schema=Context,
     )
 
     agent.invoke(
         {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="user789", session_id="session123"),
+        context=Context(user_id="user123", session_id="session456"),
     )
 
-    assert captured_agent_name == "WrapAgent"
-    assert captured_context.user_id == "user789"
-    assert captured_context.session_id == "session123"
+    assert captured_agent_name == "RuntimeAgent"
+    assert captured_context.user_id == "user123"
+    assert captured_context.session_id == "session456"
 
 
-def test_agent_runtime_default_name(fake_chat_model):
-    """Test that AgentRuntime uses default name when not specified."""
-    captured_agent_name = None
+def test_wrap_model_call_modify_request(fake_chat_model):
+    """Test modifying the model request in wrap_model_call."""
+    modified_messages = []
 
-    @before_agent
-    def capture_name(state, runtime: AgentRuntime):
-        nonlocal captured_agent_name
-        captured_agent_name = runtime.agent_name
-        return None
+    @wrap_model_call
+    def modify_request(request: ModelRequest, handler):
+        # Add a system prompt
+        modified_request = request.override(system_prompt="You are a helpful assistant")
+        modified_messages.append(modified_request.system_prompt)
+        return handler(modified_request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[capture_name],
-        # name not specified - should default to "LangGraph"
+        middleware=[modify_request],
+        name="ModifyAgent",
+    )
+
+    agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert modified_messages[0] == "You are a helpful assistant"
+
+
+def test_wrap_model_call_modify_response(fake_chat_model):
+    """Test modifying the model response in wrap_model_call."""
+
+    @wrap_model_call
+    def modify_response(request: ModelRequest, handler):
+        response = handler(request)
+        # Modify the response content
+        original_msg = response.result[0]
+        modified_msg = AIMessage(
+            content=f"[MODIFIED] {original_msg.content}",
+            id=original_msg.id,
+        )
+        return ModelResponse(
+            result=[modified_msg],
+            structured_response=response.structured_response,
+        )
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[modify_response],
+        name="ModifyResponseAgent",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert result["messages"][-1].content == "[MODIFIED] test response"
+
+
+def test_wrap_model_call_retry_logic(fake_chat_model):
+    """Test retry logic in wrap_model_call."""
+    attempt_count = 0
+    model_call_count = 0
+
+    @wrap_model_call
+    def retry_on_error(request: ModelRequest, handler):
+        nonlocal attempt_count, model_call_count
+        max_retries = 3
+        last_error = None
+
+        for attempt in range(max_retries):
+            attempt_count += 1
+            try:
+                # Simulate failure on first two attempts
+                model_call_count += 1
+                if model_call_count < 3:
+                    raise ValueError("Simulated failure")
+                return handler(request)
+            except ValueError as e:
+                last_error = e
+                if attempt == max_retries - 1:
+                    raise
+
+        raise last_error  # Should never reach here
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[retry_on_error],
+        name="RetryAgent",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert attempt_count == 3
+    # The model response should be from fake_chat_model
+    assert result["messages"][-1].content == "test response"
+
+
+def test_wrap_model_call_short_circuit(fake_chat_model):
+    """Test short-circuiting model call in wrap_model_call."""
+    handler_called = False
+
+    @wrap_model_call
+    def short_circuit(request: ModelRequest, handler):
+        nonlocal handler_called
+        # Check if we should short-circuit
+        if len(request.messages) > 0 and "bypass" in request.messages[-1].content:
+            # Return cached response without calling handler
+            return AIMessage(content="Cached response")
+
+        handler_called = True
+        return handler(request)
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[short_circuit],
+        name="ShortCircuitAgent",
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("bypass")]})
+    assert not handler_called
+    assert result["messages"][-1].content == "Cached response"
+
+
+def test_wrap_model_call_multiple_middleware(fake_chat_model):
+    """Test composing multiple wrap_model_call middleware."""
+    execution_order = []
+
+    @wrap_model_call(name="first")
+    def first_middleware(request: ModelRequest, handler):
+        execution_order.append("first_before")
+        response = handler(request)
+        execution_order.append("first_after")
+        return response
+
+    @wrap_model_call(name="second")
+    def second_middleware(request: ModelRequest, handler):
+        execution_order.append("second_before")
+        response = handler(request)
+        execution_order.append("second_after")
+        return response
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[first_middleware, second_middleware],
+        name="MultiWrapAgent",
     )
 
     agent.invoke({"messages": [HumanMessage("Hello")]})
 
-    assert captured_agent_name == "LangGraph"
+    # Middleware should compose as: first -> second -> model -> second -> first
+    assert execution_order == [
+        "first_before",
+        "second_before",
+        "second_after",
+        "first_after",
+    ]
 
 
-def test_agent_runtime_with_store(fake_chat_model):
-    """Test that AgentRuntime provides access to store directly."""
-    store = InMemoryStore()
-    store.put(("test",), "key1", {"value": "test_data"})
+async def test_awrap_model_call_basic(fake_chat_model):
+    """Test basic awrap_model_call functionality."""
+    call_count = 0
 
-    captured_store_value = None
-
-    @before_agent
-    def access_store(state, runtime: AgentRuntime):
-        nonlocal captured_store_value
-        if runtime.store:
-            item = runtime.store.get(("test",), "key1")
-            if item:
-                captured_store_value = item.value
-        return None
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[access_store],
-        name="StoreAgent",
-        store=store,
-    )
-
-    agent.invoke({"messages": [HumanMessage("Hello")]})
-
-    assert captured_store_value == {"value": "test_data"}
-
-
-async def test_agent_runtime_async_hooks(fake_chat_model):
-    """Test that AgentRuntime works with async middleware hooks."""
-    captured_agent_name = None
-
-    @before_agent
-    async def async_capture(state, runtime: AgentRuntime):
-        nonlocal captured_agent_name
-        captured_agent_name = runtime.agent_name
-        return None
+    @wrap_model_call
+    async def count_calls_async(request: ModelRequest, handler):
+        nonlocal call_count
+        call_count += 1
+        return await handler(request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[async_capture],
-        name="AsyncAgent",
+        middleware=[count_calls_async],
+        name="AsyncTestAgent",
     )
 
     await agent.ainvoke({"messages": [HumanMessage("Hello")]})
-
-    assert captured_agent_name == "AsyncAgent"
-
-
-def test_agent_runtime_multiple_middleware(fake_chat_model):
-    """Test that all middleware receive correct AgentRuntime."""
-    captured_names = []
-
-    @before_agent(name="first")
-    def first_middleware(state, runtime: AgentRuntime):
-        captured_names.append(("first_before_agent", runtime.agent_name))
-        return None
-
-    @before_model(name="second")
-    def second_middleware(state, runtime: AgentRuntime):
-        captured_names.append(("second_before_model", runtime.agent_name))
-        return None
-
-    @wrap_model_call(name="third")
-    def third_middleware(request: ModelRequest, handler):
-        captured_names.append(("third_wrap_model", request.runtime.agent_name))
-        return handler(request)
-
-    agent = create_agent(
-        fake_chat_model,
-        tools=[],
-        middleware=[first_middleware, second_middleware, third_middleware],
-        name="MultiMiddlewareAgent",
-    )
-
-    agent.invoke({"messages": [HumanMessage("Hello")]})
-
-    assert len(captured_names) == 3
-    assert all(name == "MultiMiddlewareAgent" for _, name in captured_names)
-    assert captured_names[0][0] == "first_before_agent"
-    assert captured_names[1][0] == "second_before_model"
-    assert captured_names[2][0] == "third_wrap_model"
+    assert call_count == 1
 
 
-def test_model_request_runtime_field_type():
-    """Test that ModelRequest.runtime field has correct type."""
-    from langchain.agents.middleware.types import ModelRequest
-
-    # Check that the runtime field is AgentRuntime, not Runtime
-    annotations = ModelRequest.__annotations__
-    runtime_annotation = str(annotations["runtime"])
-
-    # Should contain AgentRuntime
-    assert "AgentRuntime" in runtime_annotation
-
-
-def test_agent_runtime_access_pattern(fake_chat_model):
-    """Test the recommended pattern for accessing agent name and context."""
+async def test_awrap_model_call_access_runtime(fake_chat_model):
+    """Test accessing AgentRuntime in async wrap_model_call."""
+    captured_agent_name = None
 
     @wrap_model_call
-    def middleware_using_runtime(request: ModelRequest, handler):
-        # Access agent name directly
-        agent_name = request.runtime.agent_name
-
-        # Access runtime properties directly (flat structure)
-        user_id = request.runtime.context.user_id if request.runtime.context else None
-        store = request.runtime.store
-
-        assert agent_name == "PatternTestAgent"
-        assert user_id == "pattern_user"
-        assert store is not None
-
-        return handler(request)
+    async def capture_async(request: ModelRequest, handler):
+        nonlocal captured_agent_name
+        captured_agent_name = request.runtime.agent_name
+        return await handler(request)
 
     agent = create_agent(
         fake_chat_model,
         tools=[],
-        middleware=[middleware_using_runtime],
-        name="PatternTestAgent",
-        context_schema=Context,
-        store=InMemoryStore(),
+        middleware=[capture_async],
+        name="AsyncRuntimeAgent",
     )
 
-    agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        context=Context(user_id="pattern_user", session_id="pattern_session"),
+    await agent.ainvoke({"messages": [HumanMessage("Hello")]})
+    assert captured_agent_name == "AsyncRuntimeAgent"
+
+
+async def test_awrap_model_call_retry_logic(fake_chat_model):
+    """Test async retry logic in awrap_model_call."""
+    attempt_count = 0
+    model_call_count = 0
+
+    @wrap_model_call
+    async def async_retry_on_error(request: ModelRequest, handler):
+        nonlocal attempt_count, model_call_count
+        max_retries = 3
+        last_error = None
+
+        for attempt in range(max_retries):
+            attempt_count += 1
+            try:
+                # Simulate failure on first two attempts
+                model_call_count += 1
+                if model_call_count < 3:
+                    raise ValueError("Simulated async failure")
+                return await handler(request)
+            except ValueError as e:
+                last_error = e
+                if attempt == max_retries - 1:
+                    raise
+
+        raise last_error  # Should never reach here
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[async_retry_on_error],
+        name="AsyncRetryAgent",
     )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("Hello")]})
+    assert attempt_count == 3
+    # The model response should be from fake_chat_model
+    assert result["messages"][-1].content == "test response"
+
+
+async def test_awrap_model_call_modify_response(fake_chat_model):
+    """Test modifying response in async wrap_model_call."""
+
+    @wrap_model_call
+    async def async_modify_response(request: ModelRequest, handler):
+        response = await handler(request)
+        original_msg = response.result[0]
+        modified_msg = AIMessage(
+            content=f"[ASYNC MODIFIED] {original_msg.content}",
+            id=original_msg.id,
+        )
+        return ModelResponse(
+            result=[modified_msg],
+            structured_response=response.structured_response,
+        )
+
+    agent = create_agent(
+        fake_chat_model,
+        tools=[],
+        middleware=[async_modify_response],
+        name="AsyncModifyAgent",
+    )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("Hello")]})
+    assert result["messages"][-1].content == "[ASYNC MODIFIED] test response"

--- a/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_middleware_agent.py
@@ -1351,7 +1351,7 @@ def test_public_private_state_for_custom_middleware() -> None:
     class CustomMiddleware(AgentMiddleware[CustomState]):
         state_schema: type[CustomState] = CustomState
 
-        def before_model(self, state: CustomState) -> dict[str, Any]:
+        def before_model(self, state: CustomState, runtime) -> dict[str, Any]:
             assert "omit_input" not in state
             assert "omit_output" in state
             assert "private_state" not in state
@@ -1456,11 +1456,11 @@ def test_injected_state_in_middleware_agent() -> None:
 
 def test_jump_to_is_ephemeral() -> None:
     class MyMiddleware(AgentMiddleware):
-        def before_model(self, state: AgentState) -> dict[str, Any]:
+        def before_model(self, state: AgentState, runtime) -> dict[str, Any]:
             assert "jump_to" not in state
             return {"jump_to": "model"}
 
-        def after_model(self, state: AgentState) -> dict[str, Any]:
+        def after_model(self, state: AgentState, runtime) -> dict[str, Any]:
             assert "jump_to" not in state
             return {"jump_to": "model"}
 


### PR DESCRIPTION
Adds `AgentRuntime` and a `_build_runtime` hook so subpackages can enrich the runtime without touching langchain internals.

```python
@dataclass
class AgentRuntime(Runtime[ContextT]):
    agent_name: str
    model_name: str | None
    model: BaseChatModel | None
    system_prompt: str | None
    tools: list[BaseTool | dict]
    tool_choice: Any | None
    response_format: ResponseFormat | None
    model_settings: dict[str, Any]

class AgentMiddleware:
    def _build_runtime(self, runtime: AgentRuntime) -> AgentRuntime:
        """`_build_runtime` calls are accumulated across all middlewares before
        each hook dispatch. Subpackages override to return an enriched subclass."""
        return runtime
```

`ModelRequest` shared fields (`model`, `tools`, `system_prompt`, etc.) are now properties delegating to `runtime`, eliminating duplication.

Non-breaking: existing `runtime: Runtime` annotations accept `AgentRuntime` via Liskov substitution.