### PR TITLE
fix(openai): preserve headers for structured streaming

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1565,11 +1565,6 @@ class BaseChatOpenAI(BaseChatModel):
 
         try:
             if "response_format" in payload:
-                if self.include_response_headers:
-                    warnings.warn(
-                        "Cannot currently include response headers when "
-                        "response_format is specified."
-                    )
                 payload.pop("stream")
                 response_stream = self.root_client.beta.chat.completions.stream(
                     **payload
@@ -1584,6 +1579,10 @@ class BaseChatOpenAI(BaseChatModel):
                     response = self.client.create(**payload)
                 context_manager = response
             with context_manager as response:
+                if "response_format" in payload and self.include_response_headers:
+                    http_response = getattr(response, "_response", None)
+                    if http_response is not None:
+                        base_generation_info = {"headers": dict(http_response.headers)}
                 is_first_chunk = True
                 for chunk in response:
                     if not isinstance(chunk, dict):
@@ -1824,11 +1823,6 @@ class BaseChatOpenAI(BaseChatModel):
 
         try:
             if "response_format" in payload:
-                if self.include_response_headers:
-                    warnings.warn(
-                        "Cannot currently include response headers when "
-                        "response_format is specified."
-                    )
                 payload.pop("stream")
                 response_stream = self.root_async_client.beta.chat.completions.stream(
                     **payload
@@ -1845,6 +1839,10 @@ class BaseChatOpenAI(BaseChatModel):
                     response = await self.async_client.create(**payload)
                 context_manager = response
             async with context_manager as response:
+                if "response_format" in payload and self.include_response_headers:
+                    http_response = getattr(response, "_response", None)
+                    if http_response is not None:
+                        base_generation_info = {"headers": dict(http_response.headers)}
                 is_first_chunk = True
                 async for chunk in _astream_with_chunk_timeout(
                     response,

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3776,3 +3776,140 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+_BETA_STREAM_CHUNK = {
+    "id": "chatcmpl-test",
+    "object": "chat.completion.chunk",
+    "created": 1689989000,
+    "model": "gpt-4o",
+    "choices": [
+        {
+            "index": 0,
+            "delta": {"role": "assistant", "content": ""},
+            "finish_reason": None,
+        }
+    ],
+}
+
+_BETA_STREAM_FINAL_COMPLETION = {
+    "id": "chatcmpl-test",
+    "object": "chat.completion",
+    "created": 1689989000,
+    "model": "gpt-4o",
+    "choices": [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": '{"answer": "hello"}'},
+            "finish_reason": "stop",
+        }
+    ],
+}
+
+_BETA_RESPONSE_FORMAT = {
+    "type": "json_schema",
+    "json_schema": {"name": "answer", "schema": {"type": "object"}, "strict": True},
+}
+
+
+class MockBetaCompletionStream:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self._chunks = [_BETA_STREAM_CHUNK]
+        self._current_chunk = 0
+        self._response = MagicMock()
+        self._response.headers = headers
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> dict:
+        if self._current_chunk < len(self._chunks):
+            chunk = self._chunks[self._current_chunk]
+            self._current_chunk += 1
+            return chunk
+        raise StopIteration
+
+    def get_final_completion(self) -> dict:
+        return _BETA_STREAM_FINAL_COMPLETION
+
+
+class MockAsyncBetaCompletionStream:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self._chunks = [_BETA_STREAM_CHUNK]
+        self._current_chunk = 0
+        self._response = MagicMock()
+        self._response.headers = headers
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        pass
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> dict:
+        if self._current_chunk < len(self._chunks):
+            chunk = self._chunks[self._current_chunk]
+            self._current_chunk += 1
+            return chunk
+        raise StopAsyncIteration
+
+    async def get_final_completion(self) -> dict:
+        return _BETA_STREAM_FINAL_COMPLETION
+
+
+def test_stream_response_format_includes_response_headers() -> None:
+    """Test response headers are preserved when streaming with response_format."""
+    llm = ChatOpenAI(
+        model="gpt-4o", include_response_headers=True, api_key="test-api-key"
+    )
+    headers = {"x-request-id": "req-sync", "content-type": "application/json"}
+    mock_root_client = MagicMock()
+    mock_root_client.beta.chat.completions.stream.return_value = (
+        MockBetaCompletionStream(headers)
+    )
+
+    with patch.object(llm, "root_client", mock_root_client):
+        chunks = list(llm.stream("Say hello.", response_format=_BETA_RESPONSE_FORMAT))
+
+    assert chunks[0].response_metadata["headers"] == headers
+
+
+async def test_astream_response_format_includes_response_headers() -> None:
+    """Test response headers are preserved when async streaming with response_format."""
+    llm = ChatOpenAI(
+        model="gpt-4o", include_response_headers=True, api_key="test-api-key"
+    )
+    headers = {"x-request-id": "req-async", "content-type": "application/json"}
+    mock_root_client = MagicMock()
+    mock_root_client.beta.chat.completions.stream.return_value = (
+        MockAsyncBetaCompletionStream(headers)
+    )
+
+    with patch.object(llm, "root_async_client", mock_root_client):
+        chunks = [
+            chunk
+            async for chunk in llm.astream(
+                "Say hello.", response_format=_BETA_RESPONSE_FORMAT
+            )
+        ]
+
+    assert chunks[0].response_metadata["headers"] == headers


### PR DESCRIPTION
Fixes #37421

## Summary

`ChatOpenAI(include_response_headers=True)` now preserves HTTP response headers when streaming with `response_format`, including the path used by `with_structured_output(..., method="json_schema").stream()` and `astream()`.

The structured-output streaming path uses the OpenAI beta stream helper, which exposes the underlying HTTP response after the stream context is entered. The fix reads those headers and attaches them to the first streamed generation chunk through the existing `response_metadata` flow.

## Testing

- `./.venv/bin/python -m pytest tests/unit_tests/chat_models/test_base.py -k "stream_response_format_includes_response_headers"`
- `./.venv/bin/ruff check langchain_openai/chat_models/base.py tests/unit_tests/chat_models/test_base.py`
- `./.venv/bin/ruff format --check langchain_openai/chat_models/base.py tests/unit_tests/chat_models/test_base.py`