### PR TITLE
fix(openai): mirror parsed-field exclude into AzureChatOpenAI._create_chat_result

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -771,7 +771,12 @@ class AzureChatOpenAI(BaseChatOpenAI):
         chat_result = super()._create_chat_result(response, generation_info)
 
         if not isinstance(response, dict):
-            response = response.model_dump()
+            # `parsed` may hold arbitrary Pydantic models from structured output.
+            # Exclude it from this dump to avoid PydanticSerializationUnexpectedValue
+            # warnings — same pattern used in the base method.
+            response = response.model_dump(
+                exclude={"choices": {"__all__": {"message": {"parsed"}}}}
+            )
         for res in response["choices"]:
             if res.get("finish_reason", None) == "content_filter":
                 msg = (

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -1,11 +1,14 @@
 """Test Azure OpenAI Chat API wrapper."""
 
 import os
+import warnings
+from typing import Literal
 from unittest import mock
 
+import openai
 import pytest
 from langchain_core.messages import HumanMessage
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 from typing_extensions import TypedDict
 
 from langchain_openai import AzureChatOpenAI
@@ -265,3 +268,55 @@ def test_max_tokens_converted_to_max_completion_tokens() -> None:
     assert "max_completion_tokens" in payload
     assert payload["max_completion_tokens"] == 1000
     assert "max_tokens" not in payload
+
+
+def test_create_chat_result_avoids_parsed_model_dump_warning() -> None:
+    """Test that AzureChatOpenAI._create_chat_result does not emit
+    PydanticSerializationUnexpectedValue warnings for structured-output
+    responses — mirrors the exclude added to the base method in #35543."""
+
+    class ModelOutput(BaseModel):
+        output: str
+
+    class MockParsedMessage(openai.BaseModel):
+        role: Literal["assistant"] = "assistant"
+        content: str = '{"output": "Paris"}'
+        parsed: None = None
+        refusal: str | None = None
+
+    class MockChoice(openai.BaseModel):
+        index: int = 0
+        finish_reason: Literal["stop"] = "stop"
+        message: MockParsedMessage
+
+    class MockChatCompletion(openai.BaseModel):
+        id: str = "chatcmpl-1"
+        object: str = "chat.completion"
+        created: int = 0
+        model: str = "gpt-4o-mini"
+        choices: list[MockChoice]
+        usage: dict[str, int] | None = None
+
+    parsed_response = ModelOutput(output="Paris")
+    response = MockChatCompletion.model_construct(
+        choices=[
+            MockChoice.model_construct(
+                message=MockParsedMessage.model_construct(parsed=parsed_response)
+            )
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    llm = AzureChatOpenAI(
+        azure_deployment="gpt-4o-mini",
+        api_version="2024-10-01-preview",
+        azure_endpoint="https://example.openai.azure.com",
+        api_key=SecretStr("test"),
+    )
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        llm._create_chat_result(response)
+
+    warning_messages = [str(w.message) for w in caught_warnings]
+    assert not any("field_name='parsed'" in msg for msg in warning_messages)


### PR DESCRIPTION
 Fixes #37844

  The Azure override in `_create_chat_result` does its own `response.model_dump()` to inspect content-filter metadata,
  but it was missing the `exclude` filter that #35543 added to the base method. So every structured-output call through
  Azure still emits `PydanticSerializationUnexpectedValue` warnings on the `parsed` field.

  Added the same exclude into the Azure override. The content-filter inspection logic is unchanged — it only needed the
  dump to skip `parsed` like the base method already does.