### PR TITLE
test(ollama): add standard unit tests

### DIFF
--- a/libs/partners/ollama/tests/unit_tests/test_standard.py
+++ b/libs/partners/ollama/tests/unit_tests/test_standard.py
@@ -1,0 +1,18 @@
+"""Standard LangChain interface tests."""
+
+from langchain_core.language_models import BaseChatModel
+from langchain_tests.unit_tests.chat_models import ChatModelUnitTests
+
+from langchain_ollama import ChatOllama
+
+
+class TestOllamaStandard(ChatModelUnitTests):
+    """Run ChatOllama on LangChain standard tests."""
+
+    @property
+    def chat_model_class(self) -> type[BaseChatModel]:
+        return ChatOllama
+
+    @property
+    def chat_model_params(self) -> dict:
+        return {"model": "llama3.2"}


### PR DESCRIPTION
Closes #37786

  ---

  The langchain-ollama partner package was missing `test_standard.py` in unit_tests, which all other partner packages
  have. This PR adds it, inheriting from `ChatModelUnitTests` for `ChatOllama`, consistent with the existing patterns in
   `langchain-anthropic` and `langchain-groq`.

  ## AI Disclaimer

  This PR was generated with assistance from Claude Opus 4.7 (Anthropic), using the prompt: "Add standard unit tests for
   ChatOllama following the pattern from other partner packages like langchain-anthropic and langchain-groq."