### PR TITLE
test(langchain,partners): disable pytest-benchmark under xdist to silence `PytestBenchmarkWarning`

### DIFF
--- a/libs/langchain/Makefile
+++ b/libs/langchain/Makefile
@@ -23,7 +23,7 @@ coverage:
 		$(TEST_FILE)
 
 test tests:
-	uv run --group test pytest -n auto $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
+	uv run --group test pytest -n auto --benchmark-disable $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 extended_tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket --only-extended tests/unit_tests

--- a/libs/partners/anthropic/Makefile
+++ b/libs/partners/anthropic/Makefile
@@ -15,7 +15,7 @@ test tests:
 	uv run --group test pytest -vvv $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto --timeout 30 --retries 3 --retry-delay 1 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable --timeout 30 --retries 3 --retry-delay 1 $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/chroma/Makefile
+++ b/libs/partners/chroma/Makefile
@@ -15,7 +15,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/deepseek/Makefile
+++ b/libs/partners/deepseek/Makefile
@@ -21,7 +21,7 @@ test_watch:
 
 # integration tests are run without the --disable-socket flag to allow network calls
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto --timeout=30 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable --timeout=30 $(TEST_FILE)
 
 ######################
 # LINTING AND FORMATTING

--- a/libs/partners/exa/Makefile
+++ b/libs/partners/exa/Makefile
@@ -16,7 +16,7 @@ test:
 	uv run --group test --group test_integration pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto $(PYTEST_EXTRA) $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(PYTEST_EXTRA) $(TEST_FILE)
 
 tests:
 	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)

--- a/libs/partners/fireworks/Makefile
+++ b/libs/partners/fireworks/Makefile
@@ -15,7 +15,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto --retries 3 --retry-delay 2 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable --retries 3 --retry-delay 2 $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/groq/Makefile
+++ b/libs/partners/groq/Makefile
@@ -16,7 +16,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto --retries 3 --retry-delay 1 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable --retries 3 --retry-delay 1 $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/huggingface/Makefile
+++ b/libs/partners/huggingface/Makefile
@@ -16,7 +16,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/mistralai/Makefile
+++ b/libs/partners/mistralai/Makefile
@@ -21,7 +21,7 @@ test_watch:
 
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto --retries 3 --retry-delay 2 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable --retries 3 --retry-delay 2 $(TEST_FILE)
 
 
 ######################

--- a/libs/partners/nomic/Makefile
+++ b/libs/partners/nomic/Makefile
@@ -16,7 +16,7 @@ test:
 	uv run --group test --group test_integration pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto $(PYTEST_EXTRA) $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(PYTEST_EXTRA) $(TEST_FILE)
 
 tests:
 	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)

--- a/libs/partners/ollama/Makefile
+++ b/libs/partners/ollama/Makefile
@@ -27,7 +27,7 @@ test_watch:
 
 # integration tests are run without the --disable-socket flag to allow network calls
 integration_test:
-	OLLAMA_TEST_MODEL=$(OLLAMA_TEST_MODEL) OLLAMA_REASONING_TEST_MODEL=$(OLLAMA_REASONING_TEST_MODEL) uv run --group test --group test_integration pytest -v --tb=short -n auto $(TEST_FILE)
+	OLLAMA_TEST_MODEL=$(OLLAMA_TEST_MODEL) OLLAMA_REASONING_TEST_MODEL=$(OLLAMA_REASONING_TEST_MODEL) uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 
 # CI integration tests - disabled until ollama service is configured in CI
 

--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -25,7 +25,7 @@ test tests:
 	TIKTOKEN_CACHE_DIR=tiktoken_cache uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 
 # Run VCR cassette-backed integration tests in playback-only mode (no API keys needed).
 # Catches stale cassettes caused by test input changes without re-recording.

--- a/libs/partners/openrouter/Makefile
+++ b/libs/partners/openrouter/Makefile
@@ -21,7 +21,7 @@ test_watch:
 
 # integration tests are run without the --disable-socket flag to allow network calls
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto --timeout=120 $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable --timeout=120 $(TEST_FILE)
 
 ######################
 # LINTING AND FORMATTING

--- a/libs/partners/qdrant/Makefile
+++ b/libs/partners/qdrant/Makefile
@@ -16,7 +16,7 @@ test tests:
 	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/xai/Makefile
+++ b/libs/partners/xai/Makefile
@@ -19,7 +19,7 @@ test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)
 
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto $(TEST_FILE)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 
 ######################
 # LINTING AND FORMATTING


### PR DESCRIPTION
Test targets run with `-n auto`, which makes `pytest-benchmark` (present via `langchain-tests`) auto-disable itself and emit a `PytestBenchmarkWarning` once per xdist worker. Passing `--benchmark-disable` turns the plugin off explicitly so the warning never fires, matching what `core` and `langchain_v1` already do.

## Changes
- Add `--benchmark-disable` to the `-n auto` test targets across `langchain` (unit) and 14 partner packages' integration targets: `anthropic`, `chroma`, `deepseek`, `exa`, `fireworks`, `groq`, `huggingface`, `mistralai`, `nomic`, `ollama`, `openai`, `openrouter`, `qdrant`, `xai`.
- Deliberately excluded `text-splitters` and `model-profiles`: their `test` group doesn't install `pytest-benchmark`, so the flag would fail with `unrecognized arguments`. Verified by importing the plugin under each package's actual dependency group before editing.