### PR TITLE
fix: add separators for Perl code splitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -787,6 +787,30 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 " ",
                 "",
             ]
+        if language == Language.PERL:
+            return [
+                # Split along function definitions
+                "\nsub ",
+                # Split along variable declarations
+                "\nmy ",
+                "\nour ",
+                "\nlocal ",
+                # Split along control flow statements
+                "\nif ",
+                "\nunless ",
+                "\nfor ",
+                "\nforeach ",
+                "\nwhile ",
+                "\nuntil ",
+                # Split along packages
+                "\npackage ",
+                "\nuse ",
+                # Split by the normal type of lines
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
 
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3503,6 +3503,28 @@ def test_visualbasic6_code_splitter() -> None:
     ]
 
 
+def test_perl_code_splitter() -> None:
+    splitter = RecursiveCharacterTextSplitter.from_language(
+        Language.PERL, chunk_size=60, chunk_overlap=0
+    )
+    code = """
+# Check if a file exists
+my $filePath = "/tmp/file.txt";
+if (-e $filePath) {
+    # File exists
+} else {
+    # File does not exist
+}
+    """
+    chunks = splitter.split_text(code)
+    assert chunks == [
+        "# Check if a file exists",
+        'my $filePath = "/tmp/file.txt";',
+        "if (-e $filePath) {\n    # File exists\n} else {",
+        "# File does not exist\n}",
+    ]
+
+
 def custom_iframe_extractor(iframe_tag: Tag) -> str:
     iframe_src = iframe_tag.get("src", "")
     return f"[iframe:{iframe_src}]({iframe_src})"


### PR DESCRIPTION
Currently, Language.PERL is available in the Language enum, but using it with the recursive character text splitter throws a ValueError because no separators are defined for Perl in get_separators_for_language.

This PR adds standard Perl code separators (subroutines, packages, variable declarations, and control structures) to allow the Perl code splitter to function correctly. I've also added a unit test to verify that the splitter works as expected on Perl code snippets.

Resolves #37048