### PR TITLE
fix(anthropic): strip index from tool search results

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -672,6 +672,7 @@ def _format_messages(
                         "mcp_tool_result",
                         "web_search_tool_result",
                         "web_fetch_tool_result",
+                        "tool_search_tool_result",
                     ):
                         content.append(
                             _normalize_block_tool_use_id(

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2499,6 +2499,40 @@ def test_tool_search_result_formatting() -> None:
     assert tool_result_block["content"][1]["tool_name"] == "weather_forecast"
 
 
+def test__format_messages_strips_streaming_index_from_tool_search_tool_result() -> None:
+    """Strip streaming-only index from tool_search_tool_result history blocks."""
+    messages = [
+        HumanMessage("What tools can help with weather?"),  # type: ignore[misc]
+        AIMessage(
+            content=[
+                {
+                    "type": "server_tool_use",
+                    "id": "srvtoolu_123",
+                    "name": "tool_search_tool_regex",
+                    "input": {"query": "weather"},
+                },
+                {
+                    "type": "tool_search_tool_result",
+                    "tool_use_id": "srvtoolu_123",
+                    "content": [
+                        {"type": "tool_reference", "tool_name": "get_weather"}
+                    ],
+                    "index": 1,
+                },
+            ],
+        ),
+    ]
+
+    _, formatted = _format_messages(messages)
+
+    tool_search_result = formatted[1]["content"][1]
+    assert tool_search_result == {
+        "type": "tool_search_tool_result",
+        "tool_use_id": "srvtoolu_123",
+        "content": [{"type": "tool_reference", "tool_name": "get_weather"}],
+    }
+
+
 def test_auto_append_betas_for_mcp_servers() -> None:
     """Test that `mcp-client-2025-11-20` beta is automatically appended
     for `mcp_servers`."""


### PR DESCRIPTION
## Summary

Adds `tool_search_tool_result` to the Anthropic message formatting allowlist used for server-builtin result blocks. This strips the streaming-only `index` field before an assembled `AIMessage` is serialized back to Anthropic as conversation history.

## Why

Streaming tool search responses can leave content blocks shaped like:

```python
{"type": "tool_search_tool_result", "tool_use_id": "...", "content": [...], "index": 1}
```

`index` is a stream assembly field, not part of the request payload shape accepted by Anthropic. On the next turn, Anthropic rejects the replayed message with an error like:

```text
messages.N.content.M.tool_search_tool_result.index: Extra inputs are not permitted
```

This is the same class of issue as #37584, but that issue was auto-closed because it was filed programmatically.

## Changes

- Include `tool_search_tool_result` in the existing server-builtin result formatting branch.
- Add a unit test proving `_format_messages` drops `index` while preserving `type`, `tool_use_id`, and `content`.

## Testing

Not run locally; this patch was prepared from the GitHub-hosted source without cloning the repository. The added test is a focused unit regression for `_format_messages`.
