### PR TITLE
fix(perplexity): handle ToolMessage and AIMessage.tool_calls in _convert_message_to_dict

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -34,6 +34,7 @@ from langchain_core.messages import (
     HumanMessageChunk,
     SystemMessage,
     SystemMessageChunk,
+    ToolMessage,
     ToolMessageChunk,
 )
 from langchain_core.messages.ai import (
@@ -771,13 +772,31 @@ class ChatPerplexity(BaseChatModel):
 
     def _convert_message_to_dict(self, message: BaseMessage) -> dict[str, Any]:
         if isinstance(message, ChatMessage):
-            message_dict = {"role": message.role, "content": message.content}
+            message_dict: dict[str, Any] = {"role": message.role, "content": message.content}
         elif isinstance(message, SystemMessage):
             message_dict = {"role": "system", "content": message.content}
         elif isinstance(message, HumanMessage):
             message_dict = {"role": "user", "content": message.content}
         elif isinstance(message, AIMessage):
             message_dict = {"role": "assistant", "content": message.content}
+            if message.tool_calls:
+                message_dict["tool_calls"] = [
+                    {
+                        "type": "function",
+                        "id": tc["id"],
+                        "function": {
+                            "name": tc["name"],
+                            "arguments": json.dumps(tc["args"], ensure_ascii=False),
+                        },
+                    }
+                    for tc in message.tool_calls
+                ]
+        elif isinstance(message, ToolMessage):
+            message_dict = {
+                "role": "tool",
+                "content": message.content,
+                "tool_call_id": message.tool_call_id,
+            }
         else:
             raise TypeError(f"Got unknown type {message}")
         return message_dict


### PR DESCRIPTION
## Summary

Fixes #37912 — ChatPerplexity._convert_message_to_dict drops AIMessage.tool_calls and raises TypeError on ToolMessage.

### Problem

ChatPerplexity._convert_message_to_dict only handled ChatMessage / SystemMessage / HumanMessage / AIMessage. It had:
- No ToolMessage branch → TypeError on any ToolMessage
- AIMessage serialized without tool_calls → tool calls silently dropped

This broke client-side tool-calling loops and cross-provider message histories (e.g., RunnableWithFallbacks across providers).

### Fix

1. Added ToolMessage serialization: role=tool, content, tool_call_id
2. Added AIMessage.tool_calls serialization to OpenAI-compatible format
3. Added ToolMessage import

The fix follows the same pattern used by langchain-openai's _convert_message_to_dict.

### Files changed
| File | Change |
|------|--------|
| libs/partners/perplexity/langchain_perplexity/chat_models.py | +20/-1 |

Closes #37912