### PR TITLE
ci(infra): gate PyPI publish on prior-partner tests

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -638,8 +638,9 @@ jobs:
       - test-pypi-publish
       - pre-release-checks
       - test-dependents
-      # - test-prior-published-packages-against-new-core
-      # Run if all needed jobs succeeded or were skipped (test-dependents only runs for core/langchain_v1)
+      - test-prior-published-packages-against-new-core
+      # Run if all needed jobs succeeded or were skipped (test-dependents and
+      # test-prior-published-packages-against-new-core only run for core/langchain_v1)
     if: ${{ !cancelled() && !failure() }}
     environment: Release
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `🚀 Publish to PyPI` job no longer starts until `🔄 Test prior partners against new core` finishes. Previously that dependency was commented out, so a core release could publish to PyPI in parallel with—or before—the integration tests that install the new unreleased core against already-published partner packages, defeating their purpose as a pre-publish gate.

## Changes
- Add `test-prior-published-packages-against-new-core` to the `publish` job's `needs`, so publishing blocks on those partner integration tests completing.
- The existing `if: ${{ !cancelled() && !failure() }}` guard is unchanged: publish proceeds only if the gate **succeeded or was skipped**, and fails closed if the partner tests fail. For non-core releases the partner-test job short-circuits with `exit 0`, so this adds no friction outside `libs/core` releases.