### PR TITLE
fix(langchain): preserve state_schema subtype in create_agent return …

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -39,7 +39,7 @@ from langchain.agents.middleware.types import (
     ModelResponse,
     OmitFromSchema,
     ResponseT,
-    StateT_co,
+    StateT,
     ToolCallRequest,
     _InputAgentState,
     _OutputAgentState,
@@ -699,9 +699,9 @@ def create_agent(
     tools: Sequence[BaseTool | Callable[..., Any] | dict[str, Any]] | None = None,
     *,
     system_prompt: str | SystemMessage | None = None,
-    middleware: Sequence[AgentMiddleware[StateT_co, ContextT]] = (),
+    middleware: Sequence[AgentMiddleware[StateT, ContextT]] = (),
     response_format: ResponseFormat[ResponseT] | type[ResponseT] | dict[str, Any] | None = None,
-    state_schema: type[AgentState[ResponseT]] | None = None,
+    state_schema: type[StateT] | None = None,
     context_schema: type[ContextT] | None = None,
     checkpointer: Checkpointer | None = None,
     store: BaseStore | None = None,
@@ -712,7 +712,7 @@ def create_agent(
     cache: BaseCache[Any] | None = None,
     transformers: Sequence[TransformerFactory] | None = None,
 ) -> CompiledStateGraph[
-    AgentState[ResponseT], ContextT, _InputAgentState, _OutputAgentState[ResponseT]
+    StateT, ContextT, _InputAgentState, _OutputAgentState[ResponseT]
 ]:
     """Creates an agent graph that calls tools in a loop until a stopping condition is met.
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
@@ -323,3 +323,14 @@ def test_get_schema_type_hints_cache_accepts_distinct_local_schema_types() -> No
     assert first_info.hits == 0
     assert second_info.misses == 2
     assert second_info.hits == 2
+
+
+def test_create_agent_annotations_preserve_state_typevar() -> None:
+    annotations = create_agent.__annotations__
+
+    assert annotations["middleware"] == "Sequence[AgentMiddleware[StateT, ContextT]]"
+    assert annotations["state_schema"] == "type[StateT] | None"
+    assert annotations["return"] == (
+        "CompiledStateGraph[StateT, ContextT, _InputAgentState, "
+        "_OutputAgentState[ResponseT]]"
+    )


### PR DESCRIPTION
Fixes #37921

---

This updates `create_agent` type annotations so custom `state_schema` subtypes are preserved in static type inference. It threads `StateT` through `middleware`, `state_schema`, and the `CompiledStateGraph` return type.

Added a regression test in `test_state_schema.py` that verifies the `create_agent` annotation contract for `middleware`, `state_schema`, and return type.

No runtime behavior changes. This is a typing fix with test coverage.

How I verified this works:

- Ran `uv run --group test pytest tests/unit_tests/agents/test_state_schema.py -q`
- Ran `uv run --group test pytest tests/unit_tests/agents/test_create_agent_tool_validation.py tests/unit_tests/agents/test_injected_runtime_create_agent.py -q`
- Ran `uv run --group lint ruff check langchain/agents/factory.py tests/unit_tests/agents/test_state_schema.py`

Social handles (optional):
Twitter: @
LinkedIn: https://linkedin.com/in/shravan-khunti