### PR TITLE
fix(langchain-classic): align arank_fusion doc normalization with rank_fusion

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -294,7 +294,7 @@ class EnsembleRetriever(BaseRetriever):
         # Enforce that retrieved docs are Documents for each list in retriever_docs
         for i in range(len(retriever_docs)):
             retriever_docs[i] = [
-                Document(page_content=doc) if not isinstance(doc, Document) else doc
+                Document(page_content=cast("str", doc)) if isinstance(doc, str) else doc  # type: ignore[unreachable]
                 for doc in retriever_docs[i]
             ]
 


### PR DESCRIPTION
﻿## Summary

`arank_fusion` and `rank_fusion` normalize raw retriever output into
`Document` objects before passing to `weighted_reciprocal_rank`, but
they used different guards:

| method | guard | behaviour for non-str, non-Document values |
|---|---|---|
| `rank_fusion` (sync) | `isinstance(doc, str)` | passes through unchanged |
| `arank_fusion` (async) | `not isinstance(doc, Document)` | wraps in `Document(page_content=<value>)` → **Pydantic ValidationError** |

If a retriever returns anything other than a `str` or a `Document` (e.g.
an `int` from a malformed retriever), the sync path silently passes it
through while the async path immediately raises
`pydantic_core.ValidationError`.

**Fix:** apply the same `isinstance(doc, str)` check in `arank_fusion`
so both paths are consistent.

Before:
```python
Document(page_content=doc) if not isinstance(doc, Document) else doc
```

After:
```python
Document(page_content=cast("str", doc)) if isinstance(doc, str) else doc
```

Fixes #37736
