### PR TITLE
fix(text-splitters): fall back to nested <source> for video/audio URL preservation

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -793,6 +793,10 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
         if self._preserve_videos:
             for video_tag in _find_all_tags(soup, name="video"):
                 video_src = video_tag.get("src", "")
+                if not video_src:
+                    source_tag = video_tag.find("source")
+                    if source_tag:
+                        video_src = source_tag.get("src", "")
                 markdown_video = f"![video:{video_src}]({video_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_video
@@ -801,6 +805,10 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
         if self._preserve_audio:
             for audio_tag in _find_all_tags(soup, name="audio"):
                 audio_src = audio_tag.get("src", "")
+                if not audio_src:
+                    source_tag = audio_tag.find("source")
+                    if source_tag:
+                        audio_src = source_tag.get("src", "")
                 markdown_audio = f"![audio:{audio_src}]({audio_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_audio


### PR DESCRIPTION
﻿## Summary

`HTMLSemanticPreservingSplitter` converts `<video>` and `<audio>` tags to
Markdown media links when `preserve_videos=True` / `preserve_audio=True`.
It read the URL from the tag's own `src` attribute.

The common HTML5 pattern stores the media URL in a **nested** `<source>`
element:

```html
<video controls>
    <source src="https://example.com/video.mp4" type="video/mp4" />
</video>
```

With this pattern the tag has no direct `src`, so the splitter emitted
an empty link `![video:]()` instead of `![video:https://…](https://…)`.

**Fix:** when the tag has no direct `src`, look for the first child
`<source>` tag and use its `src` value.

Before (for both video and audio):
```python
video_src = video_tag.get("src", "")
```

After:
```python
video_src = video_tag.get("src", "")
if not video_src:
    source_tag = video_tag.find("source")
    if source_tag:
        video_src = source_tag.get("src", "")
```

Reproducer from the issue now produces correct output:
```
Watch: ![video:https://example.com/video.mp4](https://example.com/video.mp4) Listen: ![audio:https://example.com/audio.mp3](https://example.com/audio.mp3)
```

Fixes #37826
