### PR TITLE
fix(openai): convert computer_call responses to tool calls

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -412,6 +412,15 @@ def _convert_message_to_dict(
     elif isinstance(message, FunctionMessage):
         message_dict["role"] = "function"
     elif isinstance(message, ToolMessage):
+        if api == "responses" and name == "computer":
+            return {
+                "type": "computer_call_output",
+                "call_id": message.tool_call_id,
+                "output": {
+                    "type": "computer_screenshot",
+                    "image_url": message.content,
+                },
+            }
         message_dict["role"] = "tool"
         message_dict["tool_call_id"] = message.tool_call_id
         message_dict["content"] = _sanitize_chat_completions_content(
@@ -4403,6 +4412,9 @@ def _construct_responses_api_input(messages: Sequence[BaseMessage]) -> list:
                 msg["content"] = _convert_from_v1_to_responses(msg["content"], tcs)
         else:
             msg = _convert_message_to_dict(lc_msg, api="responses")
+            if msg.get("type") == "computer_call_output":
+                input_.append(msg)
+                continue
             # Get content from non-standard content blocks
             if isinstance(msg["content"], list):
                 for i, block in enumerate(msg["content"]):
@@ -4691,12 +4703,20 @@ def _construct_lc_result_from_responses_api(
                 "id": output.call_id,
             }
             tool_calls.append(tool_call)
+        elif output.type == "computer_call":
+            output_dict = output.model_dump(exclude_none=True, mode="json")
+            tool_call = {
+                "name": "computer",
+                "args": output_dict["action"],
+                "id": output_dict["call_id"],
+                "type": "tool_call",
+            }
+            tool_calls.append(tool_call)
         elif output.type in (
             "reasoning",
             "compaction",
             "web_search_call",
             "file_search_call",
-            "computer_call",
             "code_interpreter_call",
             "mcp_call",
             "mcp_list_tools",

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -37,6 +37,9 @@ from langchain_core.tracers.base import BaseTracer
 from langchain_core.tracers.schemas import Run
 from openai.types.responses import ResponseOutputMessage, ResponseReasoningItem
 from openai.types.responses.response import IncompleteDetails, Response
+from openai.types.responses.response_computer_tool_call import (
+    ResponseComputerToolCall,
+)
 from openai.types.responses.response_error import ResponseError
 from openai.types.responses.response_file_search_tool_call import (
     ResponseFileSearchToolCall,
@@ -1766,6 +1769,101 @@ def test__construct_lc_result_from_responses_api_function_call_valid_json() -> N
             "call_id": "call_123",
         }
     ]
+
+
+def test__construct_lc_result_from_responses_api_computer_call() -> None:
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseComputerToolCall(
+                type="computer_call",
+                id="computer_123",
+                call_id="call_123",
+                pending_safety_checks=[],
+                status="completed",
+                action={
+                    "type": "click",
+                    "button": "left",
+                    "x": 10,
+                    "y": 20,
+                },
+            )
+        ],
+    )
+
+    result = _construct_lc_result_from_responses_api(response)
+
+    msg = cast(AIMessage, result.generations[0].message)
+    assert msg.content == []
+    assert msg.tool_calls == [
+        {
+            "name": "computer",
+            "args": {
+                "type": "click",
+                "button": "left",
+                "x": 10,
+                "y": 20,
+            },
+            "id": "call_123",
+            "type": "tool_call",
+        }
+    ]
+
+
+def test__convert_message_to_dict_computer_tool_message_responses() -> None:
+    message = ToolMessage(
+        content="data:image/png;base64,<image_data>",
+        name="computer",
+        tool_call_id="call_123",
+    )
+
+    assert _convert_message_to_dict(message, api="responses") == {
+        "type": "computer_call_output",
+        "call_id": "call_123",
+        "output": {
+            "type": "computer_screenshot",
+            "image_url": "data:image/png;base64,<image_data>",
+        },
+    }
+
+
+def test__construct_lc_result_from_responses_api_text_only_has_no_tool_calls() -> None:
+    response = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseOutputMessage(
+                type="message",
+                id="msg_123",
+                content=[
+                    ResponseOutputText(
+                        type="output_text",
+                        text="Here is the answer.",
+                        annotations=[],
+                    )
+                ],
+                role="assistant",
+                status="completed",
+            )
+        ],
+    )
+
+    result = _construct_lc_result_from_responses_api(response)
+
+    msg = cast(AIMessage, result.generations[0].message)
+    assert msg.tool_calls == []
+    assert msg.content
 
 
 def test__construct_lc_result_from_responses_api_function_call_invalid_json() -> None:


### PR DESCRIPTION
Fixes #37938


OpenAI Responses API `computer_call` items are now surfaced as LangChain tool calls named `computer`, allowing the standard agent loop to execute them. `ToolMessage(name="computer")` results are serialized back as `computer_call_output` while preserving the original `call_id`.

Verified with:
`uv run --group test pytest tests/unit_tests/chat_models/test_base.py -k "computer_call or computer_tool_message or text_only_has_no_tool_calls"`

`uv run --group lint ruff check langchain_openai/chat_models/base.py tests/unit_tests/chat_models/test_base.py`

