### PR TITLE
fix(langchain): sort glob_search results by mtime descending

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -170,6 +170,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             if not matching:
                 return "No files found"
 
+            matching.sort(key=lambda item: item[1], reverse=True)
             file_paths = [p for p, _ in matching]
             return "\n".join(file_paths)
 


### PR DESCRIPTION
## Summary

Closes #37369

`FilesystemFileSearchMiddleware.glob_search` documents that glob results are sorted by modification time, newest first. The implementation collected `(path, mtime)` pairs but returned them in `Path.glob()` iteration order.

## Changes

- **`libs/langchain_v1/langchain/agents/middleware/file_search.py`**: Sort the matched `(path, modified_at)` tuples by timestamp descending before rendering file paths, matching the documented behavior and the Anthropic middleware variant

## Verification

- Not run; one-line ordering fix against existing collected timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
