### PR TITLE
refactor(core): migrate legacy pydantic .dict() to .model_dump()

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1465,7 +1465,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         stop: list[str] | None = None,
         **kwargs: Any,
     ) -> dict:
-        params = self.dict()
+        params = self.model_dump()
         params["stop"] = stop
         return {**params, **kwargs}
 


### PR DESCRIPTION
Closes #37949