### PR TITLE
fix(core): use get_type_hints in _create_subset_model_v2 for Pydantic…

### DIFF
--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -13,6 +13,7 @@ from typing import (
     Any,
     TypeVar,
     cast,
+    get_type_hints,
     overload,
 )
 
@@ -263,13 +264,14 @@ def _create_subset_model_v2(
     # This is done to preserve __annotations__ when working with pydantic 2.x
     # and using the Annotated type with TypedDict.
     # Comment out the following line, to trigger the relevant test case.
-    selected_annotations = [
-        (name, annotation)
-        for name, annotation in model.__annotations__.items()
+    all_annotations = get_type_hints(model, include_extras=True)
+    selected_annotations = {
+        name: annotation
+        for name, annotation in all_annotations.items()
         if name in field_names
-    ]
+    }
 
-    rtn.__annotations__ = dict(selected_annotations)
+    rtn.__annotations__ = selected_annotations
     rtn.__doc__ = textwrap.dedent(fn_description or model.__doc__ or "")
     return rtn
 

--- a/libs/core/tests/unit_tests/utils/test_pydantic.py
+++ b/libs/core/tests/unit_tests/utils/test_pydantic.py
@@ -205,3 +205,25 @@ def test_create_subset_model_v2_preserves_default_factory() -> None:
     assert schema.get("required") == ["required_field"]
     assert "names" not in schema.get("required", [])
     assert "mapping" not in schema.get("required", [])
+
+
+# This test ensures that the __annotations__ attribute of the model is not directly mutated, which can cause issues with Pydantic 2.14+ when using Annotated types with TypedDict.
+
+
+def test_create_subset_model_v2_annotations_invariant() -> None:
+    """Ensure _create_subset_model_v2 doesn't break __annotations__ invariant.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/37835
+    Importing certain langgraph models before BaseLLM caused a TypeError
+    on Pydantic 2.14+ due to direct mutation of __annotations__.
+    """
+    from langgraph.managed import RemainingSteps
+    from pydantic import BaseModel as PydanticBaseModel
+
+    class Poison(PydanticBaseModel):
+        remaining_steps: RemainingSteps = 25
+
+    # This should not raise TypeError: 'function' object is not subscriptable
+    from langchain_core.language_models.llms import BaseLLM
+
+    assert BaseLLM is not None


### PR DESCRIPTION
… 2.14+ compatibility

- Replace direct model.__annotations__ access with typing.get_type_hints()
- Avoids violating getattr/__dict__ invariant exposed by Pydantic 2.14
- Adds regression test for the import-order crash

Fixes #37835

Fixes #

I'll analyze this pull request for you. Let me load the PR understanding ability and gather the necessary details.Now let me fetch the PR details to understand what this pull request is about:Let me fetch the PR information from the comparison URL provided:Perfect! I have the comparison data. Let me present the findings about this PR:

## PR Summary: Fix Pydantic 2.14+ Type Hints Crash

**Purpose**: Fix a crash on Pydantic 2.14+ when importing certain langgraph models before BaseLLM by replacing direct `__annotations__` mutation with `get_type_hints()`.

### Changes Made

**File**: `libs/core/langchain_core/utils/pydantic.py`

The fix modifies the `_create_subset_model_v2` function:

```python name=pydantic.py url=https://github.com/langchain-ai/langchain/blob/43bdcb6856d9c37818831f56c760b522c3b8ae14/libs/core/langchain_core/utils/pydantic.py#L264-L274
# Before: Direct iteration over __annotations__
selected_annotations = [
    (name, annotation)
    for name, annotation in model.__annotations__.items()
    if name in field_names
]
rtn.__annotations__ = dict(selected_annotations)

# After: Using get_type_hints() to safely extract annotations
all_annotations = get_type_hints(model, include_extras=True)
selected_annotations = {
    name: annotation
    for name, annotation in all_annotations.items()
    if name in field_names
}
rtn.__annotations__ = selected_annotations
```

**Key improvement**: 
- **Before**: Directly accessed `model.__annotations__`, which caused issues with Pydantic 2.14+ when working with `Annotated` types and TypedDict
- **After**: Uses `get_type_hints(model, include_extras=True)` which properly resolves type hints without triggering Pydantic's internal issues

### Testing

Added a regression test in `libs/core/tests/unit_tests/utils/test_pydantic.py`:

```python name=test_pydantic.py url=https://github.com/langchain-ai/langchain/blob/43bdcb6856d9c37818831f56c760b522c3b8ae14/libs/core/tests/unit_tests/utils/test_pydantic.py#L210-L230
def test_create_subset_model_v2_annotations_invariant() -> None:
    """Ensure _create_subset_model_v2 doesn't break __annotations__ invariant.

    Regression test for https://github.com/langchain-ai/langchain/issues/37835
    Importing certain langgraph models before BaseLLM caused a TypeError
    on Pydantic 2.14+ due to direct mutation of __annotations__.
    """
```

The test reproduces the original issue by importing `RemainingSteps` from langgraph before `BaseLLM` to ensure the fix prevents the `TypeError: 'function' object is not subscriptable` error.

### Impact

✅ **Status**: Addresses issue #37835 — resolves crashes when using certain Langgraph models with LangChain on Pydantic 2.14+