### PR TITLE
fix(core): correct error message in Visitor._validate_func for operators

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (
@@ -91,7 +91,7 @@ class Expr(BaseModel):
         Returns:
             result of visiting.
         """
-        return getattr(visitor, f"visit_{_to_snake_case(self.__class__.__name__)}")(
+        return getattr(visitor, f"visit_{_to_snake_case(self.__class__.__name__)}"(
             self
         )
 

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -91,7 +91,7 @@ class Expr(BaseModel):
         Returns:
             result of visiting.
         """
-        return getattr(visitor, f"visit_{_to_snake_case(self.__class__.__name__)}"(
+        return getattr(visitor, f"visit_{_to_snake_case(self.__class__.__name__)}")(
             self
         )
 


### PR DESCRIPTION
## Summary

The error message in `Visitor._validate_func` (`libs/core/langchain_core/structured_query.py`) incorrectly said **"Allowed comparators are"** when validating an invalid operator. The word should be **"operators"** — comparators are a separate concept validated in the same method.

**Before:**
```python
msg = (
    f"Received disallowed operator {func}. Allowed "
    f"comparators are {self.allowed_operators}"
)
```

**After:**
```python
msg = (
    f"Received disallowed operator {func}. Allowed "
    f"operators are {self.allowed_operators}"
)
```

## Related issue

Closes #36701

## Testing

One-word typo fix in an error message string. No logic changes, no new dependencies.