### PR TITLE
fix: preserve original Pydantic validation error in OutputParserException (closes #36603)

### DIFF
--- a/libs/core/langchain_core/exceptions.py
+++ b/libs/core/langchain_core/exceptions.py
@@ -52,6 +52,11 @@ class OutputParserException(ValueError, LangChainException):  # noqa: N818
             error = create_message(
                 message=error, error_code=ErrorCode.OUTPUT_PARSING_FAILURE
             )
+        elif isinstance(error, Exception):
+            # Preserve original error message/details when wrapping
+            error = create_message(
+                message=str(error), error_code=ErrorCode.OUTPUT_PARSING_FAILURE
+            )
 
         super().__init__(error)
         if send_to_llm and (observation is None or llm_output is None):


### PR DESCRIPTION
## What
When Pydantic model field validation fails (e.g., type mismatch), the error message was being lost and replaced with a generic "Failed to parse output" message, making debugging impossible. The original validation error details are critical for developers to understand why their model fields are not being honored.

## Fix
Added handling for non-string `error` arguments (specifically `Exception` instances) to extract and preserve the original error message before wrapping it in the OutputParserException. This ensures that Pydantic validation errors like `Input should be a valid string` are visible in the traceback.

Closes #36603