### PR TITLE
text-splitters: don't drop content after an unterminated markdown code fence

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -446,7 +446,11 @@ class ExperimentalMarkdownSyntaxTextSplitter:
             chunk += raw_line
             if self._match_code(raw_line):
                 return chunk
-        return ""
+        # No closing fence was found: keep the accumulated content instead of returning ""
+        # and silently discarding everything after the opening fence. A truncated or
+        # unterminated code block (common in LLM output cut at max_tokens) must not drop the
+        # rest of the document, including following headers and their bodies.
+        return chunk
 
     def _complete_chunk_doc(self) -> None:
         chunk_content = self.current_chunk.page_content

--- a/libs/text-splitters/tests/unit_tests/test_markdown_unterminated_fence.py
+++ b/libs/text-splitters/tests/unit_tests/test_markdown_unterminated_fence.py
@@ -1,0 +1,21 @@
+"""Regression test: an unterminated markdown code fence must not silently drop content.
+
+ExperimentalMarkdownSyntaxTextSplitter._resolve_code_chunk consumes every remaining line
+searching for a closing fence; when none exists it returned "", so split_text dropped the
+code block AND all following sections/bodies with no error. Common with truncated LLM output.
+
+  with the fix -> PASS (following content retained)
+  without it   -> FAIL (everything after the opening fence is gone)
+"""
+from langchain_text_splitters import ExperimentalMarkdownSyntaxTextSplitter
+
+
+def test_unterminated_code_fence_preserves_following_content():
+    text = (
+        "# Title\nintro\n\n```python\nx = 1\n\n"
+        "## Important Section\ncritical content\n"
+    )
+    docs = ExperimentalMarkdownSyntaxTextSplitter(strip_headers=False).split_text(text)
+    joined = "\n".join(d.page_content for d in docs)
+    assert "critical content" in joined, joined
+    assert "x = 1" in joined, joined


### PR DESCRIPTION
Closes #37966

### Description

`ExperimentalMarkdownSyntaxTextSplitter._resolve_code_chunk` returns `""` when a markdown code fence is never closed, after consuming the rest of the input. As a result `split_text` silently discards the code block **and every following section and its body** — with no error or warning. This is easy to hit with truncated LLM output (cut at `max_tokens` mid code block), a truncated stream, or a malformed file, which RAG pipelines feed straight into the header splitter.

On `master`:

```python
from langchain_text_splitters.markdown import ExperimentalMarkdownSyntaxTextSplitter as S
md = "# Title\nintro\n\n```python\nx = 1\n\n## Important Section\ncritical content\n"
[d.page_content for d in S().split_text(md)]
# -> ['# Title\nintro\n\n']   (the code block AND "Important Section" are gone)
```

The fix returns the accumulated chunk instead of `""` when the fence doesn't close, so the remaining content is preserved.

Includes a regression test that fails on `master` and passes with the change.

### Issue

N/A (found while building a fault-injection tester for agent tools).

### Dependencies

None.
