### PR TITLE
fix: read rename source path from `path` key in file tool middleware

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -530,7 +530,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1032,7 +1032,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -268,7 +268,7 @@ class TestFileOperations:
 
         args = {
             "command": "rename",
-            "old_path": "/memories/old.txt",
+            "path": "/memories/old.txt",
             "new_path": "/memories/new.txt",
         }
         result = middleware._handle_rename(args, state, "test_id")


### PR DESCRIPTION
Fixes #35852

Both `_handle_rename` methods read `args["old_path"]`, but the file tool dispatcher only ever sets `path` (source) and `new_path` (destination), so every rename raised `KeyError` — and since `KeyError` isn't in the caught exception tuple, it propagated and crashed the tool call. Changed both handlers to read `args["path"]`.

## How I verified
- Updated `test_rename_operation` to pass the real `path` key (it previously passed a non-existent `old_path`, which is why the bug slipped through).
- `uv run --group test pytest tests/unit_tests/middleware/test_anthropic_tools.py` → 20 passed.
- Confirmed the real dispatch (`tools[0].func(runtime, command="rename", path=..., new_path=...)`) now returns a `Command` instead of raising.

LinkedIn: https://www.linkedin.com/in/shubham-phapale/