### PR TITLE
feat(huggingface): add Pydantic output parser support to with_structured_output

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,9 +47,10 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
+    PydanticToolsParser,
     make_invalid_tool_call,
     parse_tool_call,
 )
@@ -1168,11 +1169,13 @@ class ChatHuggingFace(BaseChatModel):
                 },
             )
             if is_pydantic_schema:
-                msg = "Pydantic schema is not supported for function calling"
-                raise NotImplementedError(msg)
-            output_parser: JsonOutputKeyToolsParser | JsonOutputParser = (
-                JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
-            )
+                output_parser = PydanticToolsParser(
+                    tools=[schema], first_tool_only=True
+                )
+            else:
+                output_parser = JsonOutputKeyToolsParser(
+                    key_name=tool_name, first_tool_only=True
+                )
         elif method == "json_schema":
             if schema is None:
                 msg = (
@@ -1188,7 +1191,10 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(pydantic_object=schema)
+            else:
+                output_parser = JsonOutputParser()
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1197,7 +1203,10 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(pydantic_object=schema)
+            else:
+                output_parser = JsonOutputParser()
         else:
             msg = (
                 f"Unrecognized method argument. Expected one of 'function_calling' or "

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -391,3 +391,22 @@ def test_init_chat_model_huggingface() -> None:
         # The important part is that the code path doesn't raise ValidationError
         # about missing 'llm' field, which was the original bug
         pytest.skip(f"Skipping test due to model download/initialization error: {e}")
+
+def test_with_structured_output_pydantic() -> None:
+    """Test that with_structured_output properly uses Pydantic schema."""
+    from pydantic import BaseModel, Field
+    class TestOutput(BaseModel):
+        name: str = Field(..., description="Name")
+
+    llm_mock = Mock(spec=HuggingFaceEndpoint)
+    llm_mock.repo_id = "test/model"
+    llm_mock.model = "test/model"
+    with patch("langchain_huggingface.chat_models.huggingface.ChatHuggingFace._resolve_model_id"):
+        chat = ChatHuggingFace(llm=llm_mock)
+
+        runnable_json = chat.with_structured_output(schema=TestOutput, method="json_schema")
+        assert runnable_json is not None
+
+        runnable_fn = chat.with_structured_output(schema=TestOutput, method="function_calling")
+        assert runnable_fn is not None
+

--- a/libs/partners/huggingface/uv.lock
+++ b/libs/partners/huggingface/uv.lock
@@ -1070,7 +1070,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Closes #32197

---

Added `PydanticToolsParser` and `PydanticOutputParser` support to the `with_structured_output` method in `ChatHuggingFace`. This resolves the `NotImplementedError` raised when passing a Pydantic schema in `function_calling` or `json_schema` mode, aligning the behavior with the documentation.

**How did you verify your code works?**
- Added the `test_with_structured_output_pydantic` unit test in `tests/unit_tests/test_chat_models.py` which passes both JSON schema and function calling mechanisms.
- Verified test suite passes via `uv run --group test pytest` for the huggingface partner package.

## Social handles
LinkedIn: https://linkedin.com/in/yalcin-yaman
GitHub: https://github.com/ylcnymn