### PR TITLE
fix(openai): strip `__api_exclude__` fields when dumping Responses AP…

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4577,6 +4577,15 @@ def _get_output_text(response: Response) -> str:
     return "".join(texts)
 
 
+def _dump_for_content_block(obj: BaseModel) -> dict:
+    """Dump an OpenAI SDK model to dict, honoring ``__api_exclude__``."""
+    return obj.model_dump(
+        exclude_none=True,
+        mode="json",
+        exclude=getattr(obj, "__api_exclude__", None),
+    )
+
+
 def _construct_lc_result_from_responses_api(
     response: Response,
     schema: type[_BM] | None = None,
@@ -4658,7 +4667,7 @@ def _construct_lc_result_from_responses_api(
                         refusal_block["phase"] = phase
                     content_blocks.append(refusal_block)
         elif output.type == "function_call":
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            content_blocks.append(_dump_for_content_block(output))
             try:
                 args = json.loads(output.arguments, strict=False)
                 error = None
@@ -4683,7 +4692,7 @@ def _construct_lc_result_from_responses_api(
                 }
                 invalid_tool_calls.append(tool_call)
         elif output.type == "custom_tool_call":
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            content_blocks.append(_dump_for_content_block(output))
             tool_call = {
                 "type": "tool_call",
                 "name": output.name,
@@ -4705,7 +4714,7 @@ def _construct_lc_result_from_responses_api(
             "tool_search_call",
             "tool_search_output",
         ):
-            content_blocks.append(output.model_dump(exclude_none=True, mode="json"))
+            content_blocks.append(_dump_for_content_block(output))
 
     # Workaround for parsing structured output in the streaming case.
     #    from openai import OpenAI
@@ -4960,7 +4969,7 @@ def _convert_responses_chunk_to_generation_chunk(
         "tool_search_output",
     ):
         _advance(chunk.output_index)
-        tool_output = chunk.item.model_dump(exclude_none=True, mode="json")
+        tool_output = _dump_for_content_block(chunk.item)
         tool_output["index"] = current_index
         content.append(tool_output)
     elif (
@@ -4968,7 +4977,7 @@ def _convert_responses_chunk_to_generation_chunk(
         and chunk.item.type == "custom_tool_call"
     ):
         _advance(chunk.output_index)
-        tool_output = chunk.item.model_dump(exclude_none=True, mode="json")
+        tool_output = _dump_for_content_block(chunk.item)
         tool_output["index"] = current_index
         content.append(tool_output)
         tool_call_chunks.append(
@@ -4993,7 +5002,7 @@ def _convert_responses_chunk_to_generation_chunk(
     elif chunk.type == "response.output_item.added" and chunk.item.type == "reasoning":
         _advance(chunk.output_index)
         current_sub_index = 0
-        reasoning = chunk.item.model_dump(exclude_none=True, mode="json")
+        reasoning = _dump_for_content_block(chunk.item)
         reasoning["index"] = current_index
         content.append(reasoning)
     elif chunk.type == "response.reasoning_summary_part.added":

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3803,3 +3803,61 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test__construct_lc_result_from_responses_api_parsed_function_call() -> None:
+    """Test that parsed_arguments from ParsedResponseFunctionToolCall is excluded.
+
+    When using structured output with the Responses API, the OpenAI SDK returns
+    ParsedResponseFunctionToolCall instances with a ``parsed_arguments`` field
+    marked as client-side-only via ``__api_exclude__``.  If this field leaks
+    into AIMessage.content, the next API turn fails with
+    ``BadRequestError: Unknown parameter: 'input[N].parsed_arguments'``.
+
+    See: https://github.com/langchain-ai/langchain/issues/37836
+    """
+    class MockParsedResponseFunctionToolCall(ResponseFunctionToolCall):
+        parsed_arguments: dict
+
+    output = MockParsedResponseFunctionToolCall(
+        type="function_call",
+        id="func_456",
+        call_id="call_456",
+        name="get_weather",
+        arguments='{"location": "Paris"}',
+        parsed_arguments={"location": "Paris"},
+    )
+    object.__setattr__(output, "__api_exclude__", {"parsed_arguments"})
+
+    response = Response(
+        id="resp_456",
+        created_at=1234567890,
+        model="gpt-4o",
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[output],
+    )
+
+    result = _construct_lc_result_from_responses_api(response)
+    msg: AIMessage = cast(AIMessage, result.generations[0].message)
+
+    # The content block for the function call must NOT contain parsed_arguments
+    assert len(msg.content) == 1
+    content_block = msg.content[0]
+    assert isinstance(content_block, dict)
+    assert "parsed_arguments" not in content_block
+
+    # Required fields must still be present
+    assert content_block["type"] == "function_call"
+    assert content_block["name"] == "get_weather"
+    assert content_block["arguments"] == '{"location": "Paris"}'
+    assert content_block["call_id"] == "call_456"
+    assert content_block["id"] == "func_456"
+
+    # Tool call must still be properly parsed
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0]["name"] == "get_weather"
+    assert msg.tool_calls[0]["args"] == {"location": "Paris"}
+    assert msg.tool_calls[0]["id"] == "call_456"


### PR DESCRIPTION
Closes #37836

---

When `ChatOpenAI` uses the Responses API with structured output (`responses.parse()`), the OpenAI SDK returns `ParsedResponseFunctionToolCall` instances carrying a `parsed_arguments` field marked as client-side-only via `__api_exclude__`. The `model_dump` calls did not honor this convention, so the field leaked into `AIMessage.content` blocks. On the next turn, the Responses API rejected the unknown parameter.

This contribution introduces `_dump_for_content_block`, a helper around `model_dump` that respects `__api_exclude__`, and applies it at all Responses API output-item dump sites (both non-streaming and streaming paths) inside the `ChatOpenAI` implementation.

A unit test `test__construct_lc_result_from_responses_api_parsed_function_call` has been added to verify that `parsed_arguments` is correctly excluded from the content blocks.
