### PR TITLE
fix: raise OutputParserException on malformed JSON in parse_partial_json (closes #36603)

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -103,7 +103,10 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
                 stack.pop()
             else:
                 # Mismatched closing character; the input is malformed.
-                return None
+                raise OutputParserException(
+                    "Mismatched closing character in JSON: "
+                    f"unexpected '{char}' at position {s.index(char)}"
+                )
 
         # Append the processed character to the new string.
         new_chars.append(new_char)


### PR DESCRIPTION
## What
`parse_partial_json` returns `None` when it encounters unmatched closing brackets/braces, but callers (like PydanticOutputParser) do not handle `None` and propagate it to `model_validate`, causing a confusing `OutputParserException`.

## Fix
Instead of silently returning `None` on mismatched closing characters, raise a descriptive `OutputParserException` immediately, so the user gets a clear error message about the malformed JSON.

Closes #36603