### PR TITLE
feat(anthropic): support custom http_client and http_async_client

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -974,6 +974,20 @@ class ChatAnthropic(BaseChatModel):
     default_headers: Mapping[str, str] | None = None
     """Headers to pass to the Anthropic clients, will be used for every API call."""
 
+    http_client: Any | None = Field(default=None, exclude=True)
+    """Optional `httpx.Client`.
+
+    Only used for sync invocations. Must specify `http_async_client` as well if
+    you'd like a custom client for async invocations.
+    """
+
+    http_async_client: Any | None = Field(default=None, exclude=True)
+    """Optional `httpx.AsyncClient`.
+
+    Only used for async invocations. Must specify `http_client` as well if you'd
+    like a custom client for sync invocations.
+    """
+
     betas: list[str] | None = None
     """List of beta features to enable. If specified, invocations will be routed
     through `client.beta.messages.create`.
@@ -1198,12 +1212,15 @@ class ChatAnthropic(BaseChatModel):
     @cached_property
     def _client(self) -> anthropic.Client:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
-        if "timeout" in client_params:
-            http_client_params["timeout"] = client_params["timeout"]
-        if self.anthropic_proxy:
-            http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_httpx_client(**http_client_params)
+        # Use a user-supplied client when provided, else build the default.
+        http_client = self.http_client
+        if http_client is None:
+            http_client_params = {"base_url": client_params["base_url"]}
+            if "timeout" in client_params:
+                http_client_params["timeout"] = client_params["timeout"]
+            if self.anthropic_proxy:
+                http_client_params["anthropic_proxy"] = self.anthropic_proxy
+            http_client = _get_default_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,
@@ -1213,12 +1230,15 @@ class ChatAnthropic(BaseChatModel):
     @cached_property
     def _async_client(self) -> anthropic.AsyncClient:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
-        if "timeout" in client_params:
-            http_client_params["timeout"] = client_params["timeout"]
-        if self.anthropic_proxy:
-            http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_async_httpx_client(**http_client_params)
+        # Use a user-supplied client when provided, else build the default.
+        http_client = self.http_async_client
+        if http_client is None:
+            http_client_params = {"base_url": client_params["base_url"]}
+            if "timeout" in client_params:
+                http_client_params["timeout"] = client_params["timeout"]
+            if self.anthropic_proxy:
+                http_client_params["anthropic_proxy"] = self.anthropic_proxy
+            http_client = _get_default_async_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -131,6 +131,33 @@ def test_anthropic_proxy_from_environment() -> None:
         assert llm.anthropic_proxy == explicit_proxy
 
 
+def test_http_client_used_when_provided() -> None:
+    """A user-supplied sync httpx client is passed through to the SDK client."""
+    import httpx
+
+    custom = httpx.Client()
+    llm = ChatAnthropic(model=MODEL_NAME, http_client=custom)
+    assert llm._client._client is custom
+
+
+def test_http_async_client_used_when_provided() -> None:
+    """A user-supplied async httpx client is passed through to the SDK client."""
+    import httpx
+
+    custom = httpx.AsyncClient()
+    llm = ChatAnthropic(model=MODEL_NAME, http_async_client=custom)
+    assert llm._async_client._client is custom
+
+
+def test_default_http_client_when_not_provided() -> None:
+    """Default client construction is unchanged when no client is supplied."""
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.http_client is None
+    assert llm.http_async_client is None
+    assert llm._client is not None
+    assert llm._async_client is not None
+
+
 def test_set_default_max_tokens() -> None:
     """Test the set_default_max_tokens function."""
     # Test claude-sonnet-4-5 models


### PR DESCRIPTION
Fixes #36056

`ChatAnthropic` builds its own httpx client and gives no way to inject a custom one, unlike `ChatOpenAI` which already exposes `http_client`/`http_async_client`. This adds the same two fields so users can pass a custom `httpx.Client`/`httpx.AsyncClient` for custom CA bundles, mTLS, proxies, or `verify` settings. When unset, the default client is built exactly as before.

Verified with `make format`, `make lint`, and `make test` in `libs/partners/anthropic`. Three unit tests cover the sync path, the async path, and the unchanged default.
