### PR TITLE
fix(huggingface): use PydanticOutputParser for structured output

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,7 +47,7 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
     make_invalid_tool_call,
@@ -1170,9 +1170,9 @@ class ChatHuggingFace(BaseChatModel):
             if is_pydantic_schema:
                 msg = "Pydantic schema is not supported for function calling"
                 raise NotImplementedError(msg)
-            output_parser: JsonOutputKeyToolsParser | JsonOutputParser = (
-                JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
-            )
+            output_parser: (
+                JsonOutputKeyToolsParser | JsonOutputParser | PydanticOutputParser
+            ) = JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
         elif method == "json_schema":
             if schema is None:
                 msg = (
@@ -1188,7 +1188,10 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(pydantic_object=schema)
+            else:
+                output_parser = JsonOutputParser()
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1197,7 +1200,10 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(pydantic_object=schema)
+            else:
+                output_parser = JsonOutputParser()
         else:
             msg = (
                 f"Unrecognized method argument. Expected one of 'function_calling' or "

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest  # type: ignore[import-not-found]
+from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -10,7 +11,9 @@ from langchain_core.messages import (
     SystemMessage,
 )
 from langchain_core.outputs import ChatResult
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
@@ -222,6 +225,60 @@ def test_bind_tools(chat_hugging_face: Any) -> None:
         _, kwargs = mock_super_bind.call_args
         assert kwargs["tools"] == tools
         assert kwargs["tool_choice"] == "auto"
+
+
+class PersonForStructuredOutput(BaseModel):
+    name: str
+    age: int
+
+
+def test_with_structured_output_json_schema_pydantic_returns_model(
+    chat_hugging_face: ChatHuggingFace,
+) -> None:
+    runnable = RunnableLambda(lambda _: AIMessage(content='{"name": "Ada", "age": 36}'))
+
+    with patch.object(ChatHuggingFace, "bind", return_value=runnable):
+        result = chat_hugging_face.with_structured_output(
+            PersonForStructuredOutput,
+            method="json_schema",
+        ).invoke("Return a person")
+
+    assert isinstance(result, PersonForStructuredOutput)
+    assert result.name == "Ada"
+    assert result.age == 36
+
+
+def test_with_structured_output_json_schema_pydantic_validates_output(
+    chat_hugging_face: ChatHuggingFace,
+) -> None:
+    runnable = RunnableLambda(
+        lambda _: AIMessage(content='{"name": "Ada", "age": "not-an-int"}')
+    )
+
+    with patch.object(ChatHuggingFace, "bind", return_value=runnable):
+        structured = chat_hugging_face.with_structured_output(
+            PersonForStructuredOutput,
+            method="json_schema",
+        )
+
+        with pytest.raises(OutputParserException):
+            structured.invoke("Return a person")
+
+
+def test_with_structured_output_json_mode_pydantic_returns_model(
+    chat_hugging_face: ChatHuggingFace,
+) -> None:
+    runnable = RunnableLambda(lambda _: AIMessage(content='{"name": "Ada", "age": 36}'))
+
+    with patch.object(ChatHuggingFace, "bind", return_value=runnable):
+        result = chat_hugging_face.with_structured_output(
+            PersonForStructuredOutput,
+            method="json_mode",
+        ).invoke("Return a person")
+
+    assert isinstance(result, PersonForStructuredOutput)
+    assert result.name == "Ada"
+    assert result.age == 36
 
 
 def test_property_inheritance_integration(chat_hugging_face: Any) -> None:


### PR DESCRIPTION
Fixes #32197.

This PR updates `ChatHuggingFace.with_structured_output()` to use `PydanticOutputParser` when a Pydantic schema is provided with `method="json_schema"` or `method="json_mode"`.

Previously, both paths used `JsonOutputParser`, so Pydantic schemas were not parsed into Pydantic model instances despite the documented behavior.

Changes:
- Use `PydanticOutputParser` for Pydantic schemas in `json_schema`
- Use `PydanticOutputParser` for Pydantic schemas in `json_mode`
- Keep `JsonOutputParser` for non-Pydantic schemas
- Add regression tests for valid Pydantic parsing and validation failure

Validation:
- `uv run python -m pytest tests/unit_tests/test_chat_models.py -q`
- `uv run python -m pytest tests/unit_tests/test_chat_models.py -q -k "structured_output"`
- `uv run ruff check langchain_huggingface/chat_models/huggingface.py tests/unit_tests/test_chat_models.py`