### PR TITLE
fix(core): don't evict when updating an existing `InMemoryCache` key

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -226,7 +226,11 @@ class InMemoryCache(BaseCache):
 
                 The value is a list of `Generation` (or subclasses).
         """
-        if self._maxsize is not None and len(self._cache) == self._maxsize:
+        if (
+            self._maxsize is not None
+            and len(self._cache) == self._maxsize
+            and (prompt, llm_string) not in self._cache
+        ):
             del self._cache[next(iter(self._cache))]
         self._cache[prompt, llm_string] = return_val
 

--- a/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
+++ b/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
@@ -69,6 +69,23 @@ def test_update_with_maxsize() -> None:
     assert cache.lookup(prompt3, llm_string3) == generations3
 
 
+def test_update_with_maxsize_existing_key() -> None:
+    """Test updating an existing key when the cache is full does not evict."""
+    cache = InMemoryCache(maxsize=2)
+
+    prompt1, llm_string1, generations1 = cache_item(1)
+    cache.update(prompt1, llm_string1, generations1)
+    prompt2, llm_string2, generations2 = cache_item(2)
+    cache.update(prompt2, llm_string2, generations2)
+
+    updated_generations = [Generation(text="updated")]
+    cache.update(prompt2, llm_string2, updated_generations)
+
+    assert cache.lookup(prompt2, llm_string2) == updated_generations
+    # 'prompt1' should not be evicted, since the cache did not grow
+    assert cache.lookup(prompt1, llm_string1) == generations1
+
+
 def test_clear(cache: InMemoryCache) -> None:
     """Test the clear method of InMemoryCache."""
     prompt, llm_string, generations = cache_item(1)


### PR DESCRIPTION
Fixes #36750

---

This PR fixes Bug 2 from issue #36750: when the in-memory cache is at maxsize, updating an existing key caused eviction of the oldest unrelated entry. The eviction guard previously checked only cache fullness and therefore evicted even for in-place updates. The fix adds a simple condition to evict only when inserting a new key.

Changes:
- Add guard in `InMemoryCache.update()` so eviction occurs only if the key is not already present.
- Add unit test `test_update_with_maxsize_existing_key` that fails on HEAD and passes with this change.
- Ensure aupdate() delegates to update() and inherits the fix.

Test results:
- New test fails on unpatched master and passes after the change.
- Full langchain-core test suite passes locally.
- ruff lint and format checks are clean for modified files.

Request to maintainers:
- Please assign me the InMemoryCache portion of issue #36750 so I can open this PR and have it reviewed.
- If maintainers prefer a different branch name, commit author, or sign-off, I can update accordingly.

Contribution by Johnny Wilson Dougherty.