### PR TITLE
fix(text-splitters): preserve nested media source URLs

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -773,6 +773,19 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
             transformed.extend(splits)
         return transformed
 
+    @staticmethod
+    def _get_media_src(media_tag: Tag) -> str:
+        direct_src = media_tag.get("src")
+        if isinstance(direct_src, str) and direct_src:
+            return direct_src
+
+        for source_tag in _find_all_tags(media_tag, name="source"):
+            source_src = source_tag.get("src")
+            if isinstance(source_src, str) and source_src:
+                return source_src
+
+        return ""
+
     def _process_media(self, soup: BeautifulSoup) -> None:
         """Processes the media elements.
 
@@ -792,7 +805,7 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
 
         if self._preserve_videos:
             for video_tag in _find_all_tags(soup, name="video"):
-                video_src = video_tag.get("src", "")
+                video_src = self._get_media_src(video_tag)
                 markdown_video = f"![video:{video_src}]({video_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_video
@@ -800,7 +813,7 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
 
         if self._preserve_audio:
             for audio_tag in _find_all_tags(soup, name="audio"):
-                audio_src = audio_tag.get("src", "")
+                audio_src = self._get_media_src(audio_tag)
                 markdown_audio = f"![audio:{audio_src}]({audio_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_audio

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3975,6 +3975,42 @@ def test_html_splitter_with_media_preservation() -> None:
 
 
 @pytest.mark.requires("bs4")
+def test_html_splitter_with_nested_media_sources() -> None:
+    """Test HTML splitter uses nested source tags for preserved media."""
+    html_content = """
+    <h1>Media</h1>
+    <p>Watch:</p>
+    <video controls>
+        <source src="https://example.com/video.mp4" type="video/mp4" />
+    </video>
+    <p>Listen:</p>
+    <audio controls>
+        <source src="https://example.com/audio.mp3" type="audio/mpeg" />
+    </audio>
+    """
+    with suppress_langchain_beta_warning():
+        splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")],
+            preserve_videos=True,
+            preserve_audio=True,
+            max_chunk_size=1000,
+        )
+    documents = splitter.split_text(html_content)
+
+    expected = [
+        Document(
+            page_content="Watch: ![video:https://example.com/video.mp4]"
+            "(https://example.com/video.mp4) "
+            "Listen: ![audio:https://example.com/audio.mp3]"
+            "(https://example.com/audio.mp3)",
+            metadata={"Header 1": "Media"},
+        ),
+    ]
+
+    assert documents == expected
+
+
+@pytest.mark.requires("bs4")
 def test_html_splitter_keep_separator_true() -> None:
     """Test HTML splitting with keep_separator=True."""
     html_content = """


### PR DESCRIPTION
Fixes #37826

Preserve media URLs for <video> and <audio> elements that put the URL in a nested <source src="..."> instead of on the media tag itself. Direct src values are still used first.

Verification:
- `uv run --group test pytest tests/unit_tests/test_text_splitters.py::test_html_splitter_with_nested_media_sources -q`
- `uv run --group test pytest tests/unit_tests/test_text_splitters.py::test_html_splitter_with_media_preservation tests/unit_tests/test_text_splitters.py::test_html_splitter_with_nested_media_sources -q`
- `uv run --group test pytest tests/unit_tests/test_text_splitters.py -q`
- `uv run --group lint ruff check langchain_text_splitters/html.py tests/unit_tests/test_text_splitters.py`
- `git diff --check`
