### PR TITLE
feat(openai): native content-block streaming for chat completions

### DIFF
--- a/libs/partners/openai/langchain_openai/__init__.py
+++ b/libs/partners/openai/langchain_openai/__init__.py
@@ -3,6 +3,10 @@
 from langchain_openai._version import __version__
 from langchain_openai.chat_models import AzureChatOpenAI, ChatOpenAI
 from langchain_openai.chat_models._client_utils import StreamChunkTimeoutError
+from langchain_openai.chat_models._stream_events import (
+    aconvert_openai_completions_stream,
+    convert_openai_completions_stream,
+)
 from langchain_openai.embeddings import AzureOpenAIEmbeddings, OpenAIEmbeddings
 from langchain_openai.llms import AzureOpenAI, OpenAI
 from langchain_openai.tools import custom_tool
@@ -16,5 +20,7 @@ __all__ = [
     "OpenAIEmbeddings",
     "StreamChunkTimeoutError",
     "__version__",
+    "aconvert_openai_completions_stream",
+    "convert_openai_completions_stream",
     "custom_tool",
 ]

--- a/libs/partners/openai/langchain_openai/chat_models/_stream_events.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_stream_events.py
@@ -1,0 +1,162 @@
+"""Native content-block streaming-event converter for OpenAI Chat Completions.
+
+Drives raw OpenAI Chat Completions chunks into the shared `BlockStreamTracker`,
+reusing `BaseChatOpenAI._convert_chunk_to_generation_chunk` for content
+extraction (it already yields indexed content blocks + tool-call chunks). This
+converter is the reuse seam for OpenAI-compatible providers (deepseek, groq,
+fireworks, xai, openrouter), which adapt their chunk shape to OpenAI's and call
+it with a different `provider`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.language_models.stream_events import (
+    BlockStreamTracker,
+    accumulate_usage,
+    build_message_finish,
+    iter_protocol_blocks,
+)
+from langchain_core.messages import AIMessageChunk
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from langchain_core.outputs import ChatGenerationChunk
+    from langchain_protocol.protocol import (
+        MessageMetadata,
+        MessagesData,
+        MessageStartData,
+    )
+
+# Bound `BaseChatOpenAI._convert_chunk_to_generation_chunk`.
+MakeChunk = Callable[..., "ChatGenerationChunk | None"]
+
+
+def _message_start(
+    message_id: str | None, model: str | None, provider: str
+) -> MessageStartData:
+    metadata: MessageMetadata = {"provider": provider}
+    if model:
+        metadata["model"] = model
+    return {
+        "event": "message-start",
+        "role": "ai",
+        "id": message_id or "",
+        "metadata": metadata,
+    }
+
+
+def convert_openai_completions_stream(
+    raw: Iterator[Any],
+    make_chunk: MakeChunk,
+    *,
+    base_generation_info: dict[str, Any] | None = None,
+    message_id: str | None = None,
+    provider: str = "openai",
+) -> Iterator[MessagesData]:
+    """Convert a raw OpenAI Chat Completions chunk stream to protocol events.
+
+    Args:
+        raw: Raw OpenAI chunks (dicts or SDK objects with `model_dump`).
+        make_chunk: `BaseChatOpenAI._convert_chunk_to_generation_chunk`, injected
+            so the converter stays pure and unit-testable.
+        base_generation_info: Passed to `make_chunk` for the first chunk only
+            (mirrors `_stream`), `{}` thereafter.
+        message_id: Message id for `message-start`. Left empty by default so
+            the v3 stream's seeded LangChain run id stands (matching the compat
+            bridge); the provider completion id is deliberately not used here.
+        provider: `model_provider` id for downstream reuse (groq, deepseek, ...).
+
+    Yields:
+        Protocol `MessagesData` lifecycle events.
+    """
+    tracker = BlockStreamTracker()
+    started = False
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": provider}
+    model: str | None = None
+    first = True
+
+    for chunk in raw:
+        if not isinstance(chunk, dict):
+            chunk = chunk.model_dump()
+        if model is None and chunk.get("model"):
+            model = chunk["model"]
+        gen = make_chunk(chunk, AIMessageChunk, base_generation_info if first else {})
+        first = False
+        if gen is None:
+            continue
+        msg = gen.message
+        if not started:
+            started = True
+            yield _message_start(message_id, model, provider)
+        for key, block in iter_protocol_blocks(msg):
+            yield from tracker.feed(key, block)
+        usage_metadata = getattr(msg, "usage_metadata", None)
+        if usage_metadata:
+            usage = accumulate_usage(usage, usage_metadata)
+        merged = {**(gen.generation_info or {}), **(msg.response_metadata or {})}
+        if merged:
+            response_metadata.update(merged)
+            # `_convert_chunk_to_generation_chunk` hardcodes
+            # `model_provider="openai"`; re-apply the caller's `provider` so
+            # OpenAI-compatible reuse (groq, deepseek, ...) isn't mislabeled.
+            response_metadata["model_provider"] = provider
+
+    if not started:
+        return
+    yield from tracker.finish_all()
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)
+
+
+async def aconvert_openai_completions_stream(
+    raw: AsyncIterator[Any],
+    make_chunk: MakeChunk,
+    *,
+    base_generation_info: dict[str, Any] | None = None,
+    message_id: str | None = None,
+    provider: str = "openai",
+) -> AsyncIterator[MessagesData]:
+    """Async twin of `convert_openai_completions_stream`. `make_chunk` is sync."""
+    tracker = BlockStreamTracker()
+    started = False
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": provider}
+    model: str | None = None
+    first = True
+
+    async for chunk in raw:
+        if not isinstance(chunk, dict):
+            chunk = chunk.model_dump()
+        if model is None and chunk.get("model"):
+            model = chunk["model"]
+        gen = make_chunk(chunk, AIMessageChunk, base_generation_info if first else {})
+        first = False
+        if gen is None:
+            continue
+        msg = gen.message
+        if not started:
+            started = True
+            yield _message_start(message_id, model, provider)
+        for key, block in iter_protocol_blocks(msg):
+            for ev in tracker.feed(key, block):
+                yield ev
+        usage_metadata = getattr(msg, "usage_metadata", None)
+        if usage_metadata:
+            usage = accumulate_usage(usage, usage_metadata)
+        merged = {**(gen.generation_info or {}), **(msg.response_metadata or {})}
+        if merged:
+            response_metadata.update(merged)
+            # `_convert_chunk_to_generation_chunk` hardcodes
+            # `model_provider="openai"`; re-apply the caller's `provider` so
+            # OpenAI-compatible reuse (groq, deepseek, ...) isn't mislabeled.
+            response_metadata["model_provider"] = provider
+
+    if not started:
+        return
+    for ev in tracker.finish_all():
+        yield ev
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -56,6 +56,10 @@ from langchain_core.language_models import (
     LanguageModelInput,
     ModelProfileRegistry,
 )
+from langchain_core.language_models._compat_bridge import (
+    achunks_to_events,
+    chunks_to_events,
+)
 from langchain_core.language_models.chat_models import (
     BaseChatModel,
     LangSmithParams,
@@ -149,11 +153,16 @@ from langchain_openai.chat_models._compat import (
     _convert_from_v1_to_responses,
     _convert_to_v03_ai_message,
 )
+from langchain_openai.chat_models._stream_events import (
+    aconvert_openai_completions_stream,
+    convert_openai_completions_stream,
+)
 from langchain_openai.data._profiles import _PROFILES
 
 if TYPE_CHECKING:
     import httpx
     from langchain_core.language_models import ModelProfile
+    from langchain_protocol.protocol import MessagesData
     from openai.types.responses import Response
 
 logger = logging.getLogger(__name__)
@@ -1910,6 +1919,147 @@ class BaseChatOpenAI(BaseChatModel):
                     generation_chunk.text, chunk=generation_chunk
                 )
             yield generation_chunk
+
+    def _stream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        *,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> Iterator[MessagesData]:
+        """Emit OpenAI-native content-block events for the Chat Completions path.
+
+        Defers to the compat bridge for cases this converter does not yet
+        specialize: the Responses API, structured output (`response_format`),
+        and raw-header mode. Detected by core's `_iter_v2_events`.
+        """
+        # Responses API / structured output / raw headers: bridge over `_stream`,
+        # which (on `ChatOpenAI`) routes to the Responses path when applicable.
+        # `response_format` may arrive via call kwargs or be baked into
+        # `model_kwargs`; both fold into the payload, so check both.
+        if (
+            self._use_responses_api({**kwargs, **self.model_kwargs})
+            or kwargs.get("response_format") is not None
+            or self.model_kwargs.get("response_format") is not None
+            or self.include_response_headers
+        ):
+            # Forward kwargs untouched (as core's `_iter_v2_events` would):
+            # `_stream` handles `stream_usage` itself, and the Responses path
+            # rejects a stray `stream_usage` kwarg, so we must not inject one.
+            yield from chunks_to_events(
+                self._stream(
+                    messages,
+                    stop=stop,
+                    run_manager=run_manager,
+                    **kwargs,
+                ),
+                message_id=message_id,
+            )
+            return
+
+        self._ensure_sync_client_available()
+        kwargs["stream"] = True
+        stream_usage = self._should_stream_usage(
+            kwargs.pop("stream_usage", None), **kwargs
+        )
+        if stream_usage:
+            kwargs["stream_options"] = {"include_usage": stream_usage}
+        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        try:
+            with self.client.create(**payload) as response:
+                for event in convert_openai_completions_stream(
+                    response,
+                    self._convert_chunk_to_generation_chunk,
+                    message_id=message_id,
+                ):
+                    if (
+                        run_manager is not None
+                        and event["event"] == "content-block-delta"
+                        and event["delta"].get("type") == "text-delta"
+                    ):
+                        # Text-only by design on the v3 events path: the events
+                        # themselves carry block/usage detail, so the legacy
+                        # `chunk=`/`logprobs=` callback args are not threaded.
+                        run_manager.on_llm_new_token(
+                            str(event["delta"].get("text", ""))
+                        )
+                    yield event
+        except openai.BadRequestError as e:
+            _handle_openai_bad_request(e)
+        except openai.APIError as e:
+            _handle_openai_api_error(e)
+
+    async def _astream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        *,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[MessagesData]:
+        """Async twin of `_stream_chat_model_events`."""
+        if (
+            self._use_responses_api({**kwargs, **self.model_kwargs})
+            or kwargs.get("response_format") is not None
+            or self.model_kwargs.get("response_format") is not None
+            or self.include_response_headers
+        ):
+            # Forward kwargs untouched (as core's `_aiter_v2_events` would):
+            # `_astream` handles `stream_usage` itself, and the Responses path
+            # rejects a stray `stream_usage` kwarg, so we must not inject one.
+            async for event in achunks_to_events(
+                self._astream(
+                    messages,
+                    stop=stop,
+                    run_manager=run_manager,
+                    **kwargs,
+                ),
+                message_id=message_id,
+            ):
+                yield event
+            return
+
+        kwargs["stream"] = True
+        stream_usage = self._should_stream_usage(
+            kwargs.pop("stream_usage", None), **kwargs
+        )
+        if stream_usage:
+            kwargs["stream_options"] = {"include_usage": stream_usage}
+        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        try:
+            response = await self.async_client.create(**payload)
+            async with response as stream:
+                # Mirror `_astream`: apply per-chunk stall protection before the
+                # converter consumes the stream.
+                timed_stream = _astream_with_chunk_timeout(
+                    stream,
+                    self.stream_chunk_timeout,
+                    model_name=self.model_name,
+                )
+                async for event in aconvert_openai_completions_stream(
+                    timed_stream,
+                    self._convert_chunk_to_generation_chunk,
+                    message_id=message_id,
+                ):
+                    if (
+                        run_manager is not None
+                        and event["event"] == "content-block-delta"
+                        and event["delta"].get("type") == "text-delta"
+                    ):
+                        # Text-only by design on the v3 events path: the events
+                        # themselves carry block/usage detail, so the legacy
+                        # `chunk=`/`logprobs=` callback args are not threaded.
+                        await run_manager.on_llm_new_token(
+                            str(event["delta"].get("text", ""))
+                        )
+                    yield event
+        except openai.BadRequestError as e:
+            _handle_openai_bad_request(e)
+        except openai.APIError as e:
+            _handle_openai_api_error(e)
 
     async def _agenerate(
         self,

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -635,11 +635,36 @@ def test_openai_stream_events_v3_lifecycle(mock_openai_completion: list) -> None
         events = list(llm.stream_events("你的名字叫什么？只回答名字", version="v3"))
 
     assert_valid_event_stream(events)
+    # `message-start` carries the stream's LangChain run id (threaded from core),
+    # not the provider completion id and not an empty string.
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"]
+    assert not events[0]["id"].startswith("chatcmpl")
     # At minimum, a text block with the accumulated answer.
     finishes = [e for e in events if e["event"] == "content-block-finish"]
     assert len(finishes) >= 1
     text_finishes = [f for f in finishes if f["content"]["type"] == "text"]
     assert len(text_finishes) == 1
+
+
+async def test_openai_astream_events_v3_lifecycle(mock_openai_completion: list) -> None:
+    """Async twin of `test_openai_stream_events_v3_lifecycle`."""
+    from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    mock_client = MagicMock()
+
+    async def mock_acreate(*args: Any, **kwargs: Any) -> MockAsyncContextManager:
+        return MockAsyncContextManager(mock_openai_completion)
+
+    mock_client.create = mock_acreate
+    with patch.object(llm, "async_client", mock_client):
+        stream = await llm.astream_events("test", version="v3")
+        events = [e async for e in stream]
+
+    assert_valid_event_stream(events)
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert len([f for f in finishes if f["content"]["type"] == "text"]) == 1
 
 
 @pytest.fixture

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_stream_events.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_stream_events.py
@@ -1,0 +1,291 @@
+"""Unit tests for the OpenAI Chat Completions native stream-events converter."""
+
+from typing import Any, cast
+
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+from pydantic import SecretStr
+
+from langchain_openai import ChatOpenAI
+from langchain_openai.chat_models._stream_events import (
+    convert_openai_completions_stream,
+)
+
+
+def _text_chunks() -> list[dict]:
+    cid = "chatcmpl-1"
+    return [
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": ""},
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {"index": 0, "delta": {"content": "Hello"}, "finish_reason": None}
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {"index": 0, "delta": {"content": " world"}, "finish_reason": None}
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [],
+            "usage": {"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
+        },
+    ]
+
+
+def _tool_chunks() -> list[dict]:
+    cid = "chatcmpl-2"
+    return [
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": ""},
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": ""},
+                            }
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '{"city":'}}
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": ' "Paris"}'}}
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            "usage": None,
+        },
+    ]
+
+
+def test_convert_openai_completions_text_lifecycle() -> None:
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    events: list[Any] = list(
+        convert_openai_completions_stream(
+            iter(_text_chunks()), llm._convert_chunk_to_generation_chunk
+        )
+    )
+    assert_valid_event_stream(events)
+    assert events[0]["event"] == "message-start"
+    # The provider completion id is deliberately NOT used as the message-start
+    # id: on the v3 path core seeds the stream with the LangChain run id, and an
+    # empty id here lets that stand (matching the compat bridge).
+    assert events[0]["id"] == ""
+    assert events[0]["metadata"]["provider"] == "openai"
+    text = "".join(
+        e["delta"].get("text", "")
+        for e in events
+        if e["event"] == "content-block-delta"
+        and e["delta"].get("type") == "text-delta"
+    )
+    assert text == "Hello world"
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == ["text"]
+    assert cast("dict[str, Any]", finishes[0]["content"])["text"] == "Hello world"
+    message_finish = events[-1]
+    assert message_finish["event"] == "message-finish"
+    assert message_finish["usage"] == {
+        "input_tokens": 7,
+        "output_tokens": 2,
+        "total_tokens": 9,
+    }
+    assert message_finish["metadata"]["finish_reason"] == "stop"
+
+
+def test_convert_openai_completions_tool_call() -> None:
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    events: list[Any] = list(
+        convert_openai_completions_stream(
+            iter(_tool_chunks()), llm._convert_chunk_to_generation_chunk
+        )
+    )
+    assert_valid_event_stream(events)
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    tool_finishes = [f for f in finishes if f["content"]["type"] == "tool_call"]
+    assert len(tool_finishes) == 1
+    tc = cast("dict[str, Any]", tool_finishes[0]["content"])
+    assert tc["name"] == "get_weather"
+    assert tc["args"] == {"city": "Paris"}
+
+
+def test_explicit_message_id_is_used() -> None:
+    """An explicit `message_id` (e.g. the v3 stream's run id) is honored."""
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    events: list[Any] = list(
+        convert_openai_completions_stream(
+            iter(_text_chunks()),
+            llm._convert_chunk_to_generation_chunk,
+            message_id="lc_run--abc",
+        )
+    )
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"] == "lc_run--abc"
+
+
+def test_provider_override_is_not_clobbered_by_openai() -> None:
+    """Reuse with a non-OpenAI `provider` must not be relabeled `openai`.
+
+    `_convert_chunk_to_generation_chunk` hardcodes `model_provider="openai"`;
+    the converter must re-apply the caller's `provider` so OpenAI-compatible
+    providers (groq, deepseek, ...) stay correctly labeled on both
+    `message-start` and `message-finish`.
+    """
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    events: list[Any] = list(
+        convert_openai_completions_stream(
+            iter(_text_chunks()),
+            llm._convert_chunk_to_generation_chunk,
+            provider="groq",
+        )
+    )
+    assert events[0]["metadata"]["provider"] == "groq"
+    message_finish = events[-1]
+    assert message_finish["event"] == "message-finish"
+    assert message_finish["metadata"]["model_provider"] == "groq"
+
+
+async def test_aconvert_openai_completions_text_lifecycle() -> None:
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+
+    async def _araw() -> Any:
+        for c in _text_chunks():
+            yield c
+
+    from langchain_openai.chat_models._stream_events import (
+        aconvert_openai_completions_stream,
+    )
+
+    events: list[Any] = [
+        e
+        async for e in aconvert_openai_completions_stream(
+            _araw(), llm._convert_chunk_to_generation_chunk
+        )
+    ]
+    assert_valid_event_stream(events)
+    assert events[0]["event"] == "message-start"
+    assert events[-1]["event"] == "message-finish"
+    text = "".join(
+        e["delta"].get("text", "")
+        for e in events
+        if e["event"] == "content-block-delta"
+        and e["delta"].get("type") == "text-delta"
+    )
+    assert text == "Hello world"
+
+
+def test_response_format_in_model_kwargs_takes_bridge_path() -> None:
+    """`response_format` baked into `model_kwargs` must defer to the bridge.
+
+    The native completions converter lacks the beta structured-output
+    `get_final_completion()` flow, so such models must route through
+    `_stream` (the bridge), never the native converter.
+    """
+    from unittest.mock import patch
+
+    from langchain_core.messages import AIMessageChunk
+    from langchain_core.outputs import ChatGenerationChunk
+
+    from langchain_openai.chat_models import base
+
+    llm = ChatOpenAI(
+        model="gpt-4o",
+        api_key=SecretStr("test"),
+        model_kwargs={"response_format": {"type": "json_object"}},
+    )
+
+    def _fake_stream(*args: Any, **kwargs: Any) -> Any:
+        yield ChatGenerationChunk(message=AIMessageChunk(content="hi"))
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        msg = "native converter must not run for model_kwargs response_format"
+        raise AssertionError(msg)
+
+    with (
+        patch.object(llm, "_stream", _fake_stream),
+        patch.object(base, "convert_openai_completions_stream", _boom),
+    ):
+        events: list[Any] = list(
+            llm._stream_chat_model_events([], stop=None, run_manager=None)
+        )
+
+    # Bridge path produced events from the patched `_stream` without ever
+    # entering the native converter (which would have raised).
+    assert events
+    assert events[0]["event"] == "message-start"
+    assert events[-1]["event"] == "message-finish"

--- a/libs/partners/openai/tests/unit_tests/test_imports.py
+++ b/libs/partners/openai/tests/unit_tests/test_imports.py
@@ -9,6 +9,8 @@ EXPECTED_ALL = [
     "AzureChatOpenAI",
     "AzureOpenAIEmbeddings",
     "StreamChunkTimeoutError",
+    "aconvert_openai_completions_stream",
+    "convert_openai_completions_stream",
     "custom_tool",
 ]
 


### PR DESCRIPTION
> Stacked on #37995 (the `BlockStreamTracker` foundation + Anthropic reference). Review/merge that first; this targets its branch and will retarget to `master` once it lands.

Builds on the shared `BlockStreamTracker` to give `ChatOpenAI` native content-block streaming events for the **Chat Completions** path, so `stream_events(version="v3")` no longer rides the compat bridge for plain OpenAI streaming.

### What it does

A thin pure converter (`convert_openai_completions_stream` / async twin) drives raw OpenAI Chat Completions chunks into the shared tracker, reusing the existing `_convert_chunk_to_generation_chunk` for content extraction — the same two-layer pattern Anthropic uses. `BaseChatOpenAI` gains `_stream_chat_model_events` / `_astream_chat_model_events` (the hooks core detects); `ChatOpenAI` and Azure inherit them. The converters are exported so the OpenAI-compatible providers (deepseek, fireworks, groq, xai, openrouter) can reuse them in follow-up PRs — either as a direct pass-through or via a small chunk adapter.

### Scope and deferrals

This PR specializes the **Chat Completions** path only. The hooks defer to the existing compat bridge — unchanged behavior — when any of these apply:

- the **Responses API** is active (`_use_responses_api`); a native Responses converter is the next PR,
- **structured output** (`response_format`, including when set via `model_kwargs`), whose `get_final_completion()` flow the native path doesn't reproduce,
- **raw-header** mode (`include_response_headers`).

The deferral guard mirrors `ChatOpenAI._stream`'s own dispatch so the Responses path is never hijacked.

### Worth careful review

- The deferral guard in both hooks — it must match `_stream`'s routing exactly. A test (`test_response_format_in_model_kwargs_takes_bridge_path`) is mutation-verified to fail if the `model_kwargs` branch of the guard is removed.
- The async hook preserves `stream_chunk_timeout` by wrapping the stream the same way `_astream` does.
- Parity is anchored by the pre-existing `test_openai_stream_events_v3_lifecycle`, which previously exercised the bridge and now routes through the native hook unchanged (plus a new async twin).

### Known limitation

On the v3 events path `on_llm_new_token` is called with text only (the legacy `chunk=` / `logprobs=` kwargs aren't threaded through the pure converter); the lifecycle events themselves carry the block and usage detail. Flagged in-code.