### PR TITLE
feat(openai): provider-aware native streaming for compatible subclasses

### DIFF
--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -339,6 +339,10 @@ class ChatDeepSeek(BaseChatOpenAI):
 
         return rtn
 
+    @property
+    def _stream_event_provider(self) -> str:
+        return "deepseek"
+
     def _convert_chunk_to_generation_chunk(
         self,
         chunk: dict,

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from typing import Any, Literal
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import AIMessageChunk, ToolMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 from openai import BaseModel
 from openai.types.chat import ChatCompletionMessage
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field, SecretStr
+from typing_extensions import Self
 
 from langchain_deepseek.chat_models import DEFAULT_API_BASE, ChatDeepSeek
 
@@ -447,3 +449,63 @@ def test_metadata_versions() -> None:
     assert "langchain-core" in versions
     assert "langchain-deepseek" in versions
     assert "langchain-openai" in versions
+
+
+class _MockSyncContextManager:
+    """Minimal context manager yielding OpenAI-shaped completions chunks."""
+
+    def __init__(self, chunks: list[dict[str, Any]]) -> None:
+        self._chunks = iter(chunks)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> dict[str, Any]:
+        return next(self._chunks)
+
+
+def test_deepseek_stream_events_v3_provider_label() -> None:
+    """DeepSeek's native v3 stream labels `model_provider` as 'deepseek'."""
+    # Minimal OpenAI-shaped completions chunks (deepseek uses the openai client).
+    chunks: list[dict[str, Any]] = [
+        {
+            "id": "x",
+            "model": MODEL_NAME,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "hi"},
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": "x",
+            "model": MODEL_NAME,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": None,
+        },
+    ]
+
+    llm = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("x"))
+    mock_client = MagicMock()
+
+    def mock_create(*_args: Any, **_kwargs: Any) -> _MockSyncContextManager:
+        return _MockSyncContextManager(chunks)
+
+    mock_client.create = mock_create
+    with patch.object(llm, "client", mock_client):
+        events: list[Any] = list(llm.stream_events("hi", version="v3"))
+
+    assert_valid_event_stream(events)
+    assert events[0]["event"] == "message-start"
+    assert events[0]["metadata"]["provider"] == "deepseek"
+    assert events[-1]["event"] == "message-finish"
+    assert events[-1]["metadata"]["model_provider"] == "deepseek"

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1922,6 +1922,16 @@ class BaseChatOpenAI(BaseChatModel):
                 )
             yield generation_chunk
 
+    @property
+    def _stream_event_provider(self) -> str:
+        """`model_provider` id emitted by the native streaming-event hooks.
+
+        Overridden by OpenAI-compatible subclasses (e.g. `ChatDeepSeek`,
+        `ChatXAI`) so their native `stream_events(version="v3")` output is
+        labeled with the correct provider instead of `"openai"`.
+        """
+        return "openai"
+
     def _stream_chat_model_events(
         self,
         messages: list[BaseMessage],
@@ -1976,6 +1986,7 @@ class BaseChatOpenAI(BaseChatModel):
                         schema=None,
                         output_version=self.output_version,
                         message_id=message_id,
+                        provider=self._stream_event_provider,
                     ):
                         if (
                             run_manager is not None
@@ -2006,6 +2017,7 @@ class BaseChatOpenAI(BaseChatModel):
                     response,
                     self._convert_chunk_to_generation_chunk,
                     message_id=message_id,
+                    provider=self._stream_event_provider,
                 ):
                     if (
                         run_manager is not None
@@ -2077,6 +2089,7 @@ class BaseChatOpenAI(BaseChatModel):
                         schema=None,
                         output_version=self.output_version,
                         message_id=message_id,
+                        provider=self._stream_event_provider,
                     ):
                         if (
                             run_manager is not None
@@ -2114,6 +2127,7 @@ class BaseChatOpenAI(BaseChatModel):
                     timed_stream,
                     self._convert_chunk_to_generation_chunk,
                     message_id=message_id,
+                    provider=self._stream_event_provider,
                 ):
                     if (
                         run_manager is not None

--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -603,6 +603,10 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
 
         return rtn
 
+    @property
+    def _stream_event_provider(self) -> str:
+        return "xai"
+
     def _convert_chunk_to_generation_chunk(
         self,
         chunk: dict,

--- a/libs/partners/xai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/xai/tests/unit_tests/test_chat_models.py
@@ -1,4 +1,6 @@
 import json
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest  # type: ignore[import-not-found]
 from langchain_core.messages import (
@@ -12,7 +14,9 @@ from langchain_openai.chat_models.base import (
     _convert_dict_to_message,
     _convert_message_to_dict,
 )
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 from pydantic import SecretStr
+from typing_extensions import Self
 
 from langchain_xai import ChatXAI
 
@@ -171,3 +175,65 @@ def test_metadata_versions() -> None:
     assert "langchain-core" in versions
     assert "langchain-xai" in versions
     assert "langchain-openai" in versions
+
+
+class _MockSyncContextManager:
+    """Minimal context manager yielding OpenAI-shaped completions chunks."""
+
+    def __init__(self, chunks: list) -> None:
+        self._chunks = iter(chunks)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> dict:
+        return next(self._chunks)
+
+
+def test_xai_stream_events_v3_provider_label() -> None:
+    """xai's native v3 stream labels `model_provider` as 'xai'."""
+    # `grok-4` takes the Chat Completions path (not Responses), so the
+    # inherited native hook calls `self.client.create(**payload)`.
+    chunks = [
+        {
+            "id": "x",
+            "model": MODEL_NAME,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "hi"},
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": "x",
+            "model": MODEL_NAME,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": None,
+        },
+    ]
+
+    llm = ChatXAI(model=MODEL_NAME, api_key=SecretStr("x"))
+    assert llm._use_responses_api({}) is False
+    mock_client = MagicMock()
+
+    def mock_create(*_args: Any, **_kwargs: Any) -> _MockSyncContextManager:
+        return _MockSyncContextManager(chunks)
+
+    mock_client.create = mock_create
+    with patch.object(llm, "client", mock_client):
+        events: list[Any] = list(llm.stream_events("hi", version="v3"))
+
+    assert_valid_event_stream(events)
+    assert events[0]["event"] == "message-start"
+    assert events[0]["metadata"]["provider"] == "xai"
+    assert events[-1]["event"] == "message-finish"
+    assert events[-1]["metadata"]["model_provider"] == "xai"


### PR DESCRIPTION
> Stacked on #38004 → #37999 → #37995. Review/merge those first; retargets to `master` as they land.

`ChatDeepSeek` and `ChatXAI` subclass `BaseChatOpenAI`, so they already inherit the native `stream_events(version="v3")` hooks added for OpenAI. The only missing piece was the provider label: the converters re-apply `provider`, which defaulted to `"openai"` and mislabeled deepseek/xai output.

### What it does

Adds a small `_stream_event_provider` property on `BaseChatOpenAI` (default `"openai"`) that the native hooks pass to the converters, mirroring LangChain.js's `streamEventProvider`. `ChatDeepSeek` overrides it to `"deepseek"` and `ChatXAI` to `"xai"` — one line each. No new converters: deepseek reuses the Chat Completions converter, and xai reuses both Completions and (via its existing `_use_responses_api` routing) the Responses converter.

With this, `model_provider` is labeled correctly on both `message-start.metadata` and `message-finish.metadata`, consistent with the chunk-level provider these classes already set.

### Scope

Only the two genuine `BaseChatOpenAI` subclasses. `fireworks`, `groq`, and `openrouter` subclass `BaseChatModel` with their own SDK clients and are already served by the compat bridge; bringing them onto native converters (via per-provider chunk adapters) is a separate, lower-value decision and is intentionally **not** included here.

### Worth careful review

- `ChatOpenAI` itself is unchanged (the property defaults to `"openai"`); the existing OpenAI v3 tests pass as-is.
- The per-provider tests drive `stream_events(version="v3")` through the inherited native hook (mocking the OpenAI client) and assert the provider label end-to-end; they fail without the override (TDD).