### PR TITLE
ci(model-profiles): skip profile refresh workflow on forks

### DIFF
--- a/.github/workflows/refresh_model_profiles.yml
+++ b/.github/workflows/refresh_model_profiles.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   refresh-profiles:
+    if: github.repository_owner == 'langchain-ai'
     uses: ./.github/workflows/_refresh_model_profiles.yml
     with:
       providers: >-


### PR DESCRIPTION
Closes #37997

Forked repositories with Actions enabled currently run the scheduled model profile refresh without access to the GitHub App secrets used to open the automated PR. Guarding the job to the `langchain-ai` owner prevents noisy daily failures on forks while preserving the scheduled refresh for the main repository.

## Changes
- Added a repository-owner guard to the `refresh-profiles` job so `refresh_model_profiles` only runs under `langchain-ai`.
- Kept the existing reusable workflow invocation and bot secret wiring unchanged for the canonical repository.