### PR TITLE
ci(infra): attach release artifacts from package dist directory

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -723,7 +723,11 @@ jobs:
       - name: Create Tag
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         with:
-          artifacts: "dist/*"
+          # JS actions ignore `defaults.run.working-directory`, so this glob is
+          # resolved from the repo root. Point it at the package's `dist/`
+          # (where `download-artifact` placed the wheels) instead of a bare
+          # `dist/*`, which never matched and attached no assets to releases.
+          artifacts: "${{ env.EFFECTIVE_WORKING_DIR }}/dist/*"
           token: ${{ secrets.GITHUB_TOKEN }}
           generateReleaseNotes: false
           tag: ${{needs.build.outputs.pkg-name}}==${{ needs.build.outputs.version }}


### PR DESCRIPTION
The release workflow's `mark-release` job downloads built wheels to `<package>/dist/` but told `ncipollo/release-action` to glob `dist/*`. Because JS actions don't honor `defaults.run.working-directory`, that pattern resolved against the repo root, matched nothing, and logged `Artifact pattern :dist/* did not match any files`. The warning is non-fatal, so tags and releases were still created — just with no assets attached. Verified across published releases (`langchain-groq`, `langchain-core`, `langchain-openai`, `langchain-anthropic`): every one has an empty asset list.