### PR TITLE
core: use get_running_loop() in async contexts instead of deprecated get_event_loop()

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -379,7 +379,7 @@ async def _ahandle_event_for_handler(
             elif handler.run_inline:
                 event(*args, **kwargs)
             else:
-                await asyncio.get_event_loop().run_in_executor(
+                await asyncio.get_running_loop().run_in_executor(
                     None,
                     cast(
                         "Callable",

--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -395,7 +395,7 @@ async def _render_mermaid_using_pyppeteer(
     await browser.close()
 
     if output_file_path is not None:
-        await asyncio.get_event_loop().run_in_executor(
+        await asyncio.get_running_loop().run_in_executor(
             None, Path(output_file_path).write_bytes, img_bytes
         )
 

--- a/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
@@ -550,7 +550,7 @@ def _resolve_sync_and_async_api_keys(
             sync_api_key_value = cast(Callable, api_key)
 
             async def async_api_key_wrapper() -> str:
-                return await asyncio.get_event_loop().run_in_executor(
+                return await asyncio.get_running_loop().run_in_executor(
                     None, cast(Callable, api_key)
                 )
 


### PR DESCRIPTION
## Description

`asyncio.get_event_loop()` is deprecated since Python 3.10 and emits a `DeprecationWarning` when there is no running event loop (and is slated for removal). This replaces it with `asyncio.get_running_loop()` at three call sites in `langchain-core` / `langchain-openai` where the call happens **inside an `async` function** — so a running loop is guaranteed — and is only used to schedule work via `run_in_executor`:

- `langchain_core/callbacks/manager.py` — inside `async def _ahandle_event_for_handler`
- `langchain_core/runnables/graph_mermaid.py` — inside the async mermaid-screenshot path
- `langchain_openai/chat_models/_client_utils.py` — inside `async def async_api_key_wrapper`

In all three, `get_running_loop()` is a drop-in: it returns the already-running loop and never warns.

## Deliberately out of scope

I left the `try: asyncio.get_event_loop() except RuntimeError: ...` loop-*detection* patterns (e.g. in `tracers/event_stream.py`, `tracers/log_stream.py`, `language_models/llms.py`) **untouched** — those run in sync contexts and rely on `get_event_loop()` creating/returning a loop, whereas `get_running_loop()` raises. Swapping those would change behavior; this PR only touches sites that are unambiguously inside a running loop.

## Issue

N/A — small, self-contained deprecation fix.

## Dependencies

None.
