### PR TITLE
docs(core): Fix typo in documentation for RunnableLambda

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -4610,13 +4610,11 @@ class RunnableLambda(Runnable[Input, Output]):
         await runnable.ainvoke(1)  # returns 2
         await runnable.abatch([1, 2, 3])  # returns [2, 3, 4]
 
-
-        # Alternatively, can provide both synd and sync implementations
         async def add_one_async(x: int) -> int:
             return x + 1
 
-
-        runnable = RunnableLambda(add_one, afunc=add_one_async)
+        # Alternatively, can provide both sync and async implementations
+        runnable = RunnableLambda(func=add_one, afunc=add_one_async)
         runnable.invoke(1)  # Uses add_one
         await runnable.ainvoke(1)  # Uses add_one_async
         ```

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -4736,13 +4736,11 @@ class RunnableLambda(Runnable[Input, Output]):
         await runnable.ainvoke(1)  # returns 2
         await runnable.abatch([1, 2, 3])  # returns [2, 3, 4]
 
-
-        # Alternatively, can provide both synd and sync implementations
         async def add_one_async(x: int) -> int:
             return x + 1
 
-
-        runnable = RunnableLambda(add_one, afunc=add_one_async)
+        # Alternatively, can provide both sync and async implementations
+        runnable = RunnableLambda(func=add_one, afunc=add_one_async)
         runnable.invoke(1)  # Uses add_one
         await runnable.ainvoke(1)  # Uses add_one_async
         ```

--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -4736,8 +4736,10 @@ class RunnableLambda(Runnable[Input, Output]):
         await runnable.ainvoke(1)  # returns 2
         await runnable.abatch([1, 2, 3])  # returns [2, 3, 4]
 
+
         async def add_one_async(x: int) -> int:
             return x + 1
+
 
         # Alternatively, can provide both sync and async implementations
         runnable = RunnableLambda(func=add_one, afunc=add_one_async)


### PR DESCRIPTION
Fixes https://github.com/langchain-ai/docs/issues/4387

---

<!-- Keep the `Fixes #xx` keyword at the very top and update the issue number — this auto-closes the issue on merge. Replace this comment with a 1-2 sentence description of your change. No `# Summary` header; the description is the summary. -->

There was a typo in the documentation of example provided for class `RunnableLambda` and the positioning
of the line was NOT next to the usage it was explaining. Fixed the typo and moved the line closer to the
usage example.


