### PR TITLE
core: fix RunnableSequence memory leak by removing lru_cache from get_function_nonlocals

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -11,7 +11,6 @@ import textwrap
 # Cannot move to TYPE_CHECKING as Mapping and Sequence are needed at runtime by
 # RunnableConfigurableFields.
 from collections.abc import Mapping, Sequence  # noqa: TC003
-from functools import lru_cache
 from inspect import signature
 from itertools import groupby
 from typing import (
@@ -404,7 +403,6 @@ def get_lambda_source(func: Callable) -> str | None:
     return visitor.source if visitor.count == 1 else name
 
 
-@lru_cache(maxsize=256)
 def get_function_nonlocals(func: Callable) -> list[Any]:
     """Get the nonlocal variables accessed by a function.
 

--- a/libs/core/tests/unit_tests/runnables/test_utils.py
+++ b/libs/core/tests/unit_tests/runnables/test_utils.py
@@ -73,3 +73,27 @@ def test_nonlocals() -> None:
     assert RunnableLambda(my_func3).deps == [agent]
     assert RunnableLambda(my_func4).deps == [global_agent]
     assert RunnableLambda(func).deps == [nl]
+
+
+def test_get_function_nonlocals_no_memory_leak() -> None:
+    import gc
+
+    class Container:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+        def method(self, x: str) -> str:
+            return self.value + x
+
+    def build_and_discard() -> int:
+        c = Container("hello")
+        f = c.method
+        _ = get_function_nonlocals(f)
+        return id(c)
+
+    cid = build_and_discard()
+    gc.collect()
+    # After gc.collect, Container should be freed. If lru_cache held a
+    # strong reference to the bound method, the Container would survive.
+    objs = [o for o in gc.get_objects() if id(o) == cid]
+    assert len(objs) == 0, "Container was not garbage collected"


### PR DESCRIPTION
Fixes #30667

## Problem
The `@lru_cache(maxsize=256)` decorator on `get_function_nonlocals` holds strong references to bound methods used as keys. When a bound method (e.g., `thing.call`) is passed as `func` to a `RunnableLambda`, the cache prevents the enclosing object from being garbage collected — even after the `RunnableSequence` goes out of scope.

## Fix
Remove the `@lru_cache(maxsize=256)` decorator. The function is called at most once per `RunnableLambda` instance (since `deps` is a `@functools.cached_property`), so the cross-instance caching provided marginal benefit at the cost of a memory leak.

## Testing
Added `test_get_function_nonlocals_no_memory_leak` regression test that verifies a container object with a bound method passed to `get_function_nonlocals` is garbage collected after going out of scope.

Closes #30667