### PR TITLE
fix(core): preserve usage token details in v3 streaming events

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -497,9 +497,7 @@ def _extract_start_metadata(response_metadata: dict[str, Any]) -> MessageMetadat
     return metadata
 
 
-def _accumulate_usage(
-    current: UsageInfo | None, delta: UsageMetadata
-) -> UsageInfo:
+def _accumulate_usage(current: UsageInfo | None, delta: UsageMetadata) -> UsageInfo:
     """Sum usage counts and merge detail dicts across chunks.
 
     `delta` is a chunk's `usage_metadata`; `current` is the running total.

--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -500,6 +500,13 @@ def _to_protocol_usage(usage: dict[str, Any] | None) -> UsageInfo | None:
     for key in ("input_tokens", "output_tokens", "total_tokens", "cached_tokens"):
         if key in usage:
             result[key] = usage[key]
+    # `UsageInfo` does not declare the detail dicts yet, but they must ride
+    # along: providers fold cache reads/writes into `input_tokens` and break
+    # them out in `input_token_details`, so dropping the details makes
+    # tracers price every input token at the uncached rate.
+    for detail_key in ("input_token_details", "output_token_details"):
+        if isinstance(usage.get(detail_key), dict):
+            result[detail_key] = dict(usage[detail_key])
     return cast("UsageInfo", result) if result else None
 
 

--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -53,11 +53,29 @@ from langchain_protocol.protocol import (
     TextContentBlock,
     ToolCall,
     ToolCallChunk,
-    UsageInfo,
+)
+from langchain_protocol.protocol import (
+    UsageInfo as _ProtocolUsageInfo,
 )
 
 from langchain_core.messages import AIMessageChunk, BaseMessage
 from langchain_core.utils._merge import merge_dicts
+
+
+class UsageInfo(_ProtocolUsageInfo):
+    """Protocol `UsageInfo` extended with LangChain's typed token-detail fields.
+
+    The wire protocol's `UsageInfo` declares only the flat token counts. LangChain
+    standardizes finer-grained breakdowns on `UsageMetadata` that providers populate
+    — `input_token_details` (e.g. `cache_read`, `cache_creation`, `audio`) and
+    `output_token_details` (e.g. `reasoning`, `audio`). Declaring them here keeps the
+    streaming-event usage payload aligned with non-streaming `UsageMetadata` and
+    properly typed, rather than riding along as untyped keys behind a `cast`.
+    """
+
+    input_token_details: NotRequired[InputTokenDetails]
+    output_token_details: NotRequired[OutputTokenDetails]
+
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
@@ -70,7 +88,13 @@ if TYPE_CHECKING:
         ReasoningDelta,
         TextDelta,
     )
+    from typing_extensions import NotRequired
 
+    from langchain_core.messages.ai import (
+        InputTokenDetails,
+        OutputTokenDetails,
+        UsageMetadata,
+    )
     from langchain_core.outputs import ChatGenerationChunk
 
 
@@ -474,40 +498,53 @@ def _extract_start_metadata(response_metadata: dict[str, Any]) -> MessageMetadat
 
 
 def _accumulate_usage(
-    current: dict[str, Any] | None, delta: Any
-) -> dict[str, Any] | None:
-    """Sum usage counts and merge detail dicts across chunks."""
-    if not isinstance(delta, dict):
-        return current
-    if current is None:
-        return dict(delta)
-    for key in ("input_tokens", "output_tokens", "total_tokens", "cached_tokens"):
-        if key in delta:
-            current[key] = current.get(key, 0) + delta[key]
-    for detail_key in ("input_token_details", "output_token_details"):
-        if detail_key in delta and isinstance(delta[detail_key], dict):
-            if detail_key not in current:
-                current[detail_key] = {}
-            current[detail_key].update(delta[detail_key])
-    return current
+    current: UsageInfo | None, delta: UsageMetadata
+) -> UsageInfo:
+    """Sum usage counts and merge detail dicts across chunks.
+
+    `delta` is a chunk's `usage_metadata`; `current` is the running total.
+    Both sides are read and written by literal key so the typed shape is
+    preserved end to end — no `dict[str, Any]` detour.
+    """
+    new: UsageInfo = current if current is not None else {}
+    if "input_tokens" in delta:
+        new["input_tokens"] = new.get("input_tokens", 0) + delta["input_tokens"]
+    if "output_tokens" in delta:
+        new["output_tokens"] = new.get("output_tokens", 0) + delta["output_tokens"]
+    if "total_tokens" in delta:
+        new["total_tokens"] = new.get("total_tokens", 0) + delta["total_tokens"]
+    input_details = delta.get("input_token_details")
+    if input_details:
+        merged_input = new.get("input_token_details", {})
+        merged_input.update(input_details)
+        new["input_token_details"] = merged_input
+    output_details = delta.get("output_token_details")
+    if output_details:
+        merged_output = new.get("output_token_details", {})
+        merged_output.update(output_details)
+        new["output_token_details"] = merged_output
+    return new
 
 
-def _to_protocol_usage(usage: dict[str, Any] | None) -> UsageInfo | None:
-    """Convert accumulated usage to the protocol's `UsageInfo` shape."""
-    if usage is None:
+def _isolate_usage(usage: UsageInfo | None) -> UsageInfo | None:
+    """Copy usage for the event so consumers can't mutate the source message.
+
+    The replay path (`message_to_events`) feeds the live `msg.usage_metadata`,
+    so the emitted event must not share its dicts: copy the top level plus the
+    nested `input_token_details` / `output_token_details` to de-alias it. The
+    streaming accumulator already owns the dicts it builds, so the copy is a
+    harmless no-op on that path.
+    """
+    if not usage:
         return None
-    result: dict[str, Any] = {}
-    for key in ("input_tokens", "output_tokens", "total_tokens", "cached_tokens"):
-        if key in usage:
-            result[key] = usage[key]
-    # `UsageInfo` does not declare the detail dicts yet, but they must ride
-    # along: providers fold cache reads/writes into `input_tokens` and break
-    # them out in `input_token_details`, so dropping the details makes
-    # tracers price every input token at the uncached rate.
-    for detail_key in ("input_token_details", "output_token_details"):
-        if isinstance(usage.get(detail_key), dict):
-            result[detail_key] = dict(usage[detail_key])
-    return cast("UsageInfo", result) if result else None
+    result: UsageInfo = usage.copy()
+    input_details = result.get("input_token_details")
+    if input_details is not None:
+        result["input_token_details"] = input_details.copy()
+    output_details = result.get("output_token_details")
+    if output_details is not None:
+        result["output_token_details"] = output_details.copy()
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -531,7 +568,7 @@ def _build_message_start(
 
 def _build_message_finish(
     *,
-    usage: dict[str, Any] | None,
+    usage: UsageInfo | None,
     response_metadata: dict[str, Any] | None,
     additional_kwargs: dict[str, Any] | None = None,
 ) -> MessageFinishData:
@@ -540,7 +577,7 @@ def _build_message_finish(
     # `stop_reason` now rides inside `metadata` alongside other
     # response metadata. Pass it through unchanged.
     finish_data: dict[str, Any] = {"event": "message-finish"}
-    usage_info = _to_protocol_usage(usage)
+    usage_info = _isolate_usage(usage)
     if usage_info is not None:
         finish_data["usage"] = usage_info
     if response_metadata:
@@ -599,7 +636,7 @@ def chunks_to_events(
     started = False
     blocks: dict[Any, tuple[int, CompatBlock]] = {}
     next_wire_idx = 0
-    usage: dict[str, Any] | None = None
+    usage: UsageInfo | None = None
     response_metadata: dict[str, Any] = {}
     additional_kwargs: dict[str, Any] = {}
 
@@ -690,7 +727,7 @@ async def achunks_to_events(
     started = False
     blocks: dict[Any, tuple[int, CompatBlock]] = {}
     next_wire_idx = 0
-    usage: dict[str, Any] | None = None
+    usage: UsageInfo | None = None
     response_metadata: dict[str, Any] = {}
     additional_kwargs: dict[str, Any] = {}
 

--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -53,29 +53,11 @@ from langchain_protocol.protocol import (
     TextContentBlock,
     ToolCall,
     ToolCallChunk,
-)
-from langchain_protocol.protocol import (
-    UsageInfo as _ProtocolUsageInfo,
+    UsageInfo,
 )
 
 from langchain_core.messages import AIMessageChunk, BaseMessage
 from langchain_core.utils._merge import merge_dicts
-
-
-class UsageInfo(_ProtocolUsageInfo):
-    """Protocol `UsageInfo` extended with LangChain's typed token-detail fields.
-
-    The wire protocol's `UsageInfo` declares only the flat token counts. LangChain
-    standardizes finer-grained breakdowns on `UsageMetadata` that providers populate
-    — `input_token_details` (e.g. `cache_read`, `cache_creation`, `audio`) and
-    `output_token_details` (e.g. `reasoning`, `audio`). Declaring them here keeps the
-    streaming-event usage payload aligned with non-streaming `UsageMetadata` and
-    properly typed, rather than riding along as untyped keys behind a `cast`.
-    """
-
-    input_token_details: NotRequired[InputTokenDetails]
-    output_token_details: NotRequired[OutputTokenDetails]
-
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
@@ -88,13 +70,8 @@ if TYPE_CHECKING:
         ReasoningDelta,
         TextDelta,
     )
-    from typing_extensions import NotRequired
 
-    from langchain_core.messages.ai import (
-        InputTokenDetails,
-        OutputTokenDetails,
-        UsageMetadata,
-    )
+    from langchain_core.messages.ai import UsageMetadata
     from langchain_core.outputs import ChatGenerationChunk
 
 

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "packaging>=23.2.0",
     "pydantic>=2.7.4,<3.0.0",
     "uuid-utils>=0.12.0,<1.0",
-    "langchain-protocol>=0.0.14",
+    "langchain-protocol>=0.0.17",
 ]
 
 [project.urls]

--- a/libs/core/tests/unit_tests/language_models/test_chat_model_v3_stream.py
+++ b/libs/core/tests/unit_tests/language_models/test_chat_model_v3_stream.py
@@ -1362,3 +1362,120 @@ class TestBedrockConverseToolCallArgs:
         ]
         assert len(text_blocks) == 1
         assert text_blocks[0]["text"] == "Hello Boston!"
+
+
+class _CachedUsageModel(BaseChatModel):
+    """Replays an Anthropic-shaped usage split across stream chunks.
+
+    Anthropic reports input tokens (with `input_token_details` carrying
+    `cache_read` / `cache_creation`) on the opening chunk and output
+    tokens on the terminal chunk; `input_tokens` already includes the
+    cached portions.
+    """
+
+    @property
+    def _llm_type(self) -> str:
+        return "cached-usage-fake"
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del messages, stop, run_manager, kwargs
+        raise NotImplementedError
+
+    def _stream(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        del messages, stop, run_manager, kwargs
+        yield ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="Hello",
+                usage_metadata={
+                    "input_tokens": 100,
+                    "output_tokens": 0,
+                    "total_tokens": 100,
+                    "input_token_details": {"cache_read": 90, "cache_creation": 7},
+                },
+            )
+        )
+        yield ChatGenerationChunk(message=AIMessageChunk(content=" world"))
+        yield ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="",
+                usage_metadata={
+                    "input_tokens": 0,
+                    "output_tokens": 5,
+                    "total_tokens": 5,
+                    "output_token_details": {"reasoning": 3},
+                },
+            )
+        )
+
+
+_EXPECTED_CACHED_USAGE = {
+    "input_tokens": 100,
+    "output_tokens": 5,
+    "total_tokens": 105,
+    "input_token_details": {"cache_read": 90, "cache_creation": 7},
+    "output_token_details": {"reasoning": 3},
+}
+
+
+class TestUsageTokenDetails:
+    """Regression: v3 streaming must not drop usage token detail dicts.
+
+    Providers fold cache reads/writes into `input_tokens` and break them
+    out in `input_token_details`; dropping the details makes tracers
+    (e.g. LangSmith) price every input token at the uncached rate.
+    """
+
+    def test_stream_events_v3_output_preserves_token_details(self) -> None:
+        model = _CachedUsageModel()
+        stream = model.stream_events("hi", version="v3")
+        for _ in stream:
+            pass
+        assert stream.output.usage_metadata == _EXPECTED_CACHED_USAGE
+
+    def test_stream_events_v3_on_llm_end_preserves_token_details(self) -> None:
+        end_usages: list[Any] = []
+
+        class RecordingHandler(BaseCallbackHandler):
+            def on_llm_end(self, response: Any, **_: Any) -> None:
+                end_usages.append(response.generations[0][0].message.usage_metadata)
+
+        model = _CachedUsageModel()
+        stream = model.stream_events(
+            "hi", config={"callbacks": [RecordingHandler()]}, version="v3"
+        )
+        for _ in stream:
+            pass
+        assert end_usages == [_EXPECTED_CACHED_USAGE]
+
+    @pytest.mark.asyncio
+    async def test_astream_events_v3_on_llm_end_preserves_token_details(self) -> None:
+        end_usages: list[Any] = []
+
+        class RecordingHandler(AsyncCallbackHandler):
+            async def on_llm_end(self, response: Any, **_: Any) -> None:
+                end_usages.append(response.generations[0][0].message.usage_metadata)
+
+        model = _CachedUsageModel()
+        stream = await model.astream_events(
+            "hi", config={"callbacks": [RecordingHandler()]}, version="v3"
+        )
+        async for _ in stream:
+            pass
+        # `on_llm_end` fires from the producer task; let it run to completion.
+        for _ in range(20):
+            if end_usages:
+                break
+            await asyncio.sleep(0)
+        assert end_usages == [_EXPECTED_CACHED_USAGE]

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -8,7 +8,6 @@ from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 
 from langchain_core.language_models._compat_bridge import (
     CompatBlock,
-    UsageInfo,
     _finalize_block,
     _isolate_usage,
     achunks_to_events,
@@ -32,6 +31,7 @@ if TYPE_CHECKING:
         ServerToolCall,
         TextContentBlock,
         ToolCall,
+        UsageInfo,
     )
 
 

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -9,7 +9,7 @@ from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 from langchain_core.language_models._compat_bridge import (
     CompatBlock,
     _finalize_block,
-    _to_protocol_usage,
+    _isolate_usage,
     achunks_to_events,
     amessage_to_events,
     chunks_to_events,
@@ -108,20 +108,20 @@ def test_finalize_block_server_tool_call_chunk_invalid_json() -> None:
     assert invalid.get("error") is not None
 
 
-def test_to_protocol_usage_present() -> None:
+def test_isolate_usage_present() -> None:
     usage = {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
-    result = _to_protocol_usage(usage)
+    result = _isolate_usage(usage)
     assert result is not None
     assert result["input_tokens"] == 10
     assert result["output_tokens"] == 20
 
 
-def test_to_protocol_usage_none() -> None:
-    assert _to_protocol_usage(None) is None
+def test_isolate_usage_none() -> None:
+    assert _isolate_usage(None) is None
 
 
-def test_to_protocol_usage_preserves_token_details() -> None:
-    """Cache / reasoning breakdowns must survive the protocol conversion.
+def test_isolate_usage_preserves_token_details() -> None:
+    """Cache / reasoning breakdowns must survive into the emitted event.
 
     `input_tokens` already includes cached tokens; without the detail
     dicts, tracers price every input token at the uncached rate.
@@ -133,12 +133,12 @@ def test_to_protocol_usage_preserves_token_details() -> None:
         "input_token_details": {"cache_read": 90, "cache_creation": 7},
         "output_token_details": {"reasoning": 3},
     }
-    result = cast("dict[str, Any]", _to_protocol_usage(usage))
+    result = cast("dict[str, Any]", _isolate_usage(usage))
     assert result is not None
     assert result["input_token_details"] == {"cache_read": 90, "cache_creation": 7}
     assert result["output_token_details"] == {"reasoning": 3}
-    # Detail dicts are copied, not aliased — later mutation of the
-    # accumulator must not leak into the emitted event.
+    # Detail dicts are copied, not aliased — a consumer mutating the emitted
+    # event must not reach back into the source message's usage_metadata.
     assert result["input_token_details"] is not usage["input_token_details"]
 
 

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -120,6 +120,28 @@ def test_to_protocol_usage_none() -> None:
     assert _to_protocol_usage(None) is None
 
 
+def test_to_protocol_usage_preserves_token_details() -> None:
+    """Cache / reasoning breakdowns must survive the protocol conversion.
+
+    `input_tokens` already includes cached tokens; without the detail
+    dicts, tracers price every input token at the uncached rate.
+    """
+    usage = {
+        "input_tokens": 100,
+        "output_tokens": 5,
+        "total_tokens": 105,
+        "input_token_details": {"cache_read": 90, "cache_creation": 7},
+        "output_token_details": {"reasoning": 3},
+    }
+    result = cast("dict[str, Any]", _to_protocol_usage(usage))
+    assert result is not None
+    assert result["input_token_details"] == {"cache_read": 90, "cache_creation": 7}
+    assert result["output_token_details"] == {"reasoning": 3}
+    # Detail dicts are copied, not aliased — later mutation of the
+    # accumulator must not leak into the emitted event.
+    assert result["input_token_details"] is not usage["input_token_details"]
+
+
 # ---------------------------------------------------------------------------
 # chunks_to_events: streaming lifecycle
 # ---------------------------------------------------------------------------

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -8,6 +8,7 @@ from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 
 from langchain_core.language_models._compat_bridge import (
     CompatBlock,
+    UsageInfo,
     _finalize_block,
     _isolate_usage,
     achunks_to_events,
@@ -109,7 +110,7 @@ def test_finalize_block_server_tool_call_chunk_invalid_json() -> None:
 
 
 def test_isolate_usage_present() -> None:
-    usage = {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
+    usage: UsageInfo = {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
     result = _isolate_usage(usage)
     assert result is not None
     assert result["input_tokens"] == 10
@@ -126,7 +127,7 @@ def test_isolate_usage_preserves_token_details() -> None:
     `input_tokens` already includes cached tokens; without the detail
     dicts, tracers price every input token at the uncached rate.
     """
-    usage = {
+    usage: UsageInfo = {
         "input_tokens": 100,
         "output_tokens": 5,
         "total_tokens": 105,

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1046,7 +1046,7 @@ typing = [
 [package.metadata]
 requires-dist = [
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
-    { name = "langchain-protocol", specifier = ">=0.0.14" },
+    { name = "langchain-protocol", specifier = ">=0.0.17" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
     { name = "packaging", specifier = ">=23.2.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
@@ -1091,14 +1091,14 @@ typing = [
 
 [[package]]
 name = "langchain-protocol"
-version = "0.0.14"
+version = "0.0.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/bf/efb5e2ed832e4d6d45590e25a9e5191986b291b543bc6a807b48bee070b0/langchain_protocol-0.0.14.tar.gz", hash = "sha256:bc1e8553122e6ede310280462d5813023a172ff2785ccbbdec54d43f3a15e5f2", size = 5862, upload-time = "2026-04-29T16:40:18.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/b3/4e2429876c7a35585618caa2b9f9089f7162a6b50562b614ad82ac11c17e/langchain_protocol-0.0.17.tar.gz", hash = "sha256:e7cbe58c205df4b4fd87dc6d5bb23f10e13b236d0e2e1b0b9d05bc2b648f3eea", size = 6026, upload-time = "2026-06-12T18:39:51.923Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/e9/06c47ecb2aff08f83dfa30058da3bf86be64862c19569043ed5331bbeecd/langchain_protocol-0.0.14-py3-none-any.whl", hash = "sha256:ffc35089779bd8ca217015180cef5e660fc3b074efdaa0f2e95df73583f1a047", size = 6984, upload-time = "2026-04-29T16:40:17.841Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0a/a1bfe72c6ec856e99773bbd96c8086421e554b3693d0142b9ea009c6ac92/langchain_protocol-0.0.17-py3-none-any.whl", hash = "sha256:982a08fe152586ed10d4ff3d538c2e0b5766e5f307cdea325e10be3f2c17cae6", size = 7096, upload-time = "2026-06-12T18:39:50.973Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`stream_events(version="v3")` / `astream_events(version="v3")` drops `input_token_details` and `output_token_details` from the usage metadata on the assembled message and the `on_llm_end` payload: the conversion to the protocol `UsageInfo` shape copied only the flat token counts.

Providers fold cached tokens into `input_tokens` and break them out in `input_token_details`, so tracers (e.g. LangSmith) price every input token at the uncached rate on the v3 path, inflating reported cost for prompt-cached runs (cache reads bill at roughly a tenth of the base input rate). The v2 events path and `astream` aggregation preserve the details and report correctly; reasoning-token breakdowns in `output_token_details` are lost the same way.

The detail breakdowns now live on the wire type itself: `input_token_details` / `output_token_details` were added to `UsageInfo` in `langchain-protocol` 0.0.17 (alongside `InputTokenDetails` / `OutputTokenDetails`), so core imports `UsageInfo` directly instead of carrying a local subclass. The v3 usage accumulator threads the details through end to end, shallow-copying the nested dicts (`_isolate_usage`) so later accumulator mutation cannot leak into already-emitted events. Since native provider converters share `build_message_finish`, this also covers provider-native v3 streams.

Verified against a live claude-sonnet-4-6 call with a cached prompt: v3 `on_llm_end` usage now matches v2, with `cache_read` / `cache_creation` intact. Requires `langchain-protocol>=0.0.17` (core pin bumped accordingly).