### PR TITLE
fix: support Pydantic structured output for HuggingFace

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,9 +47,10 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
+    PydanticToolsParser,
     make_invalid_tool_call,
     parse_tool_call,
 )
@@ -1167,11 +1168,10 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": formatted_tool,
                 },
             )
-            if is_pydantic_schema:
-                msg = "Pydantic schema is not supported for function calling"
-                raise NotImplementedError(msg)
-            output_parser: JsonOutputKeyToolsParser | JsonOutputParser = (
-                JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
+            output_parser: Runnable = (
+                PydanticToolsParser(tools=[schema], first_tool_only=True)
+                if is_pydantic_schema
+                else JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
             )
         elif method == "json_schema":
             if schema is None:
@@ -1188,7 +1188,11 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1197,7 +1201,11 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
         else:
             msg = (
                 f"Unrecognized method argument. Expected one of 'function_calling' or "

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -10,7 +10,9 @@ from langchain_core.messages import (
     SystemMessage,
 )
 from langchain_core.outputs import ChatResult
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
@@ -222,6 +224,49 @@ def test_bind_tools(chat_hugging_face: Any) -> None:
         _, kwargs = mock_super_bind.call_args
         assert kwargs["tools"] == tools
         assert kwargs["tool_choice"] == "auto"
+
+
+def test_with_structured_output_function_calling_supports_pydantic(
+    chat_hugging_face: Any,
+) -> None:
+    class Answer(BaseModel):
+        answer: str
+
+    fake_llm = RunnableLambda(
+        lambda _: AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "Answer",
+                    "args": {"answer": "ok"},
+                    "id": "call_1",
+                    "type": "tool_call",
+                }
+            ],
+        )
+    )
+
+    with patch.object(ChatHuggingFace, "bind_tools", return_value=fake_llm):
+        structured_llm = chat_hugging_face.with_structured_output(Answer)
+
+    assert structured_llm.invoke("question") == Answer(answer="ok")
+
+
+def test_with_structured_output_json_mode_supports_pydantic(
+    chat_hugging_face: Any,
+) -> None:
+    class Answer(BaseModel):
+        answer: str
+
+    fake_llm = RunnableLambda(lambda _: AIMessage(content='{"answer": "ok"}'))
+
+    with patch.object(ChatHuggingFace, "bind", return_value=fake_llm):
+        structured_llm = chat_hugging_face.with_structured_output(
+            Answer,
+            method="json_mode",
+        )
+
+    assert structured_llm.invoke("question") == Answer(answer="ok")
 
 
 def test_property_inheritance_integration(chat_hugging_face: Any) -> None:


### PR DESCRIPTION
Fixes #32197

`ChatHuggingFace.with_structured_output()` previously rejected Pydantic schemas for function calling and returned raw JSON for JSON modes, which made structured output inconsistent with other chat integrations.

This PR wires Pydantic schemas through the existing LangChain structured output parsers and adds focused unit coverage for function calling and JSON mode.

Verification:
- `python -m pytest libs/partners/huggingface/tests/unit_tests/test_chat_models.py -q -k structured_output`
- `python -m ruff check libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py libs/partners/huggingface/tests/unit_tests/test_chat_models.py`

Breaking changes: none.