### PR TITLE
fix(ollama): handle malformed tool call ResponseError in _acreate_cha…

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -50,6 +50,7 @@ from operator import itemgetter
 from typing import Any, Literal, cast
 from uuid import uuid4
 
+
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.callbacks.manager import AsyncCallbackManagerForLLMRun
 from langchain_core.exceptions import OutputParserException
@@ -83,7 +84,7 @@ from langchain_core.utils.function_calling import (
     convert_to_openai_tool,
 )
 from langchain_core.utils.pydantic import TypeBaseModel, is_basemodel_subclass
-from ollama import AsyncClient, Client, Message
+from ollama import AsyncClient, Client, Message, ResponseError
 from pydantic import BaseModel, PrivateAttr, field_validator, model_validator
 from pydantic.json_schema import JsonSchemaValue
 from pydantic.v1 import BaseModel as BaseModelV1
@@ -1101,12 +1102,22 @@ class ChatOllama(BaseChatModel):
             )
             raise RuntimeError(msg)
         chat_params = self._chat_params(messages, stop, **kwargs)
-
-        if chat_params["stream"]:
-            async for part in await self._async_client.chat(**chat_params):
-                yield part
-        else:
-            yield await self._async_client.chat(**chat_params)
+        try:
+            if chat_params["stream"]:
+                stream = await self._async_client.chat(**chat_params)  # <- await separately
+                async for part in stream:
+                    yield part
+            else:
+                yield await self._async_client.chat(**chat_params)
+        except ResponseError as e:
+            if "error parsing tool call" in str(e):
+                log.warning(
+                    "Ollama failed to parse a tool call and returned malformed JSON. "
+                    "Skipping response chunk. Raw error: %s",
+                    e,
+                )
+                return
+            raise
 
     def _create_chat_stream(
         self,

--- a/libs/partners/ollama/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/ollama/tests/unit_tests/test_chat_models.py
@@ -10,6 +10,9 @@ import pytest
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, BaseMessage, ChatMessage, HumanMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
+from unittest.mock import AsyncMock, MagicMock, patch
+from ollama import ResponseError
+from langchain_ollama.chat_models import ChatOllama
 
 from langchain_ollama.chat_models import (
     ChatOllama,
@@ -33,6 +36,43 @@ class TestChatOllama(ChatModelUnitTests):
     @property
     def chat_model_params(self) -> dict:
         return {"model": MODEL_NAME}
+
+@pytest.mark.asyncio
+async def test_acreate_chat_stream_handles_malformed_tool_call_response_error():
+    """Test that malformed tool call ResponseError is caught and logged, not raised."""
+    llm = ChatOllama(model="llama3.2")
+
+    mock_async_client = MagicMock()
+    mock_async_client.chat = AsyncMock(
+        side_effect=ResponseError("error parsing tool call: raw='{\"key\":}', err=invalid character")
+    )
+    llm._async_client = mock_async_client
+
+    chunks = []
+    async for chunk in llm._acreate_chat_stream(
+        messages=[], stop=None, stream=True
+    ):
+        chunks.append(chunk)
+
+    assert chunks == []
+
+
+@pytest.mark.asyncio
+async def test_acreate_chat_stream_reraises_non_tool_call_response_error():
+    """Test that ResponseErrors unrelated to tool call parsing are still raised."""
+    llm = ChatOllama(model="llama3.2")
+
+    mock_async_client = MagicMock()
+    mock_async_client.chat = AsyncMock(
+        side_effect=ResponseError("model not found")
+    )
+    llm._async_client = mock_async_client
+
+    with pytest.raises(ResponseError, match="model not found"):
+        async for _ in llm._acreate_chat_stream(
+            messages=[], stop=None, stream=True
+        ):
+            pass
 
 
 def test__parse_arguments_from_tool_call() -> None:


### PR DESCRIPTION
## Description
Fixes #34746

When Ollama returns malformed JSON for a tool call, the `_async_client.chat()` 
call raises `ollama.ResponseError` with "error parsing tool call" in the message. 
This was previously unhandled, causing the entire agent to crash.

This PR wraps the streaming and non-streaming paths in `_acreate_chat_stream` 
with a try/except that catches these specific errors, logs a warning, and returns 
gracefully instead of crashing.

## Minimal Repro
```python
from langchain_ollama import ChatOllama
from langchain_core.tools import tool

@tool
def echo(x: str) -> str:
    return x

llm = ChatOllama(model="llama3.2", base_url="http://localhost:11434")
agent = llm.bind_tools([echo])
resp = agent.invoke("call the echo tool with hello")
```

## Changes
- `libs/partners/ollama/langchain_ollama/chat_models.py`: wrap `_acreate_chat_stream` with try/except for `ResponseError`
- `libs/partners/ollama/tests/unit_tests/test_chat_models.py`: two new unit tests covering the fix and ensuring non-tool-call errors still raise

## Related PRs
Supersedes #35201 (closed without merging)

## Reach Out :)
https://www.linkedin.com/in/jonathan-zhao-74a901357/