### PR TITLE
fix(core): close RunnableSequence streams on cancellation

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -3676,6 +3676,7 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
         # steps that don't natively support transforming an input stream will
         # buffer input in memory until all available, and then start emitting output
         final_pipeline = cast("AsyncIterator[Output]", inputs)
+        pipelines: list[AsyncIterator[Any]] = []
         for idx, step in enumerate(steps):
             config = patch_config(
                 config,
@@ -3685,8 +3686,14 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
                 final_pipeline = step.atransform(final_pipeline, config, **kwargs)
             else:
                 final_pipeline = step.atransform(final_pipeline, config)
-        async for output in final_pipeline:
-            yield output
+            pipelines.append(final_pipeline)
+        try:
+            async for output in final_pipeline:
+                yield output
+        finally:
+            for pipeline in reversed(pipelines):
+                if hasattr(pipeline, "aclose"):
+                    await cast("Any", pipeline).aclose()
 
     @override
     def transform(
@@ -3718,13 +3725,15 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
         config: RunnableConfig | None = None,
         **kwargs: Any | None,
     ) -> AsyncIterator[Output]:
-        async for chunk in self._atransform_stream_with_config(
+        iterator = self._atransform_stream_with_config(
             input,
             self._atransform,
             patch_config(config, run_name=(config or {}).get("run_name") or self.name),
             **kwargs,
-        ):
-            yield chunk
+        )
+        async with aclosing(iterator):
+            async for chunk in iterator:
+                yield chunk
 
     @override
     async def astream(
@@ -3736,8 +3745,10 @@ class RunnableSequence(RunnableSerializable[Input, Output]):
         async def input_aiter() -> AsyncIterator[Input]:
             yield input
 
-        async for chunk in self.atransform(input_aiter(), config, **kwargs):
-            yield chunk
+        iterator = self.atransform(input_aiter(), config, **kwargs)
+        async with aclosing(iterator):
+            async for chunk in iterator:
+                yield chunk
 
 
 class RunnableParallel(RunnableSerializable[Input, dict[str, Any]]):

--- a/libs/core/langchain_core/utils/aiter.py
+++ b/libs/core/langchain_core/utils/aiter.py
@@ -5,6 +5,7 @@ https://github.com/maxfischer2781/asyncstdlib/blob/master/asyncstdlib/itertools.
 MIT License.
 """
 
+import importlib
 from collections import deque
 from collections.abc import (
     AsyncGenerator,
@@ -318,8 +319,22 @@ class aclosing(AbstractAsyncContextManager):  # noqa: N801
         exc_value: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
-        if hasattr(self.thing, "aclose"):
-            await self.thing.aclose()
+        if not hasattr(self.thing, "aclose"):
+            return
+
+        close = cast("Any", self.thing).aclose
+        try:
+            anyio = importlib.import_module("anyio")
+        except ImportError:
+            await close()
+        else:
+            # AnyIO/ASGI cancellation is level-triggered: cleanup awaits inside a
+            # cancelled scope are cancelled again unless explicitly shielded.
+            # Shielding here lets nested async generators run their `finally`
+            # blocks and release provider HTTP/socket resources before the
+            # outer cancellation continues.
+            with anyio.CancelScope(shield=True):
+                await close()
 
 
 async def abatch_iterate(

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -1140,6 +1140,70 @@ async def test_passthrough_tap_async(mocker: MockerFixture) -> None:
     ]
 
 
+async def test_sequence_astream_closes_nested_stream_on_cancel_scope() -> None:
+    """RunnableSequence cancellation must close nested async iterators.
+
+    ASGI servers such as Starlette/FastAPI cancel streaming response tasks through
+    AnyIO cancel scopes when a client disconnects. Cleanup code then runs inside a
+    still-cancelled scope, so unshielded `aclose()` calls can be interrupted before
+    provider HTTP streams release sockets.
+    """
+    anyio = pytest.importorskip("anyio")
+
+    class CleanupTrackingRunnable(Runnable[Any, str]):
+        def __init__(self) -> None:
+            self.started = anyio.Event()
+            self.cleanup_started = anyio.Event()
+            self.cleanup_done = anyio.Event()
+
+        def invoke(
+            self,
+            input: Any,
+            config: RunnableConfig | None = None,
+            **kwargs: Any,
+        ) -> str:
+            del config, kwargs
+            return str(input)
+
+        async def atransform(
+            self,
+            input: AsyncIterator[Any],
+            config: RunnableConfig | None = None,
+            **kwargs: Any,
+        ) -> AsyncIterator[str]:
+            del config, kwargs
+            async for _ in input:
+                break
+            try:
+                self.started.set()
+                yield "first"
+                await anyio.sleep_forever()
+            finally:
+                self.cleanup_started.set()
+                await anyio.sleep(0.01)
+                self.cleanup_done.set()
+
+    tail = CleanupTrackingRunnable()
+    seq = RunnableLambda(lambda x: x) | tail
+
+    async def consume() -> None:
+        stream = cast("Any", seq.astream("hello"))
+        try:
+            assert await anext(stream) == "first"
+            await anyio.sleep_forever()
+        finally:
+            await stream.aclose()
+
+    with anyio.fail_after(2):
+        async with anyio.create_task_group() as task_group:
+            task_group.start_soon(consume)
+            await tail.started.wait()
+            task_group.cancel_scope.cancel()
+
+    assert tail.cleanup_started.is_set()
+    assert tail.cleanup_done.is_set()
+
+
 async def test_with_config_metadata_passthrough(mocker: MockerFixture) -> None:
     fake = FakeRunnableSerializable()
     spy = mocker.spy(fake.__class__, "invoke")


### PR DESCRIPTION
Fixes #37976

## Problem
`RunnableSequence.astream()` does not reliably propagate cancellation cleanup to nested async iterators under ASGI/AnyIO cancellation. A client disconnect can leave the sequence paused after yielding a chunk; when the response task is cancelled, cleanup runs inside an already-cancelled AnyIO cancel scope. Plain `await gen.aclose()` can be interrupted before provider HTTP streams run their `finally` blocks, leaving sockets open.

There are two separate failure edges:
1. The sequence wrappers (`astream` -> `atransform` -> `_atransform_stream_with_config`) used `async for` forwarding without `aclosing`, so closing the outer generator did not reliably close the inner generator chain.
2. AnyIO level-triggered cancellation can interrupt cleanup awaits unless `aclose()` is shielded while the resource teardown completes.

## Solution
- Wrap `RunnableSequence.atransform()` and `RunnableSequence.astream()` inner async iterators with `aclosing()` so outer generator closure propagates inward.
- Track step pipelines in `RunnableSequence._atransform()` and explicitly close them in reverse order in `finally`, so nested step streams receive `aclose()`.
- Make `langchain_core.utils.aiter.aclosing` shield `aclose()` with `anyio.CancelScope(shield=True)` when AnyIO is available, falling back to the existing plain `await close()` otherwise.
- Add a regression test that runs a sequence inside an AnyIO task group, cancels the task group like an ASGI disconnect, and asserts the nested runnable's async cleanup both starts and completes.

## Verification
- `ruff check libs/core/langchain_core/runnables/base.py libs/core/langchain_core/utils/aiter.py libs/core/tests/unit_tests/runnables/test_runnable.py`
- `python -m compileall -q libs/core/langchain_core/runnables/base.py libs/core/langchain_core/utils/aiter.py libs/core/tests/unit_tests/runnables/test_runnable.py`
- `PYTHONPATH=libs/core:libs/core/tests pytest -q libs/core/tests/unit_tests/runnables/test_runnable.py::test_sequence_astream_closes_nested_stream_on_cancel_scope libs/core/tests/unit_tests/runnables/test_runnable.py::test_passthrough_tap_async libs/core/tests/unit_tests/language_models/test_chat_model_v3_stream.py::TestAsyncStreamAclose::test_aclose_cancels_producer_task libs/core/tests/unit_tests/language_models/test_chat_model_v3_stream.py::TestAsyncStreamAclose::test_aclose_propagates_caller_cancellation libs/core/tests/unit_tests/language_models/test_chat_model_v3_stream.py::TestAsyncStreamAclose::test_aclose_fires_on_llm_error_for_tracing`

Note: a full `test_runnable.py` run has unrelated snapshot drift in this checkout (`FakeListChatModel(output_version=None, ...)` repr vs existing snapshots); the new regression and targeted adjacent stream/cancellation tests pass.
