### PR TITLE
test(anthropic): make expected warnings explicit

### DIFF
--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_prompt_caching.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_prompt_caching.py
@@ -237,9 +237,12 @@ async def test_anthropic_prompt_caching_middleware_async_min_messages() -> None:
     """Test async path respects min_messages_to_cache."""
     middleware = AnthropicPromptCachingMiddleware(min_messages_to_cache=5)
 
+    mock_chat_anthropic = MagicMock(spec=ChatAnthropic)
+    mock_chat_anthropic._llm_type = "anthropic-chat"
+
     # Test with fewer messages than minimum
     fake_request = ModelRequest(
-        model=FakeToolCallingModel(),
+        model=mock_chat_anthropic,
         messages=[HumanMessage("Hello")] * 3,
         system_prompt=None,
         tool_choice=None,

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -187,9 +187,23 @@ def test_anthropic_model_kwargs() -> None:
 @pytest.mark.requires("anthropic")
 def test_anthropic_fields_in_model_kwargs() -> None:
     """Test that for backwards compatibility fields can be passed in as model_kwargs."""
-    llm = ChatAnthropic(model=MODEL_NAME, model_kwargs={"max_tokens_to_sample": 5})  # type: ignore[call-arg]
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "Parameters {'max_tokens_to_sample'} should be specified explicitly. "
+            "Instead they were passed in as part of `model_kwargs` parameter."
+        ),
+    ):
+        llm = ChatAnthropic(model=MODEL_NAME, model_kwargs={"max_tokens_to_sample": 5})  # type: ignore[call-arg]
     assert llm.max_tokens == 5
-    llm = ChatAnthropic(model=MODEL_NAME, model_kwargs={"max_tokens": 5})  # type: ignore[call-arg]
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "Parameters {'max_tokens'} should be specified explicitly. Instead they "
+            "were passed in as part of `model_kwargs` parameter."
+        ),
+    ):
+        llm = ChatAnthropic(model=MODEL_NAME, model_kwargs={"max_tokens": 5})  # type: ignore[call-arg]
     assert llm.max_tokens == 5
 
 

--- a/libs/partners/anthropic/tests/unit_tests/test_llms.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_llms.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from langchain_anthropic import AnthropicLLM
 
 os.environ["ANTHROPIC_API_KEY"] = "foo"
@@ -7,7 +9,14 @@ os.environ["ANTHROPIC_API_KEY"] = "foo"
 
 def test_anthropic_model_params() -> None:
     # Test standard tracing params
-    llm = AnthropicLLM(model="foo")  # type: ignore[call-arg]
+    with pytest.warns(
+        expected_warning=DeprecationWarning,
+        match=(
+            "The class `AnthropicLLM` was deprecated in LangChain 0.1.0 "
+            "and will be removed in 2.0.0. Use `ChatAnthropic` instead."
+        ),
+    ):
+        llm = AnthropicLLM(model="foo")  # type: ignore[call-arg]
 
     ls_params = llm._get_ls_params()
     assert ls_params == {

--- a/libs/partners/anthropic/tests/unit_tests/test_standard.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_standard.py
@@ -13,6 +13,11 @@ _MODEL = "claude-3-haiku-20240307"
 class TestAnthropicStandard(ChatModelUnitTests):
     """Use the standard chat model unit tests against the `ChatAnthropic` class."""
 
+    pytestmark = pytest.mark.filterwarnings(
+        "ignore:Unrecognized structured output method 'json_mode'. "
+        "Defaulting to 'json_schema' method.:UserWarning"
+    )
+
     @property
     def chat_model_class(self) -> type[BaseChatModel]:
         return ChatAnthropic


### PR DESCRIPTION
Warning-producing test paths now either exercise the intended Anthropic model branch or explicitly assert expected warnings. That keeps `make test` output clean while preserving coverage for backwards-compatible parameters, deprecated `AnthropicLLM`, and standard structured-output behavior.