### PR TITLE
fix(standard-tests): allow reasoning blocks in streaming content-block assertions

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -852,8 +852,11 @@ class ChatModelIntegrationTests(ChatModelTests):
         assert len(chunks) > 0
         assert isinstance(full, AIMessageChunk)
         assert full.content
-        assert len(full.content_blocks) == 1
-        assert full.content_blocks[0]["type"] == "text"
+        # Reasoning models surface a leading `reasoning` block alongside the
+        # text block; require exactly one text block and no other block types.
+        text_blocks = [b for b in full.content_blocks if b["type"] == "text"]
+        assert len(text_blocks) == 1
+        assert all(b["type"] in ("reasoning", "text") for b in full.content_blocks)
 
         # Verify chunk_position signaling
         last_chunk = chunks[-1]
@@ -902,8 +905,11 @@ class ChatModelIntegrationTests(ChatModelTests):
         assert len(chunks) > 0
         assert isinstance(full, AIMessageChunk)
         assert full.content
-        assert len(full.content_blocks) == 1
-        assert full.content_blocks[0]["type"] == "text"
+        # Reasoning models surface a leading `reasoning` block alongside the
+        # text block; require exactly one text block and no other block types.
+        text_blocks = [b for b in full.content_blocks if b["type"] == "text"]
+        assert len(text_blocks) == 1
+        assert all(b["type"] in ("reasoning", "text") for b in full.content_blocks)
 
         # Verify chunk_position signaling
         last_chunk = chunks[-1]
@@ -941,8 +947,11 @@ class ChatModelIntegrationTests(ChatModelTests):
         message = stream.output
         assert isinstance(message, AIMessage)
         assert message.content
-        assert len(message.content_blocks) == 1
-        assert message.content_blocks[0]["type"] == "text"
+        # Reasoning models surface a leading `reasoning` block alongside the
+        # text block; require exactly one text block and no other block types.
+        text_blocks = [b for b in message.content_blocks if b["type"] == "text"]
+        assert len(text_blocks) == 1
+        assert all(b["type"] in ("reasoning", "text") for b in message.content_blocks)
         # `stream_events(version="v3")` always assembles content as v1 protocol blocks.
         assert message.response_metadata.get("output_version") == "v1"
 
@@ -972,8 +981,11 @@ class ChatModelIntegrationTests(ChatModelTests):
         message = await stream.output
         assert isinstance(message, AIMessage)
         assert message.content
-        assert len(message.content_blocks) == 1
-        assert message.content_blocks[0]["type"] == "text"
+        # Reasoning models surface a leading `reasoning` block alongside the
+        # text block; require exactly one text block and no other block types.
+        text_blocks = [b for b in message.content_blocks if b["type"] == "text"]
+        assert len(text_blocks) == 1
+        assert all(b["type"] in ("reasoning", "text") for b in message.content_blocks)
         assert message.response_metadata.get("output_version") == "v1"
 
     def test_invoke_with_model_override(self, model: BaseChatModel) -> None:


### PR DESCRIPTION
The streaming integration tests (`test_stream`, `test_astream`, `test_stream_events_v3`, `test_astream_events_v3`) assert that a `"Hello"` prompt yields exactly one `text` content block. That assumption holds only for non-reasoning models. Reasoning models correctly surface a leading `reasoning` block alongside the text — especially on the native `stream_events(version="v3")` path, where reasoning is a first-class content block rather than buried in `additional_kwargs`.

This relaxes each of the four assertions to require exactly one `text` block and permit blocks only of type `reasoning` or `text`. The change is backward-compatible: non-reasoning providers still produce exactly one text block and zero reasoning blocks, so their behavior is unchanged. Reasoning-model integrations (e.g. Fireworks `kimi-k2p6`, xAI `grok`) now pass without any loss of coverage — the tests still require exactly one text block and reject unexpected block types.
