### PR TITLE
fix(huggingface): support Pydantic schemas in with_structured_output

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,9 +47,11 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
+from langchain_core.output_parsers.base import OutputParserLike
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
+    PydanticToolsParser,
     make_invalid_tool_call,
     parse_tool_call,
 )
@@ -1102,9 +1104,13 @@ class ChatHuggingFace(BaseChatModel):
 
                 - An OpenAI function/tool schema,
                 - A JSON Schema,
-                - A `TypedDict` class
+                - A `TypedDict` class,
+                - A Pydantic class.
 
-                Pydantic class is currently supported.
+                If `schema` is a Pydantic class then the model output will be a
+                Pydantic instance of that class, and the model-generated fields will
+                be validated by the Pydantic class. Otherwise the model output will
+                be a dict.
 
             method: The method for steering model generation, one of:
 
@@ -1168,11 +1174,14 @@ class ChatHuggingFace(BaseChatModel):
                 },
             )
             if is_pydantic_schema:
-                msg = "Pydantic schema is not supported for function calling"
-                raise NotImplementedError(msg)
-            output_parser: JsonOutputKeyToolsParser | JsonOutputParser = (
-                JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
-            )
+                output_parser: OutputParserLike = PydanticToolsParser(
+                    tools=[schema],  # type: ignore[list-item]
+                    first_tool_only=True,
+                )
+            else:
+                output_parser = JsonOutputKeyToolsParser(
+                    key_name=tool_name, first_tool_only=True
+                )
         elif method == "json_schema":
             if schema is None:
                 msg = (
@@ -1188,7 +1197,11 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[type-var, arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1197,11 +1210,16 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[type-var, arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
         else:
             msg = (
-                f"Unrecognized method argument. Expected one of 'function_calling' or "
-                f"'json_mode'. Received: '{method}'"
+                "Unrecognized method argument. Expected one of "
+                "'function_calling', 'json_mode', or 'json_schema'. "
+                f"Received: '{method}'"
             )
             raise ValueError(msg)
 

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -9,8 +9,15 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
+from langchain_core.output_parsers import PydanticOutputParser
+from langchain_core.output_parsers.openai_tools import (
+    JsonOutputKeyToolsParser,
+    PydanticToolsParser,
+)
 from langchain_core.outputs import ChatResult
 from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from pydantic import BaseModel
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
@@ -391,3 +398,48 @@ def test_init_chat_model_huggingface() -> None:
         # The important part is that the code path doesn't raise ValidationError
         # about missing 'llm' field, which was the original bug
         pytest.skip(f"Skipping test due to model download/initialization error: {e}")
+
+
+class _Joke(BaseModel):
+    """Joke to tell user."""
+
+    setup: str
+    punchline: str
+
+
+def test_with_structured_output_pydantic_function_calling(
+    chat_hugging_face: Any,
+) -> None:
+    """Pydantic schema with `function_calling` parses into the Pydantic class."""
+    chain = chat_hugging_face.with_structured_output(_Joke)
+    parser = chain.steps[-1]
+    assert isinstance(parser, PydanticToolsParser)
+    assert parser.first_tool_only
+    assert parser.tools == [_Joke]
+
+
+@pytest.mark.parametrize("method", ["json_schema", "json_mode"])
+def test_with_structured_output_pydantic_json_methods(
+    chat_hugging_face: Any, method: str
+) -> None:
+    """Pydantic schema with JSON methods parses into the Pydantic class."""
+    chain = chat_hugging_face.with_structured_output(_Joke, method=method)
+    parser = chain.steps[-1]
+    assert isinstance(parser, PydanticOutputParser)
+    assert parser.pydantic_object is _Joke
+
+
+def test_with_structured_output_dict_schema_function_calling(
+    chat_hugging_face: Any,
+) -> None:
+    """Non-Pydantic schemas keep returning dicts via the JSON tools parser."""
+    schema = convert_to_openai_tool(_Joke)
+    chain = chat_hugging_face.with_structured_output(schema)
+    parser = chain.steps[-1]
+    assert isinstance(parser, JsonOutputKeyToolsParser)
+    assert parser.key_name == "_Joke"
+
+
+def test_with_structured_output_invalid_method(chat_hugging_face: Any) -> None:
+    with pytest.raises(ValueError, match="json_schema"):
+        chat_hugging_face.with_structured_output(_Joke, method="bad_method")


### PR DESCRIPTION
Fixes #32197

---

`ChatHuggingFace.with_structured_output` raised `NotImplementedError` when given a Pydantic class with `method="function_calling"`, and returned plain dicts (never validated Pydantic instances) for `json_schema`/`json_mode` — even though the docstring advertises Pydantic support. Users following the documented API got a crash or unvalidated output.

This mirrors the established `langchain-groq`/`langchain-openai` pattern: `PydanticToolsParser` for function calling, `PydanticOutputParser` for the JSON methods. Also fixes the docstring and includes `json_schema` in the invalid-method error message.

Verified by new unit tests in `tests/unit_tests/test_chat_models.py` covering all three methods, the dict-schema path, and the invalid-method error; `ruff check` and `ruff format --check` pass on both files.