### PR TITLE
feat(partners): expose package versions for remaining partners

### DIFF
--- a/libs/partners/chroma/Makefile
+++ b/libs/partners/chroma/Makefile
@@ -54,6 +54,9 @@ format format_diff:
 check_imports: $(shell find langchain_chroma -name '*.py')
 	$(UV_RUN_LINT) python ./scripts/check_imports.py $^
 
+check_version:
+	uv run python ./scripts/check_version.py
+
 ######################
 # HELP
 ######################
@@ -61,6 +64,7 @@ check_imports: $(shell find langchain_chroma -name '*.py')
 help:
 	@echo '----'
 	@echo 'check_imports				- check imports'
+	@echo 'check_version                - validate version consistency'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'
 	@echo 'type                         - run type checking'

--- a/libs/partners/chroma/langchain_chroma/__init__.py
+++ b/libs/partners/chroma/langchain_chroma/__init__.py
@@ -1,7 +1,9 @@
 """LangChain integration for Chroma vector database."""
 
+from langchain_chroma._version import __version__
 from langchain_chroma.vectorstores import Chroma
 
 __all__ = [
     "Chroma",
+    "__version__",
 ]

--- a/libs/partners/chroma/langchain_chroma/_version.py
+++ b/libs/partners/chroma/langchain_chroma/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `langchain-chroma`."""
+
+__version__ = "1.1.0"

--- a/libs/partners/chroma/scripts/check_version.py
+++ b/libs/partners/chroma/scripts/check_version.py
@@ -1,0 +1,65 @@
+"""Check version consistency between `pyproject.toml` and `_version.py`.
+
+This script validates that the version defined in pyproject.toml matches the
+`__version__` variable in `langchain_chroma/_version.py`. Intended for use as a
+CI check to prevent version mismatches.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def get_pyproject_version(pyproject_path: Path) -> str | None:
+    """Extract version from `pyproject.toml`."""
+    content = pyproject_path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def get_version_py_version(version_path: Path) -> str | None:
+    """Extract `__version__` from `_version.py`."""
+    content = version_path.read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def main() -> int:
+    """Validate version consistency."""
+    script_dir = Path(__file__).parent
+    package_dir = script_dir.parent
+
+    pyproject_path = package_dir / "pyproject.toml"
+    version_path = package_dir / "langchain_chroma" / "_version.py"
+
+    if not pyproject_path.exists():
+        print(f"Error: {pyproject_path} not found")  # noqa: T201
+        return 1
+
+    if not version_path.exists():
+        print(f"Error: {version_path} not found")  # noqa: T201
+        return 1
+
+    pyproject_version = get_pyproject_version(pyproject_path)
+    version_py_version = get_version_py_version(version_path)
+
+    if pyproject_version is None:
+        print("Error: Could not find version in pyproject.toml")  # noqa: T201
+        return 1
+
+    if version_py_version is None:
+        print("Error: Could not find __version__ in langchain_chroma/_version.py")  # noqa: T201
+        return 1
+
+    if pyproject_version != version_py_version:
+        print("Error: Version mismatch detected!")  # noqa: T201
+        print(f"  pyproject.toml: {pyproject_version}")  # noqa: T201
+        print(f"  langchain_chroma/_version.py: {version_py_version}")  # noqa: T201
+        return 1
+
+    print(f"Version check passed: {pyproject_version}")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libs/partners/chroma/tests/unit_tests/test_imports.py
+++ b/libs/partners/chroma/tests/unit_tests/test_imports.py
@@ -2,6 +2,7 @@ from langchain_chroma import __all__
 
 EXPECTED_ALL = [
     "Chroma",
+    "__version__",
 ]
 
 

--- a/libs/partners/exa/Makefile
+++ b/libs/partners/exa/Makefile
@@ -57,6 +57,9 @@ format format_diff:
 check_imports: $(shell find langchain_exa -name '*.py')
 	$(UV_RUN_LINT) python ./scripts/check_imports.py $^
 
+check_version:
+	uv run python ./scripts/check_version.py
+
 ######################
 # HELP
 ######################
@@ -64,6 +67,7 @@ check_imports: $(shell find langchain_exa -name '*.py')
 help:
 	@echo '----'
 	@echo 'check_imports				- check imports'
+	@echo 'check_version                - validate version consistency'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'
 	@echo 'type                         - run type checking'

--- a/libs/partners/exa/langchain_exa/__init__.py
+++ b/libs/partners/exa/langchain_exa/__init__.py
@@ -5,6 +5,7 @@ from exa_py.api import (
     TextContentsOptions,
 )
 
+from langchain_exa._version import __version__
 from langchain_exa.retrievers import ExaSearchRetriever
 from langchain_exa.tools import ExaFindSimilarResults, ExaSearchResults
 
@@ -14,4 +15,5 @@ __all__ = [
     "ExaSearchRetriever",
     "HighlightsContentsOptions",
     "TextContentsOptions",
+    "__version__",
 ]

--- a/libs/partners/exa/langchain_exa/_version.py
+++ b/libs/partners/exa/langchain_exa/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `langchain-exa`."""
+
+__version__ = "1.1.0"

--- a/libs/partners/exa/scripts/check_version.py
+++ b/libs/partners/exa/scripts/check_version.py
@@ -1,0 +1,65 @@
+"""Check version consistency between `pyproject.toml` and `_version.py`.
+
+This script validates that the version defined in pyproject.toml matches the
+`__version__` variable in `langchain_exa/_version.py`. Intended for use as a
+CI check to prevent version mismatches.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def get_pyproject_version(pyproject_path: Path) -> str | None:
+    """Extract version from `pyproject.toml`."""
+    content = pyproject_path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def get_version_py_version(version_path: Path) -> str | None:
+    """Extract `__version__` from `_version.py`."""
+    content = version_path.read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def main() -> int:
+    """Validate version consistency."""
+    script_dir = Path(__file__).parent
+    package_dir = script_dir.parent
+
+    pyproject_path = package_dir / "pyproject.toml"
+    version_path = package_dir / "langchain_exa" / "_version.py"
+
+    if not pyproject_path.exists():
+        print(f"Error: {pyproject_path} not found")  # noqa: T201
+        return 1
+
+    if not version_path.exists():
+        print(f"Error: {version_path} not found")  # noqa: T201
+        return 1
+
+    pyproject_version = get_pyproject_version(pyproject_path)
+    version_py_version = get_version_py_version(version_path)
+
+    if pyproject_version is None:
+        print("Error: Could not find version in pyproject.toml")  # noqa: T201
+        return 1
+
+    if version_py_version is None:
+        print("Error: Could not find __version__ in langchain_exa/_version.py")  # noqa: T201
+        return 1
+
+    if pyproject_version != version_py_version:
+        print("Error: Version mismatch detected!")  # noqa: T201
+        print(f"  pyproject.toml: {pyproject_version}")  # noqa: T201
+        print(f"  langchain_exa/_version.py: {version_py_version}")  # noqa: T201
+        return 1
+
+    print(f"Version check passed: {pyproject_version}")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libs/partners/exa/tests/unit_tests/test_imports.py
+++ b/libs/partners/exa/tests/unit_tests/test_imports.py
@@ -8,6 +8,7 @@ EXPECTED_ALL = [
     "HighlightsContentsOptions",
     "TextContentsOptions",
     "ExaFindSimilarResults",
+    "__version__",
 ]
 
 

--- a/libs/partners/nomic/Makefile
+++ b/libs/partners/nomic/Makefile
@@ -57,6 +57,9 @@ format format_diff:
 check_imports: $(shell find langchain_nomic -name '*.py')
 	$(UV_RUN_LINT) python ./scripts/check_imports.py $^
 
+check_version:
+	uv run python ./scripts/check_version.py
+
 ######################
 # HELP
 ######################
@@ -64,6 +67,7 @@ check_imports: $(shell find langchain_nomic -name '*.py')
 help:
 	@echo '----'
 	@echo 'check_imports				- check imports'
+	@echo 'check_version                - validate version consistency'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'
 	@echo 'type                         - run type checking'

--- a/libs/partners/nomic/langchain_nomic/__init__.py
+++ b/libs/partners/nomic/langchain_nomic/__init__.py
@@ -1,5 +1,6 @@
 """Nomic partner integration for LangChain."""
 
+from langchain_nomic._version import __version__
 from langchain_nomic.embeddings import NomicEmbeddings
 
-__all__ = ["NomicEmbeddings"]
+__all__ = ["NomicEmbeddings", "__version__"]

--- a/libs/partners/nomic/langchain_nomic/_version.py
+++ b/libs/partners/nomic/langchain_nomic/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `langchain-nomic`."""
+
+__version__ = "1.0.1"

--- a/libs/partners/nomic/scripts/check_version.py
+++ b/libs/partners/nomic/scripts/check_version.py
@@ -1,0 +1,65 @@
+"""Check version consistency between `pyproject.toml` and `_version.py`.
+
+This script validates that the version defined in pyproject.toml matches the
+`__version__` variable in `langchain_nomic/_version.py`. Intended for use as a
+CI check to prevent version mismatches.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def get_pyproject_version(pyproject_path: Path) -> str | None:
+    """Extract version from `pyproject.toml`."""
+    content = pyproject_path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def get_version_py_version(version_path: Path) -> str | None:
+    """Extract `__version__` from `_version.py`."""
+    content = version_path.read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def main() -> int:
+    """Validate version consistency."""
+    script_dir = Path(__file__).parent
+    package_dir = script_dir.parent
+
+    pyproject_path = package_dir / "pyproject.toml"
+    version_path = package_dir / "langchain_nomic" / "_version.py"
+
+    if not pyproject_path.exists():
+        print(f"Error: {pyproject_path} not found")  # noqa: T201
+        return 1
+
+    if not version_path.exists():
+        print(f"Error: {version_path} not found")  # noqa: T201
+        return 1
+
+    pyproject_version = get_pyproject_version(pyproject_path)
+    version_py_version = get_version_py_version(version_path)
+
+    if pyproject_version is None:
+        print("Error: Could not find version in pyproject.toml")  # noqa: T201
+        return 1
+
+    if version_py_version is None:
+        print("Error: Could not find __version__ in langchain_nomic/_version.py")  # noqa: T201
+        return 1
+
+    if pyproject_version != version_py_version:
+        print("Error: Version mismatch detected!")  # noqa: T201
+        print(f"  pyproject.toml: {pyproject_version}")  # noqa: T201
+        print(f"  langchain_nomic/_version.py: {version_py_version}")  # noqa: T201
+        return 1
+
+    print(f"Version check passed: {pyproject_version}")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libs/partners/nomic/tests/unit_tests/test_imports.py
+++ b/libs/partners/nomic/tests/unit_tests/test_imports.py
@@ -4,6 +4,7 @@ from langchain_nomic import __all__
 
 EXPECTED_ALL = [
     "NomicEmbeddings",
+    "__version__",
 ]
 
 

--- a/libs/partners/qdrant/Makefile
+++ b/libs/partners/qdrant/Makefile
@@ -55,6 +55,9 @@ format format_diff:
 check_imports: $(shell find langchain_qdrant -name '*.py')
 	$(UV_RUN_LINT) python ./scripts/check_imports.py $^
 
+check_version:
+	uv run python ./scripts/check_version.py
+
 ######################
 # HELP
 ######################
@@ -62,6 +65,7 @@ check_imports: $(shell find langchain_qdrant -name '*.py')
 help:
 	@echo '----'
 	@echo 'check_imports				- check imports'
+	@echo 'check_version                - validate version consistency'
 	@echo 'format                       - run code formatters'
 	@echo 'lint                         - run linters'
 	@echo 'type                         - run type checking'

--- a/libs/partners/qdrant/langchain_qdrant/__init__.py
+++ b/libs/partners/qdrant/langchain_qdrant/__init__.py
@@ -1,5 +1,6 @@
 """Qdrant vector database integration for LangChain."""
 
+from langchain_qdrant._version import __version__
 from langchain_qdrant.fastembed_sparse import FastEmbedSparse
 from langchain_qdrant.qdrant import QdrantVectorStore, RetrievalMode
 from langchain_qdrant.sparse_embeddings import SparseEmbeddings, SparseVector
@@ -12,4 +13,5 @@ __all__ = [
     "RetrievalMode",
     "SparseEmbeddings",
     "SparseVector",
+    "__version__",
 ]

--- a/libs/partners/qdrant/langchain_qdrant/_version.py
+++ b/libs/partners/qdrant/langchain_qdrant/_version.py
@@ -1,0 +1,3 @@
+"""Version information for `langchain-qdrant`."""
+
+__version__ = "1.1.0"

--- a/libs/partners/qdrant/scripts/check_version.py
+++ b/libs/partners/qdrant/scripts/check_version.py
@@ -1,0 +1,65 @@
+"""Check version consistency between `pyproject.toml` and `_version.py`.
+
+This script validates that the version defined in pyproject.toml matches the
+`__version__` variable in `langchain_qdrant/_version.py`. Intended for use as a
+CI check to prevent version mismatches.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def get_pyproject_version(pyproject_path: Path) -> str | None:
+    """Extract version from `pyproject.toml`."""
+    content = pyproject_path.read_text(encoding="utf-8")
+    match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def get_version_py_version(version_path: Path) -> str | None:
+    """Extract `__version__` from `_version.py`."""
+    content = version_path.read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', content, re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def main() -> int:
+    """Validate version consistency."""
+    script_dir = Path(__file__).parent
+    package_dir = script_dir.parent
+
+    pyproject_path = package_dir / "pyproject.toml"
+    version_path = package_dir / "langchain_qdrant" / "_version.py"
+
+    if not pyproject_path.exists():
+        print(f"Error: {pyproject_path} not found")  # noqa: T201
+        return 1
+
+    if not version_path.exists():
+        print(f"Error: {version_path} not found")  # noqa: T201
+        return 1
+
+    pyproject_version = get_pyproject_version(pyproject_path)
+    version_py_version = get_version_py_version(version_path)
+
+    if pyproject_version is None:
+        print("Error: Could not find version in pyproject.toml")  # noqa: T201
+        return 1
+
+    if version_py_version is None:
+        print("Error: Could not find __version__ in langchain_qdrant/_version.py")  # noqa: T201
+        return 1
+
+    if pyproject_version != version_py_version:
+        print("Error: Version mismatch detected!")  # noqa: T201
+        print(f"  pyproject.toml: {pyproject_version}")  # noqa: T201
+        print(f"  langchain_qdrant/_version.py: {version_py_version}")  # noqa: T201
+        return 1
+
+    print(f"Version check passed: {pyproject_version}")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/libs/partners/qdrant/tests/unit_tests/test_imports.py
+++ b/libs/partners/qdrant/tests/unit_tests/test_imports.py
@@ -7,6 +7,7 @@ EXPECTED_ALL = [
     "SparseVector",
     "FastEmbedSparse",
     "RetrievalMode",
+    "__version__",
 ]
 
 


### PR DESCRIPTION
Chroma, Exa, Nomic, and Qdrant now expose package `__version__` values through package-local `_version.py` modules, matching the version-file pattern used by the other partner packages. Each package also gets a `check_version` target so release version drift between `pyproject.toml` and runtime exports is caught consistently.