### PR TITLE
fix: preserve data types in parse_partial_json by removing newlines outside strings (closes #36603)

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -94,6 +94,9 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
         elif char == '"':
             is_inside_string = True
             escaped = False
+        # Remove newlines outside strings to avoid breaking non-string values
+        elif char == "\n":
+            new_char = ""
         elif char == "{":
             stack.append("}")
         elif char == "[":


### PR DESCRIPTION
## What
The parse_partial_json function in langchain_core/utils/json.py was converting newlines inside strings to '\\n' but ignoring newlines outside strings. This caused non-string values (e.g., numbers, booleans) to be corrupted when a newline appeared near them, leading to OutputParserException when Pydantic models validated the parsed JSON because values were incorrectly typed (e.g., numbers became strings).

## Fix
Added handling of newline characters outside strings: they are now removed (replaced with empty string) rather than passed through. This ensures that JSON structure is preserved and non-string values retain their correct types. The fix is minimal and focused on the specific case described in the issue.

Closes #36603