### PR TITLE
fix(core): prevent `merge_dicts` from coercing differing booleans to int

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,6 +68,11 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
+            elif isinstance(merged[right_k], bool):
+                # bool is a subclass of int, so this check must come first.
+                # Differing booleans cannot be summed meaningfully (True + False = 1),
+                # so use last-wins to preserve the boolean type.
+                merged[right_k] = right_v
             elif isinstance(merged[right_k], int):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -65,6 +65,9 @@ def test_check_package_version(
         ({"a": 1.5}, {"a": 1.5}, {"a": 1.5}),
         ({"a": True}, {"a": True}, {"a": True}),
         ({"a": False}, {"a": False}, {"a": False}),
+        # Differing booleans: must stay bool (last-wins), not coerce to int.
+        ({"a": True}, {"a": False}, {"a": False}),
+        ({"a": False}, {"a": True}, {"a": True}),
         ({"a": "txt"}, {"a": "txt"}, {"a": "txttxt"}),
         ({"a": [1, 2]}, {"a": [1, 2]}, {"a": [1, 2, 1, 2]}),
         ({"a": {"b": "txt"}}, {"a": {"b": "txt"}}, {"a": {"b": "txttxt"}}),


### PR DESCRIPTION
Closes #38064

---

`bool` is a subclass of `int` in Python, so `isinstance(True, int)` returns `True`. When `merge_dicts` encounters two chunks carrying the same key with *differing* boolean values (e.g. `True` and `False`), the value falls through to the `int` branch and gets summed — silently changing the value's type from `bool` to `int` (`True + False = 1`).

This corrupts streaming aggregation for any provider that emits boolean flags in `additional_kwargs` or `response_metadata` where the value flips across chunks. The equal-boolean case (`True + True`, `False + False`) is safe because it's already short-circuited by the `merged[right_k] == right_v: continue` branch earlier in the function.

The fix adds a `bool` branch before the `int` branch with last-wins semantics (consistent with how `index`, `created`, and `timestamp` already handle int fields where summing is wrong). Two parametrised test cases are added for the differing-boolean paths that were previously missing.

*This contribution was drafted with assistance from Claude Code.*