### PR TITLE
[codex] Persist todo middleware to filesystem

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -1,6 +1,9 @@
 """Planning and task management middleware for agents."""
 
+import json
 from collections.abc import Awaitable, Callable
+from os import PathLike
+from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
@@ -205,6 +208,7 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
         *,
         system_prompt: str = WRITE_TODOS_SYSTEM_PROMPT,
         tool_description: str = WRITE_TODOS_TOOL_DESCRIPTION,
+        todos_file: str | PathLike[str] | None = None,
     ) -> None:
         """Initialize the `TodoListMiddleware` with optional custom prompts.
 
@@ -212,21 +216,79 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
             system_prompt: Custom system prompt to guide the agent on using the todo
                 tool.
             tool_description: Custom description for the `write_todos` tool.
+            todos_file: Optional path to a JSON file for persisting todo state across
+                agent runs.
         """
         super().__init__()
         self.system_prompt = system_prompt
         self.tool_description = tool_description
+        self.todos_file = Path(todos_file) if todos_file is not None else None
 
         self.tools = [
             StructuredTool.from_function(
                 name="write_todos",
                 description=tool_description,
-                func=_write_todos,
-                coroutine=_awrite_todos,
+                func=self._write_todos,
+                coroutine=self._awrite_todos,
                 args_schema=WriteTodosInput,
                 infer_schema=False,
             )
         ]
+
+    def _load_todos(self) -> list[Todo] | None:
+        """Load todos from the configured persistence file."""
+        if self.todos_file is None or not self.todos_file.exists():
+            return None
+
+        data = json.loads(self.todos_file.read_text(encoding="utf-8"))
+        todos = data["todos"] if isinstance(data, dict) else data
+        return WriteTodosInput.model_validate({"todos": todos}).todos
+
+    def _save_todos(self, todos: list[Todo]) -> None:
+        """Save todos to the configured persistence file."""
+        if self.todos_file is None:
+            return
+
+        self.todos_file.parent.mkdir(parents=True, exist_ok=True)
+        temp_file = self.todos_file.with_name(f"{self.todos_file.name}.tmp")
+        temp_file.write_text(
+            json.dumps({"todos": todos}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        temp_file.replace(self.todos_file)
+
+    def _write_todos(
+        self, runtime: ToolRuntime[ContextT, PlanningState[ResponseT]], todos: list[Todo]
+    ) -> Command[Any]:
+        """Create and manage a structured task list for your current work session."""
+        self._save_todos(todos)
+        return _write_todos(runtime, todos)
+
+    async def _awrite_todos(
+        self, runtime: ToolRuntime[ContextT, PlanningState[ResponseT]], todos: list[Todo]
+    ) -> Command[Any]:
+        """Create and manage a structured task list for your current work session."""
+        return self._write_todos(runtime, todos)
+
+    @override
+    def before_agent(
+        self, state: PlanningState[ResponseT], runtime: Runtime[ContextT]
+    ) -> dict[str, Any] | None:
+        """Load persisted todos before the agent starts if state has none."""
+        if "todos" in state:
+            return None
+
+        todos = self._load_todos()
+        if todos is None:
+            return None
+        return {"todos": todos}
+
+    @override
+    async def abefore_agent(
+        self, state: PlanningState[ResponseT], runtime: Runtime[ContextT]
+    ) -> dict[str, Any] | None:
+        """Load persisted todos before the agent starts if state has none."""
+        return self.before_agent(state, runtime)
 
     def wrap_model_call(
         self,

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -20,6 +22,8 @@ from langchain.agents.middleware.types import AgentState, ModelRequest, ModelRes
 from tests.unit_tests.agents.model import FakeToolCallingModel
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from langgraph.runtime import Runtime
 
 
@@ -295,6 +299,53 @@ def test_todo_middleware_custom_system_prompt_and_tool_description() -> None:
     assert tool.description == custom_tool_description
 
 
+def test_todo_middleware_loads_persisted_todos(tmp_path: Path) -> None:
+    """Test that TodoListMiddleware loads persisted todos before the agent starts."""
+    todos_file = tmp_path / "todos.json"
+    todos = [{"content": "Persisted task", "status": "in_progress"}]
+    todos_file.write_text(json.dumps({"todos": todos}), encoding="utf-8")
+
+    middleware = TodoListMiddleware(todos_file=todos_file)
+
+    result = middleware.before_agent({"messages": []}, _fake_runtime())
+
+    assert result == {"todos": todos}
+
+
+def test_todo_middleware_does_not_override_existing_todos(tmp_path: Path) -> None:
+    """Test that in-memory todo state takes precedence over persisted todos."""
+    todos_file = tmp_path / "todos.json"
+    todos_file.write_text(
+        json.dumps({"todos": [{"content": "Persisted task", "status": "pending"}]}),
+        encoding="utf-8",
+    )
+    state: PlanningState = {
+        "messages": [],
+        "todos": [{"content": "Current task", "status": "in_progress"}],
+    }
+    middleware = TodoListMiddleware(todos_file=todos_file)
+
+    result = middleware.before_agent(state, _fake_runtime())
+
+    assert result is None
+
+
+def test_todo_middleware_persists_todos_on_write(tmp_path: Path) -> None:
+    """Test that write_todos persists todo updates when a file is configured."""
+    todos_file = tmp_path / "nested" / "todos.json"
+    todos = [{"content": "Task 1", "status": "pending"}]
+    middleware = TodoListMiddleware(todos_file=todos_file)
+    runtime = cast(
+        "Any",
+        SimpleNamespace(tool_call_id="test_call", state={"messages": []}, context=None),
+    )
+
+    result = middleware._write_todos(runtime, todos)
+
+    assert result.update["todos"] == todos
+    assert json.loads(todos_file.read_text(encoding="utf-8")) == {"todos": todos}
+
+
 @pytest.mark.parametrize(
     ("todos", "expected_message"),
     [
@@ -411,6 +462,46 @@ def test_todo_middleware_agent_creation_with_middleware() -> None:
     # tool message (7)
     # ai message (8) - no tool calls
     assert len(result["messages"]) == 8
+
+
+def test_todo_middleware_agent_persists_todos(tmp_path: Path) -> None:
+    """Test that an agent persists todos when the middleware has a file."""
+    todos_file = tmp_path / "todos.json"
+    todos = [{"content": "Task 1", "status": "completed"}]
+    model = FakeToolCallingModel(
+        tool_calls=[
+            [
+                {
+                    "args": {"todos": todos},
+                    "name": "write_todos",
+                    "type": "tool_call",
+                    "id": "test_call",
+                }
+            ],
+            [],
+        ]
+    )
+    middleware = TodoListMiddleware(todos_file=todos_file)
+    agent = create_agent(model=model, middleware=[middleware])
+
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    assert result["todos"] == todos
+    assert json.loads(todos_file.read_text(encoding="utf-8")) == {"todos": todos}
+
+
+def test_todo_middleware_agent_loads_persisted_todos(tmp_path: Path) -> None:
+    """Test that an agent loads persisted todos at the start of a run."""
+    todos_file = tmp_path / "todos.json"
+    todos = [{"content": "Persisted task", "status": "in_progress"}]
+    todos_file.write_text(json.dumps({"todos": todos}), encoding="utf-8")
+    model = FakeToolCallingModel(tool_calls=[[]])
+    middleware = TodoListMiddleware(todos_file=todos_file)
+    agent = create_agent(model=model, middleware=[middleware])
+
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+
+    assert result["todos"] == todos
 
 
 def test_todo_middleware_custom_system_prompt_in_agent() -> None:


### PR DESCRIPTION
## Summary
- Add optional `todos_file` support to `TodoListMiddleware` for filesystem persistence.
- Persist `write_todos` updates as JSON and load persisted todos at agent start when state has no todos.
- Add focused unit coverage for load, save, state precedence, and agent-level persistence behavior.

Fixes #38066

## Testing
- `.venv/bin/ruff format --check libs/langchain_v1/langchain/agents/middleware/todo.py libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py`
- `.venv/bin/ruff check libs/langchain_v1/langchain/agents/middleware/todo.py libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py`
- `.venv/bin/pytest libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py -q`