### PR TITLE
fix(langchain): raise when structured output tool call is missing

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, SystemMessage, ToolMessage
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.constants import END, START
@@ -47,6 +47,7 @@ from langchain.agents.middleware.types import (
 from langchain.agents.structured_output import (
     AutoStrategy,
     MultipleStructuredOutputsError,
+    NoStructuredOutputError,
     OutputToolBinding,
     ProviderStrategy,
     ProviderStrategyBinding,
@@ -1087,11 +1088,21 @@ def create_agent(
             return {"messages": [output]}
 
         # Handle structured output with tool strategy
-        if (
-            isinstance(effective_response_format, ToolStrategy)
-            and isinstance(output, AIMessage)
-            and output.tool_calls
-        ):
+        if isinstance(effective_response_format, ToolStrategy) and isinstance(output, AIMessage):
+            if not output.tool_calls:
+                missing_output_error = NoStructuredOutputError(
+                    list(structured_output_tools), output
+                )
+                should_retry, error_message = _handle_structured_output_error(
+                    missing_output_error, effective_response_format
+                )
+                if not should_retry:
+                    raise missing_output_error
+
+                return {
+                    "messages": [output, HumanMessage(content=error_message)],
+                }
+
             structured_tool_calls = [
                 tc for tc in output.tool_calls if tc["name"] in structured_output_tools
             ]
@@ -1751,8 +1762,12 @@ def _make_model_to_tools_edge(
         tool_message_ids = [m.tool_call_id for m in tool_messages]
 
         # 3. If the model hasn't called any tools, exit the loop
-        # this is the classic exit condition for an agent loop
+        # this is the classic exit condition for an agent loop.
+        # When structured output is required, a retry instruction may be added
+        # after the AI message if the model forgot the structured output tool call.
         if len(last_ai_message.tool_calls) == 0:
+            if structured_output_tools and isinstance(state["messages"][-1], HumanMessage):
+                return model_destination
             return end_destination
 
         pending_tool_calls = [

--- a/libs/langchain_v1/langchain/agents/structured_output.py
+++ b/libs/langchain_v1/langchain/agents/structured_output.py
@@ -57,6 +57,25 @@ class MultipleStructuredOutputsError(StructuredOutputError):
         )
 
 
+class NoStructuredOutputError(StructuredOutputError):
+    """Raised when model fails to return a structured output tool call."""
+
+    def __init__(self, tool_names: list[str], ai_message: AIMessage) -> None:
+        """Initialize `NoStructuredOutputError`.
+
+        Args:
+            tool_names: The names of the expected structured output tools.
+            ai_message: The AI message that omitted the structured output tool call.
+        """
+        self.tool_names = tool_names
+        self.ai_message = ai_message
+
+        expected = ", ".join(tool_names) if tool_names else "structured output"
+        super().__init__(
+            f"Model failed to return the required structured response tool call for {expected}."
+        )
+
+
 class StructuredOutputValidationError(StructuredOutputError):
     """Raised when structured output tool call arguments fail to parse according to the schema."""
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -26,6 +26,7 @@ from langchain.agents.middleware.types import (
 from langchain.agents.structured_output import (
     MultipleStructuredOutputsError,
     ProviderStrategy,
+    StructuredOutputError,
     StructuredOutputValidationError,
     ToolStrategy,
 )
@@ -527,6 +528,57 @@ class TestResponseFormatAsToolStrategy:
             match=r".*WeatherBaseModel.*",
         ):
             agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+    def test_missing_structured_output_tool_call_without_retry(self) -> None:
+        """Test missing structured output tool call raises without retry."""
+        model = FakeToolCallingModel(tool_calls=[[]])
+
+        agent = create_agent(
+            model,
+            [],
+            response_format=ToolStrategy(
+                WeatherBaseModel,
+                handle_errors=False,
+            ),
+        )
+
+        with pytest.raises(
+            StructuredOutputError,
+            match=r".*WeatherBaseModel.*",
+        ):
+            agent.invoke(
+                {"messages": [HumanMessage("What's the weather?")]},
+                {"recursion_limit": 2},
+            )
+
+    def test_missing_structured_output_tool_call_with_retry(self) -> None:
+        """Test missing structured output tool call retries when configured."""
+        model = FakeToolCallingModel(
+            tool_calls=[
+                [],
+                [
+                    {
+                        "name": "WeatherBaseModel",
+                        "id": "1",
+                        "args": WEATHER_DATA,
+                    },
+                ],
+            ],
+        )
+
+        agent = create_agent(
+            model,
+            [get_weather],
+            response_format=ToolStrategy(WeatherBaseModel),
+        )
+
+        response = agent.invoke(
+            {"messages": [HumanMessage("What's the weather?")]},
+            {"recursion_limit": 4},
+        )
+
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+        assert len(response["messages"]) == 5
 
     def test_structured_output_parsing_error_with_retry(self) -> None:
         """Test that retry handles parsing errors for structured output."""


### PR DESCRIPTION
Fixes #36349

## What changed

When a ToolStrategy model returns a normal AI message without the required structured output tool call, the agent now treats that as a structured output error.

If retries are disabled, the agent raises the structured output error. If retries are enabled, it adds the same retry prompt path used by other structured output failures and routes back to the model. This also covers agents that have normal tools plus structured output tools, where the previous graph edge exited because there were no tool calls.

## Tests

```text
$ uv run pytest tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_missing_structured_output_tool_call_with_retry -q
1 passed in 0.27s
```

```text
$ uv run pytest tests/unit_tests/agents/test_response_format.py::TestResponseFormatAsToolStrategy::test_missing_structured_output_tool_call_without_retry -q
1 passed in 0.20s
```

```text
$ uv run pytest tests/unit_tests/agents/test_response_format.py -q
31 passed in 0.48s
```

```text
$ uv run ruff check langchain/agents/factory.py langchain/agents/structured_output.py tests/unit_tests/agents/test_response_format.py
All checks passed!

$ uv run ruff format --check langchain/agents/factory.py langchain/agents/structured_output.py tests/unit_tests/agents/test_response_format.py
3 files already formatted
```