### PR TITLE
feat(langchain): add state_schema to @wrap_tool_call decorator

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/types.py
+++ b/libs/langchain_v1/langchain/agents/middleware/types.py
@@ -2001,25 +2001,27 @@ def wrap_tool_call(
 def wrap_tool_call(
     func: None = None,
     *,
+    state_schema: type[StateT] | None = None,
     tools: list[BaseTool] | None = None,
     name: str | None = None,
 ) -> Callable[
     [_CallableReturningToolResponse],
-    AgentMiddleware,
+    AgentMiddleware[StateT],
 ]: ...
 
 
 def wrap_tool_call(
     func: _CallableReturningToolResponse | None = None,
     *,
+    state_schema: type[StateT] | None = None,
     tools: list[BaseTool] | None = None,
     name: str | None = None,
 ) -> (
     Callable[
         [_CallableReturningToolResponse],
-        AgentMiddleware,
+        AgentMiddleware[StateT],
     ]
-    | AgentMiddleware
+    | AgentMiddleware[StateT]
 ):
     """Create middleware with `wrap_tool_call` hook from a function.
 
@@ -2034,6 +2036,9 @@ def wrap_tool_call(
             `Command`.
 
             Can be sync or async.
+        state_schema: Custom state schema.
+
+            Defaults to `AgentState`.
         tools: Additional tools to register with this middleware.
         name: Middleware class name.
 
@@ -2101,13 +2106,13 @@ def wrap_tool_call(
 
     def decorator(
         func: _CallableReturningToolResponse,
-    ) -> AgentMiddleware:
+    ) -> AgentMiddleware[StateT]:
         is_async = iscoroutinefunction(func)
 
         if is_async:
 
             async def async_wrapped(
-                _self: AgentMiddleware,
+                _self: AgentMiddleware[StateT],
                 request: ToolCallRequest,
                 handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
             ) -> ToolMessage | Command[Any]:
@@ -2120,12 +2125,12 @@ def wrap_tool_call(
             # `type(...)` builds the correct middleware subclass at runtime, but
             # type checkers cannot infer its generic `AgentMiddleware` parameters.
             return cast(
-                "AgentMiddleware",
+                "AgentMiddleware[StateT]",
                 type(
                     middleware_name,
                     (AgentMiddleware,),
                     {
-                        "state_schema": AgentState,
+                        "state_schema": state_schema or AgentState,
                         "tools": tools or [],
                         "awrap_tool_call": async_wrapped,
                     },
@@ -2133,7 +2138,7 @@ def wrap_tool_call(
             )
 
         def wrapped(
-            _self: AgentMiddleware,
+            _self: AgentMiddleware[StateT],
             request: ToolCallRequest,
             handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
         ) -> ToolMessage | Command[Any]:
@@ -2144,12 +2149,12 @@ def wrap_tool_call(
         # `type(...)` builds the correct middleware subclass at runtime, but
         # type checkers cannot infer its generic `AgentMiddleware` parameters.
         return cast(
-            "AgentMiddleware",
+            "AgentMiddleware[StateT]",
             type(
                 middleware_name,
                 (AgentMiddleware,),
                 {
-                    "state_schema": AgentState,
+                    "state_schema": state_schema or AgentState,
                     "tools": tools or [],
                     "wrap_tool_call": wrapped,
                 },


### PR DESCRIPTION
Fixes #36409

---

Add `state_schema` parameter to `@wrap_tool_call` decorator to maintain API consistency with other middleware decorators like `@wrap_model_call`. This allows developers to define custom state schemas directly in tool call interceptors without being forced to use class-based middleware.

## Verification

- [x] Ran `make format` and `make lint` in `libs/langchain_v1`
- [x] Code follows the same pattern as `@wrap_model_call` decorator
- [x] Backward compatible - existing code without `state_schema` continues to work
- [x] Defaults to `AgentState` when not specified

## Breaking Changes

None - this is a backward-compatible addition.