### PR TITLE
fix(core): `add_texts` and `aadd_texts` exhaust generator inputs before creating documents

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -86,7 +86,7 @@ class VectorStore(ABC):
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             if ids is not None:
                 # For backward compatibility
@@ -226,7 +226,7 @@ class VectorStore(ABC):
 
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             return await self.aadd_documents(docs, **kwargs)
         return await run_in_executor(None, self.add_texts, texts, metadatas, **kwargs)

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -292,3 +292,49 @@ async def test_default_afrom_documents(vs_class: type[VectorStore]) -> None:
     store = await vs_class.afrom_documents([original_document], embeddings, ids=["6"])
     assert original_document.id == "7"  # original document should not be modified
     assert await store.aget_by_ids(["6"]) == [Document(id="6", page_content="baz")]
+
+
+# --- Regression tests for #37673 ---
+# VectorStore.add_texts / aadd_texts exhausted generator inputs before the fix.
+
+
+@pytest.mark.parametrize("vs_class", [CustomAddDocumentsVectorstore])
+def test_add_texts_with_generator_input(vs_class: type[VectorStore]) -> None:
+    """Regression test: add_texts must not exhaust a generator before building docs.
+
+    Before the fix, `texts_` was used for validation/length checks but the zip
+    still iterated the original `texts` iterable — which was already exhausted for
+    generators — resulting in zero documents being added.
+    """
+    store = vs_class()
+    ids = store.add_texts(text for text in ["alpha", "beta", "gamma"])
+    assert len(ids) == 3
+    docs = store.get_by_ids(ids)
+    assert [doc.page_content for doc in docs] == ["alpha", "beta", "gamma"]
+
+
+@pytest.mark.parametrize("vs_class", [CustomAddDocumentsVectorstore])
+def test_add_texts_generator_with_metadatas(vs_class: type[VectorStore]) -> None:
+    """Generator input with explicit metadatas must produce all documents."""
+    store = vs_class()
+    metadatas = [{"i": 0}, {"i": 1}]
+    ids = store.add_texts(
+        (text for text in ["x", "y"]),
+        metadatas=metadatas,
+    )
+    assert len(ids) == 2
+    docs = store.get_by_ids(ids)
+    assert docs[0].page_content == "x"
+    assert docs[0].metadata == {"i": 0}
+    assert docs[1].page_content == "y"
+    assert docs[1].metadata == {"i": 1}
+
+
+@pytest.mark.parametrize("vs_class", [CustomAddDocumentsVectorstore])
+async def test_aadd_texts_with_generator_input(vs_class: type[VectorStore]) -> None:
+    """Async regression: aadd_texts must not exhaust a generator before building docs."""
+    store = vs_class()
+    ids = await store.aadd_texts(text for text in ["alpha", "beta", "gamma"])
+    assert len(ids) == 3
+    docs = await store.aget_by_ids(ids)
+    assert [doc.page_content for doc in docs] == ["alpha", "beta", "gamma"]


### PR DESCRIPTION
Closes #37673

---

## Root cause

`VectorStore.add_texts` and `VectorStore.aadd_texts` materialize non-list/tuple iterables into a local variable `texts_` (for validation and length checks), but the downstream `zip` that builds the `Document` list still iterated the original `texts` parameter.

For generators and other single-pass iterables, `texts` was already exhausted after `list(texts)` ran on line 77/216, so the `zip` produced zero iterations → zero documents were added.

**Sync path** (`add_texts`, `libs/core/langchain_core/vectorstores/base.py`):
```python
# Before (line 89) — iterates already-exhausted texts
for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)

# After — iterates the materialized Sequence[str]
for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
```

**Async path** (`aadd_texts`, same file, line 229): identical one-character fix.

## Changes

| File | Change |
|------|--------|
| `libs/core/langchain_core/vectorstores/base.py` | `zip(texts, ...)` → `zip(texts_, ...)` in `add_texts` (L89) and `aadd_texts` (L229) |
| `libs/core/tests/unit_tests/vectorstores/test_vectorstore.py` | Three regression tests: sync generator, sync generator + metadatas, async generator |

## Tests

```
15 passed in 0.87s
```

All 3 new regression tests would have failed before this fix (yielding an empty document list) and pass after it. All existing tests continue to pass.