### PR TITLE
fix(core): prevent bool→int silent coercion in merge_dicts (#38064)

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -36,12 +36,6 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = right_v
             elif right_v is None:
                 continue
-            elif type(merged[right_k]) is not type(right_v):
-                msg = (
-                    f'additional_kwargs["{right_k}"] already exists in this message,'
-                    " but with a different type."
-                )
-                raise TypeError(msg)
             elif isinstance(merged[right_k], str):
                 # TODO: Add below special handling for 'type' key in 0.3 and remove
                 # merge_lists 'type' logic.
@@ -66,9 +60,17 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_dicts(merged[right_k], right_v)
             elif isinstance(merged[right_k], list):
                 merged[right_k] = merge_lists(merged[right_k], right_v)
+            elif isinstance(merged[right_k], bool) or isinstance(right_v, bool):
+                msg = (
+                    f"Additional kwargs key {right_k} already exists in left dict and "
+                    f"value has unsupported type {type(merged[right_k] if isinstance(merged[right_k], bool) else right_v)}."
+                )
+                raise TypeError(msg)
             elif merged[right_k] == right_v:
                 continue
-            elif isinstance(merged[right_k], int):
+            elif isinstance(merged[right_k], (int, float)) and not isinstance(
+                merged[right_k], bool
+            ) and isinstance(right_v, (int, float)) and not isinstance(right_v, bool):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:
                 # - index: identifies which tool call a chunk belongs to


### PR DESCRIPTION
## Problem
merge_dicts() silently converts differing bool values to int during 
streaming chunk aggregation. Since Python's bool is a subclass of int, 
True + False = 1, causing silent data corruption.

## Fix
Added explicit bool check before the int branch so differing bools 
raise a clear TypeError instead of silently coercing to int.

## Related Issue
Fixes #38064