### PR TITLE
fix(core): `merge_dicts` silently coerces differing `bool` values to `int` during streaming chunk aggregation

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,6 +68,11 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
+            elif isinstance(merged[right_k], bool):
+                # Last-wins for booleans. Because bool is a subclass of int,
+                # this check must precede the int branch to prevent silent
+                # coercion (True + False → 1).
+                merged[right_k] = right_v
             elif isinstance(merged[right_k], int):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -65,6 +65,9 @@ def test_check_package_version(
         ({"a": 1.5}, {"a": 1.5}, {"a": 1.5}),
         ({"a": True}, {"a": True}, {"a": True}),
         ({"a": False}, {"a": False}, {"a": False}),
+        # Differing booleans must stay bool, not coerce to int (#38064)
+        ({"a": True}, {"a": False}, {"a": False}),
+        ({"a": False}, {"a": True}, {"a": True}),
         ({"a": "txt"}, {"a": "txt"}, {"a": "txttxt"}),
         ({"a": [1, 2]}, {"a": [1, 2]}, {"a": [1, 2, 1, 2]}),
         ({"a": {"b": "txt"}}, {"a": {"b": "txt"}}, {"a": {"b": "txttxt"}}),
@@ -505,3 +508,37 @@ def test_merge_obj_tuple_raises() -> None:
     """Test `merge_obj` raises `ValueError` for tuples."""
     with pytest.raises(ValueError, match="Unable to merge"):
         merge_obj((1, 2), (3, 4))
+
+
+# --- Regression test for #38064 ---
+
+
+def test_merge_dicts_differing_bools_preserve_type() -> None:
+    """Regression test: differing booleans must produce bool, not int.
+
+    Before the fix, `isinstance(True, int)` was True so booleans fell into
+    the integer summation branch: True + False → 1 (int).
+    """
+    result = merge_dicts({"a": True}, {"a": False})
+    assert result == {"a": False}
+    assert isinstance(result["a"], bool), f"Expected bool, got {type(result['a'])}"
+
+    result2 = merge_dicts({"a": False}, {"a": True})
+    assert result2 == {"a": True}
+    assert isinstance(result2["a"], bool), f"Expected bool, got {type(result2['a'])}"
+
+
+def test_ai_message_chunk_add_preserves_bool_in_additional_kwargs() -> None:
+    """Regression test: AIMessageChunk.__add__ must not coerce bool to int.
+
+    The streaming chunk aggregation path uses merge_dicts under the hood.
+    A provider emitting a boolean flag like 'refusal' in additional_kwargs
+    must preserve bool type after chunk addition.
+    """
+    from langchain_core.messages import AIMessageChunk
+
+    a = AIMessageChunk(content="", additional_kwargs={"refusal": True})
+    b = AIMessageChunk(content="", additional_kwargs={"refusal": False})
+    merged = a + b
+    assert merged.additional_kwargs["refusal"] is False
+    assert isinstance(merged.additional_kwargs["refusal"], bool)


### PR DESCRIPTION
Closes #38064

---

## Root cause

`bool` is a subclass of `int` in Python, so `isinstance(True, int)` evaluates to `True`. In `merge_dicts` (which backs `AIMessageChunk.__add__`), the `isinstance(merged[right_k], int)` check catches booleans before they can be handled appropriately. When two chunks carry the same key with *differing* boolean values, the integer branch **sums** them:

```python
merged[right_k] += right_v   # True + False → 1 (int, not bool)
```

Equal booleans are safe — they hit the `merged[right_k] == right_v: continue` short-circuit. Only *differing* booleans corrupt.

A realistic trigger: a provider emitting a boolean flag like `refusal` in `additional_kwargs`, where one streamed chunk carries `True` and a later one carries `False`.

## Fix

Add an `isinstance(..., bool)` check **before** the `isinstance(..., int)` branch. Since `bool` is an `int` subclass, the more specific check must come first.

Semantics: **last-wins** for differing booleans, consistent with how `merge_dicts` already handles identification/temporal int fields (`index`, `created`, `timestamp`).

```diff
+            elif isinstance(merged[right_k], bool):
+                # Last-wins for booleans. Because bool is a subclass of int,
+                # this check must precede the int branch to prevent silent
+                # coercion (True + False → 1).
+                merged[right_k] = right_v
             elif isinstance(merged[right_k], int):
```

## Changes

| File | Change |
|------|--------|
| `libs/core/langchain_core/utils/_merge.py` | Add `bool` check before `int` branch (5 lines) |
| `libs/core/tests/unit_tests/utils/test_utils.py` | 2 parametrized cases + 2 standalone regression tests |

## Tests

```
84 passed, 2 xfailed in 0.12s
```

- `test_merge_dicts` parametrized: `True+False → False (bool)`, `False+True → True (bool)`
- `test_merge_dicts_differing_bools_preserve_type`: explicit type assertion
- `test_ai_message_chunk_add_preserves_bool_in_additional_kwargs`: end-to-end streaming path

All existing tests continue to pass unchanged.