### PR TITLE
fix(core): migrate legacy pydantic .dict() to .model_dump() (#38054)

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -724,7 +724,7 @@ class ChildTool(BaseTool):
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
                 result = input_args.parse_obj(tool_input)
-                result_dict = result.dict()
+                result_dict = result.model_dump()
             else:
                 msg = (
                     f"args_schema must be a Pydantic BaseModel, got {self.args_schema}"

--- a/libs/core/langchain_core/tracers/_compat.py
+++ b/libs/core/langchain_core/tracers/_compat.py
@@ -33,7 +33,7 @@ def run_to_dict(run: Run, **kwargs: Any) -> dict[str, Any]:
     """
     if _RUN_IS_PYDANTIC_V2:
         return run.model_dump(**kwargs)
-    return run.dict(**kwargs)  # type: ignore[deprecated]
+    return run.model_dump(**kwargs)  # type: ignore[deprecated]
 
 
 def run_copy(run: Run, **kwargs: Any) -> Run:
@@ -77,7 +77,7 @@ def pydantic_to_dict(obj: Any, **kwargs: Any) -> dict[str, Any]:
     """
     if _RUN_IS_PYDANTIC_V2:
         return obj.model_dump(**kwargs)  # type: ignore[no-any-return]
-    return obj.dict(**kwargs)  # type: ignore[no-any-return]
+    return obj.model_dump(**kwargs)  # type: ignore[no-any-return]
 
 
 def pydantic_copy(obj: T, **kwargs: Any) -> T:


### PR DESCRIPTION
## Problem
Legacy Pydantic V1 `.dict()` calls in langchain-core cause 
PydanticDeprecatedSince20 warnings. Pydantic V2 requires 
`.model_dump()` instead.

## Fix
Replaced `.dict()` with `.model_dump()` in:
- `libs/core/langchain_core/tools/base.py` (line 727)
- `libs/core/langchain_core/tracers/_compat.py` (lines 36, 80)

## Related Issue
Fixes #38054