### PR TITLE
fix(core): preserve generator inputs in `VectorStore.add_texts`

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -84,9 +84,13 @@ class VectorStore(ABC):
                 raise ValueError(msg)
             metadatas_ = iter(metadatas) if metadatas else cycle([{}])
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
+            # Reuse the materialized sequence so one-shot iterables such as generators
+            # are not exhausted before the documents are constructed.
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(
+                    texts_, metadatas_, ids_, strict=False
+                )
             ]
             if ids is not None:
                 # For backward compatibility
@@ -224,9 +228,13 @@ class VectorStore(ABC):
             metadatas_ = iter(metadatas) if metadatas else cycle([{}])
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
 
+            # Reuse the materialized sequence so one-shot iterables such as generators
+            # are not exhausted before the documents are constructed.
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(
+                    texts_, metadatas_, ids_, strict=False
+                )
             ]
             return await self.aadd_documents(docs, **kwargs)
         return await run_in_executor(None, self.add_texts, texts, metadatas, **kwargs)

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -117,6 +117,51 @@ class CustomAddDocumentsVectorstore(VectorStore):
         raise NotImplementedError
 
 
+class CustomAsyncAddDocumentsVectorstore(VectorStore):
+    """A VectorStore that only implements async add documents."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, Document] = {}
+
+    @override
+    async def aadd_documents(
+        self,
+        documents: list[Document],
+        *,
+        ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        ids_ = []
+        ids_iter = iter(ids or [])
+        for document in documents:
+            id_ = next(ids_iter) if ids else document.id or str(uuid.uuid4())
+            self.store[id_] = Document(
+                id=id_, page_content=document.page_content, metadata=document.metadata
+            )
+            ids_.append(id_)
+        return ids_
+
+    def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        return [self.store[id_] for id_ in ids if id_ in self.store]
+
+    @classmethod
+    @override
+    def from_texts(
+        cls,
+        texts: list[str],
+        embedding: Embeddings,
+        metadatas: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> CustomAsyncAddDocumentsVectorstore:
+        msg = "This test vector store only supports async document insertion."
+        raise NotImplementedError(msg)
+
+    def similarity_search(
+        self, query: str, k: int = 4, **kwargs: Any
+    ) -> list[Document]:
+        raise NotImplementedError
+
+
 @pytest.mark.parametrize(
     "vs_class", [CustomAddTextsVectorstore, CustomAddDocumentsVectorstore]
 )
@@ -178,6 +223,34 @@ def test_default_add_texts(vs_class: type[VectorStore]) -> None:
     ]
 
 
+def test_default_add_texts_accepts_generators() -> None:
+    store = CustomAddDocumentsVectorstore()
+
+    ids = store.add_texts((text for text in ["alpha", "beta"]))
+
+    assert len(ids) == 2
+    assert store.get_by_ids(ids) == [
+        Document(id=ids[0], page_content="alpha"),
+        Document(id=ids[1], page_content="beta"),
+    ]
+
+
+def test_default_add_texts_preserves_generator_metadata_and_ids() -> None:
+    store = CustomAddDocumentsVectorstore()
+
+    ids = store.add_texts(
+        (text for text in ["alpha", "beta"]),
+        metadatas=[{"source": "a"}, {"source": "b"}],
+        ids=["doc-1", "doc-2"],
+    )
+
+    assert ids == ["doc-1", "doc-2"]
+    assert store.get_by_ids(ids) == [
+        Document(id="doc-1", page_content="alpha", metadata={"source": "a"}),
+        Document(id="doc-2", page_content="beta", metadata={"source": "b"}),
+    ]
+
+
 @pytest.mark.parametrize(
     "vs_class", [CustomAddTextsVectorstore, CustomAddDocumentsVectorstore]
 )
@@ -233,6 +306,34 @@ async def test_default_aadd_texts(vs_class: type[VectorStore]) -> None:
     assert await store.aget_by_ids(ids_2) == [
         Document(id=ids_2[0], page_content="foo", metadata={"foo": "bar"}),
         Document(id=ids_2[1], page_content="bar", metadata={"foo": "bar"}),
+    ]
+
+
+async def test_default_aadd_texts_accepts_generators() -> None:
+    store = CustomAsyncAddDocumentsVectorstore()
+
+    ids = await store.aadd_texts((text for text in ["alpha", "beta"]))
+
+    assert len(ids) == 2
+    assert await store.aget_by_ids(ids) == [
+        Document(id=ids[0], page_content="alpha"),
+        Document(id=ids[1], page_content="beta"),
+    ]
+
+
+async def test_default_aadd_texts_preserves_generator_metadata_and_ids() -> None:
+    store = CustomAsyncAddDocumentsVectorstore()
+
+    ids = await store.aadd_texts(
+        (text for text in ["alpha", "beta"]),
+        metadatas=[{"source": "a"}, {"source": "b"}],
+        ids=["doc-1", "doc-2"],
+    )
+
+    assert ids == ["doc-1", "doc-2"]
+    assert await store.aget_by_ids(ids) == [
+        Document(id="doc-1", page_content="alpha", metadata={"source": "a"}),
+        Document(id="doc-2", page_content="beta", metadata={"source": "b"}),
     ]
 
 


### PR DESCRIPTION
Fixes #37673

---

`VectorStore.add_texts` and `VectorStore.aadd_texts` could consume generator inputs before building `Document` objects, causing generator-based inserts to add no documents. This change reuses the materialized text sequence and adds regression tests for sync and async generator inputs, including metadata and id handling.

How did you verify your code works?

- Ran `./.venv/bin/pytest tests/unit_tests/vectorstores/test_vectorstore.py -q`
- Confirmed all 16 tests passed

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/yojr23
