### PR TITLE
test(openai): use `gpt-4o` for image token counting

### DIFF
--- a/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_base.py
@@ -708,7 +708,7 @@ async def test_openai_response_headers_async(use_responses_api: bool) -> None:
 
 
 def test_image_token_counting_jpeg() -> None:
-    model = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+    model = ChatOpenAI(model="gpt-4o", temperature=0)
     image_url = "https://raw.githubusercontent.com/langchain-ai/docs/9f99bb977307a1bd5efeb8dc6b67eb13904c4af1/src/oss/images/checkpoints.jpg"
     message = HumanMessage(
         content=[
@@ -742,7 +742,7 @@ def test_image_token_counting_jpeg() -> None:
 
 
 def test_image_token_counting_png() -> None:
-    model = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+    model = ChatOpenAI(model="gpt-4o", temperature=0)
     image_url = "https://raw.githubusercontent.com/langchain-ai/docs/4d11d08b6b0e210bd456943f7a22febbd168b543/src/images/agentic-rag-output.png"
     message = HumanMessage(
         content=[


### PR DESCRIPTION
Image token counting integration coverage is pinned back to `gpt-4o`, whose usage metadata matches the local vision token estimator. A recent model refresh moved these checks to `gpt-4.1-mini`, which reports different live image token usage and broke the exact equality assertions.