### PR TITLE
style(core,langchain,langchain-classic,partners): replace double backticks in docstrings

### DIFF
--- a/libs/core/langchain_core/prompts/loading.py
+++ b/libs/core/langchain_core/prompts/loading.py
@@ -20,13 +20,13 @@ logger = logging.getLogger(__name__)
 
 
 def _validate_path(path: Path) -> None:
-    """Reject absolute paths and ``..`` traversal components.
+    """Reject absolute paths and `..` traversal components.
 
     Args:
         path: The path to validate.
 
     Raises:
-        ValueError: If the path is absolute or contains ``..`` components.
+        ValueError: If the path is absolute or contains `..` components.
     """
     if path.is_absolute():
         msg = (
@@ -59,10 +59,10 @@ def load_prompt_from_config(
 
     Args:
         config: Dict containing the prompt configuration.
-        allow_dangerous_paths: If ``False`` (default), file paths in the
-            config (such as ``template_path``, ``examples``, and
-            ``example_prompt_path``) are validated to reject absolute paths
-            and directory traversal (``..``) sequences. Set to ``True`` only
+        allow_dangerous_paths: If `False` (default), file paths in the
+            config (such as `template_path`, `examples`, and
+            `example_prompt_path`) are validated to reject absolute paths
+            and directory traversal (`..`) sequences. Set to `True` only
             if you trust the source of the config.
 
     Returns:
@@ -221,10 +221,10 @@ def load_prompt(
     Args:
         path: Path to the prompt file.
         encoding: Encoding of the file.
-        allow_dangerous_paths: If ``False`` (default), file paths referenced
-            inside the loaded config (such as ``template_path``, ``examples``,
-            and ``example_prompt_path``) are validated to reject absolute paths
-            and directory traversal (``..``) sequences. Set to ``True`` only
+        allow_dangerous_paths: If `False` (default), file paths referenced
+            inside the loaded config (such as `template_path`, `examples`,
+            and `example_prompt_path`) are validated to reject absolute paths
+            and directory traversal (`..`) sequences. Set to `True` only
             if you trust the source of the config.
 
     Returns:

--- a/libs/core/langchain_core/tracers/langchain.py
+++ b/libs/core/langchain_core/tracers/langchain.py
@@ -193,7 +193,7 @@ class LangChainTracer(BaseTracer):
             merged_metadata = dict(base_metadata)
             for key, value in metadata.items():
                 # For allowlisted LangSmith-only inheritable metadata keys
-                # (e.g. ``ls_agent_type``), nested callers are allowed to
+                # (e.g. `ls_agent_type`), nested callers are allowed to
                 # OVERRIDE the value inherited from an ancestor. For all
                 # other keys we keep the existing "first wins" behavior so
                 # that ancestor-provided tracing metadata is not accidentally
@@ -473,14 +473,14 @@ def _patch_missing_metadata(self: LangChainTracer, run: Run) -> None:
     metadata = run.metadata
     patched = None
     for k, v in self.tracing_metadata.items():
-        # ``OVERRIDABLE_LANGSMITH_INHERITABLE_METADATA_KEYS`` are a small,
+        # `OVERRIDABLE_LANGSMITH_INHERITABLE_METADATA_KEYS` are a small,
         # LangSmith-only allowlist that bypasses the "first wins" merge
         # so a nested caller (e.g. a subagent) can override a parent-set value.
         if k not in metadata or k in OVERRIDABLE_LANGSMITH_INHERITABLE_METADATA_KEYS:
             # Skip the copy when the value already matches (avoids cloning
             # the shared dict in the common "already set" case). Use a
-            # ``k in metadata`` guard so a legitimate missing key whose
-            # tracer value happens to be ``None`` is still patched in.
+            # `k in metadata` guard so a legitimate missing key whose
+            # tracer value happens to be `None` is still patched in.
             if k in metadata and metadata[k] == v:
                 continue
             if patched is None:

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -61,9 +61,9 @@ from langchain.chat_models import init_chat_model
 
 @dataclass
 class _ComposedExtendedModelResponse(Generic[ResponseT]):
-    """Internal result from composed ``wrap_model_call`` middleware.
+    """Internal result from composed `wrap_model_call` middleware.
 
-    Unlike ``ExtendedModelResponse`` (user-facing, single command), this holds the
+    Unlike `ExtendedModelResponse` (user-facing, single command), this holds the
     full list of commands accumulated across all middleware layers during
     composition.
     """
@@ -139,7 +139,7 @@ Option 2: Handle dynamic tools in middleware (for tools created at runtime)
 
 
 def _scrub_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
-    """Remove ``runtime`` and ``handler`` from trace inputs before sending to LangSmith."""
+    """Remove `runtime` and `handler` from trace inputs before sending to LangSmith."""
     filtered = inputs.copy()
     filtered.pop("handler", None)
     req = filtered.get("request")
@@ -178,8 +178,8 @@ def _normalize_to_model_response(
 ) -> ModelResponse:
     """Normalize middleware return value to ModelResponse.
 
-    At inner composition boundaries, ``ExtendedModelResponse`` is unwrapped to its
-    underlying ``ModelResponse`` so that inner middleware always sees ``ModelResponse``
+    At inner composition boundaries, `ExtendedModelResponse` is unwrapped to its
+    underlying `ModelResponse` so that inner middleware always sees `ModelResponse`
     from the handler.
     """
     if isinstance(result, AIMessage):
@@ -205,7 +205,7 @@ def _build_commands(
             composition (inner-first ordering).
 
     Returns:
-        List of ``Command`` objects ready to be returned from a model node.
+        List of `Command` objects ready to be returned from a model node.
     """
     state: dict[str, Any] = {"messages": model_response.result}
 
@@ -234,7 +234,7 @@ def _build_commands(
 def _chain_model_call_handlers(
     handlers: Sequence[_ModelCallHandler[ContextT]],
 ) -> _ComposedModelCallHandler[ContextT] | None:
-    """Compose multiple ``wrap_model_call`` handlers into single middleware stack.
+    """Compose multiple `wrap_model_call` handlers into single middleware stack.
 
     Composes handlers so first in list becomes outermost layer. Each handler receives a
     handler callback to execute inner layers. Commands from each layer are accumulated
@@ -246,8 +246,8 @@ def _chain_model_call_handlers(
             First handler wraps all others.
 
     Returns:
-        Composed handler returning ``_ComposedExtendedModelResponse``,
-        or ``None`` if handlers empty.
+        Composed handler returning `_ComposedExtendedModelResponse`,
+        or `None` if handlers empty.
     """
     if not handlers:
         return None
@@ -326,7 +326,7 @@ def _chain_model_call_handlers(
 def _chain_async_model_call_handlers(
     handlers: Sequence[_AsyncModelCallHandler[ContextT]],
 ) -> _ComposedAsyncModelCallHandler[ContextT] | None:
-    """Compose multiple async ``wrap_model_call`` handlers into single middleware stack.
+    """Compose multiple async `wrap_model_call` handlers into single middleware stack.
 
     Commands from each layer are accumulated into a list (inner-first, then outer)
     without merging.
@@ -337,8 +337,8 @@ def _chain_async_model_call_handlers(
             First handler wraps all others.
 
     Returns:
-        Composed async handler returning ``_ComposedExtendedModelResponse``,
-        or ``None`` if handlers empty.
+        Composed async handler returning `_ComposedExtendedModelResponse`,
+        or `None` if handlers empty.
     """
     if not handlers:
         return None

--- a/libs/langchain_v1/langchain/agents/middleware/_execution.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_execution.py
@@ -276,7 +276,7 @@ class DockerExecutionPolicy(BaseExecutionPolicy):
 
     The security guarantees depend on your Docker daemon configuration. Run the agent on
     a host where Docker is locked down (rootless mode, AppArmor/SELinux, etc.) and
-    review any additional volumes or capabilities passed through ``extra_run_args``. The
+    review any additional volumes or capabilities passed through `extra_run_args`. The
     default image is `python:3.12-alpine3.19`; supply a custom image if you need
     preinstalled tooling.
     """

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -33,7 +33,7 @@ class TestFilesystemGrepSearch:
     def test_ripgrep_command_uses_literal_pattern(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Ensure ripgrep receives pattern after ``--`` to avoid option parsing."""
+        """Ensure ripgrep receives pattern after `--` to avoid option parsing."""
         (tmp_path / "example.py").write_text("print('hello')\n", encoding="utf-8")
 
         middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=True)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_execution_policies.py
@@ -27,7 +27,7 @@ def _make_resource(
     with_prlimit: bool,
     has_rlimit_as: bool = True,
 ) -> Any:
-    """Create a fake ``resource`` module for testing."""
+    """Create a fake `resource` module for testing."""
 
     class _BaseResource:
         RLIMIT_CPU = 0

--- a/libs/langchain_v1/tests/unit_tests/agents/test_subagent_streaming.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_subagent_streaming.py
@@ -1,9 +1,9 @@
 """Regression tests for subagent stream event propagation.
 
-Reproduces a bug where `create_agent` set ``ls_agent_type`` inside the
-parent agent's ``configurable`` and, as a side effect, ``updates``,
-``values``, and ``custom`` stream events from sub-agents invoked through
-tools were dropped during ``stream(..., subgraphs=True)``.
+Reproduces a bug where `create_agent` set `ls_agent_type` inside the
+parent agent's `configurable` and, as a side effect, `updates`,
+`values`, and `custom` stream events from sub-agents invoked through
+tools were dropped during `stream(..., subgraphs=True)`.
 """
 
 from __future__ import annotations
@@ -46,8 +46,8 @@ def _make_parent_agent(call_subagent_tool) -> object:
 def test_subagent_updates_emitted_when_streaming_with_subgraphs() -> None:
     """`updates` events from a tool-invoked sub-agent must be streamed.
 
-    Without the fix, the parent agent's ``configurable`` overrode the
-    streaming machinery's per-run state, suppressing ``updates`` events
+    Without the fix, the parent agent's `configurable` overrode the
+    streaming machinery's per-run state, suppressing `updates` events
     from any sub-graph invoked inside a tool.
     """
     call_subagent_tool = _make_subagent_caller_tool()

--- a/libs/partners/fireworks/tests/integration_tests/_rate_limiter.py
+++ b/libs/partners/fireworks/tests/integration_tests/_rate_limiter.py
@@ -1,6 +1,6 @@
 """Shared rate limiter for Fireworks integration tests.
 
-Scaled by ``PYTEST_XDIST_WORKER_COUNT`` so aggregate QPS across all xdist
+Scaled by `PYTEST_XDIST_WORKER_COUNT` so aggregate QPS across all xdist
 workers stays bounded near the target rate.
 """
 

--- a/libs/partners/mistralai/tests/integration_tests/_rate_limiter.py
+++ b/libs/partners/mistralai/tests/integration_tests/_rate_limiter.py
@@ -1,6 +1,6 @@
 """Shared rate limiter for Mistral integration tests.
 
-Scaled by ``PYTEST_XDIST_WORKER_COUNT`` so aggregate QPS across all xdist
+Scaled by `PYTEST_XDIST_WORKER_COUNT` so aggregate QPS across all xdist
 workers stays bounded near the target rate.
 """
 

--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -892,13 +892,13 @@ class ChatOllama(BaseChatModel):
         self,
         response_format: dict[str, Any],
     ) -> dict[str, Any] | None:
-        """Extract the raw JSON schema from an OpenAI ``json_schema`` envelope.
+        """Extract the raw JSON schema from an OpenAI `json_schema` envelope.
 
         Args:
-            response_format: A dict with ``type: "json_schema"``.
+            response_format: A dict with `type: "json_schema"`.
 
         Returns:
-            The raw JSON schema dict, or ``None`` if extraction fails.
+            The raw JSON schema dict, or `None` if extraction fails.
         """
         json_schema_block = response_format.get("json_schema")
         if not isinstance(json_schema_block, dict):

--- a/libs/partners/openai/langchain_openai/middleware/openai_moderation.py
+++ b/libs/partners/openai/langchain_openai/middleware/openai_moderation.py
@@ -22,7 +22,7 @@ DEFAULT_VIOLATION_TEMPLATE = (
 
 
 class OpenAIModerationError(RuntimeError):
-    """Raised when OpenAI flags content and `exit_behavior` is set to ``"error"``."""
+    """Raised when OpenAI flags content and `exit_behavior` is set to `"error"`."""
 
     def __init__(
         self,

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
@@ -207,7 +207,7 @@ def test_apply_patch() -> None:
 
     apply_patch is a client-executed tool: the model proposes a file operation
     via an `apply_patch_call` block, the client applies it, and the result is
-    returned as an ``apply_patch_call_output`` block. Requires a model that
+    returned as an `apply_patch_call_output` block. Requires a model that
     supports the tool.
     """
     prompt = "Create a new file named hello.txt containing the line: hello world"

--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -1475,7 +1475,7 @@ def _convert_chunk_to_message_chunk(  # noqa: C901, PLR0911, PLR0912
 
 
 def _lc_tool_call_to_openrouter_tool_call(tool_call: ToolCall) -> dict[str, Any]:
-    """Convert a LangChain ``ToolCall`` to an OpenRouter tool call dict.
+    """Convert a LangChain `ToolCall` to an OpenRouter tool call dict.
 
     Serializes `args` (a dict) via `json.dumps`.
     """

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -2638,7 +2638,7 @@ class TestFormatMessageContent:
         assert result[0]["video_url"]["url"].startswith("data:video/mp4;base64,")
 
     def test_video_base64_source_type_format(self) -> None:
-        """Test video block using ``source_type`` + ``data`` keys."""
+        """Test video block using `source_type` + `data` keys."""
         block: dict[str, Any] = {
             "type": "video",
             "source_type": "base64",
@@ -2713,7 +2713,7 @@ class TestFormatMessageContent:
         }
 
     def test_file_base64_source_type_format(self) -> None:
-        """Test file block using ``source_type`` + ``data`` keys."""
+        """Test file block using `source_type` + `data` keys."""
         block: dict[str, Any] = {
             "type": "file",
             "source_type": "base64",
@@ -2782,7 +2782,7 @@ class TestFormatMessageContent:
 
 
 class TestWrapMessagesForSdk:
-    """Tests for ``_wrap_messages_for_sdk`` SDK validation bypass."""
+    """Tests for `_wrap_messages_for_sdk` SDK validation bypass."""
 
     def test_no_file_blocks_returns_dicts(self) -> None:
         """Messages without file blocks should be returned as plain dicts."""
@@ -2795,7 +2795,7 @@ class TestWrapMessagesForSdk:
         assert result is msgs
 
     def test_has_file_content_blocks_detection(self) -> None:
-        """Test ``_has_file_content_blocks`` detects file blocks correctly."""
+        """Test `_has_file_content_blocks` detects file blocks correctly."""
         assert not _has_file_content_blocks([{"role": "user", "content": "plain text"}])
         assert not _has_file_content_blocks(
             [

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -241,7 +241,7 @@ def test_profile() -> None:
 
 
 def test_convert_tool_message_to_dict() -> None:
-    """A ToolMessage serializes to a ``tool``-role dict so tool results can be
+    """A ToolMessage serializes to a `tool`-role dict so tool results can be
     fed back to the model in a client-side tool-calling loop."""
     llm = ChatPerplexity(model="test", api_key="test")
     message = ToolMessage(content="result text", tool_call_id="call_123")
@@ -253,7 +253,7 @@ def test_convert_tool_message_to_dict() -> None:
 
 
 def test_convert_ai_message_with_tool_calls_to_dict() -> None:
-    """``AIMessage.tool_calls`` are serialized rather than dropped."""
+    """`AIMessage.tool_calls` are serialized rather than dropped."""
     llm = ChatPerplexity(model="test", api_key="test")
     message = AIMessage(
         content="",
@@ -606,7 +606,7 @@ def test_convert_responses_stream_event_aggregates_multiple_tool_calls() -> None
     `call_id`/`id` are intentionally omitted so that `index` (derived from each
     event's `output_index`) is the *only* thing separating the two calls. This
     keeps the test sensitive to the indexing logic: with a hardcoded
-    ``index=0`` the chunks would merge into one corrupted call. Real streams
+    `index=0` the chunks would merge into one corrupted call. Real streams
     always carry a unique `call_id`, which would keep the calls distinct on its
     own, so this payload isolates the mechanism rather than mirroring the wire
     format.


### PR DESCRIPTION
Standardizes inline code markup in Python docstrings and comments by replacing Sphinx-style double backticks with single-backtick Markdown. The cleanup keeps existing code fences intact while aligning inline references with the repo's docstring convention.

## Changes
- Converted inline code references in core prompt-loading docs and LangSmith tracer comments, including `..`, `allow_dangerous_paths`, and inheritable metadata keys.
- Normalized agent-related docstrings and comments around `wrap_model_call`, `ExtendedModelResponse`, `Command`, `create_structured_chat_agent`, and `DockerExecutionPolicy`.
- Updated partner package docstrings for inline references such as `json_schema`, `ToolCall`, `apply_patch_call_output`, OpenRouter content block keys, and Perplexity tool-call serialization.
- Cleaned test and helper docstrings that referenced command separators, fake `resource` modules, stream event names, and xdist rate-limit environment variables.