### PR TITLE
[codex] fix(core): preserve block ids when reparsing v0 content blocks

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/langchain_v0.py
+++ b/libs/core/langchain_core/messages/block_translators/langchain_v0.py
@@ -80,6 +80,7 @@ def _convert_legacy_v0_content_block_to_v1(
             known_keys = {"mime_type", "type", "source_type", "url"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
+                extras.pop("id", None)
                 return types.create_image_block(
                     url=block["url"],
                     mime_type=block.get("mime_type"),
@@ -105,6 +106,7 @@ def _convert_legacy_v0_content_block_to_v1(
             known_keys = {"mime_type", "type", "source_type", "data"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
+                extras.pop("id", None)
                 return types.create_image_block(
                     base64=block["data"],
                     mime_type=block.get("mime_type"),
@@ -148,6 +150,7 @@ def _convert_legacy_v0_content_block_to_v1(
             known_keys = {"mime_type", "type", "source_type", "url"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
+                extras.pop("id", None)
                 return types.create_audio_block(
                     url=block["url"],
                     mime_type=block.get("mime_type"),
@@ -175,6 +178,7 @@ def _convert_legacy_v0_content_block_to_v1(
             known_keys = {"mime_type", "type", "source_type", "data"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
+                extras.pop("id", None)
                 return types.create_audio_block(
                     base64=block["data"],
                     mime_type=block.get("mime_type"),
@@ -219,6 +223,7 @@ def _convert_legacy_v0_content_block_to_v1(
             known_keys = {"mime_type", "type", "source_type", "url"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
+                extras.pop("id", None)
                 return types.create_file_block(
                     url=block["url"],
                     mime_type=block.get("mime_type"),
@@ -245,6 +250,7 @@ def _convert_legacy_v0_content_block_to_v1(
             known_keys = {"mime_type", "type", "source_type", "data"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
+                extras.pop("id", None)
                 return types.create_file_block(
                     base64=block["data"],
                     mime_type=block.get("mime_type"),
@@ -276,6 +282,7 @@ def _convert_legacy_v0_content_block_to_v1(
             known_keys = {"mime_type", "type", "source_type", "url"}
             extras = _extract_v0_extras(block, known_keys)
             if "id" in block:
+                extras.pop("id", None)
                 return types.create_plaintext_block(
                     # In v0, URL points to the text file content
                     # TODO: attribute this claim

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -45,6 +45,7 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
+from langchain_core.messages import content as types
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.outputs.llm_result import LLMResult
 from langchain_core.tracers import LogStreamCallbackHandler
@@ -574,6 +575,20 @@ class FakeChatModelStartTracer(FakeTracer):
         )
 
 
+class FakeChatModelStartContentBlocksTracer(FakeTracer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.content_blocks: list[list[dict[str, Any]]] = []
+
+    def on_chat_model_start(self, *args: Any, **kwargs: Any) -> Run:
+        _, messages = args
+        self.content_blocks.append(messages[0][0].content_blocks)
+        return super().on_chat_model_start(
+            *args,
+            **kwargs,
+        )
+
+
 def test_trace_images_in_openai_format() -> None:
     """Test that images are traced in OpenAI Chat Completions format."""
     llm = ParrotFakeChatModel()
@@ -645,6 +660,32 @@ def test_trace_pdfs() -> None:
             ]
         ]
     ]
+
+
+def test_trace_v1_file_block_content_blocks_in_callback() -> None:
+    llm = ParrotFakeChatModel()
+    tracer = FakeChatModelStartContentBlocksTracer()
+    file_block = types.create_file_block(
+        base64="<base64 string>",
+        mime_type="application/pdf",
+        id="block-1",
+    )
+
+    llm.invoke(
+        [HumanMessage(content_blocks=[file_block])],
+        config={"callbacks": [tracer]},
+    )
+
+    assert _content_blocks_equal_ignore_id(
+        tracer.content_blocks[0],
+        [
+            {
+                "type": "file",
+                "base64": "<base64 string>",
+                "mime_type": "application/pdf",
+            }
+        ],
+    )
 
 
 def test_content_block_transformation_v0_to_v1_image() -> None:


### PR DESCRIPTION
Closes #38084

---

Fix the v0 content block translator so callback-time `content_blocks` parsing no longer forwards `id` twice when converting legacy file/image/audio blocks.

This affects callbacks that inspect `message.content_blocks` during `on_chat_model_start`, where a file block could raise `TypeError("... got multiple values for keyword argument id")`.

Validation:
- `uv run --group test pytest tests/unit_tests/language_models/chat_models/test_base.py -k test_trace_v1_file_block_content_blocks_in_callback or test_trace_pdfs`
- `uv run --group test pytest tests/unit_tests/messages/block_translators/test_langchain_v0.py tests/unit_tests/language_models/test_compat_bridge.py -k langchain_v0 or self_contained_start_strips_heavy_fields or message_id_override`
- `uv run --group lint ruff check langchain_core/messages/block_translators/langchain_v0.py tests/unit_tests/language_models/chat_models/test_base.py`

AI-agent contribution.