### PR TITLE
fix(core,partners): rename package version trace metadata

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -206,7 +206,7 @@ class BaseLanguageModel(
     def model_post_init(self, _context: Any, /) -> None:
         """Pydantic V2 lifecycle hook called automatically after `__init__`.
 
-        Seeds `metadata["versions"]` with the installed `langchain-core`
+        Seeds `metadata["lc_versions"]` with the installed `langchain-core`
         (and `langchain`, if installed) versions so that every LLM trace
         carries the package versions that produced it.
 
@@ -235,7 +235,7 @@ class BaseLanguageModel(
             self._add_version("langchain", langchain_version)
 
     def _add_version(self, pkg: str, version: str) -> None:
-        """Record a package version in `metadata.versions` for tracing.
+        """Record a package version in `metadata.lc_versions` for tracing.
 
         Each layer in the class hierarchy (core -> langchain -> partner)
         calls this so that the resulting metadata dict accumulates *all*
@@ -245,7 +245,7 @@ class BaseLanguageModel(
 
         ```python
         {
-            "versions": {
+            "lc_versions": {
                 "langchain-core": "1.x.x",
                 "langchain": "1.x.x",
                 "langchain-openai": "1.x.x",
@@ -259,15 +259,15 @@ class BaseLanguageModel(
         """
         if self.metadata is None:
             self.metadata = {}
-        existing = self.metadata.get("versions")
+        existing = self.metadata.get("lc_versions")
         if existing is not None and not isinstance(existing, Mapping):
             warnings.warn(
-                f"metadata['versions'] expected a dict, got "
+                f"metadata['lc_versions'] expected a dict, got "
                 f"{type(existing).__name__}; overwriting with package version dict",
                 stacklevel=2,
             )
             existing = None
-        self.metadata["versions"] = {
+        self.metadata["lc_versions"] = {
             **(existing if isinstance(existing, Mapping) else {}),
             pkg: version,
         }

--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -399,12 +399,11 @@ def patch_config(
 def _merge_metadata_dicts(
     base: Mapping[str, Any], incoming: Mapping[str, Any]
 ) -> dict[str, Any]:
-    """Merge two metadata dicts one level deep (not a recursive deep merge).
+    """Merge metadata dicts, accumulating only `lc_versions` nested mappings.
 
-    If both sides have a `Mapping` value for the same key, the inner mappings
-    are merged (last-writer-wins within). Non-mapping values use
-    last-writer-wins at the top level. Only one level of depth is merged; values
-    nested more deeply are not recursively merged.
+    Metadata generally uses last-writer-wins semantics. The LangChain-owned
+    `lc_versions` key is the only nested mapping that accumulates across merges
+    so package versions from core, `langchain`, and partner packages coexist.
 
     Args:
         base: The base metadata dict.
@@ -416,27 +415,16 @@ def _merge_metadata_dicts(
 
     Returns:
         A new merged dict.
-
-            Inputs are not mutated. The returned dict performs shallow copies at
-            the top level and one level deep; mutable values nested beyond that
-            depth are shared references with the originals.
     """
-    merged = {**base}
-    for key, value in incoming.items():
-        if (
-            key in merged
-            and isinstance(merged[key], Mapping)
-            and isinstance(value, Mapping)
-        ):
-            merged[key] = {**merged[key], **value}
-        elif isinstance(value, Mapping):
-            merged[key] = {**value}
-        else:
-            merged[key] = value
-    # Ensure non-overlapping nested mappings are also copies, not shared refs.
-    for key in base:
-        if key not in incoming and isinstance(merged[key], Mapping):
-            merged[key] = {**merged[key]}
+    merged = {**base, **incoming}
+    base_versions = base.get("lc_versions")
+    incoming_versions = incoming.get("lc_versions")
+    if isinstance(base_versions, Mapping) and isinstance(incoming_versions, Mapping):
+        merged["lc_versions"] = {**base_versions, **incoming_versions}
+    elif isinstance(incoming_versions, Mapping):
+        merged["lc_versions"] = {**incoming_versions}
+    elif "lc_versions" not in incoming and isinstance(base_versions, Mapping):
+        merged["lc_versions"] = {**base_versions}
     return merged
 
 

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -1317,12 +1317,23 @@ class _VersionedFakeModel(FakeListChatModel):
         self._add_version("langchain-fake", "0.1.0")
 
 
-def test_user_versions_metadata_survives_merge() -> None:
-    """User-provided versions metadata should be deep-merged with model versions.
+def test_user_lc_versions_metadata_survives_merge() -> None:
+    """User-provided `lc_versions` metadata should merge with model versions."""
+    llm = _VersionedFakeModel(responses=["hello"])
+    user_config: RunnableConfig = {"metadata": {"lc_versions": {"my-app": "2.0"}}}
 
-    Regression test: the `add_metadata` deep-merge in `CallbackManager`
-    must preserve both user-provided and model-provided versions dicts.
-    """
+    with collect_runs() as cb:
+        llm.invoke([HumanMessage(content="hi")], config=user_config)
+        assert len(cb.traced_runs) == 1
+        run_metadata = cb.traced_runs[0].extra["metadata"]
+        assert "my-app" in run_metadata["lc_versions"]
+        assert run_metadata["lc_versions"]["my-app"] == "2.0"
+        assert "langchain-fake" in run_metadata["lc_versions"]
+        assert "langchain-core" in run_metadata["lc_versions"]
+
+
+def test_user_versions_metadata_remains_user_owned() -> None:
+    """User-owned `versions` metadata is not used for package version tracking."""
     llm = _VersionedFakeModel(responses=["hello"])
     user_config: RunnableConfig = {"metadata": {"versions": {"my-app": "2.0"}}}
 
@@ -1330,72 +1341,73 @@ def test_user_versions_metadata_survives_merge() -> None:
         llm.invoke([HumanMessage(content="hi")], config=user_config)
         assert len(cb.traced_runs) == 1
         run_metadata = cb.traced_runs[0].extra["metadata"]
-        assert "my-app" in run_metadata["versions"]
-        assert run_metadata["versions"]["my-app"] == "2.0"
-        assert "langchain-fake" in run_metadata["versions"]
-        assert "langchain-core" in run_metadata["versions"]
+        assert run_metadata["versions"] == {"my-app": "2.0"}
+        assert "langchain-fake" not in run_metadata["versions"]
+        assert "langchain-core" not in run_metadata["versions"]
+        assert "langchain-fake" in run_metadata["lc_versions"]
+        assert "langchain-core" in run_metadata["lc_versions"]
 
 
-async def test_user_versions_metadata_survives_merge_async() -> None:
-    """Async variant: user-provided versions metadata deep-merged with model's."""
+async def test_user_lc_versions_metadata_survives_merge_async() -> None:
+    """Async variant: user-provided `lc_versions` metadata merges with model's."""
     llm = _VersionedFakeModel(responses=["hello"])
-    user_config: RunnableConfig = {"metadata": {"versions": {"my-app": "2.0"}}}
+    user_config: RunnableConfig = {"metadata": {"lc_versions": {"my-app": "2.0"}}}
 
     with collect_runs() as cb:
         await llm.ainvoke([HumanMessage(content="hi")], config=user_config)
         assert len(cb.traced_runs) == 1
         run_metadata = cb.traced_runs[0].extra["metadata"]
-        assert "my-app" in run_metadata["versions"]
-        assert "langchain-fake" in run_metadata["versions"]
-        assert "langchain-core" in run_metadata["versions"]
+        assert "my-app" in run_metadata["lc_versions"]
+        assert "langchain-fake" in run_metadata["lc_versions"]
+        assert "langchain-core" in run_metadata["lc_versions"]
 
 
-def test_user_versions_metadata_survives_merge_stream() -> None:
-    """Stream variant: user-provided versions metadata deep-merged with model's."""
+def test_user_lc_versions_metadata_survives_merge_stream() -> None:
+    """Stream variant: user-provided `lc_versions` metadata merges with model's."""
     llm = _VersionedFakeModel(responses=["hello"])
-    user_config: RunnableConfig = {"metadata": {"versions": {"my-app": "2.0"}}}
+    user_config: RunnableConfig = {"metadata": {"lc_versions": {"my-app": "2.0"}}}
 
     with collect_runs() as cb:
         for _ in llm.stream([HumanMessage(content="hi")], config=user_config):
             pass
         assert len(cb.traced_runs) == 1
         run_metadata = cb.traced_runs[0].extra["metadata"]
-        assert "my-app" in run_metadata["versions"]
-        assert "langchain-fake" in run_metadata["versions"]
-        assert "langchain-core" in run_metadata["versions"]
+        assert "my-app" in run_metadata["lc_versions"]
+        assert "langchain-fake" in run_metadata["lc_versions"]
+        assert "langchain-core" in run_metadata["lc_versions"]
 
 
-async def test_user_versions_metadata_survives_merge_astream() -> None:
-    """Async stream variant: user-provided versions metadata deep-merged."""
+async def test_user_lc_versions_metadata_survives_merge_astream() -> None:
+    """Async stream variant: user-provided `lc_versions` metadata merges."""
     llm = _VersionedFakeModel(responses=["hello"])
-    user_config: RunnableConfig = {"metadata": {"versions": {"my-app": "2.0"}}}
+    user_config: RunnableConfig = {"metadata": {"lc_versions": {"my-app": "2.0"}}}
 
     with collect_runs() as cb:
         async for _ in llm.astream([HumanMessage(content="hi")], config=user_config):
             pass
         assert len(cb.traced_runs) == 1
         run_metadata = cb.traced_runs[0].extra["metadata"]
-        assert "my-app" in run_metadata["versions"]
-        assert "langchain-fake" in run_metadata["versions"]
-        assert "langchain-core" in run_metadata["versions"]
+        assert "my-app" in run_metadata["lc_versions"]
+        assert "langchain-fake" in run_metadata["lc_versions"]
+        assert "langchain-core" in run_metadata["lc_versions"]
 
 
 def test_add_version_with_none_metadata() -> None:
-    """Model constructed with metadata=None should still get versions."""
+    """Model constructed with metadata=None should still get `lc_versions`."""
     llm = FakeListChatModel(responses=["x"], metadata=None)
     assert llm.metadata is not None
-    assert "langchain-core" in llm.metadata["versions"]
+    assert "langchain-core" in llm.metadata["lc_versions"]
 
 
-def test_add_version_with_non_dict_versions() -> None:
-    """Non-dict `versions` value is silently replaced with a warning."""
+def test_add_version_with_non_dict_lc_versions() -> None:
+    """Non-dict `lc_versions` value is replaced with a warning."""
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        llm = FakeListChatModel(responses=["x"], metadata={"versions": "garbage"})
+        llm = FakeListChatModel(responses=["x"], metadata={"lc_versions": "garbage"})
         assert any("expected a dict" in str(warning.message) for warning in w)
     assert llm.metadata is not None
-    assert isinstance(llm.metadata["versions"], dict)
-    assert "langchain-core" in llm.metadata["versions"]
+    assert isinstance(llm.metadata["lc_versions"], dict)
+    assert "langchain-core" in llm.metadata["lc_versions"]
 
 
 def test_langchain_version_in_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1411,8 +1423,8 @@ def test_langchain_version_in_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
     try:
         llm = FakeListChatModel(responses=["x"])
         assert llm.metadata is not None
-        assert llm.metadata["versions"]["langchain"] == "1.2.13"
-        assert "langchain-core" in llm.metadata["versions"]
+        assert llm.metadata["lc_versions"]["langchain"] == "1.2.13"
+        assert "langchain-core" in llm.metadata["lc_versions"]
     finally:
         _get_langchain_version.cache_clear()
 
@@ -1420,7 +1432,7 @@ def test_langchain_version_in_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_langchain_version_missing_when_not_installed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When `langchain` is not installed, metadata.versions has no entry.
+    """When `langchain` is not installed, metadata.lc_versions has no entry.
 
     The lookup raises `PackageNotFoundError` (the real not-installed signal), which
     `_get_langchain_version` must swallow without dropping the rest of the dict.
@@ -1434,8 +1446,8 @@ def test_langchain_version_missing_when_not_installed(
     try:
         llm = FakeListChatModel(responses=["x"])
         assert llm.metadata is not None
-        assert "langchain" not in llm.metadata["versions"]
-        assert "langchain-core" in llm.metadata["versions"]
+        assert "langchain" not in llm.metadata["lc_versions"]
+        assert "langchain-core" in llm.metadata["lc_versions"]
     finally:
         _get_langchain_version.cache_clear()
 
@@ -1456,7 +1468,7 @@ def test_version_validator_coexists_with_core_seed() -> None:
 
     llm = _ValidatorVersionedModel(responses=["x"])
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert versions["langchain-core"] == VERSION
     assert versions["langchain-fake"] == "0.1.0"
 
@@ -1484,7 +1496,7 @@ def test_subclass_unique_validator_names_accumulate() -> None:
 
     llm = _ChildModel(responses=["x"])
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert versions["langchain-core"] == VERSION
     assert versions["langchain-parent"] == "1.0.0"
     assert versions["langchain-child"] == "2.0.0"
@@ -1777,7 +1789,7 @@ def test_invocation_params_passed_to_tracer_metadata() -> None:
             "ls_temperature": 0.7,
             "stop": None,
             "temperature": 0.7,
-            "versions": {"langchain-core": VERSION},
+            "lc_versions": {"langchain-core": VERSION},
         },
         "options": {"stop": None},
         "runtime": run.extra["runtime"],

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_fallbacks.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_fallbacks.ambr
@@ -84,7 +84,7 @@
                   "fake",
                   "FakeListLLM"
                 ],
-                "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo'], i=1)",
+                "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'], i=1)",
                 "name": "FakeListLLM"
               }
             },
@@ -128,7 +128,7 @@
                     "fake",
                     "FakeListLLM"
                   ],
-                  "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['bar'])",
+                  "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['bar'])",
                   "name": "FakeListLLM"
                 }
               },
@@ -268,7 +268,7 @@
           "fake",
           "FakeListLLM"
         ],
-        "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo'], i=1)",
+        "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'], i=1)",
         "name": "FakeListLLM"
       },
       "fallbacks": [
@@ -281,7 +281,7 @@
             "fake",
             "FakeListLLM"
           ],
-          "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['bar'])",
+          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['bar'])",
           "name": "FakeListLLM"
         }
       ],
@@ -322,7 +322,7 @@
           "fake",
           "FakeListLLM"
         ],
-        "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo'], i=1)",
+        "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'], i=1)",
         "name": "FakeListLLM"
       },
       "fallbacks": [
@@ -335,7 +335,7 @@
             "fake",
             "FakeListLLM"
           ],
-          "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['baz'], i=1)",
+          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['baz'], i=1)",
           "name": "FakeListLLM"
         },
         {
@@ -347,7 +347,7 @@
             "fake",
             "FakeListLLM"
           ],
-          "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['bar'])",
+          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['bar'])",
           "name": "FakeListLLM"
         }
       ],

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
@@ -97,7 +97,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -227,7 +227,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['baz, qux'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['baz, qux'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -346,7 +346,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         },
         {
@@ -457,7 +457,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['baz, qux'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['baz, qux'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -848,7 +848,7 @@
             "fake",
             "FakeStreamingListLLM"
           ],
-          "repr": "FakeStreamingListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['first item, second item, third item'])",
+          "repr": "FakeStreamingListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['first item, second item, third item'])",
           "name": "FakeStreamingListLLM"
         },
         {
@@ -884,7 +884,7 @@
               "fake",
               "FakeStreamingListLLM"
             ],
-            "repr": "FakeStreamingListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['this', 'is', 'a', 'test'])",
+            "repr": "FakeStreamingListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['this', 'is', 'a', 'test'])",
             "name": "FakeStreamingListLLM"
           }
         },
@@ -1009,7 +1009,7 @@
 # name: test_prompt_with_chat_model
   '''
   ChatPromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, template='{question}'), additional_kwargs={})])
-  | FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo'])
+  | FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'])
   '''
 # ---
 # name: test_prompt_with_chat_model.1
@@ -1109,7 +1109,7 @@
           "fake_chat_models",
           "FakeListChatModel"
         ],
-        "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo'])",
+        "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'])",
         "name": "FakeListChatModel"
       }
     },
@@ -1220,7 +1220,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -1249,7 +1249,7 @@
 # name: test_prompt_with_chat_model_async
   '''
   ChatPromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, template='{question}'), additional_kwargs={})])
-  | FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo'])
+  | FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'])
   '''
 # ---
 # name: test_prompt_with_chat_model_async.1
@@ -1349,7 +1349,7 @@
           "fake_chat_models",
           "FakeListChatModel"
         ],
-        "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo'])",
+        "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'])",
         "name": "FakeListChatModel"
       }
     },
@@ -1459,7 +1459,7 @@
           "fake",
           "FakeListLLM"
         ],
-        "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo', 'bar'])",
+        "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo', 'bar'])",
         "name": "FakeListLLM"
       }
     },
@@ -1576,7 +1576,7 @@
             "fake",
             "FakeListLLM"
           ],
-          "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo', 'bar'])",
+          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo', 'bar'])",
           "name": "FakeListLLM"
         }
       ],
@@ -1699,7 +1699,7 @@
             "fake",
             "FakeStreamingListLLM"
           ],
-          "repr": "FakeStreamingListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['bear, dog, cat', 'tomato, lettuce, onion'])",
+          "repr": "FakeStreamingListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['bear, dog, cat', 'tomato, lettuce, onion'])",
           "name": "FakeStreamingListLLM"
         }
       ],
@@ -1867,7 +1867,7 @@
                     "fake",
                     "FakeListLLM"
                   ],
-                  "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['4'])",
+                  "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['4'])",
                   "name": "FakeListLLM"
                 }
               },
@@ -1940,7 +1940,7 @@
                     "fake",
                     "FakeListLLM"
                   ],
-                  "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['2'])",
+                  "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['2'])",
                   "name": "FakeListLLM"
                 }
               },
@@ -13407,7 +13407,7 @@
     just_to_test_lambda: RunnableLambda(...)
   }
   | ChatPromptTemplate(input_variables=['documents', 'question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['documents', 'question'], input_types={}, partial_variables={}, template='Context:\n{documents}\n\nQuestion:\n{question}'), additional_kwargs={})])
-  | FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])
+  | FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])
   | CommaSeparatedListOutputParser()
   '''
 # ---
@@ -13610,7 +13610,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -13636,8 +13636,8 @@
   ChatPromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, template='{question}'), additional_kwargs={})])
   | RunnableLambda(...)
   | {
-      chat: FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=["i'm a chatbot"]),
-      llm: FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=["i'm a textbot"])
+      chat: FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=["i'm a chatbot"]),
+      llm: FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=["i'm a textbot"])
     }
   '''
 # ---
@@ -13762,7 +13762,7 @@
                 "fake_chat_models",
                 "FakeListChatModel"
               ],
-              "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a chatbot\"])",
+              "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a chatbot\"])",
               "name": "FakeListChatModel"
             },
             "llm": {
@@ -13774,7 +13774,7 @@
                 "fake",
                 "FakeListLLM"
               ],
-              "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a textbot\"])",
+              "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a textbot\"])",
               "name": "FakeListLLM"
             }
           }
@@ -13917,7 +13917,7 @@
                     "fake_chat_models",
                     "FakeListChatModel"
                   ],
-                  "repr": "FakeListChatModel(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a chatbot\"])",
+                  "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a chatbot\"])",
                   "name": "FakeListChatModel"
                 },
                 "kwargs": {
@@ -13938,7 +13938,7 @@
                 "fake",
                 "FakeListLLM"
               ],
-              "repr": "FakeListLLM(metadata={'versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a textbot\"])",
+              "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a textbot\"])",
               "name": "FakeListLLM"
             },
             "passthrough": {

--- a/libs/core/tests/unit_tests/runnables/test_config.py
+++ b/libs/core/tests/unit_tests/runnables/test_config.py
@@ -326,14 +326,14 @@ async def test_run_in_executor() -> None:
 
 
 class TestMergeMetadataDicts:
-    """Tests for _merge_metadata_dicts deep-merge behavior."""
+    """Tests for _merge_metadata_dicts `lc_versions` merge behavior."""
 
-    def test_deep_merge_preserves_both_nested_dicts(self) -> None:
-        base = {"versions": {"langchain-core": "0.3.1"}, "user_id": "abc"}
-        incoming = {"versions": {"langchain-anthropic": "1.3.3"}, "run": "x"}
+    def test_lc_versions_preserves_both_nested_dicts(self) -> None:
+        base = {"lc_versions": {"langchain-core": "0.3.1"}, "user_id": "abc"}
+        incoming = {"lc_versions": {"langchain-anthropic": "1.3.3"}, "run": "x"}
         result = _merge_metadata_dicts(base, incoming)
         assert result == {
-            "versions": {
+            "lc_versions": {
                 "langchain-core": "0.3.1",
                 "langchain-anthropic": "1.3.3",
             },
@@ -341,72 +341,76 @@ class TestMergeMetadataDicts:
             "run": "x",
         }
 
-    def test_last_writer_wins_within_nested_dicts(self) -> None:
-        base = {"versions": {"pkg": "1.0"}}
-        incoming = {"versions": {"pkg": "2.0"}}
+    def test_last_writer_wins_within_lc_versions(self) -> None:
+        base = {"lc_versions": {"pkg": "1.0"}}
+        incoming = {"lc_versions": {"pkg": "2.0"}}
         result = _merge_metadata_dicts(base, incoming)
-        assert result == {"versions": {"pkg": "2.0"}}
+        assert result == {"lc_versions": {"pkg": "2.0"}}
 
-    def test_non_dict_overwrites_dict(self) -> None:
-        base = {"key": {"nested": "value"}}
-        incoming = {"key": "flat"}
+    def test_generic_nested_metadata_replaces(self) -> None:
+        base = {"versions": {"app": "1.0"}, "nested": {"a": "1"}}
+        incoming = {"versions": {"plugin": "2.0"}, "nested": {"b": "2"}}
         result = _merge_metadata_dicts(base, incoming)
-        assert result == {"key": "flat"}
+        assert result == {"versions": {"plugin": "2.0"}, "nested": {"b": "2"}}
 
-    def test_dict_overwrites_non_dict(self) -> None:
-        base = {"key": "flat"}
-        incoming = {"key": {"nested": "value"}}
+    def test_non_dict_overwrites_lc_versions_dict(self) -> None:
+        base = {"lc_versions": {"nested": "value"}}
+        incoming = {"lc_versions": "flat"}
         result = _merge_metadata_dicts(base, incoming)
-        assert result == {"key": {"nested": "value"}}
+        assert result == {"lc_versions": "flat"}
 
-    def test_no_mutation_of_inputs(self) -> None:
-        base = {"versions": {"a": "1"}}
-        incoming = {"versions": {"b": "2"}}
-        base_copy = {"versions": {"a": "1"}}
-        incoming_copy = {"versions": {"b": "2"}}
+    def test_lc_versions_dict_overwrites_non_dict(self) -> None:
+        base = {"lc_versions": "flat"}
+        incoming = {"lc_versions": {"nested": "value"}}
+        result = _merge_metadata_dicts(base, incoming)
+        assert result == {"lc_versions": {"nested": "value"}}
+
+    def test_no_mutation_of_lc_versions_inputs(self) -> None:
+        base = {"lc_versions": {"a": "1"}}
+        incoming = {"lc_versions": {"b": "2"}}
+        base_copy = {"lc_versions": {"a": "1"}}
+        incoming_copy = {"lc_versions": {"b": "2"}}
         result = _merge_metadata_dicts(base, incoming)
         assert base == base_copy
         assert incoming == incoming_copy
-        # Returned nested dicts should not share identity with originals.
-        assert result["versions"] is not base["versions"]
-        assert result["versions"] is not incoming["versions"]
+        assert result["lc_versions"] is not base["lc_versions"]
+        assert result["lc_versions"] is not incoming["lc_versions"]
 
-    def test_non_overlapping_nested_dict_is_copied(self) -> None:
-        base = {"versions": {"a": "1"}, "extras": {"x": "y"}}
-        incoming = {"versions": {"b": "2"}}
-        result = _merge_metadata_dicts(base, incoming)
-        # "extras" was not in incoming — result should still be a copy.
-        assert result["extras"] is not base["extras"]
-        assert result["extras"] == {"x": "y"}
+    def test_non_overlapping_lc_versions_dict_is_copied(self) -> None:
+        base = {"lc_versions": {"a": "1"}, "extras": {"x": "y"}}
+        result = _merge_metadata_dicts(base, {})
+        assert result["lc_versions"] is not base["lc_versions"]
+        assert result["lc_versions"] == {"a": "1"}
+        assert result["extras"] is base["extras"]
 
     def test_both_empty(self) -> None:
         assert _merge_metadata_dicts({}, {}) == {}
 
     def test_empty_base(self) -> None:
-        incoming = {"versions": {"pkg": "1.0"}}
+        incoming = {"lc_versions": {"pkg": "1.0"}}
         result = _merge_metadata_dicts({}, incoming)
-        assert result == {"versions": {"pkg": "1.0"}}
-        assert result["versions"] is not incoming["versions"]
+        assert result == {"lc_versions": {"pkg": "1.0"}}
+        assert result["lc_versions"] is not incoming["lc_versions"]
 
-        result["versions"]["new"] = "2.0"
-        assert incoming == {"versions": {"pkg": "1.0"}}
+        result["lc_versions"]["new"] = "2.0"
+        assert incoming == {"lc_versions": {"pkg": "1.0"}}
 
     def test_empty_incoming(self) -> None:
-        result = _merge_metadata_dicts({"versions": {"pkg": "1.0"}}, {})
-        assert result == {"versions": {"pkg": "1.0"}}
+        result = _merge_metadata_dicts({"lc_versions": {"pkg": "1.0"}}, {})
+        assert result == {"lc_versions": {"pkg": "1.0"}}
 
     def test_merge_configs_with_none_metadata(self) -> None:
         merged = merge_configs(
             cast("RunnableConfig", {"metadata": None}),
-            {"metadata": {"versions": {"a": "1"}}},
+            {"metadata": {"lc_versions": {"a": "1"}}},
         )
-        assert merged["metadata"] == {"versions": {"a": "1"}}
+        assert merged["metadata"] == {"lc_versions": {"a": "1"}}
 
-    def test_three_config_merge_accumulates(self) -> None:
-        c1: RunnableConfig = {"metadata": {"versions": {"a": "1"}}}
-        c2: RunnableConfig = {"metadata": {"versions": {"b": "2"}}}
-        c3: RunnableConfig = {"metadata": {"versions": {"c": "3"}}}
+    def test_three_config_merge_accumulates_lc_versions(self) -> None:
+        c1: RunnableConfig = {"metadata": {"lc_versions": {"a": "1"}}}
+        c2: RunnableConfig = {"metadata": {"lc_versions": {"b": "2"}}}
+        c3: RunnableConfig = {"metadata": {"lc_versions": {"c": "3"}}}
         merged = merge_configs(c1, c2, c3)
         assert merged["metadata"] == {
-            "versions": {"a": "1", "b": "2", "c": "3"},
+            "lc_versions": {"a": "1", "b": "2", "c": "3"},
         }

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -2162,7 +2162,7 @@ async def test_prompt_with_llm(
                     "metadata": {
                         "ls_model_type": "llm",
                         "ls_provider": "fakelist",
-                        "versions": {"langchain-core": VERSION},
+                        "lc_versions": {"langchain-core": VERSION},
                     },
                     "name": "FakeListLLM",
                     "start_time": "2023-01-01T00:00:00.000+00:00",
@@ -2377,7 +2377,7 @@ async def test_prompt_with_llm_parser(
                     "metadata": {
                         "ls_model_type": "llm",
                         "ls_provider": "fakestreaminglist",
-                        "versions": {"langchain-core": VERSION},
+                        "lc_versions": {"langchain-core": VERSION},
                     },
                     "name": "FakeStreamingListLLM",
                     "start_time": "2023-01-01T00:00:00.000+00:00",

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2133,7 +2133,7 @@ def test_anthropic_model_params() -> None:
         "ls_temperature": None,
     }
     assert llm.metadata is not None
-    assert llm.metadata["versions"]["langchain-anthropic"] == __version__
+    assert llm.metadata["lc_versions"]["langchain-anthropic"] == __version__
 
     ls_params = llm._get_ls_params(model=MODEL_NAME)
     assert ls_params.get("ls_model_name") == MODEL_NAME

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -443,7 +443,7 @@ def test_metadata_versions() -> None:
     """Test that metadata reports the correct version info."""
     llm = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("test_key"))
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-deepseek" in versions
     assert "langchain-openai" in versions

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -122,7 +122,7 @@ def test_metadata_versions() -> None:
     os.environ.setdefault("FIREWORKS_API_KEY", "fake-key")
     llm = ChatFireworks(model="accounts/fireworks/models/llama-v3-70b-instruct")
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-fireworks" in versions
 

--- a/libs/partners/groq/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/groq/tests/unit_tests/test_chat_models.py
@@ -1101,6 +1101,6 @@ def test_metadata_versions() -> None:
     """Test that metadata reports the correct version info."""
     llm = ChatGroq(model="foo")  # type: ignore[call-arg]
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-groq" in versions

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -334,7 +334,7 @@ def test_metadata_versions(chat_hugging_face: Any) -> None:
     from langchain_huggingface._version import __version__
 
     assert chat_hugging_face.metadata is not None
-    versions = chat_hugging_face.metadata["versions"]
+    versions = chat_hugging_face.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-huggingface" in versions
     assert versions["langchain-huggingface"] == __version__

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -659,6 +659,6 @@ def test_metadata_versions() -> None:
     """Test that metadata reports the correct version info."""
     llm = ChatMistralAI(model="foo")  # type: ignore[call-arg]
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-mistralai" in versions

--- a/libs/partners/ollama/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/ollama/tests/unit_tests/test_chat_models.py
@@ -818,7 +818,7 @@ def test_metadata_versions() -> None:
     """Test that metadata reports the correct version info."""
     llm = ChatOllama(model=MODEL_NAME)
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-ollama" in versions
 

--- a/libs/partners/ollama/tests/unit_tests/test_llms.py
+++ b/libs/partners/ollama/tests/unit_tests/test_llms.py
@@ -96,6 +96,6 @@ def test_metadata_versions() -> None:
     """Test that metadata reports the correct version info."""
     llm = OllamaLLM(model=MODEL_NAME)
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-ollama" in versions

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -279,6 +279,6 @@ def test_metadata_versions() -> None:
         azure_endpoint="my-base-url",
     )
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-openai" in versions

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1089,7 +1089,8 @@ def test_schema_from_with_structured_output(schema: type) -> None:
         "title": schema.__name__,
         "type": "object",
     }
-    actual = structured_llm.get_output_schema().model_json_schema()
+    output_schema = cast("type[BaseModel]", structured_llm.get_output_schema())
+    actual = output_schema.model_json_schema()
     assert actual == expected
 
 
@@ -4081,7 +4082,7 @@ def test_metadata_versions() -> None:
     """Test that metadata reports the correct version info."""
     llm = ChatOpenAI()
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-openai" in versions
 

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -278,7 +278,7 @@ class TestChatOpenRouterInstantiation:
         """Test that metadata reports the correct version info."""
         model = _make_model()
         assert model.metadata is not None
-        versions = model.metadata["versions"]
+        versions = model.metadata["lc_versions"]
         assert "langchain-core" in versions
         assert "langchain-openrouter" in versions
 

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -229,7 +229,7 @@ def test_metadata_versions() -> None:
 
     llm = ChatPerplexity(model="test")
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-perplexity" in versions
     assert versions["langchain-perplexity"] == __version__

--- a/libs/partners/xai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/xai/tests/unit_tests/test_chat_models.py
@@ -167,7 +167,7 @@ def test_metadata_versions() -> None:
     """Test that metadata reports the correct version info."""
     llm = ChatXAI(model=MODEL_NAME)
     assert llm.metadata is not None
-    versions = llm.metadata["versions"]
+    versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-xai" in versions
     assert "langchain-openai" in versions


### PR DESCRIPTION
Package-version trace metadata now uses the LangChain-owned `metadata["lc_versions"]` convention instead of the user-owned `metadata["versions"]` key. Metadata merging is narrowed so only `lc_versions` accumulates nested package-version entries, while generic nested metadata keeps normal last-writer-wins behavior.

## Changes
- Renamed `BaseLanguageModel._add_version()` trace metadata from `versions` to `lc_versions`, including docstrings and the non-dict replacement warning.
- Scoped `_merge_metadata_dicts()` nested-map accumulation to only `lc_versions`; duplicate package entries remain last-writer-wins and `lc_versions` mappings are copied defensively.
- Preserved user-owned `metadata["versions"]` semantics by keeping it out of package-version tracking and generic nested metadata merging.
- Updated runnable snapshots and partner package metadata assertions across Anthropic, DeepSeek, Fireworks, Groq, Hugging Face, MistralAI, Ollama, OpenAI, OpenRouter, Perplexity, and xAI to expect `lc_versions`.

## Testing
- Added/adjusted core tests for `lc_versions` accumulation, duplicate package overwrite behavior, non-dict `lc_versions` replacement, defensive copying, and `metadata["versions"]` last-writer-wins behavior.
- Ran focused core and partner metadata tests plus Ruff checks for changed areas.