### PR TITLE
release(core): 1.4.7

### DIFF
--- a/libs/core/langchain_core/version.py
+++ b/libs/core/langchain_core/version.py
@@ -1,3 +1,3 @@
 """Version information for `langchain-core`."""
 
-VERSION = "1.4.6"
+VERSION = "1.4.7"

--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.4.6"
+version = "1.4.7"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langsmith>=0.3.45,<1.0.0",

--- a/libs/core/scripts/check_version.py
+++ b/libs/core/scripts/check_version.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 # Matches the `langchain-core` version embedded in serialized model metadata,
-# e.g. `{'versions': {'langchain-core': '1.4.6'}}`. Intentionally broad: every such
+# e.g. `{'versions': {'langchain-core': '1.4.7'}}`. Intentionally broad: every such
 # occurrence in a snapshot is expected to track the released version.
 SNAPSHOT_VERSION_PATTERN = re.compile(r"langchain-core': '([^']+)'")
 

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_fallbacks.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_fallbacks.ambr
@@ -84,7 +84,7 @@
                   "fake",
                   "FakeListLLM"
                 ],
-                "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'], i=1)",
+                "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo'], i=1)",
                 "name": "FakeListLLM"
               }
             },
@@ -128,7 +128,7 @@
                     "fake",
                     "FakeListLLM"
                   ],
-                  "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['bar'])",
+                  "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['bar'])",
                   "name": "FakeListLLM"
                 }
               },
@@ -268,7 +268,7 @@
           "fake",
           "FakeListLLM"
         ],
-        "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'], i=1)",
+        "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo'], i=1)",
         "name": "FakeListLLM"
       },
       "fallbacks": [
@@ -281,7 +281,7 @@
             "fake",
             "FakeListLLM"
           ],
-          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['bar'])",
+          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['bar'])",
           "name": "FakeListLLM"
         }
       ],
@@ -322,7 +322,7 @@
           "fake",
           "FakeListLLM"
         ],
-        "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'], i=1)",
+        "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo'], i=1)",
         "name": "FakeListLLM"
       },
       "fallbacks": [
@@ -335,7 +335,7 @@
             "fake",
             "FakeListLLM"
           ],
-          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['baz'], i=1)",
+          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['baz'], i=1)",
           "name": "FakeListLLM"
         },
         {
@@ -347,7 +347,7 @@
             "fake",
             "FakeListLLM"
           ],
-          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['bar'])",
+          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['bar'])",
           "name": "FakeListLLM"
         }
       ],

--- a/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
+++ b/libs/core/tests/unit_tests/runnables/__snapshots__/test_runnable.ambr
@@ -97,7 +97,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -227,7 +227,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['baz, qux'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['baz, qux'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -346,7 +346,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         },
         {
@@ -457,7 +457,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['baz, qux'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['baz, qux'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -848,7 +848,7 @@
             "fake",
             "FakeStreamingListLLM"
           ],
-          "repr": "FakeStreamingListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['first item, second item, third item'])",
+          "repr": "FakeStreamingListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['first item, second item, third item'])",
           "name": "FakeStreamingListLLM"
         },
         {
@@ -884,7 +884,7 @@
               "fake",
               "FakeStreamingListLLM"
             ],
-            "repr": "FakeStreamingListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['this', 'is', 'a', 'test'])",
+            "repr": "FakeStreamingListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['this', 'is', 'a', 'test'])",
             "name": "FakeStreamingListLLM"
           }
         },
@@ -1009,7 +1009,7 @@
 # name: test_prompt_with_chat_model
   '''
   ChatPromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, template='{question}'), additional_kwargs={})])
-  | FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'])
+  | FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo'])
   '''
 # ---
 # name: test_prompt_with_chat_model.1
@@ -1109,7 +1109,7 @@
           "fake_chat_models",
           "FakeListChatModel"
         ],
-        "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'])",
+        "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo'])",
         "name": "FakeListChatModel"
       }
     },
@@ -1220,7 +1220,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -1249,7 +1249,7 @@
 # name: test_prompt_with_chat_model_async
   '''
   ChatPromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, template='{question}'), additional_kwargs={})])
-  | FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'])
+  | FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo'])
   '''
 # ---
 # name: test_prompt_with_chat_model_async.1
@@ -1349,7 +1349,7 @@
           "fake_chat_models",
           "FakeListChatModel"
         ],
-        "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo'])",
+        "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo'])",
         "name": "FakeListChatModel"
       }
     },
@@ -1459,7 +1459,7 @@
           "fake",
           "FakeListLLM"
         ],
-        "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo', 'bar'])",
+        "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo', 'bar'])",
         "name": "FakeListLLM"
       }
     },
@@ -1576,7 +1576,7 @@
             "fake",
             "FakeListLLM"
           ],
-          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo', 'bar'])",
+          "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo', 'bar'])",
           "name": "FakeListLLM"
         }
       ],
@@ -1699,7 +1699,7 @@
             "fake",
             "FakeStreamingListLLM"
           ],
-          "repr": "FakeStreamingListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['bear, dog, cat', 'tomato, lettuce, onion'])",
+          "repr": "FakeStreamingListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['bear, dog, cat', 'tomato, lettuce, onion'])",
           "name": "FakeStreamingListLLM"
         }
       ],
@@ -1867,7 +1867,7 @@
                     "fake",
                     "FakeListLLM"
                   ],
-                  "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['4'])",
+                  "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['4'])",
                   "name": "FakeListLLM"
                 }
               },
@@ -1940,7 +1940,7 @@
                     "fake",
                     "FakeListLLM"
                   ],
-                  "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['2'])",
+                  "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['2'])",
                   "name": "FakeListLLM"
                 }
               },
@@ -13407,7 +13407,7 @@
     just_to_test_lambda: RunnableLambda(...)
   }
   | ChatPromptTemplate(input_variables=['documents', 'question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['documents', 'question'], input_types={}, partial_variables={}, template='Context:\n{documents}\n\nQuestion:\n{question}'), additional_kwargs={})])
-  | FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])
+  | FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo, bar'])
   | CommaSeparatedListOutputParser()
   '''
 # ---
@@ -13610,7 +13610,7 @@
             "fake_chat_models",
             "FakeListChatModel"
           ],
-          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=['foo, bar'])",
+          "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=['foo, bar'])",
           "name": "FakeListChatModel"
         }
       ],
@@ -13636,8 +13636,8 @@
   ChatPromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, messages=[SystemMessagePromptTemplate(prompt=PromptTemplate(input_variables=[], input_types={}, partial_variables={}, template='You are a nice assistant.'), additional_kwargs={}), HumanMessagePromptTemplate(prompt=PromptTemplate(input_variables=['question'], input_types={}, partial_variables={}, template='{question}'), additional_kwargs={})])
   | RunnableLambda(...)
   | {
-      chat: FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=["i'm a chatbot"]),
-      llm: FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=["i'm a textbot"])
+      chat: FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=["i'm a chatbot"]),
+      llm: FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=["i'm a textbot"])
     }
   '''
 # ---
@@ -13762,7 +13762,7 @@
                 "fake_chat_models",
                 "FakeListChatModel"
               ],
-              "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a chatbot\"])",
+              "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=[\"i'm a chatbot\"])",
               "name": "FakeListChatModel"
             },
             "llm": {
@@ -13774,7 +13774,7 @@
                 "fake",
                 "FakeListLLM"
               ],
-              "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a textbot\"])",
+              "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=[\"i'm a textbot\"])",
               "name": "FakeListLLM"
             }
           }
@@ -13917,7 +13917,7 @@
                     "fake_chat_models",
                     "FakeListChatModel"
                   ],
-                  "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a chatbot\"])",
+                  "repr": "FakeListChatModel(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=[\"i'm a chatbot\"])",
                   "name": "FakeListChatModel"
                 },
                 "kwargs": {
@@ -13938,7 +13938,7 @@
                 "fake",
                 "FakeListLLM"
               ],
-              "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.6'}}, responses=[\"i'm a textbot\"])",
+              "repr": "FakeListLLM(metadata={'lc_versions': {'langchain-core': '1.4.7'}}, responses=[\"i'm a textbot\"])",
               "name": "FakeListLLM"
             },
             "passthrough": {

--- a/libs/core/tests/unit_tests/runnables/conftest.py
+++ b/libs/core/tests/unit_tests/runnables/conftest.py
@@ -1,0 +1,37 @@
+"""Shared configuration for runnable unit tests."""
+
+import os
+from collections.abc import Iterator
+
+import pytest
+from langsmith.utils import get_env_var
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _disable_local_langsmith_tracing() -> Iterator[None]:
+    """Keep runnable unit tests independent of developer LangSmith env vars."""
+    env_vars = (
+        "LANGCHAIN_TESTS_USER_AGENT",
+        "LANGCHAIN_TRACING_V2",
+        "LANGSMITH_API_KEY",
+        "LANGSMITH_LANGGRAPH_API_VARIANT",
+        "LANGSMITH_PROJECT",
+        "LANGSMITH_TRACING",
+    )
+    previous_env = {env_var: os.environ.get(env_var) for env_var in env_vars}
+    os.environ["LANGSMITH_TRACING"] = "false"
+    for env_var in env_vars:
+        if env_var != "LANGSMITH_TRACING":
+            os.environ.pop(env_var, None)
+    if hasattr(get_env_var, "cache_clear"):
+        get_env_var.cache_clear()  # type: ignore[attr-defined]
+    try:
+        yield
+    finally:
+        for env_var, value in previous_env.items():
+            if value is None:
+                os.environ.pop(env_var, None)
+            else:
+                os.environ[env_var] = value
+        if hasattr(get_env_var, "cache_clear"):
+            get_env_var.cache_clear()  # type: ignore[attr-defined]

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1039,7 +1039,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.0.8"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "langchain-text-splitters>=1.1.2,<2.0.0",
     "langsmith>=0.1.17,<1.0.0",
     "pydantic>=2.7.4,<3.0.0",

--- a/libs/langchain/uv.lock
+++ b/libs/langchain/uv.lock
@@ -2937,7 +2937,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 version = "1.3.9"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "langgraph>=1.2.4,<1.3.0",
     "pydantic>=2.7.4,<3.0.0",
 ]

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2259,7 +2259,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/model-profiles/pyproject.toml
+++ b/libs/model-profiles/pyproject.toml
@@ -55,10 +55,10 @@ test = [
     "syrupy>=5.0.0,<6.0.0",
     "toml>=0.10.2,<1.0.0",
     "langchain[openai]>=1.0.2,<2.0.0",
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
 ]
 
-test_integration = ["langchain-core>=1.4.6,<2.0.0"]
+test_integration = ["langchain-core>=1.4.7,<2.0.0"]
 
 lint = [
     "ruff>=0.15.0,<0.16.0",

--- a/libs/model-profiles/uv.lock
+++ b/libs/model-profiles/uv.lock
@@ -573,7 +573,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.4.6"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "anthropic>=0.96.0,<1.0.0",
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.8"
+version = "1.3.9"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },
@@ -689,7 +689,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/chroma/pyproject.toml
+++ b/libs/partners/chroma/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "numpy>=1.26.0; python_version < '3.13'",
     "numpy>=2.1.0; python_version >= '3.13'",
     "chromadb>=1.5.5,<2.0.0",

--- a/libs/partners/chroma/uv.lock
+++ b/libs/partners/chroma/uv.lock
@@ -859,7 +859,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/deepseek/pyproject.toml
+++ b/libs/partners/deepseek/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "langchain-openai>=1.1.0,<2.0.0",
 ]
 

--- a/libs/partners/deepseek/uv.lock
+++ b/libs/partners/deepseek/uv.lock
@@ -433,7 +433,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/exa/pyproject.toml
+++ b/libs/partners/exa/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "exa-py>=1.0.8,<2.0.0"
 ]
 

--- a/libs/partners/exa/uv.lock
+++ b/libs/partners/exa/uv.lock
@@ -459,7 +459,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/fireworks/pyproject.toml
+++ b/libs/partners/fireworks/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.4.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "fireworks-ai>=1.2.0a71,<2.0.0",
     "openai>=2.0.0,<3.0.0",
     "requests>=2.0.0,<3.0.0",

--- a/libs/partners/fireworks/uv.lock
+++ b/libs/partners/fireworks/uv.lock
@@ -737,7 +737,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/groq/pyproject.toml
+++ b/libs/partners/groq/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "groq>=0.30.0,<1.0.0"
 ]
 

--- a/libs/partners/groq/uv.lock
+++ b/libs/partners/groq/uv.lock
@@ -377,7 +377,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/huggingface/pyproject.toml
+++ b/libs/partners/huggingface/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.2.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "tokenizers>=0.19.1,<1.0.0",
     "huggingface-hub>=0.33.4,<2.0.0",
 ]

--- a/libs/partners/huggingface/uv.lock
+++ b/libs/partners/huggingface/uv.lock
@@ -1025,7 +1025,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.7"
+version = "1.3.9"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },
@@ -1113,7 +1113,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/mistralai/pyproject.toml
+++ b/libs/partners/mistralai/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.1.5"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "tokenizers>=0.15.1,<1.0.0",
     "httpx>=0.25.2,<1.0.0",
     "httpx-sse>=0.3.1,<1.0.0",

--- a/libs/partners/mistralai/uv.lock
+++ b/libs/partners/mistralai/uv.lock
@@ -412,7 +412,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -571,10 +571,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
-test = [{ name = "langchain-core", editable = "../../core" }]
+test = []
 test-integration = []
 typing = [
-    { name = "langchain-core", editable = "../../core" },
     { name = "mypy", specifier = ">=2.1.0,<2.2.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
 ]

--- a/libs/partners/nomic/pyproject.toml
+++ b/libs/partners/nomic/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "nomic>=3.5.3,<4.0.0",
     "pillow>=12.1.1,<13.0.0",
 ]

--- a/libs/partners/nomic/uv.lock
+++ b/libs/partners/nomic/uv.lock
@@ -425,7 +425,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/ollama/pyproject.toml
+++ b/libs/partners/ollama/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.1.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "ollama>=0.6.1,<1.0.0",
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
 ]
 
 [project.urls]

--- a/libs/partners/ollama/uv.lock
+++ b/libs/partners/ollama/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.3.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "openai>=2.26.0,<3.0.0",
     "tiktoken>=0.7.0,<1.0.0",
 ]

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -601,7 +601,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.7"
+version = "1.3.9"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },
@@ -665,7 +665,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/openrouter/pyproject.toml
+++ b/libs/partners/openrouter/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "0.2.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "openrouter>=0.7.11,<1.0.0",
 ]
 

--- a/libs/partners/openrouter/uv.lock
+++ b/libs/partners/openrouter/uv.lock
@@ -387,7 +387,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/perplexity/pyproject.toml
+++ b/libs/partners/perplexity/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.4.0"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "perplexityai>=0.34.1,<1.0.0",
 ]
 

--- a/libs/partners/perplexity/uv.lock
+++ b/libs/partners/perplexity/uv.lock
@@ -476,7 +476,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/qdrant/pyproject.toml
+++ b/libs/partners/qdrant/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "qdrant-client>=1.15.1,<2.0.0",
     "pydantic>=2.7.4,<3.0.0",
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
 ]
 
 [project.urls]

--- a/libs/partners/qdrant/uv.lock
+++ b/libs/partners/qdrant/uv.lock
@@ -570,7 +570,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/xai/pyproject.toml
+++ b/libs/partners/xai/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.2.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-openai>=1.1.7,<2.0.0",
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "requests>=2.0.0,<3.0.0",
     "aiohttp>=3.9.1,<4.0.0",
 ]

--- a/libs/partners/xai/uv.lock
+++ b/libs/partners/xai/uv.lock
@@ -721,7 +721,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/standard-tests/pyproject.toml
+++ b/libs/standard-tests/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 version = "1.1.9"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
     "pytest>=9.0.3,<10.0.0",
     "pytest-asyncio>=1.3.0,<2.0.0",
     "httpx>=0.28.1,<1.0.0",

--- a/libs/standard-tests/uv.lock
+++ b/libs/standard-tests/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/text-splitters/pyproject.toml
+++ b/libs/text-splitters/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 version = "1.1.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.6,<2.0.0",
+    "langchain-core>=1.4.7,<2.0.0",
 ]
 
 [project.urls]

--- a/libs/text-splitters/uv.lock
+++ b/libs/text-splitters/uv.lock
@@ -1230,7 +1230,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },


### PR DESCRIPTION
Bumps `langchain-core` to `1.4.7` for the next patch release and updates downstream minimum `langchain-core` requirements so package locks resolve against the new core version.

This also refreshes the runnable snapshots that embed `lc_versions` metadata so the version consistency check continues to validate checked-in artifacts.

Validated with `python libs/core/scripts/check_version.py`, `uv lock --check` across package lockfiles, and the core runnable tests that own the updated snapshots with local LangSmith tracing env disabled.
