### PR TITLE
test(core,langchain): update tests for explicit deserialization allowlists

### DIFF
--- a/libs/core/tests/unit_tests/fake/test_fake_chat_model.py
+++ b/libs/core/tests/unit_tests/fake/test_fake_chat_model.py
@@ -5,6 +5,7 @@ from itertools import cycle
 from typing import Any, cast
 from uuid import UUID
 
+import pytest
 from typing_extensions import override
 
 from langchain_core.callbacks.base import AsyncCallbackHandler
@@ -141,6 +142,12 @@ async def test_generic_fake_chat_model_stream() -> None:
     )
 
 
+# This test verifies the legacy `astream_log(diff=False)` run-log state shape,
+# so it must call `astream_log` rather than the replacement `astream` API.
+@pytest.mark.filterwarnings(
+    "ignore:astream_log is deprecated. Use astream instead.:"
+    "langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
 async def test_generic_fake_chat_model_astream_log() -> None:
     """Test streaming."""
     infinite_cycle = cycle([AIMessage(content="hello goodbye")])

--- a/libs/core/tests/unit_tests/load/test_secret_injection.py
+++ b/libs/core/tests/unit_tests/load/test_secret_injection.py
@@ -45,7 +45,7 @@ def _assert_no_secret_leak(payload: Any) -> None:
     serialized = dumps(payload)
 
     # Deserialize with secrets_from_env=True (the dangerous setting)
-    deserialized = load(serialized, secrets_from_env=True)
+    deserialized = load(serialized, allowed_objects="core", secrets_from_env=True)
 
     # Re-serialize to string
     reserialized = dumps(deserialized)
@@ -198,7 +198,7 @@ class TestPydanticModelTopLevel:
         msg = AIMessage(content=[], additional_kwargs={"parsed": payload})
         gen = ChatGeneration(message=msg)
         _assert_no_secret_leak(gen)
-        round_trip = load(dumpd(gen))
+        round_trip = load(dumpd(gen), allowed_objects="core")
         assert MyModel(**(round_trip.message.additional_kwargs["parsed"])) == payload
 
     def test_pydantic_model_with_nested_secret(self) -> None:
@@ -280,7 +280,7 @@ class TestRoundTrip:
         )
 
         serialized = dumpd(msg)
-        deserialized = load(serialized, secrets_from_env=True)
+        deserialized = load(serialized, allowed_objects="core", secrets_from_env=True)
 
         # The secret-like dict should be preserved as a plain dict
         assert deserialized.additional_kwargs["data"] == MALICIOUS_SECRET_DICT
@@ -307,7 +307,7 @@ class TestRoundTrip:
         payload = {"data": MALICIOUS_SECRET_DICT}
 
         serialized = dumpd(payload)
-        deserialized = load(serialized, secrets_from_env=True)
+        deserialized = load(serialized, allowed_objects="core", secrets_from_env=True)
 
         # The secret-like dict should be preserved as a plain dict
         assert deserialized["data"] == MALICIOUS_SECRET_DICT
@@ -421,7 +421,6 @@ def test_allowed_objects() -> None:
     # Core object
     msg = AIMessage(content="foo")
     serialized = dumpd(msg)
-    assert load(serialized) == msg
     assert load(serialized, allowed_objects=[AIMessage]) == msg
     assert load(serialized, allowed_objects="core") == msg
 

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -1201,9 +1201,11 @@ def test_chat_prompt_w_msgs_placeholder_ser_des(snapshot: SnapshotAssertion) -> 
         ]
     )
     assert dumpd(MessagesPlaceholder("bar")) == snapshot(name="placeholder")
-    assert load(dumpd(MessagesPlaceholder("bar"))) == MessagesPlaceholder("bar")
+    assert load(
+        dumpd(MessagesPlaceholder("bar")), allowed_objects="core"
+    ) == MessagesPlaceholder("bar")
     assert dumpd(prompt) == snapshot(name="chat_prompt")
-    assert load(dumpd(prompt)) == prompt
+    assert load(dumpd(prompt), allowed_objects="core") == prompt
 
 
 def test_chat_tmpl_serdes(snapshot: SnapshotAssertion) -> None:
@@ -1256,7 +1258,7 @@ def test_chat_tmpl_serdes(snapshot: SnapshotAssertion) -> None:
         ]
     )
     assert dumpd(template) == snapshot()
-    assert load(dumpd(template)) == template
+    assert load(dumpd(template), allowed_objects="core") == template
 
 
 @pytest.mark.xfail(
@@ -1400,6 +1402,7 @@ def test_data_prompt_template_deserializable() -> None:
                 ]
             )
         ),
+        allowed_objects="core",
     )
 
 
@@ -1868,7 +1871,7 @@ def test_rendering_prompt_with_conditionals_no_empty_text_blocks() -> None:
     }
 
     # Load the ChatPromptTemplate from the manifest
-    template = load(manifest)
+    template = load(manifest, allowed_objects="core")
 
     # Format with conditional data - rules is empty, so mustache conditionals
     # should not render

--- a/libs/core/tests/unit_tests/prompts/test_dict.py
+++ b/libs/core/tests/unit_tests/prompts/test_dict.py
@@ -61,7 +61,7 @@ def test_dict_prompt_template_loads_payload_rejects_attribute_access() -> None:
     )
 
     with pytest.raises(ValueError, match="Variable names cannot contain attribute"):
-        loads(payload)
+        loads(payload, allowed_objects=[DictPromptTemplate])
 
 
 def test_dict_prompt_template_dumpd_round_trip_rejects_attribute_access() -> None:
@@ -93,7 +93,7 @@ def test_dict_prompt_template_deserialization_rejects_attribute_access() -> None
     )
 
     with pytest.raises(ValueError, match="Variable names cannot contain attribute"):
-        loads(payload)
+        loads(payload, allowed_objects=[DictPromptTemplate])
 
 
 def test_dict_prompt_template_legacy_deserialization_rejects_attribute_access() -> None:

--- a/libs/core/tests/unit_tests/prompts/test_image.py
+++ b/libs/core/tests/unit_tests/prompts/test_image.py
@@ -15,6 +15,7 @@ def test_image_prompt_template_deserializable() -> None:
                 [("system", [{"type": "image", "image_url": "{img}"}])]
             )
         ),
+        allowed_objects="core",
     )
 
 
@@ -109,6 +110,7 @@ def test_image_prompt_template_deserializable_old() -> None:
                 },
             }
         ),
+        allowed_objects="core",
     )
 
 
@@ -137,4 +139,4 @@ def test_image_prompt_template_deserialization_rejects_attribute_access() -> Non
     )
 
     with pytest.raises(ValueError, match="Variable names cannot contain attribute"):
-        loads(payload)
+        loads(payload, allowed_objects=[ImagePromptTemplate])

--- a/libs/core/tests/unit_tests/prompts/test_structured.py
+++ b/libs/core/tests/unit_tests/prompts/test_structured.py
@@ -78,9 +78,11 @@ def test_structured_prompt_dict() -> None:
 
     assert chain.invoke({"hello": "there"}) == {"name": 1, "value": 42}  # type: ignore[comparison-overlap]
 
-    assert loads(dumps(prompt)).model_dump() == prompt.model_dump()
+    assert (
+        loads(dumps(prompt), allowed_objects="core").model_dump() == prompt.model_dump()
+    )
 
-    chain = loads(dumps(prompt)) | model
+    chain = loads(dumps(prompt), allowed_objects="core") | model
     assert chain.invoke({"hello": "there"}) == {"name": 1, "value": 42}
 
 
@@ -102,8 +104,10 @@ def test_structured_prompt_kwargs() -> None:
     model = FakeStructuredChatModel(responses=[])
     chain = prompt | model
     assert chain.invoke({"hello": "there"}) == {"name": 1, "value": 7}  # type: ignore[comparison-overlap]
-    assert loads(dumps(prompt)).model_dump() == prompt.model_dump()
-    chain = loads(dumps(prompt)) | model
+    assert (
+        loads(dumps(prompt), allowed_objects="core").model_dump() == prompt.model_dump()
+    )
+    chain = loads(dumps(prompt), allowed_objects="core") | model
     assert chain.invoke({"hello": "there"}) == {"name": 1, "value": 7}
 
     class OutputSchema(BaseModel):

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -26,6 +26,14 @@ from langchain_core.tracers.root_listeners import (
 )
 from tests.unit_tests.pydantic_utils import _schema
 
+# This module is the compatibility test suite for `RunnableWithMessageHistory`,
+# so constructing that deprecated class is the behavior under test.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:RunnableWithMessageHistory is deprecated. Use LangGraph's built-in "
+    "persistence instead.:"
+    "langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
+
 
 def test_interfaces() -> None:
     history = InMemoryChatMessageHistory()

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -106,6 +106,13 @@ from tests.unit_tests.pydantic_utils import (
 )
 from tests.unit_tests.stubs import AnyStr, _any_id_ai_message, _any_id_ai_message_chunk
 
+# Several tests assert the legacy `RunLog` / `RunLogPatch` output produced by
+# `astream_log`, which cannot be replaced by `astream` without losing coverage.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:astream_log is deprecated. Use astream instead.:"
+    "langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
+
 PYDANTIC_VERSION_AT_LEAST_29 = version.parse("2.9") <= PYDANTIC_VERSION
 PYDANTIC_VERSION_AT_LEAST_210 = version.parse("2.10") <= PYDANTIC_VERSION
 
@@ -3486,7 +3493,7 @@ async def test_map_astream_iterator_input() -> None:
     assert final_value.get("passthrough") == llm_res
 
     simple_map = RunnableMap(passthrough=RunnablePassthrough())
-    assert loads(dumps(simple_map)) == simple_map
+    assert loads(dumps(simple_map), allowed_objects="core") == simple_map
 
 
 def test_with_config_with_config() -> None:

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
@@ -34,6 +34,16 @@ from langchain_core.runnables.schema import StreamEvent
 from langchain_core.tools import tool
 from tests.unit_tests.stubs import _any_id_ai_message, _any_id_ai_message_chunk
 
+# This module intentionally exercises `astream_events(version="v1")` and the
+# history wrapper to preserve compatibility coverage for those deprecated paths.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:astream_events version='v1' is deprecated. Use version='v2' or "
+    "astream instead.:langchain_core._api.deprecation.LangChainDeprecationWarning",
+    "ignore:RunnableWithMessageHistory is deprecated. Use LangGraph's built-in "
+    "persistence instead.:"
+    "langchain_core._api.deprecation.LangChainDeprecationWarning",
+)
+
 
 def _with_nulled_run_id(events: Sequence[StreamEvent]) -> list[StreamEvent]:
     """Removes the run IDs from events."""

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -56,6 +56,14 @@ from tests.unit_tests.runnables.test_runnable_events_v1 import (
 )
 from tests.unit_tests.stubs import _any_id_ai_message, _any_id_ai_message_chunk
 
+# The v2 event tests include a compatibility case for `RunnableWithMessageHistory`,
+# so constructing that deprecated wrapper is expected in this module.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:RunnableWithMessageHistory is deprecated. Use LangGraph's built-in "
+    "persistence instead.:"
+    "langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
+
 
 def _with_nulled_run_id(events: Sequence[StreamEvent]) -> list[StreamEvent]:
     """Removes the run IDs from events."""

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -25,7 +25,7 @@ version = "1.3.9"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.4.7,<2.0.0",
-    "langgraph>=1.2.4,<1.3.0",
+    "langgraph>=1.2.5,<1.3.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -2083,7 +2083,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.2.4,<1.3.0" },
+    { name = "langgraph", specifier = ">=1.2.5,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -2644,7 +2644,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.4"
+version = "1.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2654,9 +2654,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/43/dac5a2621c1e57f8eb7f0703f6f6fe34a5caf62f8f0fb4d2bb395bb454ea/langgraph-1.2.4.tar.gz", hash = "sha256:5df076973a2d23efb13eceb279d1e5b46feebcbbeded0a86a2ef669abd9e4399", size = 720374, upload-time = "2026-06-02T17:07:37.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9d/7c9ebd17b95569122e2d2e641f535cf086c870d66bb8e59be33cdba856b3/langgraph-1.2.5.tar.gz", hash = "sha256:09a3bdec6fdb3228623fc78b6f69a1400d383f66348d0b04d0efb692022cc6ef", size = 712532, upload-time = "2026-06-12T20:30:58.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/9e/31ca236104966d7bb14ea9e93cfd73350aea8c41008ddf057b65794ed10d/langgraph-1.2.4-py3-none-any.whl", hash = "sha256:ffe3e1e31dce28907640f82525858470f293506d2b272d07ea3b3ce97974b067", size = 245402, upload-time = "2026-06-02T17:07:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/03/187281cf61845c5a9c397ae6cd9cd73bb54b39435e5575a7b83c853e5b76/langgraph-1.2.5-py3-none-any.whl", hash = "sha256:9286bb5def82fc865959c14378fe473518dc097d586225f622f029637a2a4bb9", size = 246150, upload-time = "2026-06-12T20:30:57.018Z" },
 ]
 
 [[package]]

--- a/libs/model-profiles/uv.lock
+++ b/libs/model-profiles/uv.lock
@@ -537,7 +537,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.2.4,<1.3.0" },
+    { name = "langgraph", specifier = ">=1.2.5,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -763,7 +763,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.4"
+version = "1.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -773,9 +773,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/43/dac5a2621c1e57f8eb7f0703f6f6fe34a5caf62f8f0fb4d2bb395bb454ea/langgraph-1.2.4.tar.gz", hash = "sha256:5df076973a2d23efb13eceb279d1e5b46feebcbbeded0a86a2ef669abd9e4399", size = 720374, upload-time = "2026-06-02T17:07:37.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9d/7c9ebd17b95569122e2d2e641f535cf086c870d66bb8e59be33cdba856b3/langgraph-1.2.5.tar.gz", hash = "sha256:09a3bdec6fdb3228623fc78b6f69a1400d383f66348d0b04d0efb692022cc6ef", size = 712532, upload-time = "2026-06-12T20:30:58.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/9e/31ca236104966d7bb14ea9e93cfd73350aea8c41008ddf057b65794ed10d/langgraph-1.2.4-py3-none-any.whl", hash = "sha256:ffe3e1e31dce28907640f82525858470f293506d2b272d07ea3b3ce97974b067", size = 245402, upload-time = "2026-06-02T17:07:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/03/187281cf61845c5a9c397ae6cd9cd73bb54b39435e5575a7b83c853e5b76/langgraph-1.2.5-py3-none-any.whl", hash = "sha256:9286bb5def82fc865959c14378fe473518dc097d586225f622f029637a2a4bb9", size = 246150, upload-time = "2026-06-12T20:30:57.018Z" },
 ]
 
 [[package]]

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -580,7 +580,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.2.4,<1.3.0" },
+    { name = "langgraph", specifier = ">=1.2.5,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -807,7 +807,7 @@ typing = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.4"
+version = "1.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -817,9 +817,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/43/dac5a2621c1e57f8eb7f0703f6f6fe34a5caf62f8f0fb4d2bb395bb454ea/langgraph-1.2.4.tar.gz", hash = "sha256:5df076973a2d23efb13eceb279d1e5b46feebcbbeded0a86a2ef669abd9e4399", size = 720374, upload-time = "2026-06-02T17:07:37.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9d/7c9ebd17b95569122e2d2e641f535cf086c870d66bb8e59be33cdba856b3/langgraph-1.2.5.tar.gz", hash = "sha256:09a3bdec6fdb3228623fc78b6f69a1400d383f66348d0b04d0efb692022cc6ef", size = 712532, upload-time = "2026-06-12T20:30:58.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/9e/31ca236104966d7bb14ea9e93cfd73350aea8c41008ddf057b65794ed10d/langgraph-1.2.4-py3-none-any.whl", hash = "sha256:ffe3e1e31dce28907640f82525858470f293506d2b272d07ea3b3ce97974b067", size = 245402, upload-time = "2026-06-02T17:07:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/03/187281cf61845c5a9c397ae6cd9cd73bb54b39435e5575a7b83c853e5b76/langgraph-1.2.5-py3-none-any.whl", hash = "sha256:9286bb5def82fc865959c14378fe473518dc097d586225f622f029637a2a4bb9", size = 246150, upload-time = "2026-06-12T20:30:57.018Z" },
 ]
 
 [[package]]

--- a/libs/partners/huggingface/uv.lock
+++ b/libs/partners/huggingface/uv.lock
@@ -1053,7 +1053,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.2.4,<1.3.0" },
+    { name = "langgraph", specifier = ">=1.2.5,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -1303,7 +1303,7 @@ typing = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.4"
+version = "1.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -1313,9 +1313,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/43/dac5a2621c1e57f8eb7f0703f6f6fe34a5caf62f8f0fb4d2bb395bb454ea/langgraph-1.2.4.tar.gz", hash = "sha256:5df076973a2d23efb13eceb279d1e5b46feebcbbeded0a86a2ef669abd9e4399", size = 720374, upload-time = "2026-06-02T17:07:37.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9d/7c9ebd17b95569122e2d2e641f535cf086c870d66bb8e59be33cdba856b3/langgraph-1.2.5.tar.gz", hash = "sha256:09a3bdec6fdb3228623fc78b6f69a1400d383f66348d0b04d0efb692022cc6ef", size = 712532, upload-time = "2026-06-12T20:30:58.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/9e/31ca236104966d7bb14ea9e93cfd73350aea8c41008ddf057b65794ed10d/langgraph-1.2.4-py3-none-any.whl", hash = "sha256:ffe3e1e31dce28907640f82525858470f293506d2b272d07ea3b3ce97974b067", size = 245402, upload-time = "2026-06-02T17:07:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/03/187281cf61845c5a9c397ae6cd9cd73bb54b39435e5575a7b83c853e5b76/langgraph-1.2.5-py3-none-any.whl", hash = "sha256:9286bb5def82fc865959c14378fe473518dc097d586225f622f029637a2a4bb9", size = 246150, upload-time = "2026-06-12T20:30:57.018Z" },
 ]
 
 [[package]]

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -629,7 +629,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.2.4,<1.3.0" },
+    { name = "langgraph", specifier = ">=1.2.5,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity"]
@@ -863,7 +863,7 @@ typing = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.4"
+version = "1.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -873,9 +873,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/43/dac5a2621c1e57f8eb7f0703f6f6fe34a5caf62f8f0fb4d2bb395bb454ea/langgraph-1.2.4.tar.gz", hash = "sha256:5df076973a2d23efb13eceb279d1e5b46feebcbbeded0a86a2ef669abd9e4399", size = 720374, upload-time = "2026-06-02T17:07:37.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9d/7c9ebd17b95569122e2d2e641f535cf086c870d66bb8e59be33cdba856b3/langgraph-1.2.5.tar.gz", hash = "sha256:09a3bdec6fdb3228623fc78b6f69a1400d383f66348d0b04d0efb692022cc6ef", size = 712532, upload-time = "2026-06-12T20:30:58.498Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/9e/31ca236104966d7bb14ea9e93cfd73350aea8c41008ddf057b65794ed10d/langgraph-1.2.4-py3-none-any.whl", hash = "sha256:ffe3e1e31dce28907640f82525858470f293506d2b272d07ea3b3ce97974b067", size = 245402, upload-time = "2026-06-02T17:07:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/03/187281cf61845c5a9c397ae6cd9cd73bb54b39435e5575a7b83c853e5b76/langgraph-1.2.5-py3-none-any.whl", hash = "sha256:9286bb5def82fc865959c14378fe473518dc097d586225f622f029637a2a4bb9", size = 246150, upload-time = "2026-06-12T20:30:57.018Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Core serialization tests now opt into the object allowlists they rely on instead of assuming default deserialization permits core objects. Compatibility tests that intentionally exercise deprecated runnable streaming and history APIs also suppress the expected deprecation warnings so they can keep covering those legacy paths cleanly.

## Changes
- Updated serialization and prompt round-trip tests to pass `allowed_objects="core"` or targeted allowlists when loading `AIMessage`, prompt templates, structured prompts, runnable maps, and related core objects.
- Adjusted secret-injection regression coverage to keep testing `secrets_from_env=True` behavior while explicitly allowing core deserialization paths.
- Tightened prompt deserialization rejection tests so attribute-access payloads are loaded only through the specific prompt-template allowlist needed to reach validation.
- Added module-level warning filters around legacy runnable compatibility coverage for `astream_log`, `astream_events(version="v1")`, and `RunnableWithMessageHistory`.
- Bumped the `langchain` package's minimum `langgraph` dependency from `1.2.4` to `1.2.5`.

## Testing
- Updated unit tests across core serialization, prompt, fake chat model, runnable history, and runnable event coverage.