### PR TITLE
docs: refresh `README` installation and resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ LangChain helps developers build applications powered by LLMs through a standard
 ## Resources
 
 - [Documentation](https://docs.langchain.com/oss/python/langchain/overview) — conceptual overviews and guides
-- [LangChain ecosystem overview](https://docs.langchain.com/oss/python/concepts/products) — how Deep Agents, LangChain, LangGraph, and LangSmith fit together
+- [LangChain ecosystem overview](https://docs.langchain.com/oss/python/concepts/products) — how LangChain, LangGraph, and Deep Agents fit together
 - [API reference](https://reference.langchain.com/python) — complete reference for all public classes, functions, and types
-- [Discussions](https://forum.langchain.com/c/oss-product-help-lc-and-lg/deep-agents/18) — community forum for technical questions, ideas, and feedback
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Discussions](https://forum.langchain.com) — community forum for technical questions, ideas, and feedback
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) — how to contribute and find good first issues
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ LangChain helps developers build applications powered by LLMs through a standard
 - [Documentation](https://docs.langchain.com/oss/python/langchain/overview) — conceptual overviews and guides
 - [LangChain ecosystem overview](https://docs.langchain.com/oss/python/concepts/products) — how LangChain, LangGraph, and Deep Agents fit together
 - [API reference](https://reference.langchain.com/python) — complete reference for all public classes, functions, and types
-- [Discussions](https://forum.langchain.com) — community forum for technical questions, ideas, and feedback
+- [Discussions](https://forum.langchain.com/c/oss-product-help-lc-and-lg/langchain/14) — community forum for technical questions, ideas, and feedback
 - [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) — how to contribute and find good first issues
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/README.md
+++ b/README.md
@@ -29,19 +29,17 @@ LangChain is a framework for building agents and LLM-powered applications. It he
 ## Quickstart
 
 ```bash
-pip install langchain
-# or
 uv add langchain
 ```
 
 ```python
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model("openai:gpt-5.4")
+model = init_chat_model("openai:gpt-5.5")
 result = model.invoke("Hello, world!")
 ```
 
-If you're looking for more advanced customization or agent orchestration, check out [LangGraph](https://docs.langchain.com/oss/python/langgraph/overview), our framework for building controllable agent workflows.
+If you're looking for more advanced customization or agent orchestration, check out [LangGraph](https://github.com/langchain-ai/langgraph), our framework for building controllable agent workflows.
 
 For an equivalent JS/TS library, check out [LangChain.js](https://github.com/langchain-ai/langchainjs).
 
@@ -71,16 +69,12 @@ LangChain helps developers build applications powered by LLMs through a standard
 
 ---
 
-## Documentation
+## Resources
 
-- [docs.langchain.com](https://docs.langchain.com/oss/python/langchain/overview) – Comprehensive documentation, including conceptual overviews and guides
-- [reference.langchain.com/python](https://reference.langchain.com/python) – API reference docs for LangChain packages
-- [Chat LangChain](https://chat.langchain.com/) – Chat with the LangChain documentation and get answers to your questions
-
-**Discussions**: Visit the [LangChain Forum](https://forum.langchain.com) to connect with the community and share all of your technical questions, ideas, and feedback.
-
-## Additional resources
-
-- [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) – Learn how to contribute to LangChain projects and find good first issues.
-- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) – Our community guidelines and standards for participation.
+- [Documentation](https://docs.langchain.com/oss/python/langchain/overview) — conceptual overviews and guides
+- [LangChain ecosystem overview](https://docs.langchain.com/oss/python/concepts/products) — how Deep Agents, LangChain, LangGraph, and LangSmith fit together
+- [API reference](https://reference.langchain.com/python) — complete reference for all public classes, functions, and types
+- [Discussions](https://forum.langchain.com/c/oss-product-help-lc-and-lg/deep-agents/18) — community forum for technical questions, ideas, and feedback
 - [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview) — how to contribute and find good first issues
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -48,5 +48,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -13,7 +13,7 @@ To help you ship LangChain apps to production faster, check out [LangSmith](http
 ## Quick Install
 
 ```bash
-pip install langchain-core
+uv add langchain-core
 ```
 
 ## 🤔 What is this?
@@ -45,3 +45,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/langchain/README.md
+++ b/libs/langchain/README.md
@@ -13,7 +13,7 @@ To help you ship LangChain apps to production faster, check out [LangSmith](http
 ## Quick Install
 
 ```bash
-pip install langchain-classic
+uv add langchain-classic
 ```
 
 ## 🤔 What is this?
@@ -35,3 +35,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/langchain/README.md
+++ b/libs/langchain/README.md
@@ -38,5 +38,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/langchain_v1/README.md
+++ b/libs/langchain_v1/README.md
@@ -40,5 +40,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/langchain_v1/README.md
+++ b/libs/langchain_v1/README.md
@@ -13,7 +13,7 @@ To help you ship LangChain apps to production faster, check out [LangSmith](http
 ## Quick Install
 
 ```bash
-pip install langchain
+uv add langchain
 ```
 
 ## 🤔 What is this?
@@ -37,3 +37,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/model-profiles/README.md
+++ b/libs/model-profiles/README.md
@@ -44,5 +44,5 @@ This downloads the latest model data from models.dev, merges it with any augment
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/model-profiles/README.md
+++ b/libs/model-profiles/README.md
@@ -13,7 +13,7 @@ CLI tool for updating model profile data in LangChain integration packages.
 ## Quick Install
 
 ```bash
-pip install langchain-model-profiles
+uv add langchain-model-profiles
 ```
 
 ## 🤔 What is this?
@@ -41,3 +41,8 @@ langchain-profiles refresh --provider anthropic --data-dir ./langchain_anthropic
 ```
 
 This downloads the latest model data from models.dev, merges it with any augmentations defined in `profile_augmentations.toml`, and generates a `profiles.py` file.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/anthropic/README.md
+++ b/libs/partners/anthropic/README.md
@@ -33,5 +33,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/anthropic/README.md
+++ b/libs/partners/anthropic/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-anthropic
+uv add langchain-anthropic
 ```
 
 ## 🤔 What is this?
@@ -30,3 +30,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/chroma/README.md
+++ b/libs/partners/chroma/README.md
@@ -23,5 +23,5 @@ View the [documentation](https://docs.langchain.com/oss/python/integrations/prov
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/chroma/README.md
+++ b/libs/partners/chroma/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-chroma
+uv add langchain-chroma
 ```
 
 ## 🤔 What is this?
@@ -20,3 +20,8 @@ This package contains the LangChain integration with Chroma.
 ## 📖 Documentation
 
 View the [documentation](https://docs.langchain.com/oss/python/integrations/providers/chroma) for more details.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/deepseek/README.md
+++ b/libs/partners/deepseek/README.md
@@ -33,5 +33,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/deepseek/README.md
+++ b/libs/partners/deepseek/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-deepseek
+uv add langchain-deepseek
 ```
 
 ## 🤔 What is this?
@@ -30,3 +30,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/exa/README.md
+++ b/libs/partners/exa/README.md
@@ -23,5 +23,5 @@ View the [documentation](https://docs.langchain.com/oss/python/integrations/prov
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/exa/README.md
+++ b/libs/partners/exa/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-exa
+uv add langchain-exa
 ```
 
 ## 🤔 What is this?
@@ -20,3 +20,8 @@ This package contains the LangChain integration with [Exa](https://exa.ai), a we
 ## 📖 Documentation
 
 View the [documentation](https://docs.langchain.com/oss/python/integrations/providers/exa_search) for more details.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/fireworks/README.md
+++ b/libs/partners/fireworks/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-fireworks
+uv add langchain-fireworks
 ```
 
 ## 🤔 What is this?
@@ -30,3 +30,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/fireworks/README.md
+++ b/libs/partners/fireworks/README.md
@@ -33,5 +33,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/groq/README.md
+++ b/libs/partners/groq/README.md
@@ -29,5 +29,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/groq/README.md
+++ b/libs/partners/groq/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-groq
+uv add langchain-groq
 ```
 
 ## 📖 Documentation
@@ -26,3 +26,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/huggingface/README.md
+++ b/libs/partners/huggingface/README.md
@@ -18,7 +18,7 @@ uv add langchain-huggingface
 > install the `[full]` extra which includes `sentence-transformers>=5.2.0` and `transformers>=5.0.0`:
 >
 > ```bash
-> uv add langchain-huggingface[full]
+> uv add "langchain-huggingface[full]"
 > ```
 >
 > **Migrating from `langchain-community`?** Note that `langchain-community` accepted
@@ -49,5 +49,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/huggingface/README.md
+++ b/libs/partners/huggingface/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-huggingface
+uv add langchain-huggingface
 ```
 
 > **Note:** The base install does not include `sentence-transformers` or `transformers`.
@@ -18,7 +18,7 @@ pip install langchain-huggingface
 > install the `[full]` extra which includes `sentence-transformers>=5.2.0` and `transformers>=5.0.0`:
 >
 > ```bash
-> pip install langchain-huggingface[full]
+> uv add langchain-huggingface[full]
 > ```
 >
 > **Migrating from `langchain-community`?** Note that `langchain-community` accepted
@@ -26,7 +26,7 @@ pip install langchain-huggingface
 > If your project pins an older version, upgrade it:
 >
 > ```bash
-> pip install "sentence-transformers>=5.2.0"
+> uv add "sentence-transformers>=5.2.0"
 > ```
 
 ## 🤔 What is this?
@@ -46,3 +46,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/mistralai/README.md
+++ b/libs/partners/mistralai/README.md
@@ -29,5 +29,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/mistralai/README.md
+++ b/libs/partners/mistralai/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-mistralai
+uv add langchain-mistralai
 ```
 
 ## 📖 Documentation
@@ -26,3 +26,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/nomic/README.md
+++ b/libs/partners/nomic/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-nomic
+uv add langchain-nomic
 ```
 
 ## 🤔 What is this?
@@ -20,3 +20,8 @@ This package contains the LangChain integration with Nomic
 ## 📖 Documentation
 
 View the [documentation](https://docs.langchain.com/oss/python/integrations/providers/nomic) for more details.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/nomic/README.md
+++ b/libs/partners/nomic/README.md
@@ -23,5 +23,5 @@ View the [documentation](https://docs.langchain.com/oss/python/integrations/prov
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/ollama/README.md
+++ b/libs/partners/ollama/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-ollama
+uv add langchain-ollama
 ```
 
 ## 🤔 What is this?
@@ -30,3 +30,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/ollama/README.md
+++ b/libs/partners/ollama/README.md
@@ -33,5 +33,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/openai/README.md
+++ b/libs/partners/openai/README.md
@@ -33,5 +33,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/openai/README.md
+++ b/libs/partners/openai/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-openai
+uv add langchain-openai
 ```
 
 ## 🤔 What is this?
@@ -30,3 +30,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/openrouter/README.md
+++ b/libs/partners/openrouter/README.md
@@ -31,5 +31,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/openrouter/README.md
+++ b/libs/partners/openrouter/README.md
@@ -8,7 +8,7 @@
 ## Quick Install
 
 ```bash
-pip install langchain-openrouter
+uv add langchain-openrouter
 ```
 
 ## 🤔 What is this?
@@ -28,3 +28,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/perplexity/README.md
+++ b/libs/partners/perplexity/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-perplexity
+uv add langchain-perplexity
 ```
 
 ## 🤔 What is this?
@@ -30,3 +30,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/perplexity/README.md
+++ b/libs/partners/perplexity/README.md
@@ -33,5 +33,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/qdrant/README.md
+++ b/libs/partners/qdrant/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-qdrant
+uv add langchain-qdrant
 ```
 
 ## 🤔 What is this?
@@ -20,3 +20,8 @@ This package contains the LangChain integration with [Qdrant](https://qdrant.tec
 ## 📖 Documentation
 
 View the [documentation](https://docs.langchain.com/oss/python/integrations/providers/qdrant) for more details.
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/qdrant/README.md
+++ b/libs/partners/qdrant/README.md
@@ -23,5 +23,5 @@ View the [documentation](https://docs.langchain.com/oss/python/integrations/prov
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/xai/README.md
+++ b/libs/partners/xai/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-xai
+uv add langchain-xai
 ```
 
 ## 🤔 What is this?
@@ -30,3 +30,8 @@ See our [Releases](https://docs.langchain.com/oss/python/release-policy) and [Ve
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/partners/xai/README.md
+++ b/libs/partners/xai/README.md
@@ -33,5 +33,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/standard-tests/README.md
+++ b/libs/standard-tests/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-tests
+uv add langchain-tests
 ```
 
 ## 🤔 What is this?

--- a/libs/text-splitters/README.md
+++ b/libs/text-splitters/README.md
@@ -37,5 +37,5 @@ For detailed information on how to contribute, see the [Contributing Guide](http
 
 ## Resources
 
-- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards

--- a/libs/text-splitters/README.md
+++ b/libs/text-splitters/README.md
@@ -10,7 +10,7 @@ Looking for the JS/TS version? Check out [LangChain.js](https://github.com/langc
 ## Quick Install
 
 ```bash
-pip install langchain-text-splitters
+uv add langchain-text-splitters
 ```
 
 ## 🤔 What is this?
@@ -34,3 +34,8 @@ Not pinning your version will ensure you always have the latest tests, but it ma
 As an open-source project in a rapidly developing field, we are extremely open to contributions, whether it be in the form of a new feature, improved infrastructure, or better documentation.
 
 For detailed information on how to contribute, see the [Contributing Guide](https://docs.langchain.com/oss/python/contributing/overview).
+
+## Resources
+
+- [LangChain Academy](https://academy.langchain.com/) – Comprehensive, free courses on LangChain libraries and products, made by the LangChain team.
+- [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards


### PR DESCRIPTION
README installation examples now use `uv add` consistently, matching the repo's `uv`-based Python workflow. The top-level README also gets a cleaner quickstart and resource section with current links for docs, community, learning, and contribution guidance.

## Changes
- Replaced `pip install` snippets with `uv add` across package quick install docs, including the Hugging Face extras and `sentence-transformers` upgrade examples.
- Updated the top-level quickstart to show only `uv add langchain` and refreshed the example model to `openai:gpt-5.5`.
- Pointed the LangGraph orchestration link at the LangGraph GitHub repository.
- Consolidated top-level documentation and additional-resource links under a single `Resources` section covering docs, ecosystem overview, API reference, discussions, Academy, contributing, and the Code of Conduct.
- Added LangChain Academy and Code of Conduct links to package README resource sections.