### PR TITLE
chore(infra): wire up per-partner version-consistency pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,3 +129,87 @@ repos:
         entry: make -C libs/partners/anthropic check_version
         files: ^libs/partners/anthropic/(pyproject\.toml|langchain_anthropic/_version\.py)$
         pass_filenames: false
+      - id: chroma-version
+        name: check chroma version consistency
+        language: system
+        entry: make -C libs/partners/chroma check_version
+        files: ^libs/partners/chroma/(pyproject\.toml|langchain_chroma/_version\.py)$
+        pass_filenames: false
+      - id: deepseek-version
+        name: check deepseek version consistency
+        language: system
+        entry: make -C libs/partners/deepseek check_version
+        files: ^libs/partners/deepseek/(pyproject\.toml|langchain_deepseek/_version\.py)$
+        pass_filenames: false
+      - id: exa-version
+        name: check exa version consistency
+        language: system
+        entry: make -C libs/partners/exa check_version
+        files: ^libs/partners/exa/(pyproject\.toml|langchain_exa/_version\.py)$
+        pass_filenames: false
+      - id: fireworks-version
+        name: check fireworks version consistency
+        language: system
+        entry: make -C libs/partners/fireworks check_version
+        files: ^libs/partners/fireworks/(pyproject\.toml|langchain_fireworks/_version\.py)$
+        pass_filenames: false
+      - id: groq-version
+        name: check groq version consistency
+        language: system
+        entry: make -C libs/partners/groq check_version
+        files: ^libs/partners/groq/(pyproject\.toml|langchain_groq/_version\.py)$
+        pass_filenames: false
+      - id: huggingface-version
+        name: check huggingface version consistency
+        language: system
+        entry: make -C libs/partners/huggingface check_version
+        files: ^libs/partners/huggingface/(pyproject\.toml|langchain_huggingface/_version\.py)$
+        pass_filenames: false
+      - id: mistralai-version
+        name: check mistralai version consistency
+        language: system
+        entry: make -C libs/partners/mistralai check_version
+        files: ^libs/partners/mistralai/(pyproject\.toml|langchain_mistralai/_version\.py)$
+        pass_filenames: false
+      - id: nomic-version
+        name: check nomic version consistency
+        language: system
+        entry: make -C libs/partners/nomic check_version
+        files: ^libs/partners/nomic/(pyproject\.toml|langchain_nomic/_version\.py)$
+        pass_filenames: false
+      - id: ollama-version
+        name: check ollama version consistency
+        language: system
+        entry: make -C libs/partners/ollama check_version
+        files: ^libs/partners/ollama/(pyproject\.toml|langchain_ollama/_version\.py)$
+        pass_filenames: false
+      - id: openai-version
+        name: check openai version consistency
+        language: system
+        entry: make -C libs/partners/openai check_version
+        files: ^libs/partners/openai/(pyproject\.toml|langchain_openai/_version\.py)$
+        pass_filenames: false
+      - id: openrouter-version
+        name: check openrouter version consistency
+        language: system
+        entry: make -C libs/partners/openrouter check_version
+        files: ^libs/partners/openrouter/(pyproject\.toml|langchain_openrouter/_version\.py)$
+        pass_filenames: false
+      - id: perplexity-version
+        name: check perplexity version consistency
+        language: system
+        entry: make -C libs/partners/perplexity check_version
+        files: ^libs/partners/perplexity/(pyproject\.toml|langchain_perplexity/_version\.py)$
+        pass_filenames: false
+      - id: qdrant-version
+        name: check qdrant version consistency
+        language: system
+        entry: make -C libs/partners/qdrant check_version
+        files: ^libs/partners/qdrant/(pyproject\.toml|langchain_qdrant/_version\.py)$
+        pass_filenames: false
+      - id: xai-version
+        name: check xai version consistency
+        language: system
+        entry: make -C libs/partners/xai check_version
+        files: ^libs/partners/xai/(pyproject\.toml|langchain_xai/_version\.py)$
+        pass_filenames: false


### PR DESCRIPTION
Every partner package ships a `check_version.py` that guards against the version in `pyproject.toml` drifting out of sync with the one in `_version.py`, but only `anthropic` had that check registered as a pre-commit hook. The other 14 partners had the script and `make check_version` target sitting unused — a mismatch would sail through `git commit` undetected. This registers the missing hooks so the guard actually runs.