### PR TITLE
feat(anthropic): expose http_client and http_async_client constructor kwargs on ChatAnthropic

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -974,6 +974,36 @@ class ChatAnthropic(BaseChatModel):
     default_headers: Mapping[str, str] | None = None
     """Headers to pass to the Anthropic clients, will be used for every API call."""
 
+    http_client: Any = Field(default=None, exclude=True)
+    """Optional ``httpx.Client`` to use for **synchronous** Anthropic API calls.
+
+    If not provided, ``ChatAnthropic`` will build a default ``httpx.Client`` internally
+    using ``base_url``, ``timeout``, and ``anthropic_proxy``.
+
+    When supplied, the caller owns the client's lifecycle and is responsible for
+    configuring its ``timeout``, ``limits``, ``transport``, ``proxies``, and
+    ``follow_redirects``. This enables advanced use cases such as per-request
+    inter-chunk read-idle timeouts via ``httpx.Timeout(read=...)`` on streaming
+    responses.
+
+    Excluded from ``model_dump`` because ``httpx.Client`` is not serializable.
+    """
+
+    http_async_client: Any = Field(default=None, exclude=True)
+    """Optional ``httpx.AsyncClient`` to use for **asynchronous** Anthropic API calls.
+
+    If not provided, ``ChatAnthropic`` will build a default ``httpx.AsyncClient``
+    internally using ``base_url``, ``timeout``, and ``anthropic_proxy``.
+
+    When supplied, the caller owns the client's lifecycle and is responsible for
+    configuring its ``timeout``, ``limits``, ``transport``, ``proxies``, and
+    ``follow_redirects``. This is the relevant knob for ``ainvoke`` / ``astream``,
+    where inter-chunk read-idle timeouts (e.g. ``httpx.Timeout(read=180.0)``) detect
+    dead streams that ``default_request_timeout`` (a total-budget timeout) cannot.
+
+    Excluded from ``model_dump`` because ``httpx.AsyncClient`` is not serializable.
+    """
+
     betas: list[str] | None = None
     """List of beta features to enable. If specified, invocations will be routed
     through `client.beta.messages.create`.
@@ -1204,12 +1234,16 @@ class ChatAnthropic(BaseChatModel):
     @cached_property
     def _client(self) -> anthropic.Client:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
-        if "timeout" in client_params:
-            http_client_params["timeout"] = client_params["timeout"]
-        if self.anthropic_proxy:
-            http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_httpx_client(**http_client_params)
+        if self.http_client is not None:
+            # Adopter-supplied client takes ownership of timeout/transport/limits.
+            http_client = self.http_client
+        else:
+            http_client_params = {"base_url": client_params["base_url"]}
+            if "timeout" in client_params:
+                http_client_params["timeout"] = client_params["timeout"]
+            if self.anthropic_proxy:
+                http_client_params["anthropic_proxy"] = self.anthropic_proxy
+            http_client = _get_default_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,
@@ -1219,12 +1253,16 @@ class ChatAnthropic(BaseChatModel):
     @cached_property
     def _async_client(self) -> anthropic.AsyncClient:
         client_params = self._client_params
-        http_client_params = {"base_url": client_params["base_url"]}
-        if "timeout" in client_params:
-            http_client_params["timeout"] = client_params["timeout"]
-        if self.anthropic_proxy:
-            http_client_params["anthropic_proxy"] = self.anthropic_proxy
-        http_client = _get_default_async_httpx_client(**http_client_params)
+        if self.http_async_client is not None:
+            # Adopter-supplied client takes ownership of timeout/transport/limits.
+            http_client = self.http_async_client
+        else:
+            http_client_params = {"base_url": client_params["base_url"]}
+            if "timeout" in client_params:
+                http_client_params["timeout"] = client_params["timeout"]
+            if self.anthropic_proxy:
+                http_client_params["anthropic_proxy"] = self.anthropic_proxy
+            http_client = _get_default_async_httpx_client(**http_client_params)
         params = {
             **client_params,
             "http_client": http_client,

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3378,3 +3378,129 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+# ---------- http_client / http_async_client injection ----------
+
+
+def test_http_client_injection_threads_into_sync_sdk() -> None:
+    """When ``http_client`` is provided, it is passed verbatim to
+    ``anthropic.Client(...)`` and the default helper is NOT invoked.
+    """
+    import httpx
+
+    custom_client = httpx.Client(timeout=httpx.Timeout(60.0, read=180.0))
+
+    with (
+        patch("langchain_anthropic.chat_models.anthropic.Client") as mock_client_cls,
+        patch(
+            "langchain_anthropic.chat_models._get_default_httpx_client"
+        ) as mock_default,
+    ):
+        llm = ChatAnthropic(
+            model="claude-3-5-sonnet-latest",
+            anthropic_api_key="test-key",  # type: ignore[arg-type]
+            http_client=custom_client,
+        )
+        # Touch the cached_property so the SDK constructor is invoked.
+        _ = llm._client
+
+        mock_default.assert_not_called()
+        mock_client_cls.assert_called_once()
+        _, kwargs = mock_client_cls.call_args
+        assert kwargs["http_client"] is custom_client
+
+    custom_client.close()
+
+
+def test_http_async_client_injection_threads_into_async_sdk() -> None:
+    """When ``http_async_client`` is provided, it is passed verbatim to
+    ``anthropic.AsyncClient(...)`` and the default helper is NOT invoked.
+    """
+    import httpx
+
+    custom_async_client = httpx.AsyncClient(timeout=httpx.Timeout(60.0, read=180.0))
+
+    with (
+        patch(
+            "langchain_anthropic.chat_models.anthropic.AsyncClient"
+        ) as mock_async_client_cls,
+        patch(
+            "langchain_anthropic.chat_models._get_default_async_httpx_client"
+        ) as mock_default,
+    ):
+        llm = ChatAnthropic(
+            model="claude-3-5-sonnet-latest",
+            anthropic_api_key="test-key",  # type: ignore[arg-type]
+            http_async_client=custom_async_client,
+        )
+        _ = llm._async_client
+
+        mock_default.assert_not_called()
+        mock_async_client_cls.assert_called_once()
+        _, kwargs = mock_async_client_cls.call_args
+        assert kwargs["http_client"] is custom_async_client
+
+
+def test_default_path_preserves_existing_behavior_byte_identical() -> None:
+    """When neither ``http_client`` nor ``http_async_client`` is provided,
+    the default ``_get_default_*_httpx_client`` helpers are still invoked
+    and their returned client is forwarded to the SDK constructor.
+    """
+    # Sync default path
+    with (
+        patch(
+            "langchain_anthropic.chat_models._get_default_httpx_client"
+        ) as mock_sync_default,
+        patch("langchain_anthropic.chat_models.anthropic.Client") as mock_client_cls,
+    ):
+        mock_sync_default.return_value = MagicMock(name="default_sync_client")
+        llm = ChatAnthropic(
+            model="claude-3-5-sonnet-latest",
+            anthropic_api_key="test-key",  # type: ignore[arg-type]
+        )
+        _ = llm._client
+        assert mock_sync_default.called
+        _, kwargs = mock_client_cls.call_args
+        assert kwargs["http_client"] is mock_sync_default.return_value
+
+    # Async default path
+    with (
+        patch(
+            "langchain_anthropic.chat_models._get_default_async_httpx_client"
+        ) as mock_async_default,
+        patch(
+            "langchain_anthropic.chat_models.anthropic.AsyncClient"
+        ) as mock_async_client_cls,
+    ):
+        mock_async_default.return_value = MagicMock(name="default_async_client")
+        llm = ChatAnthropic(
+            model="claude-3-5-sonnet-latest",
+            anthropic_api_key="test-key",  # type: ignore[arg-type]
+        )
+        _ = llm._async_client
+        assert mock_async_default.called
+        _, kwargs = mock_async_client_cls.call_args
+        assert kwargs["http_client"] is mock_async_default.return_value
+
+
+def test_http_clients_are_excluded_from_model_dump() -> None:
+    """``httpx.Client`` instances are not serializable; they must not leak into
+    ``model_dump``.
+    """
+    import httpx
+
+    custom_sync = httpx.Client()
+    custom_async = httpx.AsyncClient()
+    try:
+        llm = ChatAnthropic(
+            model="claude-3-5-sonnet-latest",
+            anthropic_api_key="test-key",  # type: ignore[arg-type]
+            http_client=custom_sync,
+            http_async_client=custom_async,
+        )
+        dump = llm.model_dump()
+        assert "http_client" not in dump
+        assert "http_async_client" not in dump
+    finally:
+        custom_sync.close()


### PR DESCRIPTION
Fixes #36056

## Description

Add `http_client` and `http_async_client` constructor kwargs to `ChatAnthropic`, mirroring the equivalent fields already exposed on `ChatOpenAI`. Defaults are `None` and preserve byte-identical behavior with today's release — `ChatAnthropic` continues to build its own `httpx.Client` / `httpx.AsyncClient` internally when these kwargs are not set.

This closes a small but production-impacting gap: every other major LangChain provider class (`ChatOpenAI`, `ChatDeepSeek`, `ChatTogether`, and several others) exposes an `http_async_client` seam that lets callers configure per-request `httpx.Timeout(read=...)` semantics. `ChatAnthropic` is the last holdout: it builds its httpx clients via `_get_default_httpx_client` / `_get_default_async_httpx_client` and offers no per-instance seam.

## Motivation

Production users on Anthropic streams have hit cases where the connection stalls mid-stream — the TCP socket stays open, no bytes arrive, and the request hangs until the SDK-level total `timeout` fires. We observed a **1248-second hang** on a single Anthropic stream in a live workload before the total budget expired (~$1.51 of LLM spend burned, no answer delivered).

`default_request_timeout` (already exposed) is a **total request budget** and cannot distinguish a healthy slow generation from a dead connection. The right primitive for "no bytes have arrived in N seconds" is `httpx.Timeout(read=N)`, which lives one layer down inside the httpx client — and is only reachable today if `ChatAnthropic` accepts an injected `http_client`.

Anthropic's own Python SDK already accepts `http_client` on both `anthropic.Anthropic.__init__` and `anthropic.AsyncAnthropic.__init__` (see [anthropic-sdk-python `_client.py`](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/_client.py)). This PR is purely additive plumbing between the LangChain layer and that existing SDK seam.

## API addition

Two new optional fields on `ChatAnthropic`:

```python
http_client: Any = Field(default=None, exclude=True)
"""Optional ``httpx.Client`` for synchronous calls."""

http_async_client: Any = Field(default=None, exclude=True)
"""Optional ``httpx.AsyncClient`` for asynchronous calls."""
```

Both default to `None`. When unset, `ChatAnthropic` continues to build its own clients via the existing `_get_default_httpx_client` / `_get_default_async_httpx_client` helpers — i.e. wire-byte-identical behavior with today's release.

When set, the supplied client is passed verbatim to `anthropic.Client(http_client=...)` / `anthropic.AsyncClient(http_client=...)`. The caller owns the client's `timeout`, `limits`, `transport`, `proxies`, and lifecycle. `exclude=True` keeps the (non-serializable) httpx client objects out of `model_dump()` and Langchain's serialization round-trip.

## Use case

```python
import httpx
from langchain_anthropic import ChatAnthropic

# Detect dead streams within 180s of inter-chunk silence, while still allowing
# total generations up to 600s.
custom = httpx.AsyncClient(
    timeout=httpx.Timeout(connect=10.0, read=180.0, write=30.0, pool=10.0),
)

llm = ChatAnthropic(
    model="claude-3-5-sonnet-latest",
    http_async_client=custom,
    default_request_timeout=600.0,
)

async for chunk in llm.astream("Generate a long story."):
    print(chunk.content, end="", flush=True)
```

## Compatibility

- **Additive change**: both new fields default to `None`. Existing callers that do not set them get the exact same `anthropic.Client(...)` / `anthropic.AsyncClient(...)` invocation as before this PR — verified by the regression test `test_default_path_preserves_existing_behavior_byte_identical`.
- **No new dependencies**: `httpx` is already an indirect dependency via the `anthropic` SDK.
- **No deprecations**: `default_request_timeout`, `anthropic_proxy`, `default_headers`, and `max_retries` continue to work exactly as today on the default path.
- **Inheritance**: `ChatAnthropicTools` (in `langchain_anthropic.experimental`) inherits from `ChatAnthropic` and picks up both new kwargs transitively at no cost.

## Testing

Added to `tests/unit_tests/test_chat_models.py`:

1. `test_http_client_injection_threads_into_sync_sdk` — mocks `anthropic.Client` and asserts the user-supplied `httpx.Client` is passed verbatim and the default helper is NOT invoked.
2. `test_http_async_client_injection_threads_into_async_sdk` — same shape for `AsyncClient`.
3. `test_default_path_preserves_existing_behavior_byte_identical` — regression test confirming the no-kwarg path still calls the default helpers and forwards their return value.
4. `test_http_clients_are_excluded_from_model_dump` — guards the `exclude=True` contract.

Full `tests/unit_tests/test_chat_models.py` run locally: **111 passed** (all 107 pre-existing + 4 new).

## Acknowledgment

This is the same proposal as the earlier closed PRs #36118 (mvanhorn), #37526 (sameershaik-wq), and #37983 (charafkamel). I'm submitting because we have a specific production failure (1248s stream stall) blocked on this surface and prior PRs do not appear to have been merged. Happy to defer to baskaryan's #37718 if that lands the same surface; otherwise this is ready for review.

## Related

- Anthropic SDK `http_client` kwarg: already present in `anthropic.Anthropic.__init__` and `anthropic.AsyncAnthropic.__init__`.
- `ChatOpenAI` precedent: `langchain-openai` exposes `http_client` / `http_async_client` on `ChatOpenAI` with the exact same semantics.
- Related open work: #37718 (`feat(core,anthropic,openai): aclose() lifecycle + latched fallbacks`) may include this surface.
