### PR TITLE
fix(huggingface): use `PydanticOutputParser` for Pydantic schemas in `with_structured_output`

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,7 +47,7 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
     make_invalid_tool_call,
@@ -1177,9 +1177,9 @@ class ChatHuggingFace(BaseChatModel):
             if is_pydantic_schema:
                 msg = "Pydantic schema is not supported for function calling"
                 raise NotImplementedError(msg)
-            output_parser: JsonOutputKeyToolsParser | JsonOutputParser = (
-                JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
-            )
+            output_parser: (
+                JsonOutputKeyToolsParser | JsonOutputParser | PydanticOutputParser
+            ) = JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
         elif method == "json_schema":
             if schema is None:
                 msg = (
@@ -1195,7 +1195,11 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1204,7 +1208,11 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
         else:
             msg = (
                 f"Unrecognized method argument. Expected one of 'function_calling' or "

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -9,8 +9,10 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.outputs import ChatResult
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
@@ -402,3 +404,36 @@ def test_init_chat_model_huggingface() -> None:
         # The important part is that the code path doesn't raise ValidationError
         # about missing 'llm' field, which was the original bug
         pytest.skip(f"Skipping test due to model download/initialization error: {e}")
+
+
+class _AnswerSchema(BaseModel):
+    answer: str
+
+
+@pytest.mark.parametrize("method", ["json_schema", "json_mode"])
+def test_with_structured_output_pydantic_uses_pydantic_parser(
+    chat_hugging_face: Any, method: str
+) -> None:
+    """A Pydantic schema should be parsed with `PydanticOutputParser`.
+
+    Regression test for #32197: `json_schema` and `json_mode` previously always used
+    `JsonOutputParser`, so a `dict` was returned even though the docstring promises a
+    Pydantic instance when `schema` is a Pydantic class.
+    """
+    runnable = chat_hugging_face.with_structured_output(_AnswerSchema, method=method)
+
+    assert isinstance(runnable.last, PydanticOutputParser)
+
+
+def test_with_structured_output_dict_uses_json_parser(chat_hugging_face: Any) -> None:
+    """A non-Pydantic (dict) schema should keep using `JsonOutputParser`."""
+    dict_schema = {
+        "title": "AnswerSchema",
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+    }
+    runnable = chat_hugging_face.with_structured_output(
+        dict_schema, method="json_schema"
+    )
+
+    assert isinstance(runnable.last, JsonOutputParser)


### PR DESCRIPTION
Closes #32197

---

When a user calls `ChatHuggingFace.with_structured_output` with a Pydantic model and `include_raw=False`, the documented behavior is that the runnable returns an instance of that model. In practice, the `json_schema` and `json_mode` methods always attached a `JsonOutputParser`, so callers got back a plain `dict` instead — the Pydantic typing was silently lost, which is surprising and forces users to re-validate the output themselves.

This change attaches a `PydanticOutputParser` when the provided `schema` is a Pydantic class (for both `json_schema` and `json_mode`), and keeps `JsonOutputParser` for dict / JSON-schema inputs. This brings `langchain-huggingface` in line with how `langchain-ollama` already handles structured output, and makes the runtime behavior match the docstring.

Unit tests cover both the Pydantic path (parser is a `PydanticOutputParser`) and the dict path (parser remains a `JsonOutputParser`).

`function_calling` is intentionally left unchanged: it still raises `NotImplementedError` for Pydantic schemas, which is a separate, pre-existing limitation.

> Disclaimer: this contribution was prepared with the assistance of an AI agent; all changes were reviewed and verified (unit tests, `ruff`, and `mypy` pass locally).