### PR TITLE
fix(core): allow `RootModel` unions to deserialize schema objects

### DIFF
--- a/libs/core/langchain_core/agents.py
+++ b/libs/core/langchain_core/agents.py
@@ -69,8 +69,13 @@ class AgentAction(Serializable):
 
     # Override init to support instantiation by position for backward compat.
     def __init__(
-        self, tool: str, tool_input: str | dict[Any, Any], log: str, **kwargs: Any
-    ):
+        self,
+        tool: str | None = None,
+        tool_input: str | dict[Any, Any] | None = None,
+        log: str | None = None,
+        /,
+        **kwargs: Any,
+    ) -> None:
         """Create an `AgentAction`.
 
         Args:
@@ -78,7 +83,13 @@ class AgentAction(Serializable):
             tool_input: The input to pass in to the `Tool`.
             log: Additional information to log about the action.
         """
-        super().__init__(tool=tool, tool_input=tool_input, log=log, **kwargs)
+        if tool is not None:
+            kwargs["tool"] = tool
+        if tool_input is not None:
+            kwargs["tool_input"] = tool_input
+        if log is not None:
+            kwargs["log"] = log
+        super().__init__(**kwargs)
 
     @classmethod
     def is_lc_serializable(cls) -> bool:
@@ -166,9 +177,19 @@ class AgentFinish(Serializable):
     """
     type: Literal["AgentFinish"] = "AgentFinish"
 
-    def __init__(self, return_values: dict[Any, Any], log: str, **kwargs: Any):
-        """Override init to support instantiation by position for backward compat."""
-        super().__init__(return_values=return_values, log=log, **kwargs)
+    def __init__(
+        self,
+        return_values: dict[Any, Any] | None = None,
+        log: str | None = None,
+        /,
+        **kwargs: Any,
+    ) -> None:
+        """Support both positional and keyword initialization paths."""
+        if return_values is not None:
+            kwargs["return_values"] = return_values
+        if log is not None:
+            kwargs["log"] = log
+        super().__init__(**kwargs)
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -308,11 +308,15 @@ class Document(BaseMedia):
 
     type: Literal["Document"] = "Document"
 
-    def __init__(self, page_content: str, **kwargs: Any) -> None:
-        """Pass page_content in as positional or named arg."""
+    def __init__(
+        self, page_content: str | None = None, /, **kwargs: Any
+    ) -> None:
+        """Pass `page_content` in as a positional or named argument."""
         # my-py is complaining that page_content is not defined on the base class.
         # Here, we're relying on pydantic base class to handle the validation.
-        super().__init__(page_content=page_content, **kwargs)  # type: ignore[call-arg,unused-ignore]
+        if page_content is not None:
+            kwargs["page_content"] = page_content
+        super().__init__(**kwargs)  # type: ignore[call-arg,unused-ignore]
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/langchain/tests/unit_tests/test_schema.py
+++ b/libs/langchain/tests/unit_tests/test_schema.py
@@ -21,7 +21,6 @@ from langchain_core.prompt_values import ChatPromptValueConcrete, StringPromptVa
 from pydantic import RootModel, ValidationError
 
 
-@pytest.mark.xfail(reason="TODO: FIX BEFORE 0.3 RELEASE")
 def test_serialization_of_wellknown_objects() -> None:
     """Test that pydantic is able to serialize and deserialize well known objects."""
     well_known_lc_object = RootModel[


### PR DESCRIPTION
Fixes #38137

---

Users defining external Pydantic schemas can now round-trip well-known LangChain schema objects through `RootModel` unions without hitting `TypeError` from compatibility `__init__` overrides. This keeps positional constructor compatibility for `Document`, `AgentAction`, and `AgentFinish` while restoring keyword-based union deserialization and converts the existing schema round-trip xfail into a regression test.

Verified with `uv run --project libs/langchain --group test pytest libs/langchain/tests/unit_tests/test_schema.py -k serialization_of_wellknown_objects -vv`, `uv run --project libs/core --group lint ruff check libs/core/langchain_core/documents/base.py libs/core/langchain_core/agents.py libs/langchain/tests/unit_tests/test_schema.py`, and `uv run --project libs/core --group typing mypy libs/core/langchain_core/documents/base.py libs/core/langchain_core/agents.py`.

AI-agent assistance was used to help prepare this contribution.