### PR TITLE
core: honor `description`/docstring in `@tool(infer_schema=False)`

### DIFF
--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -316,7 +316,7 @@ def tool(
                 )
             # If someone doesn't want a schema applied, we must treat it as
             # a simple string->string function
-            if dec_func.__doc__ is None:
+            if tool_description is None and dec_func.__doc__ is None:
                 msg = (
                     "Function must have a docstring if "
                     "description not provided and infer_schema is False."
@@ -325,7 +325,7 @@ def tool(
             return Tool(
                 name=tool_name,
                 func=func,
-                description=f"{tool_name} tool",
+                description=tool_description or dec_func.__doc__ or f"{tool_name} tool",
                 return_direct=return_direct,
                 coroutine=coroutine,
                 response_format=response_format,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -348,6 +348,30 @@ def test_structured_single_str_decorator_no_infer_schema() -> None:
     assert unstructured_tool_input.run("foo") == "foo"
 
 
+def test_decorator_no_infer_schema_uses_description_then_docstring() -> None:
+    """`infer_schema=False` honors `description`, falling back to the docstring."""
+
+    @tool(description="Explicit description", infer_schema=False)
+    def with_description(tool_input: str) -> str:
+        """Docstring ignored when description is given."""
+        return tool_input
+
+    assert with_description.description == "Explicit description"
+
+    @tool(infer_schema=False)
+    def with_docstring(tool_input: str) -> str:
+        """Docstring used as the description."""
+        return tool_input
+
+    assert with_docstring.description == "Docstring used as the description."
+
+    with pytest.raises(ValueError, match="docstring"):
+
+        @tool(infer_schema=False)
+        def missing_both(tool_input: str) -> str:
+            return tool_input
+
+
 def test_structured_tool_types_parsed() -> None:
     """Test the non-primitive types are correctly passed to structured tools."""
 


### PR DESCRIPTION
**Description:**

`@tool(infer_schema=False)` (the string-in/string-out `Tool` path) hardcoded the tool description to `f"{tool_name} tool"`, so a user-provided `description=` was silently dropped and the docstring it requires was never actually used.

This honors `description`, falls back to the function docstring, and only raises when both are missing:

```python
@tool(description="Search weather data", infer_schema=False)
def f(q: str) -> str:
    """..."""
    ...

f.description  # was "f tool", now "Search weather data"
```

**Issue:** Fixes #38138

**Dependencies:** None
