### PR TITLE
fix(text-splitters): hide `HTMLSectionSplitter` title sentinel

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -21,6 +21,9 @@ from typing_extensions import override
 
 from langchain_text_splitters.character import RecursiveCharacterTextSplitter
 
+_HTML_TITLE_SENTINEL = "#TITLE#"
+_MISSING = object()
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator, Sequence
 
@@ -432,16 +435,38 @@ class HTMLSectionSplitter:
         metadatas_ = metadatas or [{}] * len(texts)
         documents = []
         for i, text in enumerate(texts):
-            for chunk in self.split_text(text):
-                metadata = copy.deepcopy(metadatas_[i])
-
-                for key in chunk.metadata:
-                    if chunk.metadata[key] == "#TITLE#":
-                        chunk.metadata[key] = metadata["Title"]
-                metadata = {**metadata, **chunk.metadata}
-                new_doc = Document(page_content=chunk.page_content, metadata=metadata)
+            file_content = self.convert_possible_tags_to_header(text)
+            for section in self.split_html_by_headers(file_content):
+                base_metadata = copy.deepcopy(metadatas_[i])
+                section_metadata = self._section_metadata(
+                    section,
+                    document_title=base_metadata.get("Title", _MISSING),
+                )
+                metadata = {**base_metadata, **section_metadata}
+                new_doc = Document(
+                    page_content=cast("str", section["content"]), metadata=metadata
+                )
                 documents.append(new_doc)
         return documents
+
+    def _section_metadata(
+        self,
+        section: dict[str, str | None],
+        *,
+        document_title: object = _MISSING,
+    ) -> dict[str, object]:
+        tag_name = section["tag_name"]
+        header = section["header"]
+        if tag_name is None or header is None:
+            return {}
+        metadata_key = self.headers_to_split_on.get(str(tag_name))
+        if metadata_key is None:
+            return {}
+        if header == _HTML_TITLE_SENTINEL:
+            if document_title is _MISSING:
+                return {}
+            header = document_title
+        return {metadata_key: header}
 
     def split_html_by_headers(self, html_doc: str) -> list[dict[str, str | None]]:
         """Split an HTML document into sections based on specified header tags.
@@ -479,7 +504,7 @@ class HTMLSectionSplitter:
 
         for i, header in enumerate(headers):
             if i == 0:
-                current_header = "#TITLE#"
+                current_header = _HTML_TITLE_SENTINEL
                 current_header_tag = "h1"
                 section_content: list[str] = []
             else:
@@ -557,11 +582,7 @@ class HTMLSectionSplitter:
         return [
             Document(
                 cast("str", section["content"]),
-                metadata={
-                    self.headers_to_split_on[str(section["tag_name"])]: section[
-                        "header"
-                    ]
-                },
+                metadata=self._section_metadata(section),
             )
             for section in sections
         ]

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3052,6 +3052,124 @@ def test_section_aware_happy_path_splitting_based_on_header_1_2() -> None:
 
 @pytest.mark.requires("bs4")
 @pytest.mark.requires("lxml")
+def test_html_section_splitter_does_not_expose_title_sentinel() -> None:
+    html_string = """<!DOCTYPE html>
+            <html>
+            <body>
+                <p>Intro before header.</p>
+                <h1>Header</h1>
+                <p>Body.</p>
+            </body>
+            </html>"""
+
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    docs = sec_splitter.split_text(html_string)
+
+    assert docs[0].page_content == "Intro before header."
+    assert docs[0].metadata == {}
+    assert docs[1].metadata == {"Header 1": "Header"}
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
+def test_html_section_splitter_uses_parent_title_when_available() -> None:
+    html_string = """<!DOCTYPE html>
+            <html>
+            <body>
+                <p>Intro before header.</p>
+                <h1>Header</h1>
+                <p>Body.</p>
+            </body>
+            </html>"""
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    docs = sec_splitter.create_documents(
+        [html_string], metadatas=[{"Title": "Parent title", "source": "example"}]
+    )
+
+    assert docs[0].metadata == {
+        "Header 1": "Parent title",
+        "Title": "Parent title",
+        "source": "example",
+    }
+    assert docs[1].metadata == {
+        "Header 1": "Header",
+        "Title": "Parent title",
+        "source": "example",
+    }
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
+def test_html_section_splitter_create_documents_without_parent_title() -> None:
+    html_string = """<!DOCTYPE html>
+            <html>
+            <body>
+                <p>Intro before header.</p>
+                <h1>Header</h1>
+                <p>Body.</p>
+            </body>
+            </html>"""
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    docs = sec_splitter.create_documents(
+        [html_string], metadatas=[{"source": "example"}]
+    )
+
+    assert docs[0].metadata == {"source": "example"}
+    assert docs[1].metadata == {"Header 1": "Header", "source": "example"}
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
+def test_html_section_splitter_create_documents_without_configured_h1() -> None:
+    html_string = """<!DOCTYPE html>
+            <html>
+            <body>
+                <p>Intro before header.</p>
+                <h2>Header</h2>
+                <p>Body.</p>
+            </body>
+            </html>"""
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h2", "Header 2")])
+
+    docs = sec_splitter.create_documents(
+        [html_string], metadatas=[{"Title": "Parent title", "source": "example"}]
+    )
+
+    assert docs[0].metadata == {"Title": "Parent title", "source": "example"}
+    assert docs[1].metadata == {
+        "Header 2": "Header",
+        "Title": "Parent title",
+        "source": "example",
+    }
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
+def test_html_section_splitter_copies_metadata_per_chunk() -> None:
+    html_string = """<!DOCTYPE html>
+            <html>
+            <body>
+                <h1>First</h1>
+                <p>First body.</p>
+                <h1>Second</h1>
+                <p>Second body.</p>
+            </body>
+            </html>"""
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    docs = sec_splitter.create_documents(
+        [html_string], metadatas=[{"nested": {"value": "original"}}]
+    )
+    docs[0].metadata["nested"]["value"] = "changed"
+
+    assert docs[1].metadata["nested"] == {"value": "original"}
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
 def test_happy_path_splitting_based_on_header_with_font_size() -> None:
     # arrange
     html_string = """<!DOCTYPE html>


### PR DESCRIPTION
Closes #38142

---

`HTMLSectionSplitter` users can get a public `#TITLE#` metadata value for content before the first configured header, and `create_documents` can raise `KeyError` when parent metadata does not include `Title`. This makes source-only parent metadata fail even though a title is not otherwise required

This change centralizes section metadata creation so pre-header chunks omit the internal sentinel unless a parent `Title` can be applied to a configured header. It keeps the existing parent-title replacement behavior for `h1` splits, avoids the missing-`Title` error, handles splitters that do not configure `h1`, and preserves independent metadata copies for each emitted chunk

I verified the focused splitter behavior and the neighboring HTML splitter tests with `uv run --group test --group typing --with lxml --with beautifulsoup4 pytest tests/unit_tests/test_text_splitters.py -q -k 'html_section_splitter'` and `uv run --group test --group typing --with lxml --with beautifulsoup4 pytest tests/unit_tests/test_text_splitters.py -q -k 'html'`. I also ran `uv run --group lint ruff check langchain_text_splitters/html.py tests/unit_tests/test_text_splitters.py`, `uv run --group lint ruff format --check langchain_text_splitters/html.py tests/unit_tests/test_text_splitters.py`, and `git diff --check`

AI-agent assistance was used to prepare this contribution
