### PR TITLE
fix(core): respect description and docstring when infer_schema is False

### DIFF
--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -319,16 +319,16 @@ def tool(
                 )
             # If someone doesn't want a schema applied, we must treat it as
             # a simple string->string function
-            if dec_func.__doc__ is None:
+            if tool_description is None and dec_func.__doc__ is None:
                 msg = (
-                    "Function must have a docstring if "
-                    "description not provided and infer_schema is False."
+                    "Either 'description' or a function docstring must be provided "
+                    "when infer_schema is False."
                 )
                 raise ValueError(msg)
             return Tool(
                 name=tool_name,
                 func=func,
-                description=f"{tool_name} tool",
+                description=tool_description or dec_func.__doc__ or f"{tool_name} tool",
                 return_direct=return_direct,
                 coroutine=coroutine,
                 response_format=response_format,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3946,3 +3946,29 @@ def test_tool_invoke_returns_list_of_mixin() -> None:
     assert isinstance(result, list)
     assert len(result) == 3
     assert all(isinstance(m, ToolMessage) for m in result)
+
+
+def test_tool_infer_schema_false_description() -> None:
+    """Test that description and docstring fallbacks work when infer_schema=False."""
+
+    @tool(description="Explicit description", infer_schema=False)
+    def my_tool_with_desc(query: str) -> str:
+        """My tool docstring."""
+        return query
+
+    assert my_tool_with_desc.description == "Explicit description"
+
+    @tool(infer_schema=False)
+    def my_tool_with_docstring(query: str) -> str:
+        """My tool docstring."""
+        return query
+
+    assert my_tool_with_docstring.description == "My tool docstring."
+
+    with pytest.raises(
+        ValueError,
+        match="Either 'description' or a function docstring must be provided",
+    ):
+        @tool(infer_schema=False)
+        def my_tool_no_desc(query: str) -> str:
+            return query


### PR DESCRIPTION
Fixes #38138

Developers using `@tool(infer_schema=False)` were unable to provide a custom tool description because the fallback logic always used a hardcoded default string. This change updates the tool factory to prioritize the explicit `description` argument, fall back to the function docstring when available, and raise a `ValueError` only when neither is provided.

## How I verified the change

* Added a regression test: `test_tool_infer_schema_false_description`
* Ran `make test`
* Ran `make lint`
* Ran `make format`

All checks pass in `libs/core`.

*(Note: An AI agent assisted with generating this fix and regression test.)*



LinkedIn: https://linkedin.com/in/isatyamks
