### PR TITLE
fix: raise OutputParserException on malformed JSON instead of returning None (closes #36603)

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -103,7 +103,9 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
                 stack.pop()
             else:
                 # Mismatched closing character; the input is malformed.
-                return None
+                raise OutputParserException(
+                    f"Malformed JSON: mismatched closing character '{char}'"
+                )
 
         # Append the processed character to the new string.
         new_chars.append(new_char)


### PR DESCRIPTION
## What
When `parse_partial_json` encounters mismatched closing characters (e.g., `}` without a corresponding `{`), it returns `None` silently. The caller in `PydanticOutputParser._parse_obj` then tries `model_validate(None)`, which fails with a traceback leading to `OutputParserException`. The root issue is that invalid JSON should raise an appropriate exception rather than returning `None`.

## Fix
Changed the mismatched closing character branch to raise `OutputParserException` with a descriptive message instead of returning `None`. This ensures that the error propagation is clear and consistent with the rest of LangChain's error handling.

Closes #36603