### PR TITLE
fix(core): lazy-import `GPT2TokenizerFast` to reduce startup overhead

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -38,12 +38,6 @@ from langchain_core.runnables import Runnable, RunnableSerializable
 if TYPE_CHECKING:
     from langchain_core.outputs import LLMResult
 
-try:
-    from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
-
-    _HAS_TRANSFORMERS = True
-except ImportError:
-    _HAS_TRANSFORMERS = False
 
 
 class LangSmithParams(TypedDict, total=False):
@@ -86,14 +80,15 @@ def get_tokenizer() -> Any:
         The GPT-2 tokenizer instance.
 
     """
-    if not _HAS_TRANSFORMERS:
+    try:
+        from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
+    except ImportError:
         msg = (
             "Could not import transformers python package. "
             "This is needed in order to calculate get_token_ids. "
             "Please install it with `pip install transformers`."
         )
         raise ImportError(msg)
-    # create a GPT-2 tokenizer instance
     return GPT2TokenizerFast.from_pretrained("gpt2")
 
 

--- a/libs/core/tests/unit_tests/language_models/test_imports.py
+++ b/libs/core/tests/unit_tests/language_models/test_imports.py
@@ -26,3 +26,31 @@ EXPECTED_ALL = [
 
 def test_all_imports() -> None:
     assert set(__all__) == set(EXPECTED_ALL)
+
+
+def test_transformers_not_imported_at_module_level() -> None:
+    """GPT2TokenizerFast should not be imported until get_tokenizer() is called.
+
+    Importing langchain_core.language_models.base must not trigger a
+    `transformers` import, since that package is large and optional.
+    """
+    import sys
+
+    # Ensure the module is importable without side-importing transformers
+    # by checking that 'transformers' is not in sys.modules after the import.
+    # (If transformers happens to be installed and already imported by another
+    # test, we just skip the assertion — we can only prove absence, not presence.)
+    before = "transformers" in sys.modules
+    import importlib
+
+    import langchain_core.language_models.base  # noqa: F401
+
+    importlib.reload(langchain_core.language_models.base)
+    after = "transformers" in sys.modules
+
+    # If transformers was not present before the reload, it must not be present after.
+    if not before:
+        assert not after, (
+            "`transformers` was imported at module level in "
+            "langchain_core.language_models.base — it should be lazy."
+        )


### PR DESCRIPTION
Closes #38035

---

Every `import langchain_core` currently triggers an unconditional
`from transformers import GPT2TokenizerFast` at module load time.
The `transformers` package is large (~500 MB with its dependencies)
and entirely optional — it is only needed when `get_tokenizer()` is
called to count tokens with the fallback GPT-2 tokenizer.

This means users who never call `get_tokenizer()` (the vast majority)
pay the import cost on every cold start, slowing application startup
and unnecessarily pulling `transformers` into the import graph for
type-checking, linting, and lightweight use-cases.

**Fix:** move the `try/except` import block inside `get_tokenizer()`.
Because the function is already decorated with `@cache`, the import
runs at most once per process — identical runtime behaviour, zero
module-level side-effect.

The `_HAS_TRANSFORMERS` flag at module level is removed; the
`ImportError` is now raised directly inside the function with the same
message as before.

A new unit test (`test_transformers_not_imported_at_module_level`)
verifies that reloading `langchain_core.language_models.base` does not
add `transformers` to `sys.modules`.

> **Note:** this contribution was developed with the assistance of an
> AI coding agent (Claude Code).