### PR TITLE
fix(core): avoid deprecated dict calls in compat helpers

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -2320,6 +2320,8 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
 
     def _dict_for_compat(self) -> builtins.dict[str, Any]:
         """Return the chat model dictionary while preserving deprecated overrides."""
+        if type(self).dict is BaseChatModel.dict:
+            return self.asdict()
         with suppress_langchain_deprecation_warning():
             return self.dict()
 

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -1402,6 +1402,8 @@ class BaseLLM(BaseLanguageModel[str], ABC):
 
     def _dict_for_compat(self) -> builtins.dict[str, Any]:
         """Return the LLM dictionary while preserving deprecated overrides."""
+        if type(self).dict is BaseLLM.dict:
+            return self.asdict()
         with suppress_langchain_deprecation_warning():
             return self.dict()
 

--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -372,6 +372,8 @@ class BasePromptTemplate(
 
     def _dict_for_compat(self) -> builtins.dict[str, Any]:
         """Return the prompt dictionary while preserving deprecated overrides."""
+        if type(self).dict is BasePromptTemplate.dict:
+            return self.asdict()
         with suppress_langchain_deprecation_warning():
             return self.dict()
 

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -111,6 +111,14 @@ def test_base_chat_model_type_hints_resolve() -> None:
     assert get_type_hints(BaseChatModel.asdict)["return"] == dict[str, Any]
 
 
+def test_dict_for_compat_uses_asdict_without_deprecation_warning() -> None:
+    model = FakeListChatModel(responses=["foo"])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LangChainDeprecationWarning)
+        assert model._dict_for_compat() == model.asdict()
+
+
 def test_invoke_preserves_deprecated_dict_override() -> None:
     """Invoking should preserve `dict()` overrides until `dict()` is removed."""
 

--- a/libs/core/tests/unit_tests/language_models/llms/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/llms/test_base.py
@@ -38,6 +38,14 @@ def test_base_llm_type_hints_resolve() -> None:
     assert get_type_hints(BaseLLM.asdict)["return"] == dict[str, Any]
 
 
+def test_dict_for_compat_uses_asdict_without_deprecation_warning() -> None:
+    llm = FakeListLLM(responses=["foo"])
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LangChainDeprecationWarning)
+        assert llm._dict_for_compat() == llm.asdict()
+
+
 def test_invoke_preserves_deprecated_dict_override() -> None:
     """Invoking should preserve `dict()` overrides until `dict()` is removed."""
 

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -1,6 +1,7 @@
 """Test functionality related to prompts."""
 
 import re
+import warnings
 from tempfile import NamedTemporaryFile
 from typing import Any, Literal
 from unittest import mock
@@ -26,6 +27,14 @@ def test_asdict_replaces_deprecated_dict() -> None:
     assert prompt_dict["_type"] == "prompt"
     with pytest.warns(LangChainDeprecationWarning, match="asdict"):
         assert prompt.dict() == prompt_dict
+
+
+def test_dict_for_compat_uses_asdict_without_deprecation_warning() -> None:
+    prompt = PromptTemplate.from_template("This is a {foo} test.")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LangChainDeprecationWarning)
+        assert prompt._dict_for_compat() == prompt.asdict()
 
 
 def test_prompt_valid() -> None:


### PR DESCRIPTION
## Summary

- Avoid calling LangChain's deprecated default `dict()` implementation from compatibility helpers.
- Use `asdict()` for the default implementation while preserving custom `dict()` overrides until removal.
- Add focused tests covering the no-warning default path for prompts, LLMs, and chat models.

Fixes #38054

## Tests

```bash
python3 -m pytest tests/unit_tests/prompts/test_prompt.py tests/unit_tests/prompts/test_loading.py tests/unit_tests/language_models/llms/test_base.py tests/unit_tests/language_models/chat_models/test_base.py
```


## Social handles
[LinkedIn: ](https://www.linkedin.com/in/akilsurya-sivakumar/)
