### PR TITLE
fix: raise OutputParserException in parse_partial_json on malformed input (closes #36603)

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -103,7 +103,9 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
                 stack.pop()
             else:
                 # Mismatched closing character; the input is malformed.
-                return None
+                raise OutputParserException(
+                    f"Mismatched closing character '{char}' in JSON string"
+                )
 
         # Append the processed character to the new string.
         new_chars.append(new_char)
@@ -126,7 +128,10 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
         try:
             return json.loads("".join(new_chars + stack), strict=strict)
         except json.JSONDecodeError:
-            # If we still can't parse the string as JSON,
+            # If we still can't parse, raise an exception with details
+            raise OutputParserException(
+                f"Failed to parse JSON: {s}"
+            ) from Nonee the string as JSON,
             # try removing the last character
             new_chars.pop()
 


### PR DESCRIPTION
## What
`parse_partial_json` returns `None` when it encounters mismatched closing braces/backets or when all attempts to parse the modified string fail. The callers (e.g., `PydanticOutputParser`) do not expect `None` and may pass it to `model_validate`, leading to a `ValidationError` that gets wrapped into an `OutputParserException` with a confusing message. This causes the parser to randomly fail without a clear reason, as reported in #36603.

## Fix
Instead of silently returning `None`, `parse_partial_json` now raises `OutputParserException` with a descriptive message when:
- A mismatched closing character is encountered.
- All attempts to parse the modified JSON string fail.

This ensures that the caller receives a proper exception that can be handled or reported meaningfully, rather than a cryptic validation error.

Closes #36603