### PR TITLE
fix(core): ignore empty reasoning_content in _extract_reasoning_from_additional_kwargs

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content is not None and isinstance(reasoning_content, str) and reasoning_content:
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None


### PR DESCRIPTION
Fixes #36194

`_extract_reasoning_from_additional_kwargs` returns an empty `ReasoningContentBlock` when providers like ChatTongyi/DeepSeek/Ollama send `reasoning_content: ""` at the end of their reasoning phase. This pollutes `content_blocks` with empty reasoning entries when `LC_OUTPUT_VERSION=v1` is set.

Added `and reasoning_content` to the existing condition to filter out empty strings.