### PR TITLE
fix(core): ignore empty reasoning_content in _extract_reasoning_from_…

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -38,7 +38,7 @@ def _extract_reasoning_from_additional_kwargs(
     additional_kwargs = getattr(message, "additional_kwargs", {})
 
     reasoning_content = additional_kwargs.get("reasoning_content")
-    if reasoning_content is not None and isinstance(reasoning_content, str):
+    if reasoning_content is not None and isinstance(reasoning_content, str) and reasoning_content:
         return {"type": "reasoning", "reasoning": reasoning_content}
 
     return None


### PR DESCRIPTION
# fix(core): ignore empty `reasoning_content` in `_extract_reasoning_from_additional_kwargs`

Closes #36194

## What's the problem?

`_extract_reasoning_from_additional_kwargs` in `libs/core/langchain_core/messages/base.py` returns a `ReasoningContentBlock` even when `reasoning_content` is an **empty string**:

```python
# Before (buggy)
reasoning_content = additional_kwargs.get("reasoning_content")
if reasoning_content is not None and isinstance(reasoning_content, str):
    return {"type": "reasoning", "reasoning": reasoning_content}
```

Several reasoning model providers (ChatTongyi, Ollama, DeepSeek, XAI, Groq) attach `reasoning_content: ""` to every token chunk after the reasoning phase ends — not just to the chunks that actually carry reasoning. Because the current check only guards against `None` and non-string types, it passes empty strings through as real content.

When `LC_OUTPUT_VERSION=v1` is set, this produces a garbled message chain: a long alternating sequence of empty `ReasoningContentBlock`s and `TextBlock`s instead of a clean structure. This makes downstream processing of reasoning content fragile and unpredictable.

## Fix

One condition added — ignore falsy strings (i.e. `""`):

```python
# After (fixed)
reasoning_content = additional_kwargs.get("reasoning_content")
if reasoning_content is not None and isinstance(reasoning_content, str) and reasoning_content:
    return {"type": "reasoning", "reasoning": reasoning_content}
```

The added `and reasoning_content` guard uses Python's truthiness check on the string, which correctly:
- Passes through any non-empty reasoning string ✅
- Rejects `""` (empty string from providers mid-stream) ✅
- Still rejects `None` and non-string types (existing guards unchanged) ✅

## Before / After

```python
# Before fix — provider sends empty string mid-stream
message.additional_kwargs = {"reasoning_content": ""}
result = _extract_reasoning_from_additional_kwargs(message)
# → {"type": "reasoning", "reasoning": ""}  ← empty block, pollutes content_blocks

# After fix
result = _extract_reasoning_from_additional_kwargs(message)
# → None  ← correctly ignored
```

## Files changed

- `libs/core/langchain_core/messages/base.py` — 1-word change inside `_extract_reasoning_from_additional_kwargs`, no other logic touched