### PR TITLE
fix(core)!: include multimodal blocks in `get_buffer_string` prefix format

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -244,6 +244,36 @@ def _format_content_block_xml(block: dict[str, Any]) -> str | None:
     return None
 
 
+def _format_content_block_prefix(block: dict[str, Any]) -> str | None:
+    """Format a multimodal content block as human-readable text for prefix format.
+
+    Returns `None` for text/reasoning blocks (text is sourced from `message.text`),
+    base64-encoded media, and block types without a human-readable reference.
+    """
+    block_type = block.get("type", "")
+
+    if block_type in {"text", "reasoning"} or _has_base64_data(block):
+        return None
+
+    # OpenAI-style image_url blocks
+    if block_type == "image_url":
+        image_url = block.get("image_url", {})
+        if isinstance(image_url, dict):
+            url = image_url.get("url", "")
+            if url and not url.startswith("data:"):
+                return f"[image: {url}]"
+        return None
+
+    # Standard image/audio/video blocks (URL or file_id, base64 already filtered)
+    if block_type in {"image", "audio", "video"}:
+        ref = block.get("url") or block.get("file_id")
+        if ref:
+            return f"[{block_type}: {ref}]"
+        return None
+
+    return None
+
+
 def _get_message_type_str(
     m: BaseMessage,
     human_prefix: str,
@@ -306,8 +336,9 @@ def get_buffer_string(
         tool_prefix: The prefix to prepend to contents of `ToolMessage`s.
         message_separator: The separator to use between messages.
         format: The output format. `'prefix'` uses `Role: content` format (default).
-            For multimodal messages, only string content and `text` blocks are
-            included; non-text blocks such as images, audio, and video are omitted.
+            For multimodal messages, `text` blocks are included as-is and
+            non-base64 image, audio, and video blocks are appended as a
+            human-readable reference (e.g. `[image: <url>]`).
 
             `'xml'` uses XML-style `<message type='role'>` format with proper
             character escaping, which is useful when message content may
@@ -495,7 +526,17 @@ def get_buffer_string(
                     f"<message type={quoteattr(msg_type)}>{joined_content}</message>"
                 )
         else:  # format == "prefix"
-            content = m.text
+            content: str = m.text
+            if not isinstance(m.content, str):
+                media_parts = [
+                    formatted
+                    for block in m.content
+                    if isinstance(block, dict)
+                    and (formatted := _format_content_block_prefix(block))
+                ]
+                if media_parts:
+                    joined_media = " ".join(media_parts)
+                    content = f"{content} {joined_media}" if content else joined_media
             message = f"{role}: {content}"
             tool_info = ""
             if isinstance(m, AIMessage):

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1952,6 +1952,137 @@ def test_get_buffer_string_prefix_custom_separator() -> None:
     assert result == expected
 
 
+def test_get_buffer_string_prefix_plain_string_unchanged() -> None:
+    """Test prefix format leaves plain string content unchanged."""
+    messages = [
+        HumanMessage(content="What does this screenshot show?"),
+        AIMessage(content="It shows the dashboard error state."),
+    ]
+    result = get_buffer_string(messages)
+    expected = (
+        "Human: What does this screenshot show?\n"
+        "AI: It shows the dashboard error state."
+    )
+    assert result == expected
+
+
+def test_get_buffer_string_prefix_image_url_block() -> None:
+    """Test prefix format includes OpenAI-style `image_url` blocks."""
+    messages: list[BaseMessage] = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "What does this screenshot show?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/screenshot.png"},
+                },
+            ]
+        ),
+    ]
+    result = get_buffer_string(messages)
+    expected = (
+        "Human: What does this screenshot show? "
+        "[image: https://example.com/screenshot.png]"
+    )
+    assert result == expected
+
+
+def test_get_buffer_string_prefix_image_block() -> None:
+    """Test prefix format includes standard image blocks (URL and `file_id`)."""
+    messages: list[BaseMessage] = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "What is in this image?"},
+                {"type": "image", "url": "https://example.com/image.png"},
+            ]
+        ),
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "Describe this:"},
+                {"type": "image", "file_id": "file-abc123"},
+            ]
+        ),
+    ]
+    result = get_buffer_string(messages)
+    expected = (
+        "Human: What is in this image? [image: https://example.com/image.png]\n"
+        "Human: Describe this: [image: file-abc123]"
+    )
+    assert result == expected
+
+
+def test_get_buffer_string_prefix_audio_and_video_blocks() -> None:
+    """Test prefix format includes audio and video blocks."""
+    messages: list[BaseMessage] = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "Transcribe this:"},
+                {"type": "audio", "url": "https://example.com/audio.mp3"},
+                {"type": "video", "url": "https://example.com/video.mp4"},
+            ]
+        ),
+    ]
+    result = get_buffer_string(messages)
+    expected = (
+        "Human: Transcribe this: "
+        "[audio: https://example.com/audio.mp3] "
+        "[video: https://example.com/video.mp4]"
+    )
+    assert result == expected
+
+
+def test_get_buffer_string_prefix_image_only_block() -> None:
+    """Test prefix format with a multimodal block and no text."""
+    messages: list[BaseMessage] = [
+        HumanMessage(
+            content=[
+                {"type": "image", "url": "https://example.com/image.png"},
+            ]
+        ),
+    ]
+    result = get_buffer_string(messages)
+    expected = "Human: [image: https://example.com/image.png]"
+    assert result == expected
+
+
+def test_get_buffer_string_prefix_base64_image_skipped() -> None:
+    """Test prefix format omits base64/data: URL media blocks."""
+    messages: list[BaseMessage] = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "What is this?"},
+                {"type": "image", "base64": "iVBORw0KGgo...", "mime_type": "image/png"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,iVBORw0KGgo..."},
+                },
+            ]
+        ),
+    ]
+    result = get_buffer_string(messages)
+    assert result == "Human: What is this?"
+    assert "base64" not in result
+    assert "data:image" not in result
+
+
+def test_get_buffer_string_xml_image_still_included() -> None:
+    """Test XML format still renders image blocks as `<image ... />`."""
+    messages: list[BaseMessage] = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "What does this screenshot show?"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/screenshot.png"},
+                },
+            ]
+        ),
+    ]
+    result = get_buffer_string(messages, format="xml")
+    assert "What does this screenshot show?" in result
+    assert '<image url="https://example.com/screenshot.png" />' in result
+
+
 def test_get_buffer_string_xml_escaping() -> None:
     """Test XML format properly escapes special characters in content."""
     messages = [


### PR DESCRIPTION
Breaking change - v2 candidate

`get_buffer_string` now includes image/audio/video block references (e.g. `[image: <url>]`) in the default prefix format instead of dropping them.

---

The default (non-XML) `get_buffer_string` only kept `text` content and silently dropped image, audio, and video blocks. That is lossy: a user who asks "what does this screenshot show?" with an attached image URL ends up with a summary that no longer references the image at all. Only the `format="xml"` path preserved that information, so callers such as `SummarizationMiddleware` had to opt into XML to avoid the loss.

This updates the shared utility so every caller of the default format benefits: non-base64 `image`, `image_url` (OpenAI-style), `audio`, and `video` blocks are appended as a concise human-readable reference. Plain string content and the XML format are unchanged, and base64/`data:` media is still omitted to avoid dumping payloads.

### Before / After

Given a multimodal `HumanMessage`:

```python
from langchain_core.messages import HumanMessage, get_buffer_string

msg = HumanMessage(content=[
    {"type": "text", "text": "What does this screenshot show?"},
    {"type": "image_url", "image_url": {"url": "https://example.com/screenshot.png"}},
])
get_buffer_string([msg])
```

**Before** (image URL silently dropped):

```text
Human: What does this screenshot show?
```

**After** (image reference preserved):

```text
Human: What does this screenshot show? [image: https://example.com/screenshot.png]
```

Made by [Open SWE](https://openswe.vercel.app)
