### PR TITLE
fix(text-splitters): hide #TITLE# sentinel from HTMLSectionSplitter metadata

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -437,7 +437,7 @@ class HTMLSectionSplitter:
 
                 for key in chunk.metadata:
                     if chunk.metadata[key] == "#TITLE#":
-                        chunk.metadata[key] = metadata["Title"]
+                        chunk.metadata[key] = metadata.get("Title", "")
                 metadata = {**metadata, **chunk.metadata}
                 new_doc = Document(page_content=chunk.page_content, metadata=metadata)
                 documents.append(new_doc)
@@ -558,9 +558,11 @@ class HTMLSectionSplitter:
             Document(
                 cast("str", section["content"]),
                 metadata={
-                    self.headers_to_split_on[str(section["tag_name"])]: section[
-                        "header"
-                    ]
+                    self.headers_to_split_on[str(section["tag_name"])]: (
+                        ""
+                        if section["header"] == "#TITLE#"
+                        else section["header"]
+                    )
                 },
             )
             for section in sections


### PR DESCRIPTION
Closes #38142

---

`HTMLSectionSplitter` uses `#TITLE#` as an internal sentinel for pre-header content, but it leaks into Document metadata in two ways:

1. `split_text()` returns `{'Header 1': '#TITLE#'}` for content before the first header
2. `create_documents()` raises `KeyError` when the parent Document doesn't have a `Title` key

**Changes:**
- In `split_text_from_file()`: replace `#TITLE#` with empty string in metadata
- In `create_documents()`: use `metadata.get('Title', '')` instead of `metadata['Title']` to handle missing keys gracefully

Both `split_text()` and `split_documents()` now return clean metadata without exposing internal sentinels.

**Testing:**
- Verified the reproduction case from the issue passes without KeyError
- All 134 existing unit tests pass
