### PR TITLE
fix(anthropic): handle rename KeyError in claude file tool middleware

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -555,7 +555,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1054,7 +1054,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -295,7 +295,7 @@ class TestFileOperations:
 
         args = {
             "command": "rename",
-            "old_path": "/memories/old.txt",
+            "path": "/memories/old.txt",
             "new_path": "/memories/new.txt",
         }
         result = middleware._handle_rename(args, state, "test_id")


### PR DESCRIPTION
Closes #35852

---

The `_handle_rename` method in both `AnthropicToolsMiddleware` and `ClaudeToolsMiddleware` reads `args["old_path"]`, but the dispatch machinery writes `args["path"]`. This causes a `KeyError` at runtime when a rename command is triggered.

**Changes**

- `AnthropicToolsMiddleware._handle_rename`: `args["old_path"]` → `args["path"]`
- `ClaudeToolsMiddleware._handle_rename`: `args["old_path"]` → `args["path"]`
- Updated the corresponding test fixture in `test_anthropic_tools.py` accordingly

**Testing**

All 68 middleware tests pass, including `test_rename_operation`. Full regression suite: 182/200 pass (18 pre-existing SOCKS proxy failures — unrelated to this change).

**Risk**

Low. This is a one-line argument name fix in two middleware classes with identical patterns. The fix is covered by existing tests.

---

🤖 This PR was prepared with assistance from an AI agent.