### PR TITLE
core: fix incorrect error message in Visitor._validate_func for operators

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
## Description

Fixes a copy-paste bug in `Visitor._validate_func` in `langchain_core/structured_query.py`.

When an **operator** fails validation, the error message incorrectly says:
```
Received disallowed operator <op>. Allowed comparators are ...
```

It should say:
```
Received disallowed operator <op>. Allowed operators are ...
```

The word `comparators` was copied from the comparator validation block below but was never updated to `operators`.

## Fix

Changed `f"comparators are {self.allowed_operators}"` → `f"operators are {self.allowed_operators}"` on line 32 of `structured_query.py`.

## Reproduction

```python
from langchain_core.structured_query import Visitor, Operator, Comparator

class TestVisitor(Visitor):
    allowed_comparators = (Comparator.EQ,)
    allowed_operators = (Operator.AND,)

    def visit_operation(self, operation): pass
    def visit_comparison(self, comparison): pass
    def visit_structured_query(self, structured_query): pass

v = TestVisitor()
v._validate_func(Operator.OR)
# Before fix: "Received disallowed operator Operator.OR. Allowed comparators are (Operator.AND,)"
# After fix:  "Received disallowed operator Operator.OR. Allowed operators are (Operator.AND,)"
```

Closes #36701