### PR TITLE
fix(openai): guard service_tier token arithmetic against None usage details

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4049,11 +4049,11 @@ def _create_usage_metadata(
     if service_tier is not None:
         # Avoid counting cache and reasoning tokens towards the service tier token
         # counts, since service tier tokens are already priced differently
-        input_token_details[service_tier] = input_tokens - input_token_details.get(
-            f"{service_tier_prefix}cache_read", 0
+        input_token_details[service_tier] = input_tokens - (
+            input_token_details.get(f"{service_tier_prefix}cache_read") or 0
         )
-        output_token_details[service_tier] = output_tokens - output_token_details.get(
-            f"{service_tier_prefix}reasoning", 0
+        output_token_details[service_tier] = output_tokens - (
+            output_token_details.get(f"{service_tier_prefix}reasoning") or 0
         )
     return UsageMetadata(
         input_tokens=input_tokens,
@@ -4090,11 +4090,11 @@ def _create_usage_metadata_responses(
     if service_tier is not None:
         # Avoid counting cache and reasoning tokens towards the service tier token
         # counts, since service tier tokens are already priced differently
-        output_token_details[service_tier] = output_tokens - output_token_details.get(
-            f"{service_tier_prefix}reasoning", 0
+        output_token_details[service_tier] = output_tokens - (
+            output_token_details.get(f"{service_tier_prefix}reasoning") or 0
         )
-        input_token_details[service_tier] = input_tokens - input_token_details.get(
-            f"{service_tier_prefix}cache_read", 0
+        input_token_details[service_tier] = input_tokens - (
+            input_token_details.get(f"{service_tier_prefix}cache_read") or 0
         )
     return UsageMetadata(
         input_tokens=input_tokens,

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1144,6 +1144,49 @@ def test__create_usage_metadata_responses() -> None:
     )
 
 
+def test__create_usage_metadata_service_tier_no_token_details() -> None:
+    """Service tier set but `cached_tokens`/`reasoning_tokens` missing.
+
+    Regression test for a `TypeError` raised when `service_tier` is `"priority"`
+    or `"flex"` but the response omits `prompt_tokens_details` /
+    `completion_tokens_details` (so `cached_tokens` / `reasoning_tokens` resolve
+    to `None`). The service-tier subtraction must treat the missing value as 0
+    rather than attempting `int - None`.
+    """
+    usage_metadata = {
+        "prompt_tokens": 100,
+        "completion_tokens": 10,
+        "total_tokens": 110,
+    }
+    result = _create_usage_metadata(usage_metadata, service_tier="priority")
+    assert result == UsageMetadata(
+        input_tokens=100,
+        output_tokens=10,
+        total_tokens=110,
+        input_token_details={"priority": 100},
+        output_token_details={"priority": 10},
+    )
+
+
+def test__create_usage_metadata_responses_service_tier_no_token_details() -> None:
+    """Responses variant of the service-tier `None`-arithmetic regression test."""
+    response_usage_metadata = {
+        "input_tokens": 100,
+        "output_tokens": 10,
+        "total_tokens": 110,
+    }
+    result = _create_usage_metadata_responses(
+        response_usage_metadata, service_tier="priority"
+    )
+    assert result == UsageMetadata(
+        input_tokens=100,
+        output_tokens=10,
+        total_tokens=110,
+        input_token_details={"priority": 100},
+        output_token_details={"priority": 10},
+    )
+
+
 def test__resize_caps_dimensions_preserving_ratio() -> None:
     """Larger side capped at 2048 then smaller at 768 keeping aspect ratio."""
     assert _resize(2048, 4096) == (768, 1536)


### PR DESCRIPTION
Closes #36657

When `service_tier` is `"priority"` or `"flex"` and the OpenAI response does not include `prompt_tokens_details` / `completion_tokens_details` (or includes them without `cached_tokens` / `reasoning_tokens`), token counting crashes with `TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'`. Anyone using a priority/flex service tier hits this whenever a response omits the optional token-detail breakdown, which makes those tiers effectively unusable for usage-metadata consumers.

The cause is subtle. `_create_usage_metadata` and `_create_usage_metadata_responses` always insert the `{service_tier}_cache_read` and `{service_tier}_reasoning` keys into their token-detail dicts, but the values are read via `(prompt_tokens_details or {}).get("cached_tokens")` and the reasoning equivalent — which return `None` when the detail block is absent. The later service-tier adjustment then does:

```python
input_token_details[service_tier] = input_tokens - input_token_details.get(
    f"{service_tier_prefix}cache_read", 0
)
```

Because the key is *present* in the dict (with value `None`), the `0` default is never used, and the subtraction becomes `int - None`.

## Fix

Change the four subtraction sites from `.get(key, 0)` to `.get(key) or 0`, so a missing or `None` value is coerced to `0`:

- `_create_usage_metadata`: the `cache_read` (input) subtraction
- `_create_usage_metadata`: the `reasoning` (output) subtraction
- `_create_usage_metadata_responses`: the `reasoning` (output) subtraction
- `_create_usage_metadata_responses`: the `cache_read` (input) subtraction

When the detail values *are* present, behavior is unchanged.

## Reproduction

```python
from langchain_openai.chat_models.base import _create_usage_metadata

_create_usage_metadata(
    {"prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110},
    service_tier="priority",
)
# Before: TypeError: unsupported operand type(s) for -: 'int' and 'NoneType'
# After:  input_token_details={"priority": 100}, output_token_details={"priority": 10}
```

## Tests

Added two regression tests in the OpenAI partner's unit tests that exercise both `_create_usage_metadata` and `_create_usage_metadata_responses` with a service tier set and no token-detail blocks. Verified they fail on `main` with the reported `TypeError` and pass with this change.

_Disclaimer: this contribution was prepared with the assistance of an AI agent and reviewed by a human._
