### PR TITLE
fix(core): validate VectorStore.add_texts ids length

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -82,11 +82,17 @@ class VectorStore(ABC):
                     f"Got {len(metadatas)} metadatas and {len(texts_)} texts."
                 )
                 raise ValueError(msg)
+            if ids is not None and len(ids) != len(texts_):
+                msg = (
+                    "The number of ids must match the number of texts."
+                    f"Got {len(ids)} ids and {len(texts_)} texts."
+                )
+                raise ValueError(msg)
             metadatas_ = iter(metadatas) if metadatas else cycle([{}])
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             if ids is not None:
                 # For backward compatibility
@@ -221,12 +227,18 @@ class VectorStore(ABC):
                     f"Got {len(metadatas)} metadatas and {len(texts_)} texts."
                 )
                 raise ValueError(msg)
+            if ids is not None and len(ids) != len(texts_):
+                msg = (
+                    "The number of ids must match the number of texts."
+                    f"Got {len(ids)} ids and {len(texts_)} texts."
+                )
+                raise ValueError(msg)
             metadatas_ = iter(metadatas) if metadatas else cycle([{}])
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
 
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             return await self.aadd_documents(docs, **kwargs)
         return await run_in_executor(None, self.add_texts, texts, metadatas, **kwargs)

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -178,6 +178,14 @@ def test_default_add_texts(vs_class: type[VectorStore]) -> None:
     ]
 
 
+@pytest.mark.parametrize("ids", [[], ["only-one"], ["1", "2", "3"]])
+def test_default_add_texts_raises_for_mismatched_ids(ids: list[str]) -> None:
+    store = CustomAddDocumentsVectorstore()
+
+    with pytest.raises(ValueError, match="number of ids must match"):
+        store.add_texts(["hello", "world"], ids=ids)
+
+
 @pytest.mark.parametrize(
     "vs_class", [CustomAddTextsVectorstore, CustomAddDocumentsVectorstore]
 )
@@ -234,6 +242,14 @@ async def test_default_aadd_texts(vs_class: type[VectorStore]) -> None:
         Document(id=ids_2[0], page_content="foo", metadata={"foo": "bar"}),
         Document(id=ids_2[1], page_content="bar", metadata={"foo": "bar"}),
     ]
+
+
+@pytest.mark.parametrize("ids", [[], ["only-one"], ["1", "2", "3"]])
+async def test_default_aadd_texts_raises_for_mismatched_ids(ids: list[str]) -> None:
+    store = CustomAddDocumentsVectorstore()
+
+    with pytest.raises(ValueError, match="number of ids must match"):
+        await store.aadd_texts(["hello", "world"], ids=ids)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #38203

Problem:
`VectorStore.add_texts` documents that mismatched `ids` should raise `ValueError`, but the default `add_texts` bridge silently truncated texts when `ids` was shorter than `texts`. The same gap existed in the async default path.

Fix:
Validate explicit `ids` length before constructing documents in both `add_texts` and `aadd_texts`, and build docs from the materialized text sequence used for validation.

Test:
- `uv run --group test pytest tests/unit_tests/vectorstores/test_vectorstore.py --benchmark-disable --disable-socket --allow-unix-socket`
- `uv run --group lint ruff check langchain_core/vectorstores/base.py tests/unit_tests/vectorstores/test_vectorstore.py`
- `uv run --group lint ruff format --check langchain_core/vectorstores/base.py tests/unit_tests/vectorstores/test_vectorstore.py`

Risk:
Low. This restores the documented contract for explicit `ids` and affects only the default bridge implementation for vector stores that implement `add_documents`/`aadd_documents` but rely on the base `add_texts` path.