### PR TITLE
fix(core): correct error message in `Visitor._validate_func` for operators

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
Closes #36701

---

When `_validate_func` receives a disallowed `Operator`, the error message incorrectly says `"Allowed comparators are ..."` instead of `"Allowed operators are ..."`. This is a copy-paste mistake from the comparator branch of the same method — the variable referenced (`self.allowed_operators`) is correct, but the label in the message says "comparators".

**Before:**
```
ValueError: Received disallowed operator Operator.OR. Allowed comparators are (Operator.AND,)
```

**After:**
```
ValueError: Received disallowed operator Operator.OR. Allowed operators are (Operator.AND,)
```

The fix is a one-word change on the affected line. No behavior change; only the error message text is corrected.

> Note: This fix was authored with AI-agent assistance.