### PR TITLE
fix(text-splitters): omit #TITLE# sentinel from HTMLSectionSplitter metadata

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -365,6 +365,8 @@ class HTMLSectionSplitter:
     Requires lxml package.
     """
 
+    _TITLE_PLACEHOLDER = "#TITLE#"
+
     def __init__(
         self,
         headers_to_split_on: list[tuple[str, str]],
@@ -432,12 +434,8 @@ class HTMLSectionSplitter:
         metadatas_ = metadatas or [{}] * len(texts)
         documents = []
         for i, text in enumerate(texts):
-            for chunk in self.split_text(text):
+            for chunk in self._split_text_with_metadata(text, metadatas_[i]):
                 metadata = copy.deepcopy(metadatas_[i])
-
-                for key in chunk.metadata:
-                    if chunk.metadata[key] == "#TITLE#":
-                        chunk.metadata[key] = metadata["Title"]
                 metadata = {**metadata, **chunk.metadata}
                 new_doc = Document(page_content=chunk.page_content, metadata=metadata)
                 documents.append(new_doc)
@@ -479,7 +477,7 @@ class HTMLSectionSplitter:
 
         for i, header in enumerate(headers):
             if i == 0:
-                current_header = "#TITLE#"
+                current_header = self._TITLE_PLACEHOLDER
                 current_header_tag = "h1"
                 section_content: list[str] = []
             else:
@@ -551,20 +549,39 @@ class HTMLSectionSplitter:
             A list of split `Document` objects.
         """
         file_content = file.getvalue()
-        file_content = self.convert_possible_tags_to_header(file_content)
+        return self._split_text_with_metadata(file_content)
+
+    def _split_text_with_metadata(
+        self, text: str, metadata: dict[Any, Any] | None = None
+    ) -> list[Document]:
+        file_content = self.convert_possible_tags_to_header(text)
         sections = self.split_html_by_headers(file_content)
 
         return [
             Document(
                 cast("str", section["content"]),
-                metadata={
-                    self.headers_to_split_on[str(section["tag_name"])]: section[
-                        "header"
-                    ]
-                },
+                metadata=self._section_metadata(section, metadata),
             )
             for section in sections
         ]
+
+    def _section_metadata(
+        self,
+        section: dict[str, str | None],
+        metadata: dict[Any, Any] | None = None,
+    ) -> dict[str, Any]:
+        header = section["header"]
+        tag_name = str(section["tag_name"])
+
+        if header == self._TITLE_PLACEHOLDER:
+            if metadata is None or "Title" not in metadata:
+                return {}
+            header_name = self.headers_to_split_on.get(tag_name)
+            if header_name is None:
+                return {}
+            return {header_name: metadata["Title"]}
+
+        return {self.headers_to_split_on[tag_name]: header}
 
 
 @beta()

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -2998,6 +2998,40 @@ def test_decode_returns_no_chunks() -> None:
 
 @pytest.mark.requires("bs4")
 @pytest.mark.requires("lxml")
+def test_html_section_splitter_omits_title_sentinel_before_first_header() -> None:
+    html_string = (
+        "<html><body><p>Intro before header.</p><h1>Header</h1>"
+        "<p>Body.</p></body></html>"
+    )
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    docs = sec_splitter.split_text(html_string)
+
+    assert docs[0].page_content == "Intro before header."
+    assert docs[0].metadata == {}
+    assert docs[1].metadata == {"Header 1": "Header"}
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
+def test_html_section_splitter_split_documents_handles_missing_title() -> None:
+    html_string = (
+        "<html><body><p>Intro before header.</p><h1>Header</h1>"
+        "<p>Body.</p></body></html>"
+    )
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    docs = sec_splitter.split_documents(
+        [Document(page_content=html_string, metadata={"source": "example"})]
+    )
+
+    assert docs[0].page_content == "Intro before header."
+    assert docs[0].metadata == {"source": "example"}
+    assert docs[1].metadata == {"source": "example", "Header 1": "Header"}
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
 def test_section_aware_happy_path_splitting_based_on_header_1_2() -> None:
     # arrange
     html_string = """<!DOCTYPE html>


### PR DESCRIPTION
## Problem

HTMLSectionSplitter leaks its internal  sentinel into  for content that appears before the first configured header. Additionally,  raises  when the input  does not contain a  key.

Fixes #38142

## Root Cause

The  sentinel is used internally to mark content before the first header, but it was being exposed in the output metadata. The  method assumed all input documents had a  key in their metadata.

## Fix

- Extract  class constant
- Add  that returns  for sentinel headers when no  is available in the input metadata
- Add  used by both  and  to keep metadata handling consistent
- Add two regression tests

## Reproduction

Before:


After:


## Tests

All 141 unit tests pass. Two new regression tests added.