### PR TITLE
fix(anthropic): recover content blocks delivered on message_start

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1553,9 +1553,43 @@ class ChatAnthropic(BaseChatModel):
             else:
                 response_metadata = {}
 
+            # The API can deliver pre-completed content blocks directly on the
+            # ``message_start`` event, with no following ``content_block_*``
+            # events. This happens with Anthropic programmatic tool calling
+            # (code execution): the follow-up turn arrives as a ``message_start``
+            # carrying finished ``tool_use`` blocks, immediately followed by
+            # ``message_stop``. Recover those blocks here so they aren't dropped,
+            # which otherwise yields an empty ``AIMessage`` after aggregation.
+            # See https://github.com/langchain-ai/langchain/issues/34406.
+            content: str | list = "" if coerce_content_to_string else []
+            tool_call_chunks = []
+            start_content = getattr(event.message, "content", None)
+            if not coerce_content_to_string and start_content:
+                content = []
+                for idx, block in enumerate(start_content):
+                    block_dict = (
+                        block.model_dump()
+                        if hasattr(block, "model_dump")
+                        else dict(block)
+                    )
+                    if block_dict.get("caller") is None:
+                        block_dict.pop("caller", None)
+                    block_dict["index"] = idx
+                    content.append(block_dict)
+                    if block_dict.get("type") == "tool_use":
+                        tool_call_chunks.append(
+                            create_tool_call_chunk(
+                                index=idx,
+                                id=block_dict.get("id"),
+                                name=block_dict.get("name"),
+                                args=json.dumps(block_dict.get("input", {})),
+                            )
+                        )
+
             message_chunk = AIMessageChunk(
-                content="" if coerce_content_to_string else [],
+                content=content,
                 response_metadata=response_metadata,
+                tool_call_chunks=tool_call_chunks,
             )
 
         elif (

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import os
 import warnings
 from collections.abc import Callable
@@ -3378,3 +3379,87 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+def test_message_start_with_precompleted_content_blocks() -> None:
+    """Recover content blocks delivered on ``message_start`` (regression #34406).
+
+    With Anthropic programmatic tool calling (code execution), a follow-up turn
+    can arrive as a ``message_start`` event whose ``message.content`` already
+    holds finished ``tool_use`` blocks, immediately followed by ``message_stop``
+    with no intervening ``content_block_*`` events. Previously the
+    ``message_start`` handler always produced an empty chunk, so the aggregated
+    ``AIMessage`` came back empty with no tool calls.
+    """
+    from anthropic.types import RawMessageStartEvent, ToolUseBlock
+
+    msg = Message(
+        id="msg_1",
+        content=[
+            ToolUseBlock(
+                id="toolu_1",
+                input={"expression": "2 + 2"},
+                name="calculate",
+                type="tool_use",
+            ),
+        ],
+        model=MODEL_NAME,
+        role="assistant",
+        stop_reason="tool_use",
+        stop_sequence=None,
+        usage=Usage(input_tokens=10, output_tokens=5),
+        type="message",
+    )
+    event = RawMessageStartEvent(message=msg, type="message_start")
+
+    llm = ChatAnthropic(model=MODEL_NAME)  # type: ignore[call-arg]
+    chunk, _ = llm._make_message_chunk_from_anthropic_event(
+        event,
+        stream_usage=True,
+        coerce_content_to_string=False,
+        block_start_event=None,
+    )
+
+    assert chunk is not None
+    # The tool_use block must survive instead of being dropped.
+    assert isinstance(chunk.content, list)
+    assert len(chunk.content) == 1
+    block = cast("dict[str, Any]", chunk.content[0])
+    assert block["type"] == "tool_use"
+    assert block["id"] == "toolu_1"
+    assert block["index"] == 0
+    # And it must surface as a tool call chunk so aggregation yields a tool call.
+    assert len(chunk.tool_call_chunks) == 1
+    tool_call_chunk = chunk.tool_call_chunks[0]
+    assert tool_call_chunk["name"] == "calculate"
+    assert tool_call_chunk["id"] == "toolu_1"
+    assert json.loads(tool_call_chunk["args"]) == {"expression": "2 + 2"}
+
+
+def test_message_start_without_content_stays_empty() -> None:
+    """A normal ``message_start`` (empty content) must still yield an empty chunk."""
+    from anthropic.types import RawMessageStartEvent
+
+    msg = Message(
+        id="msg_1",
+        content=[],
+        model=MODEL_NAME,
+        role="assistant",
+        stop_reason=None,
+        stop_sequence=None,
+        usage=Usage(input_tokens=10, output_tokens=0),
+        type="message",
+    )
+    event = RawMessageStartEvent(message=msg, type="message_start")
+
+    llm = ChatAnthropic(model=MODEL_NAME)  # type: ignore[call-arg]
+    chunk, _ = llm._make_message_chunk_from_anthropic_event(
+        event,
+        stream_usage=True,
+        coerce_content_to_string=False,
+        block_start_event=None,
+    )
+
+    assert chunk is not None
+    assert chunk.content == []
+    assert chunk.tool_call_chunks == []


### PR DESCRIPTION
**Fixes #34406**

### Problem

When streaming via `astream()`, an empty `AIMessage` is returned when the Anthropic API delivers **pre-completed content blocks directly on the `message_start` event** with no following `content_block_*` events.

This is exactly the shape Anthropic's **programmatic tool calling** (code execution, `code_execution_20250825`) produces on a follow-up turn: after a tool result is sent back, the next model call streams as

```
message_start  (message.content = [tool_use, ...], stop_reason=tool_use)
message_stop   (no content_block_start / content_block_delta events)
```

The `message_start` handler in `_make_message_chunk_from_anthropic_event` always built an **empty** chunk (`content="" if coerce_content_to_string else []`), ignoring `event.message.content`. After aggregation the result is an `AIMessage` with empty content and **no tool calls**. `ainvoke()` is unaffected because `_agenerate` processes the full response object rather than streaming events.

### Fix

In the `message_start` branch, when `event.message.content` carries blocks (structured-content path only, i.e. `coerce_content_to_string=False`), recover them into the chunk — mirroring the existing `content_block_start` handling — and emit the corresponding `tool_call_chunks` so aggregation yields real tool calls.

Normal `message_start` events (empty `content`, the overwhelmingly common case) are **unaffected**: the recovery branch is skipped and the chunk stays empty exactly as before.

### Tests

Added two unit tests in `tests/unit_tests/test_chat_models.py`:

- `test_message_start_with_precompleted_content_blocks` — a `message_start` carrying a finished `tool_use` block now surfaces as content **and** a tool-call chunk (regression for #34406).
- `test_message_start_without_content_stays_empty` — guards that an empty `message_start` still yields an empty chunk (no behavior change on the common path).

Verified that the new assertion fails against `master` (empty content) and passes with this change.

### Notes

- No public API changes; the fix is contained to the streaming event handler.
- This unblocks the broader programmatic-tool-calling / MCP code-execution work tracked in #34130, where this bug was flagged as a blocker.
