### PR TITLE
fix(core): preserve bool type for differing values in merge_dicts

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,6 +68,8 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
+            elif isinstance(merged[right_k], bool):
+                merged[right_k] = right_v
             elif isinstance(merged[right_k], int):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,8 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        ({"a": True}, {"a": False}, {"a": False}),
+        ({"a": False}, {"a": True}, {"a": True}),
     ],
 )
 def test_merge_dicts(
@@ -146,6 +148,24 @@ def test_merge_dicts(
         # no mutation
         assert left == left_copy
         assert right == right_copy
+
+@pytest.mark.parametrize(
+    ("left", "right", "expected"),
+    [
+        ({"a": True}, {"a": False}, False),
+        ({"a": False}, {"a": True}, True),
+    ],
+)
+def test_merge_dicts_bool(
+    left: dict[str, Any], right: dict[str, Any], *, expected: bool
+) -> None:
+    """Differing booleans merge last-wins and stay `bool`, never coerced to `int`.
+    `bool` is a subclass of `int`, so a plain `==` assertion cannot catch the
+    regression (`1 == True`); the type must be checked explicitly.
+    """
+    actual = merge_dicts(left, right)["a"]
+    assert actual is expected
+    assert type(actual) is bool
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #38064

---

## Description
When streaming message chunks, boolean values in additional_kwargs and response_metadata could accidentally be converted into integers because bool is a subclass of int (for example, True + False became 1). This change handles booleans separately so they keep their correct type during merges, using the latest value when chunks disagree.

There are no breaking changes.

How did you verify your code works?
Added regression tests covering both True → False and False → True.
Verified the merged value remains a bool, preventing the original type conversion bug.
Ran make format, make lint, and make test.
