### PR TITLE
fix(core): set `additionalProperties: false` on nested `$defs` for strict schemas

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -820,7 +820,10 @@ def _recursive_set_additional_properties_false(
         ):
             schema["additionalProperties"] = False
 
-        # Recursively check 'properties' and 'items' if they exist
+        # Recursively check 'properties', 'items', and nested definitions if they
+        # exist. Nested models live under '$defs' (or the older 'definitions') and are
+        # referenced via '$ref', so they must be visited here too — otherwise OpenAI's
+        # strict mode rejects the schema for missing 'additionalProperties'.
         if "anyOf" in schema:
             for sub_schema in schema["anyOf"]:
                 _recursive_set_additional_properties_false(sub_schema)
@@ -829,5 +832,9 @@ def _recursive_set_additional_properties_false(
                 _recursive_set_additional_properties_false(sub_schema)
         if "items" in schema:
             _recursive_set_additional_properties_false(schema["items"])
+        for defs_key in ("$defs", "definitions"):
+            if defs_key in schema and isinstance(schema[defs_key], dict):
+                for sub_schema in schema[defs_key].values():
+                    _recursive_set_additional_properties_false(sub_schema)
 
     return schema

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -500,6 +500,28 @@ def test_convert_to_openai_function_nested_strict() -> None:
     assert actual == expected
 
 
+def test_convert_to_openai_function_dict_with_defs_strict() -> None:
+    """Nested models referenced via `$defs` must get `additionalProperties: False`.
+
+    When a raw JSON schema produced by `model_json_schema()` is passed in directly
+    (as happens on the streaming Responses API path), nested models live under
+    `$defs` rather than being inlined. Strict mode requires those nested objects to
+    also set `additionalProperties: False`, otherwise OpenAI rejects the schema.
+    """
+
+    class Step(BaseModel):
+        explanation: str
+        output: str
+
+    class Plan(BaseModel):
+        steps: list[Step]
+
+    actual = convert_to_openai_function(Plan.model_json_schema(), strict=True)
+
+    assert actual["parameters"]["additionalProperties"] is False
+    assert actual["parameters"]["$defs"]["Step"]["additionalProperties"] is False
+
+
 def test_convert_to_openai_function_strict_union_of_objects_arg_type() -> None:
     class NestedA(BaseModel):
         foo: str

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4262,3 +4262,32 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test_responses_api_payload_nested_structured_output_streaming() -> None:
+    """Streaming structured output with nested schema must be valid strict JSON.
+
+    Regression test for the Responses API streaming path: nested Pydantic models
+    are emitted under `$defs` and OpenAI's strict mode requires every nested object
+    to set `additionalProperties: False`. See issue #38223.
+    """
+    from langchain_openai.chat_models.base import _construct_responses_api_payload
+
+    class Step(BaseModel):
+        explanation: str
+        output: str
+
+    class Plan(BaseModel):
+        steps: list[Step]
+
+    payload = {
+        "model": OPENAI_TEST_MODEL,
+        "response_format": Plan,
+        "stream": True,
+    }
+    result = _construct_responses_api_payload([], payload)
+
+    schema = result["text"]["format"]["schema"]
+    assert result["text"]["format"]["type"] == "json_schema"
+    assert schema["additionalProperties"] is False
+    assert schema["$defs"]["Step"]["additionalProperties"] is False


### PR DESCRIPTION
Closes #38223

---

When using `ChatOpenAI` with `use_responses_api=True` and `with_structured_output()` on a **nested** Pydantic model, non-streaming calls succeed but streaming calls fail with a 400 from OpenAI:

> Invalid schema for response_format: 'additionalProperties' is required to be supplied and to be false.

On the streaming Responses API path, the schema is built from `model_json_schema()` and converted with strict mode enabled. Nested models in that schema live under `$defs` and are referenced via `$ref`. However, `_recursive_set_additional_properties_false` only walked `anyOf`, `properties`, and `items` — it never recursed into `$defs` (or the legacy `definitions`). As a result, nested objects never had `additionalProperties: false` applied, producing an invalid strict schema that OpenAI rejects.

This affects anyone using structured output with nested schemas during `astream_events()` or `astream_log()`, since those attach streaming handlers to all calls.

The fix makes `_recursive_set_additional_properties_false` also recurse into `$defs`/`definitions`, so nested model schemas get `additionalProperties: false` like every other object.

Tests:
- A `langchain-core` test passing a raw `model_json_schema()` dict (the streaming scenario) and asserting nested `$defs` objects get `additionalProperties: False`.
- A `langchain-openai` regression test exercising `_construct_responses_api_payload` with `stream=True` end-to-end.

