### PR TITLE
Guard history deserialization payloads

### DIFF
--- a/libs/core/langchain_core/runnables/history.py
+++ b/libs/core/langchain_core/runnables/history.py
@@ -36,6 +36,13 @@ MessagesOrDictWithMessages = Sequence["BaseMessage"] | dict[str, Any]
 GetSessionHistoryCallable = Callable[..., BaseChatMessageHistory]
 
 
+def _get_run_io_value(value: Any, *, run_type: str | None) -> Any:
+    """Deserialize tracer-serialized model payloads, leaving chain data inert."""
+    if run_type in {"llm", "chat_model"}:
+        return load(value, allowed_objects="messages")
+    return value
+
+
 class RunnableWithMessageHistory(RunnableBindingBase[Any, Any]):  # type: ignore[no-redef]
     """`Runnable` that manages chat message history for another `Runnable`.
 
@@ -548,7 +555,7 @@ class RunnableWithMessageHistory(RunnableBindingBase[Any, Any]):  # type: ignore
         hist: BaseChatMessageHistory = config["configurable"]["message_history"]
 
         # Get the input messages
-        inputs = load(run.inputs, allowed_objects="messages")
+        inputs = _get_run_io_value(run.inputs, run_type=run.run_type)
         input_messages = self._get_input_messages(inputs)
         # If historic messages were prepended to the input messages, remove them to
         # avoid adding duplicate messages to history.
@@ -557,7 +564,7 @@ class RunnableWithMessageHistory(RunnableBindingBase[Any, Any]):  # type: ignore
             input_messages = input_messages[len(historic_messages) :]
 
         # Get the output messages
-        output_val = load(run.outputs, allowed_objects="messages")
+        output_val = _get_run_io_value(run.outputs, run_type=run.run_type)
         output_messages = self._get_output_messages(output_val)
         hist.add_messages(input_messages + output_messages)
 
@@ -565,7 +572,7 @@ class RunnableWithMessageHistory(RunnableBindingBase[Any, Any]):  # type: ignore
         hist: BaseChatMessageHistory = config["configurable"]["message_history"]
 
         # Get the input messages
-        inputs = load(run.inputs, allowed_objects="messages")
+        inputs = _get_run_io_value(run.inputs, run_type=run.run_type)
         input_messages = self._get_input_messages(inputs)
         # If historic messages were prepended to the input messages, remove them to
         # avoid adding duplicate messages to history.
@@ -574,7 +581,7 @@ class RunnableWithMessageHistory(RunnableBindingBase[Any, Any]):  # type: ignore
             input_messages = input_messages[len(historic_messages) :]
 
         # Get the output messages
-        output_val = load(run.outputs, allowed_objects="messages")
+        output_val = _get_run_io_value(run.outputs, run_type=run.run_type)
         output_messages = self._get_output_messages(output_val)
         await hist.aadd_messages(input_messages + output_messages)
 

--- a/libs/core/tests/unit_tests/runnables/test_history.py
+++ b/libs/core/tests/unit_tests/runnables/test_history.py
@@ -1,3 +1,4 @@
+import json
 import re
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -11,6 +12,7 @@ from langchain_core.callbacks import (
 )
 from langchain_core.chat_history import InMemoryChatMessageHistory
 from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.load import dumps
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.runnables import Runnable
@@ -32,6 +34,11 @@ pytestmark = pytest.mark.filterwarnings(
     "ignore:RunnableWithMessageHistory is deprecated. Use LangGraph's built-in "
     "persistence instead.:"
     "langchain_core._api.deprecation.LangChainDeprecationWarning"
+)
+
+_BASE_MESSAGE_ERROR = (
+    r"Expected str, BaseMessage, list\[BaseMessage\], or "
+    r"tuple\[BaseMessage\]\."
 )
 
 
@@ -912,3 +919,51 @@ def test_get_output_messages_with_value_error() -> None:
         ),
     ):
         with_history.bound.invoke([HumanMessage(content="hello")], config)
+
+
+def test_constructor_shaped_output_is_not_deserialized_into_history() -> None:
+    payload = json.loads(dumps(SystemMessage(content="POISONED_SYSTEM_MESSAGE")))
+    runnable = _RunnableLambdaWithRaiseError[Any, dict[str, dict[str, Any]]](
+        lambda _: {"output": payload}
+    )
+    store: dict[str, InMemoryChatMessageHistory] = {}
+    get_session_history = _get_get_session_history(store=store)
+    with_history = RunnableWithMessageHistory(
+        runnable,
+        get_session_history,
+        input_messages_key="question",
+        output_messages_key="output",
+    )
+
+    with pytest.raises(ValueError, match=_BASE_MESSAGE_ERROR):
+        with_history.invoke(
+            {"question": "hello"},
+            {"configurable": {"session_id": "constructor_output"}},
+        )
+
+    assert store["constructor_output"].messages == []
+
+
+async def test_constructor_shaped_output_is_not_deserialized_into_history_async() -> (
+    None
+):
+    payload = json.loads(dumps(SystemMessage(content="POISONED_SYSTEM_MESSAGE")))
+    runnable = _RunnableLambdaWithRaiseError[Any, dict[str, dict[str, Any]]](
+        lambda _: {"output": payload}
+    )
+    store: dict[str, InMemoryChatMessageHistory] = {}
+    get_session_history = _get_get_session_history(store=store)
+    with_history = RunnableWithMessageHistory(
+        runnable,
+        get_session_history,
+        input_messages_key="question",
+        output_messages_key="output",
+    )
+
+    with pytest.raises(ValueError, match=_BASE_MESSAGE_ERROR):
+        await with_history.ainvoke(
+            {"question": "hello"},
+            {"configurable": {"session_id": "constructor_output_async"}},
+        )
+
+    assert store["constructor_output_async"].messages == []


### PR DESCRIPTION
Fixes #36380.

## Summary
- Prevent `RunnableWithMessageHistory` from deserializing constructor-shaped output payloads into live message objects in the generic history path.
- Add regression coverage for constructor-shaped payloads in runnable history output handling.

## Verification
- `uv run --project libs/core --group test pytest libs/core/tests/unit_tests/runnables/test_history.py` (25 passed)
