### PR TITLE
fix: prevent #TITLE# sentinel leak and KeyError in HTMLSectionSplitter (#38142)

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -437,7 +437,10 @@ class HTMLSectionSplitter:
 
                 for key in chunk.metadata:
                     if chunk.metadata[key] == "#TITLE#":
-                        chunk.metadata[key] = metadata["Title"]
+                        if "Title" in metadata:
+                            chunk.metadata[key] = metadata["Title"]
+                        else:
+                            chunk.metadata[key] = ""
                 metadata = {**metadata, **chunk.metadata}
                 new_doc = Document(page_content=chunk.page_content, metadata=metadata)
                 documents.append(new_doc)
@@ -557,11 +560,15 @@ class HTMLSectionSplitter:
         return [
             Document(
                 cast("str", section["content"]),
-                metadata={
-                    self.headers_to_split_on[str(section["tag_name"])]: section[
-                        "header"
-                    ]
-                },
+                metadata=(
+                    {}
+                    if section["header"] == "#TITLE#"
+                    else {
+                        self.headers_to_split_on[str(section["tag_name"])]: section[
+                            "header"
+                        ]
+                    }
+                ),
             )
             for section in sections
         ]

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3205,6 +3205,47 @@ def test_happy_path_splitting_with_duplicate_header_tag() -> None:
     assert docs[3].metadata["Header 1"] == "Foo"
 
 
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
+def test_html_section_splitter_no_title_sentinel_leak() -> None:
+    """Test that #TITLE# sentinel is not exposed in metadata for pre-header content.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38142
+    """
+    html = """
+    <html>
+      <body>
+        <p>Intro before header.</p>
+        <h1>Header</h1>
+        <p>Body.</p>
+      </body>
+    </html>
+    """
+
+    splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    # split_text should not expose #TITLE# in metadata
+    docs = splitter.split_text(html)
+    assert len(docs) == 2
+    assert "#TITLE#" not in str(docs[0].metadata)
+    assert docs[0].metadata == {}
+
+    # split_documents should not raise KeyError when parent metadata has no Title
+    parent_doc = Document(page_content=html, metadata={"source": "example"})
+    result = splitter.split_documents([parent_doc])
+    assert len(result) >= 2
+    for doc in result:
+        assert "#TITLE#" not in str(doc.metadata)
+        assert doc.metadata.get("source") == "example"
+
+    # split_documents with Title in parent metadata should still work
+    parent_doc_with_title = Document(
+        page_content=html, metadata={"source": "example", "Title": "My Page"}
+    )
+    result_with_title = splitter.split_documents([parent_doc_with_title])
+    assert len(result_with_title) >= 2
+
+
 def test_split_json() -> None:
     """Test json text splitter."""
     max_chunk = 800


### PR DESCRIPTION
## Summary

Fixes two related issues in `HTMLSectionSplitter`:

1. **`#TITLE#` sentinel leaks into metadata** — `split_text()` exposes the internal `#TITLE#` sentinel in `Document.metadata` for content that appears before the first configured header. This is confusing and undocumented behavior.

2. **`KeyError: 'Title'` in `split_documents()`** — When calling `split_documents()` with a parent `Document` whose metadata does not contain a `"Title"` key (the common case — most Documents have `{"source": "..."}` without a title), `create_documents()` unconditionally does `metadata["Title"]` to replace the sentinel, causing a `KeyError`.

## Root Cause

`split_html_by_headers()` uses `#TITLE#` as an internal sentinel for pre-header content (the `<body>` element before any configured header). This sentinel was never meant to be user-visible, but:
- `split_text_from_file()` passed it through in Document metadata
- `create_documents()` assumed `metadata["Title"]` always existed

## Changes

### `libs/text-splitters/langchain_text_splitters/html.py`

- **`split_text_from_file()`**: For pre-header sections (where `section["header"] == "#TITLE#"`), return empty metadata `{}` instead of exposing the sentinel
- **`create_documents()`**: When encountering `#TITLE#` in chunk metadata, check if `"Title"` exists in parent metadata before replacing; use empty string as fallback

### `libs/text-splitters/tests/unit_tests/test_text_splitters.py`

- Added `test_html_section_splitter_no_title_sentinel_leak()` regression test covering:
  - `split_text()` does not expose `#TITLE#` in metadata
  - `split_documents()` does not raise `KeyError` when parent metadata has no `Title`
  - `split_documents()` with `Title` in parent metadata still works correctly

## Verification

```
33 passed, 101 deselected in 0.21s (all HTML-related tests)
```

Reproduction from the issue now works:

```python
splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
# Before: {'Header 1': '#TITLE#'}  →  After: {}
splitter.split_text(html)
# Before: KeyError: 'Title'  →  After: works, preserves parent metadata
splitter.split_documents([Document(page_content=html, metadata={"source": "example"})])
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
