### PR TITLE
fix(langchain): correct verdict-reasoning inconsistency in `CriteriaResultOutputParser`

### DIFF
--- a/libs/langchain/langchain_classic/evaluation/criteria/eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/criteria/eval_chain.py
@@ -70,6 +70,71 @@ class CriteriaResultOutputParser(BaseOutputParser[dict]):
     def _type(self) -> str:
         return "criteria_result"
 
+    @staticmethod
+    def _resolve_verdict_from_reasoning(reasoning: str, verdict: str) -> str:
+        """Check if the reasoning contradicts the verdict and correct it.
+
+        LLMs sometimes produce reasoning that clearly concludes the submission
+        does or does not meet the criteria, but then output the wrong verdict
+        letter. This method detects such inconsistencies by inspecting the
+        conclusion of the reasoning and flips the verdict when there is a clear
+        contradiction.
+
+        Args:
+            reasoning: The step-by-step reasoning text.
+            verdict: The extracted verdict letter (``"Y"`` or ``"N"``).
+
+        Returns:
+            The corrected verdict letter.
+        """
+        # Inspect the tail of the reasoning where the conclusion typically is.
+        conclusion = reasoning[-500:].lower()
+
+        # Patterns indicating the submission does NOT meet criteria.
+        negative_patterns = [
+            r"does not meet",
+            r"doesn't meet",
+            r"does not fulfill",
+            r"doesn't fulfill",
+            r"does not satisfy",
+            r"doesn't satisfy",
+            r"fails to meet",
+            r"failed to meet",
+            r"is not met\b",
+            r"are not met\b",
+            r"not meeting the criteria",
+            r"incomplete and does not",
+            r"does not align",
+            r"doesn't align",
+            r"submission is incorrect",
+            r"not correct",
+        ]
+
+        # Patterns indicating the submission DOES meet criteria.
+        positive_patterns = [
+            r"meets the criteria",
+            r"meets all criteria",
+            r"fulfills the criteria",
+            r"satisfies the criteria",
+            r"submission is correct",
+            r"criteria (?:is|are) met\b",
+        ]
+
+        has_negative = any(
+            re.search(p, conclusion) for p in negative_patterns
+        )
+        has_positive = any(
+            re.search(p, conclusion) for p in positive_patterns
+        )
+
+        # Only flip when there is an unambiguous contradiction.
+        if has_negative and not has_positive and verdict.upper() == "Y":
+            return "N"
+        if has_positive and not has_negative and verdict.upper() == "N":
+            return "Y"
+
+        return verdict
+
     def parse(self, text: str) -> dict[str, Any]:
         """Parse the output text.
 
@@ -98,13 +163,18 @@ class CriteriaResultOutputParser(BaseOutputParser[dict]):
             splits = text.strip().rsplit("\n", maxsplit=1)
             verdict = splits[-1]
 
+        reasoning = text.strip()
+
+        if verdict and verdict.upper() in ("Y", "N") and reasoning:
+            verdict = self._resolve_verdict_from_reasoning(reasoning, verdict)
+
         if verdict:
             score = (
                 1 if verdict.upper() == "Y" else (0 if verdict.upper() == "N" else None)
             )
 
         return {
-            "reasoning": text.strip(),
+            "reasoning": reasoning,
             "value": verdict,
             "score": score,
         }

--- a/libs/langchain/langchain_classic/evaluation/criteria/prompt.py
+++ b/libs/langchain/langchain_classic/evaluation/criteria/prompt.py
@@ -2,20 +2,16 @@
 
 from langchain_core.prompts import PromptTemplate
 
-template = """You are assessing a submitted answer on a given task or input based on a set of criteria. Here is the data:
-[BEGIN DATA]
-***
-[Input]: {input}
-***
-[Submission]: {output}
-***
-[Criteria]: {criteria}
-***
-[END DATA]
-Does the submission meet the Criteria? First, write out in a step by step manner your reasoning about each criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line corresponding to the correct answer of whether the submission meets all criteria. At the end, repeat just the letter again by itself on a new line."""  # noqa: E501
-
-PROMPT = PromptTemplate(
-    input_variables=["input", "output", "criteria"], template=template
+_VERDICT_INSTRUCTION = (
+    "Does the submission meet the Criteria? First, write out in a step by step manner"
+    " your reasoning about each criterion to be sure that your conclusion is correct."
+    " Avoid simply stating the correct answers at the outset."
+    ' Then print only the single character "Y" or "N" (without quotes or'
+    " punctuation) on its own line corresponding to the correct answer of whether the"
+    " submission meets all criteria. Y means the submission DOES meet the criteria."
+    " N means the submission DOES NOT meet the criteria."
+    " Make sure your verdict is consistent with your reasoning."
+    " At the end, repeat just the letter again by itself on a new line."
 )
 
 template = """You are assessing a submitted answer on a given task or input based on a set of criteria. Here is the data:
@@ -27,11 +23,30 @@ template = """You are assessing a submitted answer on a given task or input base
 ***
 [Criteria]: {criteria}
 ***
+[END DATA]
+"""  # noqa: E501
+template += _VERDICT_INSTRUCTION
+
+PROMPT = PromptTemplate(
+    input_variables=["input", "output", "criteria"], template=template
+)
+
+template_with_refs = """You are assessing a submitted answer on a given task or input based on a set of criteria. Here is the data:
+[BEGIN DATA]
+***
+[Input]: {input}
+***
+[Submission]: {output}
+***
+[Criteria]: {criteria}
+***
 [Reference]: {reference}
 ***
 [END DATA]
-Does the submission meet the Criteria? First, write out in a step by step manner your reasoning about each criterion to be sure that your conclusion is correct. Avoid simply stating the correct answers at the outset. Then print only the single character "Y" or "N" (without quotes or punctuation) on its own line corresponding to the correct answer of whether the submission meets all criteria. At the end, repeat just the letter again by itself on a new line."""  # noqa: E501
+"""  # noqa: E501
+template_with_refs += _VERDICT_INSTRUCTION
 
 PROMPT_WITH_REFERENCES = PromptTemplate(
-    input_variables=["input", "output", "criteria", "reference"], template=template
+    input_variables=["input", "output", "criteria", "reference"],
+    template=template_with_refs,
 )

--- a/libs/langchain/tests/unit_tests/evaluation/criteria/test_eval_chain.py
+++ b/libs/langchain/tests/unit_tests/evaluation/criteria/test_eval_chain.py
@@ -59,6 +59,59 @@ def test_criteria_result_output_parser_parse(text: str, want: dict) -> None:
     assert got.get("score") == want["score"]
 
 
+@pytest.mark.parametrize(
+    ("text", "want"),
+    [
+        # Reasoning says "does not meet" but verdict is Y -> should flip to N
+        (
+            "The submission does not set the departure date at all, so it is"
+            " incomplete. The submission does not meet the criteria of"
+            " correctness because it fails to perform all required actions.\n\nY",
+            {"reasoning_contains": "does not meet", "value": "N", "score": 0},
+        ),
+        # Reasoning says "doesn't meet" but verdict is Y -> should flip to N
+        (
+            "The answer is factually wrong. It doesn't meet the criteria.\n\nY",
+            {"reasoning_contains": "doesn't meet", "value": "N", "score": 0},
+        ),
+        # Reasoning says "does not fulfill" but verdict is Y -> should flip to N
+        (
+            "The submission does not fulfill the objective as specified.\n\nY",
+            {"reasoning_contains": "does not fulfill", "value": "N", "score": 0},
+        ),
+        # Reasoning says "meets the criteria" but verdict is N -> should flip to Y
+        (
+            "The submission is accurate and complete. It meets the criteria.\n\nN",
+            {"reasoning_contains": "meets the criteria", "value": "Y", "score": 1},
+        ),
+        # No contradiction — verdict should stay as-is
+        (
+            "The submission is accurate and complete. It meets the criteria.\n\nY",
+            {"reasoning_contains": "meets the criteria", "value": "Y", "score": 1},
+        ),
+        # Both positive and negative signals — ambiguous, don't flip
+        (
+            "The submission meets the criteria for relevance but does not meet"
+            " the criteria for correctness.\n\nY",
+            {
+                "reasoning_contains": "does not meet",
+                "value": "Y",
+                "score": 1,
+            },
+        ),
+    ],
+)
+def test_criteria_result_output_parser_consistency_check(
+    text: str, want: dict
+) -> None:
+    """Test that the parser corrects verdict-reasoning inconsistencies."""
+    output_parser = CriteriaResultOutputParser()
+    got = output_parser.parse(text)
+    assert want["reasoning_contains"] in got["reasoning"]
+    assert got["value"] == want["value"]
+    assert got["score"] == want["score"]
+
+
 @pytest.mark.parametrize("criterion", list(Criteria))
 def test_resolve_criteria_enum(criterion: Criteria) -> None:
     assert CriteriaEvalChain.resolve_criteria(criterion) == {


### PR DESCRIPTION
Fixes #31870

---

Users of `CriteriaEvalChain` get incorrect scores when the LLM's reasoning concludes the submission does NOT meet criteria but the final verdict letter is "Y". The parser blindly trusts the letter, returning `score: 1`. This fix adds a consistency check that detects and corrects such contradictions, and clarifies the prompt to reduce their occurrence.

Verified with `make lint`, `make format`, and `make test` — all 27 tests pass (21 existing + 6 new).

