### PR TITLE
fix(core): raise error when ids length mismatches in `VectorStore.add_texts`

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -83,6 +83,12 @@ class VectorStore(ABC):
                 )
                 raise ValueError(msg)
             metadatas_ = iter(metadatas) if metadatas else cycle([{}])
+            if ids is not None and len(ids) != len(texts_):
+                msg = (
+                    "The number of ids must match the number of texts."
+                    f"Got {len(ids)} ids and {len(texts_)} texts."
+                )
+                raise ValueError(msg)
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
@@ -222,6 +228,12 @@ class VectorStore(ABC):
                 )
                 raise ValueError(msg)
             metadatas_ = iter(metadatas) if metadatas else cycle([{}])
+            if ids is not None and len(ids) != len(texts_):
+                msg = (
+                    "The number of ids must match the number of texts."
+                    f"Got {len(ids)} ids and {len(texts_)} texts."
+                )
+                raise ValueError(msg)
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
 
             docs = [

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -177,6 +177,18 @@ def test_default_add_texts(vs_class: type[VectorStore]) -> None:
         Document(id=ids_2[1], page_content="bar", metadata={"foo": "bar"}),
     ]
 
+    # Add texts with mismatched ids length
+    if vs_class == CustomAddDocumentsVectorstore:
+        with pytest.raises(
+            ValueError, match=r"The number of ids must match the number of texts\."
+        ):
+            store.add_texts(["foo", "bar"], ids=["1"])
+
+        with pytest.raises(
+            ValueError, match=r"The number of ids must match the number of texts\."
+        ):
+            store.add_texts(["foo", "bar"], ids=["1", "2", "3"])
+
 
 @pytest.mark.parametrize(
     "vs_class", [CustomAddTextsVectorstore, CustomAddDocumentsVectorstore]
@@ -234,6 +246,18 @@ async def test_default_aadd_texts(vs_class: type[VectorStore]) -> None:
         Document(id=ids_2[0], page_content="foo", metadata={"foo": "bar"}),
         Document(id=ids_2[1], page_content="bar", metadata={"foo": "bar"}),
     ]
+
+    # Add texts with mismatched ids length
+    if vs_class == CustomAddDocumentsVectorstore:
+        with pytest.raises(
+            ValueError, match=r"The number of ids must match the number of texts\."
+        ):
+            await store.aadd_texts(["foo", "bar"], ids=["1"])
+
+        with pytest.raises(
+            ValueError, match=r"The number of ids must match the number of texts\."
+        ):
+            await store.aadd_texts(["foo", "bar"], ids=["1", "2", "3"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #38203

---

Fixes an issue where `VectorStore.add_texts` silently truncates texts if fewer `ids` are provided than `texts`.

- Validates `ids` length against `texts` in both `add_texts` and `aadd_texts`.
- Raises a `ValueError` if there's a mismatch.
- Added regression coverage in `libs/core/tests/unit_tests/vectorstores/test_vectorstore.py`.

This PR was created with the help of an AI agent.