### PR TITLE
fix(core): count audio, video, and file blocks by fixed penalty in `count_tokens_approximately`

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2243,6 +2243,9 @@ def count_tokens_approximately(
     extra_tokens_per_message: float = 3.0,
     count_name: bool = True,
     tokens_per_image: int = 85,
+    tokens_per_audio: int = 85,
+    tokens_per_video: int = 85,
+    tokens_per_file: int = 85,
     use_usage_metadata_scaling: bool = False,
     tools: list[BaseTool | dict[str, Any]] | None = None,
 ) -> int:
@@ -2252,8 +2255,8 @@ def count_tokens_approximately(
 
     - For AI messages, the token count also includes stringified tool calls.
     - For tool messages, the token count also includes the tool call ID.
-    - For multimodal messages with images, applies a fixed token penalty per image
-        instead of counting base64-encoded characters.
+    - For multimodal messages with images, audio, video, or files, applies a fixed
+        token penalty per block instead of counting base64-encoded characters.
     - If tools are provided, the token count also includes stringified tool schemas.
 
     Args:
@@ -2269,6 +2272,13 @@ def count_tokens_approximately(
         count_name: Whether to include message names in the count.
         tokens_per_image: Fixed token cost per image (default: 85, aligned with
             OpenAI's low-resolution image token cost).
+        tokens_per_audio: Fixed token cost per audio block (default: 85). Audio token
+            usage is highly model- and duration-dependent; adjust for your provider.
+        tokens_per_video: Fixed token cost per video block (default: 85). Video token
+            usage is highly model- and duration-dependent; adjust for your provider.
+        tokens_per_file: Fixed token cost per file block, e.g. a PDF document
+            (default: 85). File token usage is highly model- and size-dependent;
+            adjust for your provider.
         use_usage_metadata_scaling: If True, and all AI messages have consistent
             `response_metadata['model_provider']`, scale the approximate token count
             using the **most recent** AI message that has
@@ -2285,9 +2295,9 @@ def count_tokens_approximately(
         This is a simple approximation that may not match the exact token count used by
         specific models. For accurate counts, use model-specific tokenizers.
 
-        For multimodal messages containing images, a fixed token penalty is applied
-        per image instead of counting base64-encoded characters, which provides a
-        more realistic approximation.
+        For multimodal messages containing images, audio, video, or files, a fixed
+        token penalty is applied per block instead of counting base64-encoded
+        characters, which provides a more realistic approximation.
 
     !!! version-added "Added in `langchain-core` 0.3.46"
     """
@@ -2322,9 +2332,16 @@ def count_tokens_approximately(
                 elif isinstance(block, dict):
                     block_type = block.get("type", "")
 
-                    # Apply fixed penalty for image blocks
+                    # Apply a fixed penalty for media blocks instead of counting
+                    # their (potentially very large) base64-encoded payloads.
                     if block_type in {"image", "image_url"}:
                         token_count += tokens_per_image
+                    elif block_type in {"audio", "input_audio"}:
+                        token_count += tokens_per_audio
+                    elif block_type == "video":
+                        token_count += tokens_per_video
+                    elif block_type == "file":
+                        token_count += tokens_per_file
                     # Count text blocks normally
                     elif block_type == "text":
                         text = block.get("text", "")

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2864,6 +2864,56 @@ def test_count_tokens_approximately_with_unknown_block_type() -> None:
     assert mixed > text_only
 
 
+def test_count_tokens_approximately_with_audio_video_file_content() -> None:
+    """Test approximate token counting with audio, video, and file content blocks.
+
+    Each carries a large base64 payload that must NOT be counted character by
+    character; a fixed per-block penalty is applied instead (mirroring images).
+    """
+    large_payload = "A" * 100000
+
+    for block in (
+        {"type": "audio", "mime_type": "audio/wav", "base64": large_payload},
+        # OpenAI Chat Completions audio format
+        {
+            "type": "input_audio",
+            "input_audio": {"data": large_payload, "format": "wav"},
+        },
+        {"type": "video", "mime_type": "video/mp4", "base64": large_payload},
+        {"type": "file", "mime_type": "application/pdf", "base64": large_payload},
+    ):
+        message = HumanMessage(content=[{"type": "text", "text": "describe"}, block])
+
+        token_count = count_tokens_approximately([message])
+
+        # Should be ~85 (media) + a few (text/role/extra), NOT 25,000+ from the
+        # base64 payload.
+        assert token_count < 200, (
+            f"Expected <200 tokens for {block['type']} block, got {token_count}"
+        )
+        assert token_count > 80, (
+            f"Expected >80 tokens for {block['type']} block, got {token_count}"
+        )
+
+
+def test_count_tokens_approximately_with_custom_media_penalties() -> None:
+    """Test custom tokens_per_audio/video/file parameters."""
+    audio = HumanMessage(
+        content=[{"type": "audio", "mime_type": "audio/wav", "base64": "AAA"}]
+    )
+    video = HumanMessage(
+        content=[{"type": "video", "mime_type": "video/mp4", "base64": "AAA"}]
+    )
+    file = HumanMessage(
+        content=[{"type": "file", "mime_type": "application/pdf", "base64": "AAA"}]
+    )
+
+    # The custom penalty should dominate the (tiny) role/extra overhead.
+    assert 1600 < count_tokens_approximately([audio], tokens_per_audio=1600) < 1620
+    assert 500 < count_tokens_approximately([video], tokens_per_video=500) < 520
+    assert 2000 < count_tokens_approximately([file], tokens_per_file=2000) < 2020
+
+
 def test_count_tokens_approximately_ai_tool_calls_skipped_for_list_content() -> None:
     """Test that tool_calls aren't double-counted for list (Anthropic-style) content."""
     tool_calls = [


### PR DESCRIPTION
Fixes #38258

---

`count_tokens_approximately` powers `trim_messages` windowing. It already applies a fixed `tokens_per_image` penalty to image blocks instead of counting their base64 payloads, but `audio`, `video`, and `file` blocks fell through to the generic `repr(block)` branch — so their full base64 string was counted as characters. A single ~1 MB base64-encoded audio clip or PDF was approximated at ~250,000 tokens, silently breaking windowing for any multimodal conversation.

This applies the same fixed-penalty treatment to `audio`/`input_audio` (OpenAI Chat Completions format), `video`, and `file` blocks, exposed through new keyword-only `tokens_per_audio`, `tokens_per_video`, and `tokens_per_file` parameters (default `85`, matching `tokens_per_image`). Behavior is unchanged for text and image content; the new parameters are keyword-only with defaults, so existing callers are unaffected.

Verified with `make format`, `make lint`, and `make test` from `libs/core`. New unit tests cover the four media block types and the custom-penalty parameters.

> Disclosure: this change was prepared with the assistance of an AI coding agent.