### PR TITLE
Fix #37686

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -506,7 +506,7 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = [
                     create_tool_call_chunk(
                         name=tc["name"],
-                        args=json.dumps(tc["args"]),
+                        args=json.dumps(tc["args"], ensure_ascii=False),
                         id=tc["id"],
                         index=None,
                     )


### PR DESCRIPTION
# PR Description: Fix #37686 - Ensure non-ASCII characters in tool call args are not escaped

## Issue Title
core: AIMessageChunk validator escapes non-ASCII in tool_call_chunks[].args

## Issue Description
The `AIMessageChunk` validator escapes non-ASCII characters in `tool_call_chunks[].args` using `json.dumps` with default `ensure_ascii=True`, causing Unicode characters (e.g., Chinese, Japanese, or emoji) to be converted to `\uXXXX` escape sequences. This breaks downstream processing that expects human-readable tool call arguments.

**Reported by:** HumphreySun98

## Root Cause Analysis
The `AIMessageChunk` validator in `ai.py` serializes tool call chunk args using `json.dumps(tc["args"])` without passing `ensure_ascii=False`. By default, `json.dumps` escapes all non-ASCII characters, which corrupts Unicode content in tool call arguments.

## Changes Made

**File: `ai.py`**
- Changed `json.dumps(tc["args"])` to `json.dumps(tc["args"], ensure_ascii=False)` in the `tool_call_chunks` validator
- This preserves non-ASCII characters in tool call arguments as-is instead of escaping them

## Risk Assessment
**Low** - The change only affects serialization formatting of tool call arguments. Non-ASCII characters will now be preserved as readable UTF-8 instead of escaped sequences. This is backwards-compatible for all consumers that properly handle UTF-8 JSON.
