### PR TITLE
test(core): remove stale xfail markers for passing tests

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
@@ -2144,11 +2144,6 @@ async def test_async_in_async_stream_lambdas() -> None:
     _assert_events_equal_allow_superset_metadata(events, EXPECTED_EVENTS)
 
 
-@pytest.mark.xfail(
-    reason="This test is failing due to missing functionality."
-    "Need to implement logic in _transform_stream_with_config that mimics the async "
-    "variant that uses tap_output_iter"
-)
 async def test_sync_in_sync_lambdas() -> None:
     """Test invoking nested runnable lambda."""
 

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -409,7 +409,6 @@ def test_convert_to_openai_function(
     assert actual == expected
 
 
-@pytest.mark.xfail(reason="Direct pydantic v2 models not yet supported")
 def test_convert_to_openai_function_nested_v2() -> None:
     class NestedV2(BaseModelV2Maybe):
         nested_v2_arg1: int = FieldV2Maybe(..., description="foo")


### PR DESCRIPTION
Fixes #38266

Removes obsolete xfail markers from two langchain-core tests that now pass reliably, eliminating XPASS noise in CI.

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

## Verification
- uv run --group test pytest tests/unit_tests/utils/test_function_calling.py::test_convert_to_openai_function_nested_v2 tests/unit_tests/runnables/test_runnable_events_v1.py::test_sync_in_sync_lambdas -v (both PASSED)
- make format and make lint in libs/core (passed)
