### PR TITLE
fix(core): resolve inconsistent generations shape in chat model error callbacks (closes #38276)

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -819,11 +819,14 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 chat_generation_chunk = merge_chat_generation_chunks(chunks)
                 if chat_generation_chunk:
                     generations = [
-                        [chat_generation_chunk],
-                        generations_with_error_metadata,
+                        [chat_generation_chunk] + generations_with_error_metadata
                     ]
                 else:
-                    generations = [generations_with_error_metadata]
+                    generations = (
+                        [generations_with_error_metadata]
+                        if generations_with_error_metadata
+                        else []
+                    )
                 run_manager.on_llm_error(
                     e,
                     response=LLMResult(generations=generations),
@@ -950,9 +953,15 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             generations_with_error_metadata = _generate_response_from_error(e)
             chat_generation_chunk = merge_chat_generation_chunks(chunks)
             if chat_generation_chunk:
-                generations = [[chat_generation_chunk], generations_with_error_metadata]
+                generations = [
+                    [chat_generation_chunk] + generations_with_error_metadata
+                ]
             else:
-                generations = [generations_with_error_metadata]
+                generations = (
+                    [generations_with_error_metadata]
+                    if generations_with_error_metadata
+                    else []
+                )
             await run_manager.on_llm_error(
                 e,
                 response=LLMResult(generations=generations),
@@ -1666,7 +1675,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                     run_managers[i].on_llm_error(
                         e,
                         response=LLMResult(
-                            generations=[generations_with_error_metadata]
+                            generations=(
+                                [generations_with_error_metadata]
+                                if generations_with_error_metadata
+                                else []
+                            )
                         ),
                     )
                 raise
@@ -1797,7 +1810,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                     await run_managers[i].on_llm_error(
                         res,
                         response=LLMResult(
-                            generations=[generations_with_error_metadata]
+                            generations=(
+                                [generations_with_error_metadata]
+                                if generations_with_error_metadata
+                                else []
+                            )
                         ),
                     )
                 exceptions.append(res)

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -200,7 +200,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 


### PR DESCRIPTION
Fixes #38276

This PR ensures that `BaseChatModel` stream/astream and batch pipelines return correctly shaped `generations` values to the `on_llm_error` callbacks when an exception occurs. It eliminates malformed batch shapes (`[[]]` and `[[chunk], []]`) by ensuring callback arguments always adhere to the standard single-prompt shape.

verified locally in `libs/core`.

  - Un-xfail'ed and ran `tests/unit_tests/language_models/chat_models/test_base.py::test_stream_error_callback` alongside the rest of the unit tests in `libs/core`.
