### PR TITLE
fix(core): handle partials in `pretty_repr`

### DIFF
--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -375,10 +375,13 @@ class StringPromptTemplate(BasePromptTemplate[str], ABC):
         Returns:
             A pretty representation of the prompt.
         """
-        # TODO: handle partials
         dummy_vars = {
             input_var: "{" + f"{input_var}" + "}" for input_var in self.input_variables
         }
+        # Render partial variables as placeholders too, so the template structure
+        # is shown instead of their bound values (or the return values of callable
+        # partials).
+        dummy_vars.update({var: "{" + f"{var}" + "}" for var in self.partial_variables})
         if html:
             dummy_vars = {
                 k: get_colored_text(v, "yellow") for k, v in dummy_vars.items()

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -734,3 +734,25 @@ def test_prompt_template_add(
         variable="template",
         another_variable="other_template",
     )
+
+
+def test_pretty_repr_renders_partial_variables_as_placeholders() -> None:
+    """Partial variables should be shown as placeholders, not their bound values."""
+    # partial applied via `.partial()`
+    prompt = PromptTemplate.from_template("Hello {user}, how is {input}?").partial(
+        user="Lucy",
+    )
+    assert prompt.pretty_repr() == "Hello {user}, how is {input}?"
+
+    # partial supplied through the constructor behaves the same way
+    prompt = PromptTemplate.from_template(
+        "Hello {user}, how is {input}?",
+        partial_variables={"user": "Lucy"},
+    )
+    assert prompt.pretty_repr() == "Hello {user}, how is {input}?"
+
+
+def test_pretty_repr_renders_callable_partial_as_placeholder() -> None:
+    """Callable partials should render as placeholders, not their returned value."""
+    prompt = PromptTemplate.from_template("Now: {now}").partial(now=lambda: "12:00")
+    assert prompt.pretty_repr() == "Now: {now}"


### PR DESCRIPTION
Closes #38193

---

`StringPromptTemplate.pretty_repr` built placeholders only for `input_variables`, so `partial_variables` were rendered with their bound values (or the return value of callable partials) instead of as template placeholders. This also affected `HumanMessagePromptTemplate` and `ChatMessagePromptTemplate`, which delegate to the inner prompt's `pretty_repr`.

Partial variable names are now rendered as placeholders as well. Added regression tests covering partials applied via `.partial()`, via the constructor, and callable partials. Prompt unit suites, `ruff`, and `mypy` pass.

This contribution was made with AI assistance.
