### PR TITLE
fix(core): strip reasoning blocks (<think>) from openai structured ou…

### DIFF
--- a/libs/core/langchain_core/output_parsers/openai_tools.py
+++ b/libs/core/langchain_core/output_parsers/openai_tools.py
@@ -49,6 +49,21 @@ def parse_tool_call(
 
     arguments = raw_tool_call["function"]["arguments"]
 
+    if isinstance(arguments, str):
+        # If there is an unclosed <think> block during streaming, we haven't reached the JSON yet.
+        if "<think>" in arguments and "</think>" not in arguments:
+            if partial:
+                return None
+
+        import re
+        # Strip <think>...</think> blocks
+        arguments = re.sub(r"<think>.*?</think>\n*", "", arguments, flags=re.DOTALL)
+
+        # Safely extract everything from the first '{' to discard any leading garbage (like <tool_call>)
+        idx = arguments.find("{")
+        if idx != -1:
+            arguments = arguments[idx:]
+
     if partial:
         try:
             function_args = parse_partial_json(arguments, strict=strict)


### PR DESCRIPTION
Fixes #32120

When using reasoning models like DeepSeek-R1, they often inject `<think>` blocks and `<tool_call>` wrappers directly into the function arguments, which causes a `JSONDecodeError`. 

This PR updates `parse_tool_call` in `openai_tools.py` to safely strip out these reasoning blocks and prefix wrappers before parsing the JSON.

**How did you verify your code works?**
Tested locally by simulating a DeepSeek R1 structured output (containing a `<think>` block and `<tool_call>` tags) and verified it parses the underlying JSON cleanly without throwing a `JSONDecodeError`.
