### PR TITLE
fix(langchain): infer `openai` provider for `o4` model name prefix

### DIFF
--- a/libs/langchain/langchain_classic/chat_models/base.py
+++ b/libs/langchain/langchain_classic/chat_models/base.py
@@ -137,7 +137,7 @@ def init_chat_model(
 
             Inferred providers by prefix (case-insensitive):
 
-            - `gpt-...` | `o1...` | `o3...`               -> `openai`
+            - `gpt-...` | `o1...` | `o3...` | `o4...`       -> `openai`
             - `claude...`                                 -> `anthropic`
             - `amazon....` | `anthropic....` | `meta....` -> `bedrock`
             - `gemini...`                                 -> `google_vertexai`
@@ -566,6 +566,7 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
             "gpt-",
             "o1",
             "o3",
+            "o4",
             "chatgpt",
             "text-davinci",
         )

--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -251,7 +251,7 @@ def init_chat_model(
 
             Inferred providers by prefix (case-insensitive):
 
-            - `gpt-...` | `o1...` | `o3...`               -> `openai`
+            - `gpt-...` | `o1...` | `o3...` | `o4...`       -> `openai`
             - `claude...`                                 -> `anthropic`
             - `amazon....` | `anthropic....` | `meta....` -> `bedrock`
             - `gemini...`                                 -> `google_vertexai` (default changes in next major; pass `model_provider` to lock in)
@@ -536,6 +536,7 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
             "gpt-",
             "o1",
             "o3",
+            "o4",
             "chatgpt",
             "text-davinci",
         )

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -81,6 +81,8 @@ def test_supported_providers_is_sorted() -> None:
     [
         (OPENAI_TEST_MODEL, "openai"),
         ("o3", "openai"),
+        ("o4-mini", "openai"),
+        ("o4", "openai"),
         ("text-davinci-003", "openai"),
         ("claude-3-haiku-20240307", "anthropic"),
         ("command-r-plus", "cohere"),


### PR DESCRIPTION
Closes #38243

---

`_attempt_infer_model_provider` already recognizes `o1` and `o3` prefixes as OpenAI models, but was missing `o4`. This means `init_chat_model("o4-mini")` raises a `ValueError` even though `o4-mini` is a GA OpenAI model, while the functionally identical call `init_chat_model("o3-mini")` works fine.

The fix adds `"o4"` to the OpenAI prefix tuple in `_attempt_infer_model_provider`, matching the existing pattern for `o1` and `o3`. Applied to both the actively maintained `langchain` package and `langchain-classic`. Two unit test cases (`o4` and `o4-mini`) added to the parametrized `test_attempt_infer_model_provider` suite.

*This contribution was made with AI-agent assistance (Claude Code).*