### PR TITLE
fix(perplexity): use supported Responses API model

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -1528,7 +1528,7 @@ class ChatPerplexity(BaseChatModel):
 
         Client-side function tools require the Perplexity Responses (Agent) API:
         construct the model with `use_responses_api=True` and a tool-capable
-        model such as `openai/gpt-5.5`. The `sonar` family does not support
+        model such as `openai/gpt-5`. The `sonar` family does not support
         client-side function tools.
 
         Args:

--- a/libs/partners/perplexity/tests/integration_tests/test_chat_models_standard.py
+++ b/libs/partners/perplexity/tests/integration_tests/test_chat_models_standard.py
@@ -51,7 +51,7 @@ class TestPerplexityResponsesStandard(ChatModelIntegrationTests):
 
     @property
     def chat_model_params(self) -> dict:
-        return {"model": "openai/gpt-5.5", "use_responses_api": True}
+        return {"model": "openai/gpt-5", "use_responses_api": True}
 
     @property
     def has_tool_choice(self) -> bool:

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -532,7 +532,7 @@ def test_translate_responses_input_keeps_assistant_text_with_tool_calls() -> Non
 
 def test_to_responses_payload_flattens_tools_and_translates_messages() -> None:
     """End-to-end: `_to_responses_payload` flattens tools and translates tool turns."""
-    llm = ChatPerplexity(model="openai/gpt-5.5", api_key="test", use_responses_api=True)
+    llm = ChatPerplexity(model="openai/gpt-5", api_key="test", use_responses_api=True)
     message_dicts: list[dict[str, Any]] = [
         {"role": "user", "content": "weather in Paris?"},
         {


### PR DESCRIPTION
Perplexity's Responses API integration tests were pinned to `openai/gpt-5.5`, which now fails against the live Agent API for this test path. Use the stable `openai/gpt-5` Agent API model instead so scheduled coverage continues exercising the Responses API and tool-calling surface.