### PR TITLE
test(openai): clarify expected strict schema error

### DIFF
--- a/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
@@ -511,7 +511,9 @@ def test_parsed_strict() -> None:
 
     schema = _convert_to_openai_response_format(Joke)
     invalid_schema = cast(dict, _convert_to_openai_response_format(Joke, strict=True))
-    invalid_schema["json_schema"]["schema"]["required"] = ["setup"]  # make invalid
+    # Intentionally make the strict schema invalid. OpenAI requires every property
+    # to appear in `required`; omitting `punchline` should produce a BadRequestError.
+    invalid_schema["json_schema"]["schema"]["required"] = ["setup"]
 
     # Test not strict
     response = llm.invoke("Tell me a joke", response_format=schema)


### PR DESCRIPTION
This clarifies that the strict Responses API schema in `test_parsed_strict` is intentionally made invalid before asserting OpenAI raises `BadRequestError`.

The scheduled integration traces for this test can otherwise look like real product regressions because OpenAI reports that `punchline` is missing from `required`. The comment now makes the test intent explicit for future readers and issue triage tooling.