### PR TITLE
core: Add public API for safe message retention cutoff

### DIFF
--- a/libs/core/langchain_core/messages/__init__.py
+++ b/libs/core/langchain_core/messages/__init__.py
@@ -62,10 +62,12 @@ if TYPE_CHECKING:
         convert_to_messages,
         convert_to_openai_messages,
         filter_messages,
+        find_safe_message_cutoff,
         get_buffer_string,
         merge_message_runs,
         message_chunk_to_message,
         messages_from_dict,
+        partition_messages,
         trim_messages,
     )
 
@@ -118,6 +120,7 @@ __all__ = (
     "convert_to_openai_messages",
     "ensure_id",
     "filter_messages",
+    "find_safe_message_cutoff",
     "get_buffer_string",
     "is_data_content_block",
     "merge_content",
@@ -126,6 +129,7 @@ __all__ = (
     "message_to_dict",
     "messages_from_dict",
     "messages_to_dict",
+    "partition_messages",
     "trim_messages",
 )
 
@@ -178,11 +182,13 @@ _dynamic_imports = {
     "convert_to_openai_image_block": "block_translators.openai",
     "convert_to_openai_messages": "utils",
     "filter_messages": "utils",
+    "find_safe_message_cutoff": "utils",
     "get_buffer_string": "utils",
     "is_data_content_block": "content",
     "merge_message_runs": "utils",
     "message_chunk_to_message": "utils",
     "messages_from_dict": "utils",
+    "partition_messages": "utils",
     "trim_messages": "utils",
 }
 

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1520,6 +1520,271 @@ def trim_messages(
     raise ValueError(msg)
 
 
+def _resolve_token_counter(
+    token_counter: Callable[[list[BaseMessage]], int]
+    | Callable[[BaseMessage], int]
+    | BaseLanguageModel[Any]
+    | Literal["approximate"],
+) -> Callable[[Sequence[BaseMessage]], int]:
+    """Resolve token counter argument to a callable that accepts a sequence of messages."""
+    if isinstance(token_counter, str):
+        if token_counter in _TOKEN_COUNTER_SHORTCUTS:
+            actual_token_counter = _TOKEN_COUNTER_SHORTCUTS[token_counter]
+        else:
+            available_shortcuts = ", ".join(
+                f"'{key}'" for key in _TOKEN_COUNTER_SHORTCUTS
+            )
+            msg = (
+                f"Invalid token_counter shortcut '{token_counter}'. "
+                f"Available shortcuts: {available_shortcuts}."
+            )
+            raise ValueError(msg)
+    else:
+        actual_token_counter = token_counter
+
+    if hasattr(actual_token_counter, "get_num_tokens_from_messages"):
+        return actual_token_counter.get_num_tokens_from_messages
+    elif callable(actual_token_counter):
+        # Check if the callable expects a single message (first arg is annotated as BaseMessage)
+        params = list(inspect.signature(actual_token_counter).parameters.values())
+        if params and params[0].annotation is BaseMessage:
+
+            def list_token_counter(messages: Sequence[BaseMessage]) -> int:
+                return sum(actual_token_counter(msg) for msg in messages)  # type: ignore[arg-type, misc]
+
+            return list_token_counter
+        else:
+            return actual_token_counter  # type: ignore[return-value]
+    else:
+        msg = (
+            f"'token_counter' expected to be a model that implements "
+            f"get_num_tokens_from_messages, or a callable, or a string shortcut. "
+            f"Received {type(actual_token_counter)}."
+        )
+        raise ValueError(msg)
+
+
+@_runnable_support
+def find_safe_message_cutoff(
+    messages: Iterable[MessageLikeRepresentation] | PromptValue,
+    *,
+    max_tokens: int,
+    token_counter: Callable[[list[BaseMessage]], int]
+    | Callable[[BaseMessage], int]
+    | BaseLanguageModel[Any]
+    | Literal["approximate"] = "approximate",
+    retain: Literal["start", "end"] = "end",
+) -> int:
+    """Compute a split index for message pruning that respects tool boundaries.
+
+    Ensures that an ``AIMessage`` containing ``tool_calls`` is never separated
+    from its corresponding ``ToolMessage`` responses. This is useful when
+    building custom memory or summarization pipelines where you need to know
+    *where* to cut conversation history while keeping it valid for downstream
+    chat-model consumption.
+
+    Args:
+        messages: Sequence of messages to compute the cutoff for.
+        max_tokens: Maximum token budget for the retained subset.
+        token_counter: Function for counting tokens in a list of ``BaseMessage``.
+            Accepts a ``Callable[[list[BaseMessage]], int]`` or the string
+            shortcut ``"approximate"`` which uses
+            ``count_tokens_approximately``. Defaults to ``"approximate"``.
+        retain: Which portion of the conversation to keep:
+
+            - ``"end"`` *(default)* -- keep the most recent messages.
+            - ``"start"`` -- keep the oldest messages.
+
+    Returns:
+        The cutoff index into the converted list of messages.
+
+        * When ``retain="end"``, messages ``[cutoff:]`` are retained and
+          ``[:cutoff]`` can be removed.
+        * When ``retain="start"``, messages ``[:cutoff]`` are retained and
+          ``[cutoff:]`` can be removed.
+
+    Raises:
+        ValueError: If *retain* is not ``"start"`` or ``"end"``.
+
+    Example:
+        Compute a safe cutoff index for a conversation with tool calls:
+
+        .. code-block:: python
+
+            from langchain_core.messages import (
+                AIMessage,
+                HumanMessage,
+                ToolMessage,
+                find_safe_message_cutoff,
+            )
+
+            messages = [
+                HumanMessage(content="What's the weather?"),
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {"name": "get_weather", "args": {"city": "SF"}, "id": "c1"}
+                    ],
+                ),
+                ToolMessage(content="72F and sunny", tool_call_id="c1"),
+                HumanMessage(content="Thanks!"),
+            ]
+
+            # The AIMessage + ToolMessage are kept together as a block
+            idx = find_safe_message_cutoff(
+                messages,
+                max_tokens=30,
+                token_counter="approximate",
+                retain="end",
+            )
+
+    .. versionadded:: 0.4.0
+    """
+    if retain not in {"start", "end"}:
+        msg = f"Invalid retain={retain!r}. Expected 'start' or 'end'."
+        raise ValueError(msg)
+
+    # Convert the messages input to list[BaseMessage] just like other langchain utils do
+    converted_messages = convert_to_messages(messages)
+    if not converted_messages:
+        return 0
+
+    # Resolve token counter using the helper
+    _token_counter = _resolve_token_counter(token_counter)
+
+    # Group messages into unbreakable blocks.
+    # Each block is a tuple: (list_of_messages, start_index_in_original_list)
+    blocks: list[tuple[list[BaseMessage], int]] = []
+    i = 0
+    n = len(converted_messages)
+    while i < n:
+        current_msg = converted_messages[i]
+        if isinstance(current_msg, AIMessage) and current_msg.tool_calls:
+            block_msgs: list[BaseMessage] = [current_msg]
+            start_idx = i
+            i += 1
+            # Gather all subsequent ToolMessages
+            while i < n and isinstance(converted_messages[i], ToolMessage):
+                block_msgs.append(converted_messages[i])
+                i += 1
+            blocks.append((block_msgs, start_idx))
+        else:
+            blocks.append(([current_msg], i))
+            i += 1
+
+    if retain == "end":
+        # Suffix pruning: keep the newest blocks from the end
+        accumulated_tokens = 0
+        earliest_start_idx = len(converted_messages)
+
+        for block_msgs, start_idx in reversed(blocks):
+            block_tokens = _token_counter(block_msgs)
+            if accumulated_tokens + block_tokens <= max_tokens:
+                accumulated_tokens += block_tokens
+                earliest_start_idx = start_idx
+            else:
+                break
+
+        return earliest_start_idx
+
+    else:  # retain == "start"
+        # Prefix pruning: keep the oldest blocks from the start
+        accumulated_tokens = 0
+        end_idx = 0
+
+        for block_msgs, start_idx in blocks:
+            block_tokens = _token_counter(block_msgs)
+            if accumulated_tokens + block_tokens <= max_tokens:
+                accumulated_tokens += block_tokens
+                end_idx = start_idx + len(block_msgs)
+            else:
+                break
+
+        return end_idx
+
+
+@_runnable_support
+def partition_messages(
+    messages: Iterable[MessageLikeRepresentation] | PromptValue,
+    *,
+    max_tokens: int,
+    token_counter: Callable[[list[BaseMessage]], int]
+    | Callable[[BaseMessage], int]
+    | BaseLanguageModel[Any]
+    | Literal["approximate"] = "approximate",
+    retain: Literal["start", "end"] = "end",
+) -> tuple[list[BaseMessage], list[BaseMessage]]:
+    """Partition messages into removable and retained subsets.
+
+    A higher-level wrapper around :func:`find_safe_message_cutoff` that
+    returns the actual message lists instead of just an index. Tool-call
+    boundaries are always respected -- an ``AIMessage`` with ``tool_calls``
+    and its subsequent ``ToolMessage`` responses are treated as an atomic
+    block.
+
+    Args:
+        messages: Sequence of messages to partition.
+        max_tokens: Maximum token budget for the *retained* subset.
+        token_counter: Function for counting tokens in a list of ``BaseMessage``.
+            Accepts a ``Callable[[list[BaseMessage]], int]`` or the string
+            shortcut ``"approximate"`` which uses
+            ``count_tokens_approximately``. Defaults to ``"approximate"``.
+        retain: Which portion of the conversation to keep:
+
+            - ``"end"`` *(default)* -- keep the most recent messages.
+            - ``"start"`` -- keep the oldest messages.
+
+    Returns:
+        A ``(removable, retained)`` tuple of lists.
+
+    Raises:
+        ValueError: If *retain* is not ``"start"`` or ``"end"``.
+
+    Example:
+        Split a conversation for summarisation:
+
+        .. code-block:: python
+
+            from langchain_core.messages import (
+                HumanMessage,
+                AIMessage,
+                partition_messages,
+            )
+
+            messages = [
+                HumanMessage(content="Hello"),
+                AIMessage(content="Hi there!"),
+                HumanMessage(content="Tell me a joke"),
+                AIMessage(content="Why did the chicken cross the road?"),
+            ]
+
+            removable, retained = partition_messages(
+                messages,
+                max_tokens=20,
+                retain="end",
+            )
+            # removable contains older messages to summarise
+            # retained contains recent messages to keep verbatim
+
+    .. versionadded:: 0.4.0
+    """
+    if retain not in {"start", "end"}:
+        msg = f"Invalid retain={retain!r}. Expected 'start' or 'end'."
+        raise ValueError(msg)
+
+    converted_messages = convert_to_messages(messages)
+    cutoff_idx = find_safe_message_cutoff(
+        converted_messages,
+        max_tokens=max_tokens,
+        token_counter=token_counter,
+        retain=retain,
+    )
+    if retain == "end":
+        return converted_messages[:cutoff_idx], converted_messages[cutoff_idx:]
+    else:
+        return converted_messages[cutoff_idx:], converted_messages[:cutoff_idx]
+
+
 _SingleMessage = BaseMessage | str | dict[str, Any]
 _T = TypeVar("_T", bound=_SingleMessage)
 # A sequence of _SingleMessage that is NOT a bare str

--- a/libs/core/tests/unit_tests/messages/test_retention.py
+++ b/libs/core/tests/unit_tests/messages/test_retention.py
@@ -1,0 +1,287 @@
+"""Tests for find_safe_message_cutoff and partition_messages.
+
+These tests validate tool-boundary-safe message pruning utilities
+proposed in https://github.com/langchain-ai/langchain/issues/38249.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+    find_safe_message_cutoff,
+    partition_messages,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def char_token_counter(messages: list) -> int:
+    """Simple token counter that counts characters in message content."""
+    return sum(len(msg.content) for msg in messages)
+
+
+# ---------------------------------------------------------------------------
+# find_safe_message_cutoff
+# ---------------------------------------------------------------------------
+
+
+class TestFindSafeMessageCutoff:
+    """Tests for find_safe_message_cutoff."""
+
+    def test_empty_messages(self) -> None:
+        assert find_safe_message_cutoff([], max_tokens=10, token_counter=char_token_counter) == 0
+
+    def test_retain_end_basic(self) -> None:
+        """Keeps the last messages that fit within max_tokens."""
+        messages = [
+            HumanMessage(content="A" * 10),
+            HumanMessage(content="B" * 20),
+            HumanMessage(content="C" * 30),
+        ]
+        # limit=35 fits C (30) but not B+C (50)
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=35, token_counter=char_token_counter, retain="end"
+        )
+        assert cutoff == 2
+
+    def test_retain_start_basic(self) -> None:
+        """Keeps the first messages that fit within max_tokens."""
+        messages = [
+            HumanMessage(content="A" * 10),
+            HumanMessage(content="B" * 20),
+            HumanMessage(content="C" * 30),
+        ]
+        # limit=35 fits A (10) + B (20) = 30, but not A+B+C (60)
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=35, token_counter=char_token_counter, retain="start"
+        )
+        assert cutoff == 2
+
+    def test_tool_boundary_retain_end(self) -> None:
+        """AIMessage + ToolMessage are kept as an atomic block (retain=end)."""
+        messages = [
+            HumanMessage(content="H1"),
+            AIMessage(
+                content="AI1",
+                tool_calls=[{"name": "t1", "args": {}, "id": "call1"}],
+            ),
+            ToolMessage(content="R1", tool_call_id="call1"),
+            HumanMessage(content="H2"),
+        ]
+
+        def custom_counter(msgs: list) -> int:
+            tokens = 0
+            for m in msgs:
+                if isinstance(m, ToolMessage) or (
+                    isinstance(m, AIMessage) and m.tool_calls
+                ):
+                    tokens += 15  # AI+Tool block = 30 total
+                else:
+                    tokens += 10
+            return tokens
+
+        # limit=20: fits H2 (10) but not [AI1,R1] block (30)
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=20, token_counter=custom_counter, retain="end"
+        )
+        assert cutoff == 3
+
+        # limit=45: fits H2 (10) + [AI1,R1] (30) = 40, but not + H1 (10) = 50
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=45, token_counter=custom_counter, retain="end"
+        )
+        assert cutoff == 1
+
+    def test_tool_boundary_retain_start(self) -> None:
+        """AIMessage + ToolMessage are kept as an atomic block (retain=start)."""
+        messages = [
+            HumanMessage(content="H1"),
+            AIMessage(
+                content="AI1",
+                tool_calls=[{"name": "t1", "args": {}, "id": "call1"}],
+            ),
+            ToolMessage(content="R1", tool_call_id="call1"),
+            HumanMessage(content="H2"),
+        ]
+
+        def custom_counter(msgs: list) -> int:
+            tokens = 0
+            for m in msgs:
+                if isinstance(m, ToolMessage) or (
+                    isinstance(m, AIMessage) and m.tool_calls
+                ):
+                    tokens += 15
+                else:
+                    tokens += 10
+            return tokens
+
+        # limit=25: fits H1 (10) but not + [AI1,R1] (30)
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=25, token_counter=custom_counter, retain="start"
+        )
+        assert cutoff == 1
+
+        # limit=45: fits H1 (10) + [AI1,R1] (30) = 40, but not + H2 (10) = 50
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=45, token_counter=custom_counter, retain="start"
+        )
+        assert cutoff == 3
+
+    def test_nothing_fits(self) -> None:
+        """When no block fits, return appropriate edge values."""
+        messages = [HumanMessage(content="A" * 100)]
+
+        # retain=end, nothing fits -> cutoff = len(messages)
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=5, token_counter=char_token_counter, retain="end"
+        )
+        assert cutoff == len(messages)
+
+        # retain=start, nothing fits -> cutoff = 0
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=5, token_counter=char_token_counter, retain="start"
+        )
+        assert cutoff == 0
+
+    def test_everything_fits(self) -> None:
+        """When all messages fit, retain everything."""
+        messages = [
+            HumanMessage(content="Hi"),
+            AIMessage(content="Hello!"),
+        ]
+
+        # retain=end -> cutoff = 0 (all retained)
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=1000, token_counter=char_token_counter, retain="end"
+        )
+        assert cutoff == 0
+
+        # retain=start -> cutoff = len(messages) (all retained)
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=1000, token_counter=char_token_counter, retain="start"
+        )
+        assert cutoff == len(messages)
+
+    def test_invalid_retain_raises(self) -> None:
+        """Invalid retain value raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid retain"):
+            find_safe_message_cutoff(
+                [HumanMessage(content="Hi")],
+                max_tokens=10,
+                token_counter=char_token_counter,
+                retain="middle",  # type: ignore[arg-type]
+            )
+
+    def test_approximate_token_counter_default(self) -> None:
+        """The 'approximate' shortcut works as default token counter."""
+        messages = [
+            HumanMessage(content="Hello world!"),
+            AIMessage(content="This is a test message."),
+        ]
+        # Should not raise; uses count_tokens_approximately internally
+        cutoff = find_safe_message_cutoff(messages, max_tokens=100)
+        assert 0 <= cutoff <= len(messages)
+
+    def test_multiple_tool_calls_in_sequence(self) -> None:
+        """Multiple tool calls each form their own atomic block."""
+        messages = [
+            HumanMessage(content="Do two things"),
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "tool_a", "args": {}, "id": "a1"}],
+            ),
+            ToolMessage(content="result_a", tool_call_id="a1"),
+            AIMessage(
+                content="",
+                tool_calls=[{"name": "tool_b", "args": {}, "id": "b1"}],
+            ),
+            ToolMessage(content="result_b", tool_call_id="b1"),
+            HumanMessage(content="Thanks"),
+        ]
+
+        def fixed_counter(msgs: list) -> int:
+            return len(msgs) * 10
+
+        # limit=25: fits last 2 messages [ToolMessage, HumanMessage]?
+        # No, blocks: H(10), [AI+T](20), [AI+T](20), H(10)
+        # From end: H(10) ok, [AI+T](20) -> 30 > 25 -> stop
+        cutoff = find_safe_message_cutoff(
+            messages, max_tokens=25, token_counter=fixed_counter, retain="end"
+        )
+        assert cutoff == 5  # only last HumanMessage retained
+
+
+# ---------------------------------------------------------------------------
+# partition_messages
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionMessages:
+    """Tests for partition_messages."""
+
+    def test_empty_messages(self) -> None:
+        removable, retained = partition_messages(
+            [], max_tokens=10, token_counter=char_token_counter
+        )
+        assert removable == []
+        assert retained == []
+
+    def test_partition_retain_end(self) -> None:
+        messages = [
+            HumanMessage(content="A" * 10),
+            HumanMessage(content="B" * 20),
+            HumanMessage(content="C" * 30),
+        ]
+        removable, retained = partition_messages(
+            messages, max_tokens=35, token_counter=char_token_counter, retain="end"
+        )
+        assert removable == [messages[0], messages[1]]
+        assert retained == [messages[2]]
+
+    def test_partition_retain_start(self) -> None:
+        messages = [
+            HumanMessage(content="A" * 10),
+            HumanMessage(content="B" * 20),
+            HumanMessage(content="C" * 30),
+        ]
+        removable, retained = partition_messages(
+            messages, max_tokens=35, token_counter=char_token_counter, retain="start"
+        )
+        assert removable == [messages[2]]
+        assert retained == [messages[0], messages[1]]
+
+    def test_partition_with_tool_boundary(self) -> None:
+        """Tool boundaries respected in partition output."""
+        messages = [
+            HumanMessage(content="H1"),
+            AIMessage(
+                content="AI1",
+                tool_calls=[{"name": "t1", "args": {}, "id": "call1"}],
+            ),
+            ToolMessage(content="R1", tool_call_id="call1"),
+            HumanMessage(content="H2"),
+        ]
+
+        def custom_counter(msgs: list) -> int:
+            tokens = 0
+            for m in msgs:
+                if isinstance(m, ToolMessage) or (
+                    isinstance(m, AIMessage) and m.tool_calls
+                ):
+                    tokens += 15
+                else:
+                    tokens += 10
+            return tokens
+
+        removable, retained = partition_messages(
+            messages, max_tokens=45, token_counter=custom_counter, retain="end"
+        )
+        assert removable == [messages[0]]
+        assert retained == messages[1:]


### PR DESCRIPTION
## Description

Adds two public utility functions to `langchain_core.messages` that compute tool-boundary-safe cutoff points for conversation history pruning:

- `find_safe_message_cutoff()` — returns the optimal split index.
- `partition_messages()` — returns a `(removable, retained)` tuple of lists.

Both functions ensure that an `AIMessage` with `tool_calls` is never separated from its corresponding `ToolMessage` responses, preventing invalid message sequences in LLM APIs.

## Issue

Closes #38249

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Unit tests added
- [x] Follows existing code patterns in `messages/utils.py`
- [x] Docstrings with examples
- [x] Uses `count_tokens_approximately` as default
- [x] No breaking changes to existing API