### PR TITLE
feat(repo): resolve legacy deprecations, type mismatches, and credential security across core and partner packages

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1,4 +1,48 @@
-"""Run managers."""
+"""Callback managers for LangChain Runnable methods.
+
+Callbacks can be injected at three levels when using LCEL Runnable methods:
+
+1. **Constructor-level** – passed once when the object is created; apply to all runs:
+
+   ```python
+   from langchain_core.callbacks import BaseCallbackHandler
+
+   class MyHandler(BaseCallbackHandler):
+       def on_llm_new_token(self, token: str, **kwargs) -> None:
+           print(token, end="", flush=True)
+
+   llm = ChatOpenAI(callbacks=[MyHandler()])
+   llm.invoke("Hello")
+   ```
+
+2. **Invocation-level** – passed per call via the ``config`` argument; override or
+   extend constructor callbacks for that single call only:
+
+   ```python
+   from langchain_core.runnables import RunnableConfig
+
+   llm.invoke("Hello", config=RunnableConfig(callbacks=[MyHandler()]))
+   llm.stream("Hello", config={"callbacks": [MyHandler()]})
+   llm.batch(["Hello", "World"], config={"callbacks": [MyHandler()]})
+   ```
+
+3. **Context-level** – via ``get_callback_manager_for_config`` when building
+   custom runnables that need to propagate callbacks down to child runs:
+
+   ```python
+   from langchain_core.callbacks.manager import CallbackManager
+
+   manager = CallbackManager.configure(
+       inheritable_callbacks=[MyHandler()],
+       local_callbacks=None,
+   )
+   ```
+
+Callbacks propagate automatically through nested chains built with LCEL (``|``).
+When a parent ``CallbackManagerForChainRun`` spawns a child via
+``run_manager.get_child()``, all inherited handlers are forwarded to the child run
+so you never need to re-pass them manually.
+"""
 
 from __future__ import annotations
 

--- a/libs/langchain/langchain_classic/evaluation/agents/trajectory_eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/agents/trajectory_eval_chain.py
@@ -103,26 +103,31 @@ class TrajectoryEvalChain(AgentTrajectoryEvaluator, LLMEvalChain):
 
     Example:
     ```python
-    from langchain_classic.agents import AgentType, initialize_agent
+    from langchain_classic.agents import AgentExecutor, create_openai_tools_agent
+    from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+    from langchain_core.tools import tool
     from langchain_openai import ChatOpenAI
     from langchain_classic.evaluation import TrajectoryEvalChain
-    from langchain_classic.tools import tool
 
     @tool
     def geography_answers(country: str, question: str) -> str:
         \"\"\"Very helpful answers to geography questions.\"\"\"
         return f"{country}? IDK - We may never know {question}."
 
-    model = ChatOpenAI(model="gpt-5.5", temperature=0)
-    agent = initialize_agent(
-        tools=[geography_answers],
-        llm=model,
-        agent=AgentType.OPENAI_FUNCTIONS,
-        return_intermediate_steps=True,
+    model = ChatOpenAI(model="gpt-4o", temperature=0)
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", "You are a helpful assistant."),
+        MessagesPlaceholder("chat_history", optional=True),
+        ("human", "{input}"),
+        MessagesPlaceholder("agent_scratchpad"),
+    ])
+    agent = create_openai_tools_agent(model, tools=[geography_answers], prompt=prompt)
+    agent_executor = AgentExecutor(
+        agent=agent, tools=[geography_answers], return_intermediate_steps=True
     )
 
     question = "How many dwell in the largest minor region in Argentina?"
-    response = agent(question)
+    response = agent_executor.invoke({"input": question})
 
     eval_chain = TrajectoryEvalChain.from_llm(
         llm=model, agent_tools=[geography_answers], return_reasoning=True

--- a/libs/partners/anthropic/langchain_anthropic/_compat.py
+++ b/libs/partners/anthropic/langchain_anthropic/_compat.py
@@ -178,7 +178,12 @@ def _convert_from_v1_to_anthropic(
         elif block["type"] == "server_tool_result" and model_provider == "anthropic":
             new_block = {}
             if "output" in block:
-                new_block["content"] = block["output"]
+                output = block["output"]
+                new_block["content"] = (
+                    [{"type": "text", "text": output}]
+                    if isinstance(output, str)
+                    else output
+                )
             server_tool_result_type = block.get("extras", {}).get("block_type", "")
             if server_tool_result_type == "mcp_tool_result":
                 new_block["is_error"] = block.get("status") == "error"

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -673,22 +673,27 @@ def _format_messages(
                         "web_search_tool_result",
                         "web_fetch_tool_result",
                     ):
+                        # Normalize string content to structured text blocks to
+                        # prevent TypeErrors when downstream parsers expect dicts.
+                        block_content = block.get("content")
+                        if isinstance(block_content, str):
+                            block_content = [{"type": "text", "text": block_content}]
+                        normalized_block = {
+                            k: v
+                            for k, v in block.items()
+                            if k
+                            in (
+                                "type",
+                                "tool_use_id",
+                                "is_error",  # for mcp_tool_result
+                                "cache_control",
+                                "retrieved_at",  # for web_fetch_tool_result
+                            )
+                        }
+                        if block_content is not None:
+                            normalized_block["content"] = block_content
                         content.append(
-                            _normalize_block_tool_use_id(
-                                {
-                                    k: v
-                                    for k, v in block.items()
-                                    if k
-                                    in (
-                                        "type",
-                                        "content",
-                                        "tool_use_id",
-                                        "is_error",  # for mcp_tool_result
-                                        "cache_control",
-                                        "retrieved_at",  # for web_fetch_tool_result
-                                    )
-                                },
-                            ),
+                            _normalize_block_tool_use_id(normalized_block),
                         )
                     else:
                         content.append(block)

--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
@@ -4,8 +4,8 @@ import os
 from typing import Any
 
 from langchain_core.embeddings import Embeddings
-from langchain_core.utils import from_env
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from langchain_core.utils import secret_from_env
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
 DEFAULT_MODEL = "sentence-transformers/all-mpnet-base-v2"
@@ -53,8 +53,8 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
     model_kwargs: dict | None = None
     """Keyword arguments to pass to the model."""
 
-    huggingfacehub_api_token: str | None = Field(
-        default_factory=from_env("HUGGINGFACEHUB_API_TOKEN", default=None)
+    huggingfacehub_api_token: SecretStr | None = Field(
+        default_factory=secret_from_env("HUGGINGFACEHUB_API_TOKEN", default=None)
     )
 
     model_config = ConfigDict(
@@ -71,8 +71,10 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
                 msg = f"`{field_name}` must be a HuggingFace repo ID, not a URL."
                 raise ValueError(msg)
 
-        huggingfacehub_api_token = self.huggingfacehub_api_token or os.getenv(
-            "HF_TOKEN"
+        huggingfacehub_api_token = (
+            self.huggingfacehub_api_token.get_secret_value()
+            if self.huggingfacehub_api_token
+            else os.getenv("HF_TOKEN")
         )
 
         try:

--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_endpoint.py
@@ -13,8 +13,8 @@ from langchain_core.callbacks import (
 )
 from langchain_core.language_models.llms import LLM
 from langchain_core.outputs import GenerationChunk
-from langchain_core.utils import from_env, get_pydantic_field_names
-from pydantic import ConfigDict, Field, model_validator
+from langchain_core.utils import get_pydantic_field_names, secret_from_env
+from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import Self
 
 from langchain_huggingface._version import __version__
@@ -107,8 +107,8 @@ class HuggingFaceEndpoint(LLM):
         providers available for the model, sorted by the user's order in https://hf.co/settings/inference-providers.
         available providers can be found in the [huggingface_hub documentation](https://huggingface.co/docs/huggingface_hub/guides/inference#supported-providers-and-tasks)."""
 
-    huggingfacehub_api_token: str | None = Field(
-        default_factory=from_env("HUGGINGFACEHUB_API_TOKEN", default=None)
+    huggingfacehub_api_token: SecretStr | None = Field(
+        default_factory=secret_from_env("HUGGINGFACEHUB_API_TOKEN", default=None)
     )
 
     max_new_tokens: int = 512
@@ -260,8 +260,10 @@ class HuggingFaceEndpoint(LLM):
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
         """Validate that package is installed and that the API token is valid."""
-        huggingfacehub_api_token = self.huggingfacehub_api_token or os.getenv(
-            "HF_TOKEN"
+        huggingfacehub_api_token = (
+            self.huggingfacehub_api_token.get_secret_value()
+            if self.huggingfacehub_api_token
+            else os.getenv("HF_TOKEN")
         )
         # Local/custom endpoint URL -> don't pass HF token (avoids 401s and egress).
         if self.endpoint_url and not _is_huggingface_hosted_url(self.endpoint_url):

--- a/libs/partners/nomic/langchain_nomic/embeddings.py
+++ b/libs/partners/nomic/langchain_nomic/embeddings.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import os
-from typing import Literal, overload
+from typing import Literal, Union, overload
 
 import nomic  # type: ignore[import]
 from langchain_core.embeddings import Embeddings
 from nomic import embed
+from pydantic import SecretStr
 
 
 class NomicEmbeddings(Embeddings):
@@ -26,7 +27,7 @@ class NomicEmbeddings(Embeddings):
         self,
         *,
         model: str,
-        nomic_api_key: str | None = ...,
+        nomic_api_key: Union[str, SecretStr, None] = ...,
         dimensionality: int | None = ...,
         inference_mode: Literal["remote"] = ...,
     ) -> None: ...
@@ -36,7 +37,7 @@ class NomicEmbeddings(Embeddings):
         self,
         *,
         model: str,
-        nomic_api_key: str | None = ...,
+        nomic_api_key: Union[str, SecretStr, None] = ...,
         dimensionality: int | None = ...,
         inference_mode: Literal["local", "dynamic"],
         device: str | None = ...,
@@ -47,7 +48,7 @@ class NomicEmbeddings(Embeddings):
         self,
         *,
         model: str,
-        nomic_api_key: str | None = ...,
+        nomic_api_key: Union[str, SecretStr, None] = ...,
         dimensionality: int | None = ...,
         inference_mode: str,
         device: str | None = ...,
@@ -57,7 +58,7 @@ class NomicEmbeddings(Embeddings):
         self,
         *,
         model: str,
-        nomic_api_key: str | None = None,
+        nomic_api_key: Union[str, SecretStr, None] = None,
         dimensionality: int | None = None,
         inference_mode: str = "remote",
         device: str | None = None,
@@ -85,7 +86,10 @@ class NomicEmbeddings(Embeddings):
             vision_model: The vision model to use for image embeddings.
 
         """
-        _api_key = nomic_api_key or os.environ.get("NOMIC_API_KEY")
+        _raw_key = nomic_api_key or os.environ.get("NOMIC_API_KEY")
+        _api_key = (
+            _raw_key.get_secret_value() if isinstance(_raw_key, SecretStr) else _raw_key
+        )
         if _api_key:
             nomic.login(_api_key)
         self.model = model


### PR DESCRIPTION
Fixes #29277
Fixes #16379
Fixes #34068
Fixes #12165

## Description
This pull request introduces a comprehensive update resolving four major community tracks across the LangChain monorepo, spanning documentation standards, type-safety middlewares, and credential security protocols.

1. **Modernizing Agents Docs (Fixes #29277):** Updated legacy implementation guides (e.g., `trajectory_eval_chain.py`) to fully migrate from the deprecated monolithic `initialize_agent` method to the modern `create_openai_tools_agent` and `AgentExecutor` pattern.
2. **Standardizing Callbacks Documentation (Fixes #16379):** Added a unified, explicit guide in `libs/core/langchain_core/callbacks/manager.py` detailing exactly how constructor-level, invocation-level, and context-level callback managers propagate through LCEL Runnable methods (`.invoke()`, `.stream()`, and `.batch()`).
3. **Defensive Type Casting in Middlewares (Fixes #34068):** Normalized incoming string payloads to structured text blocks within partner integrations (such as Anthropic's tool-result formatting) to definitively eliminate runtime `TypeErrors` occurring down-stream during payload parsing.
4. **SecretStr Migration for API Keys (Fixes #12165):** Upgraded individual partner packages (including HuggingFace and Nomic) to leverage Pydantic's `SecretStr` and `secret_from_env` utilities, successfully masking highly sensitive environment variables and tokens from accidental log exposure.

## Verification
- Verified code styling by running `make format` and `make lint` within the modified sub-directories (`libs/core`, `libs/langchain`, and `libs/partners`).
- Confirmed unit tests are passing locally via `make test`.