### PR TITLE
fix: adapt test_mset_chmod for platforms with limited chmod support

### DIFF
--- a/libs/langchain/tests/unit_tests/storage/test_filesystem.py
+++ b/libs/langchain/tests/unit_tests/storage/test_filesystem.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -6,6 +7,27 @@ import pytest
 from langchain_core.stores import InvalidKeyException
 
 from langchain_classic.storage.file_system import LocalFileStore
+
+
+def _is_chmod_fully_supported() -> bool:
+    """Check if os.chmod supports full Unix-style permission bits.
+
+    On Windows, os.chmod only has full effect for the owner bits (0o700).
+    Group and other permission bits are silently ignored, so chmod(0o770)
+    actually sets permissions equivalent to 0o777 on disk.
+    """
+    import os
+    with tempfile.TemporaryDirectory() as tmp:
+        test_path = Path(tmp) / ".chmod_test"
+        test_path.touch()
+        try:
+            os.chmod(test_path, 0o770)  # group-write should be cleared
+            actual = test_path.stat().st_mode & 0o777
+            return actual != 0o777  # if Windows squashed it to 777, chmod is limited
+        except OSError:
+            return False
+        finally:
+            test_path.unlink(missing_ok=True)
 
 
 @pytest.fixture
@@ -55,8 +77,16 @@ def test_mset_chmod(chmod_dir_s: str, chmod_file_s: str) -> None:
         # (test only the standard user/group/other bits)
         dir_path = file_store.root_path
         file_path = file_store.root_path / "key1"
-        assert (dir_path.stat().st_mode & 0o777) == chmod_dir
-        assert (file_path.stat().st_mode & 0o777) == chmod_file
+
+        if _is_chmod_fully_supported():
+            assert (dir_path.stat().st_mode & 0o777) == chmod_dir
+            assert (file_path.stat().st_mode & 0o777) == chmod_file
+        else:
+            # On platforms with limited chmod (e.g. Windows), only the owner
+            # bits (read/write) are reliable. Assert that the owner bits match.
+            owner_mask = 0o700
+            assert (dir_path.stat().st_mode & owner_mask) == (chmod_dir & owner_mask)
+            assert (file_path.stat().st_mode & owner_mask) == (chmod_file & owner_mask)
 
 
 def test_mget_update_atime() -> None:


### PR DESCRIPTION
On Windows, os.chmod silently ignores group and other permission bits (e.g., chmod(0o770) results in 0o777 on disk). This caused test_mset_chmod[770-660] and test_mset_chmod[700-600] to fail with:
    AssertionError: assert (16895 & 511) == 504

This fix adds a runtime _is_chmod_fully_supported() check instead of blindly skipping the test on Windows. When full chmod is not available (e.g. Windows), only the owner permission bits (0o700) are asserted, preserving test coverage for the owner bits while accepting platform limitations for group/other bits.

Fixes #38329

Fixes #

---

<!-- Keep the `Fixes #xx` keyword at the very top and update the issue number — this auto-closes the issue on merge. Replace this comment with a 1-2 sentence description of your change. No `# Summary` header; the description is the summary. -->

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangChain! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

  - Examples:
    - fix(anthropic): resolve flag parsing error
    - feat(core): add multi-tenant support
    - test(openai): update API usage tests
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langchain/blob/master/.github/workflows/pr_lint.yml#L15-L33

2. PR description:

  - Write 1-2 sentences that make the change easy to understand: who benefits, what problem they had, and how this solves it. Prefer a simple user story over a long summary.
  - The `Fixes #xx` line at the top is **required** for external contributions — update the issue number and keep the keyword. This links your PR to the approved issue and auto-closes it on merge.
  - If there are any breaking changes, please clearly describe them.
  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

4. How did you verify your code works?

Additional guidelines:

  - All external PRs must link to an issue or discussion where a solution has been approved by a maintainer, and you must be assigned to that issue. PRs without prior approval will be closed.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/
