### PR TITLE
fix(text-splitters): preserve nested media source URLs

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -792,7 +792,7 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
 
         if self._preserve_videos:
             for video_tag in _find_all_tags(soup, name="video"):
-                video_src = video_tag.get("src", "")
+                video_src = self._get_media_src(video_tag)
                 markdown_video = f"![video:{video_src}]({video_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_video
@@ -800,11 +800,25 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
 
         if self._preserve_audio:
             for audio_tag in _find_all_tags(soup, name="audio"):
-                audio_src = audio_tag.get("src", "")
+                audio_src = self._get_media_src(audio_tag)
                 markdown_audio = f"![audio:{audio_src}]({audio_src})"
                 wrapper = soup.new_tag("media-wrapper")
                 wrapper.string = markdown_audio
                 audio_tag.replace_with(wrapper)
+
+    @staticmethod
+    def _get_media_src(media_tag: Tag) -> str:
+        """Get media source from a media tag or its first nested source tag."""
+        media_src = media_tag.get("src", "")
+        if media_src:
+            return str(media_src)
+
+        for source_tag in _find_all_tags(media_tag, name="source"):
+            source_src = source_tag.get("src", "")
+            if source_src:
+                return str(source_src)
+
+        return ""
 
     @staticmethod
     def _process_links(soup: BeautifulSoup) -> None:

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3975,6 +3975,42 @@ def test_html_splitter_with_media_preservation() -> None:
 
 
 @pytest.mark.requires("bs4")
+def test_html_splitter_preserves_nested_media_sources() -> None:
+    """Test HTML splitter preserves nested source tags for media elements."""
+    html_content = """
+    <h1>Media</h1>
+    <p>Watch:</p>
+    <video controls>
+        <source src="https://example.com/video.mp4" type="video/mp4" />
+    </video>
+    <p>Listen:</p>
+    <audio controls>
+        <source src="https://example.com/audio.mp3" type="audio/mpeg" />
+    </audio>
+    """
+    with suppress_langchain_beta_warning():
+        splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")],
+            preserve_videos=True,
+            preserve_audio=True,
+            max_chunk_size=1000,
+        )
+    documents = splitter.split_text(html_content)
+
+    expected = [
+        Document(
+            page_content="Watch: ![video:https://example.com/video.mp4]"
+            "(https://example.com/video.mp4) "
+            "Listen: ![audio:https://example.com/audio.mp3]"
+            "(https://example.com/audio.mp3)",
+            metadata={"Header 1": "Media"},
+        ),
+    ]
+
+    assert documents == expected
+
+
+@pytest.mark.requires("bs4")
 def test_html_splitter_keep_separator_true() -> None:
     """Test HTML splitting with keep_separator=True."""
     html_content = """


### PR DESCRIPTION
Fixes #37826

---

Users who preserve media with `HTMLSemanticPreservingSplitter` could lose video and audio URLs when HTML used nested `<source>` tags instead of direct media `src` attributes. This falls back to the first nested source URL for `<video>` and `<audio>` elements while preserving the existing direct-`src` behavior.

Verified with:

```powershell
uv run --no-default-groups --group test --group typing pytest tests/unit_tests/test_text_splitters.py -k "media_preservation or nested_media_sources"