### PR TITLE
fix: add missing model path to model_to_tools router in create_agent

### DIFF
--- a/create_pr.py
+++ b/create_pr.py
@@ -1,0 +1,17 @@
+import urllib.request, json, os, ssl, subprocess
+ctx = ssl.create_default_context(); ctx.check_hostname = True; ctx.verify_mode = ssl.CERT_REQUIRED
+token = os.environ.get("GITHUB_TOKEN")
+try:
+    subprocess.run(["git", "config", "user.email", "kartavyaniraj.dikshit2021@vitstudent.ac.in"], check=False)
+    subprocess.run(["git", "config", "user.name", "KartavyaDikshit"], check=False)
+    subprocess.run(["git", "add", "."], check=False)
+    subprocess.run(["git", "commit", "--signoff", "-m", "fix: add missing model path to model_to_tools router in create_agent"], check=False)
+    subprocess.run(["git", "push", f"https://{token}@github.com/KartavyaDikshit/langchain.git", "fix-model-to-tools-router", "--force"], check=False)
+except: pass
+payload = {"title": "fix: add missing model path to model_to_tools router in create_agent", "body": "The model_to_tools router in create_agent could return 'model' as a routing path, but path_map did not include a 'model' entry, causing KeyError('model'). This fix adds the missing path mapping to handle the case where the model itself (not tool-bound) should be used directly.\n\nSigned-off-by: KartavyaDikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>", "head": "KartavyaDikshit:fix-model-to-tools-router", "base": "main"}
+req = urllib.request.Request("https://api.github.com/repos/langchain-ai/langchain/pulls", data=json.dumps(payload).encode(), headers={"Authorization": f"token {token}", "Accept": "application/vnd.github.v3+json", "Content-Type": "application/json"}, method="POST")
+try:
+    with urllib.request.urlopen(req, context=ctx) as r:
+        pr_data = json.loads(r.read())
+        print("[+] PR_CREATED:", pr_data["number"])
+except Exception as e: print("[!] PR Failed:", e)

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1617,15 +1617,12 @@ def create_agent(
             tools_to_model_destinations,
         )
 
-        # base destinations are tools and exit_node
-        # we add the loop_entry node to edge destinations if:
-        # - there is an after model hook(s) -- allows jump_to to model
-        #   potentially artificially injected tool messages, ex HITL
-        # - there is a response format -- to allow for jumping to model to handle
-        #   regenerating structured output tool calls
-        model_to_tools_destinations = ["tools", exit_node]
-        if response_format or loop_exit_node != "model":
-            model_to_tools_destinations.append(loop_entry_node)
+        # base destinations are tools, exit_node, and loop_entry_node
+        # loop_entry_node must always be a destination because the
+        # model_to_tools router can return it (step 6 in the router
+        # logic) when artificial tool messages need to re-enter the
+        # model, regardless of response_format or after_model hooks.
+        model_to_tools_destinations = ["tools", exit_node, loop_entry_node]
 
         graph.add_conditional_edges(
             loop_exit_node,


### PR DESCRIPTION
The model_to_tools router in create_agent could return model as a routing path, but path_map did not include a model entry, causing KeyError. This fix adds the missing path mapping.