### PR TITLE
fix: prevent orphan ToolMessages in SummarizationMiddleware cut point

### DIFF
--- a/create_pr.py
+++ b/create_pr.py
@@ -1,0 +1,17 @@
+import urllib.request, json, os, ssl, subprocess
+ctx = ssl.create_default_context(); ctx.check_hostname = True; ctx.verify_mode = ssl.CERT_REQUIRED
+token = os.environ.get("GITHUB_TOKEN")
+try:
+    subprocess.run(["git", "config", "user.email", "kartavyaniraj.dikshit2021@vitstudent.ac.in"], check=False)
+    subprocess.run(["git", "config", "user.name", "KartavyaDikshit"], check=False)
+    subprocess.run(["git", "add", "."], check=False)
+    subprocess.run(["git", "commit", "--signoff", "-m", "fix: prevent orphan ToolMessages in SummarizationMiddleware cut point"], check=False)
+    subprocess.run(["git", "push", "fork", "fix-summarization-orphan", "--force"], check=False)
+except: pass
+payload = {"title": "fix: prevent orphan ToolMessages in SummarizationMiddleware cut point", "body": "SummarizationMiddleware._find_safe_cutoff_point could leave orphan ToolMessages in the history after cutting away the preceding AIMessage with tool_calls. This caused provider 400 errors on subsequent API calls. The fix ensures that when determining the safe cut point, ToolMessages without a corresponding AIMessage in the kept window are also removed.\n\nSigned-off-by: KartavyaDikshit <kartavyaniraj.dikshit2021@vitstudent.ac.in>", "head": "KartavyaDikshit:fix-summarization-orphan", "base": "main"}
+req = urllib.request.Request("https://api.github.com/repos/langchain-ai/langchain/pulls", data=json.dumps(payload).encode(), headers={"Authorization": f"token {token}", "Accept": "application/vnd.github.v3+json", "Content-Type": "application/json"}, method="POST")
+try:
+    with urllib.request.urlopen(req, context=ctx) as r:
+        pr_data = json.loads(r.read())
+        print("[+] PR_CREATED:", pr_data["number"])
+except Exception as e: print("[!] PR Failed:", e)

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -769,31 +769,64 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
 
         Falls back to advancing forward past `ToolMessage` objects only if no matching
         `AIMessage` is found (edge case).
+
+        Also checks for orphan `ToolMessage`s after the cutoff whose matching
+        `AIMessage` was cut, and advances the cutoff past them.
         """
-        if cutoff_index >= len(messages) or not isinstance(messages[cutoff_index], ToolMessage):
+        if cutoff_index >= len(messages):
             return cutoff_index
 
-        # Collect tool_call_ids from consecutive ToolMessages at/after cutoff
-        tool_call_ids: set[str] = set()
-        idx = cutoff_index
-        while idx < len(messages) and isinstance(messages[idx], ToolMessage):
-            tool_msg = cast("ToolMessage", messages[idx])
-            if tool_msg.tool_call_id:
-                tool_call_ids.add(tool_msg.tool_call_id)
-            idx += 1
+        if isinstance(messages[cutoff_index], ToolMessage):
+            # Collect tool_call_ids from consecutive ToolMessages at/after cutoff
+            tool_call_ids: set[str] = set()
+            idx = cutoff_index
+            while idx < len(messages) and isinstance(messages[idx], ToolMessage):
+                tool_msg = cast("ToolMessage", messages[idx])
+                if tool_msg.tool_call_id:
+                    tool_call_ids.add(tool_msg.tool_call_id)
+                idx += 1
 
-        # Search backward for AIMessage with matching tool_calls
-        for i in range(cutoff_index - 1, -1, -1):
-            msg = messages[i]
+            # Search backward for AIMessage with matching tool_calls
+            for i in range(cutoff_index - 1, -1, -1):
+                msg = messages[i]
+                if isinstance(msg, AIMessage) and msg.tool_calls:
+                    ai_tool_call_ids = {tc.get("id") for tc in msg.tool_calls if tc.get("id")}
+                    if tool_call_ids & ai_tool_call_ids:
+                        # Found the AIMessage - move cutoff to include it
+                        cutoff_index = i
+                        break
+            else:
+                # Fallback: no matching AIMessage found, advance past ToolMessages
+                # to avoid orphaned tool responses
+                cutoff_index = idx
+
+        # Ensure no orphan ToolMessages remain after the cutoff. If a ToolMessage
+        # after the cutoff references a tool_call_id from an AIMessage before the
+        # cutoff, advance past it so the pair stays together (both summarized).
+        ai_ids_before: set[str] = set()
+        for msg in messages[:cutoff_index]:
             if isinstance(msg, AIMessage) and msg.tool_calls:
-                ai_tool_call_ids = {tc.get("id") for tc in msg.tool_calls if tc.get("id")}
-                if tool_call_ids & ai_tool_call_ids:
-                    # Found the AIMessage - move cutoff to include it
-                    return i
+                for tc in msg.tool_calls:
+                    if tc.get("id"):
+                        ai_ids_before.add(tc["id"])
 
-        # Fallback: no matching AIMessage found, advance past ToolMessages to avoid
-        # orphaned tool responses
-        return idx
+        if ai_ids_before:
+            idx = cutoff_index
+            while idx < len(messages):
+                if isinstance(messages[idx], ToolMessage):
+                    tool_msg = cast("ToolMessage", messages[idx])
+                    if tool_msg.tool_call_id in ai_ids_before:
+                        # Orphan ToolMessage found - advance past it and any
+                        # remaining consecutive ToolMessages
+                        while idx < len(messages) and isinstance(messages[idx], ToolMessage):
+                            idx += 1
+                        cutoff_index = idx
+                    else:
+                        idx += 1
+                else:
+                    idx += 1
+
+        return cutoff_index
 
     def _create_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
         """Generate summary for the given messages.


### PR DESCRIPTION
SummarizationMiddleware._find_safe_cutoff_point could leave orphan ToolMessages in the history after cutting away the preceding AIMessage with tool_calls. This caused provider 400 errors on subsequent API calls. The fix ensures that when determining the safe cut point, ToolMessages without a corresponding AIMessage in the kept window are also removed.