### PR TITLE
fix: route back to model after synthetic tool messages

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1617,15 +1617,10 @@ def create_agent(
             tools_to_model_destinations,
         )
 
-        # base destinations are tools and exit_node
-        # we add the loop_entry node to edge destinations if:
-        # - there is an after model hook(s) -- allows jump_to to model
-        #   potentially artificially injected tool messages, ex HITL
-        # - there is a response format -- to allow for jumping to model to handle
-        #   regenerating structured output tool calls
-        model_to_tools_destinations = ["tools", exit_node]
-        if response_format or loop_exit_node != "model":
-            model_to_tools_destinations.append(loop_entry_node)
+        # The model-to-tools router can return loop_entry_node when middleware
+        # injects artificial ToolMessages that satisfy every tool call before the
+        # tools node runs.
+        model_to_tools_destinations = ["tools", exit_node, loop_entry_node]
 
         graph.add_conditional_edges(
             loop_exit_node,

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py
@@ -9,7 +9,8 @@ from collections.abc import Awaitable, Callable
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
 from langgraph.errors import InvalidUpdateError
 from langgraph.types import Command
 from typing_extensions import override
@@ -22,6 +23,13 @@ from langchain.agents.middleware.types import (
     ModelResponse,
     wrap_model_call,
 )
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+@tool
+def _synthetic_tool(x: int) -> int:
+    """Return an incremented integer for synthetic tool-message routing tests."""
+    return x + 1
 
 
 class TestBasicCommand:
@@ -54,6 +62,54 @@ class TestBasicCommand:
         assert messages[0].content == "Hi"
         assert messages[1].content == "Hello!"
         assert messages[2].content == "Custom message"
+
+    def test_command_with_synthetic_tool_message_routes_back_to_model(self) -> None:
+        """Command-added tool messages can satisfy tool calls before the tools node."""
+
+        class InjectToolMessageMiddleware(AgentMiddleware):
+            def wrap_model_call(
+                self,
+                request: ModelRequest,
+                handler: Callable[[ModelRequest], ModelResponse],
+            ) -> ExtendedModelResponse:
+                response = handler(request)
+                ai_message = response.result[0]
+                if isinstance(ai_message, AIMessage) and ai_message.tool_calls:
+                    synthetic_messages = [
+                        ToolMessage(
+                            content="cached",
+                            tool_call_id=tool_call["id"],
+                            name=tool_call["name"],
+                        )
+                        for tool_call in ai_message.tool_calls
+                    ]
+                    return ExtendedModelResponse(
+                        model_response=response,
+                        command=Command(update={"messages": synthetic_messages}),
+                    )
+                return ExtendedModelResponse(model_response=response)
+
+        model = FakeToolCallingModel(
+            tool_calls=[
+                [{"name": "_synthetic_tool", "args": {"x": 1}, "id": "call_1"}],
+                [],
+            ]
+        )
+        agent = create_agent(
+            model=model,
+            tools=[_synthetic_tool],
+            middleware=[InjectToolMessageMiddleware()],
+        )
+
+        result = agent.invoke({"messages": [HumanMessage(content="Hi")]})
+
+        assert [type(message) for message in result["messages"]] == [
+            HumanMessage,
+            AIMessage,
+            ToolMessage,
+            AIMessage,
+        ]
+        assert result["messages"][2].content == "cached"
 
     def test_command_with_extra_messages_and_model_response(self) -> None:
         """Middleware can add extra messages via command alongside model messages."""


### PR DESCRIPTION
Fixes #38351.

## Summary
- Allow the agent model router to route back to the model when middleware injects synthetic `ToolMessage`s that satisfy tool calls.
- Add a regression test covering an `ExtendedModelResponse(command=Command(update={"messages": ...}))` that appends a synthetic tool result.
- Preserve existing behavior for direct tool routing and exit routing.

## Evidence
- `uv run --group test pytest tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py -q` passed: `28 passed`.
- `uv run --group lint ruff check langchain/agents/factory.py tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py` passed.
- `uv run --group lint ruff format langchain/agents/factory.py tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py --diff` passed: `2 files already formatted`.
- `git diff --check` passed.