### PR TITLE
fix(core): prevent basemodel tool docstrings from inheriting parents

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -62,6 +62,7 @@ from langchain_core.utils.function_calling import (
 from langchain_core.utils.pydantic import (
     TypeBaseModel,
     _create_subset_model,
+    get_basemodel_own_docstring,
     get_fields,
     is_basemodel_subclass,
     is_pydantic_v1_subclass,
@@ -189,6 +190,9 @@ def _infer_arg_descriptions(
         description, arg_descriptions = _parse_python_function_docstring(
             fn, annotations, error_on_invalid_docstring=error_on_invalid_docstring
         )
+    elif inspect.isclass(fn) and is_basemodel_subclass(fn):
+        description = get_basemodel_own_docstring(fn) or ""
+        arg_descriptions = {}
     else:
         description = inspect.getdoc(fn) or ""
         arg_descriptions = {}

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import textwrap
 from collections.abc import Awaitable, Callable
 from inspect import signature
@@ -11,6 +12,7 @@ from typing import (
     Annotated,
     Any,
     Literal,
+    cast,
 )
 
 from pydantic import Field, SkipValidation
@@ -31,7 +33,10 @@ from langchain_core.tools.base import (
     _is_injected_arg_type,
     create_schema_from_function,
 )
-from langchain_core.utils.pydantic import is_basemodel_subclass
+from langchain_core.utils.pydantic import (
+    get_basemodel_own_docstring,
+    is_basemodel_subclass,
+)
 
 if TYPE_CHECKING:
     from langchain_core.messages import ToolCall
@@ -214,14 +219,23 @@ class StructuredTool(BaseTool):
             description_ = source_function.__doc__ or None
         if description_ is None and args_schema:
             if isinstance(args_schema, type) and is_basemodel_subclass(args_schema):
-                description_ = args_schema.__doc__
-                if (
-                    description_
-                    and "A base class for creating Pydantic models" in description_
+                if inspect.isclass(source_function) and is_basemodel_subclass(
+                    cast("type", source_function)
                 ):
-                    description_ = ""
-                elif not description_:
-                    description_ = None
+                    if "__doc__" in args_schema.__dict__:
+                        # Generated schemas may explicitly set an empty docstring.
+                        description_ = args_schema.__dict__["__doc__"] or ""
+                    else:
+                        description_ = get_basemodel_own_docstring(args_schema)
+                else:
+                    description_ = args_schema.__doc__
+                    if (
+                        description_
+                        and "A base class for creating Pydantic models" in description_
+                    ):
+                        description_ = ""
+                    elif not description_:
+                        description_ = None
             elif isinstance(args_schema, dict):
                 description_ = args_schema.get("description")
             else:

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -111,6 +111,24 @@ def is_basemodel_subclass(cls: type) -> bool:
     return issubclass(cls, (BaseModel, BaseModelV1))
 
 
+def get_basemodel_own_docstring(cls: type) -> str | None:
+    """Return the docstring defined on a `BaseModel` class, not inherited from parents.
+
+    Pydantic model subclasses do not define their own docstring in the class body
+    inherit descriptions from parent classes via attribute lookup. Tool schemas should
+    only use descriptions explicitly declared on the class itself.
+
+    Args:
+        cls: The Pydantic `BaseModel` subclass to inspect.
+
+    Returns:
+        The docstring if defined on `cls`, otherwise `None`.
+    """
+    if not is_basemodel_subclass(cls):
+        return None
+    return cls.__dict__.get("__doc__")
+
+
 def is_basemodel_instance(obj: Any) -> bool:
     """Check if the given class is an instance of Pydantic `BaseModel`.
 
@@ -226,7 +244,12 @@ def _create_subset_model_v1(
         fields[field_name] = (t, field.field_info)
 
     rtn = cast("type[BaseModelV1]", create_model_v1(name, **fields))  # type: ignore[call-overload]
-    rtn.__doc__ = textwrap.dedent(fn_description or model.__doc__ or "")
+    model_doc = (
+        get_basemodel_own_docstring(model)
+        if is_basemodel_subclass(model)
+        else model.__doc__
+    )
+    rtn.__doc__ = textwrap.dedent(fn_description or model_doc or "")
     return rtn
 
 
@@ -272,7 +295,12 @@ def _create_subset_model_v2(
     ]
 
     rtn.__annotations__ = dict(selected_annotations)
-    rtn.__doc__ = textwrap.dedent(fn_description or model.__doc__ or "")
+    model_doc = (
+        get_basemodel_own_docstring(model)
+        if is_basemodel_subclass(model)
+        else model.__doc__
+    )
+    rtn.__doc__ = textwrap.dedent(fn_description or model_doc or "")
     return rtn
 
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -770,6 +770,31 @@ def test_missing_docstring() -> None:
     assert not MyTool.description  # type: ignore[attr-defined]
 
 
+def test_tool_basemodel_does_not_inherit_parent_docstring() -> None:
+    """Child `BaseModel` tools should not inherit parent class docstrings."""
+
+    class MyTool(BaseModel):
+        """Parent Tool."""
+
+        foo: str
+
+    @tool
+    class ChildTool(MyTool):
+        bar: str
+
+    assert not ChildTool.description  # type: ignore[attr-defined]
+    child_schema = cast("type[BaseModel]", ChildTool.args_schema)  # type: ignore[attr-defined]
+    assert not child_schema.model_json_schema().get("description")
+
+    @tool
+    class ChildToolWithDoc(MyTool):
+        """Child Tool."""
+
+        bar: str
+
+    assert ChildToolWithDoc.description == "Child Tool."  # type: ignore[attr-defined]
+
+
 def test_create_tool_positional_args() -> None:
     """Test that positional arguments are allowed."""
     test_tool = Tool("test_name", lambda x: x, "test_description")


### PR DESCRIPTION
Fixes #32066

---

`@tool` on a `BaseModel` subclass without its own docstring incorrectly
inherited the parent class description via `inspect.getdoc()`. Tool
schemas now only use docstrings explicitly declared on the class itself
through a new `get_basemodel_own_docstring()` helper.

Added unit test coverage for inherited, missing, and explicit child
docstrings.

