### PR TITLE
fix(core): dedupe identical stream metadata strings

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -2,6 +2,18 @@ from __future__ import annotations
 
 from typing import Any
 
+_NON_CONCATENATED_IDENTICAL_STRING_KEYS = {
+    "finish_reason",
+    "format",
+    "id",
+    "model_name",
+    "model_provider",
+    "native_finish_reason",
+    "object",
+    "output_version",
+    "system_fingerprint",
+}
+
 
 def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]:
     r"""Merge dictionaries.
@@ -57,7 +69,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k in _NON_CONCATENATED_IDENTICAL_STRING_KEYS
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -66,6 +66,32 @@ def test_check_package_version(
         ({"a": True}, {"a": True}, {"a": True}),
         ({"a": False}, {"a": False}, {"a": False}),
         ({"a": "txt"}, {"a": "txt"}, {"a": "txttxt"}),
+        (
+            {
+                "model_name": "gpt-test",
+                "finish_reason": "stop",
+                "native_finish_reason": "stop",
+                "object": "chat.completion.chunk",
+                "system_fingerprint": "fp_123",
+                "reasoning": {"format": "text"},
+            },
+            {
+                "model_name": "gpt-test",
+                "finish_reason": "stop",
+                "native_finish_reason": "stop",
+                "object": "chat.completion.chunk",
+                "system_fingerprint": "fp_123",
+                "reasoning": {"format": "text"},
+            },
+            {
+                "model_name": "gpt-test",
+                "finish_reason": "stop",
+                "native_finish_reason": "stop",
+                "object": "chat.completion.chunk",
+                "system_fingerprint": "fp_123",
+                "reasoning": {"format": "text"},
+            },
+        ),
         ({"a": [1, 2]}, {"a": [1, 2]}, {"a": [1, 2, 1, 2]}),
         ({"a": {"b": "txt"}}, {"a": {"b": "txt"}}, {"a": {"b": "txttxt"}}),
         # Merge strings.


### PR DESCRIPTION
Fixes #38366

---

When streaming providers emit repeated terminal metadata chunks, `merge_dicts` currently concatenates identical stable string fields such as `model_name`, `finish_reason`, `object`, and `system_fingerprint`. That turns values like `stop` into `stopstop` after users add `AIMessageChunk`s together.

This keeps the existing concatenation behavior for ordinary string chunks, but extends the existing stable-field dedupe path beyond `id`, `output_version`, and `model_provider` so repeated response metadata remains unchanged when the value is identical. The regression test covers both top-level response metadata and nested `format` metadata while preserving the existing ordinary string-concatenation case.

Validated with `uv run --group test pytest tests/unit_tests/utils/test_utils.py -q`, `uv run --group lint ruff check langchain_core/utils/_merge.py tests/unit_tests/utils/test_utils.py`, and `uv run --group lint ruff format --check langchain_core/utils/_merge.py tests/unit_tests/utils/test_utils.py` from `libs/core`.

This contribution was prepared with AI-agent assistance and manually reviewed before submission.