### PR TITLE
fix(mistralai): surface cached prompt tokens in `usage_metadata`

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -306,6 +306,11 @@ def _convert_chunk_to_message_chunk(
                 "output_tokens": token_usage.get("completion_tokens", 0),
                 "total_tokens": token_usage.get("total_tokens", 0),
             }
+            cached_tokens = (token_usage.get("prompt_tokens_details") or {}).get(
+                "cached_tokens"
+            )
+            if cached_tokens is not None:
+                usage_metadata["input_token_details"] = {"cache_read": cached_tokens}
         else:
             usage_metadata = None
         if _choice.get("finish_reason") is not None and isinstance(
@@ -747,6 +752,13 @@ class ChatMistralAI(BaseChatModel):
                     "output_tokens": token_usage.get("completion_tokens", 0),
                     "total_tokens": token_usage.get("total_tokens", 0),
                 }
+                cached_tokens = (token_usage.get("prompt_tokens_details") or {}).get(
+                    "cached_tokens"
+                )
+                if cached_tokens is not None:
+                    message.usage_metadata["input_token_details"] = {
+                        "cache_read": cached_tokens
+                    }
             gen = ChatGeneration(
                 message=message,
                 generation_info={"finish_reason": finish_reason},

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -10,6 +10,7 @@ import pytest
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.messages import (
     AIMessage,
+    AIMessageChunk,
     BaseMessage,
     ChatMessage,
     HumanMessage,
@@ -22,6 +23,7 @@ from pydantic import SecretStr
 
 from langchain_mistralai.chat_models import (  # type: ignore[import]
     ChatMistralAI,
+    _convert_chunk_to_message_chunk,
     _convert_message_to_mistral_chat_message,
     _convert_mistral_chat_message_to_message,
     _convert_tool_call_id_to_mistral_compatible,
@@ -662,3 +664,74 @@ def test_metadata_versions() -> None:
     versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-mistralai" in versions
+
+
+_USAGE_WITH_CACHE = {
+    "prompt_tokens": 1013,
+    "completion_tokens": 30,
+    "total_tokens": 1043,
+    "prompt_tokens_details": {"cached_tokens": 1008},
+}
+
+
+def test_create_chat_result_surfaces_cached_tokens() -> None:
+    """Non-streaming `usage_metadata` should report Mistral's cached prompt tokens."""
+    llm = ChatMistralAI(model="mistral-small-latest")  # type: ignore[call-arg]
+    response = {
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": _USAGE_WITH_CACHE,
+        "model": "mistral-small-latest",
+    }
+    result = llm._create_chat_result(response)
+    usage_metadata = cast("AIMessage", result.generations[0].message).usage_metadata
+    assert usage_metadata is not None
+    assert usage_metadata["input_tokens"] == 1013
+    assert usage_metadata["input_token_details"]["cache_read"] == 1008
+
+
+def test_convert_chunk_surfaces_cached_tokens() -> None:
+    """Streaming `usage_metadata` should report Mistral's cached prompt tokens."""
+    chunk = {
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": _USAGE_WITH_CACHE,
+        "model": "mistral-small-latest",
+    }
+    message, _, _ = _convert_chunk_to_message_chunk(
+        chunk, AIMessageChunk, 0, "text", None
+    )
+    usage_metadata = cast("AIMessageChunk", message).usage_metadata
+    assert usage_metadata is not None
+    assert usage_metadata["input_tokens"] == 1013
+    assert usage_metadata["input_token_details"]["cache_read"] == 1008
+
+
+def test_usage_metadata_without_cached_tokens_unchanged() -> None:
+    """When no cached-token detail is present, `usage_metadata` stays unchanged."""
+    llm = ChatMistralAI(model="mistral-small-latest")  # type: ignore[call-arg]
+    response = {
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        "model": "mistral-small-latest",
+    }
+    result = llm._create_chat_result(response)
+    usage_metadata = cast("AIMessage", result.generations[0].message).usage_metadata
+    assert usage_metadata is not None
+    assert "input_token_details" not in usage_metadata


### PR DESCRIPTION
Fixes #38384

---

`ChatMistralAI` dropped Mistral's `prompt_tokens_details.cached_tokens` when building `usage_metadata`, so cost trackers like LangSmith priced cached tokens at the full input rate instead of Mistral's 10% cached rate — overcharging users who rely on prompt caching. This maps cached tokens into the standard `usage_metadata.input_token_details.cache_read` on both the streaming and non-streaming paths, mirroring the existing `langchain-openai` behavior. The change is purely additive: `input_token_details` is only added when Mistral returns cached tokens, so non-cached responses are unchanged.

How I verified: a unit test drives a Mistral-shaped `usage` payload (with `cached_tokens`) through the real `_create_chat_result` and `_convert_chunk_to_message_chunk` conversions (no network). It fails before the change (`KeyError: 'input_token_details'`) and passes after; a guard test confirms responses without cached tokens are unchanged. `make format`, `make lint`, `make test`, and `mypy` all pass.

This change was made with AI assistance and was human-reviewed and tested.
