### PR TITLE
fix(core): lazily import GPT2TokenizerFast for tokenizer fallback

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -6,6 +6,7 @@ import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from functools import cache
+from importlib import import_module
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -38,12 +39,20 @@ from langchain_core.runnables import Runnable, RunnableSerializable
 if TYPE_CHECKING:
     from langchain_core.outputs import LLMResult
 
-try:
-    from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
+_HAS_TRANSFORMERS: bool | None = None
 
+
+@cache
+def _get_gpt2_tokenizer_fast() -> Any | None:
+    """Lazily import `GPT2TokenizerFast` to avoid heavy import-time overhead."""
+    global _HAS_TRANSFORMERS  # noqa: PLW0603
+    try:
+        transformers_module = import_module("transformers")
+    except ImportError:
+        _HAS_TRANSFORMERS = False
+        return None
     _HAS_TRANSFORMERS = True
-except ImportError:
-    _HAS_TRANSFORMERS = False
+    return transformers_module.GPT2TokenizerFast
 
 
 class LangSmithParams(TypedDict, total=False):
@@ -86,7 +95,8 @@ def get_tokenizer() -> Any:
         The GPT-2 tokenizer instance.
 
     """
-    if not _HAS_TRANSFORMERS:
+    tokenizer_cls = _get_gpt2_tokenizer_fast()
+    if tokenizer_cls is None:
         msg = (
             "Could not import transformers python package. "
             "This is needed in order to calculate get_token_ids. "
@@ -94,7 +104,7 @@ def get_tokenizer() -> Any:
         )
         raise ImportError(msg)
     # create a GPT-2 tokenizer instance
-    return GPT2TokenizerFast.from_pretrained("gpt2")
+    return tokenizer_cls.from_pretrained("gpt2")
 
 
 _GPT2_TOKENIZER_WARNED = False

--- a/libs/core/tests/unit_tests/language_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/test_base.py
@@ -1,0 +1,78 @@
+import builtins
+import importlib
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+import langchain_core.language_models.base as language_models_base
+
+
+def _block_transformers_import(
+    real_import: Callable[..., Any],
+    *,
+    error_factory: Callable[[], Exception],
+) -> Callable[..., Any]:
+    def _import(
+        name: str,
+        globals_: dict[str, Any] | None = None,
+        locals_: dict[str, Any] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> Any:
+        if name == "transformers":
+            raise error_factory()
+        return real_import(name, globals_, locals_, fromlist, level)
+
+    return _import
+
+
+def test_base_module_does_not_eagerly_import_transformers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            builtins,
+            "__import__",
+            _block_transformers_import(
+                real_import,
+                error_factory=lambda: AssertionError(
+                    "base module should not eagerly import transformers"
+                ),
+            ),
+        )
+        reloaded_base = importlib.reload(language_models_base)
+        assert reloaded_base._HAS_TRANSFORMERS is None
+
+    importlib.reload(language_models_base)
+
+
+def test_get_tokenizer_raises_helpful_error_without_transformers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            builtins,
+            "__import__",
+            _block_transformers_import(
+                real_import,
+                error_factory=lambda: ImportError(
+                    "No module named 'transformers'"
+                ),
+            ),
+        )
+        reloaded_base = importlib.reload(language_models_base)
+        reloaded_base.get_tokenizer.cache_clear()
+        reloaded_base._get_gpt2_tokenizer_fast.cache_clear()
+
+        with pytest.raises(
+            ImportError,
+            match="Could not import transformers python package",
+        ):
+            reloaded_base.get_tokenizer()
+
+    importlib.reload(language_models_base)


### PR DESCRIPTION
Closes #38035

---

This change removes the eager `transformers` import from `langchain_core.language_models.base` so importing core language model modules no longer triggers heavy optional dependency startup work.

The fallback tokenizer path still raises the same ImportError when `transformers` is unavailable, preserving existing behavior for callers of `get_tokenizer()`.

Added focused unit coverage for:
- importing the base module without eager `transformers` import side effects
- `get_tokenizer()` raising the same helpful error when `transformers` is missing

Verification:
- `uv run --directory libs/core --group test pytest tests/unit_tests/language_models/test_base.py tests/unit_tests/language_models/test_imports.py`
- `uv run --directory libs/core --group lint ruff check langchain_core/language_models/base.py tests/unit_tests/language_models/test_base.py`
- `uv run --directory libs/core --group typing mypy langchain_core/language_models/base.py tests/unit_tests/language_models/test_base.py`

AI-agent disclaimer: This PR was prepared with AI coding assistance, with manual review and verification before submission.