### PR TITLE
fix(mistralai): map cached prompt tokens into usage metadata

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -46,6 +46,7 @@ from langchain_core.messages import (
     ToolMessage,
     is_data_content_block,
 )
+from langchain_core.messages.ai import InputTokenDetails, UsageMetadata
 from langchain_core.messages.block_translators.openai import (
     convert_to_openai_data_block,
 )
@@ -180,6 +181,24 @@ def _convert_mistral_chat_message_to_message(
     )
 
 
+def _create_usage_metadata(token_usage: dict[str, Any]) -> UsageMetadata:
+    usage_metadata: UsageMetadata = {
+        "input_tokens": token_usage.get("prompt_tokens", 0),
+        "output_tokens": token_usage.get("completion_tokens", 0),
+        "total_tokens": token_usage.get("total_tokens", 0),
+    }
+    input_details_dict = (
+        token_usage.get("prompt_tokens_details")
+        or token_usage.get("input_tokens_details")
+        or {}
+    )
+    if (cached_tokens := input_details_dict.get("cached_tokens")) is not None:
+        usage_metadata["input_token_details"] = InputTokenDetails(
+            cache_read=int(cached_tokens)
+        )
+    return usage_metadata
+
+
 def _raise_on_error(response: httpx.Response) -> None:
     """Raise an error if the response is an error."""
     if httpx.codes.is_error(response.status_code):
@@ -301,11 +320,7 @@ def _convert_chunk_to_message_chunk(
         else:
             tool_call_chunks = []
         if token_usage := chunk.get("usage"):
-            usage_metadata = {
-                "input_tokens": token_usage.get("prompt_tokens", 0),
-                "output_tokens": token_usage.get("completion_tokens", 0),
-                "total_tokens": token_usage.get("total_tokens", 0),
-            }
+            usage_metadata = _create_usage_metadata(token_usage)
         else:
             usage_metadata = None
         if _choice.get("finish_reason") is not None and isinstance(
@@ -742,11 +757,7 @@ class ChatMistralAI(BaseChatModel):
             finish_reason = res.get("finish_reason")
             message = _convert_mistral_chat_message_to_message(res["message"])
             if token_usage and isinstance(message, AIMessage):
-                message.usage_metadata = {
-                    "input_tokens": token_usage.get("prompt_tokens", 0),
-                    "output_tokens": token_usage.get("completion_tokens", 0),
-                    "total_tokens": token_usage.get("total_tokens", 0),
-                }
+                message.usage_metadata = _create_usage_metadata(token_usage)
             gen = ChatGeneration(
                 message=message,
                 generation_info={"finish_reason": finish_reason},

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -10,6 +10,7 @@ import pytest
 from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.messages import (
     AIMessage,
+    AIMessageChunk,
     BaseMessage,
     ChatMessage,
     HumanMessage,
@@ -22,6 +23,7 @@ from pydantic import SecretStr
 
 from langchain_mistralai.chat_models import (  # type: ignore[import]
     ChatMistralAI,
+    _convert_chunk_to_message_chunk,
     _convert_message_to_mistral_chat_message,
     _convert_mistral_chat_message_to_message,
     _convert_tool_call_id_to_mistral_compatible,
@@ -363,6 +365,60 @@ async def test_astream_with_callback() -> None:
     chat = ChatMistralAI(callbacks=[callback])
     async for token in chat.astream("Hello"):
         assert callback.last_token == token.content
+
+
+def test_create_chat_result_maps_cached_tokens_to_cache_read() -> None:
+    chat = ChatMistralAI(model="mistral-small")  # type: ignore[call-arg]
+    response = {
+        "choices": [
+            {
+                "message": {"role": "assistant", "content": "Hello!"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+            "prompt_tokens_details": {"cached_tokens": 3},
+        },
+    }
+
+    result = chat._create_chat_result(response)
+    message = cast("AIMessage", result.generations[0].message)
+    assert message.usage_metadata is not None
+    assert message.usage_metadata["input_tokens"] == 10
+    assert message.usage_metadata["output_tokens"] == 5
+    assert message.usage_metadata["total_tokens"] == 15
+    assert message.usage_metadata["input_token_details"]["cache_read"] == 3
+
+
+def test_convert_chunk_maps_cached_tokens_to_cache_read() -> None:
+    chunk = {
+        "model": "mistral-small",
+        "choices": [
+            {
+                "delta": {"role": "assistant", "content": "Hello"},
+                "finish_reason": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 7,
+            "completion_tokens": 4,
+            "total_tokens": 11,
+            "prompt_tokens_details": {"cached_tokens": 2},
+        },
+    }
+
+    message_chunk, _, _ = _convert_chunk_to_message_chunk(
+        chunk, AIMessageChunk, -1, "", None
+    )
+    usage_metadata = cast("AIMessageChunk", message_chunk).usage_metadata
+    assert usage_metadata is not None
+    assert usage_metadata["input_tokens"] == 7
+    assert usage_metadata["output_tokens"] == 4
+    assert usage_metadata["total_tokens"] == 11
+    assert usage_metadata["input_token_details"]["cache_read"] == 2
 
 
 def test__convert_dict_to_message_tool_call() -> None:


### PR DESCRIPTION
Closes #38384

---

This updates `ChatMistralAI` token usage mapping so cached prompt token counts from Mistral are exposed through `usage_metadata.input_token_details.cache_read` in both non-streaming and streaming paths.

Without this mapping, cached prompt usage is dropped, which can cause downstream cost tracking systems to bill cached input as regular input.

What changed:
- Added a small shared usage-metadata helper in the Mistral chat model implementation
- Reused it in `_create_chat_result` and `_convert_chunk_to_message_chunk`
- Added focused unit tests for both paths

Verification:
- `uv run --directory libs/partners/mistralai --group lint ruff check langchain_mistralai/chat_models.py tests/unit_tests/test_chat_models.py`
- `uv run --directory libs/partners/mistralai --group test pytest tests/unit_tests/test_chat_models.py`
- `uv run --directory libs/partners/mistralai --group typing mypy langchain_mistralai/chat_models.py`

AI-agent disclaimer: This PR was prepared with AI coding assistance, with manual review and local verification before submission.