### PR TITLE
fix(core): dedupe repeated stream metadata strings

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -2,6 +2,18 @@ from __future__ import annotations
 
 from typing import Any
 
+_DEDUPLICATE_IF_SAME_STRING_KEYS = {
+    "finish_reason",
+    "format",
+    "id",
+    "model_name",
+    "model_provider",
+    "native_finish_reason",
+    "object",
+    "output_version",
+    "system_fingerprint",
+}
+
 
 def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]:
     r"""Merge dictionaries.
@@ -57,7 +69,7 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k in _DEDUPLICATE_IF_SAME_STRING_KEYS
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -81,6 +81,39 @@ def test_check_package_version(
         ({"a": [1, 2]}, {"a": [3]}, {"a": [1, 2, 3]}),
         ({"a": 1, "b": 2}, {"a": 1}, {"a": 1, "b": 2}),
         ({"a": 1, "b": 2}, {"c": None}, {"a": 1, "b": 2, "c": None}),
+        # Stable stream metadata may be repeated verbatim across terminal chunks.
+        (
+            {"model_name": "deepseek/deepseek-v4-pro-20260423"},
+            {"model_name": "deepseek/deepseek-v4-pro-20260423"},
+            {"model_name": "deepseek/deepseek-v4-pro-20260423"},
+        ),
+        (
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+        ),
+        (
+            {"object": "chat.completion.chunk"},
+            {"object": "chat.completion.chunk"},
+            {"object": "chat.completion.chunk"},
+        ),
+        (
+            {"system_fingerprint": "fp_123"},
+            {"system_fingerprint": "fp_123"},
+            {"system_fingerprint": "fp_123"},
+        ),
+        (
+            {"format": "input_json_delta"},
+            {"format": "input_json_delta"},
+            {"format": "input_json_delta"},
+        ),
+        # Different values and non-metadata strings still concatenate.
+        (
+            {"model_name": "first"},
+            {"model_name": "second"},
+            {"model_name": "firstsecond"},
+        ),
+        ({"content": "hel"}, {"content": "lo"}, {"content": "hello"}),
         #
         # Invalid inputs.
         #


### PR DESCRIPTION
Fixes #38366.

When providers emit repeated terminal streaming chunks, stable response metadata such as `model_name`, `finish_reason`, `object`, and `system_fingerprint` can appear with the same string value in multiple chunks. `AIMessageChunk.__add__` merges these through `merge_dicts`; before this change, repeated equal strings outside the small existing allowlist were concatenated, producing values like `stopstop` or duplicated model names.

This extends the existing equal-string dedupe behavior for stable metadata keys while preserving normal string concatenation for content/delta fields and for differing metadata values.

Tests run:
- `UV_CACHE_DIR=/private/tmp/uv-cache-langchain uv run --project . --group test pytest -q tests/unit_tests/utils/test_utils.py -k merge_dicts`
- `UV_CACHE_DIR=/private/tmp/uv-cache-langchain uv run --project . --group lint ruff check langchain_core/utils/_merge.py tests/unit_tests/utils/test_utils.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache-langchain uv run --project . --group lint ruff format --check langchain_core/utils/_merge.py tests/unit_tests/utils/test_utils.py`
- Manual `AIMessageChunk` aggregation repro for repeated terminal metadata.