### PR TITLE
fix(core): don't clobber tool arguments named "config" (#34029)

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1062,7 +1062,11 @@ class ChildTool(BaseTool):
                 if signature(self._run).parameters.get("run_manager"):
                     tool_kwargs |= {"run_manager": run_manager}
                 if config_param := _get_runnable_config_param(self._run):
-                    tool_kwargs |= {config_param: config}
+                    # Only inject the RunnableConfig if the parameter is not already
+                    # populated by a user-supplied tool argument of the same name. This
+                    # avoids clobbering a real tool field named e.g. "config" (#34029).
+                    if config_param not in tool_kwargs:
+                        tool_kwargs |= {config_param: config}
                 response = context.run(self._run, *tool_args, **tool_kwargs)
             if self.response_format == "content_and_artifact":
                 msg = (
@@ -1190,7 +1194,10 @@ class ChildTool(BaseTool):
                 if signature(func_to_check).parameters.get("run_manager"):
                     tool_kwargs["run_manager"] = run_manager
                 if config_param := _get_runnable_config_param(func_to_check):
-                    tool_kwargs[config_param] = config
+                    # See sync path above: don't overwrite a user-supplied arg
+                    # that happens to be named like the config param (#34029).
+                    if config_param not in tool_kwargs:
+                        tool_kwargs[config_param] = config
 
                 coro = self._arun(*tool_args, **tool_kwargs)
                 response = await coro_with_context(coro, context)

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1061,12 +1061,13 @@ class ChildTool(BaseTool):
                 )
                 if signature(self._run).parameters.get("run_manager"):
                     tool_kwargs |= {"run_manager": run_manager}
-                if config_param := _get_runnable_config_param(self._run):
-                    # Only inject the RunnableConfig if the parameter is not already
-                    # populated by a user-supplied tool argument of the same name. This
-                    # avoids clobbering a real tool field named e.g. "config" (#34029).
-                    if config_param not in tool_kwargs:
-                        tool_kwargs |= {config_param: config}
+                # Only inject the RunnableConfig if the parameter is not already
+                # populated by a user-supplied tool argument of the same name, to
+                # avoid clobbering a real tool field named e.g. "config" (#34029).
+                if (
+                    config_param := _get_runnable_config_param(self._run)
+                ) and config_param not in tool_kwargs:
+                    tool_kwargs |= {config_param: config}
                 response = context.run(self._run, *tool_args, **tool_kwargs)
             if self.response_format == "content_and_artifact":
                 msg = (
@@ -1193,11 +1194,12 @@ class ChildTool(BaseTool):
                 )
                 if signature(func_to_check).parameters.get("run_manager"):
                     tool_kwargs["run_manager"] = run_manager
-                if config_param := _get_runnable_config_param(func_to_check):
-                    # See sync path above: don't overwrite a user-supplied arg
-                    # that happens to be named like the config param (#34029).
-                    if config_param not in tool_kwargs:
-                        tool_kwargs[config_param] = config
+                # See sync path above: don't overwrite a user-supplied arg
+                # that happens to be named like the config param (#34029).
+                if (
+                    config_param := _get_runnable_config_param(func_to_check)
+                ) and config_param not in tool_kwargs:
+                    tool_kwargs[config_param] = config
 
                 coro = self._arun(*tool_args, **tool_kwargs)
                 response = await coro_with_context(coro, context)

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -94,6 +94,12 @@ class StructuredTool(BaseTool):
                 kwargs["callbacks"] = run_manager.get_child()
             if config_param := _get_runnable_config_param(self.func):
                 kwargs[config_param] = config
+            elif "config" in signature(self.func).parameters and "config" not in kwargs:
+                # The function declares a parameter literally named "config"
+                # (a normal tool arg, not a RunnableConfig). _run captured the
+                # model-supplied value in its own keyword-only `config`; forward
+                # it so the function actually receives it (#34029).
+                kwargs["config"] = config
             return self.func(*args, **kwargs)
         msg = "StructuredTool does not support sync invocation."
         raise NotImplementedError(msg)
@@ -121,6 +127,13 @@ class StructuredTool(BaseTool):
                 kwargs["callbacks"] = run_manager.get_child()
             if config_param := _get_runnable_config_param(self.coroutine):
                 kwargs[config_param] = config
+            elif (
+                "config" in signature(self.coroutine).parameters
+                and "config" not in kwargs
+            ):
+                # See _run: forward a model-supplied arg literally named
+                # "config" to the coroutine instead of swallowing it (#34029).
+                kwargs["config"] = config
             return await self.coroutine(*args, **kwargs)
 
         # If self.coroutine is None, then this will delegate to the default

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -4033,3 +4033,65 @@ def test_tool_call_schema_json_schema_cache_invalidated_on_reassignment() -> Non
     new_schema = new_cls.model_json_schema()
     assert new_schema is not old_schema
     assert new_schema["description"] == "New description for cache test."
+
+
+def test_tool_arg_named_config_not_clobbered() -> None:
+    """A tool field literally named ``config`` must reach the function (#34029).
+
+    The reserved ``RunnableConfig`` injection must not overwrite a user-supplied
+    tool argument that happens to be named ``config``.
+    """
+    received: dict[str, Any] = {}
+
+    @tool
+    def add_config(config: str) -> str:
+        """Add a configuration file name.
+
+        Args:
+            config: The file name.
+        """
+        received["config"] = config
+        return f"added {config}"
+
+    result = add_config.invoke({"config": "config.0"})
+
+    assert result == "added config.0"
+    assert received["config"] == "config.0"
+
+
+def test_tool_runnable_config_still_injected() -> None:
+    """Regression guard: genuine RunnableConfig params are still injected (#34029)."""
+    seen: dict[str, Any] = {}
+
+    @tool
+    def needs_config(x: int, my_config: RunnableConfig) -> int:
+        """Double x.
+
+        Args:
+            x: a number.
+        """
+        seen["config"] = my_config
+        return x * 2
+
+    assert needs_config.invoke({"x": 3}) == 6
+    assert isinstance(seen["config"], dict)
+
+
+async def test_tool_arg_named_config_not_clobbered_async() -> None:
+    """Async path mirror of #34029: a ``config`` arg must reach the function."""
+    received: dict[str, Any] = {}
+
+    @tool
+    def add_config(config: str) -> str:
+        """Add a configuration file name.
+
+        Args:
+            config: The file name.
+        """
+        received["config"] = config
+        return f"added {config}"
+
+    result = await add_config.ainvoke({"config": "config.0"})
+
+    assert result == "added config.0"
+    assert received["config"] == "config.0"

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -4069,6 +4069,7 @@ def test_tool_runnable_config_still_injected() -> None:
 
         Args:
             x: a number.
+            my_config: injected runnable config.
         """
         seen["config"] = my_config
         return x * 2


### PR DESCRIPTION
Fixes #34029

### Problem

A tool whose function declares a parameter literally named `config` (a very common name) always fails:

```python
@tool
def add_config(config: str) -> str:
    """Add a configuration file name.

    Args:
        config: The file name.
    """
    return f"added {config}"

add_config.invoke({"config": "config.0"})
# TypeError: add_config() missing 1 required positional argument: 'config'
```

The model passes the value correctly; it just never reaches the function.

### Cause

`StructuredTool._run` / `_arun` reserve a keyword-only `config: RunnableConfig` parameter. Two things combine:

1. `BaseTool.run` injects the internal `RunnableConfig` by inspecting `_get_runnable_config_param(self._run)`. For a `@tool`, `self._run` is `StructuredTool._run`, whose signature always declares `config: RunnableConfig`, so the lookup returns `"config"` and overwrites the user's validated `config` argument.
2. Even with (1) fixed, the user's value (now bound to `_run`'s reserved keyword-only `config`) is never forwarded to `self.func`, because the forwarding only happens for params typed `RunnableConfig`.

### Fix

- `tools/base.py`: don't overwrite a user-supplied tool argument with the injected `RunnableConfig` when the names collide.
- `tools/structured.py`: forward the captured value to the underlying function/coroutine when it declares a (non-`RunnableConfig`) parameter named `config`.

Genuine `RunnableConfig` params are never present in model-supplied input, so their injection is unchanged.

### Tests

Added to `libs/core/tests/unit_tests/test_tools.py`: the collision case (sync + async) and a regression guard that real `RunnableConfig` params are still injected. Full `libs/core` unit suite passes (`make test`), ruff lint/format clean, mypy clean on the changed files.

### A note on direction

There are two reasonable ways to resolve this collision: make a `config`-named arg *work* (this PR), or *reject* `config` as a reserved arg name with a clear error (the approach in the earlier #34112). I went with making it work since `config` is such a common variable name, but I'm happy to switch to the fail-fast approach if you'd prefer to keep `config` reserved — let me know.
