### PR TITLE
fix(classic): skip test_mset_chmod on Windows

### DIFF
--- a/libs/langchain/tests/unit_tests/storage/test_filesystem.py
+++ b/libs/langchain/tests/unit_tests/storage/test_filesystem.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -29,6 +30,7 @@ def test_mset_and_mget(file_store: LocalFileStore) -> None:
     assert values == [b"value1", b"value2"]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="Windows does not enforce Unix-style group/other permission bits")
 @pytest.mark.parametrize(
     ("chmod_dir_s", "chmod_file_s"),
     [("777", "666"), ("770", "660"), ("700", "600")],


### PR DESCRIPTION
## Summary

`test_mset_chmod` fails on Windows 11 because Windows does not enforce Unix-style group/other permission bits (`chmod 770`, `chmod 660`, etc.). The test asserts exact octal permission values that Windows silently ignores.

### Failing cases

```
FAILED tests/unit_tests/storage/test_filesystem.py::test_mset_chmod[770-660]
FAILED tests/unit_tests/storage/test_filesystem.py::test_mset_chmod[700-600]
```

### Fix

Add `@pytest.mark.skipif(sys.platform == "win32", ...)` so the test is skipped rather than failing on Windows CI runners. The underlying `LocalFileStore.mset` code is correct; only the test assertion is non-portable.

Fixes #38329