### PR TITLE
Fix merge_dicts metadata deduplication in streaming chunks

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,9 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # String deduplication for specific keys
+        ({"model_name": "deepseek"}, {"model_name": "deepseek"}, {"model_name": "deepseek"}),
+        ({"finish_reason": "stop"}, {"finish_reason": "stop"}, {"finish_reason": "stop"}),
     ],
 )
 def test_merge_dicts(


### PR DESCRIPTION
### Description
This PR addresses a bug where `merge_dicts` concatenated identical string values in `response_metadata` across streaming chunks (e.g., `model_name` and `finish_reason` becoming doubled) instead of deduplicating them.

### Changes
- Extended the allowlist guard in `libs/core/langchain_core/utils/_merge.py` to skip concatenating string fields that should remain singular. Added `model_name`, `finish_reason`, `native_finish_reason`, `object`, `system_fingerprint`, and `format` to the skipped set.
- Added test cases in `libs/core/tests/unit_tests/utils/test_utils.py` verifying that strings like `model_name` and `finish_reason` are properly deduplicated across chunks without concatenation.

### Issues
Fixes #38366