### PR TITLE
fix(anthropic): preserve tool_use cache_control during message formatting

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -543,11 +543,15 @@ def _format_messages(
                                 for tc in message.tool_calls
                                 if tc["id"] == block["id"]
                             ]
-                            content.extend(
+                            tool_use_blocks = (
                                 _lc_tool_calls_to_anthropic_tool_use_blocks(
                                     overlapping,
-                                ),
+                                )
                             )
+                            if cache_control := block.get("cache_control"):
+                                for tool_use_block in tool_use_blocks:
+                                    tool_use_block["cache_control"] = cache_control
+                            content.extend(tool_use_blocks)
                         else:
                             if tool_input := block.get("input"):
                                 args = tool_input
@@ -566,6 +570,8 @@ def _format_messages(
                             )
                             if caller := block.get("caller"):
                                 tool_use_block["caller"] = caller
+                            if cache_control := block.get("cache_control"):
+                                tool_use_block["cache_control"] = cache_control
                             content.append(tool_use_block)
                     elif block["type"] in ("server_tool_use", "mcp_tool_use"):
                         formatted_block = {
@@ -2279,6 +2285,7 @@ class _AnthropicToolUse(TypedDict):
     input: dict
     id: str
     caller: NotRequired[dict[str, Any]]
+    cache_control: NotRequired[dict[str, str]]
 
 
 def _lc_tool_calls_to_anthropic_tool_use_blocks(

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -975,6 +975,34 @@ def test__format_tool_use_block() -> None:
     assert result == (None, [expected])
 
 
+def test__format_tool_use_block_preserves_cache_control() -> None:
+    message = AIMessage(
+        [
+            {
+                "type": "tool_use",
+                "name": "foo_1",
+                "id": "1",
+                "input": {"bar_1": "baz_1"},
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+    )
+    result = _format_messages([message])
+    expected = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "name": "foo_1",
+                "id": "1",
+                "input": {"bar_1": "baz_1"},
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+    }
+    assert result == (None, [expected])
+
+
 def test__format_messages_with_str_content_and_tool_calls() -> None:
     system = SystemMessage("fuzz")  # type: ignore[misc]
     human = HumanMessage("foo")  # type: ignore[misc]
@@ -1114,6 +1142,40 @@ def test__format_messages_with_tool_use_blocks_and_tool_calls() -> None:
     )
     actual = _format_messages(messages)
     assert expected == actual
+
+
+def test__format_messages_with_tool_use_blocks_and_tool_calls_preserves_cache_control(
+) -> None:
+    ai = AIMessage(  # type: ignore[misc]
+        [
+            {"type": "text", "text": "thought"},
+            {
+                "type": "tool_use",
+                "name": "bar",
+                "id": "1",
+                "input": {"baz": "NOT_BUZZ"},
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+        tool_calls=[{"name": "bar", "id": "1", "args": {"baz": "BUZZ"}}],
+    )
+    _, formatted = _format_messages([HumanMessage("foo"), ai])
+    assert formatted == [
+        {"role": "user", "content": "foo"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "thought"},
+                {
+                    "type": "tool_use",
+                    "name": "bar",
+                    "id": "1",
+                    "input": {"baz": "BUZZ"},
+                    "cache_control": {"type": "ephemeral"},
+                },
+            ],
+        },
+    ]
 
 
 def test__format_messages_with_cache_control() -> None:


### PR DESCRIPTION
## Summary\n- Preserve \ when an inline \ block is replaced by overlapping structured \ in \.\n- Preserve \ for directly formatted inline \ blocks as well, matching behavior of other Anthropic content block handlers.\n- Add targeted regression tests for both overlapping and inline \ paths to ensure cache breakpoint metadata survives conversion.\n\nFixes #38398\n\n## Verification\n- uv run --directory libs/partners/anthropic --group lint ruff check langchain_anthropic/chat_models.py tests/unit_tests/test_chat_models.py\n- uv run --directory libs/partners/anthropic --group test pytest tests/unit_tests/test_chat_models.py -k "tool_use_block_preserves_cache_control or tool_use_blocks_and_tool_calls_preserves_cache_control"\n- uv run --directory libs/partners/anthropic --group test pytest tests/unit_tests/test_chat_models.py -k "tool_use_block or tool_use_blocks_and_tool_calls"