### PR TITLE
fix(langchain): infer openai provider for o4 model name prefix

### DIFF
--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -536,6 +536,7 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
             "gpt-",
             "o1",
             "o3",
+            "o4",
             "chatgpt",
             "text-davinci",
         )


### PR DESCRIPTION
Fixes #38243

`init_chat_model("o4-mini")` failed because `_attempt_infer_model_provider` recognized `o1`/`o3` prefixes but not `o4`, even though o4 models are OpenAI API models like o1/o3.

Add `o4` to the OpenAI prefix list so provider inference matches the other reasoning model families.

Made with [Cursor](https://cursor.com)