### PR TITLE
fix(langchain): infer openai provider for o4 model name prefix

### DIFF
--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -536,6 +536,7 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
             "gpt-",
             "o1",
             "o3",
+            "o4",
             "chatgpt",
             "text-davinci",
         )

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -81,6 +81,7 @@ def test_supported_providers_is_sorted() -> None:
     [
         (OPENAI_TEST_MODEL, "openai"),
         ("o3", "openai"),
+        ("o4-mini", "openai"),
         ("text-davinci-003", "openai"),
         ("claude-3-haiku-20240307", "anthropic"),
         ("command-r-plus", "cohere"),


### PR DESCRIPTION
Fixes #38243

`init_chat_model("o4-mini")` raised a provider inference error because `_attempt_infer_model_provider` matched `o1`/`o3` but not `o4`. Adding `o4` to the OpenAI prefix list fixes bare o4 model names.

Made with [Cursor](https://cursor.com)