### PR TITLE
fix(anthropic): preserve tool_use cache_control

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -543,11 +543,15 @@ def _format_messages(
                                 for tc in message.tool_calls
                                 if tc["id"] == block["id"]
                             ]
-                            content.extend(
-                                _lc_tool_calls_to_anthropic_tool_use_blocks(
-                                    overlapping,
-                                ),
+                            tool_use_blocks = (
+                                _lc_tool_calls_to_anthropic_tool_use_blocks(overlapping)
                             )
+                            if "cache_control" in block:
+                                for tool_use_block in tool_use_blocks:
+                                    tool_use_block["cache_control"] = block[
+                                        "cache_control"
+                                    ]
+                            content.extend(tool_use_blocks)
                         else:
                             if tool_input := block.get("input"):
                                 args = tool_input
@@ -2279,6 +2283,7 @@ class _AnthropicToolUse(TypedDict):
     input: dict
     id: str
     caller: NotRequired[dict[str, Any]]
+    cache_control: NotRequired[dict[str, str]]
 
 
 def _lc_tool_calls_to_anthropic_tool_use_blocks(

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1116,6 +1116,46 @@ def test__format_messages_with_tool_use_blocks_and_tool_calls() -> None:
     assert expected == actual
 
 
+def test__format_messages_preserves_tool_use_cache_control_with_tool_calls() -> None:
+    system = SystemMessage("fuzz")  # type: ignore[misc]
+    human = HumanMessage("foo")  # type: ignore[misc]
+    ai = AIMessage(  # type: ignore[misc]
+        [
+            {"type": "text", "text": "thought"},
+            {
+                "type": "tool_use",
+                "name": "bar",
+                "id": "1",
+                "input": {"baz": "NOT_BUZZ"},
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+        tool_calls=[{"name": "bar", "id": "1", "args": {"baz": "BUZZ"}}],
+    )
+    messages = [system, human, ai]
+    expected = (
+        "fuzz",
+        [
+            {"role": "user", "content": "foo"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "thought"},
+                    {
+                        "type": "tool_use",
+                        "name": "bar",
+                        "id": "1",
+                        "input": {"baz": "BUZZ"},
+                        "cache_control": {"type": "ephemeral"},
+                    },
+                ],
+            },
+        ],
+    )
+    actual = _format_messages(messages)
+    assert expected == actual
+
+
 def test__format_messages_with_cache_control() -> None:
     messages = [
         SystemMessage(


### PR DESCRIPTION
## Summary

Fixes #38398.

When an `AIMessage` contains both a `tool_use` content block and a matching structured `tool_calls` entry, `_format_messages` intentionally prefers the structured `tool_calls` args. However, rebuilding the Anthropic `tool_use` block from `tool_calls` also dropped metadata on the original content block, including `cache_control` prompt-cache breakpoints.

This preserves the existing `tool_calls` precedence for name/input/id while copying `cache_control` from the original matching `tool_use` block onto the rebuilt Anthropic block.

## Tests

```bash
UV_CACHE_DIR=/Users/yinxiaogou/Documents/resume/.tmp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/langchain-pycache uv run --directory /Users/yinxiaogou/Documents/resume/langchain/libs/partners/anthropic --group test pytest tests/unit_tests/test_chat_models.py -q -k 'tool_use_blocks_and_tool_calls or preserves_tool_use_cache_control'
UV_CACHE_DIR=/Users/yinxiaogou/Documents/resume/.tmp-uv-cache uv run --directory /Users/yinxiaogou/Documents/resume/langchain/libs/partners/anthropic ruff check langchain_anthropic/chat_models.py tests/unit_tests/test_chat_models.py
UV_CACHE_DIR=/Users/yinxiaogou/Documents/resume/.tmp-uv-cache uv run --directory /Users/yinxiaogou/Documents/resume/langchain/libs/partners/anthropic ruff format --check langchain_anthropic/chat_models.py tests/unit_tests/test_chat_models.py
```
