### PR TITLE
fix(core): preserve partial placeholders in pretty_repr

### DIFF
--- a/libs/core/langchain_core/prompts/string.py
+++ b/libs/core/langchain_core/prompts/string.py
@@ -375,10 +375,10 @@ class StringPromptTemplate(BasePromptTemplate[str], ABC):
         Returns:
             A pretty representation of the prompt.
         """
-        # TODO: handle partials
         dummy_vars = {
             input_var: "{" + f"{input_var}" + "}" for input_var in self.input_variables
         }
+        dummy_vars.update({var: "{" + var + "}" for var in self.partial_variables})
         if html:
             dummy_vars = {
                 k: get_colored_text(v, "yellow") for k, v in dummy_vars.items()

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -734,3 +734,12 @@ def test_prompt_template_add(
         variable="template",
         another_variable="other_template",
     )
+
+
+def test_pretty_repr_preserves_partial_variable_placeholders() -> None:
+    prompt = PromptTemplate(
+        template="Hello {user}, how is {input}?",
+        input_variables=["input"],
+        partial_variables={"user": "Lucy"},
+    )
+    assert prompt.pretty_repr() == "Hello {user}, how is {input}?"


### PR DESCRIPTION
Fixes #38193

`StringPromptTemplate.pretty_repr()` now maps partial variable names to placeholder dummy values before formatting, so bound partials like `user="Lucy"` render as `{user}` instead of the substituted value.

Verified with `make format`, `make lint`, and the new regression test in `libs/core`.

Made with [Cursor](https://cursor.com)