### PR TITLE
fix(core): skip concatenating duplicate streaming metadata strings

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,17 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # Identical stream metadata strings should not concatenate
+        (
+            {"model_name": "gpt-4o", "finish_reason": "stop"},
+            {"model_name": "gpt-4o", "finish_reason": "stop"},
+            {"model_name": "gpt-4o", "finish_reason": "stop"},
+        ),
+        (
+            {"model_provider": "openrouter", "object": "chat.completion.chunk"},
+            {"model_provider": "openrouter", "object": "chat.completion.chunk"},
+            {"model_provider": "openrouter", "object": "chat.completion.chunk"},
+        ),
     ],
 )
 def test_merge_dicts(


### PR DESCRIPTION
Fixes #38366

---

When merging streamed LLM response chunks, `merge_dicts` was concatenating identical metadata strings like `model_name` and `finish_reason`, producing doubled values in the final output. This extends the existing skip-concatenation logic so repeated metadata fields are preserved instead of joined.

Verified with the updated `test_merge_dicts` parametrized cases in `libs/core`.

Made with [Cursor](https://cursor.com)