### PR TITLE
fix(langchain-classic): implement async RePhraseQueryRetriever

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/re_phraser.py
+++ b/libs/langchain/langchain_classic/retrievers/re_phraser.py
@@ -89,4 +89,12 @@ class RePhraseQueryRetriever(BaseRetriever):
         *,
         run_manager: AsyncCallbackManagerForRetrieverRun,
     ) -> list[Document]:
-        raise NotImplementedError
+        re_phrased_question = await self.llm_chain.ainvoke(
+            query,
+            {"callbacks": run_manager.get_child()},
+        )
+        logger.info("Re-phrased question: %s", re_phrased_question)
+        return await self.retriever.ainvoke(
+            re_phrased_question,
+            config={"callbacks": run_manager.get_child()},
+        )

--- a/libs/langchain/tests/unit_tests/retrievers/test_re_phraser.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_re_phraser.py
@@ -1,0 +1,28 @@
+import pytest
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+from langchain_core.runnables import RunnableLambda
+
+from langchain_classic.retrievers.re_phraser import RePhraseQueryRetriever
+
+
+class FakeRetriever(BaseRetriever):
+    def _get_relevant_documents(self, query, *, run_manager=None):
+        return [Document(page_content=f"relevant: {query}")]
+
+    async def _aget_relevant_documents(self, query, *, run_manager=None):
+        return [Document(page_content=f"relevant: {query}")]
+
+
+@pytest.mark.asyncio
+async def test_rephrase_query_retriever_async() -> None:
+    chain = RunnableLambda(lambda q: f"rephrased: {q}")
+    retriever = RePhraseQueryRetriever(retriever=FakeRetriever(), llm_chain=chain)
+
+    sync_result = retriever.invoke("what is langchain?")
+    assert len(sync_result) == 1
+    assert sync_result[0].page_content == "relevant: rephrased: what is langchain?"
+
+    async_result = await retriever.ainvoke("what is langchain?")
+    assert len(async_result) == 1
+    assert async_result[0].page_content == "relevant: rephrased: what is langchain?"


### PR DESCRIPTION
Fixes #37619

---

`RePhraseQueryRetriever._aget_relevant_documents` previously raised `NotImplementedError`, so async retrieval failed even though the sync path worked. This mirrors the sync implementation using `ainvoke` on the LLM chain and underlying retriever, with a unit test covering both paths.

Made with [Cursor](https://cursor.com)