### PR TITLE
fix(core): correct operator validation error message in Visitor

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (

--- a/libs/core/tests/unit_tests/test_structured_query.py
+++ b/libs/core/tests/unit_tests/test_structured_query.py
@@ -1,0 +1,25 @@
+"""Tests for structured query visitor validation."""
+
+import pytest
+
+from langchain_core.structured_query import Comparator, Operator, Visitor
+
+
+class _TestVisitor(Visitor):
+    allowed_comparators = (Comparator.EQ,)
+    allowed_operators = (Operator.AND,)
+
+    def visit_operation(self, operation):  # noqa: ANN001, ARG002
+        return None
+
+    def visit_comparison(self, comparison):  # noqa: ANN001, ARG002
+        return None
+
+    def visit_structured_query(self, structured_query):  # noqa: ANN001, ARG002
+        return None
+
+
+def test_validate_func_operator_error_message() -> None:
+    visitor = _TestVisitor()
+    with pytest.raises(ValueError, match="Allowed operators are"):
+        visitor._validate_func(Operator.OR)


### PR DESCRIPTION
## Summary

Fixes a copy-paste bug in `Visitor.validate_func`: when an unsupported operator is passed, the error message incorrectly says "Allowed comparators are" instead of "Allowed operators are".

Adds a unit test covering the corrected message.

Closes #36701

## Test plan

- [x] `uv run --group test pytest libs/core/tests/unit_tests/test_structured_query.py -q`

Made with [Cursor](https://cursor.com)