### PR TITLE
fix(langchain-classic,core): async rephrase retriever and stream metadata dedup

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,17 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # Identical stream metadata strings should not concatenate
+        (
+            {"model_name": "gpt-4o", "finish_reason": "stop"},
+            {"model_name": "gpt-4o", "finish_reason": "stop"},
+            {"model_name": "gpt-4o", "finish_reason": "stop"},
+        ),
+        (
+            {"model_provider": "openrouter", "object": "chat.completion.chunk"},
+            {"model_provider": "openrouter", "object": "chat.completion.chunk"},
+            {"model_provider": "openrouter", "object": "chat.completion.chunk"},
+        ),
     ],
 )
 def test_merge_dicts(

--- a/libs/langchain/langchain_classic/retrievers/re_phraser.py
+++ b/libs/langchain/langchain_classic/retrievers/re_phraser.py
@@ -89,4 +89,12 @@ class RePhraseQueryRetriever(BaseRetriever):
         *,
         run_manager: AsyncCallbackManagerForRetrieverRun,
     ) -> list[Document]:
-        raise NotImplementedError
+        re_phrased_question = await self.llm_chain.ainvoke(
+            query,
+            {"callbacks": run_manager.get_child()},
+        )
+        logger.info("Re-phrased question: %s", re_phrased_question)
+        return await self.retriever.ainvoke(
+            re_phrased_question,
+            config={"callbacks": run_manager.get_child()},
+        )

--- a/libs/langchain/tests/unit_tests/retrievers/test_re_phraser.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_re_phraser.py
@@ -1,0 +1,28 @@
+import pytest
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+from langchain_core.runnables import RunnableLambda
+
+from langchain_classic.retrievers.re_phraser import RePhraseQueryRetriever
+
+
+class FakeRetriever(BaseRetriever):
+    def _get_relevant_documents(self, query, *, run_manager=None):
+        return [Document(page_content=f"relevant: {query}")]
+
+    async def _aget_relevant_documents(self, query, *, run_manager=None):
+        return [Document(page_content=f"relevant: {query}")]
+
+
+@pytest.mark.asyncio
+async def test_rephrase_query_retriever_async() -> None:
+    chain = RunnableLambda(lambda q: f"rephrased: {q}")
+    retriever = RePhraseQueryRetriever(retriever=FakeRetriever(), llm_chain=chain)
+
+    sync_result = retriever.invoke("what is langchain?")
+    assert len(sync_result) == 1
+    assert sync_result[0].page_content == "relevant: rephrased: what is langchain?"
+
+    async_result = await retriever.ainvoke("what is langchain?")
+    assert len(async_result) == 1
+    assert async_result[0].page_content == "relevant: rephrased: what is langchain?"


### PR DESCRIPTION
## Summary
- Implement `RePhraseQueryRetriever._aget_relevant_documents` so async retrieval works (fixes #37619)
- Deduplicate identical string metadata keys when merging streamed LLM chunks to avoid duplicated values like `model_name` and `finish_reason` (fixes #38366)
- Add unit tests for both fixes

## Test plan
- [x] Added `test_rephrase_query_retriever_async` in langchain-classic retriever tests
- [x] Extended merge metadata dedup test cases in langchain-core utils tests
- [ ] `uv run --group test pytest libs/langchain/tests/unit_tests/retrievers/test_re_phraser.py`
- [ ] `uv run --group test pytest libs/core/tests/unit_tests/utils/test_utils.py`

Fixes #37619, #38366

Made with [Cursor](https://cursor.com)