### PR TITLE
fix(core): skip duplicate stream metadata string merges

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -66,6 +66,16 @@ def test_check_package_version(
         ({"a": True}, {"a": True}, {"a": True}),
         ({"a": False}, {"a": False}, {"a": False}),
         ({"a": "txt"}, {"a": "txt"}, {"a": "txttxt"}),
+        (
+            {"model_name": "gpt-4"},
+            {"model_name": "gpt-4"},
+            {"model_name": "gpt-4"},
+        ),
+        (
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+        ),
         ({"a": [1, 2]}, {"a": [1, 2]}, {"a": [1, 2, 1, 2]}),
         ({"a": {"b": "txt"}}, {"a": {"b": "txt"}}, {"a": {"b": "txttxt"}}),
         # Merge strings.


### PR DESCRIPTION
Closes #38366

---

When providers emit multiple terminal streaming chunks with identical metadata (for example duplicate `finish_reason` and `model_name` values), `merge_dicts` was concatenating equal strings. This change extends the existing deduplication allowlist so stable metadata fields are preserved instead of doubled during chunk aggregation.

> [!NOTE]
> AI-assisted contribution.

Made with [Cursor](https://cursor.com)