### PR TITLE
fix(core): skip concatenating duplicate streaming metadata strings

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,18 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # Stable streaming metadata should not self-concatenate when identical
+        ({"model_name": "gpt-4"}, {"model_name": "gpt-4"}, {"model_name": "gpt-4"}),
+        (
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+        ),
+        (
+            {"model_name": "gpt-4", "finish_reason": "stop"},
+            {"model_name": "gpt-4", "finish_reason": "stop"},
+            {"model_name": "gpt-4", "finish_reason": "stop"},
+        ),
     ],
 )
 def test_merge_dicts(


### PR DESCRIPTION
## Summary

Extends `merge_dicts` deduplication for stable streaming metadata fields (`model_name`, `finish_reason`, `native_finish_reason`, `object`, `system_fingerprint`, `format`) so identical values are not concatenated when merging AIMessage chunks.

Closes #38366

## Test plan

- [x] `uv run --group test pytest libs/core/tests/unit_tests/utils/test_utils.py::test_merge_dicts -q`

Made with [Cursor](https://cursor.com)