### PR TITLE
fix(langchain): include model destination in model_to_tools routing

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1643,15 +1643,11 @@ def create_agent(
             tools_to_model_destinations,
         )
 
-        # base destinations are tools and exit_node
-        # we add the loop_entry node to edge destinations if:
-        # - there is an after model hook(s) -- allows jump_to to model
-        #   potentially artificially injected tool messages, ex HITL
-        # - there is a response format -- to allow for jumping to model to handle
-        #   regenerating structured output tool calls
-        model_to_tools_destinations = ["tools", exit_node]
-        if response_format or loop_exit_node != "model":
-            model_to_tools_destinations.append(loop_entry_node)
+        # base destinations are tools, exit_node, and loop_entry_node.
+        # The router can return loop_entry_node when middleware injects synthetic
+        # tool messages before tools run, even without response_format or
+        # after_model middleware.
+        model_to_tools_destinations = ["tools", exit_node, loop_entry_node]
 
         graph.add_conditional_edges(
             loop_exit_node,

--- a/libs/langchain_v1/tests/unit_tests/agents/test_create_agent_synthetic_tool_messages.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_create_agent_synthetic_tool_messages.py
@@ -1,0 +1,55 @@
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.types import Command
+
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentMiddleware, ExtendedModelResponse
+from langchain.tools import tool
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+class InjectToolMessageMiddleware(AgentMiddleware):
+    """Inject synthetic tool messages for pre-approved tool calls."""
+
+    name = "inject_tool_msg"
+
+    def wrap_model_call(self, request, handler):  # noqa: ANN001
+        response = handler(request)
+        ai = response.result[0]
+        if isinstance(ai, AIMessage) and ai.tool_calls:
+            synthetic = [
+                ToolMessage(content="cached", tool_call_id=tc["id"], name=tc["name"])
+                for tc in ai.tool_calls
+            ]
+            return ExtendedModelResponse(
+                model_response=response,
+                command=Command(update={"messages": synthetic}),
+            )
+        return response
+
+
+@tool
+def foo(x: int) -> int:
+    """A trivial tool the agent can call."""
+    return x + 1
+
+
+def test_create_agent_routes_back_to_model_after_synthetic_tool_messages() -> None:
+    """Middleware-injected tool messages should not crash graph routing."""
+    fake = FakeToolCallingModel(
+        tool_calls=[
+            [
+                {
+                    "name": "foo",
+                    "args": {"x": 1},
+                    "id": "call_xyz",
+                    "type": "tool_call",
+                }
+            ],
+            [],
+        ]
+    )
+    agent = create_agent(model=fake, tools=[foo], middleware=[InjectToolMessageMiddleware()])
+
+    result = agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+    assert any(isinstance(message, AIMessage) for message in result["messages"])


### PR DESCRIPTION
## Summary

Always registers `loop_entry_node` in the `model_to_tools` conditional edge destinations. Middleware that injects synthetic `ToolMessage`s in `wrap_model_call` can route back to the model even when no `response_format` or `after_model` middleware is configured.

Closes #38351

## Test plan

- [x] `uv run --group test pytest libs/langchain_v1/tests/unit_tests/agents/test_create_agent_synthetic_tool_messages.py -q`

Made with [Cursor](https://cursor.com)