### PR TITLE
fix(langchain): prevent orphan ToolMessages in summarization cutoff

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -782,14 +782,19 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
                 tool_call_ids.add(tool_msg.tool_call_id)
             idx += 1
 
-        # Search backward for AIMessage with matching tool_calls
+        # Search backward for AIMessage(s) covering all tool_call_ids
+        remaining_ids = set(tool_call_ids)
+        earliest_match = cutoff_index
         for i in range(cutoff_index - 1, -1, -1):
             msg = messages[i]
             if isinstance(msg, AIMessage) and msg.tool_calls:
                 ai_tool_call_ids = {tc.get("id") for tc in msg.tool_calls if tc.get("id")}
-                if tool_call_ids & ai_tool_call_ids:
-                    # Found the AIMessage - move cutoff to include it
-                    return i
+                matched = remaining_ids & ai_tool_call_ids
+                if matched:
+                    remaining_ids -= matched
+                    earliest_match = i
+                    if not remaining_ids:
+                        return earliest_match
 
         # Fallback: no matching AIMessage found, advance past ToolMessages to avoid
         # orphaned tool responses

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -847,6 +847,35 @@ def test_summarization_middleware_find_safe_cutoff_point_orphan_tool() -> None:
     assert middleware._find_safe_cutoff_point(messages, 2) == 3
 
 
+def test_summarization_middleware_find_safe_cutoff_point_partial_ai_match() -> None:
+    """Cutoff must cover every tool_call_id, not just the first partial match."""
+    model = FakeToolCallingModel()
+    middleware = SummarizationMiddleware(
+        model=model, trigger=("messages", 10), keep=("messages", 2)
+    )
+
+    messages: list[AnyMessage] = [
+        HumanMessage(content="hi", id="h0"),
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "old_tool", "args": {}, "id": "X", "type": "tool_call"}],
+            id="a_old",
+        ),
+        ToolMessage(content="old result for X", tool_call_id="X", id="t_old_x"),
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "new_tool", "args": {}, "id": "Y", "type": "tool_call"}],
+            id="a_new",
+        ),
+        ToolMessage(content="duplicated X reply", tool_call_id="X", id="t_orphan_x"),
+        ToolMessage(content="result for Y", tool_call_id="Y", id="t_y"),
+        HumanMessage(content="next", id="h_next"),
+    ]
+
+    # Cutoff on orphan ToolMessage for X should include the original AI/Tool pair at index 1
+    assert middleware._find_safe_cutoff_point(messages, 4) == 1
+
+
 def test_summarization_cutoff_moves_backward_to_include_ai_message() -> None:
     """Test that cutoff moves backward to include `AIMessage` with its `ToolMessage`s.
 


### PR DESCRIPTION
## Summary
- Fix `SummarizationMiddleware._find_safe_cutoff_point` to require all `tool_call_ids` at the cutoff to be covered by preceding `AIMessage`s
- Prevents orphan `ToolMessage`s from surviving into the preserved window and causing provider 400 errors on the next model call

## Test plan
- [x] Added regression test for partial AI/Tool intersection at cutoff
- [ ] `pytest libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py -k partial_ai_match`

Fixes #38352

Made with [Cursor](https://cursor.com)