### PR TITLE
fix(anthropic): preserve cache_control on deduplicated tool_use blocks

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -543,11 +543,17 @@ def _format_messages(
                                 for tc in message.tool_calls
                                 if tc["id"] == block["id"]
                             ]
-                            content.extend(
+                            tool_use_blocks = (
                                 _lc_tool_calls_to_anthropic_tool_use_blocks(
                                     overlapping,
-                                ),
+                                )
                             )
+                            if cache_control := block.get("cache_control"):
+                                tool_use_blocks = [
+                                    {**tool_use_block, "cache_control": cache_control}
+                                    for tool_use_block in tool_use_blocks
+                                ]
+                            content.extend(tool_use_blocks)
                         else:
                             if tool_input := block.get("input"):
                                 args = tool_input
@@ -2279,6 +2285,7 @@ class _AnthropicToolUse(TypedDict):
     input: dict
     id: str
     caller: NotRequired[dict[str, Any]]
+    cache_control: NotRequired[dict[str, str]]
 
 
 def _lc_tool_calls_to_anthropic_tool_use_blocks(

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -14,7 +14,13 @@ import pytest
 from anthropic.types import Message, TextBlock, Usage
 from blockbuster import blockbuster_ctx
 from langchain_core.exceptions import ContextOverflowError
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolCall,
+    ToolMessage,
+)
 from langchain_core.runnables import RunnableBinding
 from langchain_core.tools import BaseTool, tool
 from langchain_core.tracers.base import BaseTracer
@@ -1114,6 +1120,26 @@ def test__format_messages_with_tool_use_blocks_and_tool_calls() -> None:
     )
     actual = _format_messages(messages)
     assert expected == actual
+
+
+def test__format_messages_preserves_tool_use_cache_control() -> None:
+    """`cache_control` on a tool_use block survives tool_call deduplication."""
+    ai = AIMessage(  # type: ignore[misc]
+        [
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+        tool_calls=[ToolCall(name="get_weather", args={"city": "Paris"}, id="toolu_1")],
+    )
+    _, formatted = _format_messages([HumanMessage(content="weather?"), ai])
+    tool_use_block = formatted[-1]["content"][-1]
+    assert tool_use_block["cache_control"] == {"type": "ephemeral"}
 
 
 def test__format_messages_with_cache_control() -> None:


### PR DESCRIPTION
Closes #38398

---

When `_format_messages` prefers structured `tool_calls` over inline `tool_use` content, it rebuilds the Anthropic tool-use block and was dropping extra keys such as `cache_control`. That silently removed prompt-cache breakpoints placed on tool calls.

This change copies `cache_control` from the original inline block onto the rebuilt tool-use block, matching how text, thinking, and server tool blocks already preserve cache metadata.

> [!NOTE]
> AI-assisted contribution.

Made with [Cursor](https://cursor.com)