### PR TITLE
fix(langchain,core): agent routing, summarization cutoff, stream metadata dedup

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,11 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        (
+            {"model_name": "gpt-4o", "finish_reason": "stop"},
+            {"model_name": "gpt-4o", "finish_reason": "stop"},
+            {"model_name": "gpt-4o", "finish_reason": "stop"},
+        ),
     ],
 )
 def test_merge_dicts(

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1643,15 +1643,10 @@ def create_agent(
             tools_to_model_destinations,
         )
 
-        # base destinations are tools and exit_node
-        # we add the loop_entry node to edge destinations if:
-        # - there is an after model hook(s) -- allows jump_to to model
-        #   potentially artificially injected tool messages, ex HITL
-        # - there is a response format -- to allow for jumping to model to handle
-        #   regenerating structured output tool calls
-        model_to_tools_destinations = ["tools", exit_node]
-        if response_format or loop_exit_node != "model":
-            model_to_tools_destinations.append(loop_entry_node)
+        # The router can return loop_entry_node when middleware injects synthetic
+        # tool messages before tools run, even without response_format or
+        # after_model middleware.
+        model_to_tools_destinations = ["tools", exit_node, loop_entry_node]
 
         graph.add_conditional_edges(
             loop_exit_node,

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -782,14 +782,19 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
                 tool_call_ids.add(tool_msg.tool_call_id)
             idx += 1
 
-        # Search backward for AIMessage with matching tool_calls
+        # Search backward for AIMessage(s) covering all tool_call_ids
+        remaining_ids = set(tool_call_ids)
+        earliest_match = cutoff_index
         for i in range(cutoff_index - 1, -1, -1):
             msg = messages[i]
             if isinstance(msg, AIMessage) and msg.tool_calls:
                 ai_tool_call_ids = {tc.get("id") for tc in msg.tool_calls if tc.get("id")}
-                if tool_call_ids & ai_tool_call_ids:
-                    # Found the AIMessage - move cutoff to include it
-                    return i
+                matched = remaining_ids & ai_tool_call_ids
+                if matched:
+                    remaining_ids -= matched
+                    earliest_match = i
+                    if not remaining_ids:
+                        return earliest_match
 
         # Fallback: no matching AIMessage found, advance past ToolMessages to avoid
         # orphaned tool responses

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -847,6 +847,34 @@ def test_summarization_middleware_find_safe_cutoff_point_orphan_tool() -> None:
     assert middleware._find_safe_cutoff_point(messages, 2) == 3
 
 
+def test_summarization_middleware_find_safe_cutoff_point_partial_ai_match() -> None:
+    """Cutoff must cover every tool_call_id, not just the first partial match."""
+    model = FakeToolCallingModel()
+    middleware = SummarizationMiddleware(
+        model=model, trigger=("messages", 10), keep=("messages", 2)
+    )
+
+    messages: list[AnyMessage] = [
+        HumanMessage(content="hi", id="h0"),
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "old_tool", "args": {}, "id": "X", "type": "tool_call"}],
+            id="a_old",
+        ),
+        ToolMessage(content="old result for X", tool_call_id="X", id="t_old_x"),
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "new_tool", "args": {}, "id": "Y", "type": "tool_call"}],
+            id="a_new",
+        ),
+        ToolMessage(content="duplicated X reply", tool_call_id="X", id="t_orphan_x"),
+        ToolMessage(content="result for Y", tool_call_id="Y", id="t_y"),
+        HumanMessage(content="next", id="h_next"),
+    ]
+
+    assert middleware._find_safe_cutoff_point(messages, 4) == 1
+
+
 def test_summarization_cutoff_moves_backward_to_include_ai_message() -> None:
     """Test that cutoff moves backward to include `AIMessage` with its `ToolMessage`s.
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_create_agent_synthetic_tool_messages.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_create_agent_synthetic_tool_messages.py
@@ -1,0 +1,55 @@
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.types import Command
+
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import AgentMiddleware, ExtendedModelResponse
+from langchain.tools import tool
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+class InjectToolMessageMiddleware(AgentMiddleware):
+    """Inject synthetic tool messages for pre-approved tool calls."""
+
+    name = "inject_tool_msg"
+
+    def wrap_model_call(self, request, handler):  # noqa: ANN001
+        response = handler(request)
+        ai = response.result[0]
+        if isinstance(ai, AIMessage) and ai.tool_calls:
+            synthetic = [
+                ToolMessage(content="cached", tool_call_id=tc["id"], name=tc["name"])
+                for tc in ai.tool_calls
+            ]
+            return ExtendedModelResponse(
+                model_response=response,
+                command=Command(update={"messages": synthetic}),
+            )
+        return response
+
+
+@tool
+def foo(x: int) -> int:
+    """A trivial tool the agent can call."""
+    return x + 1
+
+
+def test_create_agent_routes_back_to_model_after_synthetic_tool_messages() -> None:
+    """Middleware-injected tool messages should not crash graph routing."""
+    fake = FakeToolCallingModel(
+        tool_calls=[
+            [
+                {
+                    "name": "foo",
+                    "args": {"x": 1},
+                    "id": "call_xyz",
+                    "type": "tool_call",
+                }
+            ],
+            [],
+        ]
+    )
+    agent = create_agent(model=fake, tools=[foo], middleware=[InjectToolMessageMiddleware()])
+
+    result = agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+    assert any(isinstance(message, AIMessage) for message in result["messages"])


### PR DESCRIPTION
## Summary
- Include `model` in `create_agent` tool-routing destinations when synthetic tool messages are injected (#38351)
- Require all `tool_call_ids` at summarization cutoffs to be covered by preceding `AIMessage`s (#38352)
- Deduplicate identical string stream metadata keys (`model_name`, `finish_reason`, etc.) in `merge_dicts` (#38366)

## Test plan
- [x] Added regression tests for synthetic tool message routing and partial summarization cutoff
- [x] Extended merge metadata dedup test cases
- [ ] `pytest libs/langchain_v1/tests/unit_tests/agents/test_create_agent_synthetic_tool_messages.py`
- [ ] `pytest libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py -k partial_ai_match`
- [ ] `pytest libs/core/tests/unit_tests/utils/test_utils.py -k merge_dicts`

Fixes #38351, #38352, #38366

Made with [Cursor](https://cursor.com)