### PR TITLE
fix(text-splitters): preserve inline tag text order in HTML splitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -932,32 +932,28 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
                     current_content.append(placeholder)
                     placeholder_count += 1
                 else:
-                    # Recursively process children to find nested headers or
-                    # preserved elements.
-                    children = _find_all_tags(elem, recursive=False)
-                    if children:
-                        # Element has children - recursively process them.
-                        (
-                            documents,
-                            current_headers,
-                            current_content,
-                            preserved_elements,
-                            placeholder_count,
-                        ) = _process_element(
-                            children,
-                            documents,
-                            current_headers,
-                            current_content,
-                            preserved_elements,
-                            placeholder_count,
-                        )
-                        # After processing children, extract only text
-                        # strings from this element (not its children). Used
-                        # recursive=False to avoid double-counting.
-                        content = " ".join(_find_all_strings(elem, recursive=False))
-                        if content:
-                            content = self._normalize_and_clean_text(content)
-                            current_content.append(content)
+                    child_tags = _find_all_tags(elem, recursive=False)
+                    if child_tags:
+                        for child in elem.children:
+                            if isinstance(child, NavigableString):
+                                text = self._normalize_and_clean_text(str(child))
+                                if text:
+                                    current_content.append(text)
+                            elif isinstance(child, Tag):
+                                (
+                                    documents,
+                                    current_headers,
+                                    current_content,
+                                    preserved_elements,
+                                    placeholder_count,
+                                ) = _process_element(
+                                    cast("ResultSet[Tag]", [child]),
+                                    documents,
+                                    current_headers,
+                                    current_content,
+                                    preserved_elements,
+                                    placeholder_count,
+                                )
                     else:
                         # Leaf element with no children, so we extract its
                         # text and add to current content. Handles

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -4035,6 +4035,29 @@ def test_html_splitter_keep_separator_false() -> None:
 
 
 @pytest.mark.requires("bs4")
+def test_html_semantic_preserving_splitter_inline_tag_text_order() -> None:
+    """Inline tags must not reorder surrounding text when chunking."""
+    html_content = """
+    <h1>Section 1</h1>
+    <p>This is some long text that <strong>should</strong> be split into multiple chunks due to the
+    small chunk size.</p>
+    """
+    with suppress_langchain_beta_warning():
+        splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")],
+            max_chunk_size=50,
+            chunk_overlap=5,
+        )
+    documents = splitter.split_text(html_content)
+
+    assert len(documents) >= 2
+    combined = " ".join(doc.page_content for doc in documents)
+    assert "should" in combined
+    assert combined.index("should") > combined.index("long text that")
+    assert documents[0].page_content.startswith("This is some long text that")
+
+
+@pytest.mark.requires("bs4")
 def test_html_splitter_keep_separator_start() -> None:
     """Test HTML splitting with keep_separator="start"."""
     html_content = """


### PR DESCRIPTION
## Summary
- Process HTML element children in document order when building chunk text
- Prevents inline tags like `<strong>` from appearing before surrounding text during chunking

## Test plan
- [x] Added `test_html_semantic_preserving_splitter_inline_tag_text_order`
- [ ] `pytest libs/text-splitters/tests/unit_tests/test_text_splitters.py -k inline_tag_text_order`

Fixes #38404

Made with [Cursor](https://cursor.com)