### PR TITLE
fix(text-splitters): preserve inline tag text order in HTML splitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -932,32 +932,36 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
                     current_content.append(placeholder)
                     placeholder_count += 1
                 else:
-                    # Recursively process children to find nested headers or
-                    # preserved elements.
-                    children = _find_all_tags(elem, recursive=False)
-                    if children:
-                        # Element has children - recursively process them.
-                        (
-                            documents,
-                            current_headers,
-                            current_content,
-                            preserved_elements,
-                            placeholder_count,
-                        ) = _process_element(
-                            children,
-                            documents,
-                            current_headers,
-                            current_content,
-                            preserved_elements,
-                            placeholder_count,
-                        )
-                        # After processing children, extract only text
-                        # strings from this element (not its children). Used
-                        # recursive=False to avoid double-counting.
-                        content = " ".join(_find_all_strings(elem, recursive=False))
-                        if content:
-                            content = self._normalize_and_clean_text(content)
-                            current_content.append(content)
+                    child_tags = _find_all_tags(elem, recursive=False)
+                    has_direct_strings = any(
+                        isinstance(child, NavigableString) for child in elem.children
+                    )
+                    if child_tags or has_direct_strings:
+                        # Process children in document order so inline tags keep
+                        # surrounding text in the correct sequence.
+                        for child in elem.children:
+                            child_elem = cast("Tag | NavigableString", child)
+                            if isinstance(child_elem, NavigableString):
+                                content = self._normalize_and_clean_text(
+                                    str(child_elem)
+                                )
+                                if content:
+                                    current_content.append(content)
+                            elif child_elem.name:
+                                (
+                                    documents,
+                                    current_headers,
+                                    current_content,
+                                    preserved_elements,
+                                    placeholder_count,
+                                ) = _process_element(
+                                    [child_elem],
+                                    documents,
+                                    current_headers,
+                                    current_content,
+                                    preserved_elements,
+                                    placeholder_count,
+                                )
                     else:
                         # Leaf element with no children, so we extract its
                         # text and add to current content. Handles

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3770,6 +3770,34 @@ def test_html_splitter_with_small_chunk_size() -> None:
 
 
 @pytest.mark.requires("bs4")
+def test_html_splitter_preserves_inline_tag_text_order() -> None:
+    """Inline formatting tags should not reorder surrounding text."""
+    html_content = """
+    <h1>Section 1</h1>
+    <p>This is some long text that <strong>should</strong> be split into multiple chunks due to the
+    small chunk size.</p>
+    """
+    with suppress_langchain_beta_warning():
+        splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")], max_chunk_size=50, chunk_overlap=5
+        )
+    documents = splitter.split_text(html_content)
+
+    expected = [
+        Document(
+            page_content="This is some long text that should be split into",
+            metadata={"Header 1": "Section 1"},
+        ),
+        Document(
+            page_content="into multiple chunks due to the small chunk size.",
+            metadata={"Header 1": "Section 1"},
+        ),
+    ]
+
+    assert documents == expected
+
+
+@pytest.mark.requires("bs4")
 def test_html_splitter_with_denylist_tags() -> None:
     """Test HTML splitting with denylist tag filtering."""
     html_content = """


### PR DESCRIPTION
Closes #38404

---

`HTMLSemanticPreservingSplitter` was reordering inline formatting text (for example words inside `<strong>`) ahead of surrounding paragraph text when chunking. That broke reading order for inline tags introduced in #34587.

This change keeps inline tag text in document order while still preserving semantic headers and chunk boundaries. Added a regression test matching the issue's minimal reproduction.

Please review the inline text extraction path in the HTML splitter.

Disclaimer: This contribution was authored with assistance from an AI coding agent.

Made with [Cursor](https://cursor.com)