### PR TITLE
fix(core): use operators label in Visitor operator validation error

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (

--- a/libs/core/tests/unit_tests/test_structured_query.py
+++ b/libs/core/tests/unit_tests/test_structured_query.py
@@ -1,0 +1,27 @@
+"""Tests for structured query IR."""
+
+import pytest
+
+from langchain_core.structured_query import Comparator, Operator, Visitor
+
+
+class _TestVisitor(Visitor):
+    allowed_comparators = (Comparator.EQ,)
+    allowed_operators = (Operator.AND,)
+
+    def visit_operation(self, operation):  # noqa: ANN001, ANN201
+        pass
+
+    def visit_comparison(self, comparison):  # noqa: ANN001, ANN201
+        pass
+
+    def visit_structured_query(self, structured_query):  # noqa: ANN001, ANN201
+        pass
+
+
+def test_validate_func_operator_error_message_uses_operators_label() -> None:
+    """Disallowed operators should mention 'operators' in the error message."""
+    visitor = _TestVisitor()
+
+    with pytest.raises(ValueError, match="Allowed operators are"):
+        visitor._validate_func(Operator.OR)


### PR DESCRIPTION
Closes #36701

---

When `Visitor._validate_func` rejects a disallowed `Operator`, the raised `ValueError` incorrectly says "Allowed comparators are ..." even though the check is against `allowed_operators`. That makes debugging structured query translation failures confusing.

This updates the message to say "Allowed operators are ..." and adds a unit test that locks in the wording.

Disclaimer: This contribution was authored with assistance from an AI coding agent.

Made with [Cursor](https://cursor.com)