### PR TITLE
fix(core): treat empty caches as present in prompt-cache helpers

### DIFF
--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -179,7 +179,7 @@ def get_prompts(
 
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = llm_cache.lookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -214,7 +214,7 @@ async def aget_prompts(
     existing_prompts = {}
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = await llm_cache.alookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -285,7 +285,7 @@ async def aupdate_cache(
     for i, result in enumerate(new_results.generations):
         existing_prompts[missing_prompt_idxs[i]] = result
         prompt = prompts[missing_prompt_idxs[i]]
-        if llm_cache:
+        if llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result)
     return new_results.llm_output
 

--- a/libs/core/tests/unit_tests/language_models/llms/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/llms/test_cache.py
@@ -60,6 +60,49 @@ def test_local_cache_generate_sync() -> None:
         set_llm_cache(None)
 
 
+class SizedInMemoryCache(InMemoryCache):
+    """In-memory cache that reports its size via ``__len__``.
+
+    Many real cache implementations expose their entry count this way, which makes
+    an empty cache falsy. Used to guard against truthiness checks being used where
+    an identity check is intended.
+    """
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+
+async def test_local_cache_generate_async_sized_cache() -> None:
+    """A cache that defines ``__len__`` must work with ``agenerate``.
+
+    Regression test: ``aget_prompts``/``aupdate_cache`` previously used a
+    truthiness check, so an empty cache reporting ``len() == 0`` was treated as
+    absent. The prompt was added to neither the existing nor the missing set,
+    which raised ``KeyError`` when building the result.
+    """
+    local_cache = SizedInMemoryCache()
+    assert len(local_cache) == 0  # empty -> falsy
+    llm = FakeListLLM(cache=local_cache, responses=["foo", "bar"])
+    output = await llm.agenerate(["foo"])
+    assert output.generations[0][0].text == "foo"
+    # Second call must be served from the cache, not generate "bar".
+    output = await llm.agenerate(["foo"])
+    assert output.generations[0][0].text == "foo"
+    assert len(local_cache._cache) == 1
+
+
+def test_local_cache_generate_sync_sized_cache() -> None:
+    """Sync counterpart of `test_local_cache_generate_async_sized_cache`."""
+    local_cache = SizedInMemoryCache()
+    assert len(local_cache) == 0  # empty -> falsy
+    llm = FakeListLLM(cache=local_cache, responses=["foo", "bar"])
+    output = llm.generate(["foo"])
+    assert output.generations[0][0].text == "foo"
+    output = llm.generate(["foo"])
+    assert output.generations[0][0].text == "foo"
+    assert len(local_cache._cache) == 1
+
+
 class InMemoryCacheBad(BaseCache):
     """In-memory cache used for testing purposes."""
 


### PR DESCRIPTION
Fixes #38440

---

`get_prompts`, `aget_prompts`, and `aupdate_cache` in `langchain_core.language_models.llms` check whether a cache is configured using truthiness (`if llm_cache:`) instead of an identity check. The sync `update_cache` already uses `if llm_cache is not None:`.

A `BaseCache` that implements `__len__` — a natural thing to add so a cache can report how many entries it holds — is falsy when empty. In `get_prompts`/`aget_prompts` the truthiness check guards the entire lookup loop, so for an empty cache of this kind the loop body is skipped and the prompt lands in neither `existing_prompts` nor `missing_prompts`. Generation is then skipped, and assembling the result raises `KeyError`. This affects both `generate` and `agenerate`, so caching hard-crashes for any cache that implements `__len__` and starts empty.

The fix switches all three checks to `is not None`, so an empty-but-present cache behaves exactly like a populated one.

The regression tests add a cache that implements `__len__` and exercise both the sync and async paths — they crash without the fix and pass with it.