### PR TITLE
fix: infer openai provider for o4 models in init_chat_model

### DIFF
--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -251,7 +251,7 @@ def init_chat_model(
 
             Inferred providers by prefix (case-insensitive):
 
-            - `gpt-...` | `o1...` | `o3...`               -> `openai`
+            - `gpt-...` | `o1...` | `o3...` | `o4...`     -> `openai`
             - `claude...`                                 -> `anthropic`
             - `amazon....` | `anthropic....` | `meta....` -> `bedrock`
             - `gemini...`                                 -> `google_vertexai` (default changes in next major; pass `model_provider` to lock in)
@@ -536,6 +536,7 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
             "gpt-",
             "o1",
             "o3",
+            "o4",
             "chatgpt",
             "text-davinci",
         )

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -81,6 +81,7 @@ def test_supported_providers_is_sorted() -> None:
     [
         (OPENAI_TEST_MODEL, "openai"),
         ("o3", "openai"),
+        ("o4-mini", "openai"),
         ("text-davinci-003", "openai"),
         ("claude-3-haiku-20240307", "anthropic"),
         ("command-r-plus", "cohere"),


### PR DESCRIPTION
Fixes #38243

Added the "o4" prefix to `_attempt_infer_model_provider` so that the `init_chat_model` factory function correctly maps "o4-mini" and similar upcoming o4 models to the `openai` provider.

How did you verify your code works?
- Added a unit test for "o4-mini" in `test_chat_models.py` to ensure `_attempt_infer_model_provider` correctly returns "openai".

## Social handles 
LinkedIn: https://linkedin.com/in/MuhammadTahaNasir
