### PR TITLE
test(core): remove stale xfail markers from tests that now pass

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
@@ -2144,11 +2144,6 @@ async def test_async_in_async_stream_lambdas() -> None:
     _assert_events_equal_allow_superset_metadata(events, EXPECTED_EVENTS)
 
 
-@pytest.mark.xfail(
-    reason="This test is failing due to missing functionality."
-    "Need to implement logic in _transform_stream_with_config that mimics the async "
-    "variant that uses tap_output_iter"
-)
 async def test_sync_in_sync_lambdas() -> None:
     """Test invoking nested runnable lambda."""
 

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -410,7 +410,6 @@ def test_convert_to_openai_function(
     assert actual == expected
 
 
-@pytest.mark.xfail(reason="Direct pydantic v2 models not yet supported")
 def test_convert_to_openai_function_nested_v2() -> None:
     class NestedV2(BaseModelV2Maybe):
         nested_v2_arg1: int = FieldV2Maybe(..., description="foo")


### PR DESCRIPTION
Two tests in `libs/core` carry `@pytest.mark.xfail` markers for
functionality that has since been implemented. They now pass
unconditionally and produce XPASS noise in CI instead of being
counted as genuine test passes.

Changes:

- `tests/unit_tests/utils/test_function_calling.py` —
  `test_convert_to_openai_function_nested_v2`: the marker's reason
  was "Direct pydantic v2 models not yet supported". Direct Pydantic v2
  model support in `convert_to_openai_function` landed in a prior
  commit; the test now passes cleanly

- `tests/unit_tests/runnables/test_runnable_events_v1.py` —
  `test_sync_in_sync_lambdas`: the marker cited missing
  `_transform_stream_with_config` logic for sync-in-sync streaming.
  That logic was added; the test now passes cleanly

The adjacent `test_sync_in_async_stream_lambdas` (same file, same
reason string) is still genuinely failing and is left untouched

Fixes #38266