### PR TITLE
fix(core): extend merge_dicts dedup to stable streaming response metadata

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue


### PR DESCRIPTION
When a provider sends two terminal chunks that carry identical metadata
values — finish_reason, model_name, object, etc. — `merge_dicts` falls
through to `merged[right_k] += right_v` and concatenates the strings,
producing values like `"stopstop"` or a doubled model name. The bug
only appears with `.stream()` / `.astream()` when the provider emits
more than one terminal chunk; `.invoke()` is unaffected.

The existing code already handles `id`, `output_version`, and
`model_provider` with an equal-value guard (`continue` when
`merged[right_k] == right_v`). This PR applies the same guard to the
other stable response-metadata string fields that can repeat verbatim
across terminal chunks:

- `model_name`
- `finish_reason`
- `native_finish_reason`
- `object`
- `system_fingerprint`
- `format`

Values that genuinely differ across chunks still concatenate as before.
The guard only skips the `+=` when the incoming value is identical to
what is already merged.

Fixes #38366