### PR TITLE
fix(anthropic): preserve cache_control on tool_use blocks in _format_messages

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -543,11 +543,13 @@ def _format_messages(
                                 for tc in message.tool_calls
                                 if tc["id"] == block["id"]
                             ]
-                            content.extend(
-                                _lc_tool_calls_to_anthropic_tool_use_blocks(
-                                    overlapping,
-                                ),
+                            reconstructed = _lc_tool_calls_to_anthropic_tool_use_blocks(
+                                overlapping,
                             )
+                            if cache_control := block.get("cache_control"):
+                                for reconstructed_block in reconstructed:
+                                    reconstructed_block["cache_control"] = cache_control
+                            content.extend(reconstructed)
                         else:
                             if tool_input := block.get("input"):
                                 args = tool_input
@@ -566,6 +568,8 @@ def _format_messages(
                             )
                             if caller := block.get("caller"):
                                 tool_use_block["caller"] = caller
+                            if cache_control := block.get("cache_control"):
+                                tool_use_block["cache_control"] = cache_control
                             content.append(tool_use_block)
                     elif block["type"] in ("server_tool_use", "mcp_tool_use"):
                         formatted_block = {


### PR DESCRIPTION
When an AIMessage carries a `tool_use` content block that includes
`cache_control` and a matching entry in `tool_calls`, `_format_messages`
reconstructs the `tool_use` block from the structured `tool_calls` data
and discards every extra key on the original block, including
`cache_control`. A prompt-cache breakpoint placed on a `tool_use` block
is therefore silently lost during formatting.

This is inconsistent with the rest of `_format_messages`: the `text`,
`thinking`, `redacted_thinking`, `server_tool_use`, and `mcp_tool_use`
branches all carry `cache_control` through when building the formatted
block. `tool_use` was the only content-block type that dropped it.

The fix copies `cache_control` from the original content block onto the
reconstructed `tool_use` block in both affected paths:

- The overlapping-ID path, where `tool_calls` is preferred over the
  `tool_use` content block for the tool payload but the original block's
  `cache_control` should still be forwarded to the reconstructed blocks
- The inline `tool_use` path, where the block is rebuilt directly from
  its own fields

Fixes #38398