### PR TITLE
fix(langchain-classic): skip test_mset_chmod on Windows

### DIFF
--- a/libs/langchain/tests/unit_tests/storage/test_filesystem.py
+++ b/libs/langchain/tests/unit_tests/storage/test_filesystem.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -29,6 +30,7 @@ def test_mset_and_mget(file_store: LocalFileStore) -> None:
     assert values == [b"value1", b"value2"]
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="chmod group/other bits are not enforced on Windows")
 @pytest.mark.parametrize(
     ("chmod_dir_s", "chmod_file_s"),
     [("777", "666"), ("770", "660"), ("700", "600")],


### PR DESCRIPTION
Unix-style group/other permission bits are silently ignored on Windows filesystems. The `LocalFileStore` implementation is correct; only the test assertion is non-portable. Three parametrized cases (`777/666`, `770/660`, `700/600`) all fail on Windows CI because `os.chmod` accepts the call without error but the kernel does not enforce group/other bits, so the subsequent `st_mode` assertion fails.

The fix adds `@pytest.mark.skipif(sys.platform == "win32", ...)` to `test_mset_chmod` in `libs/langchain/tests/unit_tests/storage/test_filesystem.py`. No production code is changed.

Fixes #38329