### PR TITLE
fix(langchain): always include loop_entry_node in model-to-tools edge path_map

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1643,15 +1643,14 @@ def create_agent(
             tools_to_model_destinations,
         )
 
-        # base destinations are tools and exit_node
-        # we add the loop_entry node to edge destinations if:
-        # - there is an after model hook(s) -- allows jump_to to model
-        #   potentially artificially injected tool messages, ex HITL
-        # - there is a response format -- to allow for jumping to model to handle
-        #   regenerating structured output tool calls
-        model_to_tools_destinations = ["tools", exit_node]
-        if response_format or loop_exit_node != "model":
-            model_to_tools_destinations.append(loop_entry_node)
+        # The router (_make_model_to_tools_edge) returns model_destination on
+        # the "all tool calls already answered" branch regardless of whether
+        # response_format or after_model middleware are present. This happens
+        # whenever wrap_model_call middleware injects synthetic ToolMessages
+        # (e.g., HITL pre-approval, caching, replay). Always include
+        # loop_entry_node so LangGraph's branch dispatcher never raises
+        # KeyError when the router selects that destination.
+        model_to_tools_destinations = ["tools", exit_node, loop_entry_node]
 
         graph.add_conditional_edges(
             loop_exit_node,


### PR DESCRIPTION
`_make_model_to_tools_edge` returns `model_destination` on the "all pending tool calls already answered" branch regardless of whether `response_format` or `after_model` middleware are present. `create_agent` previously only added `loop_entry_node` to the conditional-edge path_map when `response_format` was set or `loop_exit_node != "model"`. When `wrap_model_call` middleware injects synthetic `ToolMessage`s (caching, HITL pre-approval, replay) the router picks `model_destination` but it is absent from the path_map, and LangGraph's branch dispatcher raises `KeyError('model')`.

The fix unconditionally includes `loop_entry_node` in `model_to_tools_destinations`. When `loop_entry_node == "model"` the list already contains `"model"` via the tools-entry check, so the extra element is a harmless duplicate in the dedup pass. Existing configurations where the router never selects that branch are unaffected.

Fixes #38351