### PR TITLE
fix(langchain): prevent orphan ToolMessages in SummarizationMiddleware cutoff

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -782,13 +782,20 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
                 tool_call_ids.add(tool_msg.tool_call_id)
             idx += 1
 
-        # Search backward for AIMessage with matching tool_calls
+        # Search backward for an AIMessage whose tool_calls fully cover every id
+        # in the cutoff run. A partial intersection means some ToolMessages in the
+        # run are orphaned (their originating AIMessage was already summarized
+        # away), so we keep walking until we find a full cover or exhaust the
+        # history.
+        remaining_ids = set(tool_call_ids)
         for i in range(cutoff_index - 1, -1, -1):
             msg = messages[i]
             if isinstance(msg, AIMessage) and msg.tool_calls:
                 ai_tool_call_ids = {tc.get("id") for tc in msg.tool_calls if tc.get("id")}
-                if tool_call_ids & ai_tool_call_ids:
-                    # Found the AIMessage - move cutoff to include it
+                remaining_ids -= ai_tool_call_ids
+                if not remaining_ids:
+                    # All tool_call_ids in the cutoff run are now accounted for;
+                    # place the cutoff just before this AIMessage.
                     return i
 
         # Fallback: no matching AIMessage found, advance past ToolMessages to avoid


### PR DESCRIPTION
`SummarizationMiddleware._find_safe_cutoff_point` used set intersection to detect a matching `AIMessage` when the cutoff landed on a `ToolMessage` run. In conversations where one `tool_call_id` in the run belongs to a surviving `AIMessage` while another belongs to an `AIMessage` that was already summarized away, the intersection matched prematurely and left the mismatched `ToolMessage` as an orphan in the preserved slice. On the next LLM call providers reject the input with a 400 error (OpenAI: "tool must be a response to a preceding message with tool_calls"; Anthropic: "tool_use_id has no matching tool_result").

The fix accumulates remaining unmatched IDs as we walk backward and only places the cutoff once every ID in the cutoff run is fully covered by `AIMessage`s encountered so far. If coverage is never complete we fall through to the existing advance-forward fallback, which is the safer choice.

Fixes #38352