### PR TITLE
fix: core: docstrings shouldn't inherit from parents

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -124,6 +124,19 @@ def _get_annotation_description(arg_type: type) -> str | None:
     return None
 
 
+def _get_docstring(obj: Callable[..., Any]) -> str | None:
+    """Get an object's docstring without inheriting it from parent classes.
+
+    `inspect.getdoc` walks the MRO for classes, which means a tool created from a
+    subclass would inherit its parent's docstring. We don't want that for tool
+    descriptions, so for classes we only consider the class's own ``__doc__``.
+    """
+    if isinstance(obj, type):
+        doc = obj.__dict__.get("__doc__")
+        return inspect.cleandoc(doc) if isinstance(doc, str) else None
+    return inspect.getdoc(obj)
+
+
 def _parse_python_function_docstring(
     function: Callable[..., Any],
     annotations: dict[str, Any],
@@ -142,7 +155,7 @@ def _parse_python_function_docstring(
     Returns:
         A tuple containing the function description and argument descriptions.
     """
-    docstring = inspect.getdoc(function)
+    docstring = _get_docstring(function)
     return _parse_google_docstring(
         docstring,
         list(annotations),
@@ -190,7 +203,7 @@ def _infer_arg_descriptions(
             fn, annotations, error_on_invalid_docstring=error_on_invalid_docstring
         )
     else:
-        description = inspect.getdoc(fn) or ""
+        description = _get_docstring(fn) or ""
         arg_descriptions = {}
     if parse_docstring:
         _validate_docstring_args_against_annotations(arg_descriptions, annotations)

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -230,6 +230,11 @@ class StructuredTool(BaseTool):
                     f"got {args_schema}"
                 )
                 raise TypeError(msg)
+        if description_ is None and isinstance(source_function, type):
+            # Tools created from a class may omit a docstring. Unlike functions,
+            # they default to an empty description instead of raising, and they do
+            # not inherit a description from parent classes.
+            description_ = ""
         if description_ is None:
             msg = "Function must have a docstring if description not provided."
             raise ValueError(msg)

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -770,6 +770,31 @@ def test_missing_docstring() -> None:
     assert not MyTool.description  # type: ignore[attr-defined]
 
 
+def test_tool_class_docstring_not_inherited() -> None:
+    """A tool created from a class should not inherit its parent's docstring."""
+
+    class ParentTool(BaseModel):
+        """Parent Tool."""
+
+        foo: str
+
+    @tool
+    class ChildTool(ParentTool):
+        bar: str
+
+    # The child has no docstring of its own, so its description must be empty
+    # rather than inheriting "Parent Tool." from the parent.
+    assert not ChildTool.description  # type: ignore[attr-defined]
+
+    @tool
+    class DocumentedChildTool(ParentTool):
+        """Child Tool."""
+
+        bar: str
+
+    assert DocumentedChildTool.description == "Child Tool."  # type: ignore[attr-defined]
+
+
 def test_create_tool_positional_args() -> None:
     """Test that positional arguments are allowed."""
     test_tool = Tool("test_name", lambda x: x, "test_description")


### PR DESCRIPTION
## Summary

When `@tool` is applied to a `BaseModel` subclass, the tool description is inferred from the class docstring during schema generation. The inference used `inspect.getdoc(fn)` in `_infer_arg_descriptions` and `_parse_python_function_docstring` (in `libs/core/langchain_core/tools/base.py`).


## Root cause

When `@tool` is applied to a `BaseModel` subclass, the tool description is inferred
from the class docstring during schema generation. The inference used
`inspect.getdoc(fn)` in `_infer_arg_descriptions` and `_parse_python_function_docstring`
(in `libs/core/langchain_core/tools/base.py`). `inspect.getdoc` walks the class MRO,
so a subclass without its own docstring inherits the parent's docstring.

In the issue example, `ChildTool` has no docstring of its own, but
`inspect.getdoc(ChildTool)` returned `"Parent Tool"` from `MyTool`. That value was
written onto the generated args schema, and `StructuredTool.from_function` then picked
it up as the tool description. So the child tool wrongly got the parent's description.


## What changed

- `libs/core/langchain_core/tools/base.py`
 - Added a small helper `_get_docstring`. For classes it reads only the class's own
 `__dict__["__doc__"]` (cleaned with `inspect.cleandoc`), so docstrings are not
 inherited from parents. For everything else it delegates to `inspect.getdoc`,
 preserving existing behavior for functions and methods.
 - Switched `_parse_python_function_docstring` and `_infer_arg_descriptions` to use
 `_get_docstring` instead of `inspect.getdoc`.

- `libs/core/langchain_core/tools/structured.py`
 - In `StructuredTool.from_function`, when the source is a class and no description
 could be resolved, default the description to an empty string instead of raising.
 Classes legitimately may omit a docstring (functions still raise), and they should
 not inherit a description from a parent class.

- `libs/core/tests/unit_tests/test_tools.py`
 - Added `test_tool_class_docstring_not_inherited` covering both a child class without
 a docstring (empty description) and a child class with its own docstring (uses its
 own).


## Issue

Fixes #32066

Issue: https://github.com/langchain-ai/langchain/issues/32066


## Diffstat

```
libs/core/langchain_core/tools/base.py | 17 +++++++++++++++--
 libs/core/langchain_core/tools/structured.py | 5 +++++
 libs/core/tests/unit_tests/test_tools.py | 25 +++++++++++++++++++++++++
 3 files changed, 45 insertions(+), 2 deletions(-)
```


## Testing


- Ran the relevant tests and linter for the changed files while developing.

- Kept the change minimal and focused on this one issue.


## AI assistance


I used GitHub Copilot to help write parts of this change. I've reviewed and tested it myself, I understand what it does, and I'll follow up on any review feedback.