### PR TITLE
fix(core): preserve bool metadata in merge_dicts

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -68,6 +68,9 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 merged[right_k] = merge_lists(merged[right_k], right_v)
             elif merged[right_k] == right_v:
                 continue
+            elif isinstance(merged[right_k], bool):
+                # bool is a subclass of int, so handle booleans before summing ints.
+                merged[right_k] = right_v
             elif isinstance(merged[right_k], int):
                 # Preserve identification and temporal fields using last-wins strategy
                 # instead of summing:

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -117,6 +117,10 @@ def test_check_package_version(
             {"a": [{"idx": 0, "b": "f"}]},
             {"a": [{"idx": 0, "b": "{"}, {"idx": 0, "b": "f"}]},
         ),
+        # Boolean metadata should not be coerced into integer sums
+        ({"cached": False}, {"cached": True}, {"cached": True}),
+        ({"cached": True}, {"cached": False}, {"cached": False}),
+        ({"cached": True}, {"cached": True}, {"cached": True}),
         # Integer 'index' should be preserved, not summed (tool call identification)
         ({"index": 1}, {"index": 1}, {"index": 1}),
         ({"index": 0}, {"index": 1}, {"index": 1}),


### PR DESCRIPTION
## Summary

Fixes #38064

`merge_dicts` treated conflicting boolean metadata as integers because `bool` is a subclass of `int`. This could silently turn values like `False + True` into `1` during streaming chunk aggregation.

## Changes

- Handle `bool` values in `merge_dicts` before the `int` merge branch.
- Use last-wins semantics for conflicting boolean values across chunks.
- Add regression tests in `libs/core/tests/unit_tests/utils/test_utils.py`.

## Verification

- `uv run --group test pytest tests/unit_tests/utils/test_utils.py -k test_merge_dicts -q` → 32 passed, 2 xfailed
- `uv run --group lint ruff check langchain_core/utils/_merge.py tests/unit_tests/utils/test_utils.py` → passed
- `uv run --group lint mypy langchain_core/utils/_merge.py` → passed
