### PR TITLE
fix(core): cache implementing __len__ makes generate/agenerate raise KeyError

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1872,9 +1872,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         # We should check the cache unless it's explicitly set to False
         # A None cache means we should use the default global cache
         # if it's configured.
-        check_cache = self.cache or self.cache is None
+        check_cache = self.cache is not False
         if check_cache:
-            if llm_cache:
+            if llm_cache is not None:
                 llm_string = self._get_llm_string(stop=stop, **kwargs)
                 normalized_messages = [
                     (
@@ -2016,7 +2016,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 **result.llm_output,
                 **result.generations[0].message.response_metadata,
             }
-        if check_cache and llm_cache:
+        if check_cache and llm_cache is not None:
             llm_cache.update(prompt, llm_string, result.generations)
         return result
 
@@ -2031,9 +2031,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         # We should check the cache unless it's explicitly set to False
         # A None cache means we should use the default global cache
         # if it's configured.
-        check_cache = self.cache or self.cache is None
+        check_cache = self.cache is not False
         if check_cache:
-            if llm_cache:
+            if llm_cache is not None:
                 llm_string = self._get_llm_string(stop=stop, **kwargs)
                 normalized_messages = [
                     (
@@ -2173,7 +2173,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 **result.llm_output,
                 **result.generations[0].message.response_metadata,
             }
-        if check_cache and llm_cache:
+        if check_cache and llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result.generations)
         return result
 

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -182,7 +182,7 @@ def get_prompts(
 
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = llm_cache.lookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -217,7 +217,7 @@ async def aget_prompts(
     existing_prompts = {}
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = await llm_cache.alookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -288,7 +288,7 @@ async def aupdate_cache(
     for i, result in enumerate(new_results.generations):
         existing_prompts[missing_prompt_idxs[i]] = result
         prompt = prompts[missing_prompt_idxs[i]]
-        if llm_cache:
+        if llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result)
     return new_results.llm_output
 

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_cache.py
@@ -39,6 +39,14 @@ class InMemoryCache(BaseCache):
         self._cache = {}
 
 
+class SizedInMemoryCache(InMemoryCache):
+    """In-memory cache that exposes its size."""
+
+    def __len__(self) -> int:
+        """Return the number of cached entries."""
+        return len(self._cache)
+
+
 def test_local_cache_sync() -> None:
     """Test that the local cache is being populated but not the global one."""
     global_cache = InMemoryCache()
@@ -99,6 +107,26 @@ async def test_local_cache_async() -> None:
         assert len(local_cache._cache) == 2
     finally:
         set_llm_cache(None)
+
+
+def test_sized_local_cache_sync() -> None:
+    """Test that an empty cache with __len__ is still used."""
+    local_cache = SizedInMemoryCache()
+    chat_model = FakeListChatModel(cache=local_cache, responses=["hello", "goodbye"])
+
+    assert chat_model.invoke("How are you?").content == "hello"
+    assert chat_model.invoke("How are you?").content == "hello"
+    assert len(local_cache) == 1
+
+
+async def test_sized_local_cache_async() -> None:
+    """Test that an empty cache with __len__ is still used asynchronously."""
+    local_cache = SizedInMemoryCache()
+    chat_model = FakeListChatModel(cache=local_cache, responses=["hello", "goodbye"])
+
+    assert (await chat_model.ainvoke("How are you?")).content == "hello"
+    assert (await chat_model.ainvoke("How are you?")).content == "hello"
+    assert len(local_cache) == 1
 
 
 def test_global_cache_sync() -> None:

--- a/libs/core/tests/unit_tests/language_models/llms/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/llms/test_cache.py
@@ -28,6 +28,14 @@ class InMemoryCache(BaseCache):
         self._cache = {}
 
 
+class SizedInMemoryCache(InMemoryCache):
+    """In-memory cache that exposes its size."""
+
+    def __len__(self) -> int:
+        """Return the number of cached entries."""
+        return len(self._cache)
+
+
 async def test_local_cache_generate_async() -> None:
     global_cache = InMemoryCache()
     local_cache = InMemoryCache()
@@ -58,6 +66,28 @@ def test_local_cache_generate_sync() -> None:
         assert len(local_cache._cache) == 1
     finally:
         set_llm_cache(None)
+
+
+def test_sized_local_cache_generate_sync() -> None:
+    local_cache = SizedInMemoryCache()
+    llm = FakeListLLM(cache=local_cache, responses=["foo", "bar"])
+
+    output = llm.generate(["foo"])
+    assert output.generations[0][0].text == "foo"
+    output = llm.generate(["foo"])
+    assert output.generations[0][0].text == "foo"
+    assert len(local_cache) == 1
+
+
+async def test_sized_local_cache_generate_async() -> None:
+    local_cache = SizedInMemoryCache()
+    llm = FakeListLLM(cache=local_cache, responses=["foo", "bar"])
+
+    output = await llm.agenerate(["foo"])
+    assert output.generations[0][0].text == "foo"
+    output = await llm.agenerate(["foo"])
+    assert output.generations[0][0].text == "foo"
+    assert len(local_cache) == 1
 
 
 class InMemoryCacheBad(BaseCache):


### PR DESCRIPTION
## Description

Fixes #38440

Cache classes that implement `__len__` (a common pattern for reporting entry count) cause `generate` and `agenerate` to raise `KeyError` when the cache is empty. This is because an empty cache with `__len__` returns 0 (falsy), so the truthiness check `if llm_cache:` skips cache lookup entirely, leaving `existing_prompts` empty.

### Root Cause

In `langchain-core`, several places used `if llm_cache:` (truthiness check) instead of `if llm_cache is not None:` (identity check):

**llms.py:**
- `get_prompts` (line 185): `if llm_cache:` → `if llm_cache is not None:`
- `aget_prompts` (line 220): `if llm_cache:` → `if llm_cache is not None:`
- `aupdate_cache` (line 291): `if llm_cache:` → `if llm_cache is not None:`

**chat_models.py:**
- `generate` (line 1877): `check_cache = self.cache or self.cache is None` → `check_cache = self.cache is not False`
- `generate` (line 1877): `if llm_cache:` → `if llm_cache is not None:`
- `generate` (line 2036): `if check_cache and llm_cache:` → `if check_cache and llm_cache is not None:`
- `agenerate` (line 2031): same pattern

### Fix

Changed all 7 occurrences from truthiness checks to `is not None` checks, matching the existing pattern used in `update_cache` (sync).

### Tests

Added regression tests with `SizedInMemoryCache` (cache implementing `__len__`) for both LLM and chat model paths:

- `test_sized_local_cache_generate_sync`
- `test_sized_local_cache_generate_async`
- `test_sized_local_cache_sync`
- `test_sized_local_cache_async`

All existing cache tests continue to pass.

## Verification

```
$ python -m pytest tests/unit_tests/language_models/llms/test_cache.py tests/unit_tests/language_models/chat_models/test_cache.py -v
...
tests/unit_tests/language_models/llms/test_cache.py::test_sized_local_cache_generate_sync PASSED
tests/unit_tests/language_models/llms/test_cache.py::test_sized_local_cache_generate_async PASSED
tests/unit_tests/language_models/chat_models/test_cache.py::test_sized_local_cache_sync PASSED
tests/unit_tests/language_models/chat_models/test_cache.py::test_sized_local_cache_async PASSED
```