### PR TITLE
fix(anthropic): preserve cache_control on tool_use blocks when tool_calls exist

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -546,6 +546,7 @@ def _format_messages(
                             content.extend(
                                 _lc_tool_calls_to_anthropic_tool_use_blocks(
                                     overlapping,
+                                    cache_control=block.get("cache_control"),
                                 ),
                             )
                         else:
@@ -2279,12 +2280,14 @@ class _AnthropicToolUse(TypedDict):
     input: dict
     id: str
     caller: NotRequired[dict[str, Any]]
+    cache_control: NotRequired[dict[str, Any]]
 
 
 def _lc_tool_calls_to_anthropic_tool_use_blocks(
     tool_calls: list[ToolCall],
+    cache_control: dict[str, Any] | None = None,
 ) -> list[_AnthropicToolUse]:
-    return [
+    blocks = [
         _AnthropicToolUse(
             type="tool_use",
             name=tool_call["name"],
@@ -2293,6 +2296,10 @@ def _lc_tool_calls_to_anthropic_tool_use_blocks(
         )
         for tool_call in tool_calls
     ]
+    if cache_control is not None:
+        for block in blocks:
+            block["cache_control"] = cache_control
+    return blocks
 
 
 def _convert_to_anthropic_output_config_format(schema: dict | type) -> dict[str, Any]:

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1116,6 +1116,68 @@ def test__format_messages_with_tool_use_blocks_and_tool_calls() -> None:
     assert expected == actual
 
 
+def test__format_messages_tool_use_cache_control_preserved_with_tool_calls() -> None:
+    """Test that cache_control on a tool_use block is preserved when a matching
+    tool_calls item exists.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38398
+    """
+    ai = AIMessage(
+        content=[
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+        tool_calls=[{"name": "get_weather", "args": {"city": "Paris"}, "id": "toolu_1"}],
+    )
+    messages = [HumanMessage("weather?"), ai]
+    _, formatted = _format_messages(messages)
+    assistant_content = formatted[-1]["content"]
+
+    # cache_control must survive the tool_calls → tool_use rebuild
+    assert any(
+        isinstance(b, dict) and b.get("cache_control") == {"type": "ephemeral"}
+        for b in assistant_content
+    ), "cache_control was silently dropped from tool_use block"
+
+    # The tool_use block should use args from tool_calls (preferred) but keep cache_control
+    tool_use_blocks = [
+        b for b in assistant_content if isinstance(b, dict) and b.get("type") == "tool_use"
+    ]
+    assert len(tool_use_blocks) == 1
+    assert tool_use_blocks[0]["input"] == {"city": "Paris"}
+    assert tool_use_blocks[0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test__format_messages_tool_use_no_cache_control_without_it() -> None:
+    """Test that tool_use blocks without cache_control don't get one added."""
+    ai = AIMessage(
+        content=[
+            {
+                "type": "tool_use",
+                "id": "toolu_2",
+                "name": "get_weather",
+                "input": {"city": "London"},
+            },
+        ],
+        tool_calls=[{"name": "get_weather", "args": {"city": "London"}, "id": "toolu_2"}],
+    )
+    messages = [HumanMessage("weather?"), ai]
+    _, formatted = _format_messages(messages)
+    assistant_content = formatted[-1]["content"]
+
+    tool_use_blocks = [
+        b for b in assistant_content if isinstance(b, dict) and b.get("type") == "tool_use"
+    ]
+    assert len(tool_use_blocks) == 1
+    assert "cache_control" not in tool_use_blocks[0]
+
+
 def test__format_messages_with_cache_control() -> None:
     messages = [
         SystemMessage(


### PR DESCRIPTION
## Summary

When an `AIMessage` has a `tool_use` content block with `cache_control` **and** a matching `tool_calls` entry, `_format_messages` rebuilds the block from `tool_calls` (the preferred source). Previously this discarded `cache_control` along with all other extra keys, silently dropping prompt-cache breakpoints.

## Root Cause

In `_format_messages` (line ~533), the `tool_use` branch calls `_lc_tool_calls_to_anthropic_tool_use_blocks()` to rebuild from `tool_calls`, but that function only copies `type`, `name`, `input`, and `id` — it never looks at `cache_control` from the original block.

## Fix

- Added `cache_control` as an optional field to `_AnthropicToolUse` TypedDict.
- Added a `cache_control` parameter to `_lc_tool_calls_to_anthropic_tool_use_blocks()` — when provided, it's applied to all generated blocks.
- The call site now passes `block.get("cache_control")` from the original content block.

## Tests

- `test__format_messages_tool_use_cache_control_preserved_with_tool_calls` — verifies `cache_control` survives the rebuild.
- `test__format_messages_tool_use_no_cache_control_without_it` — verifies blocks without `cache_control` remain clean.

Fixes #38398

🤖 Generated with [Claude Code](https://claude.com/claude-code)