### PR TITLE
fix(core): prevent merge_dicts from concatenating identical metadata strings

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,67 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # Identical metadata strings should be preserved, not concatenated
+        # (model_name, finish_reason, etc. from streaming chunks)
+        (
+            {"model_name": "gpt-4"},
+            {"model_name": "gpt-4"},
+            {"model_name": "gpt-4"},
+        ),
+        (
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+        ),
+        (
+            {"native_finish_reason": "stop"},
+            {"native_finish_reason": "stop"},
+            {"native_finish_reason": "stop"},
+        ),
+        (
+            {"object": "chat.completion.chunk"},
+            {"object": "chat.completion.chunk"},
+            {"object": "chat.completion.chunk"},
+        ),
+        (
+            {"system_fingerprint": "fp_123"},
+            {"system_fingerprint": "fp_123"},
+            {"system_fingerprint": "fp_123"},
+        ),
+        (
+            {"format": "json"},
+            {"format": "json"},
+            {"format": "json"},
+        ),
+        # Different strings for these keys should still be concatenated
+        (
+            {"model_name": "gpt-4"},
+            {"model_name": "-turbo"},
+            {"model_name": "gpt-4-turbo"},
+        ),
+        (
+            {"finish_reason": "sto"},
+            {"finish_reason": "p"},
+            {"finish_reason": "stop"},
+        ),
+        # Multiple metadata fields in a single merge
+        (
+            {
+                "model_name": "deepseek/deepseek-v4-pro",
+                "finish_reason": "stop",
+                "object": "chat.completion.chunk",
+            },
+            {
+                "model_name": "deepseek/deepseek-v4-pro",
+                "finish_reason": "stop",
+                "object": "chat.completion.chunk",
+            },
+            {
+                "model_name": "deepseek/deepseek-v4-pro",
+                "finish_reason": "stop",
+                "object": "chat.completion.chunk",
+            },
+        ),
     ],
 )
 def test_merge_dicts(


### PR DESCRIPTION
## Description

When streaming chunks from providers like OpenRouter that send multiple terminal chunks with identical metadata (`model_name`, `finish_reason`, etc.), `merge_dicts` was concatenating these identical strings instead of preserving them.

**Example**: `model_name: "gpt-4"` + `model_name: "gpt-4"` would become `model_name: "gpt-4gpt-4"`.

This fix extends the existing deduplication guard (previously only for `id`, `output_version`, `model_provider`) to also cover:
- `model_name`
- `finish_reason`
- `native_finish_reason`
- `object`
- `system_fingerprint`
- `format`

## Root Cause

In `merge_dicts` (at `libs/core/langchain_core/utils/_merge.py`), when both values are strings and identical, the code falls through to `merged[right_k] += right_v`, causing self-concatenation.

## Fix

Extended the set of keys that skip concatenation when values are equal (same pattern already used for `model_provider`).

## Tests Added

- Each protected key individually (identical values preserved)
- Different values for these keys still concatenate correctly
- Multiple metadata fields in a single merge operation

Fixes #38366