### PR TITLE
fix(agents): include loop_entry_node in model_to_tools destinations unconditionally

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1643,15 +1643,13 @@ def create_agent(
             tools_to_model_destinations,
         )
 
-        # base destinations are tools and exit_node
-        # we add the loop_entry node to edge destinations if:
-        # - there is an after model hook(s) -- allows jump_to to model
-        #   potentially artificially injected tool messages, ex HITL
-        # - there is a response format -- to allow for jumping to model to handle
-        #   regenerating structured output tool calls
-        model_to_tools_destinations = ["tools", exit_node]
-        if response_format or loop_exit_node != "model":
-            model_to_tools_destinations.append(loop_entry_node)
+        # The router (_make_model_to_tools_edge) can return model_destination
+        # (loop_entry_node) on the "artificial tool messages" branch in EVERY
+        # config, not just when response_format or after_model are present.
+        # A wrap_model_call middleware that injects synthetic ToolMessages
+        # produces this scenario (documented pattern for caching, HITL
+        # pre-approval, and replay).
+        model_to_tools_destinations = ["tools", exit_node, loop_entry_node]
 
         graph.add_conditional_edges(
             loop_exit_node,

--- a/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_return_direct_graph.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/__snapshots__/test_return_direct_graph.ambr
@@ -16,6 +16,7 @@
   	model -.-> tools;
   	tools -.-> __end__;
   	tools -.-> model;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -39,6 +40,7 @@
   	model -.-> tools;
   	tools -.-> __end__;
   	tools -.-> model;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -61,6 +63,7 @@
   	model -.-> __end__;
   	model -.-> tools;
   	tools -.-> model;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/__snapshots__/test_framework.ambr
@@ -22,6 +22,7 @@
   	model -.-> tools;
   	tools -.-> model;
   	NoopOne\2eafter_agent --> __end__;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc
@@ -29,134 +30,6 @@
   '''
 # ---
 # name: test_create_agent_jump[memory]
-  '''
-  ---
-  config:
-    flowchart:
-      curve: linear
-  ---
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	model(model)
-  	tools(tools)
-  	NoopSeven\2ebefore_model(NoopSeven.before_model)
-  	NoopSeven\2eafter_model(NoopSeven.after_model)
-  	NoopEight\2ebefore_model(NoopEight.before_model)
-  	NoopEight\2eafter_model(NoopEight.after_model)
-  	__end__([<p>__end__</p>]):::last
-  	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
-  	NoopEight\2ebefore_model -.-> model;
-  	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
-  	NoopSeven\2eafter_model -.-> tools;
-  	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
-  	__start__ --> NoopSeven\2ebefore_model;
-  	model --> NoopEight\2eafter_model;
-  	tools -.-> NoopSeven\2ebefore_model;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_create_agent_jump[postgres]
-  '''
-  ---
-  config:
-    flowchart:
-      curve: linear
-  ---
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	model(model)
-  	tools(tools)
-  	NoopSeven\2ebefore_model(NoopSeven.before_model)
-  	NoopSeven\2eafter_model(NoopSeven.after_model)
-  	NoopEight\2ebefore_model(NoopEight.before_model)
-  	NoopEight\2eafter_model(NoopEight.after_model)
-  	__end__([<p>__end__</p>]):::last
-  	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
-  	NoopEight\2ebefore_model -.-> model;
-  	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
-  	NoopSeven\2eafter_model -.-> tools;
-  	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
-  	__start__ --> NoopSeven\2ebefore_model;
-  	model --> NoopEight\2eafter_model;
-  	tools -.-> NoopSeven\2ebefore_model;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_create_agent_jump[postgres_pipe]
-  '''
-  ---
-  config:
-    flowchart:
-      curve: linear
-  ---
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	model(model)
-  	tools(tools)
-  	NoopSeven\2ebefore_model(NoopSeven.before_model)
-  	NoopSeven\2eafter_model(NoopSeven.after_model)
-  	NoopEight\2ebefore_model(NoopEight.before_model)
-  	NoopEight\2eafter_model(NoopEight.after_model)
-  	__end__([<p>__end__</p>]):::last
-  	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
-  	NoopEight\2ebefore_model -.-> model;
-  	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
-  	NoopSeven\2eafter_model -.-> tools;
-  	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
-  	__start__ --> NoopSeven\2ebefore_model;
-  	model --> NoopEight\2eafter_model;
-  	tools -.-> NoopSeven\2ebefore_model;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_create_agent_jump[postgres_pool]
-  '''
-  ---
-  config:
-    flowchart:
-      curve: linear
-  ---
-  graph TD;
-  	__start__([<p>__start__</p>]):::first
-  	model(model)
-  	tools(tools)
-  	NoopSeven\2ebefore_model(NoopSeven.before_model)
-  	NoopSeven\2eafter_model(NoopSeven.after_model)
-  	NoopEight\2ebefore_model(NoopEight.before_model)
-  	NoopEight\2eafter_model(NoopEight.after_model)
-  	__end__([<p>__end__</p>]):::last
-  	NoopEight\2eafter_model --> NoopSeven\2eafter_model;
-  	NoopEight\2ebefore_model -.-> __end__;
-  	NoopEight\2ebefore_model -.-> model;
-  	NoopSeven\2eafter_model -.-> NoopSeven\2ebefore_model;
-  	NoopSeven\2eafter_model -.-> __end__;
-  	NoopSeven\2eafter_model -.-> tools;
-  	NoopSeven\2ebefore_model --> NoopEight\2ebefore_model;
-  	__start__ --> NoopSeven\2ebefore_model;
-  	model --> NoopEight\2eafter_model;
-  	tools -.-> NoopSeven\2ebefore_model;
-  	classDef default fill:#f2f0ff,line-height:1.2
-  	classDef first fill-opacity:0
-  	classDef last fill:#bfb6fc
-  
-  '''
-# ---
-# name: test_create_agent_jump[sqlite]
   '''
   ---
   config:
@@ -204,6 +77,7 @@
   	model -.-> __end__;
   	model -.-> tools;
   	tools -.-> model;
+  	model -.-> model;
   	classDef default fill:#f2f0ff,line-height:1.2
   	classDef first fill-opacity:0
   	classDef last fill:#bfb6fc

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_wrap_model_call_state_update.py
@@ -6,10 +6,12 @@ updates through graph reducers (e.g. add_messages for messages).
 """
 
 from collections.abc import Awaitable, Callable
+from typing import Any
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
 from langgraph.errors import InvalidUpdateError
 from langgraph.types import Command
 from typing_extensions import override
@@ -917,3 +919,88 @@ class TestCommandGraphDisallowed:
 
         with pytest.raises(NotImplementedError, match="Command graph is not yet supported"):
             await agent.ainvoke({"messages": [HumanMessage(content="Hi")]})
+
+
+class TestSyntheticToolMessageInjection:
+    """Test wrap_model_call middleware that injects synthetic ToolMessages.
+
+    This reproduces the bug from langchain-ai/langchain#38351 where a
+    wrap_model_call middleware injecting synthetic ToolMessages causes
+    KeyError('model') because the path_map omits the model destination.
+    """
+
+    def test_synthetic_tool_messages_route_back_to_model(self) -> None:
+        """Middleware injecting synthetic ToolMessages should allow routing back to model.
+
+        When a wrap_model_call middleware injects synthetic ToolMessages for every
+        tool_call (e.g., for caching, HITL pre-approval, or replay), the agent should
+        route back to the model node instead of raising KeyError('model').
+        """
+
+        class ToolBindFakeModel(GenericFakeChatModel):
+            def bind_tools(self, tools: Any, **kw: Any) -> Any:  # noqa: ANN001
+                return self
+
+        @tool
+        def foo(x: int) -> int:
+            """A trivial tool the agent can call."""
+            return x + 1
+
+        class InjectToolMessageMiddleware(AgentMiddleware):
+            """Middleware that injects synthetic ToolMessages for every tool_call."""
+
+            name = "inject_tool_msg"
+
+            def wrap_model_call(
+                self,
+                request: ModelRequest,
+                handler: Callable[[ModelRequest], ModelResponse],
+            ) -> ExtendedModelResponse:
+                response = handler(request)
+                ai = response.result[0]
+                if isinstance(ai, AIMessage) and ai.tool_calls:
+                    synthetic = [
+                        ToolMessage(
+                            content="cached",
+                            tool_call_id=tc["id"],
+                            name=tc["name"],
+                        )
+                        for tc in ai.tool_calls
+                    ]
+                    return ExtendedModelResponse(
+                        model_response=response,
+                        command=Command(update={"messages": synthetic}),
+                    )
+                return response
+
+        fake = ToolBindFakeModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "foo",
+                                "args": {"x": 1},
+                                "id": "call_xyz",
+                                "type": "tool_call",
+                            },
+                        ],
+                    ),
+                    AIMessage(content="done"),
+                ]
+            )
+        )
+        agent = create_agent(
+            model=fake,
+            tools=[foo],
+            middleware=[InjectToolMessageMiddleware()],
+        )
+
+        # Should not raise KeyError('model')
+        result = agent.invoke({"messages": [HumanMessage(content="hi")]})
+
+        # Verify the agent completed successfully
+        assert "messages" in result
+        # The final message should be the "done" response
+        assert result["messages"][-1].content == "done"


### PR DESCRIPTION
## Summary

Fixes KeyError('model') when a  middleware injects synthetic ToolMessages (e.g., for caching, HITL pre-approval, or replay).

## Problem

The  router can return  (loop_entry_node) on the "artificial tool messages" branch in **every** configuration, not just when  or  middleware are present. However, the path_map only included  when those conditions were true, causing KeyError('model') from langgraph's branch dispatcher.

## Root Cause

In  (line 1652-1654):

```python
model_to_tools_destinations = ["tools", exit_node]
if response_format or loop_exit_node != "model":
    model_to_tools_destinations.append(loop_entry_node)
```

This omitted  in the default configuration, but the router could still return it.

## Fix

Always include  in :

```python
model_to_tools_destinations = ["tools", exit_node, loop_entry_node]
```

## Test

Added  that reproduces the exact scenario from the issue:
- Model returns tool_calls
- Middleware injects synthetic ToolMessages via 
- Agent routes back to model node without KeyError

Fixes langchain-ai/langchain#38351