### PR TITLE
fix(chat_models): add o4- series models to automatic provider inference

### DIFF
--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -536,6 +536,7 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
             "gpt-",
             "o1",
             "o3",
+            "o4",
             "chatgpt",
             "text-davinci",
         )

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -80,6 +80,7 @@ def test_supported_providers_is_sorted() -> None:
     ("model_name", "expected_provider"),
     [
         (OPENAI_TEST_MODEL, "openai"),
+        ("o4-mini", "openai"),
         ("o3", "openai"),
         ("text-davinci-003", "openai"),
         ("claude-3-haiku-20240307", "anthropic"),


### PR DESCRIPTION
Fixes #38243

This change adds automatic provider inference support for OpenAI's newer o4-series models (such as `o4-mini`) inside `init_chat_model`. Users will no longer hit an error when passing `model="o4-mini"` without explicitly specifying `model_provider="openai"`.

---

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

Thank you for contributing to LangChain! Follow these steps to have your pull request considered as ready for review.

1. PR title: 
fix(chat_models): add o4- series models to automatic provider inference

2. PR description:
Added `"o4"` to the OpenAI prefix tuple inside `_attempt_infer_model_provider` and added a corresponding unit test case to prevent regressions.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.
- Environment constraints blocked a full local test run, but verified the code patch via a targeted `sys.path` evaluation script to ensure `o4-mini` resolves correctly. Relying on GitHub Actions CI to confirm full compliance.

4. How did you verify your code works?
Verified by explicitly checking that `_attempt_infer_model_provider('o4-mini')` returns `'openai'`.

## Social handles (optional)
Twitter: @
LinkedIn: https://www.linkedin.com/in/dushyant2005/