### PR TITLE
fix(core): Update check for BaseException in `agenerate`

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1812,7 +1812,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                             )
                         )
                         for run_manager, res in zip(run_managers, results, strict=False)
-                        if not isinstance(res, Exception)
+                        if not isinstance(res, BaseException)
                     ]
                 )
             raise exceptions[0]

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -235,6 +235,38 @@ async def test_stream_error_callback() -> None:
         eval_response(cb_sync, i)
 
 
+async def test_agenerate_reraises_base_exception() -> None:
+    """A `BaseException` (not just `Exception`) must surface from `agenerate`.
+
+    The `on_llm_end` filter must skip failed results, else it reads `.generations`
+    off the raised exception and masks it with `AttributeError`.
+    """
+
+    class _CustomBaseException(BaseException):
+        """A `BaseException` that is deliberately not an `Exception`."""
+
+    class _RaisingChatModel(BaseChatModel):
+        @property
+        def _llm_type(self) -> str:
+            return "raising-chat-model"
+
+        def _generate(self, *_args: Any, **_kwargs: Any) -> ChatResult:
+            raise _CustomBaseException
+
+        async def _agenerate(self, *_args: Any, **_kwargs: Any) -> ChatResult:
+            raise _CustomBaseException
+
+    model = _RaisingChatModel()
+    callback = FakeAsyncCallbackHandler()
+
+    # The original `BaseException` must surface, not an `AttributeError` from the
+    # `on_llm_end` cleanup path (which runs because a callback is attached).
+    with pytest.raises(_CustomBaseException):
+        await model.agenerate([[HumanMessage(content="hello")]], callbacks=[callback])
+
+    assert callback.errors == 1
+
+
 async def test_astream_fallback_to_ainvoke() -> None:
     """Test `astream()` uses appropriate implementation."""
 


### PR DESCRIPTION
Fixes #38469

---

 `BaseChatModel.agenerate` gathers its per-message `generations` with `asyncio.gather(..., return_exceptions=True)` and collects failures with an `isinstance(res, BaseException)` check. The follow-up `on_llm_end` step, however, filtered results with the narrower `isinstance(res, Exception)`. As there are `BaseException`s that are not an `Exception` (e.g., `KeyboardInterrupt`, `asyncio.CancelledError`), and `on_llm_end` reads the `generations` field off the raised exception, it raises an `AttributeError`. 

This PR addresses this discrepancy by updating the `isinstance` check, and introduces a unit test to validate.
                                                                                                                                             
