### PR TITLE
fix(langchain): infer openai provider for o4 model name prefix

### DIFF
--- a/libs/langchain/langchain_classic/chat_models/base.py
+++ b/libs/langchain/langchain_classic/chat_models/base.py
@@ -137,7 +137,7 @@ def init_chat_model(
 
             Inferred providers by prefix (case-insensitive):
 
-            - `gpt-...` | `o1...` | `o3...`               -> `openai`
+            - `gpt-...` | `o1...` | `o3...` | `o4...`       -> `openai`
             - `claude...`                                 -> `anthropic`
             - `amazon....` | `anthropic....` | `meta....` -> `bedrock`
             - `gemini...`                                 -> `google_vertexai`
@@ -566,6 +566,7 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
             "gpt-",
             "o1",
             "o3",
+            "o4",
             "chatgpt",
             "text-davinci",
         )

--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -251,7 +251,7 @@ def init_chat_model(
 
             Inferred providers by prefix (case-insensitive):
 
-            - `gpt-...` | `o1...` | `o3...`               -> `openai`
+            - `gpt-...` | `o1...` | `o3...` | `o4...`       -> `openai`
             - `claude...`                                 -> `anthropic`
             - `amazon....` | `anthropic....` | `meta....` -> `bedrock`
             - `gemini...`                                 -> `google_vertexai` (default changes in next major; pass `model_provider` to lock in)
@@ -536,6 +536,7 @@ def _attempt_infer_model_provider(model_name: str) -> str | None:
             "gpt-",
             "o1",
             "o3",
+            "o4",
             "chatgpt",
             "text-davinci",
         )

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -81,6 +81,7 @@ def test_supported_providers_is_sorted() -> None:
     [
         (OPENAI_TEST_MODEL, "openai"),
         ("o3", "openai"),
+        ("o4-mini", "openai"),
         ("text-davinci-003", "openai"),
         ("claude-3-haiku-20240307", "anthropic"),
         ("command-r-plus", "cohere"),


### PR DESCRIPTION
Fixes #38243

Adds the `o4` prefix to `_attempt_infer_model_provider` (alongside `o1`/`o3`) so `init_chat_model("o4-mini")` infers `openai` without an explicit `model_provider`.

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

## Changes
- `libs/langchain_v1/langchain/chat_models/base.py` — add `o4` to OpenAI prefix tuple + docstring
- `libs/langchain/langchain_classic/chat_models/base.py` — same parity fix for classic
- `libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py` — regression test for `o4-mini`

## Verification
- `uv run --group test pytest tests/unit_tests/chat_models/test_chat_models.py::test_attempt_infer_model_provider -v` (21 passed, including `o4-mini`)
- `make format` and `make lint` in `libs/langchain_v1`


Made with [Cursor](https://cursor.com)