### PR TITLE
fix(anthropic): read source path from `args["path"]` in file rename handlers

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -555,7 +555,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1054,7 +1054,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -1,5 +1,6 @@
 """Unit tests for Anthropic text editor and memory tool middleware."""
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,6 +9,7 @@ from langgraph.types import Command
 
 from langchain_anthropic.middleware.anthropic_tools import (
     AnthropicToolsState,
+    FilesystemClaudeTextEditorMiddleware,
     StateClaudeMemoryMiddleware,
     StateClaudeTextEditorMiddleware,
     _validate_path,
@@ -279,7 +281,14 @@ class TestFileOperations:
         assert files.get("/memories/test.txt") is None
 
     def test_rename_operation(self) -> None:
-        """Test rename command execution (memory only)."""
+        """Test rename command execution (memory only).
+
+        Regression test for a `KeyError` on `rename`: the tool builds the
+        handler `args` with the source under the `path` key (and the
+        destination under `new_path`), never under `old_path`. The handler
+        must therefore read the source from `args["path"]`, mirroring every
+        sibling handler.
+        """
         middleware = StateClaudeMemoryMiddleware()
 
         state: AnthropicToolsState = {
@@ -293,9 +302,11 @@ class TestFileOperations:
             },
         }
 
+        # Mirror exactly what the tool produces: source path under "path",
+        # destination under "new_path". No "old_path" key is ever populated.
         args = {
             "command": "rename",
-            "old_path": "/memories/old.txt",
+            "path": "/memories/old.txt",
             "new_path": "/memories/new.txt",
         }
         result = middleware._handle_rename(args, state, "test_id")
@@ -308,6 +319,36 @@ class TestFileOperations:
         # New path has the file data
         assert files.get("/memories/new.txt") is not None
         assert files["/memories/new.txt"]["content"] == ["line1"]
+
+    def test_filesystem_rename_operation(self, tmp_path: Path) -> None:
+        """Test rename command execution for the filesystem middleware.
+
+        Regression test mirroring `test_rename_operation` for the
+        filesystem-backed middleware: the source path arrives under the
+        `path` key, so the handler must read it from `args["path"]`.
+        """
+        middleware = FilesystemClaudeTextEditorMiddleware(root_path=str(tmp_path))
+
+        # Create a file to rename, mirroring what the tool produces.
+        create_args = {
+            "command": "create",
+            "path": "/old.txt",
+            "file_text": "line1\n",
+        }
+        middleware._handle_create(create_args, "test_id")
+
+        # Source path under "path", destination under "new_path".
+        rename_args = {
+            "command": "rename",
+            "path": "/old.txt",
+            "new_path": "/new.txt",
+        }
+        result = middleware._handle_rename(rename_args, "test_id")
+
+        assert isinstance(result, Command)
+        assert not (tmp_path / "old.txt").exists()
+        assert (tmp_path / "new.txt").exists()
+        assert "line1" in (tmp_path / "new.txt").read_text()
 
 
 class TestSystemMessageHandling:


### PR DESCRIPTION
Closes #38465

---

Anyone using the Claude text editor or memory middleware hits a hard crash the moment the model tries to rename a file: every `rename` command raised `KeyError: 'old_path'`, so the operation could never succeed.

The cause is a small key mismatch. When the tool prepares the arguments for its handlers, it stores the file being operated on under the `path` key and, for renames, the destination under `new_path`. It never sets an `old_path` key. Yet both `_handle_rename` methods (the state-backed one and the filesystem-backed one) read the source from `args["old_path"]`, which simply isn't there. Every sibling handler — `_handle_view`, `_handle_create`, `_handle_str_replace`, `_handle_insert`, and `_handle_delete` — already reads `args["path"]`, so `rename` was the odd one out.

The fix is to read the source path from `args["path"]` in both `_handle_rename` methods, matching what the tool actually produces and bringing `rename` in line with its siblings. The destination still comes from `args["new_path"]`.

The existing `rename` unit test passed `old_path` directly into the handler, so it exercised arguments the tool never builds and masked the bug. It's been updated to mirror the real arguments (`path` + `new_path`), and a matching test was added for the filesystem middleware. Both fail on the old code with the `KeyError` and pass with the fix.

Disclaimer: an AI agent assisted in preparing this contribution.
