### PR TITLE
fix(mistralai): handle nested dict token usage in `_combine_llm_outputs`

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -99,6 +99,28 @@ global_ssl_context = ssl.create_default_context(cafile=certifi.where())
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
 
 
+def _merge_token_usage_value(old: Any, new: Any) -> Any:
+    """Merge two token usage values, summing numbers and recursing into dicts.
+
+    Mistral's API can return nested dicts for some token usage fields (e.g.
+    ``prompt_tokens_details: {"cached_tokens": 10}``). A plain ``+=`` raises
+    ``TypeError`` when both values are dicts, so this helper recursively merges
+    them key-by-key and falls back to ``+`` for numeric types.
+    """
+    if isinstance(old, dict) and isinstance(new, dict):
+        result = dict(old)
+        for k, v in new.items():
+            if k in result:
+                result[k] = _merge_token_usage_value(result[k], v)
+            else:
+                result[k] = v
+        return result
+    if isinstance(old, (int, float)) and isinstance(new, (int, float)):
+        return old + new
+    # Fall back to the new value for mismatched or non-numeric types.
+    return new
+
+
 def _get_default_model_profile(model_name: str) -> ModelProfile:
     default = _MODEL_PROFILES.get(model_name) or {}
     return default.copy()
@@ -657,7 +679,9 @@ class ChatMistralAI(BaseChatModel):
             if token_usage is not None:
                 for k, v in token_usage.items():
                     if k in overall_token_usage:
-                        overall_token_usage[k] += v
+                        overall_token_usage[k] = _merge_token_usage_value(
+                            overall_token_usage[k], v
+                        )
                     else:
                         overall_token_usage[k] = v
         return {"token_usage": overall_token_usage, "model_name": self.model}

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -662,3 +662,86 @@ def test_metadata_versions() -> None:
     versions = llm.metadata["lc_versions"]
     assert "langchain-core" in versions
     assert "langchain-mistralai" in versions
+
+
+def test_combine_llm_outputs_flat_int_fields() -> None:
+    """Flat integer token usage fields are summed across outputs."""
+    llm = ChatMistralAI(model="foo")  # type: ignore[call-arg]
+    result = llm._combine_llm_outputs(
+        [
+            {"token_usage": {"prompt_tokens": 10, "completion_tokens": 5}},
+            {"token_usage": {"prompt_tokens": 20, "completion_tokens": 15}},
+        ]
+    )
+    assert result["token_usage"] == {"prompt_tokens": 30, "completion_tokens": 20}
+    assert result["model_name"] == "foo"
+
+
+def test_combine_llm_outputs_nested_dicts() -> None:
+    """Nested dict token usage fields are merged recursively.
+
+    Regression test for
+    https://github.com/langchain-ai/langchain/issues/38482
+    """
+    llm = ChatMistralAI(model="foo")  # type: ignore[call-arg]
+    result = llm._combine_llm_outputs(
+        [
+            {
+                "token_usage": {
+                    "prompt_tokens": 10,
+                    "prompt_tokens_details": {"cached_tokens": 5},
+                }
+            },
+            {
+                "token_usage": {
+                    "prompt_tokens": 20,
+                    "prompt_tokens_details": {"cached_tokens": 3},
+                }
+            },
+        ]
+    )
+    assert result["token_usage"]["prompt_tokens"] == 30
+    assert result["token_usage"]["prompt_tokens_details"] == {"cached_tokens": 8}
+
+
+def test_combine_llm_outputs_none_entries() -> None:
+    """None outputs (e.g. from streaming) are skipped."""
+    llm = ChatMistralAI(model="foo")  # type: ignore[call-arg]
+    result = llm._combine_llm_outputs(
+        [
+            None,
+            {"token_usage": {"prompt_tokens": 10}},
+            None,
+        ]
+    )
+    assert result["token_usage"] == {"prompt_tokens": 10}
+
+
+def test_combine_llm_outputs_nested_key_only_in_one_output() -> None:
+    """A nested key present in only one output is preserved."""
+    llm = ChatMistralAI(model="foo")  # type: ignore[call-arg]
+    result = llm._combine_llm_outputs(
+        [
+            {
+                "token_usage": {
+                    "prompt_tokens": 10,
+                    "prompt_tokens_details": {"cached_tokens": 5},
+                }
+            },
+            {"token_usage": {"prompt_tokens": 20}},
+        ]
+    )
+    assert result["token_usage"]["prompt_tokens"] == 30
+    assert result["token_usage"]["prompt_tokens_details"] == {"cached_tokens": 5}
+
+
+def test_combine_llm_outputs_none_token_usage() -> None:
+    """None token_usage is skipped gracefully."""
+    llm = ChatMistralAI(model="foo")  # type: ignore[call-arg]
+    result = llm._combine_llm_outputs(
+        [
+            {"token_usage": None},
+            {"token_usage": {"prompt_tokens": 10}},
+        ]
+    )
+    assert result["token_usage"] == {"prompt_tokens": 10}


### PR DESCRIPTION
Fixes #38482

---

`ChatMistralAI._combine_llm_outputs` aggregated token usage across multiple API calls using `+=`, which raises `TypeError` when Mistral returns nested dict fields like `prompt_tokens_details: {"cached_tokens": 10}`. Calling `generate()` with multiple message lists would crash on the second call.

The fix adds a `_merge_token_usage_value` helper that recursively merges dict values key-by-key and falls back to `+` for numeric types, so flat fields still sum correctly while nested dicts merge without errors.