### PR TITLE
fix(openai): avoid Azure parsed model dump warnings

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -771,7 +771,9 @@ class AzureChatOpenAI(BaseChatOpenAI):
         chat_result = super()._create_chat_result(response, generation_info)
 
         if not isinstance(response, dict):
-            response = response.model_dump()
+            response = response.model_dump(
+                exclude={"choices": {"__all__": {"message": {"parsed"}}}}
+            )
         for res in response["choices"]:
             if res.get("finish_reason", None) == "content_filter":
                 msg = (

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -1,11 +1,14 @@
 """Test Azure OpenAI Chat API wrapper."""
 
 import os
+import warnings
+from typing import Literal
 from unittest import mock
 
+import openai
 import pytest
 from langchain_core.messages import HumanMessage
-from pydantic import SecretStr
+from pydantic import BaseModel, SecretStr
 from typing_extensions import TypedDict
 
 from langchain_openai import AzureChatOpenAI
@@ -176,6 +179,54 @@ def test_structured_output_old_model() -> None:
     # assert tool calling was used instead of json_schema
     assert "tools" in llm.steps[0].kwargs  # type: ignore
     assert "response_format" not in llm.steps[0].kwargs  # type: ignore
+
+
+def test_create_chat_result_avoids_parsed_model_dump_warning() -> None:
+    class ModelOutput(BaseModel):
+        output: str
+
+    class MockParsedMessage(openai.BaseModel):
+        role: Literal["assistant"] = "assistant"
+        content: str = '{"output": "Paris"}'
+        parsed: None = None
+        refusal: str | None = None
+
+    class MockChoice(openai.BaseModel):
+        index: int = 0
+        finish_reason: Literal["stop"] = "stop"
+        message: MockParsedMessage
+
+    class MockChatCompletion(openai.BaseModel):
+        id: str = "chatcmpl-1"
+        object: str = "chat.completion"
+        created: int = 0
+        model: str = "gpt-4o-mini"
+        choices: list[MockChoice]
+        usage: dict[str, int] | None = None
+
+    parsed_response = ModelOutput(output="Paris")
+    response = MockChatCompletion.model_construct(
+        choices=[
+            MockChoice.model_construct(
+                message=MockParsedMessage.model_construct(parsed=parsed_response)
+            )
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    llm = AzureChatOpenAI(
+        azure_deployment="gpt-4o-mini",
+        api_version="2024-10-01-preview",
+        azure_endpoint="https://example.openai.azure.com",
+        api_key=SecretStr("test"),
+    )
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        result = llm._create_chat_result(response)
+
+    warning_messages = [str(warning.message) for warning in caught_warnings]
+    assert not any("field_name='parsed'" in message for message in warning_messages)
+    assert result.generations[0].message.additional_kwargs["parsed"] == parsed_response
 
 
 def test_max_completion_tokens_in_payload() -> None:


### PR DESCRIPTION
Fixes #37844

This mirrors the `message.parsed` exclusion used by `BaseChatOpenAI._create_chat_result` in the `AzureChatOpenAI._create_chat_result` override. The Azure override performs its own `response.model_dump()` after delegating to the base implementation, so structured-output responses could still emit `PydanticSerializationUnexpectedValue` warnings.

The new regression test builds an Azure structured-output-style response with a parsed Pydantic model and asserts that `_create_chat_result` does not emit the parsed-field serialization warning while preserving `additional_kwargs["parsed"]`.

Validation:
- `ruff format --check langchain_openai/chat_models/azure.py tests/unit_tests/chat_models/test_azure.py`
- `ruff check langchain_openai/chat_models/azure.py tests/unit_tests/chat_models/test_azure.py`
- `AZURE_OPENAI_API_KEY=test pytest -o addopts='' tests/unit_tests/chat_models/test_azure.py -q`



LinkedIn: https://www.linkedin.com/in/pradeep-singh-ramola/
