### PR TITLE
fix(anthropic): preserve cache_control on deduplicated tool_use blocks

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -543,11 +543,15 @@ def _format_messages(
                                 for tc in message.tool_calls
                                 if tc["id"] == block["id"]
                             ]
-                            content.extend(
-                                _lc_tool_calls_to_anthropic_tool_use_blocks(
-                                    overlapping,
-                                ),
+                            tool_use_blocks = _lc_tool_calls_to_anthropic_tool_use_blocks(
+                                overlapping,
                             )
+                            if cache_control := block.get("cache_control"):
+                                block_id = _normalize_tool_call_id(block["id"])
+                                for tool_use_block in tool_use_blocks:
+                                    if tool_use_block["id"] == block_id:
+                                        tool_use_block["cache_control"] = cache_control
+                            content.extend(tool_use_blocks)
                         else:
                             if tool_input := block.get("input"):
                                 args = tool_input
@@ -566,6 +570,8 @@ def _format_messages(
                             )
                             if caller := block.get("caller"):
                                 tool_use_block["caller"] = caller
+                            if cache_control := block.get("cache_control"):
+                                tool_use_block["cache_control"] = cache_control
                             content.append(tool_use_block)
                     elif block["type"] in ("server_tool_use", "mcp_tool_use"):
                         formatted_block = {

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1122,6 +1122,38 @@ def test__format_messages_with_tool_use_blocks_and_tool_calls() -> None:
     assert expected == actual
 
 
+def test__format_messages_preserves_tool_use_cache_control() -> None:
+    """`cache_control` on a `tool_use` block survives tool_calls deduplication."""
+    ai = AIMessage(  # type: ignore[misc]
+        [
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+        tool_calls=[{"name": "get_weather", "args": {"city": "Paris"}, "id": "toolu_1"}],
+    )
+
+    _, formatted = _format_messages([HumanMessage("weather?"), ai])  # type: ignore[misc]
+    tool_use_blocks = [
+        block for block in formatted[-1]["content"] if block["type"] == "tool_use"
+    ]
+
+    assert tool_use_blocks == [
+        {
+            "type": "tool_use",
+            "name": "get_weather",
+            "input": {"city": "Paris"},
+            "id": "toolu_1",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
 def test__format_messages_with_cache_control() -> None:
     messages = [
         SystemMessage(


### PR DESCRIPTION
Closes #38398

---

When an `AIMessage` has both a `tool_use` content block and a matching `tool_calls` entry, `_format_messages` deduplicates via `_lc_tool_calls_to_anthropic_tool_use_blocks`. That path was dropping `cache_control`, so prompt caching on tools silently stopped working.

Copy `cache_control` over when rebuilding the block from `tool_calls`.


Made with [Cursor](https://cursor.com)