### PR TITLE
fix(anthropic): pass old_path when dispatching file_tool rename

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -253,6 +253,8 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
                 args["new_path"] = new_path
             if view_range is not None:
                 args["view_range"] = view_range
+            if command == "rename":
+                args["old_path"] = path
 
             # Route to appropriate handler based on command
             try:
@@ -755,6 +757,8 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
                 args["new_path"] = new_path
             if view_range is not None:
                 args["view_range"] = view_range
+            if command == "rename":
+                args["old_path"] = path
 
             # Route to appropriate handler based on command
             try:


### PR DESCRIPTION
Closes #38465

---

`file_tool` builds an args dict with `path` and `new_path` for rename, but `_handle_rename` reads `args["old_path"]` on line 1. Every rename hit `KeyError('old_path')`.

Set `old_path = path` before dispatching rename (both state and filesystem middleware).


Made with [Cursor](https://cursor.com)