### PR TITLE
fix(text-splitters): preserve inline tag text order in HTML splitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -936,28 +936,31 @@ class HTMLSemanticPreservingSplitter(BaseDocumentTransformer):
                     # preserved elements.
                     children = _find_all_tags(elem, recursive=False)
                     if children:
-                        # Element has children - recursively process them.
-                        (
-                            documents,
-                            current_headers,
-                            current_content,
-                            preserved_elements,
-                            placeholder_count,
-                        ) = _process_element(
-                            children,
-                            documents,
-                            current_headers,
-                            current_content,
-                            preserved_elements,
-                            placeholder_count,
+                        header_tags = {h[0] for h in self._headers_to_split_on}
+                        has_special_children = any(
+                            child.name in header_tags
+                            or child.name in self._elements_to_preserve
+                            for child in children
                         )
-                        # After processing children, extract only text
-                        # strings from this element (not its children). Used
-                        # recursive=False to avoid double-counting.
-                        content = " ".join(_find_all_strings(elem, recursive=False))
-                        if content:
-                            content = self._normalize_and_clean_text(content)
-                            current_content.append(content)
+                        if has_special_children:
+                            (
+                                documents,
+                                current_headers,
+                                current_content,
+                                preserved_elements,
+                                placeholder_count,
+                            ) = _process_element(
+                                children,
+                                documents,
+                                current_headers,
+                                current_content,
+                                preserved_elements,
+                                placeholder_count,
+                            )
+                        else:
+                            content = _get_element_text(elem)
+                            if content:
+                                current_content.append(content)
                     else:
                         # Leaf element with no children, so we extract its
                         # text and add to current content. Handles

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -4196,6 +4196,29 @@ def test_html_splitter_replacement_order() -> None:
     assert content == " ".join([f"Hello{i}" for i in range(1, 15)])
 
 
+def test_html_semantic_preserving_splitter_preserves_inline_tag_text_order() -> None:
+    """Inline formatting tags should not reorder surrounding text."""
+    html_content = """
+    <h1>Section 1</h1>
+    <p>This is some long text that <strong>should</strong> be split into multiple chunks due to the
+    small chunk size.</p>
+    """
+
+    with suppress_langchain_beta_warning():
+        splitter = HTMLSemanticPreservingSplitter(
+            headers_to_split_on=[("h1", "Header 1")],
+            max_chunk_size=50,
+            chunk_overlap=5,
+        )
+
+    documents = splitter.split_text(html_content)
+
+    assert documents[0].page_content.startswith(
+        "This is some long text that should be split into"
+    )
+    assert "should This is" not in documents[0].page_content
+
+
 def test_character_text_splitter_discard_regex_separator_on_merge() -> None:
     """Test that regex lookahead separator is not re-inserted when merging."""
     text = "SCE191 First chunk. SCE103 Second chunk."


### PR DESCRIPTION
Closes #38404

---

`HTMLSemanticPreservingSplitter` recursed into `<p>` tags that only had inline tags like `<strong>`. That pulled child text out of order — you'd get `"should This is"` instead of `"This is some long text that should"`.

If a paragraph only has inline children, grab the full element text instead of recursing.


Made with [Cursor](https://cursor.com)