### PR TITLE
fix(core): dedupe repeated string metadata in `merge_dicts`

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -149,6 +149,44 @@ def test_merge_dicts(
 
 
 @pytest.mark.parametrize(
+    "key",
+    [
+        "model_name",
+        "finish_reason",
+        "native_finish_reason",
+        "object",
+        "system_fingerprint",
+        "format",
+    ],
+)
+def test_merge_dicts_dedupes_repeated_stable_string_metadata(key: str) -> None:
+    actual = merge_dicts({key: "same"}, {key: "same"})
+
+    assert actual == {key: "same"}
+
+
+def test_merge_dicts_dedupes_repeated_nested_stable_string_metadata() -> None:
+    actual = merge_dicts(
+        {"reasoning_details": {"format": "unknown"}},
+        {"reasoning_details": {"format": "unknown"}},
+    )
+
+    assert actual == {"reasoning_details": {"format": "unknown"}}
+
+
+def test_merge_dicts_concatenates_different_stable_string_metadata() -> None:
+    actual = merge_dicts({"model_name": "first"}, {"model_name": "second"})
+
+    assert actual == {"model_name": "firstsecond"}
+
+
+def test_merge_dicts_concatenates_unrecognized_equal_strings() -> None:
+    actual = merge_dicts({"content": "same"}, {"content": "same"})
+
+    assert actual == {"content": "samesame"}
+
+
+@pytest.mark.parametrize(
     ("left", "right", "expected"),
     [
         # 'type' special key handling


### PR DESCRIPTION
Title: fix(core): dedupe repeated string metadata in `merge_dicts`

Summary
- Extends the existing equal-string metadata dedupe path in `merge_dicts` to cover stable streamed response metadata fields such as `model_name`, `finish_reason`, `object`, `system_fingerprint`, and nested `format` values.
- Adds regression coverage that repeated stable metadata is kept once while differing metadata and ordinary string fields still concatenate.

Test evidence
- Direct pre-patch reproduction showed `model_name` and `finish_reason` doubling.
- Direct post-patch assertions passed for `merge_dicts` and `AIMessageChunk.__add__`.
- `python -m py_compile` passed for the changed source and test files.
- `git diff --check` passed.
- Targeted pytest and Ruff commands could not run because `uv`, `pytest`, and `ruff` are not installed in this environment.

Risks or notes for maintainers
- `format` is deduped wherever `merge_dicts` recursively sees that exact equal string key, not only under reasoning metadata.
- Differing values still concatenate, so this does not convert metadata merging to a broad last-wins policy.
- This contribution was prepared with AI-agent assistance.

Fixes #38366