### PR TITLE
fix(qdrant): normalize relevance scores in legacy Qdrant vector store

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/vectorstores.py
+++ b/libs/partners/qdrant/langchain_qdrant/vectorstores.py
@@ -1967,55 +1967,6 @@ class Qdrant(VectorStore):
         )
         raise ValueError(msg)
 
-    def _similarity_search_with_relevance_scores(
-        self,
-        query: str,
-        k: int = 4,
-        **kwargs: Any,
-    ) -> list[tuple[Document, float]]:
-        """Return docs and relevance scores in the range `[0, 1]`.
-
-        `0` is dissimilar, `1` is most similar.
-
-        Args:
-            query: input text
-            k: Number of Documents to return.
-            **kwargs: Kwargs to be passed to similarity search.
-
-                Should include `score_threshold`, an optional floating point value
-                between `0` to `1` to filter the resulting set of retrieved docs.
-
-        Returns:
-            List of tuples of `(doc, similarity_score)`
-
-        """
-        return self.similarity_search_with_score(query, k, **kwargs)
-
-    @sync_call_fallback
-    async def _asimilarity_search_with_relevance_scores(
-        self,
-        query: str,
-        k: int = 4,
-        **kwargs: Any,
-    ) -> list[tuple[Document, float]]:
-        """Return docs and relevance scores in the range `[0, 1]`.
-
-        `0` is dissimilar, `1` is most similar.
-
-        Args:
-            query: input text
-            k: Number of Documents to return.
-            **kwargs: Kwargs to be passed to similarity search.
-
-                Should include `score_threshold`, an optional floating point value
-                between `0` to `1` to filter the resulting set of retrieved docs.
-
-        Returns:
-            List of tuples of `(doc, similarity_score)`
-
-        """
-        return await self.asimilarity_search_with_score(query, k, **kwargs)
-
     @classmethod
     def _build_payloads(
         cls,

--- a/libs/partners/qdrant/tests/integration_tests/async_api/test_similarity_search.py
+++ b/libs/partners/qdrant/tests/integration_tests/async_api/test_similarity_search.py
@@ -303,3 +303,31 @@ async def test_qdrant_similarity_search_with_relevance_scores(
     assert all(
         (score <= 1 or np.isclose(score, 1)) and score >= 0 for _, score in output
     )
+
+
+async def test_qdrant_asimilarity_search_with_relevance_scores_normalization() -> None:
+    """Test that async similarity search relevance scores are normalized."""
+    import math
+
+    texts = ["foo", "bar", "baz"]
+    docsearch = Qdrant.from_texts(
+        texts,
+        ConsistentFakeEmbeddings(),
+        location=":memory:",
+        distance_func="Euclid",
+    )
+
+    # 1. Get raw distance
+    docs_and_distances = await docsearch.asimilarity_search_with_score("foo", k=3)
+
+    # 2. Get normalized relevance score
+    docs_and_relevance = await docsearch.asimilarity_search_with_relevance_scores(
+        "foo", k=3
+    )
+
+    assert len(docs_and_distances) == len(docs_and_relevance)
+    zipped = zip(docs_and_distances, docs_and_relevance, strict=False)
+    for (doc_dist, dist), (doc_rel, rel) in zipped:
+        assert doc_dist.page_content == doc_rel.page_content
+        expected_rel = 1.0 - dist / math.sqrt(2)
+        assert np.isclose(rel, expected_rel)

--- a/libs/partners/qdrant/tests/integration_tests/test_similarity_search.py
+++ b/libs/partners/qdrant/tests/integration_tests/test_similarity_search.py
@@ -281,3 +281,29 @@ def test_qdrant_similarity_search_with_relevance_scores(
     assert all(
         (score <= 1 or np.isclose(score, 1)) and score >= 0 for _, score in output
     )
+
+
+def test_qdrant_similarity_search_with_relevance_scores_normalization() -> None:
+    """Test that similarity search with relevance scores is normalized."""
+    import math
+
+    texts = ["foo", "bar", "baz"]
+    docsearch = Qdrant.from_texts(
+        texts,
+        ConsistentFakeEmbeddings(),
+        location=":memory:",
+        distance_func="Euclid",
+    )
+
+    # 1. Get raw distance
+    docs_and_distances = docsearch.similarity_search_with_score("foo", k=3)
+
+    # 2. Get normalized relevance score
+    docs_and_relevance = docsearch.similarity_search_with_relevance_scores("foo", k=3)
+
+    assert len(docs_and_distances) == len(docs_and_relevance)
+    zipped = zip(docs_and_distances, docs_and_relevance, strict=False)
+    for (doc_dist, dist), (doc_rel, rel) in zipped:
+        assert doc_dist.page_content == doc_rel.page_content
+        expected_rel = 1.0 - dist / math.sqrt(2)
+        assert np.isclose(rel, expected_rel)


### PR DESCRIPTION
## Summary

Fixes the legacy `Qdrant` vector store returning raw scores from `similarity_search_with_relevance_scores` instead of normalized relevance scores.

The legacy implementation overrode `_similarity_search_with_relevance_scores` and `_asimilarity_search_with_relevance_scores`, bypassing the base `VectorStore` normalization logic. Removing these overrides restores the documented `VectorStore` behavior and aligns the legacy implementation with `QdrantVectorStore`.

Adds regression tests (sync and async) verifying that relevance scores are correctly normalized.

Closes #38504
