### PR TITLE
fix: generalize JSON custom parser to handle any field name (closes #36603)

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -44,7 +44,7 @@ def _custom_parser(multiline_string: str | bytes | bytearray) -> str:
         multiline_string = multiline_string.decode()
 
     return re.sub(
-        r'("action_input"\:\s*")(.*?)(")',
+        r'("[^"]+"\s*:\s*")(.*?)(")',
         _replace_new_line,
         multiline_string,
         flags=re.DOTALL,


### PR DESCRIPTION
## What
The `_custom_parser` function in `libs/core/langchain_core/utils/json.py` only escapes special characters inside JSON string values for the specific key `"action_input"`. When a Pydantic model has a different field name, unescaped newlines, tabs, or quotes in the value cause `json.loads` to fail, resulting in a `langchain_core.exceptions.OutputParserException`.

## Fix
Modified the regex pattern to match any JSON key-value pair where the value is a string: `r'("[^"]+"\s*:\s*")(.*?)(")'`. This ensures proper escaping for all field names, not just `"action_input"`.

Closes #36603