### PR TITLE
fix(chroma): normalize vector relevance scores

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -803,7 +803,7 @@ class Chroma(VectorStore):
 
         Returns:
             List of documents most similar to the query text and relevance score
-            in float for each. Lower score represents more similarity.
+            in float for each. Higher score represents more similarity.
         """
         results = self.__query_collection(
             query_embeddings=[embedding],
@@ -812,7 +812,9 @@ class Chroma(VectorStore):
             where_document=where_document,
             **kwargs,
         )
-        return _results_to_docs_and_scores(results)
+        relevance_score_fn = self._select_relevance_score_fn()
+        docs_and_scores = _results_to_docs_and_scores(results)
+        return [(doc, relevance_score_fn(score)) for doc, score in docs_and_scores]
 
     def similarity_search_with_score(
         self,

--- a/libs/partners/chroma/tests/integration_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/integration_tests/test_vectorstores.py
@@ -221,7 +221,7 @@ def test_chroma_with_metadatas_with_scores_using_vector() -> None:
     )
     docsearch.delete_collection()
     assert output == [
-        (Document(page_content="foo", metadata={"page": "0"}, id="id_0"), 0.0),
+        (Document(page_content="foo", metadata={"page": "0"}, id="id_0"), 1.0),
     ]
 
 


### PR DESCRIPTION
Closes #38506

---

`similarity_search_by_vector_with_relevance_scores` was returning raw Chroma distances (0 for an exact match) instead of normalized relevance scores in `[0, 1]`. The text-query path already runs scores through `_select_relevance_score_fn()` — this just applies the same transform for vector queries.

Also updated the integration test that was asserting the broken behavior.

This contribution was made with the help of an AI coding agent.


Made with [Cursor](https://cursor.com)