### PR TITLE
fix(core): don't evict on in-place InMemoryCache update

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -226,7 +226,11 @@ class InMemoryCache(BaseCache):
 
                 The value is a list of `Generation` (or subclasses).
         """
-        if self._maxsize is not None and len(self._cache) == self._maxsize:
+        if (
+            self._maxsize is not None
+            and len(self._cache) == self._maxsize
+            and (prompt, llm_string) not in self._cache
+        ):
             del self._cache[next(iter(self._cache))]
         self._cache[prompt, llm_string] = return_val
 

--- a/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
+++ b/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
@@ -69,6 +69,22 @@ def test_update_with_maxsize() -> None:
     assert cache.lookup(prompt3, llm_string3) == generations3
 
 
+def test_update_existing_key_at_maxsize_does_not_evict() -> None:
+    """Updating an existing entry should not evict other keys."""
+    cache = InMemoryCache(maxsize=2)
+
+    prompt1, llm_string1, generations1 = cache_item(1)
+    prompt2, llm_string2, generations2 = cache_item(2)
+    cache.update(prompt1, llm_string1, generations1)
+    cache.update(prompt2, llm_string2, generations2)
+
+    updated_generations = [Generation(text="updated")]
+    cache.update(prompt2, llm_string2, updated_generations)
+
+    assert cache.lookup(prompt1, llm_string1) == generations1
+    assert cache.lookup(prompt2, llm_string2) == updated_generations
+
+
 def test_clear(cache: InMemoryCache) -> None:
     """Test the clear method of InMemoryCache."""
     prompt, llm_string, generations = cache_item(1)


### PR DESCRIPTION
Closes #36750

---

When the cache was full, `update()` always evicted the oldest entry — even if you were just refreshing an existing key. That dropped unrelated prompts and made maxsize effectively smaller than it should be.

Only evict when inserting a brand new key.


Made with [Cursor](https://cursor.com)