### PR TITLE
fix(langchain): allow dotted file search path segments

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -183,7 +183,12 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             # for absolute patterns. (A `~` pattern is never expanduser'd by glob,
             # and any escape that slips through is dropped by the per-match
             # containment check below.)
-            if pattern.startswith("/") or any(part == ".." for part in pattern.split("/")):
+            pattern_path = Path(pattern)
+            if (
+                pattern_path.is_absolute()
+                or any(part == ".." for part in pattern_path.parts)
+                or any(part == ".." for part in pattern.split("/"))
+            ):
                 return "No files found"
 
             # Use pathlib glob
@@ -193,7 +198,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 # points outside the root is never enumerated.
                 if match.is_file() and _is_within_root(match, self.root_path):
                     # Convert to virtual path
-                    virtual_path = "/" + str(match.relative_to(self.root_path))
+                    virtual_path = "/" + match.relative_to(self.root_path).as_posix()
                     stat = match.stat()
                     modified_at = datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc).isoformat()
                     matching.append((virtual_path, modified_at))
@@ -271,7 +276,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             path = "/" + path
 
         # Check for path traversal
-        if ".." in path or "~" in path:
+        if any(part == ".." for part in path.split("/")) or "~" in path:
             msg = "Path traversal not allowed"
             raise ValueError(msg)
 
@@ -333,7 +338,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                     if not _is_within_root(Path(path), self.root_path):
                         continue
                     # Convert to virtual path
-                    virtual_path = "/" + str(Path(path).relative_to(self.root_path))
+                    virtual_path = "/" + Path(path).relative_to(self.root_path).as_posix()
                     line_num = data["data"]["line_number"]
                     line_text = data["data"]["lines"]["text"].rstrip("\n")
 
@@ -390,7 +395,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 # Search content
                 for line_num, line in enumerate(content.splitlines(), 1):
                     if regex.search(line):
-                        virtual_path = "/" + str(file_path.relative_to(self.root_path))
+                        virtual_path = "/" + file_path.relative_to(self.root_path).as_posix()
                         if virtual_path not in results:
                             results[virtual_path] = []
                         results[virtual_path].append((line_num, line))

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -212,6 +212,19 @@ class TestFilesystemGlobSearch:
 
         assert result == "No files found"
 
+    def test_glob_allows_double_dots_inside_path_segment(self, tmp_path: Path) -> None:
+        """Directory names containing `..` should not be treated as traversal."""
+        (tmp_path / "src..old").mkdir()
+        (tmp_path / "src..old" / "file.py").write_text("content", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.py", path="/src..old")
+
+        assert result == "/src..old/file.py"
+
     def test_glob_results_sorted_by_mtime_desc(self, tmp_path: Path) -> None:
         """Results must be ordered newest-first, as documented."""
         # Create files in alphabetical order opposite to mtime order so the


### PR DESCRIPTION
## Summary
- Treat `..` as path traversal only when it is an entire path segment.
- Allow normal file or directory names such as `src..old`.
- Normalize virtual file search paths with `as_posix()` for stable output across platforms.

Fixes #38549

## Tests
- `uv run --group test pytest tests/unit_tests/agents/middleware/implementations/test_file_search.py -q`
- `uv run --group lint ruff check langchain/agents/middleware/file_search.py tests/unit_tests/agents/middleware/implementations/test_file_search.py`
- `git diff --check`