### PR TITLE
fix(classic): report unsupported save for chat agents

### DIFF
--- a/libs/langchain/langchain_classic/agents/chat/base.py
+++ b/libs/langchain/langchain_classic/agents/chat/base.py
@@ -175,4 +175,4 @@ class ChatAgent(Agent):
 
     @property
     def _agent_type(self) -> str:
-        raise ValueError
+        raise NotImplementedError

--- a/libs/langchain/langchain_classic/agents/structured_chat/base.py
+++ b/libs/langchain/langchain_classic/agents/structured_chat/base.py
@@ -160,7 +160,7 @@ class StructuredChatAgent(Agent):
 
     @property
     def _agent_type(self) -> str:
-        raise ValueError
+        raise NotImplementedError
 
 
 def create_structured_chat_agent(

--- a/libs/langchain/tests/unit_tests/agents/test_chat.py
+++ b/libs/langchain/tests/unit_tests/agents/test_chat.py
@@ -1,8 +1,14 @@
 """Unittests for langchain.agents.chat package."""
 
-from langchain_core.agents import AgentAction
+from pathlib import Path
 
+import pytest
+from langchain_core.agents import AgentAction
+from langchain_core.tools import Tool
+
+from langchain_classic.agents.chat.base import ChatAgent
 from langchain_classic.agents.chat.output_parser import ChatOutputParser
+from tests.unit_tests.llms.fake_llm import FakeLLM
 
 output_parser = ChatOutputParser()
 
@@ -44,3 +50,13 @@ def test_parse_without_language() -> None:
     action, action_input = get_action_and_input(llm_output)
     assert action == "foo"
     assert action_input == "bar"
+
+
+def test_chat_agent_save_reports_unsupported(tmp_path: Path) -> None:
+    agent = ChatAgent.from_llm_and_tools(
+        FakeLLM(),
+        [Tool(name="foo", description="Test tool FOO", func=lambda x: x)],
+    )
+
+    with pytest.raises(NotImplementedError, match="does not support saving"):
+        agent.save(tmp_path / "agent.yaml")

--- a/libs/langchain/tests/unit_tests/agents/test_structured_chat.py
+++ b/libs/langchain/tests/unit_tests/agents/test_structured_chat.py
@@ -1,8 +1,10 @@
 """Unittests for langchain.agents.chat package."""
 
+from pathlib import Path
 from textwrap import dedent
 from typing import Any
 
+import pytest
 from langchain_core.agents import AgentAction, AgentFinish
 from langchain_core.prompts.chat import (
     ChatPromptTemplate,
@@ -15,6 +17,7 @@ from langchain_classic.agents.structured_chat.base import StructuredChatAgent
 from langchain_classic.agents.structured_chat.output_parser import (
     StructuredChatOutputParser,
 )
+from tests.unit_tests.llms.fake_llm import FakeLLM
 
 output_parser = StructuredChatOutputParser()
 
@@ -115,6 +118,16 @@ def test_parse_case_matched_and_final_answer() -> None:
     output, log = get_action_and_input(llm_output)
     assert output == "This is the final answer"
     assert log == llm_output
+
+
+def test_structured_chat_agent_save_reports_unsupported(tmp_path: Path) -> None:
+    agent = StructuredChatAgent.from_llm_and_tools(
+        FakeLLM(),
+        [Tool(name="foo", description="Test tool FOO", func=lambda x: x)],
+    )
+
+    with pytest.raises(NotImplementedError, match="does not support saving"):
+        agent.save(tmp_path / "agent.yaml")
 
 
 # TODO: add more tests.


### PR DESCRIPTION
## Summary

Fix unsupported save handling for deprecated classic chat agents.

`ChatAgent` and `StructuredChatAgent` implemented `_agent_type` by raising a bare `ValueError`. The base `BaseSingleActionAgent.dict()` path expects unsupported agent serialization to be signaled with `NotImplementedError`, so `save()` currently leaks an empty `ValueError` instead of the existing "does not support saving" message.

This changes both agents to raise `NotImplementedError` and adds regression tests for the save error path.

Fixes #38550

## Tests

- `python -m pytest -o addopts='' tests/unit_tests/agents/test_chat.py tests/unit_tests/agents/test_structured_chat.py -q`
- `python -m ruff check langchain_classic/agents/chat/base.py langchain_classic/agents/structured_chat/base.py tests/unit_tests/agents/test_chat.py tests/unit_tests/agents/test_structured_chat.py`
- `git diff --check`