### PR TITLE
core[fix]: don't inherit tool description from parent class docstring

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -190,7 +190,7 @@ def _infer_arg_descriptions(
             fn, annotations, error_on_invalid_docstring=error_on_invalid_docstring
         )
     else:
-        description = inspect.getdoc(fn) or ""
+        description = _get_own_docstring(fn) or "" # inspect.getdoc(fn) or ""
         arg_descriptions = {}
     if parse_docstring:
         _validate_docstring_args_against_annotations(arg_descriptions, annotations)
@@ -1709,3 +1709,17 @@ class BaseToolkit(BaseModel, ABC):
         Returns:
             List of tools contained in this toolkit.
         """
+def _get_own_docstring(obj: Any) -> str | None:
+    """Return obj's own docstring, not one inherited from a base class.
+    Args:
+        obj: A class or function to read the docstring from.
+    Returns:
+        The object's own cleaned docstring, or ``None`` if it doesn't define
+    
+    """
+    if isinstance(obj, type):
+        # classes store __doc__ in their own __dict__ (set to None if absent)
+        own = obj.__dict__.get("__doc__")
+    else:
+        own = getattr(obj, "__doc__", None)
+    return inspect.getdoc(obj) if own else None

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -221,7 +221,7 @@ class StructuredTool(BaseTool):
                 ):
                     description_ = ""
                 elif not description_:
-                    description_ = None
+                    description_ = "" if isinstance(source_function, type) else None
             elif isinstance(args_schema, dict):
                 description_ = args_schema.get("description")
             else:

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -4033,3 +4033,30 @@ def test_tool_call_schema_json_schema_cache_invalidated_on_reassignment() -> Non
     new_schema = new_cls.model_json_schema()
     assert new_schema is not old_schema
     assert new_schema["description"] == "New description for cache test."
+
+
+def test_tool_class_does_not_inherit_parent_docstring() -> None:
+    """A @tool class should not inherit its parent BaseModel's docstring."""
+    class ParentTool(BaseModel):
+        """Parent Tool."""
+        foo: str
+
+    @tool
+    class ChildTool(ParentTool):
+        bar: str
+
+    assert ChildTool.description == ""  # type: ignore[attr-defined]
+
+
+def test_tool_class_keeps_own_docstring() -> None:
+    """A `@tool` class with its own docstring keeps it (not the parent's)."""
+    class ParentTool(BaseModel):
+        """Parent Tool."""
+        foo: str
+
+    @tool
+    class ChildTool(ParentTool):
+        """Child Tool."""
+        bar: str
+
+    assert ChildTool.description == "Child Tool."  # type: ignore[attr-defined]


### PR DESCRIPTION
Fixes #32066

@tool classes were inheriting their parent class's docstring as the tool description, so a child tool with no docstring of its own would silently describe itself using the parent's text. This change makes the description empty in that case instead.

How I verified: added two unit tests in test_tools.py. The inheritance test fails on (`assert 'Parent Tool' == ''`) and passes with the fix. `make format`, `make lint`, and `make test` pass from `libs/core`.