### PR TITLE
fix(chroma): normalize relevance scores in similarity_search_by_vector_with_relevance_scores

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -803,7 +803,7 @@ class Chroma(VectorStore):
 
         Returns:
             List of documents most similar to the query text and relevance score
-            in float for each. Lower score represents more similarity.
+            in float for each. Higher score represents more similarity.
         """
         results = self.__query_collection(
             query_embeddings=[embedding],
@@ -812,7 +812,9 @@ class Chroma(VectorStore):
             where_document=where_document,
             **kwargs,
         )
-        return _results_to_docs_and_scores(results)
+        docs_and_scores = _results_to_docs_and_scores(results)
+        relevance_score_fn = self._select_relevance_score_fn()
+        return [(doc, relevance_score_fn(score)) for doc, score in docs_and_scores]
 
     def similarity_search_with_score(
         self,
@@ -932,7 +934,7 @@ class Chroma(VectorStore):
         if distance == "l2":
             return self._euclidean_relevance_score_fn
         if distance == "ip":
-            return self._max_inner_product_relevance_score_fn
+            return self._chroma_max_inner_product_relevance_score_fn
         msg = (
             "No supported normalization function"
             f" for distance metric of type: {distance}."
@@ -941,6 +943,16 @@ class Chroma(VectorStore):
         raise ValueError(
             msg,
         )
+
+    @staticmethod
+    def _chroma_max_inner_product_relevance_score_fn(distance: float) -> float:
+        """Normalize the distance to a score on a scale [0, 1].
+
+        Chroma defines IP distance as 1.0 - inner_product, unlike the base class
+        which assumes -inner_product. When distance is 0.0 (perfect match),
+        the score should be 1.0.
+        """
+        return 1.0 - distance
 
     def similarity_search_by_image(
         self,

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -1,30 +1,89 @@
-from langchain_core.embeddings.fake import (
-    FakeEmbeddings,
-)
+import sys
+from unittest.mock import MagicMock, patch
 
-from langchain_chroma.vectorstores import Chroma
+import pytest
+
+# Build a complete mock chromadb hierarchy before any real import
+mock_chromadb = MagicMock()
+mock_chromadb.config = MagicMock()
+mock_chromadb.api = MagicMock()
+mock_chromadb.api.CreateCollectionConfiguration = MagicMock()
+mock_chromadb.Settings = MagicMock()
+mock_chromadb.Search = MagicMock()
+mock_chromadb.Collection = MagicMock()
+
+sys.modules["chromadb"] = mock_chromadb
+sys.modules["chromadb.config"] = mock_chromadb.config
+sys.modules["chromadb.api"] = mock_chromadb.api
+
+import uuid  # noqa: E402
+
+from langchain_core.documents import Document  # noqa: E402
+from langchain_core.embeddings.fake import FakeEmbeddings  # noqa: E402
+
+from langchain_chroma.vectorstores import Chroma  # noqa: E402
+
+mock_collection = MagicMock()
+mock_collection.name = "test_collection"
+mock_collection.configuration = {"hnsw": {"space": "ip"}}
 
 
-def test_initialization() -> None:
-    """Test integration vectorstore initialization."""
-    texts = ["foo", "bar", "baz"]
-    Chroma.from_texts(
+@pytest.fixture
+def chroma_instance():
+    instance = Chroma(
         collection_name="test_collection",
-        texts=texts,
-        embedding=FakeEmbeddings(size=10),
+        embedding_function=FakeEmbeddings(size=10),
     )
+    instance._chroma_collection = mock_collection
+    return instance
 
 
-def test_similarity_search() -> None:
-    """Test similarity search by Chroma."""
-    texts = ["foo", "bar", "baz"]
-    metadatas = [{"page": str(i)} for i in range(len(texts))]
-    docsearch = Chroma.from_texts(
-        collection_name="test_collection",
-        texts=texts,
-        embedding=FakeEmbeddings(size=10),
-        metadatas=metadatas,
-    )
-    output = docsearch.similarity_search("foo", k=1)
-    docsearch.delete_collection()
-    assert len(output) == 1
+class TestChromaRelevanceScores:
+    def test_chroma_max_inner_product_relevance_score_fn(self):
+        fn = Chroma._chroma_max_inner_product_relevance_score_fn
+        assert fn(0.0) == 1.0
+        assert fn(0.5) == 0.5
+        assert fn(1.0) == 0.0
+        assert fn(2.0) == -1.0
+
+    def test_select_relevance_score_fn_ip_distance(self, chroma_instance):
+        fn = chroma_instance._select_relevance_score_fn()
+        assert fn is Chroma._chroma_max_inner_product_relevance_score_fn
+        assert fn(0.0) == 1.0
+        assert fn(1.0) == 0.0
+
+    def test_select_relevance_score_fn_with_override(self, chroma_instance):
+        custom_fn = MagicMock(return_value=0.5)
+        chroma_instance.override_relevance_score_fn = custom_fn
+        fn = chroma_instance._select_relevance_score_fn()
+        assert fn == custom_fn
+        assert fn(123.0) == 0.5
+
+    @patch.object(Chroma, "_select_relevance_score_fn", return_value=lambda d: 1.0 - d)
+    @patch.object(Chroma, "_Chroma__query_collection")
+    def test_similarity_search_by_vector_with_relevance_scores(
+        self, mock_query, mock_select_fn, chroma_instance
+    ):
+        mock_query.return_value = (
+            [["doc1", "doc2"]],
+            [[0.0, 0.5]],
+            [[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]],
+        )
+        mock_partial = MagicMock()
+        mock_partial.return_value = [
+            (Document(page_content="doc1"), 0.0),
+            (Document(page_content="doc2"), 0.5),
+        ]
+
+        with patch(
+            "langchain_chroma.vectorstores._results_to_docs_and_scores",
+            mock_partial,
+        ):
+            results = chroma_instance.similarity_search_by_vector_with_relevance_scores(
+                embedding=[0.1, 0.2, 0.3], k=2
+            )
+
+        assert len(results) == 2
+        assert results[0][1] == 1.0
+        assert results[1][1] == 0.5
+        assert mock_select_fn.called


### PR DESCRIPTION
Fixes #38506

similarity_search_by_vector_with_relevance_scores now normalizes raw distances to [0,1] relevance scores, and IP distance scoring correctly uses Chroma's 1.0 - inner_product convention.