### PR TITLE
feat(text-splitters): add IndicTextSplitter for Hindi/Indic languages

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/__init__.py
+++ b/libs/text-splitters/langchain_text_splitters/__init__.py
@@ -23,6 +23,7 @@ from langchain_text_splitters.html import (
     HTMLSectionSplitter,
     HTMLSemanticPreservingSplitter,
 )
+from langchain_text_splitters.indic import IndicTextSplitter
 from langchain_text_splitters.json import RecursiveJsonSplitter
 from langchain_text_splitters.jsx import JSFrameworkTextSplitter
 from langchain_text_splitters.konlpy import KonlpyTextSplitter
@@ -49,6 +50,7 @@ __all__ = [
     "HTMLSectionSplitter",
     "HTMLSemanticPreservingSplitter",
     "HeaderType",
+    "IndicTextSplitter",
     "JSFrameworkTextSplitter",
     "KonlpyTextSplitter",
     "Language",

--- a/libs/text-splitters/langchain_text_splitters/indic.py
+++ b/libs/text-splitters/langchain_text_splitters/indic.py
@@ -1,0 +1,29 @@
+"""Indic text splitter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_text_splitters.character import RecursiveCharacterTextSplitter
+
+
+class IndicTextSplitter(RecursiveCharacterTextSplitter):
+    """Splitting text for Indic languages (Hindi, Marathi, Nepali, Sanskrit, Bengali, etc.).
+
+    These languages often use the Poorna Viram (।) as a full stop/sentence terminator.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        """Initialize the Indic text splitter."""
+        separators = kwargs.pop("separators", None)
+        if separators is None:
+            separators = [
+                "\n\n",
+                "\n",
+                "।",  # Poorna Viram (Devanagari/Bengali full stop)
+                "॥",  # Deergha Viram (Double full stop)
+                ".",
+                " ",
+                "",
+            ]
+        super().__init__(separators=separators, **kwargs)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -4243,3 +4243,12 @@ def test_character_text_splitter_chunk_size_effect(
         keep_separator=False,
     )
     assert splitter.split_text(text) == expected
+
+def test_indic_text_splitter() -> None:
+    """Test Indic text splitter."""
+    from langchain_text_splitters.indic import IndicTextSplitter
+    text = "यह एक वाक्य है। यह दूसरा वाक्य है॥ यह तीसरा है।"
+    splitter = IndicTextSplitter(chunk_size=16, chunk_overlap=0)
+    output = splitter.split_text(text)
+    expected_output = ["यह एक वाक्य है।", "यह दूसरा वाक्य", "है॥", "यह तीसरा है।"]
+    assert output == expected_output


### PR DESCRIPTION
## Description

Adds  to . This is a subclass of  with default separators optimized for Indic languages (Hindi, Marathi, Nepali, Sanskrit, Bengali, etc.), which use the Poorna Viram (`।`) as a sentence terminator rather than a standard period.

This makes it significantly easier to chunk Hindi/Indic text for RAG pipelines without manually managing the correct punctuation separators.

Added unit test to verify correct chunking behavior on Hindi text.

## Issue
No associated issue.

## Dependencies
No new dependencies added. Only relies on core Python string/regex operations.