### PR TITLE
fix(anthropic): map path to old_path in file tool rename callback

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -253,6 +253,8 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
                 args["new_path"] = new_path
             if view_range is not None:
                 args["view_range"] = view_range
+            if command == "rename":
+                args["old_path"] = path
 
             # Route to appropriate handler based on command
             try:
@@ -281,6 +283,8 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
                 return f"Unknown command: {command}"
             except (ValueError, FileNotFoundError) as e:
                 return str(e)
+            except KeyError as e:
+                return f"KeyError: Missing required parameter {e} for command {command}"
 
         self.tools = [file_tool]
 
@@ -755,6 +759,8 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
                 args["new_path"] = new_path
             if view_range is not None:
                 args["view_range"] = view_range
+            if command == "rename":
+                args["old_path"] = path
 
             # Route to appropriate handler based on command
             try:
@@ -773,6 +779,8 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
                 return f"Unknown command: {command}"
             except (ValueError, FileNotFoundError, PermissionError) as e:
                 return str(e)
+            except KeyError as e:
+                return f"KeyError: Missing required parameter {e} for command {command}"
 
         self.tools = [file_tool]
 

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -1,5 +1,4 @@
-"""Unit tests for Anthropic text editor and memory tool middleware."""
-
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -308,6 +307,92 @@ class TestFileOperations:
         # New path has the file data
         assert files.get("/memories/new.txt") is not None
         assert files["/memories/new.txt"]["content"] == ["line1"]
+
+    def test_file_tool_rename_integration(self) -> None:
+        """Test that the file_tool callback executes rename without KeyError."""
+        import tempfile
+        from pathlib import Path
+
+        from langchain.tools import ToolRuntime
+
+        from langchain_anthropic.middleware.anthropic_tools import (
+            FilesystemClaudeMemoryMiddleware,
+        )
+
+        # 1. Test state-backed middleware
+        state_middleware = StateClaudeMemoryMiddleware()
+        state: dict[str, Any] = {
+            "messages": [],
+            "memory_files": {
+                "/memories/old.txt": {
+                    "content": ["line1"],
+                    "created_at": "2025-01-01T00:00:00",
+                    "modified_at": "2025-01-01T00:00:00",
+                }
+            },
+        }
+
+        runtime: ToolRuntime = ToolRuntime(
+            context=None,
+            state=state,
+            config={},
+            stream_writer=lambda _: None,
+            tool_call_id="test_id_state",
+            store=None,
+        )
+
+        tool = state_middleware.tools[0]
+
+        # Invoke via tool.invoke - this simulates LangGraph tool node execution
+        result = tool.invoke(
+            {
+                "runtime": runtime,
+                "command": "rename",
+                "path": "/memories/old.txt",
+                "new_path": "/memories/new.txt",
+            }
+        )
+
+        assert isinstance(result, Command)
+        assert isinstance(result.update, dict)
+        files = result.update.get("memory_files", {})
+        assert files.get("/memories/old.txt") is None
+        assert files.get("/memories/new.txt") is not None
+        assert files["/memories/new.txt"]["content"] == ["line1"]
+
+        # 2. Test filesystem-backed middleware
+        with tempfile.TemporaryDirectory() as tmpdir:
+            memories_dir = Path(tmpdir) / "memories"
+            memories_dir.mkdir()
+            old_file = memories_dir / "old.txt"
+            old_file.write_text("line1\n")
+
+            fs_middleware = FilesystemClaudeMemoryMiddleware(root_path=tmpdir)
+            fs_runtime: ToolRuntime = ToolRuntime(
+                context=None,
+                state={},
+                config={},
+                stream_writer=lambda _: None,
+                tool_call_id="test_id_fs",
+                store=None,
+            )
+
+            fs_tool = fs_middleware.tools[0]
+
+            fs_result = fs_tool.invoke(
+                {
+                    "runtime": fs_runtime,
+                    "command": "rename",
+                    "path": "/memories/old.txt",
+                    "new_path": "/memories/new.txt",
+                }
+            )
+
+            assert isinstance(fs_result, Command)
+            assert not old_file.exists()
+            new_file = memories_dir / "new.txt"
+            assert new_file.exists()
+            assert new_file.read_text() == "line1\n"
 
 
 class TestSystemMessageHandling:


### PR DESCRIPTION
Fixes #38465

This change fixes a KeyError that occurs when users attempt to rename files using the anthropic middleware tools, as the `_handle_rename` method expected `old_path` but the callback did not provide it. By mapping the input `path` to `old_path` when the command is "rename" and adding protective exception handling, developers can now safely use file renaming operations within LangGraph/Pregel runners without crashing.

I have verified these changes by adding a dedicated integration unit test (`test_file_tool_rename_integration`) in `test_anthropic_tools.py`, and successfully ran `make format`, `make lint`, and `make test` locally with all 205 package tests passing.

## Social handles (optional)
Twitter: @
LinkedIn: https://www.linkedin.com/in/carlos-andree-colquehuanca-rojas-5039a3303/