### PR TITLE
fix(core): use `is not None` instead of truthiness check for cache in `get_prompts`, `aget_prompts`, and `aupdate_cache`

### DIFF
--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -182,7 +182,7 @@ def get_prompts(
 
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = llm_cache.lookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -217,7 +217,7 @@ async def aget_prompts(
     existing_prompts = {}
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = await llm_cache.alookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -288,7 +288,7 @@ async def aupdate_cache(
     for i, result in enumerate(new_results.generations):
         existing_prompts[missing_prompt_idxs[i]] = result
         prompt = prompts[missing_prompt_idxs[i]]
-        if llm_cache:
+        if llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result)
     return new_results.llm_output
 

--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -199,6 +199,7 @@ class EvaluatorCallbackHandler(BaseTracer):
                 source_info=source_info_,
                 source_run_id=res.source_run_id or source_run_id,
                 feedback_source_type=langsmith.schemas.FeedbackSourceType.MODEL,
+                feedback_config=res.feedback_config,
             )
         return results
 

--- a/libs/core/tests/unit_tests/language_models/llms/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/llms/test_cache.py
@@ -109,3 +109,62 @@ async def test_no_cache_generate_async() -> None:
         assert global_cache._cache == {}
     finally:
         set_llm_cache(None)
+
+
+class SizedCache(BaseCache):
+    """Cache that implements __len__, making an empty instance falsy.
+
+    This exercises the `is not None` guard — a truthiness check (`if llm_cache:`)
+    would skip lookups when the cache is empty, silently dropping prompts from
+    both `existing_prompts` and `missing_prompts` and causing a KeyError later.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[tuple[str, str], RETURN_VAL_TYPE] = {}
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def lookup(self, prompt: str, llm_string: str) -> RETURN_VAL_TYPE | None:
+        return self._cache.get((prompt, llm_string))
+
+    def update(self, prompt: str, llm_string: str, return_val: RETURN_VAL_TYPE) -> None:
+        self._cache[prompt, llm_string] = return_val
+
+    @override
+    def clear(self, **kwargs: Any) -> None:
+        self._cache = {}
+
+
+def test_sized_cache_generate_sync() -> None:
+    """generate() must not raise KeyError when cache implements __len__."""
+    cache = SizedCache()
+    assert len(cache) == 0  # falsy — would break under the old truthiness check
+
+    llm = FakeListLLM(cache=cache, responses=["foo", "bar"])
+
+    # First call: cache miss → LLM called, result stored
+    output = llm.generate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1
+
+    # Second call: cache hit → same result returned, LLM NOT called again
+    output = llm.generate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1  # still 1 — no new entry
+
+
+async def test_sized_cache_generate_async() -> None:
+    """agenerate() must not raise KeyError when cache implements __len__."""
+    cache = SizedCache()
+    assert len(cache) == 0
+
+    llm = FakeListLLM(cache=cache, responses=["foo", "bar"])
+
+    output = await llm.agenerate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1
+
+    output = await llm.agenerate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1

--- a/libs/core/tests/unit_tests/tracers/test_evaluation.py
+++ b/libs/core/tests/unit_tests/tracers/test_evaluation.py
@@ -1,0 +1,113 @@
+"""Unit tests for EvaluatorCallbackHandler feedback forwarding."""
+
+from __future__ import annotations
+
+import unittest.mock
+import uuid
+from typing import Any
+from uuid import UUID
+
+from langsmith import Client
+from langsmith.evaluation.evaluator import EvaluationResult
+
+from langchain_core.tracers.evaluation import EvaluatorCallbackHandler
+from langchain_core.tracers.schemas import Run
+
+
+def _make_run(run_id: UUID | None = None) -> Run:
+    """Create a minimal Run object for testing."""
+    return Run(
+        id=run_id or uuid.uuid4(),
+        name="test_run",
+        run_type="chain",
+        inputs={},
+        outputs={"result": "ok"},
+        extra={},
+        serialized={},
+        events=[],
+        tags=[],
+    )
+
+
+def _make_handler(client: Any) -> EvaluatorCallbackHandler:
+    """Create an EvaluatorCallbackHandler with the given mock client."""
+    return EvaluatorCallbackHandler(evaluators=[], client=client)
+
+
+class TestLogEvaluationFeedbackForwardsFeedbackConfig:
+    """Verify that feedback_config is forwarded to client.create_feedback."""
+
+    def test_feedback_config_forwarded_when_set(self) -> None:
+        """feedback_config on EvaluationResult is passed to create_feedback."""
+        client = unittest.mock.MagicMock(spec=Client)
+        handler = _make_handler(client)
+        run = _make_run()
+
+        feedback_config = {"type": "continuous", "min": 0, "max": 1}
+        result = EvaluationResult(
+            key="score",
+            score=0.9,
+            feedback_config=feedback_config,
+        )
+
+        handler._log_evaluation_feedback(result, run)
+
+        client.create_feedback.assert_called_once()
+        _, kwargs = client.create_feedback.call_args
+        assert kwargs["feedback_config"] == feedback_config
+
+    def test_feedback_config_none_when_not_set(self) -> None:
+        """create_feedback receives feedback_config=None when not supplied."""
+        client = unittest.mock.MagicMock(spec=Client)
+        handler = _make_handler(client)
+        run = _make_run()
+
+        result = EvaluationResult(key="score", score=0.5)
+
+        handler._log_evaluation_feedback(result, run)
+
+        _, kwargs = client.create_feedback.call_args
+        assert kwargs["feedback_config"] is None
+
+    def test_feedback_config_categorical(self) -> None:
+        """Categorical feedback_config is forwarded intact."""
+        client = unittest.mock.MagicMock(spec=Client)
+        handler = _make_handler(client)
+        run = _make_run()
+
+        feedback_config = {
+            "type": "categorical",
+            "categories": [{"value": "good"}, {"value": "bad"}],
+        }
+        result = EvaluationResult(
+            key="quality",
+            value="good",
+            feedback_config=feedback_config,
+        )
+
+        handler._log_evaluation_feedback(result, run)
+
+        _, kwargs = client.create_feedback.call_args
+        assert kwargs["feedback_config"] == feedback_config
+
+    def test_other_fields_still_forwarded(self) -> None:
+        """Adding feedback_config does not break forwarding of other fields."""
+        client = unittest.mock.MagicMock(spec=Client)
+        handler = _make_handler(client)
+        run = _make_run()
+
+        result = EvaluationResult(
+            key="relevance",
+            score=0.7,
+            value="relevant",
+            comment="looks good",
+            feedback_config={"type": "continuous", "min": 0, "max": 1},
+        )
+
+        handler._log_evaluation_feedback(result, run)
+
+        _, kwargs = client.create_feedback.call_args
+        assert kwargs["score"] == 0.7
+        assert kwargs["value"] == "relevant"
+        assert kwargs["comment"] == "looks good"
+        assert kwargs["feedback_config"] == {"type": "continuous", "min": 0, "max": 1}

--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -555,7 +555,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1054,7 +1054,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -8,6 +8,7 @@ from langgraph.types import Command
 
 from langchain_anthropic.middleware.anthropic_tools import (
     AnthropicToolsState,
+    FilesystemClaudeTextEditorMiddleware,
     StateClaudeMemoryMiddleware,
     StateClaudeTextEditorMiddleware,
     _validate_path,
@@ -295,7 +296,7 @@ class TestFileOperations:
 
         args = {
             "command": "rename",
-            "old_path": "/memories/old.txt",
+            "path": "/memories/old.txt",
             "new_path": "/memories/new.txt",
         }
         result = middleware._handle_rename(args, state, "test_id")
@@ -476,3 +477,68 @@ class TestSystemMessageHandling:
         assert captured_request.system_message is not None
         assert "Existing instructions." in captured_request.system_message.text
         assert custom_prompt in captured_request.system_message.text
+
+
+class TestRenameOperation:
+    """Regression tests for _handle_rename KeyError bug (#38465).
+
+    file_tool stores the current path as args["path"], but _handle_rename was
+    reading args["old_path"], causing a KeyError on every rename command.
+    """
+
+    def test_state_rename_succeeds(self) -> None:
+        """State-based rename moves the file and emits a ToolMessage."""
+        middleware = StateClaudeTextEditorMiddleware()
+        state: AnthropicToolsState = {
+            "messages": [],
+            "text_editor_files": {
+                "/old.txt": {
+                    "content": ["hello"],
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "modified_at": "2026-01-01T00:00:00+00:00",
+                }
+            },
+        }
+
+        args = {"path": "/old.txt", "new_path": "/new.txt"}
+        result = middleware._handle_rename(args, state, "tc-1")
+
+        assert isinstance(result, Command)
+        assert result.update is not None
+        files = result.update.get("text_editor_files", {})
+        assert files["/old.txt"] is None, "old path should be cleared"
+        assert "/new.txt" in files, "new path should be present"
+        messages = result.update.get("messages", [])
+        assert len(messages) == 1
+        assert "old.txt" in messages[0].content
+        assert "new.txt" in messages[0].content
+
+    def test_state_rename_file_not_found_raises(self) -> None:
+        """Renaming a nonexistent file raises ValueError."""
+        middleware = StateClaudeTextEditorMiddleware()
+        state: AnthropicToolsState = {"messages": [], "text_editor_files": {}}
+
+        args = {"path": "/missing.txt", "new_path": "/other.txt"}
+        with pytest.raises(ValueError, match="File not found"):
+            middleware._handle_rename(args, state, "tc-1")
+
+    def test_filesystem_rename_succeeds(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Filesystem-based rename moves the file and emits a ToolMessage."""
+        middleware = FilesystemClaudeTextEditorMiddleware(
+            root_path=str(tmp_path),
+            allowed_prefixes=["/"],
+        )
+        # Write file at the virtual path /old.txt (resolved to tmp_path/old.txt)
+        (tmp_path / "old.txt").write_text("content")
+
+        # Use virtual paths as file_tool would pass them
+        args = {"path": "/old.txt", "new_path": "/new.txt"}
+        result = middleware._handle_rename(args, "tc-2")
+
+        assert isinstance(result, Command)
+        assert not (tmp_path / "old.txt").exists()
+        assert (tmp_path / "new.txt").exists()
+        messages = result.update.get("messages", [])
+        assert len(messages) == 1
+        assert "old.txt" in messages[0].content
+        assert "new.txt" in messages[0].content

--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -514,6 +514,26 @@ def _convert_message_to_mistral_chat_message(
     raise ValueError(msg)
 
 
+def _merge_token_usage_value(
+    existing: float | dict, incoming: float | dict
+) -> float | dict:
+    """Merge two token usage values, handling nested dicts recursively.
+
+    Mistral may return nested dicts for some token usage fields (e.g.
+    `prompt_tokens_details`). A plain `+=` raises `TypeError` when both sides
+    are dicts, so nested dicts are merged key-by-key instead.
+    """
+    if isinstance(existing, dict) and isinstance(incoming, dict):
+        merged = dict(existing)
+        for k, v in incoming.items():
+            if k in merged:
+                merged[k] = _merge_token_usage_value(merged[k], v)
+            else:
+                merged[k] = v
+        return merged
+    return existing + incoming  # type: ignore[operator]
+
+
 class ChatMistralAI(BaseChatModel):
     """A chat model that uses the Mistral AI API."""
 
@@ -657,7 +677,9 @@ class ChatMistralAI(BaseChatModel):
             if token_usage is not None:
                 for k, v in token_usage.items():
                     if k in overall_token_usage:
-                        overall_token_usage[k] += v
+                        overall_token_usage[k] = _merge_token_usage_value(
+                            overall_token_usage[k], v
+                        )
                     else:
                         overall_token_usage[k] = v
         return {"token_usage": overall_token_usage, "model_name": self.model}

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -650,6 +650,90 @@ def test_no_duplicate_tool_calls_when_multiple_tools() -> None:
     assert len(set(ids)) == 2, f"Duplicate tool call IDs found: {ids}"
 
 
+class TestCombineLlmOutputs:
+    """Tests for ChatMistralAI._combine_llm_outputs."""
+
+    def _make_llm(self) -> ChatMistralAI:
+        return ChatMistralAI(model="mistral-small-latest")  # type: ignore[call-arg]
+
+    def test_flat_integer_fields_are_summed(self) -> None:
+        """Flat int token usage fields from multiple calls are summed correctly."""
+        llm = self._make_llm()
+        outputs = [
+            {"token_usage": {"prompt_tokens": 10, "completion_tokens": 5}},
+            {"token_usage": {"prompt_tokens": 20, "completion_tokens": 8}},
+        ]
+        result = llm._combine_llm_outputs(outputs)
+        usage = result["token_usage"]
+        assert usage["prompt_tokens"] == 30
+        assert usage["completion_tokens"] == 13
+
+    def test_nested_dict_fields_are_merged(self) -> None:
+        """Nested dict fields (e.g. prompt_tokens_details) are merged recursively."""
+        llm = self._make_llm()
+        outputs = [
+            {
+                "token_usage": {
+                    "prompt_tokens": 100,
+                    "prompt_tokens_details": {
+                        "cached_tokens": 10,
+                        "reasoning_tokens": 0,
+                    },
+                }
+            },
+            {
+                "token_usage": {
+                    "prompt_tokens": 200,
+                    "prompt_tokens_details": {
+                        "cached_tokens": 30,
+                        "reasoning_tokens": 5,
+                    },
+                }
+            },
+        ]
+        result = llm._combine_llm_outputs(outputs)
+        usage = result["token_usage"]
+        assert usage["prompt_tokens"] == 300
+        assert usage["prompt_tokens_details"] == {
+            "cached_tokens": 40,
+            "reasoning_tokens": 5,
+        }
+
+    def test_none_outputs_are_skipped(self) -> None:
+        """None entries (from streaming) are silently skipped."""
+        llm = self._make_llm()
+        outputs = [
+            None,
+            {"token_usage": {"prompt_tokens": 10, "completion_tokens": 5}},
+            None,
+        ]
+        result = llm._combine_llm_outputs(outputs)
+        assert result["token_usage"]["prompt_tokens"] == 10
+
+    def test_nested_key_present_only_in_one_output(self) -> None:
+        """A nested key absent from the first output is still captured."""
+        llm = self._make_llm()
+        outputs = [
+            {"token_usage": {"prompt_tokens": 50}},
+            {
+                "token_usage": {
+                    "prompt_tokens": 50,
+                    "prompt_tokens_details": {"cached_tokens": 20},
+                }
+            },
+        ]
+        result = llm._combine_llm_outputs(outputs)
+        usage = result["token_usage"]
+        assert usage["prompt_tokens"] == 100
+        assert usage["prompt_tokens_details"] == {"cached_tokens": 20}
+
+    def test_model_name_in_result(self) -> None:
+        """The result always includes the model name."""
+        llm = self._make_llm()
+        result = llm._combine_llm_outputs([{"token_usage": {"prompt_tokens": 1}}])
+        assert result["model_name"] == "mistral-small-latest"
+
+
 def test_profile() -> None:
     model = ChatMistralAI(model="mistral-large-latest")  # type: ignore[call-arg]
     assert model.profile


### PR DESCRIPTION
Closes #38440

---

Any `BaseCache` that implements `__len__` evaluates to `False` when empty, so the old `if llm_cache:` guard in `get_prompts`, `aget_prompts`, and `aupdate_cache` silently skipped the lookup/write loop entirely on an empty cache. This left the prompt in neither `existing_prompts` nor `missing_prompts`, so no LLM call was made and the subsequent `existing_prompts[i]` access raised `KeyError: 0` on every call — making caching effectively unusable for that common pattern.

The sync `update_cache` already used `if llm_cache is not None:` correctly. This change makes the other three functions consistent with it.

A `SizedCache` fixture (a minimal `BaseCache` with `__len__`) and two regression tests (`test_sized_cache_generate_sync`, `test_sized_cache_generate_async`) are added to confirm the fix end-to-end: cache miss → LLM called → result stored → cache hit → cached result returned, with no `KeyError`.

> AI-assisted contribution.

Made with [Cursor](https://cursor.com)