### PR TITLE
fix(core): avoid retaining callables in nonlocal cache

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -408,6 +408,13 @@ def get_lambda_source(func: Callable[..., Any]) -> str | None:
 
 
 @lru_cache(maxsize=256)
+def _get_function_nonlocal_names(source: str) -> tuple[str, ...]:
+    tree = ast.parse(source)
+    visitor = FunctionNonLocals()
+    visitor.visit(tree)
+    return tuple(sorted(visitor.nonlocals))
+
+
 def get_function_nonlocals(func: Callable[..., Any]) -> list[Any]:
     """Get the nonlocal variables accessed by a function.
 
@@ -419,9 +426,7 @@ def get_function_nonlocals(func: Callable[..., Any]) -> list[Any]:
     """
     try:
         code = inspect.getsource(func)
-        tree = ast.parse(textwrap.dedent(code))
-        visitor = FunctionNonLocals()
-        visitor.visit(tree)
+        nonlocals = _get_function_nonlocal_names(textwrap.dedent(code))
         values: list[Any] = []
         closure = (
             inspect.getclosurevars(func.__wrapped__)
@@ -430,9 +435,9 @@ def get_function_nonlocals(func: Callable[..., Any]) -> list[Any]:
         )
         candidates = {**closure.globals, **closure.nonlocals}
         for k, v in candidates.items():
-            if k in visitor.nonlocals:
+            if k in nonlocals:
                 values.append(v)
-            for kk in visitor.nonlocals:
+            for kk in nonlocals:
                 if "." in kk and kk.startswith(k):
                     vv = v
                     for part in kk.split(".")[1:]:

--- a/libs/core/tests/unit_tests/runnables/test_utils.py
+++ b/libs/core/tests/unit_tests/runnables/test_utils.py
@@ -1,9 +1,12 @@
+import gc
+import weakref
 from collections.abc import Callable
 from typing import Any
 
 import pytest
 
 from langchain_core.runnables.base import RunnableLambda
+from langchain_core.runnables.passthrough import RunnablePassthrough
 from langchain_core.runnables.utils import (
     get_function_nonlocals,
     get_lambda_source,
@@ -73,3 +76,24 @@ def test_nonlocals() -> None:
     assert RunnableLambda(my_func3).deps == [agent]
     assert RunnableLambda(my_func4).deps == [global_agent]
     assert RunnableLambda(func).deps == [nl]
+
+
+def test_bound_method_nonlocals_do_not_keep_instance_alive() -> None:
+    """Regression test for bound methods in RunnableSequence leaking instances."""
+
+    class ThingWithRunnable:
+        def __init__(self) -> None:
+            self.runnable = RunnableLambda(lambda _: {"result": "ok"})
+            self.expensive = {i: [i] for i in range(10)}
+
+        def call(self, inputs: dict[str, Any]) -> dict[str, str]:
+            return self.runnable.invoke(inputs)
+
+    thing = ThingWithRunnable()
+    ref = weakref.ref(thing)
+
+    (thing.call | RunnablePassthrough()).invoke({})
+    del thing
+    gc.collect()
+
+    assert ref() is None


### PR DESCRIPTION
Fixes #30667

Bound methods used in a RunnableSequence could keep their owning instance alive because get_function_nonlocals was cached directly by callable. This keeps caching to parsed source-level nonlocal names while recomputing closure values per callable, so bound methods and their captured objects are no longer retained by the cache.

Validation:
- python -m pytest libs\core\tests\unit_tests\runnables\test_utils.py -q
- python -m ruff check libs\core\langchain_core\runnables\utils.py libs\core\tests\unit_tests\runnables\test_utils.py
- git diff --check