### PR TITLE
docs(cookbook): add Uzbek low-resource RAG cookbook

### DIFF
--- a/cookbook/rag/uzbek_low_resource_rag.ipynb
+++ b/cookbook/rag/uzbek_low_resource_rag.ipynb
@@ -1,0 +1,168 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Uzbek Low-Resource RAG Cookbook\n",
+        "\n",
+        "This cookbook demonstrates how to build a culturally grounded RAG retrieval workflow for **Uzbek**, a low-resource Central Asian language, using the public SOAS English-Uzbek RAG evaluation benchmark as the evaluation harness.\n",
+        "\n",
+        "**Headline result:** Targeted Uzbek source curation improved retrieval recall from **39% to 98%** (Cohen's *d* = 2.91) in the source benchmark.\n",
+        "\n",
+        "**Source dataset:**\n",
+        "- Hugging Face: [`rajantripathi/soas-english-uzbek-rag-evaluation`](https://huggingface.co/datasets/rajantripathi/soas-english-uzbek-rag-evaluation)\n",
+        "- GitHub: https://github.com/rajantripathi/soas-rag-evaluation\n",
+        "- License: CC-BY-4.0 (dataset), MIT (code)\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Setup\n",
+        "\n",
+        "```bash\n",
+        "pip install langchain langchain-community langchain-chroma sentence-transformers datasets\n",
+        "```\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from datasets import load_dataset\n",
+        "\n",
+        "DATASET_ID = 'rajantripathi/soas-english-uzbek-rag-evaluation'\n",
+        "RAW_JSONL = 'https://raw.githubusercontent.com/rajantripathi/soas-rag-evaluation/main/hf_dataset/manual_eval_v5_retrieval_only.jsonl'\n",
+        "\n",
+        "try:\n",
+        "    ds = load_dataset(DATASET_ID, split='train')\n",
+        "except Exception:\n",
+        "    # Public GitHub fallback for environments where the HF mirror is unavailable.\n",
+        "    ds = load_dataset('json', data_files=RAW_JSONL, split='train')\n",
+        "\n",
+        "print(f'Loaded {len(ds)} rows. Languages:', set(ds['language']))\n",
+        "print('Sample:', ds[0])"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Build a Chroma vector store over Uzbek source records\n",
+        "\n",
+        "We use `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`, a small multilingual encoder that supports Uzbek and runs on CPU. In a production RAG system, replace the stand-in documents below with the actual Uzbek source passages.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from langchain_community.embeddings import HuggingFaceEmbeddings\n",
+        "from langchain_community.vectorstores import Chroma\n",
+        "from langchain_core.documents import Document\n",
+        "\n",
+        "embeddings = HuggingFaceEmbeddings(model_name='sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2')\n",
+        "\n",
+        "uz_rows = [r for r in ds if r['language'] == 'uz']\n",
+        "documents = [\n",
+        "    Document(\n",
+        "        page_content=r.get('source_title') or r['question'],\n",
+        "        metadata={\n",
+        "            'source_doc_id': r['source_doc_ids'][0] if r.get('source_doc_ids') else None,\n",
+        "            'id': r['id'],\n",
+        "            'domain': r['domain'],\n",
+        "        },\n",
+        "    )\n",
+        "    for r in uz_rows\n",
+        "]\n",
+        "vectorstore = Chroma.from_documents(documents, embeddings, collection_name='uz_cookbook')\n",
+        "print(f'Indexed {len(documents)} documents.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Evaluate retrieval recall@5\n",
+        "\n",
+        "An item is counted as retrieved when any of the top-5 returned document IDs matches `source_doc_ids`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def retrieval_recall_at_k(retrieved, source_doc_ids, k=5):\n",
+        "    return int(bool(set(retrieved[:k]) & set(source_doc_ids or [])))\n",
+        "\n",
+        "hits = 0\n",
+        "for row in uz_rows:\n",
+        "    docs = vectorstore.similarity_search(row['question'], k=5)\n",
+        "    retrieved_ids = [doc.metadata.get('source_doc_id') for doc in docs]\n",
+        "    hits += retrieval_recall_at_k(retrieved_ids, row['source_doc_ids'], k=5)\n",
+        "\n",
+        "recall = hits / len(uz_rows)\n",
+        "print(f'Uzbek retrieval recall@5 (cookbook demo): {recall:.1%}')\n",
+        "print('Note: In the published benchmark, the full corpus raises this from 39% to 98%.')"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Why corpus coverage dominates model choice\n",
+        "\n",
+        "On this evaluation set:\n",
+        "\n",
+        "| Setting | Retrieval Recall |\n",
+        "| --- | ---: |\n",
+        "| English baseline | 63% |\n",
+        "| Uzbek baseline (no targeted corpus) | 39% |\n",
+        "| Uzbek after corpus supplementation | **98%** |\n",
+        "\n",
+        "**Interpretation:** For low-resource languages, source corpus coverage can be a first-order bottleneck. Before swapping embedding models or LLMs, audit whether the retriever has access to the documents that actually contain the answer.\n",
+        "\n",
+        "Full methodology, statistical analysis, and reproducibility notes are in the source repository: https://github.com/rajantripathi/soas-rag-evaluation\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Citation\n",
+        "\n",
+        "```bibtex\n",
+        "@dataset{tripathi_2026_soas_en_uz_rag,\n",
+        "  author       = {Tripathi, Rajan Prasad},\n",
+        "  title        = {SOAS English-Uzbek RAG Evaluation (Retrieval-Only)},\n",
+        "  year         = {2026},\n",
+        "  publisher    = {Hugging Face},\n",
+        "  version      = {manual_eval_v5},\n",
+        "  url          = {https://huggingface.co/datasets/rajantripathi/soas-english-uzbek-rag-evaluation}\n",
+        "}\n",
+        "```\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new cookbook notebook demonstrating how to build a culturally grounded RAG retrieval workflow for **Uzbek**, a low-resource Central Asian language. The notebook uses the public SOAS English-Uzbek RAG evaluation dataset as the evaluation harness.

## Why this matters

LangChain has rich RAG examples, but low-resource Central Asian languages remain underrepresented. For practitioners building RAG systems in Uzbekistan and neighboring regions, a key practical question is: did the retriever fail because the embedding model is weak, or because the source corpus does not contain the relevant document?

The cookbook walks through:

1. Loading the SOAS English-Uzbek evaluation dataset from Hugging Face, with a public GitHub JSONL fallback
2. Building a Chroma vector store over Uzbek source records
3. Running retrieval against Uzbek questions
4. Scoring retrieval recall@5 against `source_doc_ids`
5. Interpreting the benchmark result that corpus supplementation improved Uzbek retrieval recall from 39% to 98% in the source study

## Source dataset

- GitHub: https://github.com/rajantripathi/soas-rag-evaluation
- Hugging Face mirror: `rajantripathi/soas-english-uzbek-rag-evaluation`
- License: CC-BY-4.0 (dataset), MIT (code)

## Tested locally

- Validated notebook JSON with `python3 -m json.tool cookbook/rag/uzbek_low_resource_rag.ipynb`

I did not execute the full notebook in this checkout because it requires installing notebook dependencies (`langchain`, `langchain-community`, `langchain-chroma`, `sentence-transformers`, and `datasets`).

## Maintainer questions

- Preferred cookbook location? `cookbook/rag/` is a proposal because this checkout does not currently include a top-level cookbook directory.
- Should this instead live in a docs/examples repository?
- Should the notebook include a LangSmith trace example, or stay self-contained?
