### PR TITLE
docs(core): remove stale docstring parameters

### DIFF
--- a/libs/core/langchain_core/callbacks/file.py
+++ b/libs/core/langchain_core/callbacks/file.py
@@ -135,7 +135,6 @@ class FileCallbackHandler(BaseCallbackHandler):
             text: The text to write to the file.
             color: Optional color for the text. Defaults to `self.color`.
             end: String appended after the text.
-            file: Optional file to write to. Defaults to `self.file`.
 
         Raises:
             RuntimeError: If the file is closed or not available.

--- a/libs/core/langchain_core/outputs/chat_generation.py
+++ b/libs/core/langchain_core/outputs/chat_generation.py
@@ -45,11 +45,8 @@ class ChatGeneration(Generation):
     def set_text(self) -> Self:
         """Set the text attribute to be the contents of the message.
 
-        Args:
-            values: The values of the object.
-
         Returns:
-            The values of the object with the text attribute set.
+            The model instance with the `text` attribute set.
 
         Raises:
             ValueError: If the message is not a string or a list.


### PR DESCRIPTION
**Description:** Fixes two docstrings in `langchain-core` that document parameters which don't exist in their function signatures.

- `FileCallbackHandler._write` (`callbacks/file.py`) documents a `file` argument, but the method signature is `(self, text, color=None, end="")` — there is no `file` parameter.
- `ChatGeneration.set_text` (`outputs/chat_generation.py`) is a `@model_validator(mode="after")` whose signature is `(self) -> Self`. Its docstring still documents an `Args: values:` parameter and a "values of the object" return value — stale from when it was a `mode="before"` validator that received a `values` dict.

This removes the nonexistent `file` arg, drops the stale `Args` section from `set_text`, and corrects its `Returns` description.

Docstring-only change; no runtime behavior is affected.

Fixes #38536
