### PR TITLE
fix(core): correct error message in `Visitor._validate_func` for disallowed operators

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (

--- a/libs/core/tests/unit_tests/test_structured_query.py
+++ b/libs/core/tests/unit_tests/test_structured_query.py
@@ -1,0 +1,46 @@
+"""Unit tests for Visitor._validate_func error messages."""
+
+import pytest
+
+from langchain_core.structured_query import Comparator, Operator, Visitor
+
+
+class _MinimalVisitor(Visitor):
+    allowed_comparators = (Comparator.EQ,)
+    allowed_operators = (Operator.AND,)
+
+    def visit_operation(self, operation):  # type: ignore[override]
+        pass
+
+    def visit_comparison(self, comparison):  # type: ignore[override]
+        pass
+
+    def visit_structured_query(self, structured_query):  # type: ignore[override]
+        pass
+
+
+def test_validate_func_disallowed_operator_error_message() -> None:
+    """Disallowed operator error must say 'operators', not 'comparators'."""
+    visitor = _MinimalVisitor()
+    with pytest.raises(ValueError, match="operator") as exc_info:
+        visitor._validate_func(Operator.OR)
+    assert "comparators" not in str(exc_info.value), (
+        "Error message for a disallowed operator incorrectly says 'comparators'"
+    )
+
+
+def test_validate_func_disallowed_comparator_error_message() -> None:
+    """Disallowed comparator error must say 'comparators'."""
+    visitor = _MinimalVisitor()
+    with pytest.raises(ValueError, match="comparator"):
+        visitor._validate_func(Comparator.GT)
+
+
+def test_validate_func_allowed_operator_does_not_raise() -> None:
+    visitor = _MinimalVisitor()
+    visitor._validate_func(Operator.AND)  # should not raise
+
+
+def test_validate_func_allowed_comparator_does_not_raise() -> None:
+    visitor = _MinimalVisitor()
+    visitor._validate_func(Comparator.EQ)  # should not raise


### PR DESCRIPTION
Closes #36701

---

In `Visitor._validate_func`, when an operator is not in `allowed_operators`, the error message incorrectly said:

```
Received disallowed operator Operator.OR. Allowed comparators are (Operator.AND,)
```

The word **comparators** is wrong here — it should be **operators**. This was a copy-paste error from the adjacent `isinstance(func, Comparator)` branch directly below.

**After this fix:**

```
Received disallowed operator Operator.OR. Allowed operators are (Operator.AND,)
```

The comparator branch (line 42) was already correct and is unchanged.

A new test file `tests/unit_tests/test_structured_query.py` is added covering:
- The fixed operator error path (asserts "comparators" does **not** appear in the message)
- The existing comparator error path (asserts "comparator" appears)
- Happy-path cases for both allowed operator and allowed comparator (must not raise)

> Note: this contribution was prepared with the assistance of Claude Code.