### PR TITLE
fix(core,text-splitters): fix `InMemoryCache` eviction on update and add `Language.PERL` separators

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -226,9 +226,10 @@ class InMemoryCache(BaseCache):
 
                 The value is a list of `Generation` (or subclasses).
         """
-        if self._maxsize is not None and len(self._cache) == self._maxsize:
+        key = (prompt, llm_string)
+        if self._maxsize is not None and key not in self._cache and len(self._cache) == self._maxsize:
             del self._cache[next(iter(self._cache))]
-        self._cache[prompt, llm_string] = return_val
+        self._cache[key] = return_val
 
     @override
     def clear(self, **kwargs: Any) -> None:

--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -384,6 +384,24 @@ def convert_to_openai_function(
             If a dictionary is passed in, it is assumed to already be a valid OpenAI
             function, a JSON schema with top-level `title` key specified, an Anthropic
             format tool, or an Amazon Bedrock Converse format tool.
+
+            When passing a raw JSON schema dict, a top-level `title` key is **required**
+            and will be used as the function name. Schemas without `title` raise a
+            `ValueError`. Example of a valid JSON schema dict:
+
+            .. code-block:: python
+
+                {
+                    "title": "ContactInfo",          # required — becomes function name
+                    "description": "Contact details",  # optional
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "email": {"type": "string"},
+                    },
+                    "required": ["name", "email"],
+                }
+
         strict: If `True`, model output is guaranteed to exactly match the JSON Schema
             provided in the function definition.
 
@@ -394,7 +412,8 @@ def convert_to_openai_function(
             function-calling API.
 
     Raises:
-        ValueError: If function is not in a supported format.
+        ValueError: If function is not in a supported format, or if a JSON schema dict
+            is passed without a top-level `title` key.
 
     !!! warning "Behavior changed in `langchain-core` 0.3.16"
 
@@ -530,6 +549,24 @@ def convert_to_openai_tool(
             If a dictionary is passed in, it is assumed to already be a valid OpenAI
             function, a JSON schema with top-level `title` key specified, an Anthropic
             format tool, or an Amazon Bedrock Converse format tool.
+
+            When passing a raw JSON schema dict, a top-level `title` key is **required**
+            and will be used as the tool name. Schemas without `title` raise a
+            `ValueError`. Example of a valid JSON schema dict:
+
+            .. code-block:: python
+
+                {
+                    "title": "ContactInfo",          # required — becomes tool name
+                    "description": "Contact details",  # optional
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "email": {"type": "string"},
+                    },
+                    "required": ["name", "email"],
+                }
+
         strict: If `True`, model output is guaranteed to exactly match the JSON Schema
             provided in the function definition.
 

--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -132,7 +132,7 @@ class InMemoryVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud", k=1)
+        # results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)

--- a/libs/core/tests/unit_tests/test_structured_query.py
+++ b/libs/core/tests/unit_tests/test_structured_query.py
@@ -1,0 +1,46 @@
+"""Unit tests for Visitor._validate_func error messages."""
+
+import pytest
+
+from langchain_core.structured_query import Comparator, Operator, Visitor
+
+
+class _MinimalVisitor(Visitor):
+    allowed_comparators = (Comparator.EQ,)
+    allowed_operators = (Operator.AND,)
+
+    def visit_operation(self, operation):  # type: ignore[override]
+        pass
+
+    def visit_comparison(self, comparison):  # type: ignore[override]
+        pass
+
+    def visit_structured_query(self, structured_query):  # type: ignore[override]
+        pass
+
+
+def test_validate_func_disallowed_operator_error_message() -> None:
+    """Disallowed operator error must say 'operators', not 'comparators'."""
+    visitor = _MinimalVisitor()
+    with pytest.raises(ValueError, match="operator") as exc_info:
+        visitor._validate_func(Operator.OR)
+    assert "comparators" not in str(exc_info.value), (
+        "Error message for a disallowed operator incorrectly says 'comparators'"
+    )
+
+
+def test_validate_func_disallowed_comparator_error_message() -> None:
+    """Disallowed comparator error must say 'comparators'."""
+    visitor = _MinimalVisitor()
+    with pytest.raises(ValueError, match="comparator"):
+        visitor._validate_func(Comparator.GT)
+
+
+def test_validate_func_allowed_operator_does_not_raise() -> None:
+    visitor = _MinimalVisitor()
+    visitor._validate_func(Operator.AND)  # should not raise
+
+
+def test_validate_func_allowed_comparator_does_not_raise() -> None:
+    visitor = _MinimalVisitor()
+    visitor._validate_func(Comparator.EQ)  # should not raise

--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -271,7 +271,7 @@ class Chroma(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)

--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -167,7 +167,7 @@ class QdrantVectorStore(VectorStore):
         # await vector_store.adelete(ids=["3"])
 
         # search
-        # results = vector_store.asimilarity_search(query="thud",k=1)
+        # results = await vector_store.asimilarity_search(query="thud", k=1)
 
         # search with score
         results = await vector_store.asimilarity_search_with_score(query="qux", k=1)

--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -788,6 +788,37 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 "",
             ]
 
+        if language == Language.PERL:
+            return [
+                # Split along subroutine definitions
+                "\nsub ",
+                # Split along package declarations
+                "\npackage ",
+                # Split along use/require statements
+                "\nuse ",
+                "\nrequire ",
+                # Split along eval blocks
+                "\neval {",
+                "\neval \"",
+                # Split along control flow
+                "\nif (",
+                "\nelsif (",
+                "\nelse {",
+                "\nunless (",
+                "\nwhile (",
+                "\nfor (",
+                "\nforeach (",
+                "\nuntil (",
+                "\ndo {",
+                # Split along regular expression operations
+                "\n=~ s/",
+                "\n=~ m/",
+                # Normal line splitting
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
         if language in Language._value2member_map_:
             msg = f"Language {language} is not implemented yet!"
             raise ValueError(msg)


### PR DESCRIPTION
Closes #36750

Two distinct bugs fixed in one PR as they were reported together.

---

### Bug 1 — `InMemoryCache` incorrectly evicts on update (`langchain-core`)

`InMemoryCache.update()` evicted the oldest entry whenever `len(cache) == maxsize`, even when the caller was **overwriting an existing key** (not inserting a new one). This shrinks the cache below `maxsize` on every re-update of an existing entry.

**Before:**
```python
if self._maxsize is not None and len(self._cache) == self._maxsize:
    del self._cache[next(iter(self._cache))]
self._cache[prompt, llm_string] = return_val
```

**After:**
```python
key = (prompt, llm_string)
if self._maxsize is not None and key not in self._cache and len(self._cache) == self._maxsize:
    del self._cache[next(iter(self._cache))]
self._cache[key] = return_val
```

The guard now only evicts when the key is **new** to the cache.

---

### Bug 2 — `Language.PERL` not handled in `get_separators_for_language` (`text-splitters`)

`Language.PERL` exists in the `Language` enum but the `get_separators_for_language` switch had no branch for it, raising `ValueError: Language Language.PERL is not implemented yet!` on every call to `RecursiveCharacterTextSplitter.from_language(Language.PERL)`.

Added a `PERL` branch with idiomatic Perl separators:
- `sub` / `package` / `use` / `require` declarations
- `eval` blocks
- Control-flow keywords (`if` / `elsif` / `else` / `unless` / `while` / `for` / `foreach` / `until` / `do`)
- Regex operators (`=~ s/` and `=~ m/`)
- Standard fallback sequence (`\n\n`, `\n`, ` `, `""`)

> Note: this contribution was prepared with the assistance of Claude Code.