### PR TITLE
fix: raise OutputParserException in parse_partial_json on failure (closes #36603)

### DIFF
--- a/libs/core/langchain_core/utils/json.py
+++ b/libs/core/langchain_core/utils/json.py
@@ -126,7 +126,12 @@ def parse_partial_json(s: str, *, strict: bool = False) -> Any:
         try:
             return json.loads("".join(new_chars + stack), strict=strict)
         except json.JSONDecodeError:
-            # If we still can't parse the string as JSON,
+            # If we still can't parse, remove the last character and try again.
+            new_chars.pop()
+    # If we exhausted all attempts, raise an error.
+    raise OutputParserException(
+        f"Failed to parse JSON from incomplete string: {s}"
+    )e the string as JSON,
             # try removing the last character
             new_chars.pop()
 


### PR DESCRIPTION
## What
`parse_partial_json` could return `None` when it was unable to parse an incomplete JSON string, leading to hard-to-debug errors in downstream parsers (e.g., `PydanticOutputParser`). This masked the actual parsing failure and could cause random `OutputParserException` errors.

## Fix
Changed `parse_partial_json` to raise an `OutputParserException` when all attempts to parse the incomplete JSON fail, instead of silently returning `None`. This ensures clearer error messages and consistent exception handling.

Closes #36603