### PR TITLE
fix(openai): preserve OpenAI-compatible prompt manifest config

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -60,6 +60,10 @@ from langchain_core.language_models.chat_models import (
     BaseChatModel,
     LangSmithParams,
 )
+from langchain_core.load.serializable import (
+    SerializedConstructor,
+    SerializedNotImplemented,
+)
 from langchain_core.messages import (
     AIMessage,
     AIMessageChunk,
@@ -3323,10 +3327,19 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
     max_tokens: int | None = Field(default=None, alias="max_completion_tokens")
     """Maximum number of tokens to generate."""
 
+    openai_api_key_secret_id: str | None = Field(
+        default=None, alias="api_key_secret_id", exclude=True
+    )
+    """Secret id to use when serializing `openai_api_key`.
+
+    Defaults to `OPENAI_API_KEY`.
+    """
+
     @property
     def lc_secrets(self) -> dict[str, str]:
         """Mapping of secret environment variables."""
-        return {"openai_api_key": "OPENAI_API_KEY"}
+        secret_id = self.openai_api_key_secret_id or "OPENAI_API_KEY"
+        return {"openai_api_key": secret_id}
 
     @classmethod
     def get_lc_namespace(cls) -> list[str]:
@@ -3352,6 +3365,15 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
             attributes["openai_proxy"] = self.openai_proxy
 
         return attributes
+
+    def to_json(self) -> SerializedConstructor | SerializedNotImplemented:
+        """Serialize the model using public endpoint constructor aliases."""
+        serialized = super().to_json()
+        if serialized["type"] == "constructor":
+            kwargs = serialized["kwargs"]
+            if "openai_api_base" in kwargs:
+                kwargs["base_url"] = kwargs.pop("openai_api_base")
+        return serialized
 
     @classmethod
     def is_lc_serializable(cls) -> bool:

--- a/libs/partners/openai/tests/unit_tests/test_load.py
+++ b/libs/partners/openai/tests/unit_tests/test_load.py
@@ -74,6 +74,33 @@ def test_load_openai_chat() -> None:
     assert isinstance(llm2, ChatOpenAI)
 
 
+def test_load_openai_chat_openai_compatible_endpoint_config() -> None:
+    """Test serialization of OpenAI-compatible endpoint runtime config."""
+    llm = ChatOpenAI(  # type: ignore[call-arg]
+        model="google/gemini-3-flash-preview",
+        base_url="https://openrouter.ai/api/v1",
+        openai_api_key="hello",
+        api_key_secret_id="OPENROUTER_API_KEY",
+        use_responses_api=True,
+    )
+
+    llm_obj = dumpd(llm)
+    kwargs = llm_obj["kwargs"]
+    assert kwargs["base_url"] == "https://openrouter.ai/api/v1"
+    assert "openai_api_base" not in kwargs
+    assert kwargs["openai_api_key"]["id"] == ["OPENROUTER_API_KEY"]
+    assert "api_key_secret_id" not in kwargs
+
+    llm2 = load(
+        llm_obj,
+        secrets_map={"OPENROUTER_API_KEY": "hello"},
+        allowed_objects=[ChatOpenAI],
+    )
+
+    assert isinstance(llm2, ChatOpenAI)
+    assert llm2.openai_api_base == "https://openrouter.ai/api/v1"
+
+
 def test_loads_runnable_sequence_prompt_model() -> None:
     """Test serialization/deserialization of a chain:
 


### PR DESCRIPTION
Fixes #37018

---

LangSmith Prompt Hub can store OpenAI-compatible model configs that use a custom endpoint and a non-default API key name, such as OpenRouter's `base_url` and `OPENROUTER_API_KEY`.

`ChatOpenAI` serialization previously always emitted `OPENAI_API_KEY` for `openai_api_key`, so generated manifests could not faithfully represent those prompt model configs. This adds a serialization-only `api_key_secret_id` override while preserving the default `OPENAI_API_KEY` behavior for existing OpenAI users.

This also serializes custom endpoints with the public `base_url` constructor alias instead of the internal `openai_api_base` field.

Changed:
- Updated `ChatOpenAI` serialization to support custom secret ids and public `base_url` output.
- Added a regression test for OpenAI-compatible endpoint config serialization and `load()` round-trip.

Test added:
- `libs/partners/openai/tests/unit_tests/test_load.py::test_load_openai_chat_openai_compatible_endpoint_config`

Testing:
- `git diff --check`
- `python3.12 -m py_compile libs/partners/openai/langchain_openai/chat_models/base.py libs/partners/openai/tests/unit_tests/test_load.py`
- Ran an equivalent Python 3.12 serialization regression script verifying `base_url`, `OPENROUTER_API_KEY`, omitted `api_key_secret_id`, and `load()` round-trip.
- Targeted pytest command reached OpenAI partner `conftest.py` but could not complete because the local environment is missing `vcrpy` (`ModuleNotFoundError: No module named 'vcr'`) and `uv` is not available on PATH.

This contribution was prepared with AI-agent assistance.