### PR TITLE
fix(anthropic): ignore LangSmith requests in VCR cassettes

### DIFF
--- a/libs/partners/anthropic/tests/conftest.py
+++ b/libs/partners/anthropic/tests/conftest.py
@@ -25,6 +25,10 @@ def vcr_config() -> dict:
     config["before_record_response"] = remove_response_headers
     config["serializer"] = "yaml.gz"
     config["path_transformer"] = VCR.ensure_suffix(".yaml.gz")
+    config["ignore_hosts"] = [
+        *config.get("ignore_hosts", []),
+        "api.smith.langchain.com",
+    ]
 
     return config
 


### PR DESCRIPTION
Anthropic integration tests can run with LangSmith tracing enabled in scheduled CI, which sends LangSmith API requests while VCR cassettes are active. Ignore LangSmith ingest endpoints in the Anthropic VCR config so cassette playback only matches Anthropic traffic.

## Changes
- Add `api.smith.langchain.com` to the Anthropic VCR `ignore_hosts` configuration while preserving any hosts from the shared base config.
- Keep existing Anthropic cassette serialization, request redaction, and response redaction behavior unchanged.