### PR TITLE
fix(anthropic): preserve cache_control on tool_use content blocks (#38398)

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -543,11 +543,13 @@ def _format_messages(
                                 for tc in message.tool_calls
                                 if tc["id"] == block["id"]
                             ]
-                            content.extend(
-                                _lc_tool_calls_to_anthropic_tool_use_blocks(
-                                    overlapping,
-                                ),
+                            tool_use_blocks = _lc_tool_calls_to_anthropic_tool_use_blocks(
+                                overlapping,
                             )
+                            if cache_control := block.get("cache_control"):
+                                for block_dict in tool_use_blocks:
+                                    block_dict["cache_control"] = cache_control
+                            content.extend(tool_use_blocks)
                         else:
                             if tool_input := block.get("input"):
                                 args = tool_input
@@ -566,6 +568,8 @@ def _format_messages(
                             )
                             if caller := block.get("caller"):
                                 tool_use_block["caller"] = caller
+                            if cache_control := block.get("cache_control"):
+                                tool_use_block["cache_control"] = cache_control
                             content.append(tool_use_block)
                     elif block["type"] in ("server_tool_use", "mcp_tool_use"):
                         formatted_block = {
@@ -2312,6 +2316,7 @@ class _AnthropicToolUse(TypedDict):
     input: dict
     id: str
     caller: NotRequired[dict[str, Any]]
+    cache_control: NotRequired[dict[str, str]]
 
 
 def _lc_tool_calls_to_anthropic_tool_use_blocks(

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -981,6 +981,49 @@ def test__format_tool_use_block() -> None:
     assert result == (None, [expected])
 
 
+def test__format_tool_use_block_preserves_cache_control() -> None:
+    """Regression: cache_control on a tool_use content block must survive formatting."""
+    msg = AIMessage(
+        [
+            {
+                "type": "tool_use",
+                "name": "get_weather",
+                "id": "toolu_1",
+                "input": {"city": "Paris"},
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+    )
+    _, formatted = _format_messages([msg])
+    assert len(formatted) == 1
+    tool_use_blocks = [b for b in formatted[0]["content"] if b["type"] == "tool_use"]
+    assert len(tool_use_blocks) == 1
+    assert tool_use_blocks[0].get("cache_control") == {"type": "ephemeral"}
+
+
+def test__format_tool_use_block_preserves_cache_control_with_tool_calls() -> None:
+    """cache_control on a tool_use block survives when tool_calls also present."""
+    msg = AIMessage(
+        [
+            {
+                "type": "tool_use",
+                "name": "get_weather",
+                "id": "toolu_1",
+                "input": {"city": "Paris"},
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        tool_calls=[
+            {"name": "get_weather", "id": "toolu_1", "args": {"city": "Paris"}}
+        ],
+    )
+    _, formatted = _format_messages([msg])
+    assert len(formatted) == 1
+    tool_use_blocks = [b for b in formatted[0]["content"] if b["type"] == "tool_use"]
+    assert len(tool_use_blocks) == 1
+    assert tool_use_blocks[0].get("cache_control") == {"type": "ephemeral"}
+
+
 def test__format_messages_with_str_content_and_tool_calls() -> None:
     system = SystemMessage("fuzz")  # type: ignore[misc]
     human = HumanMessage("foo")  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Fixes #38398: `cache_control` on a `tool_use` content block was silently dropped when matching `tool_calls` item exists or during direct formatting.

## Root Cause

- The `_AnthropicToolUse` TypedDict did not include `cache_control` as an allowed field
- The formatter never copied `cache_control` from the original `tool_use` content block in either the `tool_calls` override path or the direct formatting path

Other block types (text, thinking, tool_result, server_tool_use, etc.) already correctly preserve `cache_control`.

## Changes

- Added `cache_control: NotRequired[dict[str, str]]` to `_AnthropicToolUse` TypedDict
- Propagate `cache_control` from original block in the direct tool_use formatting branch
- Propagate `cache_control` from original block in the tool_calls override branch
- Two regression tests: one for direct tool_use formatting, one for tool_calls override path

## Testing

```bash
cd libs/partners/anthropic
python -m pytest tests/unit_tests/test_chat_models.py -x -v
```

All 113 unit tests pass (2 new, 111 existing).

## Related Issue

Closes #38398