### PR TITLE
fix(core): don't mask non-`Exception` `BaseException` in `agenerate`

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1807,12 +1807,12 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                     *[
                         run_manager.on_llm_end(
                             LLMResult(
-                                generations=[res.generations],  # type: ignore[union-attr]
-                                llm_output=res.llm_output,  # type: ignore[union-attr]
+                                generations=[res.generations],
+                                llm_output=res.llm_output,
                             )
                         )
                         for run_manager, res in zip(run_managers, results, strict=False)
-                        if not isinstance(res, Exception)
+                        if not isinstance(res, BaseException)
                     ]
                 )
             raise exceptions[0]

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -1672,6 +1672,56 @@ def test_generate_response_from_error_handles_streaming_response_failure() -> No
     assert metadata["status_code"] == 400
 
 
+async def test_agenerate_propagates_non_exception_base_exception() -> None:
+    """A `BaseException` that is not an `Exception` must propagate unmasked.
+
+    `agenerate` gathers per-message results with `return_exceptions=True` and
+    collects failures with an `isinstance(res, BaseException)` check. The
+    subsequent `on_llm_end` filter must use the same `BaseException` check;
+    otherwise a `BaseException` that is not an `Exception` (e.g.
+    `asyncio.CancelledError`, `KeyboardInterrupt`) slips through, its
+    `generations` attribute is read off the raised object, and the resulting
+    `AttributeError` masks the original exception.
+
+    Regression test for #38469.
+    """
+
+    class _Abort(BaseException):
+        """A `BaseException` that is deliberately not an `Exception`."""
+
+    class _RaisingChatModel(BaseChatModel):
+        @property
+        @override
+        def _llm_type(self) -> str:
+            return "raising"
+
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            raise _Abort
+
+        @override
+        async def _agenerate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: AsyncCallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            raise _Abort
+
+    model = _RaisingChatModel()
+    # Attaching a callback makes `run_managers` truthy and exercises the
+    # `on_llm_end` path that previously masked the exception.
+    with pytest.raises(_Abort):
+        await model.agenerate([[HumanMessage("hi")]], callbacks=[BaseCallbackHandler()])
+
+
 def test_filter_invocation_params_for_tracing() -> None:
     """Test that large fields are filtered from invocation params for tracing."""
     params = {


### PR DESCRIPTION
Closes #38469

---

When an async generation is cancelled or interrupted, users expect to see the real cause — a `CancelledError`, a `KeyboardInterrupt`, or another library's abort sentinel. Instead, `BaseChatModel.agenerate` raised a confusing `AttributeError` that hid what actually happened, making cancellations and interrupts hard to diagnose.

The cause is a mismatch between two checks. `agenerate` runs each message through `asyncio.gather(..., return_exceptions=True)` and collects failures using `isinstance(res, BaseException)`. The follow-up `on_llm_end` step, however, filtered results with the narrower `isinstance(res, Exception)`. Because a `BaseException` such as `asyncio.CancelledError` or `KeyboardInterrupt` is not an `Exception`, it slipped past that filter, the cleanup code read `generations` off the raised object, and the resulting `AttributeError` masked the original exception.

This aligns the `on_llm_end` filter on `BaseException` so failed results are excluded consistently and the original exception propagates unchanged. The synchronous `generate` path is unaffected — it re-raises immediately and never hit this branch. Narrowing the type also lets the type checker prove the remaining results are successful, so two now-redundant `type: ignore[union-attr]` comments are removed.

A regression test covers the case: an async model that raises a `BaseException` which is not an `Exception` now surfaces that exception rather than an `AttributeError`.

---

*Disclaimer: this contribution was prepared with the assistance of an AI coding agent and reviewed before submission.*
