### PR TITLE
fix(core): render falsy items in mustache list sections

### DIFF
--- a/libs/core/langchain_core/utils/mustache.py
+++ b/libs/core/langchain_core/utils/mustache.py
@@ -12,7 +12,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    cast,
 )
 
 if TYPE_CHECKING:
@@ -21,7 +20,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-Scopes: TypeAlias = list[Literal[False, 0] | Mapping[str, Any]]
+class _SkippedScope:
+    """Sentinel pushed onto the scope stack to mark a section body to skip.
+
+    A section is skipped when its scope is falsy (e.g. `{{#x}}...{{/x}}` with a
+    falsy `x`) or when an inverted section's scope is truthy. Using a dedicated
+    sentinel - rather than the falsy value itself - means that falsy *items*
+    encountered while iterating a list section (e.g. `0`, `False`, `""`) are not
+    mistaken for a skipped section and still render their body.
+    """
+
+    __slots__ = ()
+
+
+_SKIPPED_SCOPE = _SkippedScope()
+
+Scopes: TypeAlias = list[Any]
 
 
 # Globals
@@ -529,11 +543,11 @@ def render(
             # Pop out of the latest scope
             del scopes[0]
 
-        # If the current scope is falsy and not the only scope
-        elif not current_scope and len(scopes) != 1:
+        # If we're skipping a falsy section's body and not at the only scope
+        elif current_scope is _SKIPPED_SCOPE and len(scopes) != 1:
             if tag in {"section", "inverted section"}:
-                # Set the most recent scope to a falsy value
-                scopes.insert(0, False)
+                # Keep the scope stack balanced for nested sections being skipped
+                scopes.insert(0, _SKIPPED_SCOPE)
 
         # If we're a literal tag
         elif tag == "literal":
@@ -661,16 +675,19 @@ def render(
                     output += rend
 
             else:
-                # Otherwise we're just a scope section
-                scopes.insert(0, scope)
+                # Otherwise we're just a scope section. A falsy scope means the
+                # body is skipped: push the skip sentinel rather than the falsy
+                # value itself, so falsy items in list sections still render.
+                scopes.insert(0, scope or _SKIPPED_SCOPE)
 
         # If we're an inverted section
         elif tag == "inverted section":
-            # Add the flipped scope to the scopes
+            # An inverted section renders its body only when the scope is falsy;
+            # when it's truthy we push the skip sentinel to suppress the body.
             scope = _get_key(
                 key, scopes, warn=warn, keep=keep, def_ldel=def_ldel, def_rdel=def_rdel
             )
-            scopes.insert(0, cast("Literal[False]", not scope))
+            scopes.insert(0, True if not scope else _SKIPPED_SCOPE)
 
         # If we're a partial
         elif tag == "partial":

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -251,6 +251,52 @@ def test_mustache_prompt_from_template(snapshot: SnapshotAssertion) -> None:
     }
 
 
+def test_mustache_prompt_with_falsy_list_items() -> None:
+    """Falsy items in a mustache list section must still render their body.
+
+    Iterating a list section over values like `0`, `False`, `0.0`, or `""` must
+    render the section body once per item - matching the Mustache spec's
+    implicit-iterator behavior - rather than silently skipping the falsy items.
+
+    Regression test: previously these items were dropped because the body-skip
+    check for falsy *sections* also fired for falsy list *items*.
+    """
+    prompt = PromptTemplate.from_template(
+        "{{#scores}}({{.}}){{/scores}}", template_format="mustache"
+    )
+    assert prompt.format(scores=[0, 1, 2, 0, 3]) == "(0)(1)(2)(0)(3)"
+    assert prompt.format(scores=[0]) == "(0)"
+    assert prompt.format(scores=[False]) == "(False)"
+    assert prompt.format(scores=[0.0, 1.5]) == "(0.0)(1.5)"
+
+    # Static body text must also render once per item, even for falsy items.
+    static = PromptTemplate.from_template(
+        "{{#items}}X{{/items}}", template_format="mustache"
+    )
+    assert static.format(items=[0, 0, 0]) == "XXX"
+
+    # Empty-string items render as empty (the body still runs, the value is "").
+    empties = PromptTemplate.from_template(
+        "{{#items}}[{{.}}]{{/items}}", template_format="mustache"
+    )
+    assert empties.format(items=["", "a"]) == "[][a]"
+
+    # Existing behavior is preserved: an empty list renders nothing, a falsy
+    # (non-list) section is skipped, and an inverted section still works.
+    skip = PromptTemplate.from_template(
+        "a{{#items}}X{{/items}}b{{^items}}none{{/items}}", template_format="mustache"
+    )
+    assert skip.format(items=[]) == "abnone"
+    assert skip.format(items=0) == "abnone"
+    assert skip.format(items=[1]) == "aXb"
+
+    # List of dicts (the common case) is unaffected.
+    dicts = PromptTemplate.from_template(
+        "{{#people}}{{name}},{{/people}}", template_format="mustache"
+    )
+    assert dicts.format(people=[{"name": "a"}, {"name": "b"}]) == "a,b,"
+
+
 def test_prompt_from_template_with_partial_variables() -> None:
     """Test prompts can be constructed from a template with partial variables."""
     # given


### PR DESCRIPTION
Closes #38555

---

Users rendering a Mustache prompt with `PromptTemplate`/`ChatPromptTemplate` (`template_format="mustache"`) lose data when a list variable contains falsy scalars. Iterating a list section over `[0, 1, 2]` with `{{#scores}}({{.}}){{/scores}}` produced `(1)(2)` instead of `(0)(1)(2)` — the `0` (and `False`, `0.0`, `""`, and any static body text rendered for those items) was silently dropped. This bites anyone templating numeric scores, counts, or boolean flags through a list section.

The renderer marks a section whose body should be skipped (a falsy section value, or a truthy inverted section) by pushing the scope onto the stack and then suppressing output while the current scope is falsy. The same falsiness check also fired for a genuine falsy *item* pushed while iterating a list section, so those items were treated as skipped sections.

This replaces the overloaded falsiness signal with a dedicated sentinel scope that marks "skip this body." Falsy list items are ordinary values, never the sentinel, so they render normally, while every existing skip path (falsy non-list sections, empty lists, inverted sections) maps onto the sentinel and behaves exactly as before.

Note: a list item that is literally `True` still resolves `{{.}}` to the parent scope via a separate pre-existing heuristic for boolean-coerced inverted sections; that is out of scope here and left unchanged.

---

*Disclaimer: this contribution was prepared with the assistance of an AI coding agent and reviewed before submission.*
