### PR TITLE
fix(core): honor path boundaries in `extract_sub_links` scope check

### DIFF
--- a/libs/core/langchain_core/utils/html.py
+++ b/libs/core/langchain_core/utils/html.py
@@ -59,6 +59,27 @@ def find_all_links(
     return list(set(re.findall(pattern, raw_html)))
 
 
+def _is_within_base_url(path: str, base_url: str) -> bool:
+    """Return whether `path` is `base_url` itself or a descendant of it.
+
+    A plain `str.startswith` check would treat e.g. `https://example.com/docsite`
+    as a child of `https://example.com/docs`, so require the prefix to end on a
+    path, query, or fragment boundary (unless `base_url` already ends on one).
+
+    Args:
+        path: The absolute URL to test.
+        base_url: The base URL that `path` must fall under.
+
+    Returns:
+        `True` if `path` is `base_url` or sits beneath it, `False` otherwise.
+    """
+    if path == base_url:
+        return True
+    if not path.startswith(base_url):
+        return False
+    return base_url.endswith(("/", "?", "#")) or path[len(base_url)] in ("/", "?", "#")
+
+
 def extract_sub_links(
     raw_html: str,
     url: str,
@@ -123,9 +144,9 @@ def extract_sub_links(
             if parsed_base_url.netloc != parsed_path.netloc:
                 continue
 
-            # Will take care of verifying rest of path after netloc
-            # if it's more specific
-            if not path.startswith(base_url_to_use):
+            # Verify the rest of the path falls under the base URL, requiring a
+            # path/query/fragment boundary so `/docs` does not match `/docsite`.
+            if not _is_within_base_url(path, base_url_to_use):
                 continue
 
         results.append(path)

--- a/libs/core/tests/unit_tests/utils/test_html.py
+++ b/libs/core/tests/unit_tests/utils/test_html.py
@@ -185,6 +185,40 @@ def test_prevent_outside() -> None:
     assert actual == expected
 
 
+def test_prevent_outside_path_boundary() -> None:
+    """`prevent_outside` must honor path boundaries, not raw string prefixes.
+
+    With a path-scoped base URL, a sibling path that merely shares a string
+    prefix (`/docsite` vs `/docs`) is not a child of the base URL and must be
+    excluded. Genuine descendants, the base URL itself, and the base URL
+    followed by a query must still be kept.
+    """
+    html = (
+        '<a href="https://foobar.com/docsite/sneaky">BAD</a>'
+        '<a href="https://foobar.com/docs-other">BAD</a>'
+        '<a href="https://foobar.com/docs/child">OK</a>'
+        '<a href="https://foobar.com/docs">OK</a>'
+        '<a href="https://foobar.com/docs?q=1">OK</a>'
+    )
+
+    expected = sorted(
+        [
+            "https://foobar.com/docs/child",
+            "https://foobar.com/docs",
+            "https://foobar.com/docs?q=1",
+        ]
+    )
+    actual = sorted(
+        extract_sub_links(
+            html,
+            "https://foobar.com/docs",
+            base_url="https://foobar.com/docs",
+            prevent_outside=True,
+        )
+    )
+    assert actual == expected
+
+
 def test_extract_sub_links_with_query() -> None:
     html = (
         '<a href="https://foobar.com?query=123">one</a>'


### PR DESCRIPTION
Closes #38557

---

`extract_sub_links` with `prevent_outside=True` is meant to keep only links that are children of the base URL, but the path check used a bare `str.startswith`. A base URL of `https://example.com/docs` therefore also matched siblings that merely share a string prefix, such as `https://example.com/docsite/secret`, letting a path-scoped crawl escape into unrelated paths on the same domain.

This requires the base-URL prefix to end on a path, query, or fragment boundary (or to match exactly), so `/docs` no longer matches `/docsite` while genuine descendants (`<base>/...`), the base URL itself, and the base URL followed by a query are still kept. Domain-level scoping is untouched — it continues to be handled by the existing `netloc` comparison, and all existing `prevent_outside` tests pass unchanged.

---

*Disclaimer: this contribution was prepared with the assistance of an AI coding agent and reviewed before submission.*
