### PR TITLE
fix(core): remove stale xfail markers from passing tests

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
@@ -2144,11 +2144,6 @@ async def test_async_in_async_stream_lambdas() -> None:
     _assert_events_equal_allow_superset_metadata(events, EXPECTED_EVENTS)
 
 
-@pytest.mark.xfail(
-    reason="This test is failing due to missing functionality."
-    "Need to implement logic in _transform_stream_with_config that mimics the async "
-    "variant that uses tap_output_iter"
-)
 async def test_sync_in_sync_lambdas() -> None:
     """Test invoking nested runnable lambda."""
 

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -410,7 +410,6 @@ def test_convert_to_openai_function(
     assert actual == expected
 
 
-@pytest.mark.xfail(reason="Direct pydantic v2 models not yet supported")
 def test_convert_to_openai_function_nested_v2() -> None:
     class NestedV2(BaseModelV2Maybe):
         nested_v2_arg1: int = FieldV2Maybe(..., description="foo")


### PR DESCRIPTION
Closes #38266

---

Two tests in `langchain-core` produce XPASS (unexpectedly passing) because the underlying issues were fixed in prior commits but the `@pytest.mark.xfail` decorators were never removed:

- `test_convert_to_openai_function_nested_v2` — Pydantic v2 models are now supported as function arguments
- `test_sync_in_sync_lambdas` — Sync-in-sync lambda streaming events now emit correctly

This removes the stale markers so the tests reflect the current state of the codebase. Both tests pass cleanly after the change.

This contribution was prepared with AI assistance.