### PR TITLE
fix(langchain): reject only path components equal to `..`, not segments containing two dots

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -270,8 +270,10 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
         if not path.startswith("/"):
             path = "/" + path
 
-        # Check for path traversal
-        if ".." in path or "~" in path:
+        # Check for path traversal – only reject components that are
+        # exactly `..`, not segments that merely contain two dots
+        # (e.g. `src..old` or `v1..backup` are legitimate directory names).
+        if any(part == ".." for part in path.split("/")) or "~" in path:
             msg = "Path traversal not allowed"
             raise ValueError(msg)
 


### PR DESCRIPTION
Closes #38549

---

`_validate_and_resolve_path` in `FilesystemFileSearchMiddleware` uses `".." in path` to detect directory traversal, but this substring check also rejects valid path segments like `src..old`, `v1..backup`, or `notes..archived` that merely contain two consecutive dots.

The fix switches to checking individual path components (split by `/`), so only the literal `..` component is blocked. This matches the approach already used in the glob pattern validation on line 186 of the same file.

All existing traversal security tests pass with the change.

This contribution was prepared with AI assistance.