### PR TITLE
fix: file search path validation rejects directory names containing ".."

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -270,8 +270,11 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
         if not path.startswith("/"):
             path = "/" + path
 
-        # Check for path traversal
-        if ".." in path or "~" in path:
+        # Check for path traversal.
+        # Use segment-level comparison so that directory names that legitimately
+        # contain ".." as a substring (e.g. "src..old") are not rejected.
+        # The definitive containment guard is the `relative_to` check below.
+        if any(part == ".." for part in path.split("/")) or "~" in path:
             msg = "Path traversal not allowed"
             raise ValueError(msg)
 


### PR DESCRIPTION
## Summary

`_validate_and_resolve_path` used `".." in path` (substring check) which incorrectly rejected any path whose **directory name** legitimately contains `".."` as a substring — e.g. `/src..old`, `/v1..v2`.

Path traversal requires `".."` to be a complete path *segment*, not a substring. Changed to:

```python
any(part == ".." for part in path.split("/"))
```

The definitive security guard (`full_path.relative_to(root)`) is unchanged.

Fixes #38549