### PR TITLE
fix(agent): always include model in model_to_tools_destinations (fixes #38351)

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1649,9 +1649,10 @@ def create_agent(
         #   potentially artificially injected tool messages, ex HITL
         # - there is a response format -- to allow for jumping to model to handle
         #   regenerating structured output tool calls
-        model_to_tools_destinations = ["tools", exit_node]
-        if response_format or loop_exit_node != "model":
-            model_to_tools_destinations.append(loop_entry_node)
+        # The router (_make_model_to_tools_edge) can return model_destination
+        # (loop_entry_node) in EVERY config, not just when response_format or
+        # after_model are present. See GH issue #38351.
+        model_to_tools_destinations = ["tools", exit_node, loop_entry_node]
 
         graph.add_conditional_edges(
             loop_exit_node,


### PR DESCRIPTION
## Summary

The `create_agent` conditional edge from the model to tools omitted `loop_entry_node` from the destination set unless `response_format` was set or an `after_model` middleware was present. The router (`_make_model_to_tools_edge`) can still return `loop_entry_node` as a destination in every configuration — specifically when a `wrap_model_call` middleware injects synthetic `ToolMessage`s (a documented pattern for caching, HITL pre-approval, and replay).

When this happens, LangGraph's branch dispatcher raises `KeyError('model')` because the router's return value is not in the `add_conditional_edges` path_map.

## Fix

Unconditionally include `loop_entry_node` in `model_to_tools_destinations`. This is the minimal change — the router already knows when to return this destination (it checks if every tool call has already been answered), so the fix is purely about ensuring the graph allows the routing.

## Testing

- All existing behavior is preserved: the router only returns `model` when appropriate (answered tool calls), and the destination is now always valid.
- No behavior regression on configurations without middleware or response_format — the router simply never returns `model` in those cases.

Fixes: #38351