### PR TITLE
fix(langchain): wrap deferred tools in a namespace for OpenAI tool search

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/provider_tool_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/provider_tool_search.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeAlias
 
 from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
 from typing_extensions import NotRequired, TypedDict
 
 from langchain.chat_models.base import _attempt_infer_model_provider
@@ -53,6 +54,17 @@ _SERVER_TOOL_SEARCH_TOOLS: dict[str, _ServerToolSearchSpec] = {
     "openai": {"type": "tool_search"},
 }
 
+# OpenAI's Responses API only excludes deferred tool schemas from the billed input
+# context when they are nested in a `namespace` block alongside the `tool_search`
+# tool. Sent flat with `defer_loading`, the full schemas are still billed and the
+# extra `tool_search` tool becomes pure overhead. These constants name the synthetic
+# namespace that groups the deferred tools.
+_OPENAI_DEFERRED_NAMESPACE_NAME = "deferred_tools"
+_OPENAI_DEFERRED_NAMESPACE_DESCRIPTION = (
+    "Tools deferred behind tool search. Their full schemas are retrieved on demand "
+    "when the model needs them."
+)
+
 
 class ProviderToolSearchMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
     """Defer selected tools behind provider-native tool search.
@@ -67,7 +79,10 @@ class ProviderToolSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Contex
     or when it already carries `extras["defer_loading"] is True`.
 
     Only providers with server-side tool search are supported (currently
-    Anthropic and OpenAI). The provider is inferred from the bound model.
+    Anthropic and OpenAI). The provider is inferred from the bound model. The
+    deferred-tool encoding is provider-specific: OpenAI only excludes deferred
+    schemas from the billed input context when they are nested in a `namespace`
+    block, so deferred tools are wrapped accordingly for OpenAI.
 
     !!! warning
 
@@ -150,8 +165,19 @@ class ProviderToolSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Contex
             )
             raise ValueError(msg)
 
-        bound_tools = [_defer_tool_if_needed(tool, self.searchable_tool_names) for tool in tools]
-        return request.override(tools=[*bound_tools, dict(_SERVER_TOOL_SEARCH_TOOLS[provider])])
+        search_tool = dict(_SERVER_TOOL_SEARCH_TOOLS[provider])
+        if provider == "openai":
+            # OpenAI only realizes the token savings when deferred schemas live
+            # inside a `namespace` block, so wrap them rather than emitting flat.
+            payload_tools = _build_openai_tool_payload(
+                tools, self.searchable_tool_names, search_tool
+            )
+        else:
+            bound_tools = [
+                _defer_tool_if_needed(tool, self.searchable_tool_names) for tool in tools
+            ]
+            payload_tools = [*bound_tools, search_tool]
+        return request.override(tools=payload_tools)
 
     def wrap_model_call(
         self,
@@ -229,6 +255,63 @@ def _defer_tool_if_needed(
         return tool
     extras = {**(tool.extras or {}), "defer_loading": True}
     return tool.model_copy(update={"extras": extras})
+
+
+def _build_openai_tool_payload(
+    tools: list[BaseTool | dict[str, Any]],
+    tool_names: set[str],
+    search_tool: dict[str, Any],
+) -> list[BaseTool | dict[str, Any]]:
+    """Build the OpenAI tool payload with deferred tools nested in a `namespace`.
+
+    OpenAI's Responses API only drops deferred tool schemas from the billed input
+    context when they are wrapped in a `namespace` block; emitting them flat with
+    `defer_loading` keeps the schemas billed and makes the `tool_search` tool pure
+    overhead. Non-deferred tools (and any dict-form tools, which are never
+    deferred) pass through unchanged at the top level.
+
+    Args:
+        tools: Tools bound to the model.
+        tool_names: Names of tools to defer.
+        search_tool: The provider-native tool search descriptor to append.
+
+    Returns:
+        Passthrough tools followed by the deferred-tool `namespace` block and the
+        tool search descriptor.
+    """
+    passthrough: list[BaseTool | dict[str, Any]] = []
+    deferred_specs: list[dict[str, Any]] = []
+    for tool in tools:
+        if isinstance(tool, BaseTool) and _is_deferred_tool(tool, tool_names):
+            deferred_specs.append(_to_openai_deferred_function(tool))
+        else:
+            passthrough.append(tool)
+    namespace = {
+        "type": "namespace",
+        "name": _OPENAI_DEFERRED_NAMESPACE_NAME,
+        "description": _OPENAI_DEFERRED_NAMESPACE_DESCRIPTION,
+        "tools": deferred_specs,
+    }
+    return [*passthrough, namespace, search_tool]
+
+
+def _to_openai_deferred_function(tool: BaseTool) -> dict[str, Any]:
+    """Serialize a tool to an OpenAI Responses-API deferred `function` spec.
+
+    `convert_to_openai_tool` returns Chat-Completions form
+    (`{"type": "function", "function": {...}}`), while the Responses API and its
+    `namespace` blocks expect the flattened form. The inner `function` body is
+    hoisted to the top level and flagged with `defer_loading`.
+
+    Args:
+        tool: Tool to serialize.
+
+    Returns:
+        A flattened Responses-API `function` descriptor marked as deferred.
+    """
+    converted = convert_to_openai_tool(tool)
+    function_spec = converted.get("function", converted)
+    return {"type": "function", **function_spec, "defer_loading": True}
 
 
 def _get_model_provider(model: BaseChatModel, runtime: Any) -> str | None:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_provider_tool_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_provider_tool_search.py
@@ -96,6 +96,14 @@ def _request(provider: str, tools: list[BaseTool | dict[str, Any]]) -> ModelRequ
     )
 
 
+def _openai_namespace(request: ModelRequest) -> dict[str, Any]:
+    """Return the synthetic `namespace` block OpenAI requests wrap deferred tools in."""
+    namespace = next(
+        tool for tool in request.tools if isinstance(tool, dict) and tool.get("type") == "namespace"
+    )
+    return cast("dict[str, Any]", namespace)
+
+
 def _invoke(middleware: ProviderToolSearchMiddleware, request: ModelRequest) -> ModelRequest:
     captured_request = None
 
@@ -148,13 +156,90 @@ def test_accepts_tool_instances_in_searchable_tools() -> None:
 
     modified_request = _invoke(middleware, request)
 
+    namespace = _openai_namespace(modified_request)
+    assert {spec["name"] for spec in namespace["tools"]} == {"send_email"}
+    # Non-deferred tools stay at the top level as `BaseTool` instances.
+    assert any(
+        isinstance(tool, BaseTool) and tool.name == "get_weather" for tool in modified_request.tools
+    )
+    assert OPENAI_SEARCH_TOOL in modified_request.tools
+
+
+def test_openai_wraps_deferred_tools_in_namespace() -> None:
+    """OpenAI deferred tools must be nested in a `namespace` block, not emitted flat.
+
+    Sent flat with `defer_loading`, OpenAI still bills the full schemas and the
+    `tool_search` tool only adds overhead; only the `namespace` form delivers the
+    intended token savings (see issue #38544).
+    """
+    request = _request("openai", [get_weather, send_email])
+    middleware = ProviderToolSearchMiddleware(searchable_tools=["get_weather", "send_email"])
+
+    modified_request = _invoke(middleware, request)
+
+    namespace = _openai_namespace(modified_request)
+    assert namespace["name"]
+    assert namespace["description"]
+    assert {spec["name"] for spec in namespace["tools"]} == {"get_weather", "send_email"}
+    # Deferred tools must not also leak to the top level as flat function specs.
+    assert not any(
+        isinstance(tool, BaseTool) and tool.name in {"get_weather", "send_email"}
+        for tool in modified_request.tools
+    )
+    assert OPENAI_SEARCH_TOOL in modified_request.tools
+
+
+def test_openai_namespace_specs_are_flattened_and_deferred() -> None:
+    """Namespace entries use the flattened Responses-API form flagged `defer_loading`."""
+    request = _request("openai", [send_email])
+    middleware = ProviderToolSearchMiddleware(searchable_tools=["send_email"])
+
+    modified_request = _invoke(middleware, request)
+
+    [spec] = _openai_namespace(modified_request)["tools"]
+    assert spec["type"] == "function"
+    assert spec["name"] == "send_email"
+    assert spec["defer_loading"] is True
+    assert "parameters" in spec
+    # Responses-API form is flat: the Chat-Completions `function` wrapper is hoisted.
+    assert "function" not in spec
+
+
+def test_openai_namespace_excludes_non_deferred_tools() -> None:
+    """Only deferred tools go in the namespace; the rest stay top-level to keep working."""
+    request = _request("openai", [get_weather, send_email])
+    middleware = ProviderToolSearchMiddleware(searchable_tools=["send_email"])
+
+    modified_request = _invoke(middleware, request)
+
+    namespace = _openai_namespace(modified_request)
+    assert {spec["name"] for spec in namespace["tools"]} == {"send_email"}
+    weather_tool = next(
+        tool
+        for tool in modified_request.tools
+        if isinstance(tool, BaseTool) and tool.name == "get_weather"
+    )
+    assert weather_tool.extras is None
+
+
+def test_anthropic_keeps_deferred_tools_flat() -> None:
+    """Anthropic deferral stays flat (no namespace) so its tool search is unaffected."""
+    request = _request("anthropic", [get_weather, send_email])
+    middleware = ProviderToolSearchMiddleware(searchable_tools=["send_email"])
+
+    modified_request = _invoke(middleware, request)
+
+    assert not any(
+        isinstance(tool, dict) and tool.get("type") == "namespace"
+        for tool in modified_request.tools
+    )
     email_tool = next(
         tool
         for tool in modified_request.tools
         if isinstance(tool, BaseTool) and tool.name == "send_email"
     )
     assert email_tool.extras == {"defer_loading": True}
-    assert OPENAI_SEARCH_TOOL in modified_request.tools
+    assert ANTHROPIC_SEARCH_TOOL in modified_request.tools
 
 
 def test_honors_tools_pre_marked_with_defer_loading() -> None:


### PR DESCRIPTION
Closes #38544

---

When you bind many tools to an agent, `ProviderToolSearchMiddleware` lets you defer the rarely-used ones behind provider-native tool search so their full schemas aren't sent on every turn — the whole point being to shrink the request and save input tokens.

For OpenAI this wasn't actually saving anything. The middleware marked deferred tools with `defer_loading` but left them as flat, top-level `function` entries. OpenAI's Responses API only excludes a deferred tool's schema from the billed input context when that tool lives inside a `namespace` block; sent flat, OpenAI still bills the full schema *and* the added `tool_search` tool is pure overhead. The net effect was that deferring tools made requests *larger* — the opposite of the feature's intent.

This change makes the middleware wrap OpenAI deferred tools in a single `namespace` block, serializing them into the flattened Responses-API `function` form the API expects, so their schemas are genuinely excluded from billed input. Anthropic is unchanged — its tool search uses a different mechanism where the flat form is correct. Non-deferred tools continue to pass through untouched at the top level.

The fix lives in the middleware rather than in `langchain-openai`, which already forwards explicit `namespace` blocks faithfully — nothing was constructing one. Keeping it here also avoids re-recording the existing OpenAI integration cassettes.

Tests: added unit coverage for the namespace wrapping (flattened specs, the `defer_loading` flag, non-deferred passthrough) plus an Anthropic regression guard, and verified end-to-end that a middleware-produced request serializes through `ChatOpenAI` (Responses API) into a payload where the deferred tool sits inside the namespace and no flat deferred schema remains.

---

*Disclaimer: this contribution was prepared with the assistance of an AI agent; all changes were reviewed by a human before submission.*
