### PR TITLE
docs(docs): add release note guidance to PR docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,6 +27,9 @@ Thank you for contributing to LangChain! Follow these steps to have your pull re
   - If there are any breaking changes, please clearly describe them.
   - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.
 
+## Release note
+<!-- Required for net new features or behavior-changing bugfixes. State the user-visible change in release-note-ready language. Omit this section for chores, refactors, or test-only changes. -->
+
 3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.
 
   - We will not consider a PR unless these three are passing in CI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ The description *is* the summary — do not add a `# Summary` header.
 - Do **not** cite line numbers; they go stale as soon as the file changes.
 - Rarely include full file paths or filenames. Reference the affected symbol, class, or subsystem by name instead.
 - Wrap class, function, method, parameter, and variable names in backticks.
+- For net new features or behavior-changing bugfixes, PR descriptions should include a `## Release note` section that states the user-visible change in release-note-ready language.
 - Skip dedicated "Test plan" or "Testing" sections in most cases. Mention tests only when coverage is non-obvious, risky, or otherwise notable.
 - Call out areas of the change that require careful review.
 - Add a brief disclaimer noting AI-agent involvement in the contribution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,7 @@ The description *is* the summary — do not add a `# Summary` header.
 - Do **not** cite line numbers; they go stale as soon as the file changes.
 - Rarely include full file paths or filenames. Reference the affected symbol, class, or subsystem by name instead.
 - Wrap class, function, method, parameter, and variable names in backticks.
+- For net new features or behavior-changing bugfixes, PR descriptions should include a `## Release note` section that states the user-visible change in release-note-ready language.
 - Skip dedicated "Test plan" or "Testing" sections in most cases. Mention tests only when coverage is non-obvious, risky, or otherwise notable.
 - Call out areas of the change that require careful review.
 - Add a brief disclaimer noting AI-agent involvement in the contribution.


### PR DESCRIPTION
Adds release note expectations to the contribution guidance so behavior-changing PRs have a clear place for user-visible release notes. The agent-facing repository instructions now match the PR template guidance.