### PR TITLE
feat(langchain): add `EnsembleRetriever` source dedup

### DIFF
--- a/libs/langchain/langchain_classic/retrievers/ensemble.py
+++ b/libs/langchain/langchain_classic/retrievers/ensemble.py
@@ -63,12 +63,15 @@ class EnsembleRetriever(BaseRetriever):
             of high-ranked items and the consideration given to lower-ranked items.
         id_key: The key in the document's metadata used to determine unique documents.
             If not specified, page_content is used.
+        dedup_within_retriever: Whether to deduplicate each retriever's results before
+            reciprocal rank scoring. If `id_key` is not specified, page_content is used.
     """
 
     retrievers: list[RetrieverLike]
     weights: list[float]
     c: int = 60
     id_key: str | None = None
+    dedup_within_retriever: bool = False
 
     @property
     def config_specs(self) -> list[ConfigurableFieldSpec]:
@@ -321,32 +324,33 @@ class EnsembleRetriever(BaseRetriever):
             msg = "Number of rank lists must be equal to the number of weights."
             raise ValueError(msg)
 
+        if self.dedup_within_retriever:
+            doc_lists = [
+                list(unique_by_key(doc_list, self._get_doc_key))
+                for doc_list in doc_lists
+            ]
+
         # Associate each doc's content with its RRF score for later sorting by it
         # Duplicated contents across retrievers are collapsed & scored cumulatively
-        rrf_score: dict[str, float] = defaultdict(float)
+        rrf_score: dict[Hashable, float] = defaultdict(float)
         for doc_list, weight in zip(doc_lists, self.weights, strict=False):
             for rank, doc in enumerate(doc_list, start=1):
-                rrf_score[
-                    (
-                        doc.page_content
-                        if self.id_key is None
-                        else doc.metadata[self.id_key]
-                    )
-                ] += weight / (rank + self.c)
+                rrf_score[self._get_doc_key(doc)] += weight / (rank + self.c)
 
         # Docs are deduplicated by their contents then sorted by their scores
         all_docs = chain.from_iterable(doc_lists)
         return sorted(
             unique_by_key(
                 all_docs,
-                lambda doc: (
-                    doc.page_content
-                    if self.id_key is None
-                    else doc.metadata[self.id_key]
-                ),
+                self._get_doc_key,
             ),
             reverse=True,
-            key=lambda doc: rrf_score[
-                doc.page_content if self.id_key is None else doc.metadata[self.id_key]
-            ],
+            key=lambda doc: rrf_score[self._get_doc_key(doc)],
+        )
+
+    def _get_doc_key(self, doc: Document) -> Hashable:
+        return (
+            doc.page_content
+            if self.id_key is None
+            else cast("Hashable", doc.metadata[self.id_key])
         )

--- a/libs/langchain/tests/unit_tests/retrievers/test_ensemble.py
+++ b/libs/langchain/tests/unit_tests/retrievers/test_ensemble.py
@@ -130,6 +130,57 @@ def test_rank_fusion_bare_strings() -> None:
     assert {doc.page_content for doc in results} == {"foo", "bar"}
 
 
+def test_dedup_within_retriever_keeps_default_scoring() -> None:
+    """Within-retriever duplicates should keep contributing by default."""
+    documents1 = [
+        Document(page_content="long doc chunk 1", metadata={"source": "long"}),
+        Document(page_content="long doc chunk 2", metadata={"source": "long"}),
+        Document(page_content="short doc chunk", metadata={"source": "short"}),
+    ]
+    documents2 = [
+        Document(page_content="short doc chunk", metadata={"source": "short"}),
+    ]
+
+    ensemble_retriever = EnsembleRetriever(
+        retrievers=[
+            MockRetriever(docs=documents1),
+            MockRetriever(docs=documents2),
+        ],
+        weights=[0.5, 0.5],
+        id_key="source",
+    )
+
+    ranked_documents = ensemble_retriever.invoke("_")
+
+    assert ranked_documents[0].metadata["source"] == "long"
+
+
+def test_dedup_within_retriever_removes_duplicate_score_contributions() -> None:
+    """Within-retriever duplicates can be ignored before reciprocal rank scoring."""
+    documents1 = [
+        Document(page_content="long doc chunk 1", metadata={"source": "long"}),
+        Document(page_content="long doc chunk 2", metadata={"source": "long"}),
+        Document(page_content="short doc chunk", metadata={"source": "short"}),
+    ]
+    documents2 = [
+        Document(page_content="short doc chunk", metadata={"source": "short"}),
+    ]
+
+    ensemble_retriever = EnsembleRetriever(
+        retrievers=[
+            MockRetriever(docs=documents1),
+            MockRetriever(docs=documents2),
+        ],
+        weights=[0.5, 0.5],
+        id_key="source",
+        dedup_within_retriever=True,
+    )
+
+    ranked_documents = ensemble_retriever.invoke("_")
+
+    assert ranked_documents[0].metadata["source"] == "short"
+
+
 async def test_arank_fusion_bare_strings() -> None:
     """arank_fusion should wrap bare strings the same way rank_fusion does."""
     retriever = BareStringRetriever(strings=["foo", "bar"])


### PR DESCRIPTION
Closes #37046

---

`EnsembleRetriever` now supports an opt-in `dedup_within_retriever` flag for RAG pipelines that retrieve multiple chunks from the same source document.

When `id_key` is set, users often treat documents with the same metadata key as the same source document. The final result list already deduplicates those documents, but reciprocal rank scoring still counted every duplicate returned by the same retriever. That can give longer, more heavily chunked documents extra RRF weight before the final deduplication step.

This change keeps the default behavior unchanged. When `dedup_within_retriever=True`, each retriever's rank list is deduplicated by the same document key before RRF scores are accumulated, so one retriever contributes at most one rank signal per source document.

## Release note

Added `dedup_within_retriever` to `EnsembleRetriever` so duplicate documents from the same retriever can be ignored before reciprocal rank fusion scoring.

Targeted checks run locally:

```bash
uv run --directory libs\langchain --group test pytest tests\unit_tests\retrievers\test_ensemble.py -q
uv run --directory libs\langchain --group lint ruff check langchain_classic\retrievers\ensemble.py tests\unit_tests\retrievers\test_ensemble.py
uv run --directory libs\langchain --group lint ruff format --check langchain_classic\retrievers\ensemble.py tests\unit_tests\retrievers\test_ensemble.py
git diff --check
```
