### PR TITLE
fix(core): preserve non-ASCII in convert_to_openai_messages json blocks

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -1888,7 +1888,7 @@ def convert_to_openai_messages(
                     content.append(
                         {
                             "type": "text",
-                            "text": json.dumps(block["json"]),
+                            "text": json.dumps(block["json"], ensure_ascii=False),
                         }
                     )
                 elif (block.get("type") == "guard_content") or "guard_content" in block:

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -1259,6 +1259,20 @@ def test_convert_to_openai_messages_json() -> None:
     assert json.loads(result[0]["content"][0]["text"]) == json_data
 
 
+def test_convert_to_openai_messages_json_preserves_unicode() -> None:
+    # A `json` content block with non-ASCII values must serialize the raw
+    # characters, not `\uXXXX` escapes (matching the `tool_use` path above,
+    # which already passes `ensure_ascii=False`).
+    json_data = {"customer_name": "你好啊集团", "emoji": "🚀"}
+    messages = [HumanMessage(content=[{"type": "json", "json": json_data}])]
+    result = convert_to_openai_messages(messages, text_format="block")
+    text = result[0]["content"][0]["text"]
+    assert json.loads(text) == json_data
+    assert "你好啊集团" in text
+    assert "🚀" in text
+    assert "\\u4f60" not in text  # not escaped
+
+
 def test_convert_to_openai_messages_guard_content() -> None:
     messages = [
         HumanMessage(


### PR DESCRIPTION
Fixes #38580

`convert_to_openai_messages` escapes non-ASCII for one content-block type but not another. The `tool_use` path passes `ensure_ascii=False` (and has a regression test asserting `你好啊集团` survives unescaped); the `json` block path a few lines down still calls `json.dumps(block["json"])` with the default `ensure_ascii=True`, so a `{"type": "json", "json": {...}}` block with CJK/emoji comes out as `\uXXXX` in the converted text.

One-keyword fix to make the two paths consistent, plus a non-ASCII case added to `test_convert_to_openai_messages_json` mirroring the existing `tool_use` Unicode test.

No behavior change for ASCII input (identical output bytes).

_Prepared with AI-agent assistance; the fix and test were verified locally (fails before, passes after)._