### PR TITLE
fix(openai): handle Responses API structured parse fallback

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1670,11 +1670,20 @@ class BaseChatOpenAI(BaseChatModel):
                     raw_response = self.root_client.responses.with_raw_response.parse(
                         **payload
                     )
+                    try:
+                        response = raw_response.parse()
+                    except ValidationError:
+                        raw_response = (
+                            self.root_client.responses.with_raw_response.create(
+                                **payload
+                            )
+                        )
+                        response = raw_response.parse()
                 else:
                     raw_response = self.root_client.responses.with_raw_response.create(
                         **payload
                     )
-                response = raw_response.parse()
+                    response = raw_response.parse()
                 if self.include_response_headers:
                     generation_info = {"headers": dict(raw_response.headers)}
                 return _construct_lc_result_from_responses_api(
@@ -1936,13 +1945,20 @@ class BaseChatOpenAI(BaseChatModel):
                             **payload
                         )
                     )
+                    try:
+                        response = raw_response.parse()
+                    except ValidationError:
+                        raw_response = await self.root_async_client.responses.with_raw_response.create(  # noqa: E501
+                            **payload
+                        )
+                        response = raw_response.parse()
                 else:
                     raw_response = (
                         await self.root_async_client.responses.with_raw_response.create(
                             **payload
                         )
                     )
-                response = raw_response.parse()
+                    response = raw_response.parse()
                 if self.include_response_headers:
                     generation_info = {"headers": dict(raw_response.headers)}
                 return _construct_lc_result_from_responses_api(

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1784,6 +1784,165 @@ def test__construct_lc_result_from_responses_api_error_handling() -> None:
     assert "Test error" in str(excinfo.value)
 
 
+def test_responses_api_include_raw_handles_parse_error() -> None:
+    """include_raw should catch parser errors after a Responses API fallback."""
+
+    class ReasoningSchema(BaseModel):
+        response: str
+
+    llm = ChatOpenAI(
+        model=OPENAI_TEST_MODEL,
+        api_key=SecretStr("test-api-key"),
+        reasoning={"effort": "low"},
+    )
+    structured_llm = llm.with_structured_output(ReasoningSchema, include_raw=True)
+    sequence = cast(RunnableSequence, structured_llm)
+    binding = cast(
+        RunnableBinding,
+        sequence.first.steps__["raw"],  # type: ignore[attr-defined]
+    )
+    bound_llm = cast(ChatOpenAI, binding.bound)
+
+    try:
+        ReasoningSchema.model_validate_json("Hello! How can I help you today?")
+    except Exception as exc:
+        parse_error = exc
+    else:
+        msg = "Expected invalid JSON to raise"
+        raise AssertionError(msg)
+
+    parse_raw_response = MagicMock()
+    parse_raw_response.parse.side_effect = parse_error
+
+    create_raw_response = MagicMock()
+    create_raw_response.parse.return_value = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model=OPENAI_TEST_MODEL,
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseOutputMessage(
+                type="message",
+                id="msg_123",
+                content=[
+                    ResponseOutputText(
+                        type="output_text",
+                        text="Hello! How can I help you today?",
+                        annotations=[],
+                    )
+                ],
+                role="assistant",
+                status="completed",
+            )
+        ],
+    )
+
+    mock_client = MagicMock()
+    mock_client.responses.with_raw_response.parse.return_value = parse_raw_response
+    mock_client.responses.with_raw_response.create.return_value = create_raw_response
+
+    with patch.object(bound_llm, "root_client", mock_client):
+        result = structured_llm.invoke("hi there")
+
+    assert result["raw"].content == [
+        {
+            "type": "text",
+            "text": "Hello! How can I help you today?",
+            "annotations": [],
+            "id": "msg_123",
+        }
+    ]
+    assert result["parsed"] is None
+    assert isinstance(result["parsing_error"], ValueError)
+    mock_client.responses.with_raw_response.parse.assert_called_once()
+    mock_client.responses.with_raw_response.create.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_responses_api_include_raw_handles_parse_error_async() -> None:
+    """include_raw should catch async parser errors after a Responses API fallback."""
+
+    class ReasoningSchema(BaseModel):
+        response: str
+
+    llm = ChatOpenAI(
+        model=OPENAI_TEST_MODEL,
+        api_key=SecretStr("test-api-key"),
+        reasoning={"effort": "low"},
+    )
+    structured_llm = llm.with_structured_output(ReasoningSchema, include_raw=True)
+    sequence = cast(RunnableSequence, structured_llm)
+    binding = cast(
+        RunnableBinding,
+        sequence.first.steps__["raw"],  # type: ignore[attr-defined]
+    )
+    bound_llm = cast(ChatOpenAI, binding.bound)
+
+    try:
+        ReasoningSchema.model_validate_json("Hello! How can I help you today?")
+    except Exception as exc:
+        parse_error = exc
+    else:
+        msg = "Expected invalid JSON to raise"
+        raise AssertionError(msg)
+
+    parse_raw_response = MagicMock()
+    parse_raw_response.parse.side_effect = parse_error
+
+    create_raw_response = MagicMock()
+    create_raw_response.parse.return_value = Response(
+        id="resp_123",
+        created_at=1234567890,
+        model=OPENAI_TEST_MODEL,
+        object="response",
+        parallel_tool_calls=True,
+        tools=[],
+        tool_choice="auto",
+        output=[
+            ResponseOutputMessage(
+                type="message",
+                id="msg_123",
+                content=[
+                    ResponseOutputText(
+                        type="output_text",
+                        text="Hello! How can I help you today?",
+                        annotations=[],
+                    )
+                ],
+                role="assistant",
+                status="completed",
+            )
+        ],
+    )
+
+    mock_client = MagicMock()
+    mock_client.responses.with_raw_response.parse = AsyncMock(
+        return_value=parse_raw_response
+    )
+    mock_client.responses.with_raw_response.create = AsyncMock(
+        return_value=create_raw_response
+    )
+
+    with patch.object(bound_llm, "root_async_client", mock_client):
+        result = await structured_llm.ainvoke("hi there")
+
+    assert result["raw"].content == [
+        {
+            "type": "text",
+            "text": "Hello! How can I help you today?",
+            "annotations": [],
+            "id": "msg_123",
+        }
+    ]
+    assert result["parsed"] is None
+    assert isinstance(result["parsing_error"], ValueError)
+    mock_client.responses.with_raw_response.parse.assert_awaited_once()
+    mock_client.responses.with_raw_response.create.assert_awaited_once()
+
+
 def test__construct_lc_result_from_responses_api_basic_text_response() -> None:
     """Test a basic text response with no tools or special features."""
     response = Response(


### PR DESCRIPTION
## Summary
- fall back from Responses API SDK structured parse to raw create when Pydantic parsing fails
- preserve LangChain structured-output behavior so include_raw=True can return raw output with parsing_error instead of failing before the parser fallback
- add sync and async regressions for reasoning-forced Responses API structured output

Fixes #38561

## Tests
- OPENAI_API_KEY=test-api-key PYTHONPYCACHEPREFIX=/Volumes/STOREJET/Documents/OSC/.pycache /Volumes/STOREJET/Documents/OSC/.venvs/langchain-openai-py314/bin/python -m pytest /Volumes/STOREJET/Documents/OSC/repos/langchain/libs/partners/openai/tests/unit_tests/chat_models/test_base.py -q -k "responses_api_include_raw_handles_parse_error or structured_output_verbosity"
- /Volumes/STOREJET/Documents/OSC/.venvs/langchain-openai-py314/bin/python -m ruff format --check langchain_openai/chat_models/base.py tests/unit_tests/chat_models/test_base.py
- /Volumes/STOREJET/Documents/OSC/.venvs/langchain-openai-py314/bin/python -m ruff check --ignore EXE002 langchain_openai/chat_models/base.py tests/unit_tests/chat_models/test_base.py

Note: EXE002 was ignored only because the external volume reports checked-out 100644 files as executable locally; git records both touched files as 100644.