### PR TITLE
core: fix generations shape in stream/astream on_llm_error callback (GH#38276)

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -818,12 +818,15 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 generations_with_error_metadata = _generate_response_from_error(e)
                 chat_generation_chunk = merge_chat_generation_chunks(chunks)
                 if chat_generation_chunk:
+                    # Merge error metadata into the single per-prompt row so
+                    # generations is always [list[Generation]] (one row per prompt).
                     generations = [
-                        [chat_generation_chunk],
-                        generations_with_error_metadata,
+                        [chat_generation_chunk] + generations_with_error_metadata
                     ]
-                else:
+                elif generations_with_error_metadata:
                     generations = [generations_with_error_metadata]
+                else:
+                    generations = []
                 run_manager.on_llm_error(
                     e,
                     response=LLMResult(generations=generations),
@@ -950,9 +953,13 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             generations_with_error_metadata = _generate_response_from_error(e)
             chat_generation_chunk = merge_chat_generation_chunks(chunks)
             if chat_generation_chunk:
-                generations = [[chat_generation_chunk], generations_with_error_metadata]
-            else:
+                generations = [
+                    [chat_generation_chunk] + generations_with_error_metadata
+                ]
+            elif generations_with_error_metadata:
                 generations = [generations_with_error_metadata]
+            else:
+                generations = []
             await run_manager.on_llm_error(
                 e,
                 response=LLMResult(generations=generations),

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -200,7 +200,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 


### PR DESCRIPTION
## Problem

When `BaseChatModel.stream()` / `astream()` raises, the `on_llm_error` callback receives a malformed `LLMResult.generations`:

| Scenario | Actual (buggy) | Expected |
|---|---|---|
| Error before any output | `[[]]` | `[]` |
| Partial output, then error | `[[chunk], []]` (2 outer rows!) | `[[chunk]]` |

`LLMResult.generations` is typed `list[list[Generation]]` where the **outer dimension is per-prompt (batch)**. A single-prompt stream must yield at most one outer row.

This was masked by `@pytest.mark.xfail` on `test_stream_error_callback` (which already asserted the correct shape).

## Root Cause

`_generate_response_from_error(e)` returns `list[ChatGeneration]` (empty `[]` for non-HTTP errors). The caller unconditionally wrapped it in another list:

```python
# before (buggy)
if chat_generation_chunk:
    generations = [[chat_generation_chunk], generations_with_error_metadata]  # 2 outer rows!
else:
    generations = [generations_with_error_metadata]  # [[]] when empty!
```

## Fix

Merge error metadata into the single per-prompt row and handle the empty case explicitly:

```python
if chat_generation_chunk:
    generations = [[chat_generation_chunk] + generations_with_error_metadata]
elif generations_with_error_metadata:
    generations = [generations_with_error_metadata]
else:
    generations = []
```

Applied to both sync `stream()` and async `astream()`.

Also removes the `@pytest.mark.xfail` from `test_stream_error_callback` since the bug is now fixed (the test now passes as `PASSED`, not `XPASS`).

Closes #38276