### PR TITLE
fix(core): merge_content no longer mutates its first argument

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -379,6 +379,12 @@ def merge_content(
     """
     merged: str | list[str | dict[Any, Any]]
     merged = "" if first_content is None else first_content
+    # Copy list content so we never mutate the caller's list: the branches below
+    # append to / reassign into ``merged`` in place. Without this, ``merge_content``
+    # (and therefore ``chunk_a + chunk_b``) mutates its first argument. String
+    # content is immutable, so it needs no copy.
+    if isinstance(merged, list):
+        merged = merged.copy()
 
     for content in contents:
         # If current is a string

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1101,6 +1101,30 @@ def test_merge_content(
     assert actual == expected
 
 
+def test_merge_content_does_not_mutate_first() -> None:
+    """merge_content must not mutate its first argument's list in place."""
+    # list whose last element is a non-string block -> append path
+    first: list = [{"type": "text", "text": "a"}]
+    merge_content(first, "b")
+    assert first == [{"type": "text", "text": "a"}]
+
+    # list whose last element is a string -> in-place concat path
+    first_str: list = ["x"]
+    merge_content(first_str, "y")
+    assert first_str == ["x"]
+
+
+def test_message_chunk_add_does_not_mutate_operands() -> None:
+    """chunk_a + chunk_b must not mutate chunk_a (the ``+`` immutability contract)."""
+    a = AIMessageChunk(content=[{"type": "text", "text": "a"}])
+    b = AIMessageChunk(content="b")
+    a + b
+    assert a.content == [{"type": "text", "text": "a"}]
+    # repeated addition must not compound onto the same operand
+    a + b
+    assert a.content == [{"type": "text", "text": "a"}]
+
+
 def test_tool_message_content() -> None:
     ToolMessage("foo", tool_call_id="1")
     ToolMessage(["foo"], tool_call_id="1")


### PR DESCRIPTION
## Description

`merge_content` binds `merged` to the first argument's list without copying, then appends to / reassigns into it in place (`base.py:399,405`). It therefore **mutates (and returns) its first argument**.

Via `BaseMessageChunk.__add__` (and `add_ai_message_chunks`), this means **`chunk_a + chunk_b` mutates `chunk_a.content`**, breaking the immutability contract of `+`. Any code that reuses a chunk as the left operand — streaming folds, retries, fan-out into multiple accumulators — silently gets corrupted / double-counted content.

### Reproduction (on `master`)
```python
from langchain_core.messages import AIMessageChunk
a = AIMessageChunk(content=[{"type": "text", "text": "a"}])
b = AIMessageChunk(content="b")
a + b
assert a.content == [{"type": "text", "text": "a"}]   # FAILS: a.content == [..., "b"]
a + b                                                    # compounds: [..., "bb"]
```

## Fix

Copy the list before the in-place branches (string content is immutable, so it needs no copy):
```python
if isinstance(merged, list):
    merged = merged.copy()
```

## Tests

- `test_merge_content_does_not_mutate_first` — both the append (`base.py:405`) and in-place-concat (`:399`) paths.
- `test_message_chunk_add_does_not_mutate_operands` — `chunk_a + chunk_b` leaves `chunk_a` intact, including repeated addition.

Both fail without the fix (mutation-checked); existing `test_merge_content` cases are unaffected.