### PR TITLE
docs(core): align `add_message` Raises docstring with error message

### DIFF
--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -152,8 +152,8 @@ class BaseChatMessageHistory(ABC):
             message: A `BaseMessage` object to store.
 
         Raises:
-            NotImplementedError: If the sub-class has not implemented an efficient
-                `add_messages` method.
+            NotImplementedError: If the sub-class has not implemented `add_message`
+                or `add_messages` method.
         """
         if type(self).add_messages != BaseChatMessageHistory.add_messages:
             # This means that the sub-class has implemented an efficient add_messages


### PR DESCRIPTION
Fixes #38603

---

**Summary**

Updated the Raises section in `BaseChatMessageHistory.add_message` docstring to accurately reflect the runtime behavior.

**Changes**

Modified `libs/core/langchain_core/chat_history.py` line 155-156:

**Before:**
```python
Raises:
    NotImplementedError: If the sub-class has not implemented an efficient
        `add_messages` method.
```

**After:**
```python
Raises:
    NotImplementedError: If the sub-class has not implemented `add_message`
        or `add_messages` method.
```

**Why**

The original docstring only mentioned `add_messages`, but the actual error message says "Please implement add_message or add_messages". This fix aligns the documentation with the code behavior, improving clarity for subclass implementers.

**Testing**

All existing unit tests pass:
-  `make format`, `make lint` and `make test` 
- `test_add_message_implementation_only`
- `test_bulk_message_implementation_only`
- `test_async_interface`

**Scope**

Pure documentation fix with no behavioral changes.