### PR TITLE
fix(core): use `is not None` for `llm_cache` presence checks in LLM helpers

### DIFF
--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -182,7 +182,7 @@ def get_prompts(
 
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = llm_cache.lookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -217,7 +217,7 @@ async def aget_prompts(
     existing_prompts = {}
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = await llm_cache.alookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -288,7 +288,7 @@ async def aupdate_cache(
     for i, result in enumerate(new_results.generations):
         existing_prompts[missing_prompt_idxs[i]] = result
         prompt = prompts[missing_prompt_idxs[i]]
-        if llm_cache:
+        if llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result)
     return new_results.llm_output
 

--- a/libs/core/tests/unit_tests/language_models/llms/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/llms/test_cache.py
@@ -109,3 +109,40 @@ async def test_no_cache_generate_async() -> None:
         assert global_cache._cache == {}
     finally:
         set_llm_cache(None)
+
+
+class EmptyInMemoryCache(InMemoryCache):
+    """Cache with no entries — evaluates falsy via `__len__` returning 0.
+
+    Reproduces the bug where `if llm_cache:` skips lookup/update on an
+    empty-but-configured cache, causing a `KeyError` on the result indexing.
+    """
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+
+def test_empty_cache_with_len_sync() -> None:
+    """Empty cache implementing __len__ must not be skipped on sync generate."""
+    cache = EmptyInMemoryCache()
+    assert len(cache) == 0  # falsy under `if llm_cache:`, but configured
+    llm = FakeListLLM(cache=cache, responses=["foo", "bar"])
+    output = llm.generate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    # Second call with same prompt should hit cache, not consume next response
+    output = llm.generate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1
+
+
+async def test_empty_cache_with_len_async() -> None:
+    """Empty cache implementing __len__ must not be skipped on async agenerate."""
+    cache = EmptyInMemoryCache()
+    assert len(cache) == 0  # falsy under `if llm_cache:`, but configured
+    llm = FakeListLLM(cache=cache, responses=["foo", "bar"])
+    output = await llm.agenerate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    # Second call with same prompt should hit cache, not consume next response
+    output = await llm.agenerate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1


### PR DESCRIPTION
Closes #38440

---

`get_prompts`, `aget_prompts`, and `aupdate_cache` check cache presence with `if llm_cache:`. A cache that implements `__len__` evaluates to falsy when empty (`len() == 0`), so the lookup/update is skipped even though a cache is configured. When the prompt is not found in `existing_prompts`, the subsequent `existing_prompts[i]` indexing raises `KeyError`.

The sibling function `update_cache` (sync) already uses `if llm_cache is not None:` correctly. This change makes the three async/sync helpers consistent with it.

Changed three `if llm_cache:` checks to `if llm_cache is not None:` — the only correct way to distinguish "no cache configured" from "cache configured but currently empty".

Added two regression tests (`test_empty_cache_with_len_sync` / `test_empty_cache_with_len_async`) using an `EmptyInMemoryCache` subclass that exposes `__len__`. Both confirm that `generate` and `agenerate` correctly populate and hit the cache even when it starts empty.

> Note: this fix was developed with AI assistance.