### PR TITLE
fix(core): respect descriptions for schema-free tools

### DIFF
--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -319,7 +319,9 @@ def tool(
                 )
             # If someone doesn't want a schema applied, we must treat it as
             # a simple string->string function
-            if dec_func.__doc__ is None:
+            if tool_description is None:
+                tool_description = inspect.getdoc(dec_func)
+            if tool_description is None:
                 msg = (
                     "Function must have a docstring if "
                     "description not provided and infer_schema is False."
@@ -328,7 +330,7 @@ def tool(
             return Tool(
                 name=tool_name,
                 func=func,
-                description=f"{tool_name} tool",
+                description=tool_description,
                 return_direct=return_direct,
                 coroutine=coroutine,
                 response_format=response_format,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -367,6 +367,27 @@ def test_structured_single_str_decorator_no_infer_schema() -> None:
     assert unstructured_tool_input.run("foo") == "foo"
 
 
+def test_tool_no_infer_schema_uses_explicit_description() -> None:
+    """Test that `description` is respected without schema inference."""
+
+    @tool(description="Search weather data.", infer_schema=False)
+    def search_weather(tool_input: str) -> str:
+        return tool_input
+
+    assert search_weather.description == "Search weather data."
+
+
+def test_tool_no_infer_schema_uses_docstring_description() -> None:
+    """Test that docstrings are respected without schema inference."""
+
+    @tool(infer_schema=False)
+    def search_weather(tool_input: str) -> str:
+        """Search weather data."""
+        return tool_input
+
+    assert search_weather.description == "Search weather data."
+
+
 def test_structured_tool_types_parsed() -> None:
     """Test the non-primitive types are correctly passed to structured tools."""
 


### PR DESCRIPTION
Closes #38138

---

When users decorate a simple string tool with `@tool(infer_schema=False)`, the tool now uses the explicit `description` argument when present and otherwise falls back to the function docstring. This lets schema-free tools behave consistently with the documented description precedence and avoids requiring a docstring when a description was provided.

Regression coverage now exercises both fallback paths.

## Release note

`@tool(infer_schema=False)` now respects explicit descriptions and function docstrings when constructing simple tools.

This contribution was prepared with assistance from an AI coding agent.