### PR TITLE
fix(openai): prefer AZURE_OPENAI_API_KEY with deprecation fallback

### DIFF
--- a/libs/partners/openai/langchain_openai/_azure_env.py
+++ b/libs/partners/openai/langchain_openai/_azure_env.py
@@ -1,0 +1,34 @@
+"""Azure OpenAI environment variable helpers."""
+
+from __future__ import annotations
+
+import os
+import warnings
+
+from pydantic import SecretStr
+
+
+def azure_openai_api_key_from_env() -> SecretStr | None:
+    """Resolve the Azure OpenAI API key from environment variables.
+
+    Prefers ``AZURE_OPENAI_API_KEY``. Falls back to ``OPENAI_API_KEY`` with a
+    deprecation warning for backwards compatibility.
+
+    Returns:
+        The API key if found, otherwise ``None``.
+    """
+    azure_key = os.environ.get("AZURE_OPENAI_API_KEY")
+    if azure_key:
+        return SecretStr(azure_key)
+
+    openai_key = os.environ.get("OPENAI_API_KEY")
+    if openai_key:
+        warnings.warn(
+            "Using OPENAI_API_KEY for Azure OpenAI is deprecated. "
+            "Set AZURE_OPENAI_API_KEY instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return SecretStr(openai_key)
+
+    return None

--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -17,6 +17,7 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai._azure_env import azure_openai_api_key_from_env
 from langchain_openai.chat_models.base import BaseChatOpenAI, _get_default_model_profile
 
 if TYPE_CHECKING:
@@ -483,14 +484,10 @@ class AzureChatOpenAI(BaseChatOpenAI):
         default_factory=from_env("OPENAI_API_VERSION", default=None),
     )
     """Automatically inferred from env var `OPENAI_API_VERSION` if not provided."""
-    # Check OPENAI_API_KEY for backwards compatibility.
-    # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
-    # other forms of azure credentials.
+    # Check OPENAI_API_KEY for backwards compatibility (deprecated).
     openai_api_key: SecretStr | None = Field(
         alias="api_key",
-        default_factory=secret_from_env(
-            ["AZURE_OPENAI_API_KEY", "OPENAI_API_KEY"], default=None
-        ),
+        default_factory=azure_openai_api_key_from_env,
     )
     """Automatically inferred from env var `AZURE_OPENAI_API_KEY` if not provided."""
     azure_ad_token: SecretStr | None = Field(

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -10,6 +10,7 @@ from langchain_core.utils import from_env, secret_from_env
 from pydantic import Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai._azure_env import azure_openai_api_key_from_env
 from langchain_openai.embeddings.base import OpenAIEmbeddings
 
 
@@ -113,14 +114,10 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):  # type: ignore[override]
             This means you won't be able to use non-deployment endpoints.
 
     """
-    # Check OPENAI_KEY for backwards compatibility.
-    # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
-    # other forms of azure credentials.
+    # Check OPENAI_API_KEY for backwards compatibility (deprecated).
     openai_api_key: SecretStr | None = Field(
         alias="api_key",
-        default_factory=secret_from_env(
-            ["AZURE_OPENAI_API_KEY", "OPENAI_API_KEY"], default=None
-        ),
+        default_factory=azure_openai_api_key_from_env,
     )
     """Automatically inferred from env var `AZURE_OPENAI_API_KEY` if not provided."""
     openai_api_version: str | None = Field(

--- a/libs/partners/openai/langchain_openai/llms/azure.py
+++ b/libs/partners/openai/langchain_openai/llms/azure.py
@@ -12,6 +12,7 @@ from langchain_core.utils import from_env, secret_from_env
 from pydantic import Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai._azure_env import azure_openai_api_key_from_env
 from langchain_openai._version import __version__
 from langchain_openai.llms.base import BaseOpenAI
 
@@ -58,14 +59,10 @@ class AzureOpenAI(BaseOpenAI):
         default_factory=from_env("OPENAI_API_VERSION", default=None),
     )
     """Automatically inferred from env var `OPENAI_API_VERSION` if not provided."""
-    # Check OPENAI_KEY for backwards compatibility.
-    # TODO: Remove OPENAI_API_KEY support to avoid possible conflict when using
-    # other forms of azure credentials.
+    # Check OPENAI_API_KEY for backwards compatibility (deprecated).
     openai_api_key: SecretStr | None = Field(
         alias="api_key",
-        default_factory=secret_from_env(
-            ["AZURE_OPENAI_API_KEY", "OPENAI_API_KEY"], default=None
-        ),
+        default_factory=azure_openai_api_key_from_env,
     )
     azure_ad_token: SecretStr | None = Field(
         default_factory=secret_from_env("AZURE_OPENAI_AD_TOKEN", default=None)

--- a/libs/partners/openai/tests/unit_tests/test_azure_env.py
+++ b/libs/partners/openai/tests/unit_tests/test_azure_env.py
@@ -1,0 +1,44 @@
+"""Tests for Azure OpenAI environment variable helpers."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from langchain_openai._azure_env import azure_openai_api_key_from_env
+
+
+def test_azure_key_takes_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``AZURE_OPENAI_API_KEY`` must be preferred over ``OPENAI_API_KEY``."""
+    monkeypatch.setenv("AZURE_OPENAI_API_KEY", "azure-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+
+    key = azure_openai_api_key_from_env()
+    assert key is not None
+    assert key.get_secret_value() == "azure-key"
+
+
+def test_openai_key_fallback_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Falling back to ``OPENAI_API_KEY`` should emit a deprecation warning."""
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        key = azure_openai_api_key_from_env()
+
+    assert key is not None
+    assert key.get_secret_value() == "openai-key"
+    assert any(
+        issubclass(w.category, DeprecationWarning) and "OPENAI_API_KEY" in str(w.message)
+        for w in caught
+    )
+
+
+def test_no_key_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return ``None`` when neither env var is set."""
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    assert azure_openai_api_key_from_env() is None


### PR DESCRIPTION
---

Azure OpenAI integrations historically fell back to `OPENAI_API_KEY`, which is surprising when both are set and makes key rotation harder. This introduces a shared helper that prefers the Azure-specific variable and emits a deprecation warning when falling back.

## Changes

- Add `azure_openai_api_key_from_env()` in `_azure_env.py`.
- Wire Azure chat, embeddings, and LLM classes to use the helper.

## Release note

- Azure OpenAI integrations now prefer `AZURE_OPENAI_API_KEY`. Using `OPENAI_API_KEY` as a fallback logs a deprecation warning.

## Tests

- `libs/partners/openai/tests/unit_tests/test_azure_env.py` — precedence, missing keys, deprecation warning.

```bash
uv run --group test pytest libs/partners/openai/tests/unit_tests/test_azure_env.py
```

---

_Disclaimer: This contribution was prepared with assistance from an AI coding agent._