### PR TITLE
refactor(openai): lazy-import tiktoken in embeddings

### DIFF
--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -8,7 +8,6 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from typing import Any, Literal, cast
 
 import openai
-import tiktoken
 from langchain_core.embeddings import Embeddings
 from langchain_core.runnables.config import run_in_executor
 from langchain_core.utils import from_env, get_pydantic_field_names, secret_from_env
@@ -529,6 +528,14 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
                     indices.append(i)
                     token_counts.append(len(token_chunk))
         else:
+            try:
+                import tiktoken  # noqa: PLC0415
+            except ImportError as e:
+                msg = (
+                    "tiktoken is required for OpenAI embeddings tokenization. "
+                    "Install with `pip install tiktoken` or set tiktoken_enabled=False."
+                )
+                raise ImportError(msg) from e
             try:
                 encoding = tiktoken.encoding_for_model(model_name)
             except KeyError:

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -25,8 +25,10 @@ requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.4.7,<2.0.0",
     "openai>=2.26.0,<3.0.0",
-    "tiktoken>=0.7.0,<1.0.0",
 ]
+
+[project.optional-dependencies]
+tiktoken = ["tiktoken>=0.7.0,<1.0.0"]
 
 [project.urls]
 Homepage = "https://docs.langchain.com/oss/python/integrations/providers/openai"
@@ -41,6 +43,7 @@ Reddit = "https://www.reddit.com/r/LangChain/"
 [dependency-groups]
 test = [
     "pytest>=9.0.3,<10.0.0",
+    "tiktoken>=0.7.0,<1.0.0",
     "freezegun>=1.2.2,<2.0.0",
     "pytest-mock>=3.10.0,<4.0.0",
     "syrupy>=5.0.0,<6.0.0",


### PR DESCRIPTION
---

`tiktoken` was imported at module load time for OpenAI embeddings, causing import failures when the optional dependency is not installed.

## Changes

- Lazy-import `tiktoken` inside the tokenization code path with a clear `ImportError` message.
- Move `tiktoken` from required dependencies to the optional `[tiktoken]` extra in `pyproject.toml`.

## Release note

- `langchain-openai` no longer requires `tiktoken` at install or import time. Install with `pip install langchain-openai[tiktoken]` or set `tiktoken_enabled=False` and use HuggingFace tokenization.

## Tests

```bash
uv run --group test pytest libs/partners/openai/tests/unit_tests/embeddings/ -k "not integration"
```

---

_Disclaimer: This contribution was prepared with assistance from an AI coding agent._