### PR TITLE
feat(openrouter): add OpenRouterEmbeddings

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/__init__.py
+++ b/libs/partners/openrouter/langchain_openrouter/__init__.py
@@ -2,8 +2,10 @@
 
 from langchain_openrouter._version import __version__
 from langchain_openrouter.chat_models import ChatOpenRouter
+from langchain_openrouter.embeddings import OpenRouterEmbeddings
 
 __all__ = [
     "ChatOpenRouter",
+    "OpenRouterEmbeddings",
     "__version__",
 ]

--- a/libs/partners/openrouter/langchain_openrouter/embeddings.py
+++ b/libs/partners/openrouter/langchain_openrouter/embeddings.py
@@ -1,0 +1,76 @@
+"""OpenRouter embeddings."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+from langchain_core.embeddings import Embeddings
+from langchain_core.utils import from_env, secret_from_env
+from pydantic import BaseModel, Field, SecretStr, model_validator
+from typing_extensions import Self
+
+
+class OpenRouterEmbeddings(BaseModel, Embeddings):
+    """OpenRouter embedding models via the OpenAI-compatible embeddings API."""
+
+    model: str = Field(default="openai/text-embedding-3-small")
+    openrouter_api_key: SecretStr | None = Field(
+        alias="api_key",
+        default_factory=secret_from_env("OPENROUTER_API_KEY", default=None),
+    )
+    openrouter_api_base: str = Field(
+        default_factory=from_env(
+            "OPENROUTER_API_BASE",
+            default="https://openrouter.ai/api/v1",
+        ),
+        alias="base_url",
+    )
+    request_timeout: float | None = Field(default=60.0, alias="timeout")
+
+    @model_validator(mode="after")
+    def validate_environment(self) -> Self:
+        if not (self.openrouter_api_key and self.openrouter_api_key.get_secret_value()):
+            msg = "OPENROUTER_API_KEY must be set."
+            raise ValueError(msg)
+        return self
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.openrouter_api_key.get_secret_value()}",  # type: ignore[union-attr]
+            "Content-Type": "application/json",
+        }
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        payload = {"model": self.model, "input": texts}
+        with httpx.Client(
+            base_url=self.openrouter_api_base,
+            headers=self._headers(),
+            timeout=self.request_timeout,
+        ) as client:
+            response = client.post("/embeddings", json=payload)
+            response.raise_for_status()
+            data = response.json()["data"]
+        return [item["embedding"] for item in sorted(data, key=lambda x: x["index"])]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self.embed_documents([text])[0]
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+        payload = {"model": self.model, "input": texts}
+        async with httpx.AsyncClient(
+            base_url=self.openrouter_api_base,
+            headers=self._headers(),
+            timeout=self.request_timeout,
+        ) as client:
+            response = await client.post("/embeddings", json=payload)
+            response.raise_for_status()
+            data = response.json()["data"]
+        return [item["embedding"] for item in sorted(data, key=lambda x: x["index"])]
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return (await self.aembed_documents([text]))[0]

--- a/libs/partners/openrouter/tests/unit_tests/test_embeddings.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_embeddings.py
@@ -1,0 +1,37 @@
+"""Unit tests for OpenRouter embeddings."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import SecretStr
+
+from langchain_openrouter.embeddings import OpenRouterEmbeddings
+
+
+def test_openrouter_embeddings_embed_documents() -> None:
+    embeddings = OpenRouterEmbeddings(
+        openrouter_api_key=SecretStr("test-key"),
+        openrouter_api_base="https://openrouter.ai/api/v1",
+    )
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "data": [
+            {"index": 0, "embedding": [0.1, 0.2]},
+            {"index": 1, "embedding": [0.3, 0.4]},
+        ]
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("langchain_openrouter.embeddings.httpx.Client") as client_cls:
+        client = client_cls.return_value.__enter__.return_value
+        client.post.return_value = mock_response
+        result = embeddings.embed_documents(["a", "b"])
+
+    assert result == [[0.1, 0.2], [0.3, 0.4]]
+    client.post.assert_called_once()
+    assert client.post.call_args.kwargs["json"]["model"] == "openai/text-embedding-3-small"
+
+
+def test_openrouter_embeddings_requires_api_key() -> None:
+    with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+        OpenRouterEmbeddings(openrouter_api_key=None)


### PR DESCRIPTION
---

OpenRouter exposes an embeddings API but the partner package only shipped chat models.

## Changes

- Add `OpenRouterEmbeddings` with sync/async embed APIs.
- Export from `langchain_openrouter.__init__`.

## Release note

- New `OpenRouterEmbeddings` class in `langchain-openrouter`.

## Tests

- `libs/partners/openrouter/tests/unit_tests/test_embeddings.py`

```bash
uv run --group test pytest libs/partners/openrouter/tests/unit_tests/test_embeddings.py
```

---

_Disclaimer: This contribution was prepared with assistance from an AI coding agent._