### PR TITLE
fix(agents): allow directory names containing '..' in FilesystemFileSearchMiddleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -270,8 +270,9 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
         if not path.startswith("/"):
             path = "/" + path
 
-        # Check for path traversal
-        if ".." in path or "~" in path:
+        # Check for path traversal: reject only path components that are exactly
+        # "..", not directory names that merely contain ".." (e.g. "src..old").
+        if "~" in path or any(part == ".." for part in Path(path).parts):
             msg = "Path traversal not allowed"
             raise ValueError(msg)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -325,6 +325,50 @@ class TestPathTraversalSecurity:
         assert result == "No matches found"
         assert "secret" not in result
 
+    def test_directory_name_with_double_dots_is_allowed(self, tmp_path: Path) -> None:
+        """A path segment that contains '..' but is not '..' should be allowed (issue #38549)."""
+        (tmp_path / "src..old").mkdir()
+        (tmp_path / "src..old" / "file.py").write_text("content", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.py", path="/src..old")
+
+        # Use path-separator-agnostic checks so the test passes on Windows too.
+        assert result != "No files found"
+        assert "src..old" in result
+        assert "file.py" in result
+
+    def test_grep_directory_name_with_double_dots_is_allowed(self, tmp_path: Path) -> None:
+        """Grep should also allow path segments like 'v1..backup' (issue #38549)."""
+        (tmp_path / "v1..backup").mkdir()
+        (tmp_path / "v1..backup" / "main.py").write_text("hello = 1\n", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+        result = middleware.grep_search.func(pattern="hello", path="/v1..backup")
+
+        assert result != "No matches found"
+        assert "v1..backup" in result
+        assert "main.py" in result
+
+    def test_real_traversal_still_blocked_after_fix(self, tmp_path: Path) -> None:
+        """Actual '..' traversal components must still be rejected after the fix."""
+        (tmp_path / "safe").mkdir()
+        (tmp_path / "secret.txt").write_text("secret", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path / "safe"))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.txt", path="/../")
+
+        assert result == "No files found"
+
 
 class TestGlobPatternTraversalSecurity:
     """Security tests for the glob `pattern` argument (not just the base `path`)."""


### PR DESCRIPTION
﻿## Problem

`FilesystemFileSearchMiddleware._validate_and_resolve_path` rejects any path whose string contains `..`, including **valid directory names** like `src..old`, `v1..backup`, or `notes..archived` (issue #38549).

```python
# Before fix: this returns "No files found" even though the directory exists
middleware.glob_search.func(pattern="*.py", path="/src..old")
```

## Root cause

Line 274 used `".." in path` (substring check on the full path string):

```python
if ".." in path or "~" in path:
    raise ValueError("Path traversal not allowed")
```

This rejects `"/src..old"` because the string `..` appears in `src..old`.

## Fix

Check individual path components instead: reject only components that are **exactly** `".."`.

```python
if "~" in path or any(part == ".." for part in Path(path).parts):
    raise ValueError("Path traversal not allowed")
```

The `_is_within_root` containment check and the `_validate_and_resolve_path` root guard remain as independent defenses against actual traversal.

## Tests

Added 3 regression tests to `TestPathTraversalSecurity`:

- `test_directory_name_with_double_dots_is_allowed` — glob finds files under `src..old/`
- `test_grep_directory_name_with_double_dots_is_allowed` — grep finds content under `v1..backup/`
- `test_real_traversal_still_blocked_after_fix` — actual `/../` traversal is still rejected

All 3 new tests pass. The 3 pre-existing failures in the suite are unrelated Windows path-separator issues present before this change.

Closes #38549.
