### PR TITLE
fix(openai): prevent pydantic serializer warnings when streaming structured output

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1613,7 +1613,10 @@ class BaseChatOpenAI(BaseChatModel):
                 is_first_chunk = True
                 for chunk in response:
                     if not isinstance(chunk, dict):
-                        chunk = chunk.model_dump()
+                        # `parsed` may hold arbitrary Pydantic models.
+                        chunk = chunk.model_dump(
+                            exclude={"choices": {"__all__": {"delta": {"parsed"}}}}
+                        )
                     generation_chunk = self._convert_chunk_to_generation_chunk(
                         chunk,
                         default_chunk_class,
@@ -1878,7 +1881,10 @@ class BaseChatOpenAI(BaseChatModel):
                     model_name=self.model_name,
                 ):
                     if not isinstance(chunk, dict):
-                        chunk = chunk.model_dump()
+                        # `parsed` may hold arbitrary Pydantic models.
+                        chunk = chunk.model_dump(
+                            exclude={"choices": {"__all__": {"delta": {"parsed"}}}}
+                        )
                     generation_chunk = self._convert_chunk_to_generation_chunk(
                         chunk,
                         default_chunk_class,


### PR DESCRIPTION
Closes #38034

In PR #35543, `parsed` was correctly excluded from `model_dump` on the standard chat completion path to prevent Pydantic serialization warnings when using `with_structured_output`. However, this exclusion was omitted in the `_stream` and `_astream` generators, causing massive terminal spam (`UserWarning: Pydantic serializer warnings`) when users stream structured outputs.

This PR applies the identical exclusion logic (`exclude={"choices": {"__all__": {"delta": {"parsed"}}}}`) to the streaming chunk `model_dump()` calls, silently resolving the serialization warnings without altering the public API.

## Release note
Fixes Pydantic serialization warnings printed to the console when streaming with `with_structured_output`.
