### PR TITLE
fix: handle unhashable metadata in MultiQueryRetriever.unique_union()

### DIFF
--- a/libs/langchain/langchain/retrievers/multi_query.py
+++ b/libs/langchain/langchain/retrievers/multi_query.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from typing import List
 
@@ -145,10 +146,9 @@ class MultiQueryRetriever(BaseRetriever):
         Returns:
             List of unique retrieved Documents
         """
-        # Create a dictionary with page_content as keys to remove duplicates
-        # TODO: Add Document ID property (e.g., UUID)
+        # Create a dictionary with page_content + metadata as keys to remove duplicates
         unique_documents_dict = {
-            (doc.page_content, tuple(sorted(doc.metadata.items()))): doc
+            (doc.page_content, json.dumps(doc.metadata, sort_keys=True, default=str)): doc
             for doc in documents
         }
 


### PR DESCRIPTION
## Summary

Fix `TypeError: unhashable type: 'list'` crash in `MultiQueryRetriever.unique_union()` when documents have list or dict metadata values.

## Problem

`unique_union()` uses `tuple(sorted(doc.metadata.items()))` as a dict key for deduplication. This crashes when metadata contains unhashable types (lists, dicts, sets) — which is extremely common in practice:

```python
from langchain_core.documents import Document

docs = [
    Document(page_content="hello", metadata={"tags": ["python", "ai"]}),
    Document(page_content="hello", metadata={"tags": ["python", "ai"]}),
]

# Calling unique_union on these:
# TypeError: unhashable type: 'list'
```

Also crashes with nested dicts:
```python
docs = [Document(page_content="test", metadata={"source": {"type": "api", "url": "..."}})]
# TypeError: unhashable type: 'dict'
```

## Fix

Use `json.dumps(doc.metadata, sort_keys=True, default=str)` which handles any metadata type safely while preserving correct deduplication semantics.

## Test plan

- [x] Documents with list metadata values no longer crash
- [x] Documents with nested dict metadata no longer crash
- [x] Deduplication still works correctly for identical documents
- [x] Different metadata still produces separate entries