### PR TITLE
fix(core): clarify `add_message` error docs

### DIFF
--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -152,8 +152,8 @@ class BaseChatMessageHistory(ABC):
             message: A `BaseMessage` object to store.
 
         Raises:
-            NotImplementedError: If the sub-class has not implemented an efficient
-                `add_messages` method.
+            NotImplementedError: If the sub-class has not implemented `add_message`
+                or `add_messages`.
         """
         if type(self).add_messages != BaseChatMessageHistory.add_messages:
             # This means that the sub-class has implemented an efficient add_messages


### PR DESCRIPTION
Fixes #38603

---

`BaseChatMessageHistory.add_message` raised wording now matches the existing error message: subclass authors can implement either `add_message` or `add_messages`. This is a documentation-only clarification with no runtime behavior change.

Verified by reviewing the rendered diff for the single docstring update.

AI assistance was used to prepare this contribution, and the final change was reviewed before submission.
