### PR TITLE
fix(langchain): allow double dots in file search path segments

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -271,7 +271,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
             path = "/" + path
 
         # Check for path traversal
-        if ".." in path or "~" in path:
+        if any(part == ".." for part in path.split("/")) or "~" in path:
             msg = "Path traversal not allowed"
             raise ValueError(msg)
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -190,6 +190,19 @@ class TestFilesystemGlobSearch:
         assert "/src/file1.py" in result
         assert "/other/file2.py" not in result
 
+    def test_glob_allows_path_segments_containing_double_dots(self, tmp_path: Path) -> None:
+        """Test glob search with normal path segments that contain double dots."""
+        (tmp_path / "src..old").mkdir()
+        (tmp_path / "src..old" / "file.py").write_text("content", encoding="utf-8")
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path))
+
+        assert isinstance(middleware.glob_search, StructuredTool)
+        assert middleware.glob_search.func is not None
+        result = middleware.glob_search.func(pattern="*.py", path="/src..old")
+
+        assert result == "/src..old/file.py"
+
     def test_glob_no_matches(self, tmp_path: Path) -> None:
         """Test glob search with no matches."""
         (tmp_path / "file.txt").write_text("content", encoding="utf-8")


### PR DESCRIPTION
Fixes #38549

---

`FilesystemFileSearchMiddleware` now rejects only actual `..` path segments instead of every path string containing two dots. This keeps traversal protection intact while allowing normal directory names like `src..old`, with a regression test covering the glob search case.

I verified the changed files with `python3 -m py_compile` and reviewed the focused diff.

## Release note

`FilesystemFileSearchMiddleware` now accepts valid path segments that contain double dots while still blocking `..` traversal segments.

AI assistance was used to prepare this contribution, and the final change was reviewed before submission.
