### PR TITLE
fix(core): correct typo in Visitor._validate_func operator error message

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
Fixes #36701

---

The error message for disallowed operators says "Allowed comparators are" but it should say "Allowed operators are" to match the actual context. The message reads "Received disallowed operator {func}. Allowed comparators are {self.allowed_operators}" which is confusing — it references both operators and comparators in the same sentence.