### PR TITLE
fixed the bug #38637

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
@@ -53,6 +53,12 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
     model_kwargs: dict | None = None
     """Keyword arguments to pass to the model."""
 
+    bill_to: str | None = None
+    """Organization or billing identifier to pass to Hugging Face Inference API."""
+
+    additional_headers: dict[str, str] | None = None
+    """Additional request headers to send to the Hugging Face Inference API."""
+
     huggingfacehub_api_token: str | None = Field(
         default_factory=from_env("HUGGINGFACEHUB_API_TOKEN", default=None)
     )
@@ -89,16 +95,24 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
                 self.model = DEFAULT_MODEL
                 self.repo_id = DEFAULT_MODEL
 
+            client_kwargs: dict[str, Any] = {}
+            if self.bill_to is not None:
+                client_kwargs["bill_to"] = self.bill_to
+            if self.additional_headers is not None:
+                client_kwargs["headers"] = self.additional_headers
+
             client = InferenceClient(
                 model=self.model,
                 token=huggingfacehub_api_token,
                 provider=self.provider,  # type: ignore[arg-type]
+                **client_kwargs,
             )
 
             async_client = AsyncInferenceClient(
                 model=self.model,
                 token=huggingfacehub_api_token,
                 provider=self.provider,  # type: ignore[arg-type]
+                **client_kwargs,
             )
 
             if self.task not in VALID_TASKS:


### PR DESCRIPTION
`HuggingFaceEndpointEmbeddings` currently does not expose a way to pass
`bill_to` or custom headers to the underlying `huggingface_hub.InferenceClient`,
even though `InferenceClient` itself supports both parameters natively.

This was previously possible via the deprecated `HuggingFaceInferenceAPIEmbeddings`
(from `langchain_community`), which accepted an `additional_headers` parameter
(e.g. to set `X-HF-Bill-To` for org-level billing on the HF Inference API).

This PR adds that functionality back to `HuggingFaceEndpointEmbeddings` so users
with org-scoped API tokens don't need to fall back to the deprecated class or
write a manual wrapper.

## Changes

- Add optional `bill_to` parameter to `HuggingFaceEndpointEmbeddings.__init__`
- Add optional `additional_headers` parameter to `HuggingFaceEndpointEmbeddings.__init__`
- Pass both through to the underlying `InferenceClient` constructor
- Update docstrings to document the new parameters

## Issue

Fixes #38637

## Reproduction (before fix)

```python
from langchain_huggingface import HuggingFaceEndpointEmbeddings

hf = HuggingFaceEndpointEmbeddings(
    model="sentence-transformers/all-mpnet-base-v2",
    task="feature-extraction",
    huggingfacehub_api_token="my-api-key",
)
hf.embed_query("This is a test query")
# Raises: huggingface_hub.errors.HfHubHTTPError: 401 Unauthorized
```

## Usage (after fix)

```python
from langchain_huggingface import HuggingFaceEndpointEmbeddings

hf = HuggingFaceEndpointEmbeddings(
    model="sentence-transformers/all-mpnet-base-v2",
    task="feature-extraction",
    huggingfacehub_api_token="my-api-key",
    bill_to="my-organization",
)
hf.embed_query("This is a test query")
```

## Testing

- [ ] Added/updated unit tests covering the new parameters
- [ ] Ran existing test suite locally — all passing
- [ ] Manually verified against a real HF org-scoped token (if applicable)

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Linked the issue this PR resolves
- [ ] Added/updated docstrings
- [ ] Added/updated tests
- [ ] Ran `make lint` / `make format` (or repo's equivalent) locally