### PR TITLE
fix(fireworks): merge nested token_usage dicts in _combine_llm_outputs

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from operator import itemgetter
 from typing import (
@@ -403,6 +404,34 @@ def _usage_to_metadata(usage: Mapping[str, Any]) -> dict[str, int]:
         "output_tokens": output_tokens,
         "total_tokens": usage.get("total_tokens", input_tokens + output_tokens),
     }
+
+
+def _update_token_usage(
+    overall_token_usage: int | dict, new_usage: int | dict
+) -> int | dict:
+    # Token usage is either ints or dictionaries;
+    # e.g. `cached_tokens` is nested inside `prompt_tokens_details`.
+    if isinstance(new_usage, int):
+        if not isinstance(overall_token_usage, int):
+            msg = (
+                f"Got different types for token usage: "
+                f"{type(new_usage)} and {type(overall_token_usage)}"
+            )
+            raise ValueError(msg)
+        return new_usage + overall_token_usage
+    if isinstance(new_usage, dict):
+        if not isinstance(overall_token_usage, dict):
+            msg = (
+                f"Got different types for token usage: "
+                f"{type(new_usage)} and {type(overall_token_usage)}"
+            )
+            raise ValueError(msg)
+        return {
+            k: _update_token_usage(overall_token_usage.get(k, 0), v)
+            for k, v in new_usage.items()
+        }
+    warnings.warn(f"Unexpected type for token usage: {type(new_usage)}")
+    return new_usage
 
 
 def _convert_chunk_to_message_chunk(
@@ -963,8 +992,12 @@ class ChatFireworks(BaseChatModel):
             token_usage = output["token_usage"]
             if token_usage is not None:
                 for k, v in token_usage.items():
+                    if v is None:
+                        continue
                     if k in overall_token_usage:
-                        overall_token_usage[k] += v
+                        overall_token_usage[k] = _update_token_usage(
+                            overall_token_usage[k], v
+                        )
                     else:
                         overall_token_usage[k] = v
             if system_fingerprint is None:

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1591,3 +1591,109 @@ def test_request_timeout_tuple_normalized_to_httpx_timeout(
     assert forwarded.connect == 5.0
     assert forwarded.read == 30.0
     assert async_mock.call_args.kwargs["timeout"] == forwarded
+
+
+@pytest.mark.parametrize(
+    ("llm_outputs", "expected_token_usage"),
+    [
+        pytest.param(
+            [
+                {
+                    "token_usage": {
+                        "prompt_tokens": 32,
+                        "completion_tokens": 51,
+                        "total_tokens": 83,
+                        "prompt_tokens_details": {"cached_tokens": 0},
+                    },
+                    "model_name": MODEL_NAME,
+                },
+                {
+                    "token_usage": {
+                        "prompt_tokens": 100,
+                        "completion_tokens": 10,
+                        "total_tokens": 110,
+                        "prompt_tokens_details": {"cached_tokens": 75},
+                    },
+                    "model_name": MODEL_NAME,
+                },
+            ],
+            {
+                "prompt_tokens": 132,
+                "completion_tokens": 61,
+                "total_tokens": 193,
+                "prompt_tokens_details": {"cached_tokens": 75},
+            },
+            id="nested-details-summed",
+        ),
+        pytest.param(
+            [
+                {
+                    "token_usage": {
+                        "prompt_tokens": 32,
+                        "prompt_tokens_details": {"cached_tokens": 5},
+                    },
+                    "model_name": MODEL_NAME,
+                },
+                {
+                    "token_usage": {
+                        "prompt_tokens": 10,
+                        "prompt_tokens_details": None,
+                    },
+                    "model_name": MODEL_NAME,
+                },
+            ],
+            {
+                "prompt_tokens": 42,
+                "prompt_tokens_details": {"cached_tokens": 5},
+            },
+            id="none-value-skipped",
+        ),
+        pytest.param(
+            [
+                None,
+                {
+                    "token_usage": {"prompt_tokens": 7, "completion_tokens": 3},
+                    "model_name": MODEL_NAME,
+                },
+            ],
+            {"prompt_tokens": 7, "completion_tokens": 3},
+            id="none-output-from-streaming-skipped",
+        ),
+        pytest.param(
+            [
+                {
+                    "token_usage": {"prompt_tokens": 1},
+                    "model_name": MODEL_NAME,
+                },
+                {
+                    "token_usage": {
+                        "prompt_tokens": 2,
+                        "completion_tokens_details": {"reasoning_tokens": 4},
+                    },
+                    "model_name": MODEL_NAME,
+                },
+            ],
+            {
+                "prompt_tokens": 3,
+                "completion_tokens_details": {"reasoning_tokens": 4},
+            },
+            id="key-first-seen-in-later-output",
+        ),
+    ],
+)
+def test_combine_llm_outputs_merges_nested_token_usage(
+    llm_outputs: list[dict[str, Any] | None],
+    expected_token_usage: dict[str, Any],
+) -> None:
+    """Nested usage dicts (e.g. `prompt_tokens_details`) must merge, not crash.
+
+    Fireworks responses include nested dicts in `usage` such as
+    `prompt_tokens_details: {"cached_tokens": ...}`; naive `+=` on those
+    raised `TypeError: unsupported operand type(s) for +=: 'dict' and 'dict'`.
+    """
+    llm = ChatFireworks(model=MODEL_NAME, api_key="fake-key")  # type: ignore[arg-type]
+
+    combined = llm._combine_llm_outputs(llm_outputs)
+
+    assert combined["token_usage"] == expected_token_usage
+    assert combined["model_name"] == MODEL_NAME


### PR DESCRIPTION
Fixes #38648

---

Batched `generate()` with ChatFireworks crashed with `TypeError: unsupported operand type(s) for +=: 'dict' and 'dict'` because Fireworks returns nested usage details (`prompt_tokens_details: {"cached_tokens": ...}`) while `_combine_llm_outputs` assumed int values. Fixed by mirroring the `langchain-openai` approach: a recursive `_update_token_usage` helper plus skipping `None` values, with parametrized unit tests for both failure modes.

Verified with `make format lint test` in `libs/partners/fireworks` (118 passed).
