### PR TITLE
fix(huggingface): pass client options to endpoint embeddings

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
@@ -53,6 +53,12 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
     model_kwargs: dict | None = None
     """Keyword arguments to pass to the model."""
 
+    additional_headers: dict[str, str] | None = None
+    """Additional HTTP headers to send with Hugging Face inference requests."""
+
+    bill_to: str | None = None
+    """Hugging Face organization to bill for inference requests."""
+
     huggingfacehub_api_token: str | None = Field(
         default_factory=from_env("HUGGINGFACEHUB_API_TOKEN", default=None)
     )
@@ -93,12 +99,16 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
                 model=self.model,
                 token=huggingfacehub_api_token,
                 provider=self.provider,  # type: ignore[arg-type]
+                headers=self.additional_headers,
+                bill_to=self.bill_to,
             )
 
             async_client = AsyncInferenceClient(
                 model=self.model,
                 token=huggingfacehub_api_token,
                 provider=self.provider,  # type: ignore[arg-type]
+                headers=self.additional_headers,
+                bill_to=self.bill_to,
             )
 
             if self.task not in VALID_TASKS:

--- a/libs/partners/huggingface/tests/unit_tests/test_huggingface_endpoint_embeddings.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_huggingface_endpoint_embeddings.py
@@ -1,0 +1,33 @@
+"""Tests for HuggingFaceEndpointEmbeddings client configuration."""
+
+from unittest.mock import MagicMock, patch
+
+from langchain_huggingface.embeddings import HuggingFaceEndpointEmbeddings
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_huggingface_endpoint_embeddings_passes_headers_and_bill_to(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """Custom headers and billing org are forwarded to HF inference clients."""
+    mock_inference_client.return_value = MagicMock()
+    mock_async_client.return_value = MagicMock()
+
+    HuggingFaceEndpointEmbeddings(
+        model="sentence-transformers/all-mpnet-base-v2",
+        huggingfacehub_api_token="hf_xxx",  # noqa: S106
+        additional_headers={"X-HF-Bill-To": "my-org"},
+        bill_to="my-org",
+    )
+
+    mock_inference_client.assert_called_once()
+    call_kwargs = mock_inference_client.call_args[1]
+    assert call_kwargs["headers"] == {"X-HF-Bill-To": "my-org"}
+    assert call_kwargs["bill_to"] == "my-org"
+
+    mock_async_client.assert_called_once()
+    async_call_kwargs = mock_async_client.call_args[1]
+    assert async_call_kwargs["headers"] == {"X-HF-Bill-To": "my-org"}
+    assert async_call_kwargs["bill_to"] == "my-org"


### PR DESCRIPTION
Closes #38637

## Release note

`HuggingFaceEndpointEmbeddings` now accepts `additional_headers` and `bill_to`, and passes them to both sync and async Hugging Face inference clients so users can set custom request headers and organization billing.

---

This contribution was prepared with assistance from an AI coding agent.