### PR TITLE
Fix: Prevent concatenation of identical metadata fields during streaming

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -57,7 +57,18 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 #             "all dicts."
                 #         )
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
-                    right_k in {"id", "output_version", "model_provider"}
+                    right_k
+                    in {
+                        "id",
+                        "output_version",
+                        "model_provider",
+                        "model_name",
+                        "finish_reason",
+                        "native_finish_reason",
+                        "object",
+                        "system_fingerprint",
+                        "format",
+                    }
                     and merged[right_k] == right_v
                 ):
                     continue

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -129,6 +129,33 @@ def test_check_package_version(
         # Other integer fields should still be summed (e.g., token counts)
         ({"tokens": 10}, {"tokens": 5}, {"tokens": 15}),
         ({"count": 1}, {"count": 2}, {"count": 3}),
+        # Metadata fields should not concatenate when identical (issue #38366)
+        ({"model_name": "gpt-4"}, {"model_name": "gpt-4"}, {"model_name": "gpt-4"}),
+        (
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+            {"finish_reason": "stop"},
+        ),
+        (
+            {"native_finish_reason": "end_turn"},
+            {"native_finish_reason": "end_turn"},
+            {"native_finish_reason": "end_turn"},
+        ),
+        ({"object": "chat.completion"}, {"object": "chat.completion"}, {"object": "chat.completion"}),
+        (
+            {"system_fingerprint": "fp_abc123"},
+            {"system_fingerprint": "fp_abc123"},
+            {"system_fingerprint": "fp_abc123"},
+        ),
+        ({"format": "json"}, {"format": "json"}, {"format": "json"}),
+        # Differing metadata values should still concatenate (no regression)
+        (
+            {"model_name": "gpt-4"},
+            {"model_name": "-turbo"},
+            {"model_name": "gpt-4-turbo"},
+        ),
+        # Unrelated string fields should still concatenate normally
+        ({"content": "hello"}, {"content": " world"}, {"content": "hello world"}),
     ],
 )
 def test_merge_dicts(


### PR DESCRIPTION
## Summary

Fixes #38366 

During streaming, `merge_dicts` was concatenating identical string metadata fields across chunks, resulting in doubled values like `"stopstop"` for `finish_reason` and `"model_namemodel_name"` for `model_name`.

This occurred because providers (OpenRouter, Bedrock, etc.) repeat stable metadata fields verbatim across terminal chunks, and these fields fell through to the string concatenation logic.

## Changes

- Extended the deduplication allowlist in `merge_dicts` to include:
  - `model_name`
  - `finish_reason`
  - `native_finish_reason`
  - `object`
  - `system_fingerprint`
  - `format`
- These fields now skip concatenation when values are identical (matching existing behavior for `model_provider`)
- Added comprehensive test coverage for all newly allowlisted fields
- Added regression tests confirming differing values still concatenate

## Verification

- ✅ All new tests pass
- ✅ Existing behavior preserved for non-metadata fields
- ✅ Fixes reported issue with OpenRouter and similar providers

## Test Plan

\`\`\`bash
cd libs/core
pytest tests/unit_tests/utils/test_utils.py::test_merge_dicts -v
\`\`\`

All parametrized test cases pass, including:
- Identical metadata values deduplicate correctly
- Differing metadata values still concatenate (no regression)
- Unrelated string fields continue to work as before

Made with [Cursor](https://cursor.com)