### PR TITLE
fix(huggingface): pass bound tools to pipeline chat template

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -754,7 +754,8 @@ class ChatHuggingFace(BaseChatModel):
             }
             answer = self.llm.client.chat_completion(messages=message_dicts, **params)
             return self._create_chat_result(answer)
-        llm_input = self._to_chat_prompt(messages)
+        tools = kwargs.pop("tools", None)
+        llm_input = self._to_chat_prompt(messages, tools=tools)
 
         if should_stream:
             stream_iter = self.llm._stream(
@@ -799,7 +800,8 @@ class ChatHuggingFace(BaseChatModel):
         if _is_huggingface_pipeline(self.llm):
             msg = "async generation is not supported with HuggingFacePipeline"
             raise NotImplementedError(msg)
-        llm_input = self._to_chat_prompt(messages)
+        tools = kwargs.pop("tools", None)
+        llm_input = self._to_chat_prompt(messages, tools=tools)
         llm_result = await self.llm._agenerate(
             prompts=[llm_input], stop=stop, run_manager=run_manager, **kwargs
         )
@@ -882,7 +884,8 @@ class ChatHuggingFace(BaseChatModel):
                     )
                 yield generation_chunk
         else:
-            llm_input = self._to_chat_prompt(messages)
+            tools = kwargs.pop("tools", None)
+            llm_input = self._to_chat_prompt(messages, tools=tools)
             stream_iter = self.llm._stream(
                 llm_input, stop=stop, run_manager=run_manager, **kwargs
             )
@@ -952,6 +955,8 @@ class ChatHuggingFace(BaseChatModel):
     def _to_chat_prompt(
         self,
         messages: list[BaseMessage],
+        *,
+        tools: list[dict[str, Any]] | None = None,
     ) -> str:
         """Convert a list of messages into a prompt format expected by wrapped LLM."""
         if not messages:
@@ -964,9 +969,14 @@ class ChatHuggingFace(BaseChatModel):
 
         messages_dicts = [self._to_chatml_format(m) for m in messages]
 
-        return self.tokenizer.apply_chat_template(
-            messages_dicts, tokenize=False, add_generation_prompt=True
-        )
+        template_kwargs: dict[str, Any] = {
+            "tokenize": False,
+            "add_generation_prompt": True,
+        }
+        if tools:
+            template_kwargs["tools"] = tools
+
+        return self.tokenizer.apply_chat_template(messages_dicts, **template_kwargs)
 
     def _to_chatml_format(self, message: BaseMessage) -> dict:
         """Convert LangChain message to ChatML format."""

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest  # type: ignore[import-not-found]
 from langchain_core.messages import (
@@ -9,14 +9,14 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from langchain_core.outputs import ChatResult
+from langchain_core.outputs import ChatResult, Generation, LLMResult
 from langchain_core.tools import BaseTool
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
     _convert_dict_to_message,
 )
-from langchain_huggingface.llms import HuggingFaceEndpoint
+from langchain_huggingface.llms import HuggingFaceEndpoint, HuggingFacePipeline
 
 
 @pytest.fixture
@@ -100,6 +100,57 @@ def test_to_chat_prompt_valid_messages(chat_hugging_face: Any) -> None:
         ],
         tokenize=False,
         add_generation_prompt=True,
+    )
+
+
+def test_bind_tools_passes_tools_to_pipeline_chat_template() -> None:
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the weather.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string",
+                            "description": "The city and state.",
+                        }
+                    },
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+    expected_prompt = "Generated tool prompt"
+
+    tokenizer = MagicMock()
+    tokenizer.apply_chat_template.return_value = expected_prompt
+    llm = Mock(spec=HuggingFacePipeline)
+    llm.model_id = "test/model"
+    llm.model_kwargs = {}
+    llm._generate.return_value = LLMResult(
+        generations=[[Generation(text="tool result")]], llm_output={}
+    )
+
+    with patch(
+        "langchain_huggingface.chat_models.huggingface.ChatHuggingFace._resolve_model_id"
+    ):
+        chat = ChatHuggingFace(llm=llm, tokenizer=tokenizer)
+    chat_with_tools = chat.bind_tools(tools)
+
+    result = chat_with_tools.invoke([HumanMessage(content="What is the weather?")])
+
+    assert result.content == "tool result"
+    tokenizer.apply_chat_template.assert_called_once_with(
+        [{"role": "user", "content": "What is the weather?"}],
+        tokenize=False,
+        add_generation_prompt=True,
+        tools=tools,
+    )
+    llm._generate.assert_called_once_with(
+        prompts=[expected_prompt], stop=None, run_manager=ANY
     )
 
 


### PR DESCRIPTION
Closes #29033

## Summary
- forward bound tools into `tokenizer.apply_chat_template` for local `HuggingFacePipeline` prompts
- remove the bound `tools` kwarg before calling the underlying pipeline generation methods
- add a regression test covering `bind_tools(...).invoke(...)` with a pipeline-backed `ChatHuggingFace`

## Tests
- `python -m pytest tests/unit_tests/test_chat_models.py -q`
- `ruff check langchain_huggingface/chat_models/huggingface.py tests/unit_tests/test_chat_models.py`
- `ruff format --check langchain_huggingface/chat_models/huggingface.py tests/unit_tests/test_chat_models.py`