### PR TITLE
fix(core): stop non-`Args` docstring sections leaking into tool descriptions

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -726,6 +726,31 @@ def tool_example_to_messages(
 
 _MIN_DOCSTRING_BLOCKS = 2
 
+# Google-style docstring section headers that are not part of the function's
+# summary/description. Description blocks are collected only until one of these
+# headers is reached, so a section such as `Raises:` or `Note:` that appears
+# before (or in the absence of) an `Args:` block does not leak into the
+# description advertised to a model.
+_DESCRIPTION_TERMINATORS = (
+    "Args:",
+    "Arguments:",
+    "Attributes:",
+    "Example:",
+    "Examples:",
+    "Note:",
+    "Notes:",
+    "Raises:",
+    "References:",
+    "Return:",
+    "Returns:",
+    "Todo:",
+    "Warning:",
+    "Warnings:",
+    "Warns:",
+    "Yield:",
+    "Yields:",
+)
+
 
 def _parse_google_docstring(
     docstring: str | None,
@@ -767,7 +792,7 @@ def _parse_google_docstring(
             if block.startswith("Args:"):
                 args_block = block
                 break
-            if block.startswith(("Returns:", "Example:")):
+            if block.startswith(_DESCRIPTION_TERMINATORS):
                 # Don't break in case Args come after
                 past_descriptors = True
             elif not past_descriptors:

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1370,6 +1370,52 @@ class TestParseGoogleDocstring:
         assert set(args) == {"x"}
         assert "y: the y value" in args["x"]
 
+    def test_raises_section_before_args_excluded_from_description(self) -> None:
+        """A `Raises:` block before `Args:` must not leak into the description.
+
+        Only `Returns:`/`Example:` used to terminate description collection, so
+        other Google-style sections (`Raises:`, `Note:`, `Yields:`, ...) placed
+        before the `Args:` block were concatenated into the description that is
+        advertised to a model.
+        """
+        docstring = (
+            "Summary line.\n"
+            "\n"
+            "Raises:\n"
+            "    ValueError: when the input is bad\n"
+            "\n"
+            "Args:\n"
+            "    x: The x value"
+        )
+        desc, args = _parse_google_docstring(docstring, ["x"])
+        assert desc == "Summary line."
+        assert args == {"x": "The x value"}
+
+    def test_note_section_without_args_excluded_from_description(self) -> None:
+        """A `Note:` section with no `Args:` block must not leak into the description.
+
+        With no `Args:` block to break on, every block is scanned; a trailing
+        `Note:` section previously folded into the description.
+        """
+        docstring = "Do a thing.\n\nNote:\n    be careful here"
+        desc, args = _parse_google_docstring(docstring, [])
+        assert desc == "Do a thing."
+        assert args == {}
+
+    def test_multiple_non_arg_sections_excluded_from_description(self) -> None:
+        """`Yields:`/`Warning:` sections stay out of the description too."""
+        docstring = (
+            "Stream items.\n"
+            "\n"
+            "Yields:\n"
+            "    Each item in turn.\n"
+            "\n"
+            "Warning:\n"
+            "    This is lazy."
+        )
+        desc, _args = _parse_google_docstring(docstring, [])
+        assert desc == "Stream items."
+
 
 def test_convert_to_openai_tool_apply_patch_passthrough() -> None:
     """Test apply_patch is passed through as an OpenAI built-in tool."""


### PR DESCRIPTION
Closes #38654

---

When LangChain turns a Python function into a tool, the text a model sees as the tool's description comes from the function's docstring. `_parse_google_docstring` builds that description by collecting the leading blocks of the docstring and stopping once it reaches a structured section.

The problem: it only recognized `Returns:` and `Example:` as stopping points. Any other Google-style section — `Raises:`, `Note:`, `Yields:`, `Warning:`, `Attributes:`, and so on — that appears *before* the `Args:` block, or in a docstring that has no `Args:` block at all, was swept into the description and advertised to the model verbatim.

For example, this tool docstring:

```python
"""Summary line.

Raises:
    ValueError: when the input is bad

Args:
    x: The x value
"""
```

previously produced the description `"Summary line. Raises:\n    ValueError: when the input is bad"` instead of just `"Summary line."`. Every tool whose docstring documents what it raises, or carries a `Note:`/`Warning:` before its arguments, was leaking that boilerplate into the model's prompt — adding noise and, in some cases, misleading guidance about how to call the tool.

The fix widens the set of recognized section headers to the standard Google-style sections (introduced as a named `_DESCRIPTION_TERMINATORS` constant), so only the summary and free-form description text is used. Behavior for docstrings that already terminated on `Returns:`/`Example:` is unchanged.

## Release note

Tool descriptions derived from Google-style docstrings no longer include the contents of `Raises:`, `Note:`, `Yields:`, `Warning:`, and similar sections when they appear before (or without) an `Args:` block. Only the function summary and description are sent to the model as the tool description.

---

Added unit tests in `TestParseGoogleDocstring` covering a `Raises:` section before `Args:`, a `Note:` section with no `Args:` block, and multiple non-argument sections; each fails against the previous behavior and passes with this change.

Disclaimer: this contribution was prepared with the assistance of an AI agent (Claude).
