### PR TITLE
fix(core): preserve MIME type on base64 file blocks in openai translator

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/openai.py
+++ b/libs/core/langchain_core/messages/block_translators/openai.py
@@ -92,6 +92,11 @@ def convert_to_openai_data_block(
 
     elif block["type"] == "file":
         if block.get("source_type") == "base64" or "base64" in block:
+            if api == "chat/completions" and block.get("mime_type") != "application/pdf":
+                raise ValueError(
+                    f"OpenAI Chat Completions only supports PDF files for base64 file blocks. "
+                    f"Received mime_type: {block.get('mime_type')}"
+            )
             # Handle v0 format (Base64CB): {"source_type": "base64", "data": "...", ...}
             # Handle v1 format (IDCB): {"base64": "...", ...}
             base64_data = block["data"] if "source_type" in block else block["base64"]
@@ -548,7 +553,7 @@ def _convert_openai_format_to_data_block(
         filename = block["file"].get("filename")
         return types.create_file_block(
             base64=parsed["data"],
-            mime_type="application/pdf",
+            mime_type=parsed["mime_type"],
             filename=filename,
             **all_extras,
         )

--- a/reproduce_issue.py
+++ b/reproduce_issue.py
@@ -1,0 +1,14 @@
+from langchain_core.messages import HumanMessage  
+from langchain_core.language_models._utils import _normalize_messages  
+  
+msg = HumanMessage(content=[  
+    {  
+        "type": "file",  
+        "file": {  
+            "filename": "test.csv",  
+            "file_data": "data:text/csv;base64,aGVsbG8=",  
+        },  
+    },  
+])  
+# This is the line that currently returns 'application/pdf' incorrectly
+print(f"MIME Type: {_normalize_messages([msg])[0].content[0]['mime_type']}")

--- a/verify_fix.py
+++ b/verify_fix.py
@@ -1,0 +1,44 @@
+from langchain_core.messages import HumanMessage  
+from langchain_core.language_models._utils import _normalize_messages  
+
+def test_mime_preservation():
+    print("Testing MIME type preservation...")
+    msg = HumanMessage(content=[  
+        {  
+            "type": "file",  
+            "file": {  
+                "filename": "test.csv",  
+                "file_data": "data:text/csv;base64,aGVsbG8=",  
+            },  
+        },  
+    ])  
+    # This is the logic that you fixed
+    normalized = _normalize_messages([msg])[0].content[0]
+    mime = normalized.get('mime_type')
+    print(f"Result: {mime}")
+    
+    if mime == "text/csv":
+        print("✅ SUCCESS: MIME type preserved!")
+    else:
+        print(f"❌ FAILED: Expected text/csv, but got {mime}")
+
+def test_openai_guard():
+    print("\nTesting OpenAI Guard...")
+    from langchain_core.messages.block_translators.openai import convert_to_openai_data_block
+    
+    block = {
+        "type": "file",
+        "mime_type": "text/csv",
+        "base64": "aGVsbG8=",
+        "filename": "test.csv"
+    }
+    
+    try:
+        convert_to_openai_data_block(block, api="chat/completions")
+        print("❌ FAILED: Should have raised ValueError for CSV in Chat Completions")
+    except ValueError as e:
+        print(f"✅ SUCCESS: Guard caught invalid file: {e}")
+
+if __name__ == "__main__":
+    test_mime_preservation()
+    test_openai_guard()


### PR DESCRIPTION
### Description
This PR fixes a bug where base64 file blocks were hard-coded to `application/pdf` regardless of the actual content. This caused issues for non-OpenAI providers (like Anthropic) that support various file types.

### Changes
1. **MIME Preservation:** Updated `_convert_openai_format_to_data_block` in `openai.py` to use the actual `parsed["mime_type"]` instead of the hard-coded PDF string.
2. **OpenAI Guard:** Added a `ValueError` check in `convert_to_openai_data_block` for the `chat/completions` API. Since OpenAI strictly requires PDFs for this endpoint, the code now fails fast with a helpful error message instead of sending an invalid request.

### Verification Results
I created a local verification script to test both the preservation and the guard.

**Test Output:**
```text
Testing MIME type preservation...
Result: text/csv
✅ SUCCESS: MIME type preserved!

Testing OpenAI Guard...
✅ SUCCESS: Guard caught invalid file: OpenAI Chat Completions only supports PDF files for base64 file blocks. Received mime_type: text/csv  
```


Fixes #36939