### PR TITLE
langchain_anthropic: add advisor_ to _BUILTIN_TOOL_PREFIXES to fix KeyError on bind_tools

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -161,6 +161,7 @@ _BUILTIN_TOOL_PREFIXES = [
     "mcp_toolset",
     "memory_",
     "tool_search_",
+    "advisor_",
 ]
 
 _ANTHROPIC_EXTRA_FIELDS: set[str] = {

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2579,6 +2579,33 @@ def test_tool_search_is_builtin_tool() -> None:
     assert not _is_builtin_tool(regular_tool)
 
 
+def test_advisor_is_builtin_tool() -> None:
+    """Test that advisor_ tools are recognized as built-in and pass through bind_tools.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38644.
+    advisor_20260301 (Anthropic Advisor native tool) was missing from
+    _BUILTIN_TOOL_PREFIXES, causing bind_tools() to route it through
+    convert_to_anthropic_tool() which crashed with KeyError: 'parameters'.
+    """
+    advisor_tool = {
+        "type": "advisor_20260301",
+        "name": "advisor",
+        "model": MODEL_NAME,
+        "max_uses": 3,
+        "max_tokens": 1024,
+    }
+    assert _is_builtin_tool(advisor_tool)
+
+    # bind_tools() must pass the advisor tool through unchanged, not raise KeyError
+    model = ChatAnthropic(model=MODEL_NAME)  # type: ignore[call-arg]
+    bound = model.bind_tools([advisor_tool])
+    payload = bound._get_request_payload(  # type: ignore[attr-defined]
+        [HumanMessage("hello")],
+        **bound.kwargs,  # type: ignore[attr-defined]
+    )
+    assert advisor_tool in payload["tools"]
+
+
 def test_tool_search_beta_headers() -> None:
     """Test that tool search tools auto-append the correct beta headers."""
     # Test regex variant


### PR DESCRIPTION
## Description

Fixes #38644

**Problem:**

`ChatAnthropic.bind_tools()` crashes with `KeyError: 'parameters'` when passed an `advisor_20260301` tool spec:

```python
advisor_tool = {
    "type": "advisor_20260301",
    "name": "advisor",
    "model": "claude-sonnet-4-6",
    "max_uses": 3,
    "max_tokens": 1024,
}
model.bind_tools([advisor_tool]).invoke("hello")
# KeyError: 'parameters'
```

**Root cause:**

`advisor_20260301` was missing from `_BUILTIN_TOOL_PREFIXES`. Without it, `_is_builtin_tool()` returns `False`, so `bind_tools()` routes the spec through `convert_to_anthropic_tool()`. That function expects a function-style schema with a `parameters` key — which advisor specs don't have — and crashes.

**Fix:**

Add `"advisor_"` to `_BUILTIN_TOOL_PREFIXES`. This makes `_is_builtin_tool()` return `True` for all `advisor_*` tool types, so `bind_tools()` passes the dict through unchanged — the same path already used for `web_search_`, `computer_`, `memory_`, `tool_search_`, etc.

The existing comment in the source (lines 128–136) documents exactly this maintenance pattern.

## Tests

Added `test_advisor_is_builtin_tool` to `tests/unit_tests/test_chat_models.py`:
- Asserts `_is_builtin_tool({"type": "advisor_20260301", ...})` is `True`
- Asserts `bind_tools([advisor_tool])` includes the tool dict unchanged in the request payload

All three related unit tests pass: `test_advisor_is_builtin_tool`, `test_tool_search_is_builtin_tool`, `test_tool_search_beta_headers`.