### PR TITLE
feat(anthropic): support dynamic auth providers

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 import copy
 import datetime
 import hashlib
+import inspect
 import json
 import re
 import warnings
-from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
 from functools import cached_property
 from operator import itemgetter
 from typing import Any, Final, Literal, cast
@@ -956,11 +964,25 @@ class ChatAnthropic(BaseChatModel):
     `ANTHROPIC_API_URL` and if that is not set, `ANTHROPIC_BASE_URL`.
     """
 
-    anthropic_api_key: SecretStr = Field(
+    anthropic_api_key: (
+        SecretStr | None | Callable[[], str] | Callable[[], Awaitable[str]]
+    ) = Field(
         alias="api_key",
         default_factory=secret_from_env("ANTHROPIC_API_KEY", default=""),
     )
-    """Automatically read from env var `ANTHROPIC_API_KEY` if not provided."""
+    """API key to use.
+
+    Can be inferred from the `ANTHROPIC_API_KEY` environment variable, specified
+    as a string, or provided as a sync or async callable that returns a string.
+    Callable keys are refreshed before each request.
+    """
+
+    auth_token_provider: Callable[[], str] | Callable[[], Awaitable[str]] | None = None
+    """Bearer token provider for Anthropic-compatible gateways.
+
+    When set, the callable is invoked before each request and the returned token
+    is sent through the Anthropic SDK's `Authorization: Bearer <token>` auth path.
+    """
 
     anthropic_proxy: str | None = Field(
         default_factory=from_env("ANTHROPIC_PROXY", default=None)
@@ -1182,6 +1204,62 @@ class ChatAnthropic(BaseChatModel):
             profile["max_input_tokens"] = 1_000_000
         return profile
 
+    def _static_api_key(self) -> str | None:
+        if isinstance(self.anthropic_api_key, SecretStr):
+            return self.anthropic_api_key.get_secret_value()
+        if self.anthropic_api_key is None or callable(self.anthropic_api_key):
+            return None
+        return cast(str, self.anthropic_api_key)
+
+    def _resolve_sync_auth_value(
+        self,
+        provider: Callable[[], str] | Callable[[], Awaitable[str]],
+        field_name: str,
+    ) -> str:
+        value = provider()
+        if inspect.isawaitable(value):
+            close = getattr(value, "close", None)
+            if close is not None:
+                close()
+            msg = (
+                f"Async {field_name} providers cannot be used with sync "
+                "ChatAnthropic invocations. Use async methods or provide a sync "
+                "callable."
+            )
+            raise ValueError(msg)
+        return cast(str, value)
+
+    async def _resolve_async_auth_value(
+        self,
+        provider: Callable[[], str] | Callable[[], Awaitable[str]],
+    ) -> str:
+        value = provider()
+        if inspect.isawaitable(value):
+            return cast(str, await value)
+        return cast(str, value)
+
+    def _refresh_sync_auth(self, client: anthropic.Client) -> None:
+        if callable(self.anthropic_api_key):
+            client.api_key = self._resolve_sync_auth_value(
+                self.anthropic_api_key,
+                "api_key",
+            )
+        if self.auth_token_provider is not None:
+            client.auth_token = self._resolve_sync_auth_value(
+                self.auth_token_provider,
+                "auth_token_provider",
+            )
+
+    async def _refresh_async_auth(self, client: anthropic.AsyncClient) -> None:
+        if callable(self.anthropic_api_key):
+            client.api_key = await self._resolve_async_auth_value(
+                self.anthropic_api_key
+            )
+        if self.auth_token_provider is not None:
+            client.auth_token = await self._resolve_async_auth_value(
+                self.auth_token_provider
+            )
+
     @cached_property
     def _client_params(self) -> dict[str, Any]:
         # Merge User-Agent with user-provided headers (user headers take precedence)
@@ -1190,11 +1268,12 @@ class ChatAnthropic(BaseChatModel):
             default_headers.update(self.default_headers)
 
         client_params: dict[str, Any] = {
-            "api_key": self.anthropic_api_key.get_secret_value(),
             "base_url": self.anthropic_api_url,
             "max_retries": self.max_retries,
             "default_headers": default_headers,
         }
+        if (api_key := self._static_api_key()) is not None:
+            client_params["api_key"] = api_key
         # value <= 0 indicates the param should be ignored. None is a meaningful value
         # for Anthropic client and treated differently than not specifying the param at
         # all.
@@ -1428,11 +1507,13 @@ class ChatAnthropic(BaseChatModel):
         return {k: v for k, v in payload.items() if v is not None}
 
     def _create(self, payload: dict) -> Any:
+        self._refresh_sync_auth(self._client)
         if "betas" in payload:
             return self._client.beta.messages.create(**payload)
         return self._client.messages.create(**payload)
 
     async def _acreate(self, payload: dict) -> Any:
+        await self._refresh_async_auth(self._async_client)
         if "betas" in payload:
             return await self._async_client.beta.messages.create(**payload)
         return await self._async_client.messages.create(**payload)
@@ -2206,6 +2287,7 @@ class ChatAnthropic(BaseChatModel):
             kwargs["context_management"] = self.context_management
 
         if self.betas is not None:
+            self._refresh_sync_auth(self._client)
             beta_response = self._client.beta.messages.count_tokens(
                 betas=self.betas,
                 model=self.model,
@@ -2213,6 +2295,7 @@ class ChatAnthropic(BaseChatModel):
                 **kwargs,
             )
             return beta_response.input_tokens
+        self._refresh_sync_auth(self._client)
         response = self._client.messages.count_tokens(
             model=self.model,
             messages=formatted_messages,  # type: ignore[arg-type]

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -7,7 +7,7 @@ import os
 import warnings
 from collections.abc import Callable
 from typing import Any, Literal, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import anthropic
 import pytest
@@ -74,6 +74,82 @@ def test_user_agent_header_in_client_params() -> None:
     assert "default_headers" in params
     assert "User-Agent" in params["default_headers"]
     assert params["default_headers"]["User-Agent"].startswith("langchain-anthropic/")
+
+
+def test_callable_api_key_refreshes_before_sync_request() -> None:
+    """Test that sync API key callables are resolved for each request."""
+    tokens = iter(["token-1", "token-2"])
+
+    def api_key_provider() -> str:
+        return next(tokens)
+
+    llm = ChatAnthropic(model=MODEL_NAME, api_key=api_key_provider)  # type: ignore[arg-type]
+    client = llm._client
+    client.messages.create = MagicMock(return_value="ok")  # type: ignore[method-assign]
+
+    assert llm._create({}) == "ok"
+    assert client.api_key == "token-1"
+
+    assert llm._create({}) == "ok"
+    assert client.api_key == "token-2"
+
+
+def test_auth_token_provider_refreshes_before_sync_request() -> None:
+    """Test that bearer token providers refresh the SDK auth token."""
+    expected_values = ["bearer-1", "bearer-2"]
+    tokens = iter(expected_values)
+
+    def auth_token_provider() -> str:
+        return next(tokens)
+
+    llm = ChatAnthropic(
+        model=MODEL_NAME,
+        api_key=None,
+        auth_token_provider=auth_token_provider,
+    )
+    client = llm._client
+    client.messages.create = MagicMock(return_value="ok")  # type: ignore[method-assign]
+
+    assert llm._create({}) == "ok"
+    assert client.auth_token == expected_values[0]
+    assert client.auth_headers["Authorization"] == f"Bearer {expected_values[0]}"
+
+    assert llm._create({}) == "ok"
+    assert client.auth_token == expected_values[1]
+    assert client.auth_headers["Authorization"] == f"Bearer {expected_values[1]}"
+
+
+@pytest.mark.asyncio
+async def test_async_callable_api_key_refreshes_before_async_request() -> None:
+    """Test that async API key callables are resolved for async requests."""
+    calls = 0
+
+    async def api_key_provider() -> str:
+        nonlocal calls
+        calls += 1
+        return f"async-token-{calls}"
+
+    llm = ChatAnthropic(model=MODEL_NAME, api_key=api_key_provider)  # type: ignore[arg-type]
+    client = llm._async_client
+    client.messages.create = AsyncMock(return_value="ok")  # type: ignore[method-assign]
+
+    assert await llm._acreate({}) == "ok"
+    assert client.api_key == "async-token-1"
+
+    assert await llm._acreate({}) == "ok"
+    assert client.api_key == "async-token-2"
+
+
+def test_async_callable_api_key_fails_for_sync_request() -> None:
+    """Test that sync requests fail clearly for async-only API key callables."""
+
+    async def api_key_provider() -> str:
+        return "async-token"
+
+    llm = ChatAnthropic(model=MODEL_NAME, api_key=api_key_provider)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Async api_key providers"):
+        llm._create({})
 
 
 @pytest.mark.parametrize("async_api", [True, False])


### PR DESCRIPTION
## Summary

- Allow `ChatAnthropic(api_key=...)` to accept sync or async callables, matching the rotating-key pattern already available in other provider integrations.
- Add `auth_token_provider` for Anthropic-compatible gateways that use bearer tokens instead of static API keys.
- Refresh dynamic auth immediately before sync, async, streaming, batched, and token-count requests while preserving the cached HTTP client path.

## Why

Issue #38661 describes deployments that authenticate Anthropic-compatible endpoints with short-lived tokens. The Anthropic SDK accepts static `api_key` and `auth_token` strings, but it builds auth headers from mutable client attributes. Refreshing those attributes before dispatch keeps existing client reuse intact while letting long-running processes rotate credentials safely.

## Tests

- `uv run --directory libs/partners/anthropic --group test pytest -q tests/unit_tests/test_chat_models.py -q`
- `uv run --directory libs/partners/anthropic --group lint ruff check langchain_anthropic/chat_models.py tests/unit_tests/test_chat_models.py`
- `uv run --directory libs/partners/anthropic --group lint ruff format --check langchain_anthropic/chat_models.py tests/unit_tests/test_chat_models.py`
- `uv run --directory libs/partners/anthropic --all-groups mypy langchain_anthropic/chat_models.py tests/unit_tests/test_chat_models.py --cache-dir .mypy_cache_codex`

Addresses #38661.