### PR TITLE
Feat: added message param to ToolCallLimitMiddleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/tool_call_limit.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_call_limit.py
@@ -202,6 +202,7 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
         self,
         *,
         tool_name: str | None = None,
+        message: str | None = None,
         thread_limit: int | None = None,
         run_limit: int | None = None,
         exit_behavior: ExitBehavior = "continue",
@@ -211,6 +212,8 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
         Args:
             tool_name: Name of the specific tool to limit. If `None`, limits apply
                 to all tools.
+            message: Custom model-facing message to use for blocked tool calls.
+                If `None`, the default blocked-tool wording is used.
             thread_limit: Maximum number of tool calls allowed per thread.
                 `None` means no limit.
             run_limit: Maximum number of tool calls allowed per run.
@@ -248,6 +251,7 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
             raise ValueError(msg)
 
         self.tool_name = tool_name
+        self.message = message
         self.thread_limit = thread_limit
         self.run_limit = run_limit
         self.exit_behavior = exit_behavior
@@ -404,8 +408,13 @@ class ToolCallLimitMiddleware(AgentMiddleware[ToolCallLimitState[ResponseT], Con
                 tool_name=self.tool_name,
             )
 
-        # Build tool message content (sent to model - no thread/run details)
-        tool_msg_content = _build_tool_message_content(self.tool_name)
+        # Build tool message content (sent to model - no thread/run details).
+        # Use custom message when provided, otherwise keep default wording.
+        tool_msg_content = (
+            self.message
+            if self.message is not None
+            else _build_tool_message_content(self.tool_name)
+        )
 
         # Inject artificial error ToolMessages for blocked tool calls
         artificial_messages: list[ToolMessage | AIMessage] = [

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py
@@ -27,6 +27,7 @@ def test_middleware_initialization_validation() -> None:
     assert middleware.run_limit == 3
     assert middleware.exit_behavior == "continue"
     assert middleware.tool_name is None
+    assert middleware.message is None
 
     # Test with tool name
     middleware = ToolCallLimitMiddleware(tool_name="search", thread_limit=5)
@@ -78,6 +79,103 @@ def test_middleware_name_property() -> None:
     assert middleware1.name != middleware2.name
     assert middleware1.name == "ToolCallLimitMiddleware[search]"
     assert middleware2.name == "ToolCallLimitMiddleware[calculator]"
+
+
+def test_custom_message_blocks_tool_call_in_continue_mode() -> None:
+    """Test that custom blocked-tool messages are used for continue mode."""
+    middleware = ToolCallLimitMiddleware(
+        thread_limit=1,
+        exit_behavior="continue",
+        message="Please do not call this tool again.",
+    )
+    runtime = None
+
+    state = ToolCallLimitState(
+        messages=[
+            AIMessage(
+                "Response",
+                tool_calls=[
+                    {"name": "search", "args": {}, "id": "1"},
+                    {"name": "search", "args": {}, "id": "2"},
+                ],
+            )
+        ],
+        thread_tool_call_count={"__all__": 0},
+        run_tool_call_count={"__all__": 0},
+    )
+
+    result = middleware.after_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "Please do not call this tool again."
+
+
+def test_custom_message_blocks_tool_call_in_end_mode() -> None:
+    """Test that custom blocked-tool messages are used for end mode."""
+    middleware = ToolCallLimitMiddleware(
+        thread_limit=1,
+        exit_behavior="end",
+        message="This conversation was handed off; do not call the tool again.",
+    )
+    runtime = None
+
+    state = ToolCallLimitState(
+        messages=[
+            AIMessage(
+                "Response",
+                tool_calls=[
+                    {"name": "search", "args": {}, "id": "1"},
+                    {"name": "search", "args": {}, "id": "2"},
+                ],
+            )
+        ],
+        thread_tool_call_count={"__all__": 0},
+        run_tool_call_count={"__all__": 0},
+    )
+
+    result = middleware.after_model(state, runtime)  # type: ignore[arg-type]
+    assert result is not None
+    assert result["jump_to"] == "end"
+
+    tool_messages = [msg for msg in result["messages"] if isinstance(msg, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].content == "This conversation was handed off; do not call the tool again."
+
+    ai_messages = [msg for msg in result["messages"] if isinstance(msg, AIMessage)]
+    assert len(ai_messages) == 1
+    assert "limit" in ai_messages[0].content.lower()
+
+
+def test_custom_message_does_not_change_error_exit_behavior() -> None:
+    """Test that custom message does not affect error exit behavior."""
+    middleware = ToolCallLimitMiddleware(
+        thread_limit=1,
+        exit_behavior="error",
+        message="Custom blocked tool message should not be used.",
+    )
+    runtime = None
+
+    state = ToolCallLimitState(
+        messages=[
+            AIMessage(
+                "Response",
+                tool_calls=[
+                    {"name": "search", "args": {}, "id": "1"},
+                    {"name": "search", "args": {}, "id": "2"},
+                ],
+            )
+        ],
+        thread_tool_call_count={"__all__": 0},
+        run_tool_call_count={"__all__": 0},
+    )
+
+    with pytest.raises(ToolCallLimitExceededError) as exc_info:
+        middleware.after_model(state, runtime)  # type: ignore[arg-type]
+
+    assert "Custom blocked tool message" not in str(exc_info.value)
+    assert "limit" in str(exc_info.value).lower()
 
 
 def test_middleware_unit_functionality() -> None:


### PR DESCRIPTION
Fixes #37970

Add an optional `message: str | None = None` parameter to `ToolCallLimitMiddleware`.
When provided, this custom text is used only for the artificial blocked `ToolMessage` content in `continue` and `end` modes.

The final `AIMessage` produced in `end` mode and the `ToolCallLimitExceededError` raised in `error` mode keep the existing diagnostic behavior.

## Testing

- `cd libs/langchain_v1 && uv run --group test pytest tests/unit_tests/agents/middleware/implementations/test_tool_call_limit.py`
- Result: `20 passed`
