### PR TITLE
fix(core): set additionalProperties=false in $defs/definitions for strict JSON schemas

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -843,5 +843,18 @@ def _recursive_set_additional_properties_false(
                 _recursive_set_additional_properties_false(sub_schema)
         if "items" in schema:
             _recursive_set_additional_properties_false(schema["items"])
+        # Pydantic 2 emits nested models via `$defs` (JSON Schema 2020-12) or
+        # `definitions` (older drafts), with `properties` referencing them by
+        # `$ref`. OpenAI's strict-mode validator requires `additionalProperties`
+        # on every object schema, including those living inside `$defs` — see
+        # langchain-ai/langchain#38223. Without this descent the inner models
+        # come back to OpenAI without `additionalProperties: false` and the
+        # request is rejected with a 400 ("additionalProperties is required to
+        # be supplied and to be false").
+        for defs_key in ("$defs", "definitions"):
+            defs = schema.get(defs_key)
+            if isinstance(defs, dict):
+                for sub_schema in defs.values():
+                    _recursive_set_additional_properties_false(sub_schema)
 
     return schema

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -501,6 +501,95 @@ def test_convert_to_openai_function_nested_strict() -> None:
     assert actual == expected
 
 
+def test_convert_to_openai_function_strict_pydantic_defs() -> None:
+    """Regression test for https://github.com/langchain-ai/langchain/issues/38223.
+
+    Pydantic 2 emits nested models into ``$defs`` and references them via
+    ``$ref``. OpenAI's strict-mode validator rejects the request unless
+    ``additionalProperties: false`` is set on every object schema — including
+    those living inside ``$defs``. Previously the recursive fixup only walked
+    ``properties`` / ``items`` / ``anyOf`` and missed ``$defs`` entirely.
+
+    Note: passing a Pydantic class to ``convert_to_openai_function`` would
+    route through ``_convert_json_schema_to_openai_function`` which inlines
+    ``$defs`` (after dereferencing) before the strict fixup ever runs. The
+    only path that preserves ``$defs`` is when the schema is supplied as a
+    JSON-schema dict (the form ``ChatOpenAI._get_request_payload`` emits on
+    the streaming structured-output path) — this is exactly the case the
+    issue reproduces, so we test it directly.
+    """
+    schema_dict: dict = {
+        "title": "Plan",
+        "type": "object",
+        "properties": {
+            "steps": {
+                "description": "ordered steps",
+                "type": "array",
+                "items": {"$ref": "#/$defs/Step"},
+            },
+        },
+        "required": ["steps"],
+        "$defs": {
+            "Step": {
+                "type": "object",
+                "title": "Step",
+                "properties": {
+                    "name": {"type": "string", "title": "Name"},
+                    "detail": {
+                        "anyOf": [{"type": "string"}, {"type": "null"}],
+                        "default": None,
+                        "title": "Detail",
+                    },
+                },
+                "required": ["name"],
+            },
+        },
+    }
+
+    fn = convert_to_openai_function(schema_dict, strict=True)
+    params = fn["parameters"]
+
+    # Top-level object
+    assert params["additionalProperties"] is False
+    assert params["required"] == ["steps"]
+
+    # Inner model in $defs — was the bug surface.
+    step_def = params["$defs"]["Step"]
+    assert step_def["additionalProperties"] is False
+    # ``detail`` is Optional so only ``name`` should be required.
+    assert step_def["required"] == ["name"]
+
+
+def test_convert_to_openai_function_strict_dict_definitions_block() -> None:
+    """``definitions`` (older JSON Schema drafts) should also be walked."""
+    schema_dict: dict = {
+        "title": "Plan",
+        "type": "object",
+        "properties": {
+            "steps": {
+                "type": "array",
+                "items": {"$ref": "#/definitions/Step"},
+            },
+        },
+        "required": ["steps"],
+        "definitions": {
+            "Step": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "detail": {"type": "string"},
+                },
+                "required": ["name", "detail"],
+            },
+        },
+    }
+
+    fn = convert_to_openai_function(schema_dict, strict=True)
+    params = fn["parameters"]
+    assert params["additionalProperties"] is False
+    assert params["definitions"]["Step"]["additionalProperties"] is False
+
+
 def test_convert_to_openai_function_strict_union_of_objects_arg_type() -> None:
     class NestedA(BaseModel):
         foo: str


### PR DESCRIPTION
Fixes #38223.

## Problem

`convert_to_openai_function(..., strict=True)` applies
`additionalProperties: false` to every object schema in the JSON schema,
but the recursive walker only descends through `properties`, `items`,
and `anyOf`. It does not enter `$defs` (JSON Schema 2020-12) or
`definitions` (older drafts).

Nested Pydantic models live in `$defs` and are referenced via `$ref`,
so the inner object schemas come back without the required
`additionalProperties: false`. OpenAI's strict-mode validator then
rejects the request with HTTP 400:

> Invalid schema for response_format 'Plan': In context=(),
> 'additionalProperties' is required to be supplied and to be false.

This is the exact path triggered by `ChatOpenAI(use_responses_api=True)`
with a nested Pydantic schema on the streaming structured-output path:
`with_structured_output` routes streaming calls through the manual
`text.format` build (because `responses.parse` only handles non-stream),
and any `.ainvoke()` made inside an `astream_events` run also takes this
path — so the bug silently breaks every streaming structured-output call
with a nested model.

## Fix

In `_recursive_set_additional_properties_false`, also walk `$defs` and
`definitions` blocks. The recursive call applies the same
`additionalProperties: false` rule to each entry inside the defs block,
which is exactly what OpenAI's strict-mode validator requires.

## Tests

Two regression tests in `libs/core/tests/unit_tests/utils/test_function_calling.py`:

- `test_convert_to_openai_function_strict_pydantic_defs`: full repro
  matching the issue (nested Pydantic with `$ref` to `$defs/Step`).
- `test_convert_to_openai_function_strict_dict_definitions_block`: same
  shape against the legacy `definitions` key, for completeness.

Both pass with the fix; the first fails without it.

## Notes

- The Pydantic-class path (`convert_to_openai_function(Plan, ...)`)
  inlines `$defs` via `_convert_json_schema_to_open_function` and never
  hits the bug, so the test uses a JSON schema dict (the form that
  `ChatOpenAI._get_request_payload` emits on the streaming path).
- No partner-side change is required: `langchain-openai` already calls
  the recursive helper — it just couldn't reach `$defs` until this fix.

## Checklist

- [x] Targeted the root cause in `langchain-core` (where the recursive
      helper lives).
- [x] Added unit tests in the same module.
- [x] `uv run --group lint ruff check` and `ruff format` clean on
      both files.
- [x] All existing `tests/unit_tests/utils/test_function_calling.py`
      tests still pass (42 passed, 1 xfail, 1 xpass).
- [x] DCO: `Signed-off-by:` in commit message.

Made with [Cursor](https://cursor.com)