### PR TITLE
fix(core): avoid inherited docstrings for tools

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -142,7 +142,7 @@ def _parse_python_function_docstring(
     Returns:
         A tuple containing the function description and argument descriptions.
     """
-    docstring = inspect.getdoc(function)
+    docstring = _get_direct_doc(function)
     return _parse_google_docstring(
         docstring,
         list(annotations),
@@ -168,6 +168,14 @@ def _validate_docstring_args_against_annotations(
             raise ValueError(msg)
 
 
+def _get_direct_doc(obj: Any) -> str | None:
+    """Return the docstring defined directly on `obj`, if any."""
+    doc = getattr(obj, "__doc__", None)
+    if doc is None:
+        return None
+    return inspect.cleandoc(doc)
+
+
 def _infer_arg_descriptions(
     fn: Callable[..., Any],
     *,
@@ -190,7 +198,7 @@ def _infer_arg_descriptions(
             fn, annotations, error_on_invalid_docstring=error_on_invalid_docstring
         )
     else:
-        description = inspect.getdoc(fn) or ""
+        description = _get_direct_doc(fn) or ""
         arg_descriptions = {}
     if parse_docstring:
         _validate_docstring_args_against_annotations(arg_descriptions, annotations)

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -230,6 +230,12 @@ class StructuredTool(BaseTool):
                     f"got {args_schema}"
                 )
                 raise TypeError(msg)
+        if (
+            description_ is None
+            and isinstance(source_function, type)
+            and is_basemodel_subclass(source_function)
+        ):
+            description_ = ""
         if description_ is None:
             msg = "Function must have a docstring if description not provided."
             raise ValueError(msg)

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -770,6 +770,24 @@ def test_missing_docstring() -> None:
     assert not MyTool.description  # type: ignore[attr-defined]
 
 
+def test_tool_class_does_not_inherit_parent_docstring() -> None:
+    """Test tool class descriptions use only directly defined docstrings."""
+
+    class ParentTool(BaseModel):
+        """Parent tool."""
+
+        foo: str
+
+    @tool
+    class ChildTool(ParentTool):
+        bar: str
+
+    assert not ChildTool.description  # type: ignore[attr-defined]
+    assert (
+        _schema(ChildTool.args_schema).get("description", "") == ""  # type: ignore[attr-defined]
+    )
+
+
 def test_create_tool_positional_args() -> None:
     """Test that positional arguments are allowed."""
     test_tool = Tool("test_name", lambda x: x, "test_description")


### PR DESCRIPTION
Fixes #32066

---

Class-based tools built from Pydantic models should only use a docstring that is defined directly on the tool class. Before this change, schema inference used `inspect.getdoc`, which can walk the MRO and pull in a parent model's docstring. That made a subclass without its own docstring appear to have the parent's description.

This updates tool schema description inference to read direct docstrings only, while preserving the existing behavior that Pydantic class tools without a docstring are allowed and receive an empty description. Regular functions without a docstring still raise the existing error.

## Release note

Class-based tools no longer inherit parent Pydantic model docstrings as their tool or schema description when the subclass does not define its own docstring.

Verified with `uv run pytest tests/unit_tests/test_tools.py -q`, `uv run ruff check langchain_core/tools/base.py langchain_core/tools/structured.py tests/unit_tests/test_tools.py`, and `uv run ruff format --check langchain_core/tools/base.py langchain_core/tools/structured.py tests/unit_tests/test_tools.py` from `libs/core`.

AI assistance was used to prepare this contribution; the diff and test results were reviewed before submission.