### PR TITLE
fix(mistralai): preserve index zero when merging streamed tool calls

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -325,7 +325,9 @@ def _convert_chunk_to_message_chunk(
             try:
                 tool_call_chunks = []
                 for raw_tool_call in raw_tool_calls:
-                    if not raw_tool_call.get("index") and not raw_tool_call.get("id"):
+                    if raw_tool_call.get("index") is None and not raw_tool_call.get(
+                        "id"
+                    ):
                         tool_call_id = uuid.uuid4().hex[:]
                     else:
                         tool_call_id = raw_tool_call.get("id")

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -690,6 +690,60 @@ def test__convert_chunk_to_message_chunk_with_citations() -> None:
     assert str(full.text) == "The answer is 42"
 
 
+def test__convert_chunk_to_message_chunk_preserves_tool_call_index_zero() -> None:
+    """Streaming tool call chunks with index 0 should merge by index."""
+    name_chunk = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"name": "search", "arguments": ""},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    }
+    args_chunk = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": '{"q": "weather"}'},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ],
+    }
+
+    result_1, index, index_type = _convert_chunk_to_message_chunk(
+        name_chunk, AIMessageChunk, -1, "", None
+    )
+    result_2, _, _ = _convert_chunk_to_message_chunk(
+        args_chunk, AIMessageChunk, index, index_type, None
+    )
+
+    full = result_1 + result_2
+
+    assert isinstance(full, AIMessageChunk)
+    assert full.tool_calls == [
+        {
+            "name": "search",
+            "args": {"q": "weather"},
+            "id": None,
+            "type": "tool_call",
+        }
+    ]
+    assert full.invalid_tool_calls == []
+
+
 def test_citation_round_trip() -> None:
     """Round-trip through v1 preserves text and reference metadata."""
     from langchain_mistralai._compat import (


### PR DESCRIPTION
﻿Fixes #38673

---

Mistral streaming tool-call chunks can include `index: 0` without an `id` while arguments are still being streamed. The current converter treats `index: 0` as missing, so chunks from the same tool call can receive different generated IDs instead of merging by index.

This PR updates the fallback guard to distinguish a missing index from `index == 0`, preserving the existing random-ID fallback only for chunks that have neither `index` nor `id`.

## Release note

Fixed Mistral streaming tool-call chunk handling so chunks with `index: 0` are not treated as missing an index when no provider tool-call ID is present.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

- Focused regression test:

```shell
uv run --directory libs/partners/mistralai --group test pytest tests/unit_tests/test_chat_models.py -k "preserves_tool_call_index_zero" -q
```

- Full Mistral chat model unit test file:

```shell
uv run --directory libs/partners/mistralai --group test pytest tests/unit_tests/test_chat_models.py -q
```

- Targeted formatting and lint checks:

```shell
uv run --directory libs/partners/mistralai --group lint ruff format langchain_mistralai/chat_models.py tests/unit_tests/test_chat_models.py --check
uv run --directory libs/partners/mistralai --group lint ruff check langchain_mistralai/chat_models.py tests/unit_tests/test_chat_models.py
git diff --check
```

4. How did you verify your code works?

The new focused regression test constructs two streamed Mistral tool-call chunks with `index: 0` and no provider `id`, then verifies the chunks merge into one tool call with the expected name and arguments instead of splitting into separate generated IDs.

This PR was prepared with assistance from an AI coding agent. The change and test were reviewed locally before submission.

## Social handles (optional)
Twitter: @
LinkedIn: https://linkedin.com/in/
