### PR TITLE
fix(core): don't fire tool calls mid-stream when first SSE chunk has empty args

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -554,7 +554,22 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
 
         for chunk in self.tool_call_chunks:
             try:
-                args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}
+                args_str = chunk["args"]
+                if args_str == "" and self.chunk_position != "last":
+                    # An empty-string args field during streaming means the
+                    # provider has not yet sent any argument data for this tool
+                    # call — upstream SSE implementations (e.g. OpenRouter,
+                    # deepseek-v3.2) commonly fragment tool-call arguments
+                    # across multiple chunks, emitting args='' in the first
+                    # chunk before the actual JSON arrives in subsequent ones.
+                    # Parsing '' as {} here and populating tool_calls would
+                    # cause the tool to be invoked prematurely with empty
+                    # arguments before all argument chunks have been received.
+                    # We skip the chunk now; once the full argument string is
+                    # accumulated (or the stream ends with chunk_position="last")
+                    # the args will be parsed correctly on the next validator run.
+                    continue
+                args_ = parse_partial_json(args_str) if args_str else {}
                 if isinstance(args_, dict):
                     tool_calls.append(
                         create_tool_call(

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -211,6 +211,79 @@ def test_init_tool_calls() -> None:
     msg.tool_calls = [{"name": "bar", "args": {"c": "d"}, "id": "def"}]
 
 
+def test_streaming_tool_call_empty_args_not_fired_prematurely() -> None:
+    """Fragmented SSE providers (e.g. OpenRouter, deepseek-v3.2) send the first
+    tool-call chunk with args='' before subsequent chunks carry the actual JSON.
+    The accumulator must NOT create a tool_call with args={} from that empty-
+    string fragment — doing so causes tools to be invoked with missing arguments
+    before all argument chunks have arrived (issue #35514).
+    """
+    # Simulate provider behaviour: first chunk carries name/id but args=''
+    chunk1 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(name="get_weather", args="", id="call_abc", index=0),
+        ],
+    )
+
+    # No tool_calls on the first chunk — args haven't arrived yet
+    assert chunk1.tool_calls == [], (
+        "tool_calls must be empty when first SSE chunk has args='' "
+        "(premature tool invocation with {} args)"
+    )
+
+    # Second chunk carries the actual argument JSON (fragmented)
+    chunk2 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name=None, args='{"city": "London"}', id=None, index=0
+            ),
+        ],
+    )
+
+    # Third chunk is the end-of-stream sentinel
+    chunk3 = AIMessageChunk(content="", chunk_position="last")
+
+    # Accumulate all chunks as BaseCumulativeTransformOutputParser does
+    accumulated = chunk1 + chunk2 + chunk3
+
+    assert accumulated.chunk_position == "last"
+    assert len(accumulated.tool_calls) == 1
+    tc = accumulated.tool_calls[0]
+    assert tc["name"] == "get_weather"
+    assert tc["id"] == "call_abc"
+    assert tc["args"] == {"city": "London"}, (
+        "Full args must be present in the accumulated message"
+    )
+
+
+def test_streaming_tool_call_zero_arg_tool_fires_at_stream_end() -> None:
+    """A tool that genuinely takes no arguments may stream args='' across all
+    its chunks. The tool call must still be created (with args={}) once the
+    stream is complete (chunk_position='last'), even though args never exceeded
+    the empty string.
+    """
+    chunk_zero_arg = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(name="get_time", args="", id="call_xyz", index=0),
+        ],
+    )
+    # Mid-stream: no tool call yet
+    assert chunk_zero_arg.tool_calls == []
+
+    # Stream ends
+    sentinel = AIMessageChunk(content="", chunk_position="last")
+    accumulated = chunk_zero_arg + sentinel
+
+    assert accumulated.chunk_position == "last"
+    assert len(accumulated.tool_calls) == 1
+    tc = accumulated.tool_calls[0]
+    assert tc["name"] == "get_time"
+    assert tc["args"] == {}, "Zero-arg tool must fire with args={} at stream end"
+
+
 def test_content_blocks() -> None:
     message = AIMessage(
         "",


### PR DESCRIPTION
Fixes #38679

## Summary

When SSE-fragmenting providers (OpenRouter, deepseek-v3.2) stream tool calls, the first chunk arrives with `args=""` (empty string — still streaming). `AIMessageChunk.init_tool_calls` treats `args=""` identically to `args=None`, resolving both to `{}` and immediately creating the tool call before arguments have been received. Agents then invoke the tool with `{}`, crashing with `ValidationError: Field required`.

## Root cause

`init_tool_calls` in `libs/core/langchain_core/messages/ai.py` takes the `else {}` branch for any falsy `args` value. An empty string and `None` are both falsy, so both produce a premature tool call with empty args.

## Fix

Added an 8-line guard at the top of the per-chunk loop: skip creating the tool call when `args_str == ""` and the current chunk is not the last chunk in the stream. The `chunk_position != "last"` gate preserves correct semantics for tools that genuinely take no arguments.

Two regression tests added:
1. `test_streaming_tool_call_empty_args_not_fired_prematurely` — verifies `tool_calls == []` after first empty-args chunk, full args in final accumulated message
2. `test_streaming_tool_call_zero_arg_tool_fires_at_stream_end` — verifies zero-arg tools still fire correctly at stream completion