### PR TITLE
fix(core): handle malformed Anthropic content blocks

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/anthropic.py
+++ b/libs/core/langchain_core/messages/block_translators/anthropic.py
@@ -54,41 +54,46 @@ def _convert_to_v1_from_anthropic_input(
         ]
         for block in blocks:
             block_type = block.get("type")
+            source = block.get("source")
 
             if (
                 block_type == "document"
-                and "source" in block
-                and "type" in block["source"]
+                and isinstance(source, dict)
+                and "type" in source
             ):
-                if block["source"]["type"] == "base64":
+                if (
+                    source["type"] == "base64"
+                    and "data" in source
+                    and "media_type" in source
+                ):
                     file_block: types.FileContentBlock = {
                         "type": "file",
-                        "base64": block["source"]["data"],
-                        "mime_type": block["source"]["media_type"],
+                        "base64": source["data"],
+                        "mime_type": source["media_type"],
                     }
                     _populate_extras(file_block, block, {"type", "source"})
                     yield file_block
 
-                elif block["source"]["type"] == "url":
+                elif source["type"] == "url" and "url" in source:
                     file_block = {
                         "type": "file",
-                        "url": block["source"]["url"],
+                        "url": source["url"],
                     }
                     _populate_extras(file_block, block, {"type", "source"})
                     yield file_block
 
-                elif block["source"]["type"] == "file":
+                elif source["type"] == "file" and "file_id" in source:
                     file_block = {
                         "type": "file",
-                        "id": block["source"]["file_id"],
+                        "id": source["file_id"],
                     }
                     _populate_extras(file_block, block, {"type", "source"})
                     yield file_block
 
-                elif block["source"]["type"] == "text":
+                elif source["type"] == "text" and "data" in source:
                     plain_text_block: types.PlainTextContentBlock = {
                         "type": "text-plain",
-                        "text": block["source"]["data"],
+                        "text": source["data"],
                         "mime_type": block.get("media_type", "text/plain"),
                     }
                     _populate_extras(plain_text_block, block, {"type", "source"})
@@ -98,31 +103,33 @@ def _convert_to_v1_from_anthropic_input(
                     yield {"type": "non_standard", "value": block}
 
             elif (
-                block_type == "image"
-                and "source" in block
-                and "type" in block["source"]
+                block_type == "image" and isinstance(source, dict) and "type" in source
             ):
-                if block["source"]["type"] == "base64":
+                if (
+                    source["type"] == "base64"
+                    and "data" in source
+                    and "media_type" in source
+                ):
                     image_block: types.ImageContentBlock = {
                         "type": "image",
-                        "base64": block["source"]["data"],
-                        "mime_type": block["source"]["media_type"],
+                        "base64": source["data"],
+                        "mime_type": source["media_type"],
                     }
                     _populate_extras(image_block, block, {"type", "source"})
                     yield image_block
 
-                elif block["source"]["type"] == "url":
+                elif source["type"] == "url" and "url" in source:
                     image_block = {
                         "type": "image",
-                        "url": block["source"]["url"],
+                        "url": source["url"],
                     }
                     _populate_extras(image_block, block, {"type", "source"})
                     yield image_block
 
-                elif block["source"]["type"] == "file":
+                elif source["type"] == "file" and "file_id" in source:
                     image_block = {
                         "type": "image",
-                        "id": block["source"]["file_id"],
+                        "id": source["file_id"],
                     }
                     _populate_extras(image_block, block, {"type", "source"})
                     yield image_block
@@ -143,6 +150,12 @@ def _convert_citation_to_v1(citation: dict[str, Any]) -> types.Annotation:
     citation_type = citation.get("type")
 
     if citation_type == "web_search_result_location":
+        if "cited_text" not in citation or "url" not in citation:
+            return {
+                "type": "non_standard_annotation",
+                "value": citation,
+            }
+
         url_citation: types.Citation = {
             "type": "citation",
             "cited_text": citation["cited_text"],
@@ -165,6 +178,12 @@ def _convert_citation_to_v1(citation: dict[str, Any]) -> types.Annotation:
         "page_location",
         "search_result_location",
     }:
+        if "cited_text" not in citation:
+            return {
+                "type": "non_standard_annotation",
+                "value": citation,
+            }
+
         document_citation: types.Citation = {
             "type": "citation",
             "cited_text": citation["cited_text"],

--- a/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
@@ -507,3 +507,61 @@ def test_convert_to_v1_from_anthropic_input() -> None:
     ]
 
     assert message.content_blocks == expected
+
+
+def test_anthropic_input_malformed_sources_do_not_raise() -> None:
+    malformed_blocks = [
+        {"type": "image", "source": {"type": "base64"}},
+        {"type": "document", "source": {"type": "url"}},
+        {"type": "document", "source": {"type": "file"}},
+        {"type": "document", "source": {"type": "text"}},
+        {"type": "document", "source": None},
+    ]
+    message = HumanMessage(malformed_blocks)
+
+    assert message.content_blocks == [
+        malformed_blocks[0],
+        *[{"type": "non_standard", "value": block} for block in malformed_blocks[1:]],
+    ]
+
+
+def test_anthropic_malformed_citations_fall_back_to_non_standard() -> None:
+    message = AIMessage(
+        [
+            {
+                "type": "text",
+                "text": "Cited answer",
+                "citations": [
+                    {
+                        "type": "web_search_result_location",
+                        "url": "https://example.com",
+                    },
+                    {"type": "char_location", "document_title": "Example document"},
+                ],
+            }
+        ],
+        response_metadata={"model_provider": "anthropic"},
+    )
+
+    assert message.content_blocks == [
+        {
+            "type": "text",
+            "text": "Cited answer",
+            "annotations": [
+                {
+                    "type": "non_standard_annotation",
+                    "value": {
+                        "type": "web_search_result_location",
+                        "url": "https://example.com",
+                    },
+                },
+                {
+                    "type": "non_standard_annotation",
+                    "value": {
+                        "type": "char_location",
+                        "document_title": "Example document",
+                    },
+                },
+            ],
+        }
+    ]


### PR DESCRIPTION
Fixes #38667.

## Summary

- Guard Anthropic document/image source conversion so missing required fields do not raise `KeyError` while reading `BaseMessage.content_blocks`.
- Keep malformed Anthropic-shaped blocks on the fallback path instead of indexing required fields directly.
- Guard Anthropic citation conversion so incomplete citations become `non_standard_annotation` instead of raising.
- Add regression coverage for malformed input sources and malformed citations.

## Testing

- `uv run --directory libs\core --group test pytest tests\unit_tests\messages\block_translators\test_anthropic.py -q`
- `uv run --directory libs\core --group lint ruff check langchain_core\messages\block_translators\anthropic.py tests\unit_tests\messages\block_translators\test_anthropic.py`
- `uv run --directory libs\core --group lint ruff format langchain_core\messages\block_translators\anthropic.py tests\unit_tests\messages\block_translators\test_anthropic.py --check`
- `git diff --check`

Note: the focused pytest run passes with the existing Python 3.14/Pydantic v1 compatibility warning from `langchain_core.utils.pydantic`.