### PR TITLE
test(openai): skip Codex VCR tests before cassette setup

### DIFF
--- a/libs/partners/openai/tests/integration_tests/chat_models/conftest.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures for chat-model integration tests.
+"""Shared fixtures and collection hooks for chat-model integration tests.
 
 The `_ChatOpenAICodex` integration tests run under VCR cassette playback in
 CI (`make test_vcr`), but its `_FileChatGPTOAuthTokenProvider` still tries
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -62,15 +63,33 @@ def _vcr_record_mode(config: pytest.Config) -> str | None:
     return None
 
 
-@pytest.fixture(autouse=True)
-def _skip_codex_live_ci(request: pytest.FixtureRequest) -> None:
-    """Skip Codex tests in CI unless they are replaying VCR cassettes."""
-    if "codex" not in request.module.__name__:
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Skip Codex tests in CI unless they are replaying VCR cassettes.
+
+    Applied at collection time so Codex tests are deselected before
+    pytest-recording opens a cassette. An autouse skip fixture would instead
+    fire during test setup, after the `vcr` fixture has already tried (and
+    failed) to open the cassette against CI's missing on-disk token.
+
+    `pytest_collection_modifyitems` hooks receive the whole session's items, so
+    matches are scoped to this conftest's own directory. Otherwise a same-named
+    module collected elsewhere in the session (e.g. the unit `test_codex`
+    module) would be skipped too.
+    """
+    if not os.getenv("CI") or _vcr_record_mode(config) == "none":
         return
-    if _vcr_record_mode(request.config) == "none":
-        return
-    if os.getenv("CI"):
-        pytest.skip("Codex tests require VCR playback in CI.")
+    here = Path(__file__).parent
+    skip_codex = pytest.mark.skip(reason="Codex tests require VCR playback in CI.")
+    for item in items:
+        item_path = getattr(item, "path", None)
+        if item_path is None or here not in Path(str(item_path)).parents:
+            continue
+        module = getattr(item, "module", None)
+        module_name = getattr(module, "__name__", "")
+        if "codex" in module_name:
+            item.add_marker(skip_codex)
 
 
 @pytest.fixture(autouse=True)

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -398,7 +398,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -776,7 +776,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = []
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
+lint = [{ name = "ruff", specifier = ">=0.13.1,<0.16.0" }]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain", editable = "../../langchain_v1" },


### PR DESCRIPTION
Codex integration tests need to be skipped in CI whenever VCR is not in playback mode, but the setup-time skip ran too late: `pytest-recording` could already try to open a cassette and hit the missing on-disk OAuth token first. Moving the skip to collection time marks the matching Codex tests before cassette setup while keeping the existing VCR-token fake for playback runs.

## Changes
- Add a `pytest_collection_modifyitems` hook that marks Codex chat-model integration tests as skipped in CI unless VCR is replaying existing cassettes.
- Scope collection-time matching to the local chat-model integration-test directory so same-named modules collected elsewhere are not skipped accidentally.
- Keep the OAuth-token fake path active for VCR playback by preserving `_fake_codex_oauth_token` behavior when `record_mode` is `none`.