### PR TITLE
test(deepseek): assert strict mode targets the beta endpoint

### DIFF
--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -12,7 +12,11 @@ from openai.types.chat import ChatCompletionMessage
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field, SecretStr
 
-from langchain_deepseek.chat_models import DEFAULT_API_BASE, ChatDeepSeek
+from langchain_deepseek.chat_models import (
+    DEFAULT_API_BASE,
+    DEFAULT_BETA_API_BASE,
+    ChatDeepSeek,
+)
 
 MODEL_NAME = "deepseek-chat"
 
@@ -281,10 +285,10 @@ class TestChatDeepSeekStrictMode:
         # Bind tools with strict=True
         bound_model = llm.bind_tools([SampleTool], strict=True)
 
-        # The bound model should have its internal model using beta endpoint
-        # We can't directly access the internal model, but we can verify the behavior
-        # by checking that the binding operation succeeds
-        assert bound_model is not None
+        # bind_tools returns a RunnableBinding whose .bound is the underlying
+        # chat model; strict=True should have swapped it for a copy that targets
+        # the beta endpoint.
+        assert bound_model.bound.api_base == DEFAULT_BETA_API_BASE  # type: ignore[attr-defined]
 
     def test_bind_tools_without_strict_mode_uses_default_endpoint(self) -> None:
         """Test bind_tools without strict or with strict=False uses default endpoint."""
@@ -295,11 +299,11 @@ class TestChatDeepSeekStrictMode:
 
         # Test with strict=False
         bound_model_false = llm.bind_tools([SampleTool], strict=False)
-        assert bound_model_false is not None
+        assert bound_model_false.bound.api_base == DEFAULT_API_BASE  # type: ignore[attr-defined]
 
         # Test with strict=None (default)
         bound_model_none = llm.bind_tools([SampleTool])
-        assert bound_model_none is not None
+        assert bound_model_none.bound.api_base == DEFAULT_API_BASE  # type: ignore[attr-defined]
 
     def test_with_structured_output_strict_mode_uses_beta_endpoint(self) -> None:
         """Test that with_structured_output with strict=True uses beta endpoint."""
@@ -314,8 +318,10 @@ class TestChatDeepSeekStrictMode:
         # Create structured output with strict=True
         structured_model = llm.with_structured_output(SampleTool, strict=True)
 
-        # The structured model should work with beta endpoint
-        assert structured_model is not None
+        # with_structured_output returns a RunnableSequence; its first step is the
+        # tool-bound chat model, which strict=True should target at the beta
+        # endpoint.
+        assert structured_model.first.bound.api_base == DEFAULT_BETA_API_BASE  # type: ignore[attr-defined]
 
 
 class TestChatDeepSeekAzureToolChoice:
@@ -427,9 +433,13 @@ class TestChatDeepSeekAzureToolChoice:
 
     def test_bind_tools_azure_with_strict_mode(self) -> None:
         """Test Azure endpoint with strict mode enabled."""
-        llm = self._get_azure_model()
+        endpoint = "https://my-resource.openai.azure.com/"
+        llm = self._get_azure_model(endpoint)
         bound_model = llm.bind_tools([SampleTool], strict=True)
-        assert bound_model is not None
+        # The beta-endpoint swap only applies to the default DeepSeek base, so a
+        # non-default (Azure) endpoint must be preserved as-is.
+        assert bound_model.bound.api_base == endpoint  # type: ignore[attr-defined]
+        assert bound_model.bound.api_base != DEFAULT_BETA_API_BASE  # type: ignore[attr-defined]
 
 
 def test_profile() -> None:


### PR DESCRIPTION


The DeepSeek integration switches to a separate `beta` API base when a caller sets `strict=True` on `bind_tools` or `with_structured_output`, because DeepSeek only honors strict tool schemas on its beta endpoint. Three unit tests in the `deepseek` partner package are named to protect that switch, but each only asserted `bound_model is not None`.

`bind_tools` returns a `RunnableBinding` and `with_structured_output` returns a `RunnableSequence`; both objects are always truthy, so those assertions could never fail. If the beta swap regressed (a wrong URL, a dropped `model_copy`, or a broken condition on the API base), the tests would still pass and the regression would ship silently.

This asserts the effective endpoint instead:

- `bind_tools(strict=True)` should produce a bound model whose `api_base` is the beta base (`DEFAULT_BETA_API_BASE`).
- The non-strict paths (`strict=False` and the default) should stay on `DEFAULT_API_BASE`.
- `with_structured_output(strict=True)` should target the beta base through the first step of its `RunnableSequence`.
- A non-default endpoint with `strict=True` must be preserved as-is and must not be rewritten to the beta base, since the swap only applies to the default DeepSeek base.

The bound model is reachable through the public `RunnableBinding.bound` and `RunnableSequence.first` attributes, so no private state is touched. No production code changes; this only tightens existing test coverage.

I verified the new assertions catch a real regression: temporarily disabling the strict-to-beta branch in the source makes the two beta-endpoint tests fail with a clear default-base vs beta-base mismatch, while the non-strict and non-default endpoint tests stay green. `make format`, `make lint`, and `make test` all pass from the `deepseek` package root.

Disclaimer: this contribution was prepared with the assistance of an AI agent and reviewed by me before submission.
