### PR TITLE
fix(langchain): clear stale structured_response on retry

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -193,6 +193,8 @@ def _normalize_to_model_response(
 def _build_commands(
     model_response: ModelResponse,
     middleware_commands: list[Command[Any]] | None = None,
+    *,
+    clear_structured_response: bool = False,
 ) -> list[Command[Any]]:
     """Build a list of Commands from a model response and middleware commands.
 
@@ -204,16 +206,24 @@ def _build_commands(
             structured output.
         middleware_commands: Commands accumulated from middleware layers during
             composition (inner-first ordering).
+        clear_structured_response: Whether to clear checkpointed structured output
+            when the model produced no fresh parsed response.
 
     Returns:
         List of `Command` objects ready to be returned from a model node.
     """
     state: dict[str, Any] = {"messages": model_response.result}
+    middleware_commands = middleware_commands or []
 
     if model_response.structured_response is not None:
         state["structured_response"] = model_response.structured_response
+    elif clear_structured_response and not any(
+        isinstance(cmd.update, dict) and "structured_response" in cmd.update
+        for cmd in middleware_commands
+    ):
+        state["structured_response"] = None
 
-    for cmd in middleware_commands or []:
+    for cmd in middleware_commands:
         if cmd.goto:
             msg = (
                 "Command goto is not yet supported in wrap_model_call middleware. "
@@ -1445,10 +1455,17 @@ def create_agent(
 
         if wrap_model_call_handler is None:
             model_response = _execute_model_sync(request)
-            return _build_commands(model_response)
+            return _build_commands(
+                model_response,
+                clear_structured_response=request.response_format is not None,
+            )
 
         result = wrap_model_call_handler(request, _execute_model_sync)
-        return _build_commands(result.model_response, result.commands)
+        return _build_commands(
+            result.model_response,
+            result.commands,
+            clear_structured_response=request.response_format is not None,
+        )
 
     async def _execute_model_async(request: ModelRequest[ContextT]) -> ModelResponse:
         """Execute model asynchronously and return response.
@@ -1493,10 +1510,17 @@ def create_agent(
 
         if awrap_model_call_handler is None:
             model_response = await _execute_model_async(request)
-            return _build_commands(model_response)
+            return _build_commands(
+                model_response,
+                clear_structured_response=request.response_format is not None,
+            )
 
         result = await awrap_model_call_handler(request, _execute_model_async)
-        return _build_commands(result.model_response, result.commands)
+        return _build_commands(
+            result.model_response,
+            result.commands,
+            clear_structured_response=request.response_format is not None,
+        )
 
     # Use sync or async based on model capabilities
     graph.add_node("model", RunnableCallable(model_node, amodel_node, trace=False))
@@ -1881,7 +1905,7 @@ def _make_model_to_tools_edge(
             return [Send("tools", [tool_call]) for tool_call in pending_tool_calls]
 
         # 5. If there is a structured response, exit the loop
-        if "structured_response" in state:
+        if state.get("structured_response") is not None:
             return end_destination
 
         # 6. AIMessage has tool calls, but there are no pending tool calls which suggests
@@ -1908,7 +1932,7 @@ def _make_model_to_model_edge(
             )
 
         # 2. Exit condition: A structured response was generated
-        if "structured_response" in state:
+        if state.get("structured_response") is not None:
             return end_destination
 
         # 3. Default: Continue the loop, there may have been an issue with structured

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -11,7 +11,8 @@ from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import HumanMessage
-from langchain_core.runnables import Runnable
+from langchain_core.runnables import Runnable, RunnableConfig
+from langgraph.checkpoint.memory import InMemorySaver
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict, override
 
@@ -71,6 +72,10 @@ weather_json_schema = {
 class LocationResponse(BaseModel):
     city: str = Field(description="The city name")
     country: str = Field(description="The country name")
+
+
+class Answer(BaseModel):
+    text: str
 
 
 class LocationTypedDict(TypedDict):
@@ -563,6 +568,50 @@ class TestResponseFormatAsToolStrategy:
         # HumanMessage, AIMessage, ToolMessage, AIMessage, ToolMessage
         assert len(response["messages"]) == 5
         assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+
+    def test_checkpointer_clears_stale_structured_response_on_retry(self) -> None:
+        class ToolCallingGenericFakeChatModel(GenericFakeChatModel):
+            @override
+            def bind_tools(
+                self,
+                tools: Sequence[dict[str, Any] | type[BaseModel] | Callable[..., Any] | BaseTool],
+                *,
+                tool_choice: str | None = None,
+                **kwargs: Any,
+            ) -> Runnable[LanguageModelInput, AIMessage]:
+                return self.bind(tools=tools, tool_choice=tool_choice, **kwargs)
+
+        model = ToolCallingGenericFakeChatModel(
+            messages=iter(
+                [
+                    AIMessage(
+                        content="",
+                        tool_calls=[{"name": "Answer", "args": {"text": "Hi"}, "id": "call_1"}],
+                    ),
+                    AIMessage(
+                        content="",
+                        tool_calls=[{"name": "Answer", "args": {"text": 2}, "id": "call_2"}],
+                    ),
+                    AIMessage(
+                        content="",
+                        tool_calls=[{"name": "Answer", "args": {"text": "Bye"}, "id": "call_3"}],
+                    ),
+                ]
+            )
+        )
+        agent = create_agent(
+            model,
+            [],
+            response_format=ToolStrategy(schema=Answer, handle_errors=True),
+            checkpointer=InMemorySaver(),
+        )
+        config: RunnableConfig = {"configurable": {"thread_id": "thread_36957"}}
+
+        response1 = agent.invoke({"messages": [HumanMessage("Hi")]}, config)
+        response2 = agent.invoke({"messages": [HumanMessage("Bye")]}, config)
+
+        assert response1["structured_response"].text == "Hi"
+        assert response2["structured_response"].text == "Bye"
 
     def test_retry_with_custom_function(self) -> None:
         """Test retry with custom message generation."""


### PR DESCRIPTION
Fixes #36957

When a `create_agent` uses a checkpointer and `response_format`, a retry on the same thread could return the previous parsed output. A first turn could parse `Answer(text="Hi")`, then a second turn that should parse `Answer(text="Bye")` could stop on the checkpointed `Hi`.

The root cause was checkpointed `structured_response` state plus routing that treated key presence as success. When the active structured output step produced retry messages but no fresh parsed response, nothing cleared the old value.

This change makes `_build_commands` clear stale structured output to `None` when `response_format` is active and no fresh parsed response was produced. The flag is wired through all four model node call sites: sync with middleware, sync without middleware, async with middleware, and async without middleware. Middleware supplied `structured_response` updates are preserved.

The model routing edges now check `state.get("structured_response") is not None`, so a cleared `None` is not terminal and the fresh retry result can overwrite it.

## Release note

When `response_format` is set, resumed agents now clear stale checkpointed structured output during retry. If a run ends without parsed structured output, outputs can include `structured_response: None` instead of omitting the key.

## Verification

The new regression test fails on the stale behavior and passes with this fix. The agents unit suite passed with 967 passed and 0 failed. I also checked the negative control by reverting `factory.py`, which makes the new test fail with the stale value again.

## AI assistance

AI tooling assisted this contribution. I reviewed the change and own the result.
