### PR TITLE
chore(standard-tests): fix some typings detected by ty

### DIFF
--- a/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/chat_models.py
@@ -6,7 +6,7 @@ import base64
 import json
 import os
 import warnings
-from typing import TYPE_CHECKING, Annotated, Any, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
 from unittest.mock import MagicMock
 
 import httpx
@@ -759,6 +759,7 @@ class ChatModelIntegrationTests(ChatModelTests):
             will use the cassette instead of making HTTP calls.
     '''  # noqa: E501
 
+    @override
     @property
     def standard_chat_model_params(self) -> dict[str, Any]:
         """Standard parameters for chat model."""
@@ -1710,7 +1711,7 @@ class ChatModelIntegrationTests(ChatModelTests):
         for chunk in model_with_tools.stream(query):
             if tool_call_streaming and isinstance(chunk, AIMessageChunk):
                 found_tool_call_chunk |= _validate_tool_call_chunk(chunk)
-            full = chunk if full is None else full + chunk  # type: ignore[assignment]
+            full = chunk if full is None else (cast("AIMessageChunk", full) + chunk)
         assert isinstance(full, AIMessage)
         _validate_tool_call_message(full)
 
@@ -1789,7 +1790,7 @@ class ChatModelIntegrationTests(ChatModelTests):
         async for chunk in model_with_tools.astream(query):
             if tool_call_streaming and isinstance(chunk, AIMessageChunk):
                 found_tool_call_chunk |= _validate_tool_call_chunk(chunk)
-            full = chunk if full is None else full + chunk  # type: ignore[assignment]
+            full = chunk if full is None else (cast("AIMessageChunk", full) + chunk)
         assert isinstance(full, AIMessage)
         _validate_tool_call_message(full)
 
@@ -2146,7 +2147,7 @@ class ChatModelIntegrationTests(ChatModelTests):
 
         full: BaseMessage | None = None
         for chunk in model_with_tools.stream(query):
-            full = chunk if full is None else full + chunk  # type: ignore[assignment]
+            full = chunk if full is None else (cast("AIMessageChunk", full) + chunk)
         assert isinstance(full, AIMessage)
         _validate_tool_call_message_no_args(full)
 
@@ -3248,7 +3249,7 @@ class ChatModelIntegrationTests(ChatModelTests):
             "cache_control": {"type": "ephemeral"},
         }
 
-        human_content = [
+        human_content: list[str | dict[Any, Any]] = [
             {
                 "type": "text",
                 "text": "what's your favorite color in this image",
@@ -3272,7 +3273,7 @@ class ChatModelIntegrationTests(ChatModelTests):
             )
         messages = [
             SystemMessage("you're a good assistant"),
-            HumanMessage(human_content),  # type: ignore[arg-type]
+            HumanMessage(human_content),
             AIMessage(
                 [
                     {"type": "text", "text": "Hmm let me think about that"},

--- a/libs/standard-tests/langchain_tests/integration_tests/sandboxes.py
+++ b/libs/standard-tests/langchain_tests/integration_tests/sandboxes.py
@@ -46,6 +46,7 @@ import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from pydantic import Field
+from typing_extensions import override
 
 deepagents = pytest.importorskip("deepagents")
 
@@ -76,7 +77,8 @@ class _ScriptedToolModel(GenericFakeChatModel):
 
     messages: Iterator[AIMessage | str] = Field(exclude=True)
 
-    def bind_tools(self, tools: Any, **kwargs: Any) -> _ScriptedToolModel:  # noqa: ARG002
+    @override
+    def bind_tools(self, tools: Any, **kwargs: Any) -> _ScriptedToolModel:
         return self
 
 

--- a/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
+++ b/libs/standard-tests/langchain_tests/unit_tests/chat_models.py
@@ -14,6 +14,7 @@ from langchain_core.load import dumpd, load
 from langchain_core.runnables import RunnableBinding
 from langchain_core.tools import BaseTool, tool
 from pydantic import BaseModel, Field, SecretStr, ValidationError
+from typing_extensions import override
 
 from langchain_tests.base import BaseStandardTests
 
@@ -901,6 +902,7 @@ class ChatModelUnitTests(ChatModelTests):
         ```
     '''  # noqa: E501,D214
 
+    @override
     @property
     def standard_chat_model_params(self) -> dict[str, Any]:
         """Standard chat model parameters."""
@@ -1082,12 +1084,14 @@ class ChatModelUnitTests(ChatModelTests):
         class ExpectedParams(BaseModel):
             ls_provider: str
             ls_model_name: str
-            ls_model_type: Literal["chat"]
+            ls_model_type: str
             ls_temperature: float | None = None
             ls_max_tokens: int | None = None
             ls_stop: list[str] | None = None
+            ls_integration: str | None = None
 
         ls_params = model._get_ls_params()
+        assert ls_params["ls_model_type"] == "chat"
         try:
             ExpectedParams(**ls_params)
         except ValidationError as e:
@@ -1100,6 +1104,7 @@ class ChatModelUnitTests(ChatModelTests):
             **self.chat_model_params,
         )
         ls_params = model._get_ls_params()
+        assert ls_params["ls_model_type"] == "chat"
         try:
             ExpectedParams(**ls_params)
         except ValidationError as e:

--- a/libs/standard-tests/langchain_tests/unit_tests/tools.py
+++ b/libs/standard-tests/langchain_tests/unit_tests/tools.py
@@ -87,7 +87,10 @@ class ToolsUnitTests(ToolsTests):
         env_params, tools_params, expected_attrs = self.init_from_env_params
         if env_params:
             with mock.patch.dict(os.environ, env_params):
-                tool = self.tool_constructor(**tools_params)  # type: ignore[operator]
+                if isinstance(self.tool_constructor, BaseTool):
+                    tool = self.tool_constructor
+                else:
+                    tool = self.tool_constructor(**tools_params)
             assert tool is not None
             for k, expected in expected_attrs.items():
                 actual = getattr(tool, k)

--- a/libs/standard-tests/tests/unit_tests/custom_chat_model.py
+++ b/libs/standard-tests/tests/unit_tests/custom_chat_model.py
@@ -164,14 +164,16 @@ class ChatParrotLink(BaseChatModel):
         if run_manager:
             # This is optional in newer versions of LangChain
             # The on_llm_new_token will be called automatically
-            run_manager.on_llm_new_token(token, chunk=chunk)
+            run_manager.on_llm_new_token("", chunk=chunk)
         yield chunk
 
+    @override
     @property
     def _llm_type(self) -> str:
         """Get the type of language model used by this chat model."""
         return "echoing-chat-model-advanced"
 
+    @override
     @property
     def _identifying_params(self) -> dict[str, Any]:
         """Return a dictionary of identifying parameters.

--- a/libs/standard-tests/tests/unit_tests/test_basic_retriever.py
+++ b/libs/standard-tests/tests/unit_tests/test_basic_retriever.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
+from typing_extensions import override
 
 from langchain_tests.integration_tests import RetrieversIntegrationTests
 
@@ -10,20 +11,24 @@ class ParrotRetriever(BaseRetriever):
     parrot_name: str
     k: int = 3
 
+    @override
     def _get_relevant_documents(self, query: str, **kwargs: Any) -> list[Document]:
         k = kwargs.get("k", self.k)
         return [Document(page_content=f"{self.parrot_name} says: {query}")] * k
 
 
 class TestParrotRetrieverIntegration(RetrieversIntegrationTests):
+    @override
     @property
     def retriever_constructor(self) -> type[ParrotRetriever]:
         return ParrotRetriever
 
+    @override
     @property
     def retriever_constructor_params(self) -> dict[str, Any]:
         return {"parrot_name": "Polly"}
 
+    @override
     @property
     def retriever_query_example(self) -> str:
         return "parrot"

--- a/libs/standard-tests/tests/unit_tests/test_basic_tool.py
+++ b/libs/standard-tests/tests/unit_tests/test_basic_tool.py
@@ -31,10 +31,12 @@ class ParrotMultiplyArtifactTool(BaseTool):
 
 
 class TestParrotMultiplyToolUnit(ToolsUnitTests):
+    @override
     @property
     def tool_constructor(self) -> type[ParrotMultiplyTool]:
         return ParrotMultiplyTool
 
+    @override
     @property
     def tool_constructor_params(self) -> dict[str, Any]:
         # if your tool constructor instead required initialization arguments like
@@ -42,6 +44,7 @@ class TestParrotMultiplyToolUnit(ToolsUnitTests):
         # as a dictionary, e.g.: `return {'some_arg': 42}`
         return {}
 
+    @override
     @property
     def tool_invoke_params_example(self) -> dict[str, Any]:
         """Returns a dictionary representing the "args" of an example tool call.
@@ -53,10 +56,12 @@ class TestParrotMultiplyToolUnit(ToolsUnitTests):
 
 
 class TestParrotMultiplyToolIntegration(ToolsIntegrationTests):
+    @override
     @property
     def tool_constructor(self) -> type[ParrotMultiplyTool]:
         return ParrotMultiplyTool
 
+    @override
     @property
     def tool_constructor_params(self) -> dict[str, Any]:
         # if your tool constructor instead required initialization arguments like
@@ -64,6 +69,7 @@ class TestParrotMultiplyToolIntegration(ToolsIntegrationTests):
         # as a dictionary, e.g.: `return {'some_arg': 42}`
         return {}
 
+    @override
     @property
     def tool_invoke_params_example(self) -> dict[str, Any]:
         """Returns a dictionary representing the "args" of an example tool call.
@@ -75,10 +81,12 @@ class TestParrotMultiplyToolIntegration(ToolsIntegrationTests):
 
 
 class TestParrotMultiplyArtifactToolIntegration(ToolsIntegrationTests):
+    @override
     @property
     def tool_constructor(self) -> type[ParrotMultiplyArtifactTool]:
         return ParrotMultiplyArtifactTool
 
+    @override
     @property
     def tool_constructor_params(self) -> dict[str, Any]:
         # if your tool constructor instead required initialization arguments like
@@ -86,6 +94,7 @@ class TestParrotMultiplyArtifactToolIntegration(ToolsIntegrationTests):
         # as a dictionary, e.g.: `return {'some_arg': 42}`
         return {}
 
+    @override
     @property
     def tool_invoke_params_example(self) -> dict[str, Any]:
         """Returns a dictionary representing the "args" of an example tool call.

--- a/libs/standard-tests/tests/unit_tests/test_custom_chat_model.py
+++ b/libs/standard-tests/tests/unit_tests/test_custom_chat_model.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from typing_extensions import override
 
 from langchain_tests.integration_tests import ChatModelIntegrationTests
 from langchain_tests.unit_tests import ChatModelUnitTests
@@ -15,29 +16,34 @@ if TYPE_CHECKING:
 
 
 class TestChatParrotLinkUnit(ChatModelUnitTests):
+    @override
     @property
     def chat_model_class(self) -> type[ChatParrotLink]:
         return ChatParrotLink
 
+    @override
     @property
     def chat_model_params(self) -> dict[str, Any]:
         return {"model": "bird-brain-001", "temperature": 0, "parrot_buffer_length": 50}
 
 
 class TestChatParrotLinkIntegration(ChatModelIntegrationTests):
+    @override
     @property
     def chat_model_class(self) -> type[ChatParrotLink]:
         return ChatParrotLink
 
+    @override
     @property
     def chat_model_params(self) -> dict[str, Any]:
         return {"model": "bird-brain-001", "temperature": 0, "parrot_buffer_length": 50}
 
+    @override
     @pytest.mark.xfail(reason="ChatParrotLink doesn't implement bind_tools method")
     def test_unicode_tool_call_integration(
         self,
         model: BaseChatModel,
         tool_choice: str | None = None,  # noqa: PT028
-        force_tool_call: bool = True,  # noqa: FBT001, FBT002, PT028
+        force_tool_call: bool = True,  # noqa: PT028
     ) -> None:
         """Expected failure as ChatParrotLink doesn't support tool calling yet."""

--- a/libs/standard-tests/tests/unit_tests/test_decorated_tool.py
+++ b/libs/standard-tests/tests/unit_tests/test_decorated_tool.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from langchain_core.tools import BaseTool, tool
+from typing_extensions import override
 
 from langchain_tests.integration_tests import ToolsIntegrationTests
 from langchain_tests.unit_tests import ToolsUnitTests
@@ -13,10 +14,12 @@ def parrot_multiply_tool(a: int, b: int) -> int:
 
 
 class TestParrotMultiplyToolUnit(ToolsUnitTests):
+    @override
     @property
     def tool_constructor(self) -> BaseTool:
         return parrot_multiply_tool
 
+    @override
     @property
     def tool_invoke_params_example(self) -> dict[str, Any]:
         """Returns a dictionary representing the "args" of an example tool call.
@@ -28,10 +31,12 @@ class TestParrotMultiplyToolUnit(ToolsUnitTests):
 
 
 class TestParrotMultiplyToolIntegration(ToolsIntegrationTests):
+    @override
     @property
     def tool_constructor(self) -> BaseTool:
         return parrot_multiply_tool
 
+    @override
     @property
     def tool_invoke_params_example(self) -> dict[str, Any]:
         """Returns a dictionary representing the "args" of an example tool call.

--- a/libs/standard-tests/tests/unit_tests/test_embeddings.py
+++ b/libs/standard-tests/tests/unit_tests/test_embeddings.py
@@ -1,26 +1,31 @@
 from typing import Any
 
 from langchain_core.embeddings import DeterministicFakeEmbedding, Embeddings
+from typing_extensions import override
 
 from langchain_tests.integration_tests import EmbeddingsIntegrationTests
 from langchain_tests.unit_tests import EmbeddingsUnitTests
 
 
 class TestFakeEmbeddingsUnit(EmbeddingsUnitTests):
+    @override
     @property
     def embeddings_class(self) -> type[Embeddings]:
         return DeterministicFakeEmbedding
 
+    @override
     @property
     def embedding_model_params(self) -> dict[str, Any]:
         return {"size": 6}  # embedding dimension
 
 
 class TestFakeEmbeddingsIntegration(EmbeddingsIntegrationTests):
+    @override
     @property
     def embeddings_class(self) -> type[Embeddings]:
         return DeterministicFakeEmbedding
 
+    @override
     @property
     def embedding_model_params(self) -> dict[str, Any]:
         return {"size": 6}

--- a/libs/standard-tests/tests/unit_tests/test_in_memory_vectorstore.py
+++ b/libs/standard-tests/tests/unit_tests/test_in_memory_vectorstore.py
@@ -5,11 +5,13 @@ from langchain_core.vectorstores import (
     InMemoryVectorStore,
     VectorStore,
 )
+from typing_extensions import override
 
 from langchain_tests.integration_tests.vectorstores import VectorStoreIntegrationTests
 
 
 class TestInMemoryVectorStore(VectorStoreIntegrationTests):
+    @override
     @pytest.fixture
     def vectorstore(self) -> VectorStore:
         embeddings = self.get_embeddings()
@@ -23,11 +25,13 @@ class WithoutGetByIdsVectorStore(InMemoryVectorStore):
 
 
 class TestWithoutGetByIdVectorStore(VectorStoreIntegrationTests):
+    @override
     @pytest.fixture
     def vectorstore(self) -> VectorStore:
         embeddings = self.get_embeddings()
         return WithoutGetByIdsVectorStore(embedding=embeddings)
 
+    @override
     @property
     def has_get_by_ids(self) -> bool:
         return False


### PR DESCRIPTION
* Fix some `type:ignore`
* Fix some `ty` rules violations
* Not switching to `ty` atm because it gives too much false positives with pydantic. This should be [fixed soon in ty](https://github.com/astral-sh/ruff/pull/26520).