### PR TITLE
fix(langchain): process duplicate schemas at last position

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -428,6 +428,7 @@ def _resolve_schemas(schemas: list[type]) -> tuple[type, type, type]:
     same field is declared by multiple schemas.  Duplicates are harmless — a type
     that appears more than once is processed at its last position.
     """
+    schemas = list(reversed(dict.fromkeys(reversed(schemas))))
     schema_hints = {schema: _get_schema_type_hints(schema) for schema in schemas}
     return (
         _resolve_schema(schema_hints, "StateSchema", None),

--- a/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
@@ -302,6 +302,10 @@ def test_last_schema_wins_for_conflicting_field() -> None:
     hints = get_type_hints(resolved, include_extras=True)
     assert get_args(hints["shared_field"])[1] == "last"
 
+    resolved, _, _ = factory._resolve_schemas([LastState, MiddleState, LastState])
+    hints = get_type_hints(resolved, include_extras=True)
+    assert get_args(hints["shared_field"])[1] == "last"
+
 
 def test_get_schema_type_hints_cache_hits_for_reused_schema() -> None:
     """Test repeated schema resolution reuses cached type hints for the same schema."""


### PR DESCRIPTION
Fixes #38720

---

When the same state schema appears both in middleware and as the explicit `state_schema`, `_resolve_schemas` documented that the final occurrence should win. The previous dict-comprehension dedupe kept the first insertion position for repeated schema classes, so a later middleware could still override the explicit schema.

This change deduplicates schemas by their last occurrence before the existing merge step, preserving the intended “later schemas override earlier schemas” behavior. The existing state-schema conflict regression now also covers a repeated schema class so this contract stays pinned.

## Release note

Fixed duplicate agent state schemas in `create_agent` so the last schema occurrence consistently wins field conflicts.

This contribution was prepared with assistance from an AI coding agent and reviewed before submission.
