### PR TITLE
fix(text-splitters): normalize CRLF before matching markdown lines

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -392,7 +392,7 @@ class ExperimentalMarkdownSyntaxTextSplitter:
         raw_lines = text.splitlines(keepends=True)
 
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.pop(0).replace("\r\n", "\n")
             header_match = self._match_header(raw_line)
             code_match = self._match_code(raw_line)
             horz_match = self._match_horz(raw_line)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -2099,6 +2099,34 @@ def test_experimental_markdown_syntax_text_splitter_split_lines() -> None:
     assert output == expected_output
 
 
+def test_experimental_markdown_syntax_text_splitter_crlf() -> None:
+    """CRLF line endings must split on horizontal rules and not leak ``\\r``.
+
+    Regression test: with Windows-style ``\\r\\n`` newlines the experimental
+    splitter failed to split on ``---``/``***`` rules and kept a trailing
+    carriage return in header metadata values.
+    """
+    text = (
+        "# Header 1\r\n"
+        "\r\n"
+        "Some text before the rule.\r\n"
+        "\r\n"
+        "---\r\n"
+        "\r\n"
+        "Text after the rule.\r\n"
+    )
+    markdown_splitter = ExperimentalMarkdownSyntaxTextSplitter(
+        headers_to_split_on=[("#", "Header 1")], strip_headers=True
+    )
+    output = markdown_splitter.split_text(text)
+
+    assert len(output) == 2
+    assert output[0].page_content == "\nSome text before the rule.\n\n"
+    assert output[0].metadata == {"Header 1": "Header 1"}
+    assert output[1].page_content == "\nText after the rule.\n"
+    assert output[1].metadata == {"Header 1": "Header 1"}
+
+
 EXPERIMENTAL_MARKDOWN_DOCUMENTS = [
     (
         "# My Header 1 From Document 1\n"


### PR DESCRIPTION
## Summary
- `ExperimentalMarkdownSyntaxTextSplitter.split_text` used `text.splitlines(keepends=True)`, which keeps `\r\n` intact. All three match regexes (`_match_header`, `_match_code`, `_match_horz`) are written for `\n`-terminated lines only.
- On Windows/CRLF markdown (git auto-CRLF / Windows editors), the `---`/`***`/`___` horizontal-rule split never fired and header metadata values got a dangling `\r` (e.g. `{'Header 1': 'Header 1\r'}`). `\r` also polluted `page_content`.
- Normalized `\r\n` to `\n` when popping each line.

## Test plan
- Added `test_experimental_markdown_syntax_text_splitter_crlf` to `libs/text-splitters/tests/unit_tests/test_text_splitters.py`.
- Fail-before/pass-after verified locally (9 passed in the experimental group, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>