### PR TITLE
docs(infra): clarify `uv.lock` step in release process guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,7 +287,7 @@ Each partner package is released independently. The full flow is:
 1. **Version bump PR.** Create a PR that bumps three files by one line each:
    - `langchain_<partner>/_version.py` — `__version__`
    - `pyproject.toml` — `version`
-   - `uv.lock` — regenerate with `uv lock` from the package directory; keep only the package-version line if `uv lock` touches unrelated entries
+   - `uv.lock` — run `uv lock` from the package directory. If the diff includes unrelated changes (e.g. environment-dependent marker lines from a different local Python version), revert them and keep only the `version = "..."` line for the package being released
 
    Title follows Conventional Commits: `release(<partner>): <version>` (e.g. `release(openrouter): 0.2.6`). Use the branch name `release/<partner>-<version>`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ Each partner package is released independently. The full flow is:
 1. **Version bump PR.** Create a PR that bumps three files by one line each:
    - `langchain_<partner>/_version.py` — `__version__`
    - `pyproject.toml` — `version`
-   - `uv.lock` — regenerate with `uv lock` from the package directory; keep only the package-version line if `uv lock` touches unrelated entries
+   - `uv.lock` — run `uv lock` from the package directory. If the diff includes unrelated changes (e.g. environment-dependent marker lines from a different local Python version), revert them and keep only the `version = "..."` line for the package being released
 
    Title follows Conventional Commits: `release(<partner>): <version>` (e.g. `release(openrouter): 0.2.6`). Use the branch name `release/<partner>-<version>`.
 


### PR DESCRIPTION
## What

The release process guide in `AGENTS.md` and `CLAUDE.md` instructs the reader to "keep only the package-version line if `uv lock` touches unrelated entries." This is vague — it doesn't explain *why* unrelated entries appear or *what* the offending lines look like.

## Why

When you bump a package's version in `pyproject.toml` and run `uv lock` from the package directory, the lockfile diff can include unrelated changes such as environment-dependent marker lines (e.g. `typing-extensions` losing a `python_full_version < '3.11'` marker) caused by a different local Python version resolving the environment. These are artifacts of the machine running the lock, not intentional dependency changes, and should not be committed.

## Change

Replaced the vague instruction with a precise one:

> `uv.lock` — run `uv lock` from the package directory. If the diff includes unrelated changes (e.g. environment-dependent marker lines from a different local Python version), revert them and keep only the `version = "..."` line for the package being released

This came up during the langchain-core/langchain release on July 8, where the original instruction was flagged as questionable and traced back via git blame to commit 917f1a62 (PR #38683).
