### PR TITLE
fix(core): unwrap RootModel[TypedDict] in `convert_runnable_to_tool`

### DIFF
--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -4,7 +4,8 @@ import inspect
 from collections.abc import Callable
 from typing import Any, Literal, cast, get_type_hints, overload
 
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel, Field, RootModel, create_model
+from typing_extensions import is_typeddict
 
 from langchain_core.callbacks import Callbacks
 from langchain_core.runnables import Runnable
@@ -469,6 +470,30 @@ def convert_runnable_to_tool(
         args_schema = _get_schema_from_runnable_and_arg_types(
             runnable, name, arg_types=arg_types
         )
+
+    # If the input schema is a RootModel wrapping a TypedDict and the
+    # resulting args_schema is empty (e.g. because InputType is typing.Any),
+    # unwrap the RootModel and convert the TypedDict to a proper Pydantic
+    # model. RootModel wrapping causes the OpenAI tool schema to have a
+    # nested "root" property, which breaks tool call validation.
+    input_schema = runnable.input_schema
+    if isinstance(input_schema, type) and RootModel in input_schema.__mro__:
+        fields = getattr(input_schema, "model_fields", {})
+        if "root" in fields and is_typeddict(fields["root"].annotation):
+            td = fields["root"].annotation
+            td_hints = get_type_hints(td)
+            td_fields = {key: (hint, Field(...)) for key, hint in td_hints.items()}
+            has_empty_fields = (
+                not getattr(args_schema, "model_fields", None)
+                if isinstance(args_schema, type)
+                else True
+            )
+            if has_empty_fields:
+                td_name: str = getattr(td, "__name__", "model")
+                args_schema = cast(
+                    "type[BaseModel]",
+                    create_model(td_name, **td_fields),  # type: ignore[call-overload]
+                )
 
     return StructuredTool.from_function(
         name=name,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, RootModel, ValidationError
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import ValidationError as ValidationErrorV1
 from typing_extensions import TypedDict, override
@@ -2272,6 +2272,58 @@ def test_convert_runnable_to_tool_v1_input_schema() -> None:
     tool = convert_runnable_to_tool(V1InputRunnable())
 
     assert set(tool.args) == {"a"}
+
+
+def test_convert_runnable_to_tool_typed_dict_input() -> None:
+    """`convert_runnable_to_tool` unwraps RootModel[TypedDict] for proper schema.
+
+    Regression test: when a Runnable's input_schema is a RootModel wrapping a
+    TypedDict (e.g. from a StateGraph with TypedDict input), the tool schema
+    should not have a nested "root" property. The TypedDict fields should be
+    promoted to top-level fields.
+    """
+
+    class InputState(TypedDict):
+        foo: str
+        bar: str
+
+    class PassthroughRunnable(Runnable[Any, Any]):
+        @override
+        def invoke(
+            self,
+            input: Any,
+            config: RunnableConfig | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            return input
+
+        @override
+        def get_input_schema(
+            self, config: RunnableConfig | None = None
+        ) -> TypeBaseModel:
+            return create_model_v2("PassthroughInput", root=InputState)
+
+    tool = convert_runnable_to_tool(PassthroughRunnable())
+
+    # The args_schema should be a plain Pydantic model with foo and bar as
+    # top-level fields, NOT a RootModel with a single "root" field.
+    args_schema = tool.args_schema
+    assert args_schema is not None
+    assert isinstance(args_schema, type)
+    assert issubclass(args_schema, BaseModel)
+    assert not issubclass(args_schema, RootModel)
+    assert set(args_schema.model_fields.keys()) == {"foo", "bar"}
+
+    # The OpenAI tool schema should have foo and bar at the top level.
+    oai_schema = convert_to_openai_tool(tool)
+    params = oai_schema["function"]["parameters"]
+    assert "root" not in params.get("properties", {})
+    assert "foo" in params["properties"]
+    assert "bar" in params["properties"]
+
+    # invoke should accept the flat dict directly.
+    result = tool.invoke({"foo": "hello", "bar": "world"})
+    assert result == {"foo": "hello", "bar": "world"}
 
 
 @pytest.mark.parametrize("pydantic_model", TEST_MODELS)


### PR DESCRIPTION
Fixes #38713

When exposing a compiled `StateGraph` (with `TypedDict` input) as a tool, the OpenAI tool schema advertised a nested `root` property that didn't match what `tool.invoke()` accepted, causing validation errors for LLM tool calls.

## Release note
`convert_runnable_to_tool` now correctly unwraps `RootModel[TypedDict]` input schemas so the OpenAI tool schema matches the accepted invoke payload.