### PR TITLE
docs: add community health files (CONTRIBUTING.md, CODE_OF_CONDUCT.md, CHANGELOG.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Future features and improvements will be listed here
+
+### Changed
+- Ongoing updates and modifications
+
+### Fixed
+- Bug fixes and corrections
+
+---
+
+## How to Update This Changelog
+
+When making changes, add an entry under `[Unreleased]` in the appropriate category:
+
+- **Added** – new features
+- **Changed** – changes to existing functionality
+- **Deprecated** – soon-to-be removed features
+- **Removed** – removed features
+- **Fixed** – bug fixes
+- **Security** – vulnerability fixes
+
+When releasing, change `[Unreleased]` to the version number and date,
+then add a new empty `[Unreleased]` section at the top.
+
+---
+*Documentation contributed by [Mukller](https://github.com/Mukller)*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,67 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+
+---
+*Documentation contributed by [Mukller](https://github.com/Mukller)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing
+
+Thank you for your interest in contributing! We appreciate all contributions,
+from bug reports to feature requests and code improvements.
+
+## How to Contribute
+
+### Reporting Bugs
+- Check existing [issues](../../issues) first to avoid duplicates
+- Open a new issue with a clear title and description
+- Include steps to reproduce, expected vs actual behavior, and environment details
+
+### Suggesting Features
+- Open an issue with the `enhancement` label
+- Describe the feature and explain why it would be valuable
+
+### Submitting Code
+
+1. **Fork** this repository
+2. **Create a branch** from `main`:
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+3. **Make your changes** and add tests if applicable
+4. **Commit** with a clear message:
+   ```bash
+   git commit -m "feat: add your feature description"
+   ```
+5. **Push** to your fork and open a **Pull Request**
+
+## Guidelines
+
+- Follow the existing code style and conventions
+- Keep PRs focused on a single concern
+- Write clear commit messages
+- Update documentation when changing behavior
+- Be respectful and constructive in all interactions (see [Code of Conduct](CODE_OF_CONDUCT.md))
+
+## Development Setup
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/REPO_NAME.git
+cd REPO_NAME
+
+# Install dependencies (see README for details)
+```
+
+## Questions?
+
+Open an issue or start a discussion — we're happy to help!
+
+---
+*Documentation contributed by [Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Add Community Health Files

This PR adds the following community health files to `langchain`:

- CONTRIBUTING.md
- CODE_OF_CONDUCT.md
- CHANGELOG.md

### What's included

**CONTRIBUTING.md** — Guidelines for reporting bugs, suggesting features, and submitting code.

**CODE_OF_CONDUCT.md** — Contributor Covenant 2.1, a widely-adopted standard for inclusive communities.

**CHANGELOG.md** — A structured template following [Keep a Changelog](https://keepachangelog.com/) format.

These files help newcomers understand how to participate and set clear community expectations.
