### PR TITLE
fix(fireworks): handle nested dicts in _combine_llm_outputs

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -964,7 +964,16 @@ class ChatFireworks(BaseChatModel):
             if token_usage is not None:
                 for k, v in token_usage.items():
                     if k in overall_token_usage:
-                        overall_token_usage[k] += v
+                        if isinstance(v, dict) and isinstance(
+                            overall_token_usage[k], dict
+                        ):
+                            overall_token_usage[k].update(v)
+                        elif isinstance(v, (int, float)) and isinstance(
+                            overall_token_usage[k], (int, float)
+                        ):
+                            overall_token_usage[k] += v
+                        else:
+                            overall_token_usage[k] = v
                     else:
                         overall_token_usage[k] = v
             if system_fingerprint is None:


### PR DESCRIPTION
## Summary

Fix `TypeError` in `ChatFireworks._combine_llm_outputs` when Fireworks returns nested `token_usage` details (e.g. `prompt_tokens_details`).

### Problem

When using `batched generate()` (e.g. `llm.generate([[msg1], [msg2]])`), `_combine_llm_outputs` iterates over token usage dicts and sums values with `+=`. Fireworks returns nested dicts like `prompt_tokens_details: {"cached_tokens": 41518}` — attempting `dict += dict` raises `TypeError`.

### Fix

Check value types before combining:
- **dicts** → merged with `update()`  
- **numerics** (int/float) → summed as before  
- **other types** → replaced with latest value  

This is backward-compatible: existing numeric-only token usage works identically.

### Reproduction

```python
from langchain_fireworks import ChatFireworks
llm = ChatFireworks(model="accounts/fireworks/models/kimi-k2-instruct")
llm.generate([[HumanMessage("a")], [HumanMessage("b")]])
# TypeError: unsupported operand type(s) for +=: 'dict' and 'dict'
```

Closes #38648
