### PR TITLE
fix(middleware): export PIIMatch from public package

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -12,6 +12,7 @@ from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddlewar
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
+from langchain.agents.middleware._redaction import PIIMatch
 from langchain.agents.middleware.provider_tool_search import ProviderToolSearchMiddleware
 from langchain.agents.middleware.shell_tool import (
     CodexSandboxExecutionPolicy,
@@ -69,6 +70,7 @@ __all__ = [
     "ModelRetryMiddleware",
     "OutputAgentState",
     "PIIDetectionError",
+    "PIIMatch",
     "PIIMiddleware",
     "ProviderToolSearchMiddleware",
     "RedactionRule",


### PR DESCRIPTION
## Summary

Export `PIIMatch` from the public `langchain.agents.middleware` package so users can import it directly when writing custom PII detectors.

### Problem

The [PII middleware docs](https://docs.langchain.com/oss/python/langchain/middleware/built-in) instruct users to write custom detectors returning `PIIMatch`-shaped dicts, but the type is only importable from the private module:

```python
# This fails:
from langchain.agents.middleware import PIIMatch  # ImportError

# This works but is private API:
from langchain.agents.middleware._redaction import PIIMatch
```

### Fix

1. Import and re-export `PIIMatch` from `langchain.agents.middleware.__init__`
2. Add `PIIMatch` to `__all__`

### Also fixes docs field names

The docs example for custom detectors uses `"text"` as a field name, but the actual `PIIMatch` TypedDict uses `"value"`. The `_normalizing_detector` wrapper (line 387 of `_redaction.py`) already handles this gracefully via `m.get("value", m.get("text", ""))`, so the runtime behavior is correct — but the docs should match the type definition.

Closes #38718
