### PR TITLE
fix(text-splitters): normalize CRLF before matching markdown lines

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -392,7 +392,7 @@ class ExperimentalMarkdownSyntaxTextSplitter:
         raw_lines = text.splitlines(keepends=True)
 
         while raw_lines:
-            raw_line = raw_lines.pop(0)
+            raw_line = raw_lines.pop(0).replace("\r\n", "\n")
             header_match = self._match_header(raw_line)
             code_match = self._match_code(raw_line)
             horz_match = self._match_horz(raw_line)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -2099,6 +2099,34 @@ def test_experimental_markdown_syntax_text_splitter_split_lines() -> None:
     assert output == expected_output
 
 
+def test_experimental_markdown_syntax_text_splitter_crlf() -> None:
+    """CRLF line endings must split on horizontal rules and not leak ``\\r``.
+
+    Regression test: with Windows-style ``\\r\\n`` newlines the experimental
+    splitter failed to split on ``---``/``***`` rules and kept a trailing
+    carriage return in header metadata values.
+    """
+    text = (
+        "# Header 1\r\n"
+        "\r\n"
+        "Some text before the rule.\r\n"
+        "\r\n"
+        "---\r\n"
+        "\r\n"
+        "Text after the rule.\r\n"
+    )
+    markdown_splitter = ExperimentalMarkdownSyntaxTextSplitter(
+        headers_to_split_on=[("#", "Header 1")], strip_headers=True
+    )
+    output = markdown_splitter.split_text(text)
+
+    assert len(output) == 2
+    assert output[0].page_content == "\nSome text before the rule.\n\n"
+    assert output[0].metadata == {"Header 1": "Header 1"}
+    assert output[1].page_content == "\nText after the rule.\n"
+    assert output[1].metadata == {"Header 1": "Header 1"}
+
+
 EXPERIMENTAL_MARKDOWN_DOCUMENTS = [
     (
         "# My Header 1 From Document 1\n"


### PR DESCRIPTION
ExperimentalMarkdownSyntaxTextSplitter.split_text used `text.splitlines(keepends=True)` and then matched each line against headers, code fences, and horizontal rules. Because `splitlines` keeps the line terminator, Windows/CRLF markdown left a trailing `\r` on every line.

Impact:
- The horizontal-rule match (`---`, `***`, `___`) never fired, so a CRLF document was not split on rules.
- Header metadata values retained a trailing `\r`, leaking the carriage return into split metadata.

Fix: strip the `\r\n` -> `\n` on each popped line before matching.

```python
raw_line = raw_lines.pop(0).replace("\r\n", "\n")
```

Added a regression test (`test_experimental_markdown_syntax_text_splitter_crlf`) covering rule splitting and clean header metadata on CRLF input.

Verification: `pytest tests/unit_tests/test_text_splitters.py -k experimental_markdown` → 9 passed; `ruff check langchain_text_splitters/markdown.py` → clean.