### PR TITLE
fix(fireworks): await `response.text()` in async error handling

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/llms.py
+++ b/libs/partners/fireworks/langchain_fireworks/llms.py
@@ -227,12 +227,14 @@ class Fireworks(LLM):
                 msg = f"Fireworks Server: Error {response.status}"
                 raise Exception(msg)
             if response.status >= 400:
-                msg = f"Fireworks received an invalid payload: {response.text}"
+                error_text = await response.text()
+                msg = f"Fireworks received an invalid payload: {error_text}"
                 raise ValueError(msg)
             if response.status != 200:
+                error_text = await response.text()
                 msg = (
                     f"Fireworks returned an unexpected response with status "
-                    f"{response.status}: {response.text}"
+                    f"{response.status}: {error_text}"
                 )
                 raise Exception(msg)
 

--- a/libs/partners/fireworks/tests/unit_tests/test_llms.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_llms.py
@@ -1,9 +1,12 @@
 """Test Fireworks LLM."""
 
 from typing import cast
+from unittest.mock import patch
 
+import pytest
 from pydantic import SecretStr
 from pytest import CaptureFixture, MonkeyPatch
+from typing_extensions import Self
 
 from langchain_fireworks import Fireworks
 
@@ -97,3 +100,59 @@ def test_fireworks_model_params() -> None:
         "ls_max_tokens": 10,
         "ls_temperature": 0.1,
     }
+
+
+class _FakeAsyncResponse:
+    """Minimal stand-in for an `aiohttp.ClientResponse` used as an async CM."""
+
+    def __init__(self, status: int, body: str) -> None:
+        self.status = status
+        self._body = body
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: object) -> bool:
+        return False
+
+    async def text(self) -> str:
+        return self._body
+
+    async def json(self) -> dict:
+        return {}
+
+
+class _FakeAsyncSession:
+    """Minimal stand-in for an `aiohttp.ClientSession` used as an async CM."""
+
+    def __init__(self, response: _FakeAsyncResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *args: object) -> bool:
+        return False
+
+    def post(self, *args: object, **kwargs: object) -> _FakeAsyncResponse:
+        return self._response
+
+
+async def test_fireworks_acall_error_surfaces_response_body() -> None:
+    """Async error paths should include the API response body, not a coroutine repr.
+
+    On an `aiohttp` response, `.text` is a coroutine method, not a property (as it is
+    on a `requests` response), so `_acall` must `await` it. Regression test: the raised
+    error must contain the real API message, not `<bound method ...>`.
+    """
+    response = _FakeAsyncResponse(status=400, body="model does not exist")
+    llm = Fireworks(model="foo", api_key="secret-api-key")  # type: ignore[arg-type]
+    with (
+        patch(
+            "langchain_fireworks.llms.ClientSession",
+            return_value=_FakeAsyncSession(response),
+        ),
+        pytest.raises(ValueError, match="model does not exist") as exc_info,
+    ):
+        await llm._acall("hi")
+    assert "bound method" not in str(exc_info.value)


### PR DESCRIPTION
Closes #38741

---

`Fireworks._acall` (the async completions path) built its HTTP error messages with `{response.text}`. On an `aiohttp` response, `.text` is a coroutine method, not a property — unlike a `requests` response, where it is a property — so it was never awaited and the raised error embedded a bound-method `repr()` instead of the API's response body. Any async error (`ainvoke` / `agenerate` hitting a 4xx/5xx) surfaced `<bound method ClientResponse.text ...>` instead of the reason the request failed. The synchronous `_call` path (which uses `requests`) already handled this correctly, and the async method already translated `requests`' `.status_code` to aiohttp's `.status`, so this was an oversight rather than intent.

This awaits the body in both error branches, matching the sync path.

A regression unit test is added (the async error path previously had no unit coverage); it fails on the prior behavior — asserting the message contained a coroutine `repr()` — and passes with the fix.

## Release note

Fixed `Fireworks` async calls (`ainvoke` / `agenerate`) so API error messages include the actual response body instead of a coroutine `repr()`.

---

*Disclaimer: this contribution was prepared with the assistance of an AI agent.*
