### PR TITLE
docs: clarify HuggingFace Pydantic structured output support

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -1111,7 +1111,7 @@ class ChatHuggingFace(BaseChatModel):
                 - A JSON Schema,
                 - A `TypedDict` class
 
-                Pydantic class is currently supported.
+                Pydantic classes are not currently supported with `function_calling`; use a JSON schema/dict or a JSON mode instead.
 
             method: The method for steering model generation, one of:
 


### PR DESCRIPTION
## Summary

- Clarifies the `ChatHuggingFace.with_structured_output` docstring for Pydantic schemas.
- Avoids implying that Pydantic schemas are supported with `function_calling`, where the current implementation raises `NotImplementedError`.

## Testing

- Docs-only change; no tests run.

Related to #32197
