### PR TITLE
feat(anthropic): support callable api_key and auth_token_provider

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -8,7 +8,9 @@ import hashlib
 import json
 import re
 import warnings
-from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
+import inspect
+import asyncio
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Mapping, Sequence
 from functools import cached_property
 from operator import itemgetter
 from typing import Any, Final, Literal, cast
@@ -956,11 +958,20 @@ class ChatAnthropic(BaseChatModel):
     `ANTHROPIC_API_URL` and if that is not set, `ANTHROPIC_BASE_URL`.
     """
 
-    anthropic_api_key: SecretStr = Field(
+    anthropic_api_key: (
+        SecretStr | None | Callable[[], str] | Callable[[], Awaitable[str]]
+    ) = Field(
         alias="api_key",
-        default_factory=secret_from_env("ANTHROPIC_API_KEY", default=""),
+        default_factory=secret_from_env("ANTHROPIC_API_KEY", default=None),
     )
     """Automatically read from env var `ANTHROPIC_API_KEY` if not provided."""
+
+    auth_token_provider: (
+        Callable[[], str] | Callable[[], Awaitable[str]] | None
+    ) = None
+    """Provider function for an authorization token (e.g., for Azure Entra ID).
+    If provided, the resolved token will be sent in the `Authorization: Bearer` header.
+    """
 
     anthropic_proxy: str | None = Field(
         default_factory=from_env("ANTHROPIC_PROXY", default=None)
@@ -1189,8 +1200,17 @@ class ChatAnthropic(BaseChatModel):
         if self.default_headers:
             default_headers.update(self.default_headers)
 
+        if isinstance(self.anthropic_api_key, SecretStr):
+            api_key = self.anthropic_api_key.get_secret_value()
+        elif isinstance(self.anthropic_api_key, str):
+            api_key = self.anthropic_api_key
+        elif self.anthropic_api_key is None and self.auth_token_provider is None:
+            api_key = None
+        else:
+            api_key = "dummy-api-key-for-deferred-resolution"
+
         client_params: dict[str, Any] = {
-            "api_key": self.anthropic_api_key.get_secret_value(),
+            "api_key": api_key,
             "base_url": self.anthropic_api_url,
             "max_retries": self.max_retries,
             "default_headers": default_headers,
@@ -1427,12 +1447,71 @@ class ChatAnthropic(BaseChatModel):
 
         return {k: v for k, v in payload.items() if v is not None}
 
+    def _resolve_auth_headers(self) -> dict[str, str]:
+        if self.auth_token_provider is not None:
+            token = self.auth_token_provider()
+            if inspect.isawaitable(token):
+                try:
+                    loop = asyncio.get_running_loop()
+                except RuntimeError:
+                    loop = None
+                if loop and loop.is_running():
+                    raise RuntimeError(
+                        "Cannot use async auth_token_provider in sync methods when an event loop is running. "
+                        "Use the async methods (e.g. ainvoke, astream) instead."
+                    )
+                token = asyncio.run(token)
+            return {"Authorization": f"Bearer {token}"}
+        elif self.anthropic_api_key is not None:
+            if isinstance(self.anthropic_api_key, SecretStr):
+                return {"x-api-key": self.anthropic_api_key.get_secret_value()}
+            elif isinstance(self.anthropic_api_key, str):
+                return {"x-api-key": self.anthropic_api_key}
+            else:
+                key = self.anthropic_api_key()
+                if inspect.isawaitable(key):
+                    try:
+                        loop = asyncio.get_running_loop()
+                    except RuntimeError:
+                        loop = None
+                    if loop and loop.is_running():
+                        raise RuntimeError(
+                            "Cannot use async api_key callable in sync methods when an event loop is running."
+                        )
+                    key = asyncio.run(key)
+                return {"x-api-key": key}
+        return {}
+
+    async def _aresolve_auth_headers(self) -> dict[str, str]:
+        if self.auth_token_provider is not None:
+            token = self.auth_token_provider()
+            if inspect.isawaitable(token):
+                token = await token
+            return {"Authorization": f"Bearer {token}"}
+        elif self.anthropic_api_key is not None:
+            if isinstance(self.anthropic_api_key, SecretStr):
+                return {"x-api-key": self.anthropic_api_key.get_secret_value()}
+            elif isinstance(self.anthropic_api_key, str):
+                return {"x-api-key": self.anthropic_api_key}
+            else:
+                key = self.anthropic_api_key()
+                if inspect.isawaitable(key):
+                    key = await key
+                return {"x-api-key": key}
+        return {}
+
     def _create(self, payload: dict) -> Any:
+        auth_headers = self._resolve_auth_headers()
+        if auth_headers:
+            payload["extra_headers"] = {**payload.get("extra_headers", {}), **auth_headers}
         if "betas" in payload:
             return self._client.beta.messages.create(**payload)
         return self._client.messages.create(**payload)
 
     async def _acreate(self, payload: dict) -> Any:
+        auth_headers = await self._aresolve_auth_headers()
+        if auth_headers:
+            payload["extra_headers"] = {**payload.get("extra_headers", {}), **auth_headers}
         if "betas" in payload:
             return await self._async_client.beta.messages.create(**payload)
         return await self._async_client.messages.create(**payload)

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models_auth.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models_auth.py
@@ -1,0 +1,80 @@
+import os
+import pytest
+import asyncio
+from unittest.mock import MagicMock, patch
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage
+
+def test_chat_anthropic_callable_api_key() -> None:
+    mock_key = "mock-key-from-callable"
+    def get_key() -> str:
+        return mock_key
+    
+    llm = ChatAnthropic(api_key=get_key, model="claude-3-opus-20240229")
+    
+    with patch.object(llm._client.messages, "create") as mock_create:
+        mock_message = MagicMock()
+        mock_message.text = "response"
+        mock_message.type = "text"
+        mock_response = MagicMock(content=[mock_message])
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=10)
+        mock_response.id = "msg_123"
+        mock_response.model = "claude-3-opus-20240229"
+        mock_response.role = "assistant"
+        mock_create.return_value = mock_response
+        
+        llm.invoke("Hello")
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        assert "extra_headers" in kwargs
+        assert kwargs["extra_headers"]["x-api-key"] == mock_key
+
+def test_chat_anthropic_auth_token_provider() -> None:
+    mock_token = "mock-token"
+    def get_token() -> str:
+        return mock_token
+    
+    llm = ChatAnthropic(auth_token_provider=get_token, model="claude-3-opus-20240229")
+    
+    with patch.object(llm._client.messages, "create") as mock_create:
+        mock_message = MagicMock()
+        mock_message.text = "response"
+        mock_message.type = "text"
+        mock_response = MagicMock(content=[mock_message])
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=10)
+        mock_response.id = "msg_123"
+        mock_response.model = "claude-3-opus-20240229"
+        mock_response.role = "assistant"
+        mock_create.return_value = mock_response
+
+        llm.invoke("Hello")
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        assert "extra_headers" in kwargs
+        assert kwargs["extra_headers"]["Authorization"] == f"Bearer {mock_token}"
+
+@pytest.mark.asyncio
+async def test_chat_anthropic_async_auth_token_provider() -> None:
+    mock_token = "mock-async-token"
+    async def get_token() -> str:
+        await asyncio.sleep(0.01)
+        return mock_token
+    
+    llm = ChatAnthropic(auth_token_provider=get_token, model="claude-3-opus-20240229")
+    
+    with patch.object(llm._async_client.messages, "create") as mock_create:
+        mock_message = MagicMock()
+        mock_message.text = "response"
+        mock_message.type = "text"
+        mock_response = MagicMock(content=[mock_message])
+        mock_response.usage = MagicMock(input_tokens=10, output_tokens=10)
+        mock_response.id = "msg_123"
+        mock_response.model = "claude-3-opus-20240229"
+        mock_response.role = "assistant"
+        mock_create.return_value = mock_response
+
+        await llm.ainvoke("Hello")
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        assert "extra_headers" in kwargs
+        assert kwargs["extra_headers"]["Authorization"] == f"Bearer {mock_token}"


### PR DESCRIPTION
# feat(anthropic): support callable api_key and auth_token_provider

Closes #38661

---

## Summary

This PR addresses issue #38661 by extending `ChatAnthropic` to natively support dynamic credential rotation (such as short-lived Azure Entra ID tokens), bringing parity with `ChatOpenAI`. 

### Key Changes
- **`auth_token_provider` Parameter**: Added a new parameter in `ChatAnthropic` allowing users to pass a callable (`Callable[[], str]` or `Callable[[], Awaitable[str]]`) that resolves the token to be sent in the `Authorization: Bearer <token>` header.
- **Callable `api_key`**: Extended the `api_key` parameter type to accept a `Callable` that is resolved dynamically before each request, and injected into the `x-api-key` header.
- **Async Support**: Fully supports `Awaitable` functions when using the async pathways (`ainvoke`, `astream`, etc.).
- **Per-request Injection**: Employs an internal resolution method (`_resolve_auth_headers`) that resolves the token dynamically on each `invoke`/`stream` instead of pinning the authentication key during instantiation. 

### Why is this necessary?
Long-running applications using cloud-provided token credentials encounter failures when the token expires because the underlying Anthropic SDK client pins the credentials upon initialization. This patch dynamically evaluates and injects the header per-request, keeping the credentials always fresh.

## Testing
- Unit tests added in `tests/unit_tests/test_chat_models_auth.py` validating that the provided callbacks are successfully called and the credentials properly attached via `extra_headers` before calling the Anthropic SDK.
