### PR TITLE
Add first-class retry configuration to ChatOllama 

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -50,6 +50,7 @@ from operator import itemgetter
 from typing import Any, Literal, cast
 from uuid import uuid4
 
+import httpx
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.callbacks.manager import AsyncCallbackManagerForLLMRun
 from langchain_core.exceptions import OutputParserException
@@ -737,6 +738,13 @@ class ChatOllama(BaseChatModel):
     For a full list of the params, see the [httpx documentation](https://www.python-httpx.org/api/#client).
     """
 
+    max_retries: int | None = None
+    """Maximum number of retries for client requests.
+
+    Applies to the underlying HTTP transport used by both the sync and async
+    Ollama clients. Set to `0` or `None` to disable retries.
+    """
+
     _client: Client = PrivateAttr()
     """The client to use for making requests."""
 
@@ -950,9 +958,21 @@ class ChatOllama(BaseChatModel):
         if self.sync_client_kwargs:
             sync_client_kwargs = {**sync_client_kwargs, **self.sync_client_kwargs}
 
+        if self.max_retries is not None and "transport" not in sync_client_kwargs:
+            sync_client_kwargs = {
+                **sync_client_kwargs,
+                "transport": httpx.HTTPTransport(retries=self.max_retries),
+            }
+
         async_client_kwargs = client_kwargs
         if self.async_client_kwargs:
             async_client_kwargs = {**async_client_kwargs, **self.async_client_kwargs}
+
+        if self.max_retries is not None and "transport" not in async_client_kwargs:
+            async_client_kwargs = {
+                **async_client_kwargs,
+                "transport": httpx.AsyncHTTPTransport(retries=self.max_retries),
+            }
 
         self._client = Client(host=cleaned_url, **sync_client_kwargs)
         self._async_client = AsyncClient(host=cleaned_url, **async_client_kwargs)

--- a/libs/partners/ollama/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/ollama/tests/unit_tests/test_chat_models.py
@@ -138,6 +138,32 @@ def test_validate_model_on_init(mock_validate_model: Any) -> None:
     mock_validate_model.assert_not_called()
 
 
+def test_max_retries_is_a_constructor_field() -> None:
+    """Test that `max_retries` is retained as a first-class model field."""
+    assert "max_retries" in ChatOllama.model_fields
+
+    with (
+        patch("langchain_ollama.chat_models.httpx.HTTPTransport") as mock_transport,
+        patch("langchain_ollama.chat_models.httpx.AsyncHTTPTransport") as mock_async_transport,
+        patch("langchain_ollama.chat_models.Client") as mock_client_class,
+        patch("langchain_ollama.chat_models.AsyncClient") as mock_async_client_class,
+    ):
+        sync_transport = MagicMock(name="sync_transport")
+        async_transport = MagicMock(name="async_transport")
+        mock_transport.return_value = sync_transport
+        mock_async_transport.return_value = async_transport
+        mock_client_class.return_value = MagicMock()
+        mock_async_client_class.return_value = AsyncMock()
+
+        llm = ChatOllama(model=MODEL_NAME, max_retries=3)
+
+        assert llm.max_retries == 3
+        mock_transport.assert_called_once_with(retries=3)
+        mock_async_transport.assert_called_once_with(retries=3)
+        assert mock_client_class.call_args.kwargs["transport"] is sync_transport
+        assert mock_async_client_class.call_args.kwargs["transport"] is async_transport
+
+
 @pytest.mark.parametrize(
     ("input_string", "expected_output"),
     [


### PR DESCRIPTION
#38045

This PR adds support for a constructor-level max_retries parameter to ChatOllama, bringing its behavior in line with other LangChain chat integrations.

Changes
Added max_retries as a first-class model field in langchain_ollama/chat_models.py.
Applied the retry policy to both synchronous and asynchronous Ollama client calls.
Added unit tests covering the new behavior in tests/unit_tests/test_chat_models.py.

This enables provider-agnostic retry configuration while preserving the existing API and aligns ChatOllama with the retry semantics used by other LangChain chat models.

### Verification

- ✅ Ran `make format` and `make lint` in `libs/partners/ollama`
- ✅ Added unit tests covering constructor-level `max_retries` behavior
- ✅ Verified `max_retries` is retained as a `ChatOllama` model field
- ✅ Confirmed retry policy is applied to both synchronous and asynchronous client calls
- ✅ Backward compatible — existing code without `max_retries` continues to work

