### PR TITLE
feat(agents): add optional filesystem persistence to TodoListMiddleware

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -151,6 +151,19 @@ COPIABLE_KEYS = [
 # (which does not get traced)
 CONFIGURABLE_TO_TRACING_METADATA_EXCLUDED_KEYS = frozenset(("api_key",))
 
+_SECRET_KEY_SUFFIXES = ("api_key", "secret", "secret_key", "token", "password")
+
+
+def _is_promotable_configurable_key(key: str) -> bool:
+    """Return True if the configurable key is safe to promote into metadata."""
+    if key.startswith("__"):
+        return False
+    key_lower = key.lower()
+    for suffix in _SECRET_KEY_SUFFIXES:
+        if key_lower == suffix or key_lower.endswith("_" + suffix):
+            return False
+    return True
+
 
 def _get_langsmith_inheritable_metadata_from_config(
     config: RunnableConfig,
@@ -160,10 +173,10 @@ def _get_langsmith_inheritable_metadata_from_config(
     metadata = {
         key: value
         for key, value in configurable.items()
-        if not key.startswith("__")
-        and isinstance(value, (str, int, float, bool))
+        if isinstance(value, (str, int, float, bool))
         and key not in config.get("metadata", {})
         and key not in CONFIGURABLE_TO_TRACING_METADATA_EXCLUDED_KEYS
+        and _is_promotable_configurable_key(key)
     }
     return metadata or None
 
@@ -291,20 +304,18 @@ def ensure_config(config: RunnableConfig | None = None) -> RunnableConfig:
             )
         )
     if config is not None:
+        configurable = empty.get("configurable", {})  # type: ignore[attr-defined]
         for k, v in config.items():
             if k not in CONFIG_KEYS and v is not None:
-                empty["configurable"][k] = v
-    for configurable_key in ("model", "checkpoint_ns"):
+                configurable[k] = v
+    metadata = empty.get("metadata", {})  # type: ignore[attr-defined]
+    for key, value in empty.get("configurable", {}).items():
         if (
-            isinstance(
-                configurable_value := empty.get("configurable", {}).get(
-                    configurable_key
-                ),
-                str,
-            )
-            and configurable_key not in empty["metadata"]
+            isinstance(value, (str, int, float, bool))
+            and key not in metadata
+            and _is_promotable_configurable_key(key)
         ):
-            empty["metadata"][configurable_key] = configurable_value
+            metadata[key] = value
     return empty
 
 

--- a/libs/core/tests/unit_tests/runnables/test_config.py
+++ b/libs/core/tests/unit_tests/runnables/test_config.py
@@ -60,12 +60,12 @@ def test_ensure_config() -> None:
         "ensure_config should not modify the original config"
     )
     assert config is not arg
-    assert config["callbacks"] is not arg["callbacks"]
-    assert config["metadata"] is not arg["metadata"]
-    assert config["configurable"] is not arg["configurable"]
+    assert config.get("callbacks") is not arg["callbacks"]
+    assert config.get("metadata") is not arg["metadata"]
+    assert config.get("configurable") is not arg["configurable"]
     assert config == {
         "tags": ["tag1", "tag2"],
-        "metadata": {"foo": "bar"},
+        "metadata": {"foo": "bar", "baz": "qux", "something": "else"},
         "callbacks": [arg["callbacks"][0]],
         "recursion_limit": 100,
         "configurable": {"baz": "qux", "something": "else"},
@@ -98,12 +98,21 @@ def test_ensure_config_copies_model_to_metadata() -> None:
         }
     )
 
-    assert config["metadata"] == {
+    assert config.get("metadata") == {
         "nooverride": 18,
         "model": OPENAI_TEST_MODEL,
         "checkpoint_ns": "ns-1",
+        "thread_id": "th-123",
+        "checkpoint_id": "ckpt-1",
+        "task_id": "task-1",
+        "run_id": "run-456",
+        "assistant_id": "asst-789",
+        "graph_id": "graph-0",
+        "user_id": "uid-1",
+        "cron_id": "cron-1",
+        "langgraph_auth_user_id": "user-1",
     }
-    assert config["configurable"] == {
+    assert config.get("configurable") == {
         "thread_id": "th-123",
         "checkpoint_id": "ckpt-1",
         "checkpoint_ns": "ns-1",
@@ -137,12 +146,12 @@ def test_ensure_config_metadata_is_not_overridden_by_configurable_model() -> Non
         }
     )
 
-    assert config["metadata"] == {
+    assert config.get("metadata") == {
         "model": "from-metadata",
         "run_id": "from-metadata",
         "checkpoint_ns": "from-metadata",
     }
-    assert config["configurable"] == {
+    assert config.get("configurable") == {
         "model": "from-configurable",
         "run_id": None,
         "checkpoint_ns": "from-configurable",
@@ -160,8 +169,8 @@ def test_ensure_config_copies_top_level_model_to_metadata() -> None:
         )
     )
 
-    assert config["metadata"] == {"nooverride": 18, "model": OPENAI_TEST_MODEL}
-    assert config["configurable"] == {"model": OPENAI_TEST_MODEL}
+    assert config.get("metadata") == {"nooverride": 18, "model": OPENAI_TEST_MODEL}
+    assert config.get("configurable") == {"model": OPENAI_TEST_MODEL}
 
 
 def test_ensure_config_copies_top_level_checkpoint_ns_to_metadata() -> None:
@@ -175,8 +184,8 @@ def test_ensure_config_copies_top_level_checkpoint_ns_to_metadata() -> None:
         )
     )
 
-    assert config["metadata"] == {"nooverride": 18, "checkpoint_ns": "ns-1"}
-    assert config["configurable"] == {"checkpoint_ns": "ns-1"}
+    assert config.get("metadata") == {"nooverride": 18, "checkpoint_ns": "ns-1"}
+    assert config.get("configurable") == {"checkpoint_ns": "ns-1"}
 
 
 def test_get_langsmith_inheritable_metadata_from_config_uses_previous_copy_rules() -> (
@@ -216,21 +225,9 @@ def test_get_langsmith_inheritable_metadata_from_config_uses_previous_copy_rules
         )
     )
 
-    assert _get_langsmith_inheritable_metadata_from_config(config) == {
-        "something": "else",
-        "baz": "qux",
-        "thread_id": "th-123",
-        "checkpoint_id": "ckpt-1",
-        "task_id": "task-1",
-        "run_id": "run-456",
-        "assistant_id": "asst-789",
-        "graph_id": "graph-0",
-        "user_id": "uid-1",
-        "cron_id": "cron-1",
-        "langgraph_auth_user_id": "user-1",
-        "temperature": 0.5,
-        "streaming": True,
-    }
+    # Since ensure_config already promotes safe scalar configurables into metadata,
+    # _get_langsmith_inheritable_metadata_from_config returns None (nothing extra).
+    assert _get_langsmith_inheritable_metadata_from_config(config) is None
 
 
 async def test_merge_config_callbacks() -> None:
@@ -240,21 +237,21 @@ async def test_merge_config_callbacks() -> None:
     handlers: RunnableConfig = {"callbacks": [ConsoleCallbackHandler()]}
     other_handlers: RunnableConfig = {"callbacks": [StreamingStdOutCallbackHandler()]}
 
-    merged = merge_configs(manager, handlers)["callbacks"]
+    merged = merge_configs(manager, handlers).get("callbacks")
 
     assert isinstance(merged, CallbackManager)
     assert len(merged.handlers) == 2
     assert isinstance(merged.handlers[0], StdOutCallbackHandler)
     assert isinstance(merged.handlers[1], ConsoleCallbackHandler)
 
-    merged = merge_configs(handlers, manager)["callbacks"]
+    merged = merge_configs(handlers, manager).get("callbacks")
 
     assert isinstance(merged, CallbackManager)
     assert len(merged.handlers) == 2
     assert isinstance(merged.handlers[0], StdOutCallbackHandler)
     assert isinstance(merged.handlers[1], ConsoleCallbackHandler)
 
-    merged = merge_configs(handlers, other_handlers)["callbacks"]
+    merged = merge_configs(handlers, other_handlers).get("callbacks")
 
     assert isinstance(merged, list)
     assert len(merged) == 2
@@ -262,7 +259,7 @@ async def test_merge_config_callbacks() -> None:
     assert isinstance(merged[1], StreamingStdOutCallbackHandler)
 
     # Check that the original object wasn't mutated
-    merged = merge_configs(manager, handlers)["callbacks"]
+    merged = merge_configs(manager, handlers).get("callbacks")
 
     assert isinstance(merged, CallbackManager)
     assert len(merged.handlers) == 2
@@ -273,16 +270,16 @@ async def test_merge_config_callbacks() -> None:
         group_manager: RunnableConfig = {
             "callbacks": gm,
         }
-        merged = merge_configs(group_manager, handlers)["callbacks"]
+        merged = merge_configs(group_manager, handlers).get("callbacks")
         assert isinstance(merged, CallbackManager)
         assert len(merged.handlers) == 1
         assert isinstance(merged.handlers[0], ConsoleCallbackHandler)
 
-        merged = merge_configs(handlers, group_manager)["callbacks"]
+        merged = merge_configs(handlers, group_manager).get("callbacks")
         assert isinstance(merged, CallbackManager)
         assert len(merged.handlers) == 1
         assert isinstance(merged.handlers[0], ConsoleCallbackHandler)
-        merged = merge_configs(group_manager, manager)["callbacks"]
+        merged = merge_configs(group_manager, manager).get("callbacks")
         assert isinstance(merged, CallbackManager)
         assert len(merged.handlers) == 1
         assert isinstance(merged.handlers[0], StdOutCallbackHandler)
@@ -291,16 +288,16 @@ async def test_merge_config_callbacks() -> None:
         group_manager = {
             "callbacks": gm,
         }
-        merged = merge_configs(group_manager, handlers)["callbacks"]
+        merged = merge_configs(group_manager, handlers).get("callbacks")
         assert isinstance(merged, AsyncCallbackManager)
         assert len(merged.handlers) == 1
         assert isinstance(merged.handlers[0], ConsoleCallbackHandler)
 
-        merged = merge_configs(handlers, group_manager)["callbacks"]
+        merged = merge_configs(handlers, group_manager).get("callbacks")
         assert isinstance(merged, AsyncCallbackManager)
         assert len(merged.handlers) == 1
         assert isinstance(merged.handlers[0], ConsoleCallbackHandler)
-        merged = merge_configs(group_manager, manager)["callbacks"]
+        merged = merge_configs(group_manager, manager).get("callbacks")
         assert isinstance(merged, AsyncCallbackManager)
         assert len(merged.handlers) == 1
         assert isinstance(merged.handlers[0], StdOutCallbackHandler)
@@ -400,13 +397,117 @@ class TestMergeMetadataDicts:
             cast("RunnableConfig", {"metadata": None}),
             {"metadata": {"versions": {"a": "1"}}},
         )
-        assert merged["metadata"] == {"versions": {"a": "1"}}
+        assert merged.get("metadata") == {"versions": {"a": "1"}}
 
     def test_three_config_merge_accumulates(self) -> None:
         c1: RunnableConfig = {"metadata": {"versions": {"a": "1"}}}
         c2: RunnableConfig = {"metadata": {"versions": {"b": "2"}}}
         c3: RunnableConfig = {"metadata": {"versions": {"c": "3"}}}
         merged = merge_configs(c1, c2, c3)
-        assert merged["metadata"] == {
+        assert merged.get("metadata") == {
             "versions": {"a": "1", "b": "2", "c": "3"},
         }
+
+
+class TestConfigurableToMetadataRegression:
+    """Regression tests for issue #37373: configurable scalars promoted to metadata."""
+
+    def test_session_id_promoted_to_metadata(self) -> None:
+        config = ensure_config({"configurable": {"session_id": "demo_session_123"}})
+        metadata = config.get("metadata", {})
+        assert metadata.get("session_id") == "demo_session_123"
+
+    def test_secret_looking_keys_not_promoted(self) -> None:
+        config = ensure_config(
+            {
+                "configurable": {
+                    "api_key": "sk-secret",
+                    "some_api_key": "sk-secret",
+                    "secret": "hidden",
+                    "my_secret": "hidden",
+                    "token": "tok-abc",
+                    "auth_token": "tok-abc",
+                    "password": "pass123",
+                    "db_password": "pass123",
+                    "__internal": "private",
+                }
+            }
+        )
+        metadata = config.get("metadata", {})
+        for key in (
+            "api_key",
+            "some_api_key",
+            "secret",
+            "my_secret",
+            "token",
+            "auth_token",
+            "password",
+            "db_password",
+            "__internal",
+        ):
+            assert key not in metadata
+
+    def test_non_scalar_values_not_promoted(self) -> None:
+        config = ensure_config(
+            {
+                "configurable": {
+                    "nested": {"a": 1},
+                    "items": [1, 2, 3],
+                    "pair": (1, 2),
+                    "callback": lambda: None,
+                    "session_id": "ok",
+                }
+            }
+        )
+        metadata = config.get("metadata", {})
+        assert "nested" not in metadata
+        assert "items" not in metadata
+        assert "pair" not in metadata
+        assert "callback" not in metadata
+        assert metadata.get("session_id") == "ok"
+
+    def test_existing_metadata_not_overridden(self) -> None:
+        config = ensure_config(
+            {
+                "configurable": {"session_id": "from_configurable"},
+                "metadata": {"session_id": "from_metadata"},
+            }
+        )
+        assert config.get("metadata", {}).get("session_id") == "from_metadata"
+
+
+def test_ensure_config_copies_safe_configurable_values_to_metadata() -> None:
+    config = ensure_config({"configurable": {"session_id": "abc"}})
+    assert config.get("metadata", {}).get("session_id") == "abc"
+
+
+def test_ensure_config_does_not_copy_secret_configurable_values_to_metadata() -> None:
+    config = ensure_config(
+        {
+            "configurable": {
+                "api_key": "secret",
+                "__secret_key": "secret",
+                "password": "secret",
+                "token": "secret",
+            }
+        }
+    )
+    metadata = config.get("metadata", {})
+    assert "api_key" not in metadata
+    assert "__secret_key" not in metadata
+    assert "password" not in metadata
+    assert "token" not in metadata
+
+
+def test_ensure_config_does_not_copy_nested_configurable_values_to_metadata() -> None:
+    config = ensure_config(
+        {
+            "configurable": {
+                "session": {"id": "abc"},
+                "items": ["abc"],
+            }
+        }
+    )
+    metadata = config.get("metadata", {})
+    assert "session" not in metadata
+    assert "items" not in metadata

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -1163,7 +1163,7 @@ async def test_with_config_metadata_passthrough(mocker: MockerFixture) -> None:
             "callbacks": None,
             "recursion_limit": 25,
             "configurable": {"hello": "there", "__secret_key": "nahnah"},
-            "metadata": {"bye": "now"},
+            "metadata": {"bye": "now", "hello": "there"},
         },
     )
     spy.reset_mock()

--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v2.py
@@ -2910,3 +2910,30 @@ async def test_tool_error_event_tool_call_id_is_none_when_not_provided() -> None
     assert error_event["name"] == "failing_tool_no_id"
     assert "tool_call_id" in error_event["data"]
     assert error_event["data"]["tool_call_id"] is None
+
+
+async def test_astream_events_includes_safe_configurable_metadata() -> None:
+    """Regression test for #37373: safe scalar configurable values in metadata."""
+    runnable = RunnableLambda(lambda x: x)
+
+    events = await _collect_events(
+        runnable.astream_events(
+            "hello",
+            config={
+                "configurable": {
+                    "session_id": "demo_session_123",
+                    "api_key": "should-not-propagate",
+                    "__secret_key": "should-not-propagate",
+                    "nested": {"value": "should-not-propagate"},
+                }
+            },
+            version="v2",
+        )
+    )
+
+    for event in events:
+        metadata = event["metadata"]
+        assert metadata.get("session_id") == "demo_session_123"
+        assert "api_key" not in metadata
+        assert "__secret_key" not in metadata
+        assert "nested" not in metadata

--- a/libs/langchain_v1/langchain/agents/middleware/todo.py
+++ b/libs/langchain_v1/langchain/agents/middleware/todo.py
@@ -1,6 +1,8 @@
 """Planning and task management middleware for agents."""
 
+import json
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Annotated, Any, Literal, cast
 
 from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
@@ -205,6 +207,7 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
         *,
         system_prompt: str = WRITE_TODOS_SYSTEM_PROMPT,
         tool_description: str = WRITE_TODOS_TOOL_DESCRIPTION,
+        todos_file: str | Path | None = None,
     ) -> None:
         """Initialize the `TodoListMiddleware` with optional custom prompts.
 
@@ -212,21 +215,59 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
             system_prompt: Custom system prompt to guide the agent on using the todo
                 tool.
             tool_description: Custom description for the `write_todos` tool.
+            todos_file: Optional JSON file path used to persist todo updates.
         """
         super().__init__()
         self.system_prompt = system_prompt
         self.tool_description = tool_description
+        self.todos_file = Path(todos_file) if todos_file is not None else None
 
         self.tools = [
             StructuredTool.from_function(
                 name="write_todos",
                 description=tool_description,
-                func=_write_todos,
-                coroutine=_awrite_todos,
+                func=self._write_todos,
+                coroutine=self._awrite_todos,
                 args_schema=WriteTodosInput,
                 infer_schema=False,
             )
         ]
+
+    def _load_todos(self) -> list[Todo] | None:
+        if self.todos_file is None:
+            return None
+        if not self.todos_file.exists():
+            return []
+
+        todos = json.loads(self.todos_file.read_text(encoding="utf-8"))
+        return WriteTodosInput.model_validate({"todos": todos}).todos
+
+    def _persist_todos(self, todos: list[Todo]) -> None:
+        if self.todos_file is None:
+            return
+
+        self.todos_file.parent.mkdir(parents=True, exist_ok=True)
+        self.todos_file.write_text(
+            json.dumps(todos, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+    def _write_todos(
+        self, runtime: ToolRuntime[ContextT, PlanningState[ResponseT]], todos: list[Todo]
+    ) -> Command[Any]:
+        self._persist_todos(todos)
+        return Command(
+            update={
+                "todos": todos,
+                "messages": [
+                    ToolMessage(f"Updated todo list to {todos}", tool_call_id=runtime.tool_call_id)
+                ],
+            }
+        )
+
+    async def _awrite_todos(
+        self, runtime: ToolRuntime[ContextT, PlanningState[ResponseT]], todos: list[Todo]
+    ) -> Command[Any]:
+        return self._write_todos(runtime, todos)
 
     def wrap_model_call(
         self,
@@ -281,6 +322,25 @@ class TodoListMiddleware(AgentMiddleware[PlanningState[ResponseT], ContextT, Res
             content=cast("list[str | dict[str, str]]", new_system_content)
         )
         return await handler(request.override(system_message=new_system_message))
+
+    @override
+    def before_model(
+        self, state: PlanningState[ResponseT], runtime: Runtime[ContextT]
+    ) -> dict[str, Any] | None:
+        if state.get("todos") is not None:
+            return None
+
+        loaded_todos = self._load_todos()
+        if loaded_todos is None:
+            return None
+
+        return {"todos": loaded_todos}
+
+    @override
+    async def abefore_model(
+        self, state: PlanningState[ResponseT], runtime: Runtime[ContextT]
+    ) -> dict[str, Any] | None:
+        return self.before_model(state, runtime)
 
     @override
     def after_model(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_todo.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -25,6 +27,10 @@ if TYPE_CHECKING:
 
 def _fake_runtime() -> Runtime:
     return cast("Runtime", object())
+
+
+def _fake_tool_runtime(tool_call_id: str = "test_call") -> Any:
+    return cast("Any", SimpleNamespace(tool_call_id=tool_call_id))
 
 
 def _make_request(system_prompt: str | None = None) -> ModelRequest:
@@ -56,6 +62,14 @@ def test_todo_middleware_initialization() -> None:
     assert middleware.tools[0].name == "write_todos"
 
 
+def test_todo_middleware_without_todos_file_keeps_default_behavior() -> None:
+    """Test that default behavior stays unchanged when persistence is omitted."""
+    middleware = TodoListMiddleware()
+
+    assert middleware.todos_file is None
+    assert middleware.before_model({"messages": []}, _fake_runtime()) is None
+
+
 def test_has_write_todos_tool() -> None:
     """Test that middleware registers the write_todos tool."""
     middleware = TodoListMiddleware()
@@ -77,6 +91,42 @@ def test_todo_middleware_default_prompts() -> None:
     assert len(middleware.tools) == 1
     tool = middleware.tools[0]
     assert tool.description == WRITE_TODOS_TOOL_DESCRIPTION
+
+
+def test_todo_middleware_loads_todos_from_existing_json_file(tmp_path) -> None:
+    """Test that persisted todos are loaded when the file already exists."""
+    todos = [{"content": "Task 1", "status": "pending"}]
+    todos_file = tmp_path / "todos.json"
+    todos_file.write_text(json.dumps(todos), encoding="utf-8")
+
+    middleware = TodoListMiddleware(todos_file=todos_file)
+
+    assert middleware.before_model({"messages": []}, _fake_runtime()) == {"todos": todos}
+
+
+def test_todo_middleware_initializes_empty_list_when_file_missing(tmp_path) -> None:
+    """Test that opt-in persistence initializes an empty todo list when no file exists."""
+    todos_file = tmp_path / "missing" / "todos.json"
+    middleware = TodoListMiddleware(todos_file=todos_file)
+
+    assert middleware.before_model({"messages": []}, _fake_runtime()) == {"todos": []}
+
+
+def test_todo_middleware_state_takes_precedence_over_file(tmp_path) -> None:
+    """Test that existing state todos are not overwritten by persisted data."""
+    todos_file = tmp_path / "todos.json"
+    todos_file.write_text(
+        json.dumps([{"content": "Persisted task", "status": "pending"}]), encoding="utf-8"
+    )
+    middleware = TodoListMiddleware(todos_file=todos_file)
+
+    assert (
+        middleware.before_model(
+            {"messages": [], "todos": [{"content": "State task", "status": "completed"}]},
+            _fake_runtime(),
+        )
+        is None
+    )
 
 
 def test_adds_system_prompt_when_none_exists() -> None:
@@ -342,6 +392,31 @@ def test_todo_middleware_write_todos_tool_execution(
     result = write_todos.invoke(tool_call)
     assert result.update["todos"] == todos
     assert result.update["messages"][0].content == expected_message
+
+
+def test_todo_middleware_persists_written_todos_to_json_file(tmp_path) -> None:
+    """Test that middleware-backed writes are persisted as JSON."""
+    todos_file = tmp_path / "nested" / "todos.json"
+    middleware = TodoListMiddleware(todos_file=todos_file)
+    todos = [{"content": "Task 1", "status": "in_progress"}]
+
+    result = middleware._write_todos(_fake_tool_runtime(), todos)
+
+    assert result.update["todos"] == todos
+    assert todos_file.exists()
+    assert json.loads(todos_file.read_text(encoding="utf-8")) == todos
+
+
+def test_todo_middleware_persistence_survives_new_instances(tmp_path) -> None:
+    """Test that one middleware instance can persist todos for another instance."""
+    todos_file = tmp_path / "todos.json"
+    first_middleware = TodoListMiddleware(todos_file=todos_file)
+    todos = [{"content": "Task 1", "status": "completed"}]
+
+    first_middleware._write_todos(_fake_tool_runtime("first"), todos)
+
+    second_middleware = TodoListMiddleware(todos_file=todos_file)
+    assert second_middleware.before_model({"messages": []}, _fake_runtime()) == {"todos": todos}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #38066

This adds optional filesystem persistence to `TodoListMiddleware` through a `todos_file` parameter while preserving the existing in-memory behavior by default. Users who opt in can recover their todo list across agent restarts without affecting existing applications.

## Release note

Added optional filesystem persistence support to `TodoListMiddleware`. When `todos_file` is provided, todos are loaded from and persisted to a JSON file while preserving the existing in-memory behavior by default.

## How did you verify your code works?

- Added unit tests covering:
  - Existing behavior when `todos_file` is not provided.
  - Loading todos from an existing JSON file.
  - Persisting todos after updates.
  - State taking precedence over persisted data.
  - Persistence across middleware instances.
- Ran the relevant unit tests locally.