### PR TITLE
fix(langchain): bound Python file search regex execution

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_file_search_worker.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_file_search_worker.py
@@ -1,0 +1,177 @@
+"""Standalone worker for the Python grep fallback in `file_search`.
+
+`FilesystemFileSearchMiddleware._python_search` executes this module in a
+subprocess so the search is bounded by a wall-clock timeout. A user-controlled
+regex can trigger catastrophic backtracking (ReDoS) in `re`, which cannot be
+interrupted in-process; running the search in a child process lets the parent
+kill it when the timeout expires — mirroring how `_ripgrep_search` already
+bounds `rg`.
+
+Because the child runs this file as a plain script (not as a package import),
+this module must only import from the standard library and must not use
+relative imports. Keeping it free of `langchain` imports also keeps the
+per-search interpreter startup cheap.
+
+Protocol: the parent writes one JSON object to stdin with keys `pattern`,
+`base_path`, `root_path`, `include`, and `max_file_size_bytes`; the worker
+writes a JSON object mapping virtual paths to `[line_number, line_text]`
+pairs to stdout.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def _is_within_root(candidate: Path, root: Path) -> bool:
+    """Return True iff `candidate` resolves to a path inside `root` (symlinks resolved).
+
+    Args:
+        candidate: The path to check. It is resolved (following symlinks and
+            normalizing `..`) before the containment check.
+        root: The allowed root directory. Also resolved before comparison.
+
+    Returns:
+        `True` if the fully resolved `candidate` lies inside the resolved `root`,
+        using path-segment boundaries; `False` otherwise (including on resolution
+        errors).
+    """
+    try:
+        return candidate.resolve().is_relative_to(root.resolve())
+    except (OSError, ValueError):
+        return False
+
+
+def _expand_include_patterns(pattern: str) -> list[str] | None:
+    """Expand brace patterns like `*.{py,pyi}` into a list of globs."""
+    if "}" in pattern and "{" not in pattern:
+        return None
+
+    expanded: list[str] = []
+
+    def _expand(current: str) -> None:
+        start = current.find("{")
+        if start == -1:
+            expanded.append(current)
+            return
+
+        end = current.find("}", start)
+        if end == -1:
+            raise ValueError
+
+        prefix = current[:start]
+        suffix = current[end + 1 :]
+        inner = current[start + 1 : end]
+        if not inner:
+            raise ValueError
+
+        for option in inner.split(","):
+            _expand(prefix + option + suffix)
+
+    try:
+        _expand(pattern)
+    except ValueError:
+        return None
+
+    return expanded
+
+
+def _match_include_pattern(basename: str, pattern: str) -> bool:
+    """Return True if the basename matches the include pattern."""
+    expanded = _expand_include_patterns(pattern)
+    if not expanded:
+        return False
+
+    return any(fnmatch.fnmatch(basename, candidate) for candidate in expanded)
+
+
+def _search_files(
+    *,
+    pattern: str,
+    base_path: str,
+    root_path: str,
+    include: str | None,
+    max_file_size_bytes: int,
+) -> dict[str, list[tuple[int, str]]]:
+    """Search files under `base_path` for regex matches, line by line.
+
+    Args:
+        pattern: Regular expression applied to each line.
+        base_path: Directory to walk. Already validated by the parent to lie
+            inside `root_path`.
+        root_path: Resolved search root, used for containment checks and to
+            build virtual paths.
+        include: Optional glob filter applied to file basenames.
+        max_file_size_bytes: Files larger than this are skipped.
+
+    Returns:
+        Mapping of virtual file path to `(line_number, line_text)` matches.
+    """
+    regex = re.compile(pattern)
+    root = Path(root_path)
+    results: dict[str, list[tuple[int, str]]] = {}
+
+    # Walk directory tree without following symlinked directories so traversal
+    # cannot leave the root via a symlinked subdirectory.
+    for walk_root, _dirs, files in os.walk(base_path, followlinks=False):
+        for name in files:
+            file_path = Path(walk_root) / name
+
+            # Re-check containment after resolving so an in-root symlinked file
+            # pointing outside the root is never read.
+            if not _is_within_root(file_path, root):
+                continue
+
+            if not file_path.is_file():
+                continue
+
+            # Check include filter
+            if include and not _match_include_pattern(file_path.name, include):
+                continue
+
+            # Skip files that are too large, and files that disappear or become
+            # inaccessible mid-walk.
+            try:
+                if file_path.stat().st_size > max_file_size_bytes:
+                    continue
+            except OSError:
+                continue
+
+            try:
+                content = file_path.read_text()
+            except (UnicodeDecodeError, PermissionError):
+                continue
+
+            # Search content
+            for line_num, line in enumerate(content.splitlines(), 1):
+                if regex.search(line):
+                    virtual_path = "/" + str(file_path.relative_to(root))
+                    if virtual_path not in results:
+                        results[virtual_path] = []
+                    results[virtual_path].append((line_num, line))
+
+    return results
+
+
+def main() -> None:
+    """Run one search request read from stdin and write results to stdout."""
+    request = json.load(sys.stdin)
+    results = _search_files(
+        pattern=request["pattern"],
+        base_path=request["base_path"],
+        root_path=request["root_path"],
+        include=request["include"],
+        max_file_size_bytes=request["max_file_size_bytes"],
+    )
+    # Default `ensure_ascii` keeps the payload pure ASCII, so no stream
+    # encoding configuration is needed on either side of the pipe.
+    json.dump(results, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/langchain_v1/langchain/agents/middleware/file_search.py
+++ b/libs/langchain_v1/langchain/agents/middleware/file_search.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 import fnmatch
 import json
 import operator
-import os
 import re
 import subprocess
+import sys
 from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
@@ -19,60 +19,14 @@ from typing import Literal
 
 from langchain_core.tools import tool
 
+from langchain.agents.middleware._file_search_worker import (
+    _expand_include_patterns,
+    _is_within_root,
+)
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ResponseT
 
-
-def _is_within_root(candidate: Path, root: Path) -> bool:
-    """Return True iff `candidate` resolves to a path inside `root` (symlinks resolved).
-
-    Args:
-        candidate: The path to check. It is resolved (following symlinks and
-            normalizing `..`) before the containment check.
-        root: The allowed root directory. Also resolved before comparison.
-
-    Returns:
-        `True` if the fully resolved `candidate` lies inside the resolved `root`,
-        using path-segment boundaries; `False` otherwise (including on resolution
-        errors).
-    """
-    try:
-        return candidate.resolve().is_relative_to(root.resolve())
-    except (OSError, ValueError):
-        return False
-
-
-def _expand_include_patterns(pattern: str) -> list[str] | None:
-    """Expand brace patterns like `*.{py,pyi}` into a list of globs."""
-    if "}" in pattern and "{" not in pattern:
-        return None
-
-    expanded: list[str] = []
-
-    def _expand(current: str) -> None:
-        start = current.find("{")
-        if start == -1:
-            expanded.append(current)
-            return
-
-        end = current.find("}", start)
-        if end == -1:
-            raise ValueError
-
-        prefix = current[:start]
-        suffix = current[end + 1 :]
-        inner = current[start + 1 : end]
-        if not inner:
-            raise ValueError
-
-        for option in inner.split(","):
-            _expand(prefix + option + suffix)
-
-    try:
-        _expand(pattern)
-    except ValueError:
-        return None
-
-    return expanded
+_SEARCH_TIMEOUT_SECONDS = 30
+_PYTHON_SEARCH_WORKER_PATH = Path(__file__).with_name("_file_search_worker.py")
 
 
 def _is_valid_include_pattern(pattern: str) -> bool:
@@ -94,15 +48,6 @@ def _is_valid_include_pattern(pattern: str) -> bool:
         return False
 
     return True
-
-
-def _match_include_pattern(basename: str, pattern: str) -> bool:
-    """Return True if the basename matches the include pattern."""
-    expanded = _expand_include_patterns(pattern)
-    if not expanded:
-        return False
-
-    return any(fnmatch.fnmatch(basename, candidate) for candidate in expanded)
 
 
 class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
@@ -315,7 +260,7 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
                 cmd,
                 capture_output=True,
                 text=True,
-                timeout=30,
+                timeout=_SEARCH_TIMEOUT_SECONDS,
                 check=False,
             )
         except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -349,7 +294,14 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
     def _python_search(
         self, pattern: str, base_path: str, include: str | None
     ) -> dict[str, list[tuple[int, str]]]:
-        """Search using Python regex (fallback)."""
+        """Search using Python regex (fallback).
+
+        The search itself runs in a worker subprocess (`_file_search_worker.py`)
+        bounded by a wall-clock timeout, because a user-controlled regex can
+        trigger catastrophic backtracking (ReDoS) in `re` that cannot be
+        interrupted in-process. On timeout the worker is killed and no results
+        are returned.
+        """
         try:
             base_full = self._validate_and_resolve_path(base_path)
         except ValueError:
@@ -358,45 +310,45 @@ class FilesystemFileSearchMiddleware(AgentMiddleware[AgentState[ResponseT], Cont
         if not base_full.exists():
             return {}
 
-        regex = re.compile(pattern)
-        results: dict[str, list[tuple[int, str]]] = {}
+        request = json.dumps(
+            {
+                "pattern": pattern,
+                "base_path": str(base_full),
+                "root_path": str(self.root_path),
+                "include": include,
+                "max_file_size_bytes": self.max_file_size_bytes,
+            }
+        )
 
-        # Walk directory tree without following symlinked directories so traversal
-        # cannot leave the root via a symlinked subdirectory.
-        for walk_root, _dirs, files in os.walk(base_full, followlinks=False):
-            for name in files:
-                file_path = Path(walk_root) / name
+        # `-I` (isolated mode) is required: it keeps the worker's directory off
+        # `sys.path`, where the sibling `types.py` module would shadow the
+        # stdlib `types` module and break the child's stdlib imports.
+        try:
+            result = subprocess.run(  # noqa: S603
+                [sys.executable, "-I", str(_PYTHON_SEARCH_WORKER_PATH)],
+                input=request,
+                capture_output=True,
+                text=True,
+                timeout=_SEARCH_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            # `subprocess.run` kills the worker on timeout, so a runaway regex
+            # cannot outlive this call.
+            return {}
 
-                # Re-check containment after resolving so an in-root symlinked file
-                # pointing outside the root is never read.
-                if not _is_within_root(file_path, self.root_path):
-                    continue
+        if result.returncode != 0:
+            return {}
 
-                if not file_path.is_file():
-                    continue
+        try:
+            raw = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return {}
 
-                # Check include filter
-                if include and not _match_include_pattern(file_path.name, include):
-                    continue
-
-                # Skip files that are too large
-                if file_path.stat().st_size > self.max_file_size_bytes:
-                    continue
-
-                try:
-                    content = file_path.read_text()
-                except (UnicodeDecodeError, PermissionError):
-                    continue
-
-                # Search content
-                for line_num, line in enumerate(content.splitlines(), 1):
-                    if regex.search(line):
-                        virtual_path = "/" + str(file_path.relative_to(self.root_path))
-                        if virtual_path not in results:
-                            results[virtual_path] = []
-                        results[virtual_path].append((line_num, line))
-
-        return results
+        return {
+            path: [(line_num, line_text) for line_num, line_text in matches]
+            for path, matches in raw.items()
+        }
 
     @staticmethod
     def _format_grep_results(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_file_search.py
@@ -1,18 +1,22 @@
 """Unit tests for file search middleware."""
 
 import os
+import subprocess
+import time
 from pathlib import Path
 from typing import Any
 
 import pytest
 from langchain_core.tools import StructuredTool
 
-from langchain.agents.middleware.file_search import (
-    FilesystemFileSearchMiddleware,
+from langchain.agents.middleware._file_search_worker import (
     _expand_include_patterns,
-    _is_valid_include_pattern,
     _is_within_root,
     _match_include_pattern,
+)
+from langchain.agents.middleware.file_search import (
+    FilesystemFileSearchMiddleware,
+    _is_valid_include_pattern,
 )
 
 
@@ -553,6 +557,69 @@ class TestMatchIncludePattern:
     def test_match_pattern_invalid_expansion(self) -> None:
         """Test matching with pattern that cannot be expanded returns False."""
         assert not _match_include_pattern("test.py", "*.{}")
+
+
+class TestPythonSearchTimeout:
+    """Tests for the wall-clock timeout on the Python fallback search."""
+
+    def test_redos_pattern_is_cut_off(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A catastrophically backtracking regex must be killed, not hang."""
+        # `(a+)+$` against a long run of `a`s with a non-matching tail forces
+        # exponential backtracking in `re`, which can take a very long time
+        # without a timeout.
+        (tmp_path / "test.txt").write_text("a" * 40 + "!\n", encoding="utf-8")
+
+        # Shorten the timeout so the test stays fast.
+        monkeypatch.setattr("langchain.agents.middleware.file_search._SEARCH_TIMEOUT_SECONDS", 2)
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert isinstance(middleware.grep_search, StructuredTool)
+        assert middleware.grep_search.func is not None
+        start = time.monotonic()
+        result = middleware.grep_search.func(pattern="(a+)+$")
+        elapsed = time.monotonic() - start
+
+        assert result == "No matches found"
+        # Generous bound: proves the worker was killed at the timeout rather
+        # than left to backtrack to completion.
+        assert elapsed < 30
+
+    def test_python_search_timeout_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`_python_search` must return no results when the worker times out."""
+        (tmp_path / "test.txt").write_text("hello\n", encoding="utf-8")
+
+        def fake_run(*args: Any, **kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+        monkeypatch.setattr("langchain.agents.middleware.file_search.subprocess.run", fake_run)
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert middleware._python_search("hello", "/", None) == {}
+
+    def test_python_search_worker_failure_returns_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A worker exiting nonzero must yield no results, not an error."""
+        (tmp_path / "test.txt").write_text("hello\n", encoding="utf-8")
+
+        class DummyResult:
+            returncode = 1
+            stdout = ""
+
+        def fake_run(*_args: Any, **_kwargs: Any) -> DummyResult:
+            return DummyResult()
+
+        monkeypatch.setattr("langchain.agents.middleware.file_search.subprocess.run", fake_run)
+
+        middleware = FilesystemFileSearchMiddleware(root_path=str(tmp_path), use_ripgrep=False)
+
+        assert middleware._python_search("hello", "/", None) == {}
 
 
 class TestGrepEdgeCases:


### PR DESCRIPTION
## Summary
- Bound the Python fallback grep search with a killable subprocess timeout
- Preserved regex semantics while preventing catastrophic backtracking from hanging the main process
- Moved the blocking search loop into a stdlib-only worker module
- Added regression coverage for ReDoS timeout behavior and worker failure handling

## Tests
- uv run --directory libs/langchain_v1 pytest tests/unit_tests/agents/middleware/implementations/test_file_search.py -q
- uv run --directory libs/langchain_v1 ruff check langchain/agents/middleware/file_search.py langchain/agents/middleware/_file_search_worker.py tests/unit_tests/agents/middleware/implementations/test_file_search.py
- uv run --directory libs/langchain_v1 ruff format --check langchain/agents/middleware/file_search.py langchain/agents/middleware/_file_search_worker.py tests/unit_tests/agents/middleware/implementations/test_file_search.py

Related to #38737