### PR TITLE
feat(middleware): add AskQuestionMiddleware for structured HITL questions

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -3,6 +3,7 @@
 from langgraph.runtime import Runtime
 
 from langchain.agents.middleware.context_editing import ClearToolUsesEdit, ContextEditingMiddleware
+from langchain.agents.middleware.ask_question import AskQuestionMiddleware
 from langchain.agents.middleware.file_search import FilesystemFileSearchMiddleware
 from langchain.agents.middleware.human_in_the_loop import (
     HumanInTheLoopMiddleware,
@@ -49,6 +50,7 @@ from langchain.agents.middleware.types import (
 __all__ = [
     "AgentMiddleware",
     "AgentState",
+    "AskQuestionMiddleware",
     "ClearToolUsesEdit",
     "CodexSandboxExecutionPolicy",
     "ContextEditingMiddleware",

--- a/libs/langchain_v1/langchain/agents/middleware/_hitl_structured_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_hitl_structured_tool.py
@@ -1,0 +1,233 @@
+"""StructuredTool variant that does not treat GraphInterrupt as a tool error.
+
+LangGraph documents calling ``interrupt()`` inside a tool. That raises
+``GraphInterrupt``, which subclasses ``Exception``. LangChain's ``BaseTool.run`` /
+``arun`` invoke ``on_tool_error`` for any ``Exception`` before re-raising.
+
+This helper re-raises ``GraphInterrupt`` before the broad error handler so human-
+in-the-loop pauses are not reported as tool failures. See langgraph #8218.
+"""
+
+from __future__ import annotations
+
+import uuid
+from inspect import signature
+from typing import Any
+
+from langchain_core.callbacks import (
+    AsyncCallbackManager,
+    CallbackManager,
+    Callbacks,
+)
+from langchain_core.runnables import RunnableConfig, patch_config
+from langchain_core.runnables.config import set_config_context
+from langchain_core.runnables.utils import coro_with_context
+from langchain_core.tools.base import (
+    BaseTool,
+    ToolException,
+    _format_output,
+    _get_runnable_config_param,
+    _handle_tool_error,
+    _handle_validation_error,
+)
+from langchain_core.tools.structured import StructuredTool
+from langgraph.errors import GraphInterrupt
+from pydantic import ValidationError
+from pydantic.v1 import ValidationError as ValidationErrorV1
+
+
+class HITLStructuredTool(StructuredTool):
+    """Like ``StructuredTool``, but does not signal ``on_tool_error`` for ``GraphInterrupt``."""
+
+    def run(  # noqa: PLR0913
+        self,
+        tool_input: str | dict[str, Any],
+        verbose: bool | None = None,  # noqa: FBT001
+        start_color: str | None = "green",
+        color: str | None = "green",
+        callbacks: Callbacks = None,
+        *,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        run_name: str | None = None,
+        run_id: uuid.UUID | None = None,
+        config: RunnableConfig | None = None,
+        tool_call_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        callback_manager = CallbackManager.configure(
+            callbacks,
+            self.callbacks,
+            self.verbose or bool(verbose),
+            tags,
+            self.tags,
+            metadata,
+            self.metadata,
+        )
+
+        filtered_tool_input = (
+            self._filter_injected_args(tool_input) if isinstance(tool_input, dict) else None
+        )
+
+        tool_input_str = (
+            tool_input
+            if isinstance(tool_input, str)
+            else str(filtered_tool_input if filtered_tool_input is not None else tool_input)
+        )
+
+        run_manager = callback_manager.on_tool_start(
+            {"name": self.name, "description": self.description},
+            tool_input_str,
+            color=start_color,
+            name=run_name,
+            run_id=run_id,
+            inputs=filtered_tool_input,
+            tool_call_id=tool_call_id,
+            **kwargs,
+        )
+
+        content = None
+        artifact = None
+        status = "success"
+        try:
+            child_config = patch_config(config, callbacks=run_manager.get_child())
+            with set_config_context(child_config) as context:
+                tool_args, tool_kwargs = self._to_args_and_kwargs(tool_input, tool_call_id)
+                if signature(self._run).parameters.get("run_manager"):
+                    tool_kwargs |= {"run_manager": run_manager}
+                config_param = _get_runnable_config_param(self._run)
+                if config_param:
+                    tool_kwargs |= {config_param: config}
+                response = context.run(self._run, *tool_args, **tool_kwargs)
+            if self.response_format == "content_and_artifact":
+                msg = (
+                    "Since response_format='content_and_artifact' "
+                    "a two-tuple of the message content and raw tool output is "
+                    f"expected. Instead, generated response is of type: "
+                    f"{type(response)}."
+                )
+                if not isinstance(response, tuple):
+                    raise ValueError(msg)
+                content, artifact = response
+            else:
+                content = response
+        except (ValidationError, ValidationErrorV1) as e:
+            if not self.handle_validation_error:
+                run_manager.on_tool_error(e, tool_call_id=tool_call_id)
+                raise
+            content = _handle_validation_error(e, flag=self.handle_validation_error)
+            status = "error"
+        except ToolException as e:
+            if not self.handle_tool_error:
+                run_manager.on_tool_error(e, tool_call_id=tool_call_id)
+                raise
+            content = _handle_tool_error(e, flag=self.handle_tool_error)
+            status = "error"
+        except GraphInterrupt:
+            raise
+        except (Exception, KeyboardInterrupt) as e:
+            run_manager.on_tool_error(e, tool_call_id=tool_call_id)
+            raise
+        output = _format_output(content, artifact, tool_call_id, self.name, status)
+        run_manager.on_tool_end(output, color=color, name=self.name, **kwargs)
+        return output
+
+    async def arun(  # noqa: PLR0913
+        self,
+        tool_input: str | dict,
+        verbose: bool | None = None,  # noqa: FBT001
+        start_color: str | None = "green",
+        color: str | None = "green",
+        callbacks: Callbacks = None,
+        *,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        run_name: str | None = None,
+        run_id: uuid.UUID | None = None,
+        config: RunnableConfig | None = None,
+        tool_call_id: str | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        callback_manager = AsyncCallbackManager.configure(
+            callbacks,
+            self.callbacks,
+            self.verbose or bool(verbose),
+            tags,
+            self.tags,
+            metadata,
+            self.metadata,
+        )
+
+        filtered_tool_input = (
+            self._filter_injected_args(tool_input) if isinstance(tool_input, dict) else None
+        )
+
+        tool_input_str = (
+            tool_input
+            if isinstance(tool_input, str)
+            else str(filtered_tool_input if filtered_tool_input is not None else tool_input)
+        )
+
+        run_manager = await callback_manager.on_tool_start(
+            {"name": self.name, "description": self.description},
+            tool_input_str,
+            color=start_color,
+            name=run_name,
+            run_id=run_id,
+            inputs=filtered_tool_input,
+            tool_call_id=tool_call_id,
+            **kwargs,
+        )
+        content = None
+        artifact = None
+        status = "success"
+        try:
+            tool_args, tool_kwargs = self._to_args_and_kwargs(tool_input, tool_call_id)
+            child_config = patch_config(config, callbacks=run_manager.get_child())
+            with set_config_context(child_config) as context:
+                func_to_check = (
+                    self._run
+                    if self.__class__._arun is BaseTool._arun
+                    else self._arun  # noqa: SLF001
+                )
+                if signature(func_to_check).parameters.get("run_manager"):
+                    tool_kwargs["run_manager"] = run_manager
+                config_param = _get_runnable_config_param(func_to_check)
+                if config_param:
+                    tool_kwargs[config_param] = config
+
+                coro = self._arun(*tool_args, **tool_kwargs)
+                response = await coro_with_context(coro, context)
+            if self.response_format == "content_and_artifact":
+                msg = (
+                    "Since response_format='content_and_artifact' "
+                    "a two-tuple of the message content and raw tool output is "
+                    f"expected. Instead, generated response is of type: "
+                    f"{type(response)}."
+                )
+                if not isinstance(response, tuple):
+                    raise ValueError(msg)
+                content, artifact = response
+            else:
+                content = response
+        except ValidationError as e:
+            if not self.handle_validation_error:
+                await run_manager.on_tool_error(e, tool_call_id=tool_call_id)
+                raise
+            content = _handle_validation_error(e, flag=self.handle_validation_error)
+            status = "error"
+        except ToolException as e:
+            if not self.handle_tool_error:
+                await run_manager.on_tool_error(e, tool_call_id=tool_call_id)
+                raise
+            content = _handle_tool_error(e, flag=self.handle_tool_error)
+            status = "error"
+        except GraphInterrupt:
+            raise
+        except (Exception, KeyboardInterrupt) as e:
+            await run_manager.on_tool_error(e, tool_call_id=tool_call_id)
+            raise
+
+        output = _format_output(content, artifact, tool_call_id, self.name, status)
+        await run_manager.on_tool_end(output, color=color, name=self.name, **kwargs)
+        return output

--- a/libs/langchain_v1/langchain/agents/middleware/ask_question.py
+++ b/libs/langchain_v1/langchain/agents/middleware/ask_question.py
@@ -1,0 +1,391 @@
+"""Structured multi-choice questions middleware for human-in-the-loop agents."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+
+from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+from langgraph.runtime import Runtime
+from langgraph.types import interrupt
+from pydantic import BaseModel, Field, model_validator
+from typing_extensions import override
+
+from langchain.agents.middleware._hitl_structured_tool import HITLStructuredTool
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    ModelRequest,
+    ModelResponse,
+    ResponseT,
+)
+
+ASK_QUESTION_SCHEMA_VERSION = "1.1"
+
+
+class QuestionOption(BaseModel):
+    """A single selectable option within a question."""
+
+    id: str = Field(description="Unique identifier for this option")
+    label: str = Field(description="Display text for this option")
+    requires_free_text: bool = Field(
+        default=False,
+        description=(
+            "If true, selecting this option opens a free-text field so the user can "
+            "add flexible detail. That text is merged into the resume payload."
+        ),
+    )
+    free_text_placeholder: str | None = Field(
+        default=None,
+        description="Short hint for the text field when requires_free_text is true.",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Optional secondary helper text for this option.",
+    )
+    disabled: bool = Field(
+        default=False,
+        description="If true, option is visible but not selectable.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_free_text_fields(self) -> QuestionOption:
+        if self.requires_free_text and not (self.free_text_placeholder or "").strip():
+            msg = "free_text_placeholder is required when requires_free_text is true"
+            raise ValueError(msg)
+        return self
+
+
+class Question(BaseModel):
+    """A single question with multiple-choice options."""
+
+    id: str = Field(description="Unique identifier for this question")
+    prompt: str = Field(description="The question text to display to the user")
+    options: list[QuestionOption] = Field(
+        description="Array of answer options (minimum 2 required)",
+        min_length=2,
+    )
+    allow_multiple: bool | None = Field(
+        default=False,
+        description="If true, user can select multiple options. Defaults to false.",
+    )
+    required: bool = Field(
+        default=True,
+        description="If true, user must answer this question before submitting.",
+    )
+    min_select: int | None = Field(
+        default=None,
+        ge=0,
+        description="Minimum selections required for multi-select questions.",
+    )
+    max_select: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum selections allowed for multi-select questions.",
+    )
+    validation_message: str | None = Field(
+        default=None,
+        description="Optional custom validation message shown to the user.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_question_constraints(self) -> Question:
+        option_ids = [str(option.id).strip() for option in self.options]
+        if len(option_ids) != len(set(option_ids)):
+            msg = f"Question '{self.id}' has duplicate option ids"
+            raise ValueError(msg)
+
+        if not self.allow_multiple:
+            if self.min_select is not None and self.min_select > 1:
+                msg = (
+                    f"Question '{self.id}' cannot set min_select > 1 "
+                    "when allow_multiple is false"
+                )
+                raise ValueError(msg)
+            if self.max_select is not None and self.max_select > 1:
+                msg = (
+                    f"Question '{self.id}' cannot set max_select > 1 "
+                    "when allow_multiple is false"
+                )
+                raise ValueError(msg)
+            return self
+
+        option_count = len(self.options)
+        if self.min_select is not None and self.min_select > option_count:
+            msg = f"Question '{self.id}' min_select cannot exceed option count"
+            raise ValueError(msg)
+        if self.max_select is not None and self.max_select > option_count:
+            msg = f"Question '{self.id}' max_select cannot exceed option count"
+            raise ValueError(msg)
+        if (
+            self.min_select is not None
+            and self.max_select is not None
+            and self.min_select > self.max_select
+        ):
+            msg = f"Question '{self.id}' min_select cannot be greater than max_select"
+            raise ValueError(msg)
+        return self
+
+
+class AskQuestionInput(BaseModel):
+    """Input schema for the AskQuestion tool."""
+
+    title: str | None = Field(
+        default=None,
+        description="Title for the questions form",
+    )
+    questions: list[Question] = Field(
+        description="Array of questions to present to the user (minimum 1 required)",
+        min_length=1,
+    )
+    context_note: str | None = Field(
+        default=None,
+        description="Optional explanatory text shown above questions.",
+    )
+    submit_label: str | None = Field(
+        default=None,
+        description="Optional custom submit button label.",
+    )
+    cancel_label: str | None = Field(
+        default=None,
+        description="Optional custom cancel button label.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_unique_question_ids(self) -> AskQuestionInput:
+        question_ids = [str(question.id).strip() for question in self.questions]
+        if len(question_ids) != len(set(question_ids)):
+            msg = "AskQuestionInput contains duplicate question ids"
+            raise ValueError(msg)
+        return self
+
+
+def build_ask_question_interrupt_payload(
+    *,
+    questions: list[Question],
+    title: str | None = None,
+    context_note: str | None = None,
+    submit_label: str | None = None,
+    cancel_label: str | None = None,
+) -> dict[str, Any]:
+    """Build the versioned interrupt payload surfaced to human-in-the-loop consumers."""
+    return {
+        "schema_version": ASK_QUESTION_SCHEMA_VERSION,
+        "title": title,
+        "context_note": context_note,
+        "submit_label": submit_label,
+        "cancel_label": cancel_label,
+        "questions": [question.model_dump() for question in questions],
+    }
+
+
+def _normalize_interrupt_resume(human_input: Any) -> str:
+    """Normalize interrupt resume values to a string for the model."""
+    if isinstance(human_input, str):
+        return human_input
+    if isinstance(human_input, dict):
+        messages = human_input.get("messages", [])
+        if messages and hasattr(messages[0], "content"):
+            return str(messages[0].content)
+        return json.dumps(human_input)
+    if isinstance(human_input, list):
+        return json.dumps(human_input)
+    return str(human_input)
+
+
+def _ask_question(
+    questions: list[Question],
+    title: str | None = None,
+    context_note: str | None = None,
+    submit_label: str | None = None,
+    cancel_label: str | None = None,
+) -> str:
+    """Present structured multiple-choice questions and wait for human answers."""
+    interrupt_payload = build_ask_question_interrupt_payload(
+        questions=questions,
+        title=title,
+        context_note=context_note,
+        submit_label=submit_label,
+        cancel_label=cancel_label,
+    )
+    human_input = interrupt(interrupt_payload)
+    return _normalize_interrupt_resume(human_input)
+
+
+async def _aask_question(
+    questions: list[Question],
+    title: str | None = None,
+    context_note: str | None = None,
+    submit_label: str | None = None,
+    cancel_label: str | None = None,
+) -> str:
+    """Async variant of `_ask_question`."""
+    return _ask_question(
+        questions=questions,
+        title=title,
+        context_note=context_note,
+        submit_label=submit_label,
+        cancel_label=cancel_label,
+    )
+
+
+ASK_QUESTION_TOOL_DESCRIPTION = """Use this tool to ask the user one or more structured multiple-choice questions.
+
+Use when you need specific information through a structured selection format — for example
+to clarify ambiguous requests, confirm a date range, or choose between report types.
+
+Each question must have:
+- A unique id (used to match answers)
+- A clear prompt
+- At least 2 options, each with an id and label
+- Optional `requires_free_text` on an option to collect typed detail from the user
+- Optional `allow_multiple` for multi-select questions (defaults to false)
+
+The tool pauses execution until the user submits answers. The return value is a JSON
+string the agent can parse to continue processing."""
+
+
+ASK_QUESTION_SYSTEM_PROMPT = """## `AskQuestion`
+
+You have access to the `AskQuestion` tool to collect structured answers from the user.
+
+Use it when free-form chat is insufficient and you need the user to pick from defined
+options (single or multi-select). Prefer one call with multiple related questions rather
+than many separate calls.
+
+Do not use `AskQuestion` for simple yes/no confirmations that fit naturally in chat.
+Do not use it when the user already provided the needed information."""
+
+
+class AskQuestionMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
+    """Middleware that registers the `AskQuestion` interrupt tool for agents.
+
+    This middleware adds an `AskQuestion` tool that pauses graph execution via
+    LangGraph's `interrupt()` primitive and resumes with structured user answers.
+    Consumers render the versioned interrupt payload (`schema_version: "1.1"`) as a
+    form in their UI.
+
+    Unlike `HumanInTheLoopMiddleware`, which intercepts tool execution for approval,
+    `AskQuestion` lets the model proactively ask clarification questions mid-task.
+
+    Example:
+        ```python
+        from langchain.agents import create_agent
+        from langchain.agents.middleware import AskQuestionMiddleware
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        agent = create_agent(
+            "openai:gpt-4.1-mini",
+            middleware=[AskQuestionMiddleware()],
+            checkpointer=InMemorySaver(),
+        )
+        ```
+    """
+
+    def __init__(
+        self,
+        *,
+        system_prompt: str = ASK_QUESTION_SYSTEM_PROMPT,
+        tool_description: str = ASK_QUESTION_TOOL_DESCRIPTION,
+    ) -> None:
+        """Initialize `AskQuestionMiddleware`.
+
+        Args:
+            system_prompt: System prompt appended to guide when to use `AskQuestion`.
+            tool_description: Description exposed to the model for the tool.
+        """
+        super().__init__()
+        self.system_prompt = system_prompt
+        self.tool_description = tool_description
+        self.tools = [
+            HITLStructuredTool.from_function(
+                func=_ask_question,
+                coroutine=_aask_question,
+                name="AskQuestion",
+                description=tool_description,
+                args_schema=AskQuestionInput,
+                infer_schema=False,
+            )
+        ]
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
+    ) -> ModelResponse[ResponseT] | AIMessage:
+        """Append AskQuestion guidance to the system prompt."""
+        if request.system_message is not None:
+            new_system_content = [
+                *request.system_message.content_blocks,
+                {"type": "text", "text": f"\n\n{self.system_prompt}"},
+            ]
+        else:
+            new_system_content = [{"type": "text", "text": self.system_prompt}]
+        new_system_message = SystemMessage(
+            content=cast("list[str | dict[str, str]]", new_system_content)
+        )
+        return handler(request.override(system_message=new_system_message))
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT] | AIMessage:
+        """Async variant of `wrap_model_call`."""
+        if request.system_message is not None:
+            new_system_content = [
+                *request.system_message.content_blocks,
+                {"type": "text", "text": f"\n\n{self.system_prompt}"},
+            ]
+        else:
+            new_system_content = [{"type": "text", "text": self.system_prompt}]
+        new_system_message = SystemMessage(
+            content=cast("list[str | dict[str, str]]", new_system_content)
+        )
+        return await handler(request.override(system_message=new_system_message))
+
+    @override
+    def after_model(
+        self, state: AgentState[ResponseT], runtime: Runtime[ContextT]
+    ) -> dict[str, Any] | None:
+        """Reject parallel `AskQuestion` calls in the same model turn."""
+        del runtime
+        messages = state["messages"]
+        if not messages:
+            return None
+
+        last_ai_msg = next((msg for msg in reversed(messages) if isinstance(msg, AIMessage)), None)
+        if not last_ai_msg or not last_ai_msg.tool_calls:
+            return None
+
+        ask_question_calls = [
+            tool_call for tool_call in last_ai_msg.tool_calls if tool_call["name"] == "AskQuestion"
+        ]
+        if len(ask_question_calls) <= 1:
+            return None
+
+        error_messages = [
+            ToolMessage(
+                content=(
+                    "Error: Call `AskQuestion` only once per model turn. "
+                    "Combine related questions into a single tool call."
+                ),
+                tool_call_id=tool_call["id"],
+                status="error",
+            )
+            for tool_call in ask_question_calls
+        ]
+        return {"messages": error_messages}
+
+    @override
+    async def aafter_model(
+        self, state: AgentState[ResponseT], runtime: Runtime[ContextT]
+    ) -> dict[str, Any] | None:
+        """Async variant of `after_model`."""
+        return self.after_model(state, runtime)
+
+
+# Re-exported for tests and advanced callers.
+AskQuestion = AskQuestionMiddleware().tools[0]

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_ask_question.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_ask_question.py
@@ -1,0 +1,188 @@
+"""Unit tests for AskQuestionMiddleware."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import patch
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from pydantic import ValidationError
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware.ask_question import (
+    ASK_QUESTION_SCHEMA_VERSION,
+    ASK_QUESTION_SYSTEM_PROMPT,
+    AskQuestion,
+    AskQuestionInput,
+    AskQuestionMiddleware,
+    Question,
+    QuestionOption,
+    build_ask_question_interrupt_payload,
+)
+from langchain.agents.middleware.types import AgentState, ModelRequest, ModelResponse
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+if TYPE_CHECKING:
+    from langgraph.runtime import Runtime
+
+
+def _fake_runtime() -> Runtime:
+    return cast("Runtime", object())
+
+
+def _sample_questions() -> list[Question]:
+    return [
+        Question(
+            id="range",
+            prompt="Which date range?",
+            options=[
+                QuestionOption(id="7d", label="Last 7 days"),
+                QuestionOption(id="30d", label="Last 30 days"),
+            ],
+        )
+    ]
+
+
+def _make_request(system_prompt: str | None = None) -> ModelRequest:
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="response")]))
+    return ModelRequest(
+        model=model,
+        system_prompt=system_prompt,
+        messages=[],
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+        state=AgentState(messages=[]),
+        runtime=_fake_runtime(),
+        model_settings={},
+    )
+
+
+def test_ask_question_middleware_initialization() -> None:
+    middleware = AskQuestionMiddleware()
+    assert len(middleware.tools) == 1
+    assert middleware.tools[0].name == "AskQuestion"
+
+
+def test_question_option_requires_free_text_placeholder() -> None:
+    with pytest.raises(ValidationError):
+        QuestionOption(id="custom", label="Custom", requires_free_text=True)
+
+
+def test_question_rejects_duplicate_option_ids() -> None:
+    with pytest.raises(ValidationError):
+        Question(
+            id="q1",
+            prompt="Pick one",
+            options=[
+                QuestionOption(id="same", label="A"),
+                QuestionOption(id="same", label="B"),
+            ],
+        )
+
+
+def test_ask_question_input_rejects_duplicate_question_ids() -> None:
+    questions = _sample_questions() + [
+        Question(
+            id="range",
+            prompt="Duplicate id",
+            options=[
+                QuestionOption(id="a", label="A"),
+                QuestionOption(id="b", label="B"),
+            ],
+        )
+    ]
+    with pytest.raises(ValidationError):
+        AskQuestionInput(questions=questions)
+
+
+def test_build_ask_question_interrupt_payload() -> None:
+    questions = _sample_questions()
+    payload = build_ask_question_interrupt_payload(
+        questions=questions,
+        title="Clarify request",
+        context_note="Need your preference before continuing.",
+    )
+    assert payload["schema_version"] == ASK_QUESTION_SCHEMA_VERSION
+    assert payload["title"] == "Clarify request"
+    assert payload["context_note"] == "Need your preference before continuing."
+    assert len(payload["questions"]) == 1
+    assert payload["questions"][0]["id"] == "range"
+
+
+def test_ask_question_tool_returns_resume_value() -> None:
+    questions = _sample_questions()
+    tool_call = {
+        "args": {
+            "questions": [question.model_dump() for question in questions],
+            "title": "Clarify request",
+        },
+        "name": "AskQuestion",
+        "type": "tool_call",
+        "id": "test_call",
+    }
+
+    def mock_resume(_: dict[str, Any]) -> str:
+        return '{"range": {"selected": ["7d"]}}'
+
+    with patch(
+        "langchain.agents.middleware.ask_question.interrupt",
+        side_effect=mock_resume,
+    ):
+        result = AskQuestion.invoke(tool_call)
+
+    assert result == '{"range": {"selected": ["7d"]}}'
+
+
+def test_wrap_model_call_appends_system_prompt() -> None:
+    middleware = AskQuestionMiddleware()
+    request = _make_request(system_prompt="Base prompt")
+    captured_request = None
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        nonlocal captured_request
+        captured_request = req
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    middleware.wrap_model_call(request, mock_handler)
+    assert captured_request is not None
+    assert captured_request.system_prompt is not None
+    assert "Base prompt" in captured_request.system_prompt
+    assert ASK_QUESTION_SYSTEM_PROMPT.splitlines()[0] in captured_request.system_prompt
+
+
+def test_parallel_ask_question_calls_rejected() -> None:
+    middleware = AskQuestionMiddleware()
+    ai_message = AIMessage(
+        content="Need clarification",
+        tool_calls=[
+            {"name": "AskQuestion", "args": {"questions": []}, "id": "1"},
+            {"name": "AskQuestion", "args": {"questions": []}, "id": "2"},
+        ],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hello"), ai_message])
+    result = middleware.after_model(state, _fake_runtime())
+    assert result is not None
+    assert len(result["messages"]) == 2
+    assert all(isinstance(message, ToolMessage) for message in result["messages"])
+    assert all(message.status == "error" for message in result["messages"])
+
+
+def test_single_ask_question_call_allowed() -> None:
+    middleware = AskQuestionMiddleware()
+    ai_message = AIMessage(
+        content="Need clarification",
+        tool_calls=[{"name": "AskQuestion", "args": {"questions": []}, "id": "1"}],
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hello"), ai_message])
+    result = middleware.after_model(state, _fake_runtime())
+    assert result is None
+
+
+def test_agent_creation_with_ask_question_middleware() -> None:
+    model = FakeToolCallingModel(tool_calls=[[], []])
+    agent = create_agent(model=model, middleware=[AskQuestionMiddleware()])
+    result = agent.invoke({"messages": [HumanMessage("Hello")]})
+    assert "messages" in result


### PR DESCRIPTION
## Summary

- Adds **`AskQuestionMiddleware`** — registers an `AskQuestion` tool that pauses the agent via LangGraph `interrupt()` with a versioned multi-choice payload (`schema_version: 1.1`).
- Adds Pydantic schemas (`QuestionOption`, `Question`, `AskQuestionInput`) with validation for duplicate ids, min/max select, and free-text placeholder rules.
- Adds **`HITLStructuredTool`** helper so `GraphInterrupt` is not reported as a tool error (related: langgraph #8218, #8217).
- Rejects parallel `AskQuestion` calls in one model turn (same guard pattern as `TodoListMiddleware`).
- Unit tests for schemas, interrupt payload, system-prompt injection, and parallel-call guarding.

Closes #38766

## Motivation

`HumanInTheLoopMiddleware` handles **approval of pending tool calls**. Agents also need to **ask structured clarification questions** mid-task. Raw `interrupt("string")` gives UIs no schema to render forms.

This mirrors the `TodoListMiddleware` pattern: middleware registers a tool + injects system guidance.

## Usage

```python
from langchain.agents import create_agent
from langchain.agents.middleware import AskQuestionMiddleware
from langgraph.checkpoint.memory import InMemorySaver

agent = create_agent(
    model,
    middleware=[AskQuestionMiddleware()],
    checkpointer=InMemorySaver(),
)
```

## Interrupt payload

```json
{
  "schema_version": "1.1",
  "title": "Clarify your request",
  "questions": [
    {
      "id": "range",
      "prompt": "Which date range?",
      "options": [
        {"id": "7d", "label": "Last 7 days"},
        {"id": "30d", "label": "Last 30 days"}
      ]
    }
  ]
}
```

Resume with `Command(resume='{"range": {"selected": ["7d"]}}')`.

## Test plan

- [x] Unit tests: `tests/unit_tests/agents/middleware/implementations/test_ask_question.py`
- [ ] CI green on langchain_v1 package
- [ ] Manual: `create_agent` + checkpointer + AskQuestion interrupt/resume (follow-up integration test if maintainers want)

## Notes

Complementary to `HumanInTheLoopMiddleware`, not a replacement.