### PR TITLE
feat(langchain-openai): surface reasoning_content from streaming delta onto additional_kwargs

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1406,6 +1406,22 @@ class BaseChatOpenAI(BaseChatModel):
         if logprobs:
             generation_info["logprobs"] = logprobs
 
+        # Surface `reasoning_content` (and the OpenRouter-style `reasoning` alias) from
+        # the streaming delta onto additional_kwargs so downstream consumers can read
+        # the chain-of-thought text. Many reasoning models (GLM-5, DeepSeek, etc.)
+        # expose this on their OpenAI-compatible streaming endpoint. Without this
+        # pass-through the upper layer only sees the final answer and the thinking
+        # text is dropped on the floor.
+        if isinstance(message_chunk, AIMessageChunk):
+            delta = choice.get("delta") or {}
+            reasoning_content = delta.get("reasoning_content")
+            if reasoning_content is None:
+                # OpenRouter routes both DeepSeek and other reasoning models through
+                # its OpenAI-compatible API using the `reasoning` key.
+                reasoning_content = delta.get("reasoning")
+            if reasoning_content is not None:
+                message_chunk.additional_kwargs["reasoning_content"] = reasoning_content
+
         if usage_metadata and isinstance(message_chunk, AIMessageChunk):
             message_chunk.usage_metadata = usage_metadata
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1508,6 +1508,101 @@ def test_convert_chunk_to_generation_chunk_v1_keeps_string_content() -> None:
     assert gen.message.response_metadata.get("model_provider") == "openai"
 
 
+def test_convert_chunk_to_generation_chunk_surfaces_reasoning_content() -> None:
+    """OpenAI-compatible streaming endpoints (GLM-5, DeepSeek, etc.) carry the
+    chain-of-thought text on `choices[0].delta.reasoning_content`. Surface it
+    via `additional_kwargs["reasoning_content"]` so downstream consumers can
+    read the reasoning alongside the streamed answer."""
+
+    llm = ChatOpenAI(model="gpt-4o")
+
+    chunk: dict[str, Any] = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning_content": "Let me think about this...",
+                },
+                "logprobs": None,
+                "finish_reason": None,
+            }
+        ],
+        "usage": None,
+    }
+    gen = llm._convert_chunk_to_generation_chunk(chunk, AIMessageChunk, None)
+    assert gen is not None
+    assert (
+        gen.message.additional_kwargs.get("reasoning_content")
+        == "Let me think about this..."
+    )
+
+
+def test_convert_chunk_to_generation_chunk_falls_back_to_reasoning_alias() -> None:
+    """OpenRouter routes DeepSeek and other reasoning models through its
+    OpenAI-compatible API using the `reasoning` key instead of
+    `reasoning_content`. The OpenAI integration should still surface the
+    chain-of-thought text under the canonical `reasoning_content` key."""
+
+    llm = ChatOpenAI(model="gpt-4o")
+
+    chunk: dict[str, Any] = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning": "Reasoning under the OpenRouter `reasoning` alias.",
+                },
+                "logprobs": None,
+                "finish_reason": None,
+            }
+        ],
+        "usage": None,
+    }
+    gen = llm._convert_chunk_to_generation_chunk(chunk, AIMessageChunk, None)
+    assert gen is not None
+    assert gen.message.additional_kwargs.get("reasoning_content") == (
+        "Reasoning under the OpenRouter `reasoning` alias."
+    )
+
+
+def test_convert_chunk_to_generation_chunk_no_reasoning_content_unchanged() -> None:
+    """A chunk without reasoning fields should leave additional_kwargs untouched
+    (no spurious empty string)."""
+
+    llm = ChatOpenAI(model="gpt-4o")
+
+    chunk: dict[str, Any] = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "gpt-4o",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": "hi"},
+                "logprobs": None,
+                "finish_reason": None,
+            }
+        ],
+        "usage": None,
+    }
+    gen = llm._convert_chunk_to_generation_chunk(chunk, AIMessageChunk, None)
+    assert gen is not None
+    assert "reasoning_content" not in gen.message.additional_kwargs
+
+
 def test_v1_streaming_tool_calls_in_content_blocks() -> None:
     """End-to-end: streaming chunks with tool calls produce correct content_blocks."""
     stream_chunks: list[dict[str, Any]] = [


### PR DESCRIPTION
Closes #38764.

Many reasoning models (GLM-5, DeepSeek, etc.) expose their chain-of-thought text via the OpenAI-compatible streaming endpoint at `choices[0].delta.reasoning_content`. The native `ChatOpenAI._convert_chunk_to_generation_chunk` was dropping these fields, so the upper layer never saw the reasoning text.

After the base chunk conversion, lift `reasoning_content` (or the OpenRouter-style `reasoning` alias) onto `additional_kwargs["reasoning_content"]`, matching the existing xai and deepseek integrations so downstream consumers can read the chain-of-thought text alongside the streamed answer.

Tests cover three cases: reasoning_content surfaced, reasoning alias surfaced, no reasoning field leaves additional_kwargs untouched. lint + format clean; 213 chat_models unit tests pass.