### PR TITLE
fix(core): flatten RootModel TypedDict tool schemas

### DIFF
--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from typing import Any, Literal, cast, get_type_hints, overload
 
 from pydantic import BaseModel, Field, create_model
+from typing_extensions import is_typeddict
 
 from langchain_core.callbacks import Callbacks
 from langchain_core.runnables import Runnable
@@ -419,6 +420,17 @@ def _get_schema_from_runnable_and_arg_types(
     return cast("type[BaseModel]", create_model(name, **fields))  # type: ignore[call-overload]
 
 
+def _is_root_model_wrapping_typed_dict(schema: TypeBaseModel) -> bool:
+    """Check whether a Pydantic v2 RootModel wraps a TypedDict input."""
+    if not isinstance(schema, type) or not issubclass(schema, BaseModel):
+        return False
+    if not getattr(schema, "__pydantic_root_model__", False):
+        return False
+
+    root_field = schema.model_fields.get("root")
+    return root_field is not None and is_typeddict(root_field.annotation)
+
+
 def convert_runnable_to_tool(
     runnable: Runnable[Any, Any],
     args_schema: TypeBaseModel | None = None,
@@ -464,7 +476,11 @@ def convert_runnable_to_tool(
         and schema.get("type") == "object"
         and schema.get("properties")
     ):
-        args_schema = runnable.input_schema
+        input_schema = runnable.input_schema
+        if _is_root_model_wrapping_typed_dict(input_schema):
+            args_schema = _get_schema_from_runnable_and_arg_types(runnable, name)
+        else:
+            args_schema = input_schema
     else:
         args_schema = _get_schema_from_runnable_and_arg_types(
             runnable, name, arg_types=arg_types

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -1758,6 +1758,59 @@ def test_convert_from_runnable_dict() -> None:
     assert result == "6"
 
 
+def test_convert_runnable_to_tool_unwraps_root_model_typed_dict() -> None:
+    """RootModel-wrapped TypedDict input should produce flat tool arguments."""
+
+    class InputState(TypedDict):
+        foo: str
+        bar: str
+
+    class RootTypedDictRunnable(Runnable[InputState, dict[str, str]]):
+        @override
+        def get_input_schema(
+            self, config: RunnableConfig | None = None
+        ) -> TypeBaseModel:
+            return create_model_v2("RootTypedDictInput", root=InputState)
+
+        @override
+        def get_input_jsonschema(
+            self, config: RunnableConfig | None = None
+        ) -> dict[str, Any]:
+            return {
+                "type": "object",
+                "properties": {
+                    "foo": {"type": "string"},
+                    "bar": {"type": "string"},
+                },
+                "required": ["foo", "bar"],
+            }
+
+        @override
+        def invoke(
+            self,
+            input: InputState,
+            config: RunnableConfig | None = None,
+            **kwargs: Any,
+        ) -> dict[str, str]:
+            return dict(input)
+
+    as_tool = convert_runnable_to_tool(
+        RootTypedDictRunnable(),
+        name="my_tool",
+        description="Example tool.",
+    )
+
+    assert set(as_tool.args) == {"foo", "bar"}
+
+    openai_tool = convert_to_openai_tool(as_tool)
+    parameters = openai_tool["function"]["parameters"]
+    assert "root" not in parameters["properties"]
+    assert set(parameters["properties"]) == {"foo", "bar"}
+
+    result = as_tool.invoke({"foo": "hello", "bar": "world"})
+    assert result == {"foo": "hello", "bar": "world"}
+
+
 def test_convert_from_runnable_other() -> None:
     # String input
     def f(x: str) -> str:


### PR DESCRIPTION
## Summary

Fixes #38713.

`convert_runnable_to_tool` currently trusts `runnable.input_schema` whenever `runnable.get_input_jsonschema()` looks like a normal object schema. That breaks for runnables whose public JSON schema is flat but whose Pydantic input schema is a `RootModel[TypedDict]`, such as a compiled LangGraph exposed through `Runnable.as_tool(...)`.

In that case the exported OpenAI tool schema can advertise a nested `root` property, while `tool.invoke(...)` still expects the TypedDict fields at the top level. This PR detects the RootModel-wrapped TypedDict case and derives the tool args from the runnable input type instead, preserving the flat public schema shape.

## Current state

This PR was automatically closed by the assignment gate because I am not assigned to the linked issue yet. I posted the detailed approach and validation on #38713 and will wait for maintainer direction before reopening. Corrected fork branch head: `dc6e0cd2245363d9e96be0f0dd012f98ec831f24`.

## Tests

- `uv run --directory libs/core --group test pytest tests/unit_tests/test_tools.py::test_convert_runnable_to_tool_unwraps_root_model_typed_dict -q`
- `uv run --directory libs/core --group test pytest tests/unit_tests/test_tools.py -q` -> 180 passed, 7 skipped
- `uv run --directory libs/core --all-groups mypy tests/unit_tests/test_tools.py --cache-dir .mypy_cache_test`
- `uv run --directory libs/core --group lint ruff check langchain_core/tools/convert.py tests/unit_tests/test_tools.py`
- `uv run --directory libs/core --group lint ruff format --check langchain_core/tools/convert.py tests/unit_tests/test_tools.py`
- `git diff --check`

I also re-ran the issue shape with a `StateGraph(..., input_schema=TypedDict).compile(...).as_tool(...)`; after the fix the exported OpenAI schema is flat and `tool.invoke({'foo': 'hello', 'bar': 'world'})` succeeds.