### PR TITLE
fix(core): unwrap RootModel[TypedDict] in convert_runnable_to_tool

### DIFF
--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -4,7 +4,8 @@ import inspect
 from collections.abc import Callable
 from typing import Any, Literal, cast, get_type_hints, overload
 
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel, Field, RootModel, create_model
+from typing_extensions import is_typeddict
 
 from langchain_core.callbacks import Callbacks
 from langchain_core.runnables import Runnable
@@ -459,16 +460,35 @@ def convert_runnable_to_tool(
     def invoke_wrapper(callbacks: Callbacks | None = None, **kwargs: Any) -> Any:
         return runnable.invoke(kwargs, config={"callbacks": callbacks})
 
+    # If the input schema is a RootModel wrapping a TypedDict, unwrap it.
+    # RootModel wrapping causes the OpenAI tool schema to have a nested
+    # "root" property, which breaks tool call validation.
+    input_schema = runnable.input_schema
     if (
-        arg_types is None
-        and schema.get("type") == "object"
-        and schema.get("properties")
+        args_schema is None
+        and isinstance(input_schema, type)
+        and issubclass(input_schema, RootModel)
     ):
-        args_schema = runnable.input_schema
-    else:
-        args_schema = _get_schema_from_runnable_and_arg_types(
-            runnable, name, arg_types=arg_types
-        )
+        fields = getattr(input_schema, "model_fields", {})
+        if "root" in fields and is_typeddict(fields["root"].annotation):
+            td = fields["root"].annotation
+            td_hints = get_type_hints(td)
+            td_fields = {key: (hint, Field(...)) for key, hint in td_hints.items()}
+            args_schema = cast(
+                "type[BaseModel]",
+                create_model(name, **td_fields),
+            )
+    if args_schema is None:
+        if (
+            arg_types is None
+            and schema.get("type") == "object"
+            and schema.get("properties")
+        ):
+            args_schema = input_schema
+        else:
+            args_schema = _get_schema_from_runnable_and_arg_types(
+                runnable, name, arg_types=arg_types
+            )
 
     return StructuredTool.from_function(
         name=name,

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, RootModel, ValidationError
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import ValidationError as ValidationErrorV1
 from typing_extensions import TypedDict, override
@@ -2272,6 +2272,53 @@ def test_convert_runnable_to_tool_v1_input_schema() -> None:
     tool = convert_runnable_to_tool(V1InputRunnable())
 
     assert set(tool.args) == {"a"}
+
+
+def test_convert_runnable_to_tool_unwraps_root_model_typed_dict() -> None:
+    """`convert_runnable_to_tool` unwraps RootModel[TypedDict] for proper schema.
+
+    Regression test: when a Runnable's input_schema is a RootModel wrapping a
+    TypedDict (e.g. from a StateGraph with TypedDict input), the tool schema
+    should not have a nested "root" property. The TypedDict fields should be
+    promoted to top-level fields.
+    """
+
+    class InputState(TypedDict):
+        foo: str
+        bar: str
+
+    class PassthroughRunnable(Runnable[Any, Any]):
+        @override
+        def invoke(
+            self,
+            input: Any,
+            config: RunnableConfig | None = None,
+            **kwargs: Any,
+        ) -> Any:
+            return input
+
+        @override
+        def get_input_schema(
+            self, config: RunnableConfig | None = None
+        ) -> TypeBaseModel:
+            return create_model_v2("PassthroughInput", root=InputState)
+
+    tool = convert_runnable_to_tool(PassthroughRunnable())
+
+    args_schema = tool.args_schema
+    assert args_schema is not None
+    assert isinstance(args_schema, type)
+    assert issubclass(args_schema, BaseModel)
+    assert not issubclass(args_schema, RootModel)
+    assert set(args_schema.model_fields.keys()) == {"foo", "bar"}
+
+    params = convert_to_openai_tool(tool)["function"]["parameters"]
+    assert "root" not in params.get("properties", {})
+    assert "foo" in params["properties"]
+    assert "bar" in params["properties"]
+
+    result = tool.invoke({"foo": "hello", "bar": "world"})
+    assert result == {"foo": "hello", "bar": "world"}
 
 
 @pytest.mark.parametrize("pydantic_model", TEST_MODELS)


### PR DESCRIPTION
Closes #38713

---

## Problem

When exposing a compiled `StateGraph` (with `TypedDict` input) as a tool via `convert_runnable_to_tool`, the OpenAI tool schema advertised a nested `"root"` property that didn't match what `tool.invoke()` accepted, causing validation errors for LLM tool calls.

The root cause is that `StateGraph.get_input_schema()` returns `RootModel[TypedDict]` (via `create_model_v2(root=TypedDict)`). The `$ref` in its JSON schema bypasses the `type == "object"` branch in `convert_runnable_to_tool`, falling through to `_get_schema_from_runnable_and_arg_types` which uses `InputType = Any` and produces an empty model.

## What Changed

### `libs/core/langchain_core/tools/convert.py`

Added imports for `RootModel` (from pydantic) and `is_typeddict` (from typing_extensions).

Before the existing schema-branch logic in `convert_runnable_to_tool`, added a check that detects when `runnable.input_schema` is a `RootModel` wrapping a `TypedDict`. When detected, the `TypedDict` fields are extracted and used to create a flat `BaseModel` via `create_model()`, with the tool name as the model title. This runs only when no explicit `args_schema` was provided by the caller, so existing behavior for custom schemas and `arg_types` is fully preserved.

### `libs/core/tests/unit_tests/test_tools.py`

Added `test_convert_runnable_to_tool_unwraps_root_model_typed_dict` — a regression test that:
1. Creates a `PassthroughRunnable` whose `get_input_schema()` returns `create_model_v2("PassthroughInput", root=InputState)` (a `RootModel[TypedDict]`)
2. Converts it to a tool via `convert_runnable_to_tool`
3. Asserts the resulting `args_schema` is a flat `BaseModel` (not a `RootModel`) with fields `{"foo", "bar"}`
4. Asserts the OpenAI tool schema has `foo` and `bar` at the top level with no nested `"root"` property
5. Asserts `tool.invoke({"foo": "hello", "bar": "world"})` succeeds with the flat dict

## Test Results

All 180 tools unit tests pass (7 skipped). Ruff lint and format checks pass.

## Release note

`convert_runnable_to_tool` now correctly unwraps `RootModel[TypedDict]` input schemas so the OpenAI tool schema matches the accepted invoke payload.