### PR TITLE
fix(langchain): export PIIMatch from langchain.agents.middleware public API

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -11,7 +11,7 @@ from langchain.agents.middleware.human_in_the_loop import (
 from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddleware
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
-from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
+from langchain.agents.middleware.pii import PIIDetectionError, PIIMatch, PIIMiddleware
 from langchain.agents.middleware.provider_tool_search import ProviderToolSearchMiddleware
 from langchain.agents.middleware.shell_tool import (
     CodexSandboxExecutionPolicy,
@@ -69,6 +69,7 @@ __all__ = [
     "ModelRetryMiddleware",
     "OutputAgentState",
     "PIIDetectionError",
+    "PIIMatch",
     "PIIMiddleware",
     "ProviderToolSearchMiddleware",
     "RedactionRule",

--- a/libs/langchain_v1/langchain/agents/middleware/pii.py
+++ b/libs/langchain_v1/langchain/agents/middleware/pii.py
@@ -583,10 +583,27 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
 
             detector: Custom detector function or regex pattern.
 
-                * If `Callable`: Function that takes content string and returns
-                    list of `PIIMatch` objects
+                * If `Callable`: Function that takes a content string and returns
+                    a list of :class:`PIIMatch` objects. Each ``PIIMatch`` must have
+                    ``type`` (str), ``value`` (str), ``start`` (int), and ``end`` (int)
+                    fields. Example::
+
+                        import re
+                        from langchain.agents.middleware import PIIMatch
+
+                        def detect_ssn(content: str) -> list[PIIMatch]:
+                            return [
+                                PIIMatch(
+                                    type="ssn",
+                                    value=m.group(),
+                                    start=m.start(),
+                                    end=m.end(),
+                                )
+                                for m in re.finditer(r"\\d{3}-\\d{2}-\\d{4}", content)
+                            ]
+
                 * If `str`: Regex pattern to match PII
-                * If `None`: Uses built-in detector for the `pii_type`
+                * If `None`: Uses built-in detector for the ``pii_type``
             apply_to_input: Whether to check user messages before model call.
             apply_to_output: Whether to check AI messages after model call.
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -35,6 +35,37 @@ from langchain.agents.middleware.pii import (
 from tests.unit_tests.agents.model import FakeToolCallingModel
 
 # ============================================================================
+# Public API Export Tests
+# ============================================================================
+
+
+class TestPublicAPIExports:
+    """Verify that PIIMatch and related types are importable from the public module."""
+
+    def test_piimatch_importable_from_public_module(self) -> None:
+        """PIIMatch must be importable from langchain.agents.middleware (issue #38718)."""
+        from langchain.agents.middleware import PIIMatch  # noqa: F401
+
+        assert PIIMatch is not None
+
+    def test_piimatch_has_required_fields(self) -> None:
+        """PIIMatch TypedDict must have type, value, start, end fields."""
+        import re
+
+        from langchain.agents.middleware import PIIMatch
+
+        matches = [
+            PIIMatch(type="test", value=m.group(), start=m.start(), end=m.end())
+            for m in re.finditer(r"\d+", "foo 123 bar 456")
+        ]
+        assert len(matches) == 2
+        assert matches[0]["type"] == "test"
+        assert matches[0]["value"] == "123"
+        assert matches[0]["start"] == 4
+        assert matches[0]["end"] == 7
+
+
+# ============================================================================
 # Detection Function Tests
 # ============================================================================
 


### PR DESCRIPTION
## Summary

`PIIMatch` — the return type required for custom callable detectors — was omitted from `langchain.agents.middleware.__init__.py`, forcing users to import from the private `_redaction` module. This PR adds it to the public package and improves its docstring.

Fixes #38718

## Root Cause

`pii.py` correctly lists `PIIMatch` in its own `__all__`. However, the `agents/middleware/__init__.py` re-export line only included `PIIDetectionError` and `PIIMiddleware`:

```python
# before (missing PIIMatch)
from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
```

Users following the documented custom-detector pattern hit an `ImportError` when trying to type their return value with `PIIMatch`.

## Changes

| File | What changed |
|------|-------------|
| `langchain/agents/middleware/__init__.py` | Add `PIIMatch` to import and `__all__` |
| `langchain/agents/middleware/pii.py` | Expand `detector` docstring with `PIIMatch` field names and an inline example |
| `tests/.../test_pii.py` | Add `TestPublicAPIExports` with two tests: public import succeeds, and `PIIMatch` has the correct `type`/`value`/`start`/`end` fields |

## Testing

- [x] Existing tests pass (`TestEmailDetection`, `TestCreditCardDetection`, etc.)
- [x] New test: `test_piimatch_importable_from_public_module` — verifies `from langchain.agents.middleware import PIIMatch` no longer raises `ImportError`
- [x] New test: `test_piimatch_has_required_fields` — verifies the `type`, `value`, `start`, `end` shape

## Impact

Custom detector authors can now import `PIIMatch` from the public API and get correct type-checker guidance on the required field names.