### PR TITLE
ChatAnthropic.bind_tools mutates caller-provided tool_choice dictionary

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1923,7 +1923,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1567,6 +1567,29 @@ def test_anthropic_bind_tools_tool_choice() -> None:
     }
 
 
+def test_bind_tools_does_not_mutate_tool_choice() -> None:
+    chat_model = ChatAnthropic(
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+
+    tool_choice = {
+        "type": "tool",
+        "name": "GetWeather",
+    }
+
+    chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=tool_choice,
+        parallel_tool_calls=False,
+    )
+
+    assert tool_choice == {
+        "type": "tool",
+        "name": "GetWeather",
+    }
+
+
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""
     # Test with betas parameter at initialization


### PR DESCRIPTION
## Checklist

- Fixes #37619

## Description

`ChatAnthropic.bind_tools()` mutates the caller-provided `tool_choice` dictionary when `parallel_tool_calls=False`.

The mutation happens because the implementation stores a reference to the original dictionary and later adds `disable_parallel_tool_use` to it. Since the caller's dictionary and the internal reference point to the same object, the caller's input is unexpectedly modified.

## Reproduction

```python
from langchain_anthropic import ChatAnthropic

model = ChatAnthropic(
    model="claude-sonnet-4-5-20250929",
    anthropic_api_key="dummy",
)

tool_choice = {
    "type": "tool",
    "name": "GetWeather",
}

print("Before:", tool_choice)

model.bind_tools(
    [],
    tool_choice=tool_choice,
    parallel_tool_calls=False,
)

print("After:", tool_choice)
```

### Current behavior

```python
Before: {'type': 'tool', 'name': 'GetWeather'}

After: {
    'type': 'tool',
    'name': 'GetWeather',
    'disable_parallel_tool_use': True,
}
```

### Expected behavior

The original `tool_choice` dictionary should remain unchanged after calling `bind_tools()`.

```python
{
    "type": "tool",
    "name": "GetWeather",
}
```

## Root cause

The current implementation assigns the caller's dictionary directly:

```python
kwargs["tool_choice"] = tool_choice
```

Later, it modifies the same dictionary:

```python
kwargs["tool_choice"]["disable_parallel_tool_use"] = (
    disable_parallel_tool_use
)
```

Since both variables reference the same object, the caller's input is mutated.

## Proposed solution

Create a shallow copy of the provided dictionary before storing it in `kwargs`:

```python
kwargs["tool_choice"] = tool_choice.copy()
```

This preserves the existing behavior while preventing unexpected mutation of the caller's object.

## Verification

I reproduced the issue locally, implemented the proposed fix, and added a regression test that fails before the fix and passes after it. I also verified that the existing `test_anthropic_bind_tools_tool_choice` test continues to pass.