### PR TITLE
feat(langchain): `ToolErrorMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -24,6 +24,7 @@ from langchain.agents.middleware.summarization import SummarizationMiddleware, T
 from langchain.agents.middleware.todo import TodoListMiddleware
 from langchain.agents.middleware.tool_call_limit import ToolCallLimitMiddleware
 from langchain.agents.middleware.tool_emulator import LLMToolEmulator
+from langchain.agents.middleware.tool_error import ToolErrorMiddleware
 from langchain.agents.middleware.tool_retry import ToolRetryMiddleware
 from langchain.agents.middleware.tool_selection import LLMToolSelectorMiddleware
 from langchain.agents.middleware.types import (
@@ -78,6 +79,7 @@ __all__ = [
     "TodoListMiddleware",
     "ToolCallLimitMiddleware",
     "ToolCallRequest",
+    "ToolErrorMiddleware",
     "ToolRetryMiddleware",
     "TriggerClause",
     "after_agent",

--- a/libs/langchain_v1/langchain/agents/middleware/tool_error.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_error.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import inspect
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from langchain_core.messages import ToolMessage
 from langgraph.errors import GraphBubbleUp
@@ -12,43 +10,43 @@ from langgraph.errors import GraphBubbleUp
 from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ResponseT
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
+    from collections.abc import Awaitable, Callable
 
+    from langchain_core.messages import ContentBlock
     from langgraph.types import Command
 
     from langchain.agents.middleware.types import ToolCallRequest
     from langchain.tools import BaseTool
 
-Catch = tuple[type[Exception], ...] | Callable[[Exception], bool]
-"""Exceptions to catch: a tuple of exception types, or a predicate ``(exc) -> bool``."""
+    OnError = Callable[[Exception, ToolCallRequest], str | list[ContentBlock] | None]
+    """Sync handler: return content to surface the error as a `ToolMessage`; return
+    `None` (or nothing) to let the exception propagate."""
 
-OnError = Callable[
-    [Exception, "ToolCallRequest"],
-    "str | list[str | dict[Any, Any]] | Awaitable[str | list[str | dict[Any, Any]]]",
-]
-"""Handler for a caught exception, returning `ToolMessage` content.
-
-May be sync or async. An async `on_error` requires async execution (`ainvoke`/`astream`).
-"""
-
-
-def _should_catch(exc: Exception, catch: Catch) -> bool:
-    """Return whether `exc` should be caught and returned to the model."""
-    if isinstance(catch, tuple):
-        return isinstance(exc, catch)
-    return bool(catch(exc))
+    AOnError = Callable[[Exception, ToolCallRequest], Awaitable[str | list[ContentBlock] | None]]
+    """Async handler: return content to surface the error as a `ToolMessage`; return
+    `None` (or nothing) to let the exception propagate."""
 
 
 class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
-    """Return tool-execution exceptions to the model as error `ToolMessage`s.
+    """Return selected tool-execution exceptions to the model as error `ToolMessage`s.
 
-    Only the exceptions named in `catch` are converted into a
-    `ToolMessage(status="error")`; any other exception propagates and halts the run.
-    Langgraph control-flow signals (interrupts, parent commands) always propagate.
+    `on_error` is called for each exception raised by tool execution. Return content
+    (a `str` or a list of content blocks) to convert the exception into a
+    `ToolMessage(status="error")`; return `None` — or simply don't return — to let the
+    exception propagate (halting the run). Handling is therefore opt-in — exceptions you
+    do not return content for propagate unchanged, so arbitrary internal exceptions are
+    never serialized to the model or end user unless you choose to surface them.
 
-    `catch` is required: there is intentionally no catch-all default, so arbitrary
-    internal exceptions are not serialized to the model or end user. Use `on_error`
-    to control (and sanitize) exactly what content the model sees.
+    Langgraph control-flow signals (interrupts, parent commands) always propagate and
+    never reach `on_error`.
+
+    Prefer returning content that names the exception type over the raw exception message,
+    which may carry sensitive or internal detail.
+
+    Provide at least one of `on_error` or `aon_error`. `aon_error` handles errors on the
+    async execution path (falling back to `on_error` when omitted); the sync path only
+    ever calls `on_error`. For async-only usage, pass `aon_error` alone — running such a
+    middleware on the sync path raises, since the async handler cannot be awaited there.
 
     This middleware does not retry. For retries, compose with `ToolRetryMiddleware`
     placed *inner* and configured with `on_failure="error"` so exceptions reach this
@@ -56,67 +54,57 @@ class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
 
     This middleware only sees exceptions raised by tool *execution*. Argument-binding
     and validation errors are handled upstream by `ToolNode` (converted to an error
-    `ToolMessage` before the tool runs), so they do not pass through `catch` or
-    `on_error` and are not sanitized by `on_error`.
+    `ToolMessage` before the tool runs), so they do not reach `on_error`.
 
-    Guidance on what to `catch`:
-
-    - **Catch** (return to the model): anticipated, model-actionable, non-sensitive
-        errors raised by the tool — e.g. tool-domain errors the model can correct.
-    - **Do not catch** (let propagate): programming bugs, auth/permission errors, and
-        anything whose message may carry secrets or internal infrastructure detail.
-
-    Examples:
-        !!! example "Catch a specific tool error"
-
-            ```python
-            from langchain.agents import create_agent
-            from langchain.agents.middleware import ToolErrorMiddleware
-
-            agent = create_agent(
-                model,
-                tools=[search_tool],
-                middleware=[ToolErrorMiddleware(catch=(ValueError,))],
-            )
-            ```
-
-        !!! example "Custom, sanitized error message"
-
-            ```python
-            def on_error(exc: Exception, request: ToolCallRequest) -> str:
-                name = request.tool_call["name"]
-                return f"`{name}` failed with invalid input. Check the arguments and retry."
+    Example:
+        ```python
+        from langchain.agents import create_agent
+        from langchain.agents.middleware import ToolErrorMiddleware
 
 
-            ToolErrorMiddleware(catch=(ValueError,), on_error=on_error)
-            ```
+        def on_error(exc: Exception, request: ToolCallRequest) -> str | None:
+            if isinstance(exc, ValueError):
+                return f"`{request.tool_call['name']}` failed; fix the input and retry."
+            return None  # propagate everything else
+
+
+        agent = create_agent(model, tools=[...], middleware=[ToolErrorMiddleware(on_error)])
+        ```
     """
 
     def __init__(
         self,
-        catch: Catch,
-        *,
         on_error: OnError | None = None,
+        *,
+        aon_error: AOnError | None = None,
         tools: list[BaseTool | str] | None = None,
     ) -> None:
         """Initialize `ToolErrorMiddleware`.
 
         Args:
-            catch: Exceptions to convert into an error `ToolMessage`. Either a tuple of
-                exception types, or a predicate `(exc) -> bool`. Exceptions that are not
-                caught propagate (halting the run).
-            on_error: Optional formatter for the `ToolMessage` content. Receives the
-                exception and the tool call request (tool name, args, call id). Defaults
-                to a conservative prose message. May return a string or a list of
-                content blocks.
-            tools: Optional list of tools or tool names to apply handling to. Can be a
-                list of `BaseTool` instances or tool name strings. If `None`, applies to
-                all tools.
+            on_error: Handler called for each exception raised by tool execution. Return
+                content (`str` or list of content blocks) to convert the exception into an
+                error `ToolMessage`. Return `None` — or simply don't return — to let the
+                exception propagate. Falling through without a return therefore re-raises,
+                so handle only the exceptions you mean to. Receives the exception and the
+                tool call request (tool name, args, call id). Used on the sync path and,
+                unless `aon_error` is given, on the async path.
+            aon_error: Optional async handler, used on the async execution path. Falls back
+                to `on_error` when not provided.
+            tools: Optional list of tools or tool names to apply handling to. If `None`,
+                applies to all tools.
+
+        Raises:
+            ValueError: If neither `on_error` nor `aon_error` is provided.
         """
         super().__init__()
 
-        self.catch = catch
+        if on_error is None and aon_error is None:
+            msg = "ToolErrorMiddleware requires `on_error` and/or `aon_error`."
+            raise ValueError(msg)
+
         self.on_error = on_error
+        self.aon_error = aon_error
 
         # Extract tool names from BaseTool instances or strings
         self._tool_filter: list[str] | None
@@ -133,46 +121,12 @@ class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
             return True
         return tool_name in self._tool_filter
 
-    @staticmethod
-    def _format_error(tool_name: str, exc: Exception) -> str:
-        """Default formatter for a caught exception.
-
-        Names the exception type but omits its message, which may contain sensitive
-        or internal detail. Provide `on_error` to include a sanitized message.
-        """
-        return f"Tool '{tool_name}' failed with {type(exc).__name__}."
-
-    def _sync_content(
-        self, exc: Exception, request: ToolCallRequest, tool_name: str
-    ) -> str | list[str | dict[Any, Any]]:
-        """Resolve the error message content in a sync context."""
-        if self.on_error is None:
-            return self._format_error(tool_name, exc)
-        result = self.on_error(exc, request)
-        if inspect.isawaitable(result):
-            if inspect.iscoroutine(result):
-                result.close()
-            msg = "async on_error requires async execution (ainvoke or astream)"
-            raise TypeError(msg)
-        return result
-
-    async def _async_content(
-        self, exc: Exception, request: ToolCallRequest, tool_name: str
-    ) -> str | list[str | dict[Any, Any]]:
-        """Resolve the error message content in an async context."""
-        if self.on_error is None:
-            return self._format_error(tool_name, exc)
-        result = self.on_error(exc, request)
-        if inspect.isawaitable(result):
-            return await result
-        return result
-
     def wrap_tool_call(
         self,
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
     ) -> ToolMessage | Command[Any]:
-        """Intercept tool execution and convert caught exceptions to error messages.
+        """Intercept tool execution and convert handled exceptions to error messages.
 
         Args:
             request: Tool call request with call dict, `BaseTool`, state, and runtime.
@@ -192,10 +146,18 @@ class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
             # Control-flow signals (interrupts, parent commands) must propagate.
             raise
         except Exception as exc:
-            if not _should_catch(exc, self.catch):
+            if self.on_error is None:
+                # Async-only config (aon_error) cannot be awaited on the sync path.
+                msg = (
+                    "ToolErrorMiddleware has no sync `on_error`; run async "
+                    "(ainvoke/astream) or provide `on_error`."
+                )
+                raise RuntimeError(msg) from exc
+            content = self.on_error(exc, request)
+            if content is None:
                 raise
             return ToolMessage(
-                content=self._sync_content(exc, request, tool_name),
+                content=cast("str | list[str | dict[Any, Any]]", content),
                 tool_call_id=request.tool_call["id"],
                 name=tool_name,
                 status="error",
@@ -206,7 +168,11 @@ class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
     ) -> ToolMessage | Command[Any]:
-        """Async version of `wrap_tool_call`."""
+        """Async version of `wrap_tool_call`.
+
+        Uses `aon_error` if provided, otherwise the sync `on_error`. The sync path never
+        awaits.
+        """
         tool_name = request.tool.name if request.tool else request.tool_call["name"]
 
         if not self._should_handle_tool(tool_name):
@@ -218,10 +184,16 @@ class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
             # Control-flow signals (interrupts, parent commands) must propagate.
             raise
         except Exception as exc:
-            if not _should_catch(exc, self.catch):
+            if self.aon_error is not None:
+                content = await self.aon_error(exc, request)
+            elif self.on_error is not None:
+                content = self.on_error(exc, request)
+            else:  # pragma: no cover - __init__ guarantees at least one handler
+                raise
+            if content is None:
                 raise
             return ToolMessage(
-                content=await self._async_content(exc, request, tool_name),
+                content=cast("str | list[str | dict[Any, Any]]", content),
                 tool_call_id=request.tool_call["id"],
                 name=tool_name,
                 status="error",

--- a/libs/langchain_v1/langchain/agents/middleware/tool_error.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_error.py
@@ -54,10 +54,15 @@ class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
     placed *inner* and configured with `on_failure="error"` so exceptions reach this
     middleware.
 
+    This middleware only sees exceptions raised by tool *execution*. Argument-binding
+    and validation errors are handled upstream by `ToolNode` (converted to an error
+    `ToolMessage` before the tool runs), so they do not pass through `catch` or
+    `on_error` and are not sanitized by `on_error`.
+
     Guidance on what to `catch`:
 
     - **Catch** (return to the model): anticipated, model-actionable, non-sensitive
-        errors — e.g. validation errors or tool-domain errors the model can correct.
+        errors raised by the tool — e.g. tool-domain errors the model can correct.
     - **Do not catch** (let propagate): programming bugs, auth/permission errors, and
         anything whose message may carry secrets or internal infrastructure detail.
 

--- a/libs/langchain_v1/langchain/agents/middleware/tool_error.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_error.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -21,8 +22,14 @@ if TYPE_CHECKING:
 Catch = tuple[type[Exception], ...] | Callable[[Exception], bool]
 """Exceptions to catch: a tuple of exception types, or a predicate ``(exc) -> bool``."""
 
-OnError = Callable[[Exception, "ToolCallRequest"], "str | list[str | dict[Any, Any]]"]
-"""Formatter for a caught exception, returning `ToolMessage` content."""
+OnError = Callable[
+    [Exception, "ToolCallRequest"],
+    "str | list[str | dict[Any, Any]] | Awaitable[str | list[str | dict[Any, Any]]]",
+]
+"""Handler for a caught exception, returning `ToolMessage` content.
+
+May be sync or async. An async `on_error` requires async execution (`ainvoke`/`astream`).
+"""
 
 
 def _should_catch(exc: Exception, catch: Catch) -> bool:
@@ -130,6 +137,31 @@ class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
         """
         return f"Tool '{tool_name}' failed with {type(exc).__name__}."
 
+    def _sync_content(
+        self, exc: Exception, request: ToolCallRequest, tool_name: str
+    ) -> str | list[str | dict[Any, Any]]:
+        """Resolve the error message content in a sync context."""
+        if self.on_error is None:
+            return self._format_error(tool_name, exc)
+        result = self.on_error(exc, request)
+        if inspect.isawaitable(result):
+            if inspect.iscoroutine(result):
+                result.close()
+            msg = "async on_error requires async execution (ainvoke or astream)"
+            raise TypeError(msg)
+        return result
+
+    async def _async_content(
+        self, exc: Exception, request: ToolCallRequest, tool_name: str
+    ) -> str | list[str | dict[Any, Any]]:
+        """Resolve the error message content in an async context."""
+        if self.on_error is None:
+            return self._format_error(tool_name, exc)
+        result = self.on_error(exc, request)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
     def wrap_tool_call(
         self,
         request: ToolCallRequest,
@@ -157,13 +189,8 @@ class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
         except Exception as exc:
             if not _should_catch(exc, self.catch):
                 raise
-            content = (
-                self.on_error(exc, request)
-                if self.on_error is not None
-                else self._format_error(tool_name, exc)
-            )
             return ToolMessage(
-                content=content,
+                content=self._sync_content(exc, request, tool_name),
                 tool_call_id=request.tool_call["id"],
                 name=tool_name,
                 status="error",
@@ -188,13 +215,8 @@ class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
         except Exception as exc:
             if not _should_catch(exc, self.catch):
                 raise
-            content = (
-                self.on_error(exc, request)
-                if self.on_error is not None
-                else self._format_error(tool_name, exc)
-            )
             return ToolMessage(
-                content=content,
+                content=await self._async_content(exc, request, tool_name),
                 tool_call_id=request.tool_call["id"],
                 name=tool_name,
                 status="error",

--- a/libs/langchain_v1/langchain/agents/middleware/tool_error.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_error.py
@@ -1,0 +1,201 @@
+"""Tool error middleware for agents."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import ToolMessage
+from langgraph.errors import GraphBubbleUp
+
+from langchain.agents.middleware.types import AgentMiddleware, AgentState, ContextT, ResponseT
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from langgraph.types import Command
+
+    from langchain.agents.middleware.types import ToolCallRequest
+    from langchain.tools import BaseTool
+
+Catch = tuple[type[Exception], ...] | Callable[[Exception], bool]
+"""Exceptions to catch: a tuple of exception types, or a predicate ``(exc) -> bool``."""
+
+OnError = Callable[[Exception, "ToolCallRequest"], "str | list[str | dict[Any, Any]]"]
+"""Formatter for a caught exception, returning `ToolMessage` content."""
+
+
+def _should_catch(exc: Exception, catch: Catch) -> bool:
+    """Return whether `exc` should be caught and returned to the model."""
+    if isinstance(catch, tuple):
+        return isinstance(exc, catch)
+    return bool(catch(exc))
+
+
+class ToolErrorMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
+    """Return tool-execution exceptions to the model as error `ToolMessage`s.
+
+    Only the exceptions named in `catch` are converted into a
+    `ToolMessage(status="error")`; any other exception propagates and halts the run.
+    Langgraph control-flow signals (interrupts, parent commands) always propagate.
+
+    `catch` is required: there is intentionally no catch-all default, so arbitrary
+    internal exceptions are not serialized to the model or end user. Use `on_error`
+    to control (and sanitize) exactly what content the model sees.
+
+    This middleware does not retry. For retries, compose with `ToolRetryMiddleware`
+    placed *inner* and configured with `on_failure="error"` so exceptions reach this
+    middleware.
+
+    Guidance on what to `catch`:
+
+    - **Catch** (return to the model): anticipated, model-actionable, non-sensitive
+        errors — e.g. validation errors or tool-domain errors the model can correct.
+    - **Do not catch** (let propagate): programming bugs, auth/permission errors, and
+        anything whose message may carry secrets or internal infrastructure detail.
+
+    Examples:
+        !!! example "Catch a specific tool error"
+
+            ```python
+            from langchain.agents import create_agent
+            from langchain.agents.middleware import ToolErrorMiddleware
+
+            agent = create_agent(
+                model,
+                tools=[search_tool],
+                middleware=[ToolErrorMiddleware(catch=(ValueError,))],
+            )
+            ```
+
+        !!! example "Custom, sanitized error message"
+
+            ```python
+            def on_error(exc: Exception, request: ToolCallRequest) -> str:
+                name = request.tool_call["name"]
+                return f"`{name}` failed with invalid input. Check the arguments and retry."
+
+
+            ToolErrorMiddleware(catch=(ValueError,), on_error=on_error)
+            ```
+    """
+
+    def __init__(
+        self,
+        catch: Catch,
+        *,
+        on_error: OnError | None = None,
+        tools: list[BaseTool | str] | None = None,
+    ) -> None:
+        """Initialize `ToolErrorMiddleware`.
+
+        Args:
+            catch: Exceptions to convert into an error `ToolMessage`. Either a tuple of
+                exception types, or a predicate `(exc) -> bool`. Exceptions that are not
+                caught propagate (halting the run).
+            on_error: Optional formatter for the `ToolMessage` content. Receives the
+                exception and the tool call request (tool name, args, call id). Defaults
+                to a conservative prose message. May return a string or a list of
+                content blocks.
+            tools: Optional list of tools or tool names to apply handling to. Can be a
+                list of `BaseTool` instances or tool name strings. If `None`, applies to
+                all tools.
+        """
+        super().__init__()
+
+        self.catch = catch
+        self.on_error = on_error
+
+        # Extract tool names from BaseTool instances or strings
+        self._tool_filter: list[str] | None
+        if tools is not None:
+            self._tool_filter = [tool.name if not isinstance(tool, str) else tool for tool in tools]
+        else:
+            self._tool_filter = None
+
+        self.tools = []  # No additional tools registered by this middleware
+
+    def _should_handle_tool(self, tool_name: str) -> bool:
+        """Check if error handling should apply to this tool."""
+        if self._tool_filter is None:
+            return True
+        return tool_name in self._tool_filter
+
+    @staticmethod
+    def _format_error(tool_name: str, exc: Exception) -> str:
+        """Default formatter for a caught exception.
+
+        Names the exception type but omits its message, which may contain sensitive
+        or internal detail. Provide `on_error` to include a sanitized message.
+        """
+        return f"Tool '{tool_name}' failed with {type(exc).__name__}."
+
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command[Any]],
+    ) -> ToolMessage | Command[Any]:
+        """Intercept tool execution and convert caught exceptions to error messages.
+
+        Args:
+            request: Tool call request with call dict, `BaseTool`, state, and runtime.
+            handler: Callable to execute the tool.
+
+        Returns:
+            `ToolMessage` or `Command` (the final result).
+        """
+        tool_name = request.tool.name if request.tool else request.tool_call["name"]
+
+        if not self._should_handle_tool(tool_name):
+            return handler(request)
+
+        try:
+            return handler(request)
+        except GraphBubbleUp:
+            # Control-flow signals (interrupts, parent commands) must propagate.
+            raise
+        except Exception as exc:
+            if not _should_catch(exc, self.catch):
+                raise
+            content = (
+                self.on_error(exc, request)
+                if self.on_error is not None
+                else self._format_error(tool_name, exc)
+            )
+            return ToolMessage(
+                content=content,
+                tool_call_id=request.tool_call["id"],
+                name=tool_name,
+                status="error",
+            )
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]],
+    ) -> ToolMessage | Command[Any]:
+        """Async version of `wrap_tool_call`."""
+        tool_name = request.tool.name if request.tool else request.tool_call["name"]
+
+        if not self._should_handle_tool(tool_name):
+            return await handler(request)
+
+        try:
+            return await handler(request)
+        except GraphBubbleUp:
+            # Control-flow signals (interrupts, parent commands) must propagate.
+            raise
+        except Exception as exc:
+            if not _should_catch(exc, self.catch):
+                raise
+            content = (
+                self.on_error(exc, request)
+                if self.on_error is not None
+                else self._format_error(tool_name, exc)
+            )
+            return ToolMessage(
+                content=content,
+                tool_call_id=request.tool_call["id"],
+                name=tool_name,
+                status="error",
+            )

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_error.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_error.py
@@ -26,12 +26,16 @@ def _model() -> FakeToolCallingModel:
     )
 
 
-def test_tool_error_caught_returns_tool_message() -> None:
-    """A caught exception becomes an error ToolMessage; default omits the raw message."""
+def test_tool_error_handled_returns_tool_message() -> None:
+    """`on_error` content is returned as an error ToolMessage and controls disclosure."""
+
+    def on_error(exc: Exception, request: ToolCallRequest) -> str | None:
+        return f"`{request.tool_call['name']}` failed with {type(exc).__name__}."
+
     agent = create_agent(
         model=_model(),
         tools=[failing_tool],
-        middleware=[ToolErrorMiddleware(catch=(ValueError,))],
+        middleware=[ToolErrorMiddleware(on_error)],
     )
 
     result = agent.invoke({"messages": [HumanMessage("go")]})
@@ -40,60 +44,39 @@ def test_tool_error_caught_returns_tool_message() -> None:
     assert len(tool_messages) == 1
     assert tool_messages[0].status == "error"
     assert tool_messages[0].name == "failing_tool"
-    assert "ValueError" in tool_messages[0].content
-    # Default formatter must not leak the raw exception message.
+    assert tool_messages[0].content == "`failing_tool` failed with ValueError."
+    # on_error controls disclosure — the raw exception message is not leaked.
     assert "secret detail" not in tool_messages[0].content
 
 
-def test_tool_error_uncaught_propagates() -> None:
-    """An exception not listed in `catch` propagates out of the agent."""
+def test_tool_error_none_propagates() -> None:
+    """Returning `None` from `on_error` lets the exception propagate."""
+
+    def on_error(exc: Exception, _request: ToolCallRequest) -> str | None:
+        if isinstance(exc, KeyError):
+            return "handled"
+        return None  # ValueError is not handled -> propagates
+
     agent = create_agent(
         model=_model(),
         tools=[failing_tool],
-        middleware=[ToolErrorMiddleware(catch=(KeyError,))],
+        middleware=[ToolErrorMiddleware(on_error)],
     )
 
     with pytest.raises(ValueError, match="secret detail"):
         agent.invoke({"messages": [HumanMessage("go")]})
 
 
-def test_tool_error_on_error_formats_content() -> None:
-    """`on_error` sets the ToolMessage content and can use the tool call context."""
+async def test_tool_error_async_only() -> None:
+    """`aon_error` alone (no `on_error`) handles errors on the async path."""
 
-    def on_error(exc: Exception, request: ToolCallRequest) -> str:
-        return (
-            f"`{request.tool_call['name']}` raised {type(exc).__name__} for "
-            f"{request.tool_call['args']}; fix the arguments and retry."
-        )
-
-    agent = create_agent(
-        model=_model(),
-        tools=[failing_tool],
-        middleware=[ToolErrorMiddleware(catch=(ValueError,), on_error=on_error)],
-    )
-
-    result = agent.invoke({"messages": [HumanMessage("go")]})
-
-    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
-    assert len(tool_messages) == 1
-    assert tool_messages[0].status == "error"
-    assert tool_messages[0].content == (
-        "`failing_tool` raised ValueError for {'value': 'x'}; fix the arguments and retry."
-    )
-    # Custom formatter controls disclosure — the raw exception message is not leaked.
-    assert "secret detail" not in tool_messages[0].content
-
-
-async def test_tool_error_async_on_error() -> None:
-    """An async `on_error` is awaited under async execution."""
-
-    async def on_error(exc: Exception, request: ToolCallRequest) -> str:
+    async def aon_error(exc: Exception, request: ToolCallRequest) -> str | None:
         return f"async handled `{request.tool_call['name']}`: {type(exc).__name__}"
 
     agent = create_agent(
         model=_model(),
         tools=[failing_tool],
-        middleware=[ToolErrorMiddleware(catch=(ValueError,), on_error=on_error)],
+        middleware=[ToolErrorMiddleware(aon_error=aon_error)],
     )
 
     result = await agent.ainvoke({"messages": [HumanMessage("go")]})
@@ -102,3 +85,9 @@ async def test_tool_error_async_on_error() -> None:
     assert len(tool_messages) == 1
     assert tool_messages[0].status == "error"
     assert tool_messages[0].content == "async handled `failing_tool`: ValueError"
+
+
+def test_tool_error_requires_a_handler() -> None:
+    """At least one of `on_error`/`aon_error` must be provided."""
+    with pytest.raises(ValueError, match="on_error"):
+        ToolErrorMiddleware()

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_error.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_error.py
@@ -1,0 +1,56 @@
+"""Tests for ToolErrorMiddleware functionality."""
+
+import pytest
+from langchain_core.messages import HumanMessage, ToolCall, ToolMessage
+from langchain_core.tools import tool
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware import ToolErrorMiddleware
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+@tool
+def failing_tool(value: str) -> str:
+    """Tool that always fails."""
+    msg = f"secret detail: {value}"
+    raise ValueError(msg)
+
+
+def _model() -> FakeToolCallingModel:
+    return FakeToolCallingModel(
+        tool_calls=[
+            [ToolCall(name="failing_tool", args={"value": "x"}, id="1")],
+            [],
+        ]
+    )
+
+
+def test_tool_error_caught_returns_tool_message() -> None:
+    """A caught exception becomes an error ToolMessage; default omits the raw message."""
+    agent = create_agent(
+        model=_model(),
+        tools=[failing_tool],
+        middleware=[ToolErrorMiddleware(catch=(ValueError,))],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("go")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].status == "error"
+    assert tool_messages[0].name == "failing_tool"
+    assert "ValueError" in tool_messages[0].content
+    # Default formatter must not leak the raw exception message.
+    assert "secret detail" not in tool_messages[0].content
+
+
+def test_tool_error_uncaught_propagates() -> None:
+    """An exception not listed in `catch` propagates out of the agent."""
+    agent = create_agent(
+        model=_model(),
+        tools=[failing_tool],
+        middleware=[ToolErrorMiddleware(catch=(KeyError,))],
+    )
+
+    with pytest.raises(ValueError, match="secret detail"):
+        agent.invoke({"messages": [HumanMessage("go")]})

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_error.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_tool_error.py
@@ -3,6 +3,7 @@
 import pytest
 from langchain_core.messages import HumanMessage, ToolCall, ToolMessage
 from langchain_core.tools import tool
+from langgraph.prebuilt.tool_node import ToolCallRequest
 
 from langchain.agents.factory import create_agent
 from langchain.agents.middleware import ToolErrorMiddleware
@@ -54,3 +55,50 @@ def test_tool_error_uncaught_propagates() -> None:
 
     with pytest.raises(ValueError, match="secret detail"):
         agent.invoke({"messages": [HumanMessage("go")]})
+
+
+def test_tool_error_on_error_formats_content() -> None:
+    """`on_error` sets the ToolMessage content and can use the tool call context."""
+
+    def on_error(exc: Exception, request: ToolCallRequest) -> str:
+        return (
+            f"`{request.tool_call['name']}` raised {type(exc).__name__} for "
+            f"{request.tool_call['args']}; fix the arguments and retry."
+        )
+
+    agent = create_agent(
+        model=_model(),
+        tools=[failing_tool],
+        middleware=[ToolErrorMiddleware(catch=(ValueError,), on_error=on_error)],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("go")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].status == "error"
+    assert tool_messages[0].content == (
+        "`failing_tool` raised ValueError for {'value': 'x'}; fix the arguments and retry."
+    )
+    # Custom formatter controls disclosure — the raw exception message is not leaked.
+    assert "secret detail" not in tool_messages[0].content
+
+
+async def test_tool_error_async_on_error() -> None:
+    """An async `on_error` is awaited under async execution."""
+
+    async def on_error(exc: Exception, request: ToolCallRequest) -> str:
+        return f"async handled `{request.tool_call['name']}`: {type(exc).__name__}"
+
+    agent = create_agent(
+        model=_model(),
+        tools=[failing_tool],
+        middleware=[ToolErrorMiddleware(catch=(ValueError,), on_error=on_error)],
+    )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("go")]})
+
+    tool_messages = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 1
+    assert tool_messages[0].status == "error"
+    assert tool_messages[0].content == "async handled `failing_tool`: ValueError"


### PR DESCRIPTION
Resolves https://github.com/langchain-ai/langchain/issues/37195

Adds a `ToolErrorMiddleware` that allows specification of exceptions to be caught and translated into ToolMessages.

Usage patterns below.

Basic usage: `MyError` becomes `ToolMessage("Tool 'failing_tool' failed with MyError")`
```python
def on_error(exc: Exception, request: ToolCallRequest) -> str | None:
    if isinstance(exc, MyError):
        return f"Tool '{request.tool_call['name']}' failed with {type(exc).__name__}"
    # propagates everything else


agent = create_agent(
    model="...",
    tools=[failing_tool],
    middleware=[ToolErrorMiddleware(on_error)],
)
```