### PR TITLE
fix(core): preserve tool fields populated by validation aliases

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -831,9 +831,9 @@ class ChildTool(BaseTool):
                 )
                 raise NotImplementedError(msg)
 
-            # Include fields from tool_input, plus fields with explicit defaults.
-            # This applies Pydantic defaults (like Field(default=1)) while excluding
-            # synthetic "args"/"kwargs" fields that Pydantic creates for *args/**kwargs.
+            # Include fields provided in the input, fields populated through Pydantic
+            # validation aliases, and fields with explicit defaults. Exclude synthetic
+            # "args"/"kwargs" fields that Pydantic creates for *args/**kwargs.
             field_info = get_fields(input_args)
             validated_input = {}
             for k in result_dict:
@@ -841,18 +841,10 @@ class ChildTool(BaseTool):
                     # Field was provided in input - include it (validated)
                     validated_input[k] = getattr(result, k)
                 elif k in field_info and k not in {"args", "kwargs"}:
-                    # Check if field has an explicit default defined in the schema.
-                    # Exclude "args"/"kwargs" as these are synthetic fields for variadic
-                    # parameters that should not be passed as keyword arguments.
-                    fi = field_info[k]
-                    # Pydantic v2 uses is_required() method, v1 uses required attribute
-                    has_default = (
-                        not fi.is_required()
-                        if hasattr(fi, "is_required")
-                        else not getattr(fi, "required", True)
-                    )
-                    if has_default:
-                        validated_input[k] = getattr(result, k)
+                    # Field was populated by the schema, e.g. via validation_alias
+                    # or an explicit default. Include real schema fields after
+                    # validation while still excluding synthetic variadic fields.
+                    validated_input[k] = getattr(result, k)
 
             for k in self._injected_args_keys:
                 if k in tool_input:

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, ValidationError
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import ValidationError as ValidationErrorV1
 from typing_extensions import TypedDict, override
@@ -241,6 +241,23 @@ def test_decorator_with_specified_schema() -> None:
 
     assert isinstance(tool_func, BaseTool)
     assert tool_func.args_schema == _MockSchema
+
+
+def test_decorator_with_schema_validation_alias() -> None:
+    """Test that schema validation aliases are passed to the tool function."""
+
+    class _AliasedSchema(BaseModel):
+        model_config = ConfigDict(populate_by_name=True)
+
+        query_text: str = Field(validation_alias=AliasChoices("query_text", "query"))
+
+    @tool(args_schema=_AliasedSchema)
+    def tool_func(query_text: str) -> str:
+        """Return the aliased argument directly."""
+        return query_text
+
+    assert tool_func.invoke({"query_text": "canonical"}) == "canonical"
+    assert tool_func.invoke({"query": "alias"}) == "alias"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Closes #38780

---

Tools with a Pydantic `args_schema` can accept alternate input names using `validation_alias`, but `BaseTool._parse_input()` only forwarded fields whose canonical name was present in the original input or whose schema field had a default. That meant a required field populated through an alias validated successfully and then got silently dropped before the tool function was called.

This change keeps real schema fields from the validated model output, including fields populated through `validation_alias`, while continuing to exclude Pydantic's synthetic variadic `args`/`kwargs` fields. I added a regression test covering both the canonical field name and an `AliasChoices` alias.

## Release note

`BaseTool` now preserves required tool arguments populated through Pydantic `validation_alias` definitions instead of silently dropping them before invocation.

AI-agent assistance was used to prepare this contribution; the change was locally inspected and tested before submission.
