### PR TITLE
fix(anthropic): prevent bind_tools from mutating caller's tool_choice dict

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1923,7 +1923,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1567,6 +1567,22 @@ def test_anthropic_bind_tools_tool_choice() -> None:
     }
 
 
+def test_anthropic_bind_tools_tool_choice_no_mutation() -> None:
+    """Test that bind_tools does not mutate the caller's tool_choice dict."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    tool_choice = {"type": "tool", "name": "GetWeather"}
+    original = tool_choice.copy()
+    chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=tool_choice,
+        parallel_tool_calls=False,
+    )
+    assert tool_choice == original, f"tool_choice was mutated: {tool_choice}"
+
+
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""
     # Test with betas parameter at initialization


### PR DESCRIPTION
Fixes #38779

`ChatAnthropic.bind_tools` stored the caller-provided `tool_choice` dict by reference (`kwargs["tool_choice"] = tool_choice`) and later mutated it in-place with `disable_parallel_tool_use` when `parallel_tool_calls` was also specified. This silently corrupted the caller's original dict.

**Root cause:** line 1926 stored the dict without copying; lines 1962-1965 wrote `disable_parallel_tool_use` directly into it.

**Fix:** shallow-copy the dict before storing: `kwargs["tool_choice"] = tool_choice.copy()`. Only ChatAnthropic was affected — other integrations like OpenAI, Groq, and Fireworks don't mutate after storage.

**Test:** added `test_anthropic_bind_tools_tool_choice_no_mutation` that passes a dict, calls `bind_tools` with `parallel_tool_calls=False`, and asserts the original dict is unchanged.

---