### PR TITLE
fix(anthropic): prevent bind_tools from mutating caller-provided tool_choice dict

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1923,7 +1923,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):


### PR DESCRIPTION
## Summary

`ChatAnthropic.bind_tools()` mutates the caller-provided `tool_choice` dictionary when `parallel_tool_calls=False`. The implementation stores a reference to the original dict and later adds `disable_parallel_tool_use` to it, unexpectedly modifying the caller's input.

## Reproduction

```python
from langchain_anthropic import ChatAnthropic

model = ChatAnthropic(model="claude-sonnet-4-5-20250929", anthropic_api_key="dummy")

tool_choice = {"type": "tool", "name": "GetWeather"}
print("Before:", tool_choice)

model.bind_tools([], tool_choice=tool_choice, parallel_tool_calls=False)
print("After:", tool_choice)
```

**Before fix:** `{'type': 'tool', 'name': 'GetWeather', 'disable_parallel_tool_use': True}`
**After fix:** `{'type': 'tool', 'name': 'GetWeather'}`

## Fix

Create a shallow copy of the `tool_choice` dict before storing it in `kwargs`:

```python
# Before (mutates caller's dict):
kwargs["tool_choice"] = tool_choice

# After (preserves caller's dict):
kwargs["tool_choice"] = tool_choice.copy()
```

## Test Plan

- [ ] Caller-provided `tool_choice` dict remains unchanged after `bind_tools()`
- [ ] Existing `test_anthropic_bind_tools_tool_choice` test continues to pass
- [ ] `disable_parallel_tool_use` is still correctly added to the internal copy

Closes #38779
