### PR TITLE
fix(core): append string content when merging into an empty list

### DIFF
--- a/libs/core/langchain_core/messages/base.py
+++ b/libs/core/langchain_core/messages/base.py
@@ -401,7 +401,7 @@ def merge_content(
         elif content == "":
             pass
         # Otherwise, add the second content as a new element of the list
-        elif merged:
+        else:
             merged.append(content)
     return merged
 

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -1090,6 +1090,13 @@ def test_tool_message_str() -> None:
             [[{"index": 0, "text": "bar"}]],
             [{"text": "foo"}, {"index": 0, "text": "bar"}],
         ),
+        # A non-empty string must be appended even when the accumulator list is
+        # empty; previously `elif merged:` dropped it because `[]` is falsy.
+        ([], ["bar"], ["bar"]),
+        ([], ["bar", "baz"], ["barbaz"]),
+        # Regression guard: a non-empty accumulator whose last element is not a
+        # string still appends (the fix only changes the empty-accumulator case).
+        ([{"text": "foo"}], ["bar"], [{"text": "foo"}, "bar"]),
     ],
 )
 def test_merge_content(


### PR DESCRIPTION
## Description

`merge_content` drops a non-empty string when the accumulated content is an empty list.

The final branch guards on `elif merged:`, but an empty list `[]` is falsy, so the string is silently discarded:

```python
>>> from langchain_core.messages import AIMessageChunk
>>> (AIMessageChunk(content=[]) + AIMessageChunk(content="bar")).content
[]          # expected: ["bar"]
```

Only a non-empty string can reach that branch — list content is handled by the earlier `isinstance(content, list)` branch, and an empty string is a no-op via `elif content == "":` — so the value should always be appended. This is silent data loss on the message-chunk `+` path (and `merge_message_runs`) whenever a chunk's accumulated content is an empty list, e.g. when streaming from providers that use list content.

The `elif merged:` guard was introduced in the v1.0.0 refactor (#32567), replacing `elif content:`; this restores the intended behavior. Since `else` differs from `elif merged:` only when `merged` is falsy (the empty-list case), no other path changes.

## Fix

```diff
-        elif merged:
+        else:
             merged.append(content)
```

## Tests

Extended the existing `test_merge_content` parametrized table (its `([], [""], [])` row covered empty *strings* but not a non-empty string into an empty list), plus a regression guard for a non-empty accumulator whose last element isn't a string:

- `([], ["bar"], ["bar"])`
- `([], ["bar", "baz"], ["barbaz"])`
- `([{"text": "foo"}], ["bar"], [{"text": "foo"}, "bar"])`

The first two fail before the change (they return `[]`) and pass after; the full `test_messages.py` suite (266 tests) passes, and `ruff check`/`format` are clean.
