### PR TITLE
fix(openai): support o-series models in get_num_tokens_from_messages

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2136,7 +2136,7 @@ class BaseChatOpenAI(BaseChatModel):
             tokens_per_message = 4
             # if there's a name, the role is omitted
             tokens_per_name = -1
-        elif model.startswith(("gpt-3.5-turbo", "gpt-4", "gpt-5")):
+        elif model.startswith(("gpt-3.5-turbo", "gpt-4", "gpt-5", "o1", "o3", "o4")):
             tokens_per_message = 3
             tokens_per_name = 1
         else:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1091,6 +1091,40 @@ def test_get_num_tokens_from_messages() -> None:
     assert actual
 
 
+@pytest.mark.parametrize(
+    "model",
+    ["o1", "o1-preview", "o1-mini", "o3", "o3-mini", "o3-pro", "o4-mini"],
+)
+def test_get_num_tokens_from_messages_o_series(model: str) -> None:
+    """o-series reasoning models use the same message-overhead accounting as
+    gpt-4/gpt-5 chat models (3 tokens/message, 1 token/name).
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38700:
+    these previously raised NotImplementedError because the model-prefix
+    check only recognized "gpt-3.5-turbo", "gpt-4", and "gpt-5".
+    """
+    llm = ChatOpenAI(model=model)
+    messages = [
+        SystemMessage("you're a good assistant"),
+        HumanMessage("how are you"),
+    ]
+    actual = llm.get_num_tokens_from_messages(messages)
+    expected = ChatOpenAI(model=OPENAI_TEST_MODEL).get_num_tokens_from_messages(
+        messages
+    )
+    assert actual == expected
+
+
+def test_get_num_tokens_from_messages_unsupported_model_still_raises() -> None:
+    """The fix for o-series models must not silently broaden the match to
+    arbitrary/unknown model families -- unsupported models should still
+    raise NotImplementedError with a helpful message."""
+    llm = ChatOpenAI(model="some-future-unsupported-model")
+    messages = [HumanMessage("hi")]
+    with pytest.raises(NotImplementedError, match="not presently implemented"):
+        llm.get_num_tokens_from_messages(messages)
+
+
 class Foo(BaseModel):
     bar: int
 


### PR DESCRIPTION
## Description

`ChatOpenAI.get_num_tokens_from_messages()` raises `NotImplementedError` for OpenAI's o-series reasoning models (`o1`, `o1-mini`, `o1-preview`, `o3`, `o3-mini`, `o3-pro`, `o4-mini`, etc.), even though these models use the exact same message-overhead token accounting as `gpt-4`/`gpt-5` chat models.

### Root cause

In `libs/partners/openai/langchain_openai/chat_models/base.py`, the per-message/per-name token overhead logic is selected by matching the model name prefix:

```python
elif model.startswith(("gpt-3.5-turbo", "gpt-4", "gpt-5")):
    tokens_per_message = 3
    tokens_per_name = 1
```

Because `"o1"`, `"o3"`, `"o4"` aren't in that prefix tuple, calling `get_num_tokens_from_messages()` on any o-series model falls through to the `else` branch, which raises:

```
NotImplementedError(
    f"get_num_tokens_from_messages() is not presently implemented "
    f"for model {model}."
)
```

This breaks token counting for any user on an o-series model (a common and growing case, since o-series are OpenAI's current reasoning-model line).

### Fix

Added `"o1"`, `"o3"`, `"o4"` to the prefix tuple so o-series models use the same `tokens_per_message = 3`, `tokens_per_name = 1` accounting as gpt-4/gpt-5:

```python
elif model.startswith(("gpt-3.5-turbo", "gpt-4", "gpt-5", "o1", "o3", "o4")):
```

This is a minimal, targeted change — it does not alter behavior for any already-supported model family, and unsupported/unknown models still correctly raise `NotImplementedError`.

### Tests

Added to `libs/partners/openai/tests/unit_tests/chat_models/test_base.py`:

1. `test_get_num_tokens_from_messages_o_series` — parametrized over `o1`, `o1-preview`, `o1-mini`, `o3`, `o3-mini`, `o3-pro`, `o4-mini`. Asserts each produces the same token count as an already-supported gpt model for identical messages.
2. `test_get_num_tokens_from_messages_unsupported_model_still_raises` — regression guard confirming the fix doesn't overly broaden matching: an arbitrary/unknown model name must still raise `NotImplementedError`.

**Verification note:** in my local sandbox, `tiktoken` couldn't download its BPE vocab file (no network access to `openaipublic.blob.core.windows.net`), so I couldn't execute these exact pytest functions end-to-end there. I verified the underlying control-flow logic directly with an isolated script that monkeypatches the encoding lookup, confirming: (a) all o-series prefixes route to the correct branch and produce identical counts to gpt-4/gpt-5, and (b) unsupported models still raise `NotImplementedError`. The committed tests use real `tiktoken` exactly like the pre-existing `test_get_num_tokens_from_messages` test they sit next to, and will run normally in CI, which has standard internet access.

### Issue

Fixes #38700

## Checklist

- [x] Change is minimal and scoped to the reported bug
- [x] Added regression tests covering the fix
- [x] Added a test confirming unsupported models still raise `NotImplementedError`
- [x] No changes to public API signatures

