### PR TITLE
docs(langchain-core): fix BaseChatMessageHistory.add_message Raises docstring

### DIFF
--- a/libs/core/langchain_core/chat_history.py
+++ b/libs/core/langchain_core/chat_history.py
@@ -152,8 +152,8 @@ class BaseChatMessageHistory(ABC):
             message: A `BaseMessage` object to store.
 
         Raises:
-            NotImplementedError: If the sub-class has not implemented an efficient
-                `add_messages` method.
+            NotImplementedError: If the subclass implements neither
+                `add_message` nor `add_messages`.
         """
         if type(self).add_messages != BaseChatMessageHistory.add_messages:
             # This means that the sub-class has implemented an efficient add_messages


### PR DESCRIPTION
Fixes #38603

Update the `Raises` section of `BaseChatMessageHistory.add_message` to match the current implementation by documenting that `NotImplementedError` is raised when neither `add_message` nor `add_messages` is implemented.