### PR TITLE
fix(anthropic): prevent bind_tools from mutating caller-provided tool_choice

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1923,7 +1923,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1566,6 +1566,15 @@ def test_anthropic_bind_tools_tool_choice() -> None:
         "type": "any",
     }
 
+    # Verify tool_choice dictionary is not mutated when parallel_tool_calls=False
+    tool_choice_dict = {"type": "tool", "name": "GetWeather"}
+    chat_model.bind_tools(
+        [GetWeather],
+        tool_choice=tool_choice_dict,
+        parallel_tool_calls=False,
+    )
+    assert tool_choice_dict == {"type": "tool", "name": "GetWeather"}
+
 
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""


### PR DESCRIPTION
Resolves #38779.

### Description
`ChatAnthropic.bind_tools()` unexpectedly mutated the caller-provided `tool_choice` dictionary when `parallel_tool_calls=False` by adding `"disable_parallel_tool_use": True` in-place. This was because it stored a direct reference to the dictionary instead of a copy.

### Changes
- Changed `kwargs["tool_choice"] = tool_choice` to `kwargs["tool_choice"] = tool_choice.copy()` when it is a dictionary.
- Added a regression unit test in `test_chat_models.py` verifying that the caller`s dictionary remains unmodified.
- Checked that all existing unit tests in `test_chat_models.py` continue to pass successfully.