### PR TITLE
fix: export PIIMatch from langchain.agents.middleware public package

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -12,6 +12,7 @@ from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddlewar
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
+from langchain.agents.middleware._redaction import PIIMatch
 from langchain.agents.middleware.provider_tool_search import ProviderToolSearchMiddleware
 from langchain.agents.middleware.shell_tool import (
     CodexSandboxExecutionPolicy,
@@ -70,6 +71,7 @@ __all__ = [
     "OutputAgentState",
     "PIIDetectionError",
     "PIIMiddleware",
+    "PIIMatch",
     "ProviderToolSearchMiddleware",
     "RedactionRule",
     "Runtime",


### PR DESCRIPTION
## Summary

Fixes #38718

 is defined in  and used by , but it was not exported from the public  package. Users writing custom detectors following the official docs had to import from the private  module.

## Changes

- Added  import
- Added  to  in 

## Before



## After



## Verification



---
*Note: The second part of #38718 (docs using wrong field names // instead of //) is a documentation issue in a separate repo.*