### PR TITLE
Fix multiple critical bugs across Anthropic, Perplexity, and Agent Middlewares

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -345,6 +345,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         try:
             return handler(request)
         except Exception as e:
+            if type(e).__name__ in ("GraphInterrupt", "NodeInterrupt"):
+                raise e
             last_exception = e
 
         # Try fallback models — sanitize cache markers only when the fallback
@@ -360,6 +362,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             try:
                 return handler(fallback_request.override(model=fallback_model))
             except Exception as e:
+                if type(e).__name__ in ("GraphInterrupt", "NodeInterrupt"):
+                    raise e
                 last_exception = e
                 continue
 
@@ -387,6 +391,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         try:
             return await handler(request)
         except Exception as e:
+            if type(e).__name__ in ("GraphInterrupt", "NodeInterrupt"):
+                raise e
             last_exception = e
 
         # Try fallback models — sanitize cache markers only when the fallback
@@ -402,6 +408,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             try:
                 return await handler(fallback_request.override(model=fallback_model))
             except Exception as e:
+                if type(e).__name__ in ("GraphInterrupt", "NodeInterrupt"):
+                    raise e
                 last_exception = e
                 continue
 

--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -233,6 +233,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
             try:
                 return handler(request)
             except Exception as exc:
+                if type(exc).__name__ in ("GraphInterrupt", "NodeInterrupt"):
+                    raise exc
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
                 # Check if we should retry this exception
@@ -283,6 +285,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
             try:
                 return await handler(request)
             except Exception as exc:
+                if type(exc).__name__ in ("GraphInterrupt", "NodeInterrupt"):
+                    raise exc
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
                 # Check if we should retry this exception

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1923,7 +1923,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -909,14 +909,19 @@ class ChatPerplexity(BaseChatModel):
             params["web_search_options"] = self.web_search_options.model_dump(
                 exclude_none=True
             )
+        merged = {**params, **self.model_kwargs}
+
+        if "extra_body" in merged and isinstance(merged["extra_body"], dict):
+            merged["extra_body"] = merged["extra_body"].copy()
+
         if self.media_response:
-            if "extra_body" not in params:
-                params["extra_body"] = {}
-            params["extra_body"]["media_response"] = self.media_response.model_dump(
+            if "extra_body" not in merged:
+                merged["extra_body"] = {}
+            merged["extra_body"]["media_response"] = self.media_response.model_dump(
                 exclude_none=True
             )
 
-        return {**params, **self.model_kwargs}
+        return merged
 
     def _convert_message_to_dict(self, message: BaseMessage) -> dict[str, Any]:
         message_dict: dict[str, Any]
@@ -1074,7 +1079,10 @@ class ChatPerplexity(BaseChatModel):
                 payload["tools"] = [_flatten_responses_tool(tool) for tool in value]
                 continue
             if key in _RESPONSES_PASSTHROUGH_KEYS:
-                payload[key] = value
+                if key == "extra_body" and isinstance(value, dict):
+                    payload[key] = value.copy()
+                else:
+                    payload[key] = value
                 continue
             # Unknown / Perplexity-specific keys: route under extra_body so the
             # SDK forwards them to the Agent API without breaking strict typing.


### PR DESCRIPTION
Fixes three issues: 1. ChatAnthropic.bind_tools mutating caller-provided tool_choice dictionaries. 2. ChatPerplexity Responses route mutating caller's extra_body dict in place. 3. ModelRetryMiddleware and ModelFallbackMiddleware swallowing GraphInterrupt.