### PR TITLE
Validate InterruptOnConfig during HumanInTheLoopMiddleware initialization

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -255,7 +255,17 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
                     resolved_configs[tool_name] = InterruptOnConfig(
                         allowed_decisions=["approve", "edit", "reject", "respond"]
                     )
-            elif tool_config.get("allowed_decisions"):
+            elif isinstance(tool_config, dict):
+                if "allowed_decisions" not in tool_config:
+                    raise ValueError(
+                        f"InterruptOnConfig for tool '{tool_name}' must define "
+                        "'allowed_decisions'."
+                    )
+                allowed_decisions = tool_config["allowed_decisions"]
+                if not allowed_decisions:
+                    raise ValueError(
+                        f"'allowed_decisions' for tool '{tool_name}' cannot be empty."
+                    )
                 resolved_configs[tool_name] = tool_config
         self.interrupt_on = resolved_configs
         self.description_prefix = description_prefix

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -1019,3 +1019,73 @@ def test_when_predicate_receives_correct_args() -> None:
     assert req.runtime.state is state
     assert req.runtime.context is runtime.context
     assert req.runtime.store is runtime.store
+
+
+def test_human_in_the_loop_middleware_missing_allowed_decisions() -> None:
+    """Test that missing allowed_decisions raises ValueError."""
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "InterruptOnConfig for tool 'delete_database' must define "
+            "'allowed_decisions'."
+        ),
+    ):
+        HumanInTheLoopMiddleware(
+            interrupt_on={
+                "delete_database": {
+                    "allowed_decision": ["approve"],  # type: ignore[typeddict-unknown-key]
+                }
+            }
+        )
+
+
+def test_human_in_the_loop_middleware_empty_allowed_decisions() -> None:
+    """Test that empty allowed_decisions raises ValueError."""
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "'allowed_decisions' for tool 'delete_database' cannot be empty."
+        ),
+    ):
+        HumanInTheLoopMiddleware(
+            interrupt_on={
+                "delete_database": {
+                    "allowed_decisions": [],
+                }
+            }
+        )
+
+
+def test_human_in_the_loop_middleware_valid_interrupt_config() -> None:
+    """Test that a valid interrupt config is accepted."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={
+            "delete_database": {
+                "allowed_decisions": ["approve"],
+            }
+        }
+    )
+
+    assert middleware.interrupt_on == {
+        "delete_database": {
+            "allowed_decisions": ["approve"],
+        }
+    }
+
+
+def test_human_in_the_loop_middleware_when_only_config() -> None:
+    """Test that a when-only config raises ValueError."""
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "InterruptOnConfig for tool 'delete_database' must define "
+            "'allowed_decisions'."
+        ),
+    ):
+        HumanInTheLoopMiddleware(
+            interrupt_on={  # type: ignore[arg-type]
+                "delete_database": {
+                    "when": lambda req: True,
+                }
+            }
+        )


### PR DESCRIPTION
## Summary

Fixes #38838.

This PR validates `InterruptOnConfig` during `HumanInTheLoopMiddleware`
initialization to prevent invalid configurations from being silently ignored.

## Changes

- Raise `ValueError` when `allowed_decisions` is missing.
- Raise `ValueError` when `allowed_decisions` is empty.
- Add regression tests for:
  - missing `allowed_decisions`
  - empty `allowed_decisions`
  - valid configuration
  - `when`-only configuration

This prevents safety middleware from silently disabling human approval due to configuration mistakes.