### PR TITLE
fix(langchain): respect middleware `tool_choice` override with structured output tools

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1384,8 +1384,12 @@ def create_agent(
                     )
                     raise ValueError(msg)
 
-            # Force tool use if we have structured output tools
-            tool_choice = "any" if structured_output_tools else request.tool_choice
+            # Force tool use if we have structured output tools, unless a middleware
+            # already set an explicit tool_choice (e.g. to steer the model toward a
+            # specific structured output tool via wrap_model_call).
+            tool_choice = request.tool_choice
+            if tool_choice is None and structured_output_tools:
+                tool_choice = "any"
             return (
                 request.model.bind_tools(
                     final_tools, tool_choice=tool_choice, **request.model_settings

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -684,6 +684,93 @@ class TestResponseFormatAsToolStrategy:
         ):
             agent.invoke({"messages": [HumanMessage("What's the weather?")]})
 
+    def test_middleware_tool_choice_override_is_respected(self) -> None:
+        """A middleware-set `tool_choice` should not be silently forced to "any".
+
+        Regression test: `_get_bound_model` used to force `tool_choice="any"`
+        whenever structured output tools were present, even when a middleware had
+        already set a specific `tool_choice` via `wrap_model_call` (e.g. to steer
+        the model toward a particular structured output tool before ending the run).
+        """
+        captured_tool_choices: list[Any] = []
+        original_bind_tools = FakeToolCallingModel.bind_tools
+
+        def spying_bind_tools(
+            self: FakeToolCallingModel,
+            tools: Sequence[Any],
+            *,
+            tool_choice: str | None = None,
+            **kwargs: Any,
+        ) -> Runnable[LanguageModelInput, AIMessage]:
+            captured_tool_choices.append(tool_choice)
+            return original_bind_tools(self, tools, tool_choice=tool_choice, **kwargs)
+
+        class ForceStructuredToolMiddleware(AgentMiddleware):
+            def wrap_model_call(
+                self,
+                request: ModelRequest,
+                handler: Callable[[ModelRequest], ModelResponse],
+            ) -> ModelCallResult:
+                return handler(
+                    request.override(tool_choice={"type": "tool", "name": "WeatherBaseModel"})
+                )
+
+        tool_calls = [
+            [
+                {
+                    "name": "WeatherBaseModel",
+                    "id": "1",
+                    "args": WEATHER_DATA,
+                }
+            ],
+        ]
+        model = FakeToolCallingModel(tool_calls=tool_calls)
+
+        with patch.object(FakeToolCallingModel, "bind_tools", spying_bind_tools):
+            agent = create_agent(
+                model,
+                [],
+                middleware=[ForceStructuredToolMiddleware()],
+                response_format=ToolStrategy(WeatherBaseModel),
+            )
+            response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        assert captured_tool_choices == [{"type": "tool", "name": "WeatherBaseModel"}]
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+
+    def test_default_tool_choice_is_any_without_middleware_override(self) -> None:
+        """Without a middleware override, `tool_choice` still defaults to "any"."""
+        captured_tool_choices: list[Any] = []
+        original_bind_tools = FakeToolCallingModel.bind_tools
+
+        def spying_bind_tools(
+            self: FakeToolCallingModel,
+            tools: Sequence[Any],
+            *,
+            tool_choice: str | None = None,
+            **kwargs: Any,
+        ) -> Runnable[LanguageModelInput, AIMessage]:
+            captured_tool_choices.append(tool_choice)
+            return original_bind_tools(self, tools, tool_choice=tool_choice, **kwargs)
+
+        tool_calls = [
+            [
+                {
+                    "name": "WeatherBaseModel",
+                    "id": "1",
+                    "args": WEATHER_DATA,
+                }
+            ],
+        ]
+        model = FakeToolCallingModel(tool_calls=tool_calls)
+
+        with patch.object(FakeToolCallingModel, "bind_tools", spying_bind_tools):
+            agent = create_agent(model, [], response_format=ToolStrategy(WeatherBaseModel))
+            response = agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+        assert captured_tool_choices == ["any"]
+        assert response["structured_response"] == EXPECTED_WEATHER_PYDANTIC
+
 
 class TestResponseFormatAsProviderStrategy:
     def test_pydantic_model(self) -> None:


### PR DESCRIPTION
Closes #38847

---

When `create_agent` (or `create_deep_agent`) is used with structured output (`ToolStrategy` / a `response_format`), the final model binding in `_get_bound_model` always forced `tool_choice="any"` whenever structured output tools were present. This silently discarded any explicit `tool_choice` a middleware had already set via `request.override(tool_choice=...)` inside `wrap_model_call`.

The user-facing symptom (originally reported against `deepagents` in langchain-ai/deepagents#4721): a middleware such as `ModelCallLimitMiddleware(exit_behavior="end")` wants its final call to steer the model toward the *specific* structured-output tool so the run ends with a populated `structured_response`. Because the framework overrode `tool_choice` back to the generic `"any"`, the model was only told "call some tool" — it could pick a different tool (e.g. keep investigating) and burn its last call, ending with `structured_response=None` and losing all the work it had gathered.

The fix only defaults `tool_choice` to `"any"` when nothing has explicitly set it; an explicit `tool_choice` from middleware is now respected.

## Release note

`create_agent` now respects a `tool_choice` set by middleware via `wrap_model_call` even when structured output tools are present, instead of always forcing `tool_choice="any"`. This lets middleware steer the model toward a specific structured-output tool (for example, to guarantee a populated `structured_response` on a final call before the run ends).

---

_This contribution was prepared with AI-agent assistance._
