### PR TITLE
fix(langchain-perplexity): copy extra_body before merging routed keys — prevents caller-dict mutation

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -1074,7 +1074,9 @@ class ChatPerplexity(BaseChatModel):
                 payload["tools"] = [_flatten_responses_tool(tool) for tool in value]
                 continue
             if key in _RESPONSES_PASSTHROUGH_KEYS:
-                payload[key] = value
+                # Copy dict values so caller-provided structures (e.g. extra_body)
+                # are not mutated when Perplexity-specific keys are merged in below.
+                payload[key] = dict(value) if isinstance(value, dict) else value
                 continue
             # Unknown / Perplexity-specific keys: route under extra_body so the
             # SDK forwards them to the Agent API without breaking strict typing.


### PR DESCRIPTION
## Summary

Fixes caller-dict mutation in `ChatPerplexity._to_responses_payload`.

Closes #38840 (same bug class as #38779 and #38659).

## Root Cause

When a caller passes `extra_body={...}` either as a per-call kwarg or at
construction time, `_to_responses_payload` stores it in the payload **by
reference**:

```python
if key in _RESPONSES_PASSTHROUGH_KEYS:
    payload[key] = value   # stores caller's dict by reference
    continue
```

Later, `payload.setdefault("extra_body", {})` returns that **same caller dict**,
and Perplexity-specific keys (e.g. `search_mode`) are written into it in place.
Two user-visible consequences:

1. **Caller's dict is mutated** — a shared `extra_body` passed per-call gains
   keys it never had.
2. **Per-call params become permanent instance state** — because `model_kwargs`
   holds a reference to the same `extra_body` dict, any key written into it
   during one call persists into all subsequent calls of that instance.

## Fix

Shallow-copy dict values when storing them in the passthrough block:

```python
payload[key] = dict(value) if isinstance(value, dict) else value
```

This is the minimal targeted fix: a shallow copy is sufficient because the
routed keys (search_mode, disable_search, etc.) are scalars, and the callers
own the top-level dict — not any nested structures inside it.

## Testing

The reproduction script from the issue now prints the expected (unmodified)
values for both the caller's `extra_body` and `model_kwargs` across calls.

```python
caller's extra_body after payload build: {'country': 'US'}          # was mutated before
model_kwargs after call 1: {'extra_body': {'country': 'US'}}         # stable
call 2 extra_body (search_mode NOT passed): {'country': 'US'}       # no leak
```