### PR TITLE
fix(core): `AddableDict` raises on type-incompatible merge

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -485,8 +485,13 @@ class AddableDict(dict[str, Any]):
             elif other[key] is not None:
                 try:
                     added = chunk[key] + other[key]
-                except TypeError:
-                    added = other[key]
+                except TypeError as e:
+                    msg = (
+                        f"Error while merging chunks for key '{key}': cannot add "
+                        f"value of type {type(chunk[key]).__name__!r} to value of "
+                        f"type {type(other[key]).__name__!r}."
+                    )
+                    raise TypeError(msg) from e
                 chunk[key] = added
         return chunk
 
@@ -506,8 +511,13 @@ class AddableDict(dict[str, Any]):
             elif self[key] is not None:
                 try:
                     added = chunk[key] + self[key]
-                except TypeError:
-                    added = self[key]
+                except TypeError as e:
+                    msg = (
+                        f"Error while merging chunks for key '{key}': cannot add "
+                        f"value of type {type(chunk[key]).__name__!r} to value of "
+                        f"type {type(self[key]).__name__!r}."
+                    )
+                    raise TypeError(msg) from e
                 chunk[key] = added
         return chunk
 

--- a/libs/core/tests/unit_tests/runnables/test_utils.py
+++ b/libs/core/tests/unit_tests/runnables/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 
 from langchain_core.runnables.base import RunnableLambda
 from langchain_core.runnables.utils import (
+    AddableDict,
     get_function_nonlocals,
     get_lambda_source,
     indent_lines_after_first,
@@ -73,3 +74,31 @@ def test_nonlocals() -> None:
     assert RunnableLambda(my_func3).deps == [agent]
     assert RunnableLambda(my_func4).deps == [global_agent]
     assert RunnableLambda(func).deps == [nl]
+
+
+def test_addable_dict_add_merges_compatible_types() -> None:
+    """Test that adding `AddableDict`s with compatible types still merges."""
+    left = AddableDict({"count": 1, "text": "foo"})
+    right = AddableDict({"count": 2, "text": "bar"})
+
+    result = left + right
+
+    assert result == {"count": 3, "text": "foobar"}
+
+
+def test_addable_dict_add_raises_on_type_incompatible_merge() -> None:
+    """Test that merging type-incompatible values raises instead of dropping data."""
+    left = AddableDict({"count": 1})
+    right = AddableDict({"count": "some_string"})
+
+    with pytest.raises(TypeError, match="count"):
+        left + right
+
+
+def test_addable_dict_radd_raises_on_type_incompatible_merge() -> None:
+    """Test that `__radd__` also raises instead of silently dropping data."""
+    left = AddableDict({"count": 1})
+    right = AddableDict({"count": "some_string"})
+
+    with pytest.raises(TypeError, match="count"):
+        right.__radd__(left)


### PR DESCRIPTION
Fixes #38850

---

`AddableDict.__add__`/`__radd__` are used internally by `RunnablePassthrough` and LCEL's streaming/chunk-aggregation path to merge dict-shaped chunks as they stream in. When two chunks had a type-incompatible value at the same key (e.g. an `int` in one chunk and a `str` in another), the merge caught the resulting `TypeError` internally and silently fell back to the right-hand value — discarding the left-hand value with no error, warning, or log line.

This changes that fallback to raise a clear `TypeError` naming the key and the two conflicting types, so the corruption is surfaced instead of hidden. No public signatures changed; this only affects the case that previously produced silently wrong output.

## Release note

`AddableDict.__add__`/`__radd__` now raise a `TypeError` (naming the offending key and types) when merging values of incompatible types, instead of silently discarding data.
