### PR TITLE
core: prevent docstring inheritance from parent BaseModel classes

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -124,6 +124,22 @@ def _get_annotation_description(arg_type: type) -> str | None:
     return None
 
 
+def _get_own_docstring(fn: Callable[..., Any]) -> str | None:
+    """Get the docstring defined directly on the object, without inheriting.
+
+    For Pydantic BaseModel subclasses, ``inspect.getdoc`` inherits docstrings
+    from parent classes.  Pydantic itself sets ``__doc__`` to ``None`` for
+    child classes that don't define their own docstring, so we use that value
+    directly to avoid the inheritance behavior.
+
+    For all other callables we keep using ``inspect.getdoc`` because it also
+    handles de-denting.
+    """
+    if isinstance(fn, type) and is_basemodel_subclass(fn):
+        return fn.__doc__
+    return inspect.getdoc(fn)
+
+
 def _parse_python_function_docstring(
     function: Callable[..., Any],
     annotations: dict[str, Any],
@@ -142,7 +158,7 @@ def _parse_python_function_docstring(
     Returns:
         A tuple containing the function description and argument descriptions.
     """
-    docstring = inspect.getdoc(function)
+    docstring = _get_own_docstring(function)
     return _parse_google_docstring(
         docstring,
         list(annotations),
@@ -190,7 +206,7 @@ def _infer_arg_descriptions(
             fn, annotations, error_on_invalid_docstring=error_on_invalid_docstring
         )
     else:
-        description = inspect.getdoc(fn) or ""
+        description = _get_own_docstring(fn) or ""
         arg_descriptions = {}
     if parse_docstring:
         _validate_docstring_args_against_annotations(arg_descriptions, annotations)

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -763,11 +763,12 @@ def test_missing_docstring() -> None:
         def search_api(query: str) -> str:
             return "API result"
 
-    @tool
-    class MyTool(BaseModel):
-        foo: str
+    # BaseModel subclasses without their own docstring should also raise
+    with pytest.raises(ValueError, match="Function must have a docstring"):
 
-    assert not MyTool.description  # type: ignore[attr-defined]
+        @tool
+        class MyTool(BaseModel):
+            foo: str
 
 
 def test_create_tool_positional_args() -> None:


### PR DESCRIPTION
## Problem

When using `@tool` on a Pydantic BaseModel subclass that doesn't define its own docstring, the tool's description incorrectly inherits from the parent class via `inspect.getdoc()`.

```python
from langchain_core.tools import tool
from pydantic import BaseModel

class MyTool(BaseModel):
    """Parent Tool"""
    foo: str

@tool
class ChildTool(MyTool):
    bar: str

print(ChildTool.description)  # "Parent Tool" — wrong!
```

## Root Cause

`inspect.getdoc()` follows Python's MRO and returns the parent class's docstring. However, Pydantic intentionally sets `__doc__ = None` for child classes that don't define their own docstring.

| Method | Result |
|--------|--------|
| `inspect.getdoc(ChildTool)` | `"Parent Tool"` (inherited) |
| `ChildTool.__doc__` | `None` (Pydantic behavior) |

## Fix

Added `_get_own_docstring()` helper that uses `fn.__doc__` directly for BaseModel subclasses instead of `inspect.getdoc()`.

**Files changed:**
- `libs/core/langchain_core/tools/base.py` — new `_get_own_docstring()` function
- `libs/core/tests/unit_tests/test_tools.py` — updated test to expect ValueError for BaseModel without docstring

## After Fix

- Child class with own docstring → uses that docstring ✓
- Child class with explicit `description` param → uses that ✓  
- Child class without docstring → raises ValueError (consistent with functions) ✓

Closes #32066
