### PR TITLE
Expose PIIMatch in public agents.middleware entrypoint

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -11,7 +11,7 @@ from langchain.agents.middleware.human_in_the_loop import (
 from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddleware
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
-from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
+from langchain.agents.middleware.pii import PIIDetectionError, PIIMatch, PIIMiddleware
 from langchain.agents.middleware.provider_tool_search import ProviderToolSearchMiddleware
 from langchain.agents.middleware.shell_tool import (
     CodexSandboxExecutionPolicy,
@@ -70,6 +70,7 @@ __all__ = [
     "ModelRetryMiddleware",
     "OutputAgentState",
     "PIIDetectionError",
+    "PIIMatch",
     "PIIMiddleware",
     "ProviderToolSearchMiddleware",
     "RedactionRule",

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/test_exports.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/test_exports.py
@@ -1,0 +1,19 @@
+from langchain.agents.middleware import PIIMatch
+
+def test_pii_match_export() -> None:
+    """Verify that PIIMatch is exported and behaves like a TypedDict."""
+    # Check that PIIMatch is a class type (TypedDict)
+    assert isinstance(PIIMatch, type)
+    
+    # Verify we can construct a PIIMatch dict and it adheres to the type keys
+    match: PIIMatch = {
+        "type": "email",
+        "value": "test@example.com",
+        "start": 0,
+        "end": 16,
+    }
+    
+    assert match["type"] == "email"
+    assert match["value"] == "test@example.com"
+    assert match["start"] == 0
+    assert match["end"] == 16


### PR DESCRIPTION
Fixes #38718.

Exposed `PIIMatch` from the public `langchain.agents.middleware` entrypoint, and added a unit test to verify it.