### PR TITLE
docs: detail input formats in ModelProfile

### DIFF
--- a/libs/core/langchain_core/language_models/model_profile.py
+++ b/libs/core/langchain_core/language_models/model_profile.py
@@ -55,8 +55,7 @@ class ModelProfile(TypedDict, total=False):
     """Whether text inputs are supported."""
 
     image_inputs: bool
-    """Whether image inputs are supported."""
-    # TODO: add more detail about formats?
+    """Whether image inputs are supported (e.g., via base64 encoded strings or bytes)."""
 
     image_url_inputs: bool
     """Whether [image URL inputs](https://docs.langchain.com/oss/python/langchain/models#multimodal)
@@ -64,18 +63,15 @@ class ModelProfile(TypedDict, total=False):
 
     pdf_inputs: bool
     """Whether [PDF inputs](https://docs.langchain.com/oss/python/langchain/models#multimodal)
-    are supported."""
-    # TODO: add more detail about formats? e.g. bytes or base64
+    are supported (e.g., via base64 encoded strings or bytes)."""
 
     audio_inputs: bool
     """Whether [audio inputs](https://docs.langchain.com/oss/python/langchain/models#multimodal)
-    are supported."""
-    # TODO: add more detail about formats? e.g. bytes or base64
+    are supported (e.g., via base64 encoded strings or bytes)."""
 
     video_inputs: bool
     """Whether [video inputs](https://docs.langchain.com/oss/python/langchain/models#multimodal)
-    are supported."""
-    # TODO: add more detail about formats? e.g. bytes or base64
+    are supported (e.g., via base64 encoded strings or bytes)."""
 
     image_tool_message: bool
     """Whether images can be included in `ToolMessage` content."""


### PR DESCRIPTION
Fixes #38872

Resolves TODOs in `model_profile.py` by documenting that image, audio, video, and pdf inputs are typically supported via base64 encoded strings or bytes.
