### PR TITLE
fix(perplexity): avoid mutating caller extra_body dict in _to_responses_payload

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -910,8 +910,8 @@ class ChatPerplexity(BaseChatModel):
                 exclude_none=True
             )
         if self.media_response:
-            if "extra_body" not in params:
-                params["extra_body"] = {}
+            # Shallow-copy before mutating to avoid modifying the caller's dict.
+            params["extra_body"] = dict(params.get("extra_body") or {})
             params["extra_body"]["media_response"] = self.media_response.model_dump(
                 exclude_none=True
             )
@@ -1074,7 +1074,9 @@ class ChatPerplexity(BaseChatModel):
                 payload["tools"] = [_flatten_responses_tool(tool) for tool in value]
                 continue
             if key in _RESPONSES_PASSTHROUGH_KEYS:
-                payload[key] = value
+                # Shallow-copy extra_body so later mutations (forwarding unknown keys
+                # under extra_body) don't write into the caller's original dict.
+                payload[key] = dict(value) if key == "extra_body" and isinstance(value, dict) else value
                 continue
             # Unknown / Perplexity-specific keys: route under extra_body so the
             # SDK forwards them to the Agent API without breaking strict typing.


### PR DESCRIPTION
## Summary

Fixes #38840.

`ChatPerplexity._to_responses_payload` (and `_default_params`) mutated the caller's
`extra_body` dict in place. Any per-call `extra_body` passed via `.invoke(extra_body=...)`
was modified: subsequent unknown-key forwarding wrote into the caller's original object,
leaking call-specific values into later requests.

## Root Cause

Two mutation sites:

**`_default_params`** — when `media_response` is set and the caller already supplied
an `extra_body`, the code did:
```python
# existing dict from caller, mutated in place!
params["extra_body"]["media_response"] = self.media_response.model_dump(...)
```

**`_to_responses_payload`** — `extra_body` is in `_RESPONSES_PASSTHROUGH_KEYS`, so
`payload["extra_body"] = value` stored a **reference** to the caller's dict.
The subsequent unknown-key forwarding loop then called:
```python
extra_body = payload.setdefault("extra_body", {})   # returns caller's dict
extra_body[key] = value                              # mutates it!
```

## Fix

**`_default_params`**: shallow-copy before mutating:
```python
# Before:
if "extra_body" not in params:
    params["extra_body"] = {}
params["extra_body"]["media_response"] = ...

# After:
params["extra_body"] = dict(params.get("extra_body") or {})
params["extra_body"]["media_response"] = ...
```

**`_to_responses_payload`**: copy when routing `extra_body` to payload:
```python
# Before:
payload[key] = value

# After:
payload[key] = dict(value) if key == "extra_body" and isinstance(value, dict) else value
```

## Reproduction (no network needed)

```python
from langchain_perplexity import ChatPerplexity

llm = ChatPerplexity(pplx_api_key="fake", model="sonar-pro", use_responses_api=True)
shared = {"country": "US"}
llm._to_responses_payload(
    [], {"extra_body": shared, "search_mode": "academic"}, user_set_keys=set()
)
# Before fix: shared == {"country": "US", "search_mode": "academic"}  ← mutation
# After fix:  shared == {"country": "US"}                              ← unchanged
```

Closes #38840.
