### PR TITLE
fix(core): raise TypeError on type-incompatible AddableDict merge instead of silent data loss

### DIFF
--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -485,8 +485,12 @@ class AddableDict(dict[str, Any]):
             elif other[key] is not None:
                 try:
                     added = chunk[key] + other[key]
-                except TypeError:
-                    added = other[key]
+                except TypeError as exc:
+                    raise TypeError(
+                        f"Cannot add incompatible types for key {key!r}: "
+                        f"{type(chunk[key]).__name__!r} and "
+                        f"{type(other[key]).__name__!r}"
+                    ) from exc
                 chunk[key] = added
         return chunk
 
@@ -506,8 +510,12 @@ class AddableDict(dict[str, Any]):
             elif self[key] is not None:
                 try:
                     added = chunk[key] + self[key]
-                except TypeError:
-                    added = self[key]
+                except TypeError as exc:
+                    raise TypeError(
+                        f"Cannot add incompatible types for key {key!r}: "
+                        f"{type(chunk[key]).__name__!r} and "
+                        f"{type(self[key]).__name__!r}"
+                    ) from exc
                 chunk[key] = added
         return chunk
 

--- a/libs/core/langchain_core/runnables/utils.py
+++ b/libs/core/langchain_core/runnables/utils.py
@@ -486,11 +486,12 @@ class AddableDict(dict[str, Any]):
                 try:
                     added = chunk[key] + other[key]
                 except TypeError as exc:
-                    raise TypeError(
+                    msg = (
                         f"Cannot add incompatible types for key {key!r}: "
                         f"{type(chunk[key]).__name__!r} and "
                         f"{type(other[key]).__name__!r}"
-                    ) from exc
+                    )
+                    raise TypeError(msg) from exc
                 chunk[key] = added
         return chunk
 
@@ -511,11 +512,12 @@ class AddableDict(dict[str, Any]):
                 try:
                     added = chunk[key] + self[key]
                 except TypeError as exc:
-                    raise TypeError(
+                    msg = (
                         f"Cannot add incompatible types for key {key!r}: "
                         f"{type(chunk[key]).__name__!r} and "
                         f"{type(self[key]).__name__!r}"
-                    ) from exc
+                    )
+                    raise TypeError(msg) from exc
                 chunk[key] = added
         return chunk
 


### PR DESCRIPTION
## Summary

Fixes #38850.

`AddableDict.__add__` and `__radd__` silently discarded the left-hand value when
`chunk[key] + other[key]` raised `TypeError`. The right-hand value quietly replaced
it with no exception, no log, and no indication that data was lost.

## Root Cause

```python
try:
    added = chunk[key] + other[key]
except TypeError:
    added = other[key]   # left-hand value silently dropped!
chunk[key] = added
```

`AddableDict` is used in LCEL streaming chunk aggregation via
`RunnablePassthrough` and `.astream_events`. When two streamed chunks have
incompatible types for the same key (e.g. `int` from one chunk, `str` from the
next), the `int` is silently replaced by the `str` — with no way for the caller
to know data was lost.

## Fix

Re-raise the `TypeError` with a clear, actionable message:

```python
except TypeError as exc:
    raise TypeError(
        f"Cannot add incompatible types for key {key!r}: "
        f"{type(chunk[key]).__name__!r} and {type(other[key]).__name__!r}"
    ) from exc
```

Both `__add__` and `__radd__` are fixed identically.

## Example

```python
from langchain_core.runnables.utils import AddableDict

a = AddableDict({"count": 1})
b = AddableDict({"count": "some_string"})

# Before fix: silently returns AddableDict({"count": "some_string"})
# After fix:
# TypeError: Cannot add incompatible types for key 'count': 'int' and 'str'
result = a + b
```

## Why not keep the fallback?

Silent data loss is strictly worse than a loud failure — the caller has no
signal that their chain is producing incorrect results. Any streaming pipeline
where chunks have type-mismatched values at the same key is already broken; the
fix surfaces the problem rather than hiding it.

Closes #38850.
