### PR TITLE
fix(anthropic): copy tool_choice dict in bind_tools

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1923,7 +1923,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1567,6 +1567,18 @@ def test_anthropic_bind_tools_tool_choice() -> None:
     }
 
 
+def test_anthropic_bind_tools_does_not_mutate_tool_choice_dict() -> None:
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    tool_choice = {"type": "tool", "name": "GetWeather"}
+
+    chat_model.bind_tools([GetWeather], tool_choice=tool_choice, parallel_tool_calls=False)
+
+    assert tool_choice == {"type": "tool", "name": "GetWeather"}
+
+
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""
     # Test with betas parameter at initialization


### PR DESCRIPTION
## Summary

`ChatAnthropic.bind_tools` stored a reference to the caller's `tool_choice` dict and then added `disable_parallel_tool_use` in place when `parallel_tool_calls=False`.

This change copies the dict before storing it so the caller's object stays unchanged.

Fixes #38779

## Test plan

- [x] `pytest tests/unit_tests/test_chat_models.py::test_anthropic_bind_tools_does_not_mutate_tool_choice_dict`
- [x] `pytest tests/unit_tests/test_chat_models.py::test_anthropic_bind_tools_tool_choice`