### PR TITLE
fix(langchain): export PIIMatch from agents.middleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -11,6 +11,7 @@ from langchain.agents.middleware.human_in_the_loop import (
 from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddleware
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
+from langchain.agents.middleware._redaction import PIIMatch
 from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
 from langchain.agents.middleware.provider_tool_search import ProviderToolSearchMiddleware
 from langchain.agents.middleware.shell_tool import (
@@ -70,6 +71,7 @@ __all__ = [
     "ModelRetryMiddleware",
     "OutputAgentState",
     "PIIDetectionError",
+    "PIIMatch",
     "PIIMiddleware",
     "ProviderToolSearchMiddleware",
     "RedactionRule",

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -2369,3 +2369,9 @@ class TestPIIStreamingEndToEnd:
             "raw PII leaked through a subgraph's content-block-finish snapshot"
         )
         assert seen_redaction, "transformer never fired at the subgraph scope"
+
+
+def test_piimatch_exported_from_public_middleware_package() -> None:
+    from langchain.agents.middleware import PIIMatch as public_piimatch
+
+    assert public_piimatch is PIIMatch


### PR DESCRIPTION
## Summary

`PIIMatch` is the return type for custom PII detectors, but it was not exported from `langchain.agents.middleware`. Users had to import it from the private `_redaction` module instead.

This exports `PIIMatch` from the public middleware package and adds a regression test.

Fixes #38718

## Test plan

- [x] Verified `from langchain.agents.middleware import PIIMatch` works
- [x] Added `test_piimatch_exported_from_public_middleware_package`