### PR TITLE
fix(core): forward EvaluationResult.feedback_config to create_feedback

### DIFF
--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -199,6 +199,7 @@ class EvaluatorCallbackHandler(BaseTracer):
                 source_info=source_info_,
                 source_run_id=res.source_run_id or source_run_id,
                 feedback_source_type=langsmith.schemas.FeedbackSourceType.MODEL,
+                feedback_config=res.feedback_config,
             )
         return results
 

--- a/libs/core/tests/unit_tests/tracers/test_evaluation.py
+++ b/libs/core/tests/unit_tests/tracers/test_evaluation.py
@@ -1,0 +1,71 @@
+from unittest import mock
+
+from langsmith.evaluation.evaluator import EvaluationResult
+
+from langchain_core.tracers.evaluation import EvaluatorCallbackHandler
+
+
+def test_feedback_config_forwarded_to_create_feedback() -> None:
+    client = mock.MagicMock()
+    handler = EvaluatorCallbackHandler(
+        evaluators=[],
+        client=client,
+    )
+    run = mock.MagicMock()
+    run.id = mock.sentinel.run_id
+
+    eval_result = EvaluationResult(
+        key="sentiment",
+        score=1.0,
+        feedback_config={"type": "continuous", "min": 0, "max": 1},
+    )
+
+    handler._log_evaluation_feedback(eval_result, run)
+
+    client.create_feedback.assert_called_once()
+    _, kwargs = client.create_feedback.call_args
+    assert kwargs["feedback_config"] == {"type": "continuous", "min": 0, "max": 1}
+
+
+def test_feedback_config_none_is_not_sent_as_arg() -> None:
+    client = mock.MagicMock()
+    handler = EvaluatorCallbackHandler(
+        evaluators=[],
+        client=client,
+    )
+    run = mock.MagicMock()
+    run.id = mock.sentinel.run_id
+
+    eval_result = EvaluationResult(
+        key="sentiment",
+        score=1.0,
+        feedback_config=None,
+    )
+
+    handler._log_evaluation_feedback(eval_result, run)
+
+    client.create_feedback.assert_called_once()
+    _, kwargs = client.create_feedback.call_args
+    assert kwargs["feedback_config"] is None
+
+
+def test_feedback_config_with_arbitrary_dict() -> None:
+    client = mock.MagicMock()
+    handler = EvaluatorCallbackHandler(
+        evaluators=[],
+        client=client,
+    )
+    run = mock.MagicMock()
+    run.id = mock.sentinel.run_id
+
+    eval_result = EvaluationResult(
+        key="sentiment",
+        score=1.0,
+        feedback_config={"threshold": 0.5, "custom_key": "value"},
+    )
+
+    handler._log_evaluation_feedback(eval_result, run)
+
+    client.create_feedback.assert_called_once()
+    _, kwargs = client.create_feedback.call_args
+    assert kwargs["feedback_config"] == {"threshold": 0.5, "custom_key": "value"}


### PR DESCRIPTION
The `_log_evaluation_feedback` method was not forwarding `feedback_config` from `EvaluationResult` to `Client.create_feedback`, silently dropping any feedback configuration that an evaluator set on the result.

Previously:
- `score`, `value`, `comment`, `correction`, `source_info`, `source_run_id` were all forwarded
- `feedback_config` was the only field omitted

This change adds `feedback_config=res.feedback_config` to the `create_feedback` call so that the config reaches LangSmith.

**Tests added:**
- `test_feedback_config_forwarded_to_create_feedback` — verifies config is forwarded
- `test_feedback_config_none_is_not_sent_as_arg` — verifies `None` is passed correctly
- `test_feedback_config_with_arbitrary_dict` — verifies unknown keys are preserved

Closes #31802

Co-authored-by: lohitkolluri <35792322+lohitkolluri@users.noreply.github.com>