### PR TITLE
fix(core): forward EvaluationResult.feedback_config to create_feedback

### DIFF
--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -199,6 +199,7 @@ class EvaluatorCallbackHandler(BaseTracer):
                 source_info=source_info_,
                 source_run_id=res.source_run_id or source_run_id,
                 feedback_source_type=langsmith.schemas.FeedbackSourceType.MODEL,
+                feedback_config=res.feedback_config,
             )
         return results
 


### PR DESCRIPTION
Fixes #31802

The `_log_evaluation_feedback` method was not forwarding `feedback_config` from `EvaluationResult` to `Client.create_feedback`, silently dropping any feedback configuration that an evaluator set on the result.

Now `feedback_config=res.feedback_config` is passed along so the langsmith SDK can store it.