### PR TITLE
fix: prevent ChatOpenAI Responses API from mutating model_kwargs["text"] in place

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4340,6 +4340,10 @@ def _construct_responses_api_payload(
         else:
             payload["tool_choice"] = tool_choice
 
+    # Ensure we don't mutate the caller's model_kwargs["text"] in place
+    if isinstance(payload.get("text"), dict):
+        payload["text"] = payload["text"].copy()
+
     # Structured output
     if schema := payload.pop("response_format", None):
         # For pydantic + non-streaming case, we use responses.parse.


### PR DESCRIPTION
## Description

With `use_responses_api=True`, `_construct_responses_api_payload` writes response format and verbosity directly into `payload["text"]`, but since the payload is built by shallow-merging `self.model_kwargs`, `payload["text"]` is the same dict object the caller passed as `model_kwargs={"text": {...}}`. This means:

1. After one JSON mode call, `model_kwargs["text"]` permanently contains `format`, forcing all later plain calls into JSON mode
2. The caller's original dict is also corrupted
3. Sharing one options dict across two ChatOpenAI instances spreads the pollution

## Fix

Copies the `text` dict during payload construction before writing into it, preventing mutation of the instance's model_kwargs or the caller's input dict. Same fix pattern as applied in langchain-perplexity (#38840).

## Related Issues

Fixes #38869
Related: #38840 (same bug class in langchain-perplexity)

## Testing

- Ran the reproduction script from the issue - confirms the caller's dict is no longer mutated
- All existing tests in `libs/partners/openai/tests/` pass