### PR TITLE
fix(langchain): propagate interrupts through ModelRetryMiddleware and ModelFallbackMiddleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -19,6 +19,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.tools import BaseTool
+from langgraph.errors import GraphBubbleUp
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
@@ -344,6 +345,10 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         last_exception: Exception
         try:
             return handler(request)
+        except GraphBubbleUp:
+            # Control-flow signals (interrupts, parent commands) must
+            # propagate, not trigger fallbacks.
+            raise
         except Exception as e:
             last_exception = e
 
@@ -359,6 +364,9 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             try:
                 return handler(fallback_request.override(model=fallback_model))
+            except GraphBubbleUp:
+                # Control-flow signals must propagate from fallback attempts too.
+                raise
             except Exception as e:
                 last_exception = e
                 continue
@@ -386,6 +394,10 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         last_exception: Exception
         try:
             return await handler(request)
+        except GraphBubbleUp:
+            # Control-flow signals (interrupts, parent commands) must
+            # propagate, not trigger fallbacks.
+            raise
         except Exception as e:
             last_exception = e
 
@@ -401,6 +413,9 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             try:
                 return await handler(fallback_request.override(model=fallback_model))
+            except GraphBubbleUp:
+                # Control-flow signals must propagate from fallback attempts too.
+                raise
             except Exception as e:
                 last_exception = e
                 continue

--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -7,6 +7,7 @@ import time
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage
+from langgraph.errors import GraphBubbleUp
 
 from langchain.agents.middleware._retry import (
     OnFailure,
@@ -232,6 +233,10 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
         for attempt in range(self.max_retries + 1):
             try:
                 return handler(request)
+            except GraphBubbleUp:
+                # Control-flow signals (interrupts, parent commands) must
+                # propagate, not be retried or converted to error messages.
+                raise
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
@@ -282,6 +287,10 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
         for attempt in range(self.max_retries + 1):
             try:
                 return await handler(request)
+            except GraphBubbleUp:
+                # Control-flow signals (interrupts, parent commands) must
+                # propagate, not be retried or converted to error messages.
+                raise
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -11,6 +11,8 @@ from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.tools import BaseTool, tool
+from langgraph.errors import GraphInterrupt, ParentCommand
+from langgraph.types import Command
 from typing_extensions import override
 
 from langchain.agents.factory import create_agent
@@ -1067,3 +1069,39 @@ async def test_fallback_sanitizer_error_is_not_masked_async(
 
     with pytest.raises(RuntimeError, match="sanitizer boom"):
         await middleware.awrap_model_call(request, mock_handler)
+
+
+def test_fallback_reraises_graph_bubble_up() -> None:
+    """GraphBubbleUp signals (e.g. interrupts) must propagate, not trigger fallbacks."""
+    fallback_model = GenericFakeChatModel(messages=iter([AIMessage(content="fallback")]))
+    middleware = ModelFallbackMiddleware(fallback_model)
+
+    calls = 0
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:  # noqa: ARG001
+        nonlocal calls
+        calls += 1
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        middleware.wrap_model_call(_make_request(), mock_handler)
+
+    assert calls == 1  # bubbled up on first raise, no fallback attempts
+
+
+async def test_fallback_reraises_graph_bubble_up_async() -> None:
+    """Async: GraphBubbleUp signals (e.g. ParentCommand) must propagate, not trigger fallbacks."""
+    fallback_model = GenericFakeChatModel(messages=iter([AIMessage(content="fallback")]))
+    middleware = ModelFallbackMiddleware(fallback_model)
+
+    calls = 0
+
+    async def mock_handler(req: ModelRequest) -> ModelResponse:  # noqa: ARG001
+        nonlocal calls
+        calls += 1
+        raise ParentCommand(Command(goto="some_node"))
+
+    with pytest.raises(ParentCommand):
+        await middleware.awrap_model_call(_make_request(), mock_handler)
+
+    assert calls == 1  # bubbled up on first raise, no fallback attempts

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -2,13 +2,16 @@
 
 import time
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.errors import GraphInterrupt, ParentCommand
+from langgraph.types import Command, interrupt
 from pydantic import Field
 from typing_extensions import override
 
@@ -16,12 +19,16 @@ from langchain.agents.factory import create_agent
 from langchain.agents.middleware._retry import calculate_delay
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
 from langchain.agents.middleware.types import (
+    AgentState,
     ModelCallResult,
     ModelRequest,
     ModelResponse,
     wrap_model_call,
 )
 from tests.unit_tests.agents.model import FakeToolCallingModel
+
+if TYPE_CHECKING:
+    from langgraph.runtime import Runtime
 
 
 class TemporaryFailureModel(FakeToolCallingModel):
@@ -700,3 +707,97 @@ def test_model_retry_multiple_middleware_composition() -> None:
     ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
     assert len(ai_messages) >= 1
     assert "Hello" in ai_messages[-1].content
+
+
+def _fake_runtime() -> "Runtime":
+    return cast("Runtime", object())
+
+
+def _make_request() -> ModelRequest:
+    """Create a minimal ModelRequest for testing."""
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="unused")]))
+    return ModelRequest(
+        model=model,
+        system_prompt=None,
+        messages=[],
+        tool_choice=None,
+        tools=[],
+        response_format=None,
+        state=AgentState(messages=[]),
+        runtime=_fake_runtime(),
+        model_settings={},
+    )
+
+
+def test_model_retry_does_not_retry_interrupt() -> None:
+    """Interrupts raised during the model call pause the agent, not retried."""
+    calls = 0
+
+    @wrap_model_call
+    def approval(
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelCallResult:
+        nonlocal calls
+        calls += 1
+        interrupt("approve model call?")
+        return handler(request)
+
+    retry = ModelRetryMiddleware(max_retries=2, initial_delay=0.01, jitter=False)
+
+    agent = create_agent(
+        model=FakeToolCallingModel(),
+        tools=[],
+        middleware=[retry, approval],
+        checkpointer=InMemorySaver(),
+    )
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    # The interrupt bubbles up and pauses the agent instead of being retried
+    # or converted to an error message.
+    assert "__interrupt__" in result
+    assert calls == 1
+
+    # Resuming completes the model call without re-raising.
+    final = agent.invoke(Command(resume="approved"), {"configurable": {"thread_id": "test"}})
+    assert "__interrupt__" not in final
+    ai_messages = [m for m in final["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) >= 1
+
+
+def test_model_retry_reraises_graph_bubble_up() -> None:
+    """GraphBubbleUp signals (e.g. ParentCommand) must propagate, not be retried."""
+    middleware = ModelRetryMiddleware(max_retries=3, initial_delay=0.01, jitter=False)
+
+    calls = 0
+
+    def handler(request: ModelRequest) -> ModelResponse:  # noqa: ARG001
+        nonlocal calls
+        calls += 1
+        raise ParentCommand(Command(goto="some_node"))
+
+    with pytest.raises(ParentCommand):
+        middleware.wrap_model_call(_make_request(), handler)
+
+    assert calls == 1  # bubbled up on first raise, not retried
+
+
+async def test_model_retry_reraises_graph_bubble_up_async() -> None:
+    """Async: GraphBubbleUp signals must propagate, not be retried."""
+    middleware = ModelRetryMiddleware(max_retries=3, initial_delay=0.01, jitter=False)
+
+    calls = 0
+
+    async def handler(request: ModelRequest) -> ModelResponse:  # noqa: ARG001
+        nonlocal calls
+        calls += 1
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        await middleware.awrap_model_call(_make_request(), handler)
+
+    assert calls == 1  # bubbled up on first raise, not retried


### PR DESCRIPTION
**Description:**

`ModelRetryMiddleware` and `ModelFallbackMiddleware` catch bare `Exception`, which traps langgraph's `GraphBubbleUp` control-flow signals (`GraphInterrupt`, `ParentCommand`). The consequences:

- **`ModelRetryMiddleware`**: an interrupt raised during the model call (e.g. a human-in-the-loop approval middleware running inside the retry wrapper) is retried `max_retries` times with backoff, then converted into an error `AIMessage` with `on_failure="continue"` (the default). The agent never pauses — instead the conversation gets polluted with:

  ```
  Model call failed after 3 attempts with GraphInterrupt: (Interrupt(value='approve model call?', id='...'),)
  ```

- **`ModelFallbackMiddleware`**: an interrupt triggers pointless fallback traversal — every fallback model's handler is invoked (each hitting the interrupt again) before the signal finally escapes via `raise last_exception`.

This PR re-raises `GraphBubbleUp` before the generic handlers in both sync and async paths of both middlewares (4 sites), exactly mirroring the fix #38722 applied to `ToolRetryMiddleware` (and the existing guard in `ToolErrorMiddleware`).

Tests added:

- `test_model_retry_does_not_retry_interrupt` — agent-level: an interrupt raised during the model call pauses the agent (`__interrupt__` in result) on the first attempt, and resuming with `Command(resume=...)` completes normally.
- `test_model_retry_reraises_graph_bubble_up` / `..._async` — direct: `ParentCommand`/`GraphInterrupt` propagate on the first raise without retries.
- `test_fallback_reraises_graph_bubble_up` / `..._async` — direct: interrupts propagate immediately without any fallback attempts.

**Issue:** Fixes #38837

**Dependencies:** none