### PR TITLE
fix(langchain): propagate `GraphInterrupt` through model retry/fallback

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -19,6 +19,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.tools import BaseTool
+from langgraph.errors import GraphBubbleUp
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
@@ -344,6 +345,10 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         last_exception: Exception
         try:
             return handler(request)
+        except GraphBubbleUp:
+            # Control-flow signals (interrupts, parent commands) must propagate,
+            # not be treated as a model failure and routed to fallback models.
+            raise
         except Exception as e:
             last_exception = e
 
@@ -359,6 +364,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             try:
                 return handler(fallback_request.override(model=fallback_model))
+            except GraphBubbleUp:
+                raise
             except Exception as e:
                 last_exception = e
                 continue
@@ -386,6 +393,10 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         last_exception: Exception
         try:
             return await handler(request)
+        except GraphBubbleUp:
+            # Control-flow signals (interrupts, parent commands) must propagate,
+            # not be treated as a model failure and routed to fallback models.
+            raise
         except Exception as e:
             last_exception = e
 
@@ -401,6 +412,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             try:
                 return await handler(fallback_request.override(model=fallback_model))
+            except GraphBubbleUp:
+                raise
             except Exception as e:
                 last_exception = e
                 continue

--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -7,6 +7,7 @@ import time
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage
+from langgraph.errors import GraphBubbleUp
 
 from langchain.agents.middleware._retry import (
     OnFailure,
@@ -232,6 +233,10 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
         for attempt in range(self.max_retries + 1):
             try:
                 return handler(request)
+            except GraphBubbleUp:
+                # Control-flow signals (interrupts, parent commands) must
+                # propagate, not be retried or converted to error messages.
+                raise
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
@@ -282,6 +287,10 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
         for attempt in range(self.max_retries + 1):
             try:
                 return await handler(request)
+            except GraphBubbleUp:
+                # Control-flow signals (interrupts, parent commands) must
+                # propagate, not be retried or converted to error messages.
+                raise
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -11,6 +11,7 @@ from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.tools import BaseTool, tool
+from langgraph.errors import GraphInterrupt
 from typing_extensions import override
 
 from langchain.agents.factory import create_agent
@@ -1067,3 +1068,46 @@ async def test_fallback_sanitizer_error_is_not_masked_async(
 
     with pytest.raises(RuntimeError, match="sanitizer boom"):
         await middleware.awrap_model_call(request, mock_handler)
+
+
+def test_fallback_propagates_graph_interrupt() -> None:
+    """A `GraphInterrupt` propagates instead of walking the fallback chain.
+
+    Regression test for #38837: interrupts (and parent `Command`s) are
+    `GraphBubbleUp`/`Exception` subclasses, so the catch-all treated them as a
+    model failure and pointlessly re-invoked the interrupt once per fallback
+    model. It must escape on the first raise, before any fallback is tried.
+    """
+    fallback_a = GenericFakeChatModel(messages=iter([AIMessage(content="a")]))
+    fallback_b = GenericFakeChatModel(messages=iter([AIMessage(content="b")]))
+    middleware = ModelFallbackMiddleware(fallback_a, fallback_b)
+    request = _make_request()
+
+    calls = {"n": 0}
+
+    def handler(_req: ModelRequest) -> ModelResponse:
+        calls["n"] += 1
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        middleware.wrap_model_call(request, handler)
+    assert calls["n"] == 1, f"fallback chain was walked: handler called {calls['n']}x"
+
+
+@pytest.mark.asyncio
+async def test_fallback_propagates_graph_interrupt_async() -> None:
+    """Async path: a `GraphInterrupt` propagates without walking fallbacks (#38837)."""
+    fallback_a = GenericFakeChatModel(messages=iter([AIMessage(content="a")]))
+    fallback_b = GenericFakeChatModel(messages=iter([AIMessage(content="b")]))
+    middleware = ModelFallbackMiddleware(fallback_a, fallback_b)
+    request = _make_request()
+
+    calls = {"n": 0}
+
+    async def handler(_req: ModelRequest) -> ModelResponse:
+        calls["n"] += 1
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        await middleware.awrap_model_call(request, handler)
+    assert calls["n"] == 1, f"fallback chain was walked: handler called {calls['n']}x"

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -9,6 +9,7 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.errors import GraphInterrupt
 from pydantic import Field
 from typing_extensions import override
 
@@ -700,3 +701,46 @@ def test_model_retry_multiple_middleware_composition() -> None:
     ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
     assert len(ai_messages) >= 1
     assert "Hello" in ai_messages[-1].content
+
+
+def test_model_retry_propagates_graph_interrupt() -> None:
+    """A `GraphInterrupt` from an inner handler propagates instead of being retried.
+
+    Regression test for #38837: control-flow signals (interrupts, parent
+    `Command`s) are `GraphBubbleUp`/`Exception` subclasses. Catching bare
+    `Exception` retried them `max_retries` times and, with the default
+    `on_failure="continue"`, converted them into a plain `AIMessage` — silently
+    destroying a human-in-the-loop pause. The interrupt must escape on the first
+    raise with no retries.
+    """
+    model = FakeToolCallingModel()
+    request = ModelRequest(model=model, messages=[])
+    retry = ModelRetryMiddleware(max_retries=2, initial_delay=0.0, jitter=False)
+
+    calls = {"n": 0}
+
+    def handler(_req: ModelRequest) -> ModelResponse:
+        calls["n"] += 1
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        retry.wrap_model_call(request, handler)
+    assert calls["n"] == 1, f"interrupt was retried: handler called {calls['n']}x"
+
+
+@pytest.mark.asyncio
+async def test_model_retry_async_propagates_graph_interrupt() -> None:
+    """Async path: a `GraphInterrupt` propagates instead of being retried (#38837)."""
+    model = FakeToolCallingModel()
+    request = ModelRequest(model=model, messages=[])
+    retry = ModelRetryMiddleware(max_retries=2, initial_delay=0.0, jitter=False)
+
+    calls = {"n": 0}
+
+    async def handler(_req: ModelRequest) -> ModelResponse:
+        calls["n"] += 1
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        await retry.awrap_model_call(request, handler)
+    assert calls["n"] == 1, f"interrupt was retried: handler called {calls['n']}x"


### PR DESCRIPTION
Fixes #38837

---

`ModelRetryMiddleware` and `ModelFallbackMiddleware` catch bare `Exception` around the wrapped handler. langgraph's `GraphInterrupt` — what `interrupt()` raises — is an `Exception` subclass via `GraphBubbleUp`, so an interrupt raised by an inner `wrap_model_call` middleware (e.g. a human-approval gate placed before an expensive model call) is treated as a model failure:

- `ModelRetryMiddleware` retries it `max_retries` times (with backoff sleeps) and, under the default `on_failure="continue"`, converts it into a plain error `AIMessage` — the run completes normally instead of pausing, silently destroying the human-in-the-loop interrupt. With `on_failure="error"` it surfaces as `ModelRetryLimitExceededError`, which is equally wrong.
- `ModelFallbackMiddleware` walks the entire fallback chain, re-invoking the interrupt once per fallback model, before the signal finally escapes.

This is the same defect class fixed for the tool side in #38722 (`ToolRetryMiddleware`); the model-side middleware never received the same guard.

The fix mirrors #38722: re-raise `GraphBubbleUp` immediately, ahead of the generic exception handling, in all four affected paths — `wrap_model_call` and `awrap_model_call` on both middleware. The guard is deliberately independent of `retry_on` filtering: control-flow signals are not errors, so they must propagate unconditionally regardless of user-configured retry predicates. No behavior change for real exceptions.

Regression tests cover sync and async paths for both middleware, asserting that a handler raising `GraphInterrupt` propagates on the first call — no retries, no fallback traversal, no `AIMessage` conversion. The tests fail when the guard is removed.

## Release note

Fixed `ModelRetryMiddleware` and `ModelFallbackMiddleware` swallowing langgraph control-flow signals: a `GraphInterrupt` (or other `GraphBubbleUp`) raised beneath them now propagates immediately instead of being retried, routed through fallbacks, or converted into an error `AIMessage`.

---

*This contribution was developed with assistance from an AI coding agent (Claude Code); all changes were reviewed and verified by the author.*
