### PR TITLE
docs(langchain): clarify `ToolRetryMiddleware` exception handling

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/tool_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/tool_retry.py
@@ -152,7 +152,8 @@ class ToolRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Respo
             retry_on: Either a tuple of exception types to retry on, or a callable
                 that takes an exception and returns `True` if it should be retried.
 
-                Default is to retry on all exceptions.
+                Default is to retry on all exceptions. Exceptions that do not match
+                propagate immediately and are not handled by `on_failure`.
             on_failure: Behavior when all retries are exhausted.
 
                 Options:


### PR DESCRIPTION
## Description
Clarifies the `ToolRetryMiddleware` API reference so users know that exceptions excluded by `retry_on` propagate immediately and bypass `on_failure`.

## Test Plan
- [x] Ruff format and lint on the updated module

Made by [Open SWE](https://openswe.vercel.app/agents/98d413e7-9150-507c-543c-a9d17f752651)