### PR TITLE
chore: standard-tests: require patched vcrpy

### DIFF
--- a/libs/standard-tests/pyproject.toml
+++ b/libs/standard-tests/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pytest-benchmark",
     "pytest-codspeed",
     "pytest-recording",
-    "vcrpy>=8.0.0,<9.0.0",
+    "vcrpy>=8.2.1,<9.0.0",
     "numpy>=1.26.2; python_version<'3.13'",
     "numpy>=2.1.0; python_version>='3.13'",
 ]

--- a/libs/standard-tests/uv.lock
+++ b/libs/standard-tests/uv.lock
@@ -487,7 +487,7 @@ requires-dist = [
     { name = "pytest-recording" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
     { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
+    { name = "vcrpy", specifier = ">=8.2.1,<9.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- Raise `langchain-tests`' `vcrpy` lower bound to `>=8.2.1` to address GHSA-rpj2-4hq8-938g / Dependabot alert #3861.
- Update the standard-tests uv lock metadata for the new constraint.

## Validation
- `uv lock --project /tmp/langchain/libs/standard-tests --locked`

## Scope
- Scoped to the `libs/standard-tests` vcrpy alert; no package version change was required because the lock already resolved to a patched vcrpy release.