### PR TITLE
fix(langchain): ModelRetryMiddleware propagates non-retryable exceptions

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -128,7 +128,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
             retry_on: Either a tuple of exception types to retry on, or a callable
                 that takes an exception and returns `True` if it should be retried.
 
-                Default is to retry on all exceptions.
+                Default is to retry on all exceptions. Exceptions that do not match
+                propagate immediately and are not handled by `on_failure`.
             on_failure: Behavior when all retries are exhausted.
 
                 Options:
@@ -237,8 +238,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -287,8 +288,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -311,15 +311,11 @@ def test_model_retry_specific_exceptions() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
-
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-    # RuntimeError should fail immediately (1 attempt only)
-    assert "1 attempt" in ai_messages[-1].content
+    with pytest.raises(RuntimeError, match="Runtime error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
 
 def test_model_retry_custom_exception_filter() -> None:
@@ -389,17 +385,14 @@ def test_model_retry_custom_exception_filter() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
-
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
+    with pytest.raises(CustomError, match="Non-retryable error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
     # Should retry once (attempt 1 with retry_me=True), then fail on attempt 2 (retry_me=False)
     assert attempt_count["value"] == 2
-    assert "2 attempts" in ai_messages[-1].content
 
 
 def test_model_retry_backoff_timing() -> None:
@@ -700,3 +693,88 @@ def test_model_retry_multiple_middleware_composition() -> None:
     ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
     assert len(ai_messages) >= 1
     assert "Hello" in ai_messages[-1].content
+
+
+def test_model_retry_non_matching_exception_propagates_immediately() -> None:
+    """Non-matching exceptions should propagate immediately, not routed through on_failure."""
+    class CountingRuntimeErrorModel(FakeToolCallingModel):
+        attempt: int = Field(default=0)
+
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            self.attempt += 1
+            raise RuntimeError("boom")
+
+    model = CountingRuntimeErrorModel()
+    retry = ModelRetryMiddleware(
+        max_retries=3,
+        retry_on=(ValueError,),
+        initial_delay=0.01,
+        jitter=False,
+        on_failure="continue",
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[retry],
+        checkpointer=InMemorySaver(),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
+
+    # Should only attempt once since exception is not retryable
+    assert model.attempt == 1
+
+
+@pytest.mark.asyncio
+async def test_model_retry_async_non_matching_exception_propagates_immediately() -> None:
+    """Async: Non-matching exceptions should propagate immediately, not routed through on_failure."""
+    class CountingRuntimeErrorModel(FakeToolCallingModel):
+        attempt: int = Field(default=0)
+
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            self.attempt += 1
+            raise RuntimeError("boom")
+
+    model = CountingRuntimeErrorModel()
+    retry = ModelRetryMiddleware(
+        max_retries=3,
+        retry_on=(ValueError,),
+        initial_delay=0.01,
+        jitter=False,
+        on_failure="continue",
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[retry],
+        checkpointer=InMemorySaver(),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await agent.ainvoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
+
+    # Should only attempt once since exception is not retryable
+    assert model.attempt == 1


### PR DESCRIPTION
Fixes #38893.

## Problem

`ModelRetryMiddleware.wrap_model_call`/`awrap_model_call` route exceptions that don't match `retry_on` into `_handle_failure`, which under the default `on_failure="continue"` fabricates an error `AIMessage` instead of propagating. `ToolRetryMiddleware` already re-raises immediately in this branch since #38845, and #38884 documented the intended contract: exceptions that do not match `retry_on` propagate immediately and are not handled by `on_failure`. The model side never received the #38845 change.

Credit to @Yigtwxx for the full diagnosis in #38893 — the root cause, the exact fix location, and the reproduction comparing both middleware side-by-side are all theirs; this PR implements the fix they described.

## Changes

- Mirror #38845 on the model side: bare `raise` instead of `return self._handle_failure(...)` in both `wrap_model_call` and `awrap_model_call`.
- Align the `retry_on` docstring with the contract documented in #38884.
- Update the two existing tests that asserted the old absorb-and-continue behavior (`test_model_retry_specific_exceptions`, `test_model_retry_custom_exception_filter`) to assert propagation instead.
- Add sync + async tests covering non-matching-exception propagation under `on_failure="continue"`, the path where the message was fabricated.

`ModelFallbackMiddleware` does not use `retry_on` and is out of scope, per the issue.

## Test plan

- [x] Reproduced the issue's exact repro script before the fix (model side swallowed `TypeError`, tool side propagated it)
- [x] Confirmed after the fix both sides propagate identically
- [x] Full `tests/unit_tests/agents/middleware/implementations/` suite passes: 511 passed, 1 skipped, 0 failed