### PR TITLE
feat(openrouter): add Responses API support

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/_responses.py
+++ b/libs/partners/openrouter/langchain_openrouter/_responses.py
@@ -1,0 +1,733 @@
+"""Helpers for OpenRouter's beta Responses API.
+
+OpenRouter's Responses API is OpenAI-compatible in shape but **stateless**:
+`store` and `previous_response_id` are rejected by the server. Sticky routing /
+prompt-cache affinity should use `session_id` instead.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+from uuid import uuid4
+
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    ChatMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.messages.tool import tool_call_chunk
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+
+_STATEFUL_UNSUPPORTED_MSG = (
+    "OpenRouter's Responses API is stateless and does not support `{param}`. "
+    "Requests that set `store: true` or a non-null `previous_response_id` are "
+    "rejected by OpenRouter with a 400 error. "
+    "Send the full conversation history on each request, and use `session_id` "
+    "for sticky routing / prompt-cache affinity. "
+    "See https://openrouter.ai/docs/api/reference/responses/overview"
+)
+
+# Params that must never be forwarded to OpenRouter Responses.
+_RESPONSES_DROP_PARAMS = frozenset(
+    {
+        "stop",
+        "n",
+        "stream_options",
+        "max_tokens",
+        "max_completion_tokens",
+        "seed",  # not in Responses request surface
+        "route",  # chat-completions-oriented OpenRouter param
+    }
+)
+
+_VALID_MESSAGE_STATUSES = frozenset({"completed", "incomplete", "in_progress"})
+
+
+def _assert_stateless_responses_supported(
+    params: dict[str, Any],
+    *,
+    use_previous_response_id: bool = False,
+) -> None:
+    """Raise if unsupported stateful Responses parameters are present.
+
+    Args:
+        params: Merged invocation / model kwargs.
+        use_previous_response_id: Constructor flag mirroring OpenAI's API.
+
+    Raises:
+        ValueError: If a stateful Responses parameter is set.
+    """
+    if use_previous_response_id:
+        msg = _STATEFUL_UNSUPPORTED_MSG.format(param="use_previous_response_id")
+        raise ValueError(msg)
+    if params.get("previous_response_id") is not None:
+        msg = _STATEFUL_UNSUPPORTED_MSG.format(param="previous_response_id")
+        raise ValueError(msg)
+    if params.get("store") is True:
+        msg = _STATEFUL_UNSUPPORTED_MSG.format(param="store")
+        raise ValueError(msg)
+
+
+def _block_to_input_part(block: Any) -> dict[str, Any] | None:  # noqa: PLR0911
+    """Convert a single content block to a Responses input part."""
+    if isinstance(block, str):
+        return {"type": "input_text", "text": block} if block else None
+    if not isinstance(block, dict):
+        return None
+
+    block_type = block.get("type")
+    if block_type in ("text", "input_text"):
+        text = block.get("text", "")
+        return {"type": "input_text", "text": text} if text else None
+    if block_type == "image_url":
+        image_url = block.get("image_url")
+        url = image_url.get("url") if isinstance(image_url, dict) else image_url
+        return {"type": "input_image", "image_url": url} if url else None
+    if block_type in ("input_image", "input_file"):
+        return block
+    if block_type != "file":
+        return None
+
+    file_obj = block.get("file") or {}
+    file_part: dict[str, Any] = {"type": "input_file"}
+    if file_data := file_obj.get("file_data"):
+        file_part["file_data"] = file_data
+    if filename := file_obj.get("filename"):
+        file_part["filename"] = filename
+    return file_part
+
+
+def _content_to_input_parts(content: Any) -> list[dict[str, Any]]:
+    """Convert message content into Responses `input_*` content parts."""
+    # Lazy import avoids a circular dependency with chat_models.
+    from langchain_openrouter.chat_models import (  # noqa: PLC0415
+        _format_message_content,
+    )
+
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": "input_text", "text": content}] if content else []
+
+    return [
+        part
+        for block in _format_message_content(content) or []
+        if (part := _block_to_input_part(block)) is not None
+    ]
+
+
+def _assistant_text_parts(content: Any) -> list[dict[str, Any]]:
+    """Convert assistant content into Responses `output_text` parts."""
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return (
+            [{"type": "output_text", "text": content, "annotations": []}]
+            if content
+            else []
+        )
+
+    parts: list[dict[str, Any]] = []
+    for block in content:
+        if isinstance(block, str):
+            if block:
+                parts.append({"type": "output_text", "text": block, "annotations": []})
+            continue
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type in ("text", "output_text"):
+            text = block.get("text")
+            if text is None:
+                continue
+            parts.append(
+                {
+                    "type": "output_text",
+                    "text": text,
+                    "annotations": block.get("annotations") or [],
+                }
+            )
+        elif block_type == "refusal":
+            parts.append({"type": "refusal", "refusal": block["refusal"]})
+    return parts
+
+
+def _resolve_assistant_message_id(message: AIMessage) -> str:
+    """Resolve a `msg_*` id for multi-turn Responses replay."""
+    msg_id = message.id
+    if isinstance(msg_id, str) and msg_id.startswith("msg_"):
+        return msg_id
+    if isinstance(message.response_metadata, dict):
+        stored = message.response_metadata.get("message_id")
+        if isinstance(stored, str) and stored:
+            return stored
+    return f"msg_{uuid4().hex}"
+
+
+def _resolve_assistant_status(message: AIMessage) -> str:
+    """Resolve assistant item status for multi-turn Responses replay."""
+    status = "completed"
+    if isinstance(message.response_metadata, dict):
+        status = (
+            message.response_metadata.get("message_status")
+            or message.response_metadata.get("status")
+            or status
+        )
+    if status not in _VALID_MESSAGE_STATUSES:
+        return "completed"
+    return status
+
+
+def _append_ai_message_items(
+    message: AIMessage, input_items: list[dict[str, Any]]
+) -> None:
+    """Append Responses input items derived from an `AIMessage`."""
+    text_parts = _assistant_text_parts(message.content)
+    msg_id = _resolve_assistant_message_id(message)
+    status = _resolve_assistant_status(message)
+
+    if text_parts:
+        input_items.append(
+            {
+                "type": "message",
+                "role": "assistant",
+                "id": msg_id,
+                "status": status,
+                "content": text_parts,
+            }
+        )
+
+    for tool_call in message.tool_calls:
+        args = tool_call.get("args")
+        if isinstance(args, str):
+            arguments = args
+        else:
+            arguments = json.dumps(args or {}, ensure_ascii=False)
+        input_items.append(
+            {
+                "type": "function_call",
+                "name": tool_call["name"],
+                "arguments": arguments,
+                "call_id": tool_call.get("id") or f"call_{uuid4().hex}",
+            }
+        )
+
+    reasoning_details = message.additional_kwargs.get("reasoning_details")
+    if isinstance(reasoning_details, list):
+        input_items.extend(
+            detail
+            for detail in reasoning_details
+            if isinstance(detail, dict) and detail.get("type") == "reasoning"
+        )
+
+
+def _construct_responses_api_input(
+    messages: Sequence[BaseMessage],
+) -> list[dict[str, Any]]:
+    """Convert LangChain messages into OpenRouter Responses `input` items.
+
+    Args:
+        messages: Conversation history.
+
+    Returns:
+        A list of Responses API input items.
+    """
+    input_items: list[dict[str, Any]] = []
+
+    for message in messages:
+        if isinstance(message, ToolMessage):
+            output = message.content
+            if not isinstance(output, str):
+                output = json.dumps(output, ensure_ascii=False)
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": message.tool_call_id,
+                    "output": output,
+                }
+            )
+            continue
+
+        if isinstance(message, AIMessage):
+            _append_ai_message_items(message, input_items)
+            continue
+
+        if isinstance(message, HumanMessage):
+            role = "user"
+        elif isinstance(message, SystemMessage):
+            role = "system"
+        elif isinstance(message, ChatMessage):
+            role = message.role
+        else:
+            msg = f"Got unknown type {message}"
+            raise TypeError(msg)
+
+        parts = _content_to_input_parts(message.content)
+        # OpenRouter accepts empty content for some roles; still send a message.
+        input_items.append(
+            {
+                "type": "message",
+                "role": role,
+                "content": parts or [{"type": "input_text", "text": ""}],
+            }
+        )
+
+    return input_items
+
+
+def _flatten_responses_tool(tool: dict[str, Any]) -> dict[str, Any]:
+    """Convert Chat Completions-style tools to Responses shape."""
+    if tool.get("type") == "function" and "function" in tool:
+        extra = {k: v for k, v in tool.items() if k not in ("type", "function")}
+        return {"type": "function", **tool["function"], **extra}
+    return tool
+
+
+def _flatten_responses_tool_choice(tool_choice: Any) -> Any:
+    """Convert Chat Completions-style tool_choice to Responses shape."""
+    if (
+        isinstance(tool_choice, dict)
+        and tool_choice.get("type") == "function"
+        and "function" in tool_choice
+    ):
+        return {"type": "function", **tool_choice["function"]}
+    return tool_choice
+
+
+def _apply_response_format(payload: dict[str, Any], schema: Any) -> None:
+    """Map Chat Completions `response_format` onto Responses `text.format`."""
+    strict = payload.pop("strict", None)
+    if schema == {"type": "json_object"}:
+        payload["text"] = {"format": {"type": "json_object"}}
+        return
+    if isinstance(schema, dict) and schema.get("type") == "json_schema":
+        payload["text"] = {"format": {"type": "json_schema", **schema["json_schema"]}}
+        return
+    if isinstance(schema, dict):
+        name = schema.get("title") or "response"
+        text_format: dict[str, Any] = {
+            "type": "json_schema",
+            "name": name,
+            "schema": schema,
+        }
+        if strict is not None:
+            text_format["strict"] = strict
+        payload["text"] = {"format": text_format}
+
+
+def _construct_responses_api_payload(
+    messages: Sequence[BaseMessage],
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Build an OpenRouter Responses API request payload.
+
+    Args:
+        messages: Conversation history.
+        params: Merged model / invocation parameters.
+
+    Returns:
+        Keyword arguments suitable for `client.beta.responses.send`.
+    """
+    payload = dict(params)
+
+    for legacy_token_param in ("max_tokens", "max_completion_tokens"):
+        if legacy_token_param in payload and "max_output_tokens" not in payload:
+            payload["max_output_tokens"] = payload[legacy_token_param]
+
+    for key in _RESPONSES_DROP_PARAMS:
+        payload.pop(key, None)
+
+    # Stateful knobs must never be forwarded.
+    payload.pop("previous_response_id", None)
+    payload.pop("store", None)
+    payload.pop("use_previous_response_id", None)
+
+    payload["input"] = _construct_responses_api_input(messages)
+
+    if tools := payload.pop("tools", None):
+        payload["tools"] = [_flatten_responses_tool(tool) for tool in tools]
+
+    if "tool_choice" in payload:
+        payload["tool_choice"] = _flatten_responses_tool_choice(payload["tool_choice"])
+
+    if schema := payload.pop("response_format", None):
+        _apply_response_format(payload, schema)
+
+    return payload
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    """Normalize SDK models / dicts to a plain dict."""
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        return value.model_dump(by_alias=True, exclude_none=False)
+    msg = f"Expected dict or pydantic model, got {type(value)!r}"
+    raise TypeError(msg)
+
+
+def _extract_output_text(response: dict[str, Any]) -> str:
+    """Join all `output_text` parts from a Responses result."""
+    texts: list[str] = []
+    for item in response.get("output") or []:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        texts.extend(
+            part.get("text") or ""
+            for part in item.get("content") or []
+            if isinstance(part, dict) and part.get("type") == "output_text"
+        )
+    return "".join(texts)
+
+
+def _raise_response_error(error: Any, *, streaming: bool = False) -> None:
+    """Raise a `ValueError` for an OpenRouter Responses error payload."""
+    if isinstance(error, dict):
+        err_msg = error.get("message", str(error))
+        code = error.get("code", "unknown")
+    else:
+        err_msg = str(error)
+        code = "unknown"
+    prefix = (
+        "OpenRouter API returned an error during streaming"
+        if streaming
+        else "OpenRouter API returned an error"
+    )
+    msg = f"{prefix}: {err_msg} (code: {code})"
+    raise ValueError(msg)
+
+
+def _parse_function_call_item(
+    item: dict[str, Any],
+    tool_calls: list[dict[str, Any]],
+    invalid_tool_calls: list[dict[str, Any]],
+) -> None:
+    """Parse a Responses `function_call` output item into tool call lists."""
+    raw_args = item.get("arguments") or "{}"
+    try:
+        args = json.loads(raw_args) if isinstance(raw_args, str) else raw_args
+        tool_calls.append(
+            {
+                "type": "tool_call",
+                "name": item.get("name") or "",
+                "args": args,
+                "id": item.get("call_id"),
+            }
+        )
+    except json.JSONDecodeError as e:
+        invalid_tool_calls.append(
+            {
+                "type": "invalid_tool_call",
+                "name": item.get("name") or "",
+                "args": raw_args,
+                "id": item.get("call_id"),
+                "error": str(e),
+            }
+        )
+
+
+def _consume_output_items(
+    output_items: list[Any],
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    dict[str, Any],
+    str | None,
+    str | None,
+]:
+    """Parse Responses `output` into tool calls, kwargs, and message ids."""
+    tool_calls: list[dict[str, Any]] = []
+    invalid_tool_calls: list[dict[str, Any]] = []
+    additional_kwargs: dict[str, Any] = {}
+    message_id: str | None = None
+    message_status: str | None = None
+
+    for item in output_items:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if item_type == "message":
+            message_id = item.get("id") or message_id
+            message_status = item.get("status") or message_status
+            for part in item.get("content") or []:
+                if isinstance(part, dict) and part.get("type") == "refusal":
+                    additional_kwargs["refusal"] = part.get("refusal")
+        elif item_type == "function_call":
+            _parse_function_call_item(item, tool_calls, invalid_tool_calls)
+        elif item_type == "reasoning":
+            details = additional_kwargs.setdefault("reasoning_details", [])
+            details.append(item)
+
+    return tool_calls, invalid_tool_calls, additional_kwargs, message_id, message_status
+
+
+def _build_response_metadata(
+    response_dict: dict[str, Any],
+    *,
+    model_name: str,
+    message_id: str | None,
+    message_status: str | None,
+) -> dict[str, Any]:
+    """Build `AIMessage.response_metadata` from a Responses result."""
+    response_metadata: dict[str, Any] = {
+        "model_provider": "openrouter",
+        "model_name": response_dict.get("model") or model_name,
+    }
+    if response_id := response_dict.get("id"):
+        response_metadata["id"] = response_id
+    if created_at := response_dict.get("created_at"):
+        response_metadata["created_at"] = created_at
+    if status := response_dict.get("status"):
+        response_metadata["status"] = status
+    if message_id:
+        response_metadata["message_id"] = message_id
+    if message_status:
+        response_metadata["message_status"] = message_status
+    if object_ := response_dict.get("object"):
+        response_metadata["object"] = object_
+    return response_metadata
+
+
+def _construct_lc_result_from_responses_api(
+    response: Any,
+    *,
+    model_name: str,
+) -> ChatResult:
+    """Convert an OpenRouter Responses result into a `ChatResult`.
+
+    Args:
+        response: SDK `OpenResponsesResult` or equivalent dict.
+        model_name: Fallback model name when the response omits `model`.
+
+    Returns:
+        A LangChain `ChatResult`.
+    """
+    response_dict = _as_dict(response)
+
+    if error := response_dict.get("error"):
+        _raise_response_error(error)
+
+    (
+        tool_calls,
+        invalid_tool_calls,
+        additional_kwargs,
+        message_id,
+        message_status,
+    ) = _consume_output_items(response_dict.get("output") or [])
+
+    content = _extract_output_text(response_dict)
+    # Prefer empty string over None for tool-only responses (matches chat path).
+    if tool_calls and not content:
+        content = ""
+
+    response_metadata = _build_response_metadata(
+        response_dict,
+        model_name=model_name,
+        message_id=message_id,
+        message_status=message_status,
+    )
+
+    usage_metadata = None
+    if usage := response_dict.get("usage"):
+        from langchain_openrouter.chat_models import (  # noqa: PLC0415
+            _create_usage_metadata,
+        )
+
+        usage_metadata = _create_usage_metadata(usage)
+        if isinstance(usage, dict):
+            if "cost" in usage:
+                response_metadata["cost"] = usage["cost"]
+            if "cost_details" in usage:
+                response_metadata["cost_details"] = usage["cost_details"]
+
+    # Use msg_* as AIMessage.id for multi-turn Responses replay; fall back to
+    # the response id when no message item is present.
+    ai_id = message_id or response_dict.get("id")
+
+    message = AIMessage(
+        content=content,
+        id=ai_id,
+        additional_kwargs=additional_kwargs,
+        tool_calls=tool_calls,  # type: ignore[arg-type]
+        invalid_tool_calls=invalid_tool_calls,  # type: ignore[arg-type]
+        usage_metadata=usage_metadata,
+        response_metadata=response_metadata,
+    )
+
+    llm_output: dict[str, Any] = {
+        "model_name": response_metadata["model_name"],
+    }
+    if response_id := response_dict.get("id"):
+        llm_output["id"] = response_id
+    if object_ := response_dict.get("object"):
+        llm_output["object"] = object_
+
+    return ChatResult(
+        generations=[ChatGeneration(message=message)],
+        llm_output=llm_output,
+    )
+
+
+def _chunk_to_dict(chunk: Any) -> dict[str, Any]:
+    """Normalize a streaming event to a dict."""
+    if isinstance(chunk, dict):
+        return chunk
+    if hasattr(chunk, "model_dump"):
+        return chunk.model_dump(by_alias=True, exclude_none=False)
+    # Fallback for attribute-style SDK events.
+    data: dict[str, Any] = {}
+    for key in (
+        "type",
+        "delta",
+        "output_index",
+        "content_index",
+        "item_id",
+        "response",
+        "item",
+        "name",
+        "arguments",
+        "call_id",
+    ):
+        if hasattr(chunk, key):
+            value = getattr(chunk, key)
+            if hasattr(value, "model_dump"):
+                value = value.model_dump(by_alias=True, exclude_none=False)
+            data[key] = value
+    return data
+
+
+def _text_delta_chunk(delta: Any) -> ChatGenerationChunk | None:
+    """Build a chunk from a text delta event payload."""
+    if isinstance(delta, dict):
+        delta = delta.get("text") or delta.get("delta") or ""
+    if not delta:
+        return None
+    return ChatGenerationChunk(
+        message=AIMessageChunk(
+            content=delta,
+            response_metadata={"model_provider": "openrouter"},
+        )
+    )
+
+
+def _function_call_added_chunk(
+    item: dict[str, Any], output_index: Any
+) -> ChatGenerationChunk:
+    """Build a chunk for a newly added function_call output item."""
+    return ChatGenerationChunk(
+        message=AIMessageChunk(
+            content="",
+            tool_call_chunks=[
+                tool_call_chunk(
+                    name=item.get("name"),
+                    args=item.get("arguments") or "",
+                    id=item.get("call_id"),
+                    index=output_index,
+                )
+            ],
+            response_metadata={"model_provider": "openrouter"},
+        )
+    )
+
+
+def _completed_response_chunk(
+    response: dict[str, Any], *, model_name: str
+) -> ChatGenerationChunk | None:
+    """Build a terminal chunk from a completed/incomplete Responses event."""
+    result = _construct_lc_result_from_responses_api(response, model_name=model_name)
+    message = result.generations[0].message
+    if not isinstance(message, AIMessage):
+        return None
+    return ChatGenerationChunk(
+        message=AIMessageChunk(
+            content="",
+            usage_metadata=message.usage_metadata,
+            response_metadata={
+                k: v
+                for k, v in message.response_metadata.items()
+                if k != "model_provider"
+            }
+            | {"model_provider": "openrouter"},
+            id=message.id,
+        ),
+        generation_info={"finish_reason": response.get("status")},
+    )
+
+
+def _convert_responses_chunk_to_generation_chunk(  # noqa: C901, PLR0911
+    chunk: Any,
+    *,
+    model_name: str,
+) -> ChatGenerationChunk | None:
+    """Convert a Responses SSE event into a `ChatGenerationChunk`.
+
+    Args:
+        chunk: Streaming event from `client.beta.responses.send(stream=True)`.
+        model_name: Fallback model name for metadata.
+
+    Returns:
+        A generation chunk, or `None` for events that should be skipped.
+    """
+    event = _chunk_to_dict(chunk)
+    event_type = event.get("type")
+
+    if event_type in (
+        "response.output_text.delta",
+        "response.content_part.delta",
+    ):
+        return _text_delta_chunk(event.get("delta") or "")
+
+    if event_type == "response.function_call_arguments.delta":
+        return ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="",
+                tool_call_chunks=[
+                    tool_call_chunk(
+                        args=event.get("delta") or "",
+                        index=event.get("output_index"),
+                    )
+                ],
+                response_metadata={"model_provider": "openrouter"},
+            )
+        )
+
+    if event_type == "response.output_item.added":
+        item = event.get("item") or {}
+        if isinstance(item, dict) and item.get("type") == "function_call":
+            return _function_call_added_chunk(item, event.get("output_index"))
+        return None
+
+    if event_type == "response.created":
+        response = event.get("response") or {}
+        if not isinstance(response, dict):
+            response = _as_dict(response)
+        response_id = response.get("id")
+        if not response_id:
+            return None
+        return ChatGenerationChunk(
+            message=AIMessageChunk(
+                content="",
+                id=response_id,
+                response_metadata={
+                    "model_provider": "openrouter",
+                    "id": response_id,
+                },
+            )
+        )
+
+    if event_type in ("response.completed", "response.done", "response.incomplete"):
+        response = event.get("response") or {}
+        if not isinstance(response, dict):
+            response = _as_dict(response)
+        return _completed_response_chunk(response, model_name=model_name)
+
+    if event_type == "error" or event.get("error"):
+        _raise_response_error(event.get("error") or event, streaming=True)
+
+    return None

--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -142,6 +142,7 @@ class ChatOpenRouter(BaseChatModel):
         | `trace` | `dict[str, Any] | None` | Trace metadata for broadcasts. |
         | `default_headers` | `Mapping[str, str] | None` | Extra request headers. |
         | `max_retries` | `int` | Max retries (default `2`). Set to `0` to disable. |
+        | `use_responses_api` | `bool` | Use OpenRouter's beta Responses API. |
 
     ??? info "Instantiate"
 
@@ -153,8 +154,19 @@ class ChatOpenRouter(BaseChatModel):
             temperature=0,
             # api_key="...",
             # openrouter_provider={"order": ["Anthropic"]},
+            # use_responses_api=True,  # beta Responses API (stateless)
         )
         ```
+
+    !!! warning "Responses API is beta and stateless"
+
+        When `use_responses_api=True`, requests go to OpenRouter's
+        [Responses API](https://openrouter.ai/docs/api/reference/responses/overview).
+        Unlike OpenAI's Responses API, OpenRouter does **not** persist conversation
+        state: `previous_response_id`, `use_previous_response_id`, and `store=True`
+        raise a clear error before any network call. Send the full conversation
+        history on each turn. Use `session_id` for sticky routing / prompt-cache
+        affinity.
 
     See https://openrouter.ai/docs for platform documentation.
     """
@@ -372,6 +384,28 @@ class ChatOpenRouter(BaseChatModel):
     See https://openrouter.ai/docs/guides/features/broadcast/overview
     """
 
+    use_responses_api: bool = False
+    """Whether to use OpenRouter's beta Responses API instead of Chat Completions.
+
+    When `True`, requests are sent via `client.beta.responses.send` with
+    Responses-shaped `input` / tools. Defaults to `False` (Chat Completions).
+
+    OpenRouter's Responses API is **stateless**: full conversation history must
+    still be sent each turn. Stateful parameters (`previous_response_id`,
+    `use_previous_response_id`, `store=True`) are unsupported and raise
+    `ValueError`. Prefer `session_id` for sticky routing / cache affinity.
+
+    See https://openrouter.ai/docs/api/reference/responses/overview
+    """
+
+    use_previous_response_id: bool = False
+    """Accepted for API familiarity with `ChatOpenAI`; always unsupported.
+
+    OpenRouter's Responses API rejects `previous_response_id`. Setting this to
+    `True` raises `ValueError` at construction time. Use `session_id` instead
+    for sticky routing / prompt-cache affinity.
+    """
+
     model_config = ConfigDict(populate_by_name=True)
 
     @model_validator(mode="before")
@@ -480,6 +514,12 @@ class ChatOpenRouter(BaseChatModel):
         if self.n > 1 and self.streaming:
             msg = "n must be 1 when streaming."
             raise ValueError(msg)
+        if self.use_previous_response_id:
+            from langchain_openrouter._responses import (  # noqa: PLC0415
+                _assert_stateless_responses_supported,
+            )
+
+            _assert_stateless_responses_supported({}, use_previous_response_id=True)
 
         if not self.client:
             try:
@@ -530,8 +570,40 @@ class ChatOpenRouter(BaseChatModel):
             "reasoning": self.reasoning,
             "openrouter_provider": self.openrouter_provider,
             "route": self.route,
+            "use_responses_api": self.use_responses_api,
             "model_kwargs": self.model_kwargs,
         }
+
+    def _use_responses_api(self) -> bool:
+        """Return whether to route requests to the Responses API."""
+        return bool(self.use_responses_api)
+
+    def _check_stateless_responses_params(self, params: dict[str, Any]) -> None:
+        """Raise if unsupported stateful Responses parameters are present."""
+        from langchain_openrouter._responses import (  # noqa: PLC0415
+            _assert_stateless_responses_supported,
+        )
+
+        _assert_stateless_responses_supported(
+            params, use_previous_response_id=self.use_previous_response_id
+        )
+
+    def _prepare_responses_request(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Build Responses API kwargs after validating stateful params."""
+        from langchain_openrouter._responses import (  # noqa: PLC0415
+            _construct_responses_api_payload,
+        )
+
+        _, params = self._create_message_dicts(messages, stop)
+        params = {**params, **kwargs}
+        _strip_internal_kwargs(params)
+        self._check_stateless_responses_params(params)
+        return _construct_responses_api_payload(messages, params)
 
     def _get_ls_params(
         self,
@@ -564,9 +636,20 @@ class ChatOpenRouter(BaseChatModel):
                 messages, stop=stop, run_manager=run_manager, **kwargs
             )
             return generate_from_stream(stream_iter)
+        if self._use_responses_api():
+            from langchain_openrouter._responses import (  # noqa: PLC0415
+                _construct_lc_result_from_responses_api,
+            )
+
+            payload = self._prepare_responses_request(messages, stop, **kwargs)
+            response = self.client.beta.responses.send(**payload)
+            return _construct_lc_result_from_responses_api(
+                response, model_name=self.model_name
+            )
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs}
         _strip_internal_kwargs(params)
+        self._check_stateless_responses_params(params)
         response = self.client.chat.send(messages=message_dicts, **params)
         return self._create_chat_result(response)
 
@@ -582,11 +665,77 @@ class ChatOpenRouter(BaseChatModel):
                 messages, stop=stop, run_manager=run_manager, **kwargs
             )
             return await agenerate_from_stream(stream_iter)
+        if self._use_responses_api():
+            from langchain_openrouter._responses import (  # noqa: PLC0415
+                _construct_lc_result_from_responses_api,
+            )
+
+            payload = self._prepare_responses_request(messages, stop, **kwargs)
+            response = await self.client.beta.responses.send_async(**payload)
+            return _construct_lc_result_from_responses_api(
+                response, model_name=self.model_name
+            )
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs}
         _strip_internal_kwargs(params)
+        self._check_stateless_responses_params(params)
         response = await self.client.chat.send_async(messages=message_dicts, **params)
         return self._create_chat_result(response)
+
+    def _stream_responses(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        """Stream via OpenRouter's beta Responses API."""
+        from langchain_openrouter._responses import (  # noqa: PLC0415
+            _convert_responses_chunk_to_generation_chunk,
+        )
+
+        payload = self._prepare_responses_request(
+            messages, stop, **{**kwargs, "stream": True}
+        )
+        for chunk in self.client.beta.responses.send(**payload):
+            generation_chunk = _convert_responses_chunk_to_generation_chunk(
+                chunk, model_name=self.model_name
+            )
+            if generation_chunk is None:
+                continue
+            if run_manager:
+                run_manager.on_llm_new_token(
+                    generation_chunk.text, chunk=generation_chunk
+                )
+            yield generation_chunk
+
+    async def _astream_responses(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        """Async stream via OpenRouter's beta Responses API."""
+        from langchain_openrouter._responses import (  # noqa: PLC0415
+            _convert_responses_chunk_to_generation_chunk,
+        )
+
+        payload = self._prepare_responses_request(
+            messages, stop, **{**kwargs, "stream": True}
+        )
+        stream = await self.client.beta.responses.send_async(**payload)
+        async for chunk in stream:
+            generation_chunk = _convert_responses_chunk_to_generation_chunk(
+                chunk, model_name=self.model_name
+            )
+            if generation_chunk is None:
+                continue
+            if run_manager:
+                await run_manager.on_llm_new_token(
+                    token=generation_chunk.text, chunk=generation_chunk
+                )
+            yield generation_chunk
 
     def _stream(  # noqa: C901
         self,
@@ -595,11 +744,18 @@ class ChatOpenRouter(BaseChatModel):
         run_manager: CallbackManagerForLLMRun | None = None,
         **kwargs: Any,
     ) -> Iterator[ChatGenerationChunk]:
+        if self._use_responses_api():
+            yield from self._stream_responses(
+                messages, stop=stop, run_manager=run_manager, **kwargs
+            )
+            return
+
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs, "stream": True}
         if self.stream_usage:
             params["stream_options"] = {"include_usage": True}
         _strip_internal_kwargs(params)
+        self._check_stateless_responses_params(params)
 
         default_chunk_class: type[BaseMessageChunk] = AIMessageChunk
         terminal_generation_info: dict[str, Any] = {}
@@ -678,11 +834,19 @@ class ChatOpenRouter(BaseChatModel):
         run_manager: AsyncCallbackManagerForLLMRun | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[ChatGenerationChunk]:
+        if self._use_responses_api():
+            async for chunk in self._astream_responses(
+                messages, stop=stop, run_manager=run_manager, **kwargs
+            ):
+                yield chunk
+            return
+
         message_dicts, params = self._create_message_dicts(messages, stop)
         params = {**params, **kwargs, "stream": True}
         if self.stream_usage:
             params["stream_options"] = {"include_usage": True}
         _strip_internal_kwargs(params)
+        self._check_stateless_responses_params(params)
 
         default_chunk_class: type[BaseMessageChunk] = AIMessageChunk
         terminal_generation_info: dict[str, Any] = {}

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -3731,3 +3731,329 @@ def test_profile() -> None:
     """Test that the model has a profile."""
     model = _make_model()
     assert model.profile
+
+
+# ===========================================================================
+# Responses API tests
+# ===========================================================================
+
+_SIMPLE_RESPONSES_DICT: dict[str, Any] = {
+    "id": "resp_abc123",
+    "object": "response",
+    "created_at": 1700000000,
+    "model": MODEL_NAME,
+    "status": "completed",
+    "output": [
+        {
+            "type": "message",
+            "id": "msg_abc123",
+            "status": "completed",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Hello from Responses!",
+                    "annotations": [],
+                }
+            ],
+        }
+    ],
+    "usage": {
+        "input_tokens": 12,
+        "output_tokens": 6,
+        "total_tokens": 18,
+    },
+}
+
+_TOOL_RESPONSES_DICT: dict[str, Any] = {
+    "id": "resp_tool123",
+    "object": "response",
+    "created_at": 1700000000,
+    "model": MODEL_NAME,
+    "status": "completed",
+    "output": [
+        {
+            "type": "function_call",
+            "id": "fc_1",
+            "call_id": "call_1",
+            "name": "GetWeather",
+            "arguments": '{"location": "San Francisco"}',
+            "status": "completed",
+        }
+    ],
+    "usage": {
+        "input_tokens": 20,
+        "output_tokens": 10,
+        "total_tokens": 30,
+    },
+}
+
+_RESPONSES_STREAM_EVENTS: list[dict[str, Any]] = [
+    {
+        "type": "response.created",
+        "response": {
+            "id": "resp_stream1",
+            "object": "response",
+            "status": "in_progress",
+        },
+    },
+    {
+        "type": "response.output_text.delta",
+        "delta": "Hello",
+        "output_index": 0,
+        "content_index": 0,
+    },
+    {
+        "type": "response.output_text.delta",
+        "delta": " world",
+        "output_index": 0,
+        "content_index": 0,
+    },
+    {
+        "type": "response.completed",
+        "response": {
+            "id": "resp_stream1",
+            "object": "response",
+            "status": "completed",
+            "model": MODEL_NAME,
+            "output": [
+                {
+                    "type": "message",
+                    "id": "msg_stream1",
+                    "status": "completed",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Hello world",
+                            "annotations": [],
+                        }
+                    ],
+                }
+            ],
+            "usage": {
+                "input_tokens": 5,
+                "output_tokens": 2,
+                "total_tokens": 7,
+            },
+        },
+    },
+]
+
+
+class TestResponsesApi:
+    """Tests for `use_responses_api=True` on `ChatOpenRouter`."""
+
+    def test_default_still_uses_chat_completions(self) -> None:
+        """Default path must keep calling `client.chat.send`."""
+        model = _make_model()
+        model.client = MagicMock()
+        model.client.chat.send.return_value = _make_sdk_response(_SIMPLE_RESPONSE_DICT)
+
+        model.invoke("Hello")
+        model.client.chat.send.assert_called_once()
+        model.client.beta.responses.send.assert_not_called()
+
+    def test_invoke_basic(self) -> None:
+        """Responses invoke returns text + usage via `beta.responses.send`."""
+        model = _make_model(use_responses_api=True)
+        model.client = MagicMock()
+        model.client.beta.responses.send.return_value = _make_sdk_response(
+            _SIMPLE_RESPONSES_DICT
+        )
+
+        result = model.invoke("Hello")
+        assert isinstance(result, AIMessage)
+        assert result.content == "Hello from Responses!"
+        assert result.id == "msg_abc123"
+        assert result.response_metadata["id"] == "resp_abc123"
+        assert result.response_metadata["model_provider"] == "openrouter"
+        assert result.usage_metadata is not None
+        assert result.usage_metadata["input_tokens"] == 12
+        assert result.usage_metadata["output_tokens"] == 6
+        model.client.beta.responses.send.assert_called_once()
+        model.client.chat.send.assert_not_called()
+
+    def test_invoke_with_tool_response(self) -> None:
+        """Responses tool calls are parsed onto `AIMessage.tool_calls`."""
+        model = _make_model(use_responses_api=True)
+        model.client = MagicMock()
+        model.client.beta.responses.send.return_value = _make_sdk_response(
+            _TOOL_RESPONSES_DICT
+        )
+
+        result = model.invoke("What's the weather?")
+        assert isinstance(result, AIMessage)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "GetWeather"
+        assert result.tool_calls[0]["args"] == {"location": "San Francisco"}
+        assert result.tool_calls[0]["id"] == "call_1"
+
+    def test_payload_uses_input_not_messages(self) -> None:
+        """Responses requests must send `input`, not chat `messages`."""
+        model = _make_model(use_responses_api=True)
+        model.client = MagicMock()
+        model.client.beta.responses.send.return_value = _make_sdk_response(
+            _SIMPLE_RESPONSES_DICT
+        )
+
+        model.invoke([HumanMessage(content="Hi")])
+        call_kwargs = model.client.beta.responses.send.call_args[1]
+        assert "messages" not in call_kwargs
+        assert call_kwargs["input"] == [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "Hi"}],
+            }
+        ]
+
+    def test_max_tokens_mapped_to_max_output_tokens(self) -> None:
+        """`max_tokens` is renamed to `max_output_tokens` for Responses."""
+        model = _make_model(use_responses_api=True, max_tokens=256)
+        model.client = MagicMock()
+        model.client.beta.responses.send.return_value = _make_sdk_response(
+            _SIMPLE_RESPONSES_DICT
+        )
+
+        model.invoke("Hello")
+        call_kwargs = model.client.beta.responses.send.call_args[1]
+        assert call_kwargs["max_output_tokens"] == 256
+        assert "max_tokens" not in call_kwargs
+
+    def test_stop_omitted_from_payload(self) -> None:
+        """Responses API has no `stop` parameter."""
+        model = _make_model(use_responses_api=True, stop_sequences=["END"])
+        model.client = MagicMock()
+        model.client.beta.responses.send.return_value = _make_sdk_response(
+            _SIMPLE_RESPONSES_DICT
+        )
+
+        model.invoke("Hello")
+        call_kwargs = model.client.beta.responses.send.call_args[1]
+        assert "stop" not in call_kwargs
+
+    def test_tools_flattened_to_responses_shape(self) -> None:
+        """Chat Completions-style tools are flattened for Responses."""
+        model = _make_model(use_responses_api=True)
+        model.client = MagicMock()
+        model.client.beta.responses.send.return_value = _make_sdk_response(
+            _SIMPLE_RESPONSES_DICT
+        )
+
+        model.bind_tools([GetWeather]).invoke("Weather?")
+        call_kwargs = model.client.beta.responses.send.call_args[1]
+        assert call_kwargs["tools"] == [
+            {
+                "type": "function",
+                "name": "GetWeather",
+                "description": "Get the current weather in a given location.",
+                "parameters": {
+                    "properties": {
+                        "location": {
+                            "description": "The city and state",
+                            "type": "string",
+                        }
+                    },
+                    "required": ["location"],
+                    "type": "object",
+                },
+            }
+        ]
+
+    def test_multi_turn_includes_assistant_id_and_status(self) -> None:
+        """Prior assistant turns include required `id` and `status`."""
+        model = _make_model(use_responses_api=True)
+        model.client = MagicMock()
+        model.client.beta.responses.send.return_value = _make_sdk_response(
+            _SIMPLE_RESPONSES_DICT
+        )
+
+        model.invoke(
+            [
+                HumanMessage(content="Capital of France?"),
+                AIMessage(
+                    content="Paris",
+                    id="msg_prev",
+                    response_metadata={"message_status": "completed"},
+                ),
+                HumanMessage(content="Population?"),
+            ]
+        )
+        call_kwargs = model.client.beta.responses.send.call_args[1]
+        assistant = next(
+            item for item in call_kwargs["input"] if item.get("role") == "assistant"
+        )
+        assert assistant["id"] == "msg_prev"
+        assert assistant["status"] == "completed"
+        assert assistant["content"] == [
+            {"type": "output_text", "text": "Paris", "annotations": []}
+        ]
+
+    def test_stream_basic(self) -> None:
+        """Responses streaming emits text deltas via `beta.responses.send`."""
+        model = _make_model(use_responses_api=True)
+        model.client = MagicMock()
+        model.client.beta.responses.send.return_value = _MockSyncStream(
+            [dict(c) for c in _RESPONSES_STREAM_EVENTS]
+        )
+
+        chunks = list(model.stream("Hello"))
+        assert len(chunks) > 0
+        assert all(isinstance(c, AIMessageChunk) for c in chunks)
+        full_content = "".join(c.content for c in chunks if isinstance(c.content, str))
+        assert "Hello" in full_content
+        assert "world" in full_content
+        model.client.beta.responses.send.assert_called_once()
+        call_kwargs = model.client.beta.responses.send.call_args[1]
+        assert call_kwargs["stream"] is True
+
+    async def test_ainvoke_basic(self) -> None:
+        """Async Responses invoke uses `send_async`."""
+        model = _make_model(use_responses_api=True)
+        model.client = MagicMock()
+        model.client.beta.responses.send_async = AsyncMock(
+            return_value=_make_sdk_response(_SIMPLE_RESPONSES_DICT)
+        )
+
+        result = await model.ainvoke("Hello")
+        assert isinstance(result, AIMessage)
+        assert result.content == "Hello from Responses!"
+        model.client.beta.responses.send_async.assert_called_once()
+
+    def test_previous_response_id_hard_fails(self) -> None:
+        """`previous_response_id` raises before any SDK call."""
+        model = _make_model(use_responses_api=True)
+        model.client = MagicMock()
+
+        with pytest.raises(ValueError, match="previous_response_id"):
+            model.invoke("Hello", previous_response_id="resp_123")
+        model.client.beta.responses.send.assert_not_called()
+
+    def test_previous_response_id_hard_fails_on_completions_path(self) -> None:
+        """Stateful knobs raise even when Completions mode is selected."""
+        model = _make_model()
+        model.client = MagicMock()
+
+        with pytest.raises(ValueError, match="previous_response_id"):
+            model.invoke("Hello", previous_response_id="resp_123")
+        model.client.chat.send.assert_not_called()
+
+    def test_store_true_hard_fails(self) -> None:
+        """`store=True` raises before any SDK call."""
+        model = _make_model(use_responses_api=True)
+        model.client = MagicMock()
+
+        with pytest.raises(ValueError, match="store"):
+            model.invoke("Hello", store=True)
+        model.client.beta.responses.send.assert_not_called()
+
+    def test_use_previous_response_id_hard_fails_at_construction(self) -> None:
+        """`use_previous_response_id=True` raises at construction."""
+        with pytest.raises(ValueError, match="use_previous_response_id"):
+            _make_model(use_previous_response_id=True)
+
+    def test_identifying_params_include_use_responses_api(self) -> None:
+        """`use_responses_api` is part of identifying params."""
+        model = _make_model(use_responses_api=True)
+        assert model._identifying_params["use_responses_api"] is True

--- a/libs/partners/openrouter/uv.lock
+++ b/libs/partners/openrouter/uv.lock
@@ -547,7 +547,7 @@ requires-dist = [
     { name = "pytest-recording" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
     { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
+    { name = "vcrpy", specifier = ">=8.2.1,<9.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Closes #38896

---

## Summary

`ChatOpenRouter` currently supports only OpenRouter's Chat Completions API. This PR adds an explicit `use_responses_api=True` option for applications that require the Responses API's input/output format, reasoning, tool-calling, and streaming capabilities.

The implementation uses the official OpenRouter SDK's `beta.responses` client for synchronous, asynchronous, and streaming requests. It converts LangChain messages, tools, usage metadata, and response events while preserving the existing Chat Completions API behavior by default.

OpenRouter's Responses API is currently stateless. Since OpenRouter rejects `previous_response_id` and `store=True`, this PR validates these unsupported parameters before making a network request. `use_previous_response_id=True` is also unsupported when using the Responses API.

Users should provide the complete conversation history with each request. They can use `session_id` for sticky routing and prompt-cache affinity.

## Tests

Unit tests cover:

- Message and parameter conversion
- Tool calls
- Streaming event conversion
- Usage metadata
- Multi-turn input
- Validation of unsupported stateful parameters

## Areas for Review

- Responses API input and output conversion
- Streaming event conversion
- Early validation of stateful parameters

## Release Note

`ChatOpenRouter` now supports OpenRouter's beta Responses API through `use_responses_api=True`, including synchronous, asynchronous, streaming, reasoning, and tool-calling workflows.

OpenRouter's Responses API remains stateless; therefore, `previous_response_id`, `use_previous_response_id=True`, and `store=True` are not supported.