### PR TITLE
fix(core): correct generations assertion in test_stream_error_callback

### DIFF
--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -200,7 +200,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 
@@ -209,7 +208,7 @@ async def test_stream_error_callback() -> None:
         assert len(callback.errors_args) == 1
         llm_result: LLMResult = callback.errors_args[0]["kwargs"]["response"]
         if i == 0:
-            assert llm_result.generations == []
+            assert llm_result.generations == [[]]
         else:
             assert llm_result.generations[0][0].text == message[:i]
 


### PR DESCRIPTION
Fixes #38904
---

LLMResult.generations is typed as list[list[Generation]]. The test sends one prompt and the error fires on chunk 0 before any content, so generations is [[]], not []. Removed the xfail decorator and corrected the assertion.