### PR TITLE
fix(core): handle 'type' key as identity marker in merge_dicts

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -43,19 +43,16 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 )
                 raise TypeError(msg)
             elif isinstance(merged[right_k], str):
-                # TODO: Add below special handling for 'type' key in 0.3 and remove
-                # merge_lists 'type' logic.
-                #
-                # if right_k == "type":
-                #     if merged[right_k] == right_v:
-                #         continue
-                #     else:
-                #         raise ValueError(
-                #             "Unable to merge. Two different values seen for special "
-                #             f"key 'type': {merged[right_k]} and {right_v}. 'type' "
-                #             "should either occur once or have the same value across "
-                #             "all dicts."
-                #         )
+                if right_k == "type":
+                    if merged[right_k] == right_v:
+                        continue
+                    msg = (
+                        "Unable to merge. Two different values seen for special "
+                        f"key 'type': {merged[right_k]} and {right_v}. 'type' "
+                        "should either occur once or have the same value across "
+                        "all dicts."
+                    )
+                    raise ValueError(msg)
                 if (right_k == "index" and merged[right_k].startswith("lc_")) or (
                     right_k in {"id", "output_version", "model_provider"}
                     and merged[right_k] == right_v

--- a/libs/core/tests/unit_tests/utils/test_utils.py
+++ b/libs/core/tests/unit_tests/utils/test_utils.py
@@ -160,7 +160,6 @@ def test_merge_dicts(
         ),
     ],
 )
-@pytest.mark.xfail(reason="Refactors to make in 0.3")
 def test_merge_dicts_0_3(
     left: dict[str, Any],
     right: dict[str, Any],


### PR DESCRIPTION
Fixes #38908

---

merge_dicts previously treated the type key like any other string field, concatenating values. This is incorrect because type is an identity marker that should either match (preserved) or conflict (raise ValueError). The functionality was planned in a TODO and xfail test. This commit implements it and removes the xfail.