### PR TITLE
fix(openai): raise clear error on unexpected response type in `_create_chat_result`

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1801,6 +1801,21 @@ class BaseChatOpenAI(BaseChatModel):
     ) -> ChatResult:
         generations = []
 
+        if not isinstance(response, dict | openai.BaseModel):
+            # `raw_response.parse()` can hand back something other than a
+            # dict or BaseModel when the upstream endpoint returns a non-JSON
+            # body (e.g. an Azure 302 redirect that yields an HTML string, or
+            # another OpenAI-compatible backend returning plain text). Without
+            # this guard the code below calls `.model_dump()` on the value and
+            # surfaces an opaque `AttributeError: 'str' object has no attribute
+            # 'model_dump'`, hiding the real cause. Raise a clear error so the
+            # caller knows the response shape is unexpected.
+            msg = (
+                "Unexpected response type from OpenAI-compatible endpoint. "
+                f"Expected a dict or openai.BaseModel, got "
+                f"{type(response).__name__}: {response!r}"
+            )
+            raise ValueError(msg)
         response_dict = (
             response
             if isinstance(response, dict)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1899,6 +1899,23 @@ def test_create_chat_result_avoids_parsed_model_dump_warning() -> None:
     )
 
 
+def test_create_chat_result_raises_on_unexpected_response_type() -> None:
+    """Non-dict / non-BaseModel responses must surface a clear error.
+
+    `raw_response.parse()` can hand back a `str` (or other non-model value)
+    when an OpenAI-compatible endpoint returns a non-JSON body, e.g. an Azure
+    302 redirect that serves an HTML page. Previously this reached
+    `response.model_dump()` and raised an opaque
+    `AttributeError: 'str' object has no attribute 'model_dump'`. See #38866.
+    """
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+
+    # Simulate the Azure 302 redirect scenario where `parse()` returns the raw
+    # HTML body as a string instead of a typed completion model.
+    with pytest.raises(ValueError, match="Unexpected response type"):
+        llm._create_chat_result("<html><body>Moved</body></html>")  # type: ignore[arg-type]
+
+
 @pytest.mark.skipif(
     (PYDANTIC_VERSION.major, PYDANTIC_VERSION.minor) < (2, 8),
     reason=(


### PR DESCRIPTION
Closes #38866.

---

When an OpenAI-compatible endpoint returns a non-JSON body (e.g. an Azure 302 redirect that serves an HTML page, or another backend returning plain text), `raw_response.parse()` can hand back a value that is neither a dict nor an `openai.BaseModel`. Previously this flowed straight into `response.model_dump()` and raised an opaque `AttributeError: 'str' object has no attribute 'model_dump'`, which hid the real cause and gave the caller no signal about the unexpected response shape. `_create_chat_result` now guards against non-dict/non-BaseModel responses at the top and raises a clear `ValueError` naming the unexpected type and value, so the failure is diagnosable. A unit test covers the Azure-302-returns-HTML scenario.

This change is backward compatible for any caller passing a valid dict or BaseModel; it only changes the error class and message for the already-broken non-model case.

Co-authored-by: Hermes Agent (AI coding assistant). I reviewed and tested the change myself.