### PR TITLE
fix(openai): preserve caller's `model_kwargs["text"]` across Responses API calls

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4340,6 +4340,14 @@ def _construct_responses_api_payload(
         else:
             payload["tool_choice"] = tool_choice
 
+    # `payload["text"]` may be the caller's `model_kwargs["text"]` dict, passed
+    # in by reference. The structured-output and verbosity handling below mutate
+    # it in place (e.g. setting a `format` key), which would corrupt the
+    # caller-owned object across calls. Copy it before mutating so the original
+    # is preserved. See issue #38869.
+    if "text" in payload and isinstance(payload["text"], dict):
+        payload["text"] = {**payload["text"]}
+
     # Structured output
     if schema := payload.pop("response_format", None):
         # For pydantic + non-streaming case, we use responses.parse.

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1593,6 +1593,41 @@ def test_chat_completions_payload_includes_stop() -> None:
     assert payload["stop"] == ["END"]
 
 
+def test_responses_api_does_not_mutate_caller_model_kwargs_text() -> None:
+    """A structured-output (JSON mode) call must not mutate the caller-owned
+    `model_kwargs["text"]` dict in place.
+
+    Regression test for #38869: `_construct_responses_api_payload` reused the
+    caller's `text` dict reference when merging `response_format`, so one JSON
+    mode call permanently forced `format` into the dict and leaked into later
+    plain calls.
+    """
+    caller_text_opts = {"verbosity": "low"}
+    llm = ChatOpenAI(
+        model=OPENAI_TEST_MODEL,
+        api_key=SecretStr("test-api-key"),
+        use_responses_api=True,
+        model_kwargs={"text": caller_text_opts},
+    )
+
+    # First call: JSON mode via response_format. This used to write
+    # `format` into caller_text_opts in place.
+    payload_json = llm._get_request_payload(
+        "give me json", response_format={"type": "json_object"}
+    )
+    assert payload_json["text"]["format"] == {"type": "json_object"}
+    # The caller's dict must be untouched.
+    assert caller_text_opts == {"verbosity": "low"}
+    # The model_kwargs on the llm instance must also be untouched.
+    assert llm.model_kwargs["text"] == {"verbosity": "low"}
+
+    # Second call: a plain call with no response_format. It must not carry
+    # the leaked `format` key from the previous structured call.
+    payload_plain = llm._get_request_payload("just chat normally")
+    assert "format" not in payload_plain["text"]
+    assert payload_plain["text"] == {"verbosity": "low"}
+
+
 def test_output_version_compat() -> None:
     llm = ChatOpenAI(model="gpt-5", output_version="responses/v1")
     assert llm._use_responses_api({}) is True


### PR DESCRIPTION
Closes #38869

---

On the Responses API route, `_construct_responses_api_payload` reused the caller-owned `model_kwargs["text"]` dict by reference when merging `response_format` (JSON mode and json_schema) and `verbosity`. The in-place writes leaked back into the caller's object, so a single structured-output call permanently stamped a `format` key into it. Every later plain call then silently inherited JSON mode (or a json_schema), because the leaked `format` was still sitting in the shared dict.

This was especially nasty for callers who build one `ChatOpenAI` with a reusable options dict and then issue a mix of structured and plain calls: the first JSON-mode call corrupted the dict, and the second plain call would unexpectedly request `{"type": "json_object"}` again.

The fix copies the `text` dict once, before any structured-output or verbosity handling touches it, so the caller's object (and the model instance's `model_kwargs`) are left untouched. Only the per-call payload sees the merged keys.

Added a regression test that reproduces the original repro from the issue: it asserts both the caller dict and `llm.model_kwargs["text"]` stay equal to `{"verbosity": "low"}` after a JSON-mode call, and that a follow-up plain call does not carry a `format` key.

Co-authored-by: Hermes Agent <noreply@nousresearch.com>