### PR TITLE
fix(core): do not treat empty primary stream as failure in `RunnableWithFallbacks`

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -486,6 +486,8 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        _sentinel: Any = object()
+        first_chunk: Output | None = _sentinel  # type: ignore[assignment]
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -497,7 +499,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    first_chunk = context.run(next, stream, _sentinel)
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -511,8 +513,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             run_manager.on_chain_error(first_error)
             raise first_error
 
-        yield chunk
-        output: Output | None = chunk
+        output: Output | None = None
+        if first_chunk is not _sentinel:
+            output = cast("Output", first_chunk)
+            yield cast("Output", first_chunk)
         try:
             for chunk in stream:
                 yield chunk
@@ -550,6 +554,8 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        _sentinel: Any = object()
+        first_chunk: Output | None = _sentinel  # type: ignore[assignment]
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -561,7 +567,9 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         child_config,
                         **kwargs,
                     )
-                    chunk = await coro_with_context(anext(stream), context)
+                    first_chunk = await coro_with_context(
+                        anext(stream, _sentinel), context
+                    )
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -575,8 +583,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             await run_manager.on_chain_error(first_error)
             raise first_error
 
-        yield chunk
-        output: Output | None = chunk
+        output: Output | None = None
+        if first_chunk is not _sentinel:
+            output = cast("Output", first_chunk)
+            yield cast("Output", first_chunk)
         try:
             async for chunk in stream:
                 yield chunk

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -288,6 +288,24 @@ def test_fallbacks_stream() -> None:
         list(runnable.stream({}))
 
 
+def _generate_empty(_: Iterator[Any]) -> Iterator[str]:
+    yield from ()
+
+
+def test_fallbacks_stream_empty_primary_does_not_trigger_fallback() -> None:
+    """A legitimately empty primary stream should not be treated as a failure."""
+    runnable = RunnableGenerator(_generate_empty).with_fallbacks(
+        [RunnableGenerator(_generate)]
+    )
+    assert list(runnable.stream({})) == []
+
+
+def test_fallbacks_stream_empty_primary_no_fallback_does_not_raise() -> None:
+    """An empty primary with no fallbacks should yield nothing, not raise."""
+    runnable = RunnableGenerator(_generate_empty).with_fallbacks([])
+    assert list(runnable.stream({})) == []
+
+
 async def _agenerate(_: AsyncIterator[Any]) -> AsyncIterator[str]:
     for c in "foo bar":
         yield c
@@ -316,6 +334,25 @@ async def test_fallbacks_astream() -> None:
     )
     with pytest.raises(ValueError, match="delayed error"):
         _ = [_ async for _ in runnable.astream({})]
+
+
+async def _agenerate_empty(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    return
+    yield  # type: ignore[unreachable]  # make this an async generator
+
+
+async def test_fallbacks_astream_empty_primary_does_not_trigger_fallback() -> None:
+    """A legitimately empty primary stream should not be treated as a failure."""
+    runnable = RunnableGenerator(_agenerate_empty).with_fallbacks(
+        [RunnableGenerator(_agenerate)]
+    )
+    assert [_ async for _ in runnable.astream({})] == []
+
+
+async def test_fallbacks_astream_empty_primary_no_fallback_does_not_raise() -> None:
+    """An empty primary with no fallbacks should yield nothing, not raise."""
+    runnable = RunnableGenerator(_agenerate_empty).with_fallbacks([])
+    assert [_ async for _ in runnable.astream({})] == []
 
 
 class FakeStructuredOutputModel(BaseChatModel):


### PR DESCRIPTION
Closes #38892

---

`RunnableWithFallbacks.stream()`/`astream()` decided whether a runnable "succeeded" by peeking its first chunk with a bare `next(stream)` / `anext(stream)`. When the primary produced a legitimately empty stream (an LLM returning empty content, a filtering step that drops everything, a moderation-blocked response), the `StopIteration` signaling "no more items" was caught by the default `exceptions_to_handle = (Exception,)` and treated exactly like a real runtime failure. That had two bad outcomes: (1) a configured fallback silently replaced the primary's valid empty output, and (2) with no fallback configured, re-raising a caught `StopIteration` inside a generator got converted per PEP 479 into an opaque `RuntimeError: generator raised StopIteration`, completely hiding the real cause.

The fix uses `next(stream, sentinel)` / `anext(stream, sentinel)` with a unique sentinel object so an empty stream is distinguishable from a stream that raised. When the sentinel comes back, the run ends cleanly with `on_chain_end(None)` and yields nothing — matching what calling the primary directly would produce — instead of substituting the fallback or raising.

Four regression tests added (sync + async): an empty primary with a fallback configured no longer triggers the fallback, and an empty primary with no fallbacks yields an empty stream instead of raising `RuntimeError`. Existing `test_fallbacks_stream`/`test_fallbacks_astream` cases (immediate error, delayed error, normal flow) still pass.

Co-authored-with: Hermes Agent (Nous Research)