### PR TITLE
fix(langchain): re-raise non-retryable exceptions in `ModelRetryMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -128,7 +128,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
             retry_on: Either a tuple of exception types to retry on, or a callable
                 that takes an exception and returns `True` if it should be retried.
 
-                Default is to retry on all exceptions.
+                Default is to retry on all exceptions. Exceptions that do not match
+                propagate immediately and are not handled by `on_failure`.
             on_failure: Behavior when all retries are exhausted.
 
                 Options:
@@ -237,8 +238,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -287,8 +288,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -291,7 +291,12 @@ def test_model_retry_succeeds_after_retries() -> None:
 
 
 def test_model_retry_specific_exceptions() -> None:
-    """Test ModelRetryMiddleware only retries specific exception types."""
+    """Test ModelRetryMiddleware only retries specific exception types.
+
+    A non-retryable exception (one that does not match ``retry_on``) is re-raised
+    immediately rather than being converted into an error ``AIMessage``, matching
+    ``ToolRetryMiddleware``'s behavior.
+    """
     # This model will fail with RuntimeError, which we won't retry
     model = AlwaysFailingModel(error_message="Runtime error", error_type=RuntimeError)
 
@@ -311,15 +316,76 @@ def test_model_retry_specific_exceptions() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
+    # RuntimeError does not match retry_on, so it is re-raised
+    # even though on_failure="continue"
+    with pytest.raises(RuntimeError, match="Runtime error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
+
+
+def test_model_retry_non_retryable_exception_reraises_with_on_failure_continue() -> None:
+    """Non-retryable exceptions are re-raised even when on_failure='continue'.
+
+    Mirrors ``test_tool_retry_non_retryable_exception_reraises``: ``on_failure``
+    only applies once retries are exhausted on a retryable exception, so a
+    ``TypeError`` excluded from ``retry_on=(ValueError,)`` propagates unchanged.
+    """
+    # This model fails with TypeError, which we won't retry
+    model = AlwaysFailingModel(error_message="boom", error_type=TypeError)
+
+    # Only retry ValueError
+    retry = ModelRetryMiddleware(
+        max_retries=2,
+        retry_on=(ValueError,),
+        initial_delay=0.01,
+        jitter=False,
+        on_failure="continue",
     )
 
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-    # RuntimeError should fail immediately (1 attempt only)
-    assert "1 attempt" in ai_messages[-1].content
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[retry],
+        checkpointer=InMemorySaver(),
+    )
+
+    # TypeError does not match retry_on, so it is re-raised
+    # even though on_failure="continue"
+    with pytest.raises(TypeError, match="boom"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
+
+
+async def test_model_retry_async_non_retryable_exception_reraises() -> None:
+    """Async path: non-retryable exceptions propagate instead of becoming AIMessage."""
+    # This model fails with TypeError, which we won't retry
+    model = AlwaysFailingModel(error_message="boom async", error_type=TypeError)
+
+    # Only retry ValueError
+    retry = ModelRetryMiddleware(
+        max_retries=2,
+        retry_on=(ValueError,),
+        initial_delay=0.01,
+        jitter=False,
+        on_failure="continue",
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[retry],
+        checkpointer=InMemorySaver(),
+    )
+
+    with pytest.raises(TypeError, match="boom async"):
+        await agent.ainvoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
 
 def test_model_retry_custom_exception_filter() -> None:
@@ -389,17 +455,17 @@ def test_model_retry_custom_exception_filter() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
+    # Attempt 1 raises a retryable CustomError (retried); attempt 2 raises a
+    # non-retryable CustomError (retry_me=False), which now propagates instead
+    # of being converted to an error AIMessage.
+    with pytest.raises(CustomError, match="Non-retryable error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-
-    # Should retry once (attempt 1 with retry_me=True), then fail on attempt 2 (retry_me=False)
+    # Should retry once (attempt 1 with retry_me=True), then propagate on attempt 2
     assert attempt_count["value"] == 2
-    assert "2 attempts" in ai_messages[-1].content
 
 
 def test_model_retry_backoff_timing() -> None:


### PR DESCRIPTION
Closes #38893

---

`ModelRetryMiddleware.wrap_model_call()` / `awrap_model_call()` converted non-retryable exceptions (those not matching `retry_on`) into an error `AIMessage` via `_handle_failure()`, instead of re-raising them. This was inconsistent with `ToolRetryMiddleware`, which was changed in #38845 to re-raise non-retryable exceptions immediately.

A user who configured `retry_on=(APITimeoutError,)` to retry only timeouts would silently receive an `AIMessage` for a `TypeError` or `KeyError` instead of seeing the real exception surface — genuine programming bugs became invisible, and the agent would continue running against an error placeholder rather than failing fast. The two middlewares accepted the same config and behaved differently for the same non-matching exception.

The fix re-raises non-retryable exceptions immediately in both the sync and async paths, matching `ToolRetryMiddleware`'s post-#38845 behavior. `on_failure` now only applies when retries are genuinely exhausted on a retryable exception, which is the documented contract (the `retry_on` docstring is clarified to say so, mirroring `ToolRetryMiddleware`'s wording).

Two existing tests encoded the old buggy behavior (`test_model_retry_specific_exceptions` and `test_model_retry_custom_exception_filter` both asserted that a non-matching exception became an `AIMessage`); they now assert it propagates. Two new dedicated regression tests (sync + async) mirror `test_tool_retry_non_retryable_exception_reraises`. All 726 middleware tests pass.

## Release note

`ModelRetryMiddleware` now re-raises exceptions that do not match `retry_on` instead of converting them into an error `AIMessage`, matching `ToolRetryMiddleware`'s behavior. `on_failure` only applies when retries are exhausted on a retryable exception.

Co-authored-with: Hermes Agent (Nous Research)