### PR TITLE
fix(anthropic): don't mutate caller-provided tool_choice dict in bind_tools

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1923,7 +1923,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1566,6 +1566,14 @@ def test_anthropic_bind_tools_tool_choice() -> None:
         "type": "any",
     }
 
+    # bind_tools must not mutate the caller-provided tool_choice dict (#38779)
+    original_tool_choice = {"type": "tool", "name": "GetWeather"}
+    chat_model.bind_tools([], tool_choice=original_tool_choice, parallel_tool_calls=False)
+    assert original_tool_choice == {
+        "type": "tool",
+        "name": "GetWeather",
+    }, "bind_tools must not mutate the caller-provided tool_choice dict"
+
 
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""


### PR DESCRIPTION
Fixes #38779.

## Problem

`ChatAnthropic.bind_tools()` mutates the caller-provided `tool_choice`
dictionary when `parallel_tool_calls=False` is also passed.

```python
tool_choice = {type: tool, name: GetWeather}
model.bind_tools([], tool_choice=tool_choice, parallel_tool_calls=False)
print(tool_choice)
# {type: tool, name: GetWeather, disable_parallel_tool_use: True}  # mutated!
```

**Root cause**: when `tool_choice` is a `dict`, the code stored the
caller's object directly in `kwargs`:

```python
kwargs[tool_choice] = tool_choice          # same reference
```

…and then added `disable_parallel_tool_use` to that same dict object in-place.

## Fix

Copy the dict before storing it so the caller's object is never modified:

```python
kwargs[tool_choice] = tool_choice.copy()   # safe copy
```

## Tests

Added a regression test to `test_anthropic_bind_tools_tool_choice` that
verifies the original dict is unchanged after the call.