### PR TITLE
fix(anthropic): fix KeyError in _handle_rename (reads 'old_path' but callback emits 'path')

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/anthropic_tools.py
@@ -555,7 +555,7 @@ class _StateClaudeFileToolMiddleware(AgentMiddleware):
         self, args: dict, state: AnthropicToolsState, tool_call_id: str | None
     ) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         normalized_old = _validate_path(
@@ -1054,7 +1054,7 @@ class _FilesystemClaudeFileToolMiddleware(AgentMiddleware):
 
     def _handle_rename(self, args: dict, tool_call_id: str | None) -> Command:
         """Handle rename command."""
-        old_path = args["old_path"]
+        old_path = args["path"]
         new_path = args["new_path"]
 
         old_full = self._validate_and_resolve_path(old_path)

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_anthropic_tools.py
@@ -295,7 +295,7 @@ class TestFileOperations:
 
         args = {
             "command": "rename",
-            "old_path": "/memories/old.txt",
+            "path": "/memories/old.txt",
             "new_path": "/memories/new.txt",
         }
         result = middleware._handle_rename(args, state, "test_id")


### PR DESCRIPTION
Fixes #38465.

## Problem

Both `StateClaudeTextEditorMiddleware` / `StateClaudeMemoryMiddleware` and
`FilesystemClaudeTextEditorMiddleware` / `FilesystemClaudeMemoryMiddleware`
crash with `KeyError: 'old_path'` on every `rename` command.

The `file_tool` callback (and its filesystem counterpart) builds the args
dict using `path` as the key for the source path:

```python
args: dict[str, Any] = {path: path}
```

But both `_handle_rename` implementations read from `args[old_path]`
which is never populated.

## Fix

Change both `_handle_rename` methods to read `args[path]` — matching
the key the callbacks write. The local variable is still named `old_path`
for readability within the method body.

Also update the existing unit test which called `_handle_rename` directly
with `old_path` in the args dict (bypassing the real call path, so the
bug wasn't caught).