### PR TITLE
fix(anthropic): preserve cache_control on tool_use blocks in _format_messages

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -543,11 +543,13 @@ def _format_messages(
                                 for tc in message.tool_calls
                                 if tc["id"] == block["id"]
                             ]
-                            content.extend(
-                                _lc_tool_calls_to_anthropic_tool_use_blocks(
-                                    overlapping,
-                                ),
+                            built_blocks = _lc_tool_calls_to_anthropic_tool_use_blocks(
+                                overlapping,
                             )
+                            if "cache_control" in block:
+                                for b in built_blocks:
+                                    b["cache_control"] = block["cache_control"]
+                            content.extend(built_blocks)
                         else:
                             if tool_input := block.get("input"):
                                 args = tool_input

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1122,6 +1122,36 @@ def test__format_messages_with_tool_use_blocks_and_tool_calls() -> None:
     assert expected == actual
 
 
+def test__format_messages_preserves_cache_control_on_tool_use() -> None:
+    """cache_control on a tool_use content block must survive _format_messages.
+
+    When both a tool_use content block and a matching tool_calls entry exist,
+    _format_messages prefers the structured tool_calls data for name/input/id
+    but must still carry over any cache_control from the original content block.
+    Regression test for https://github.com/langchain-ai/langchain/issues/38398
+    """
+    human = HumanMessage("weather?")  # type: ignore[misc]
+    ai = AIMessage(  # type: ignore[misc]
+        content=[
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "tool_use",
+                "id": "toolu_1",
+                "name": "get_weather",
+                "input": {"city": "Paris"},
+                "cache_control": {"type": "ephemeral"},
+            },
+        ],
+        tool_calls=[{"name": "get_weather", "args": {"city": "Paris"}, "id": "toolu_1"}],
+    )
+    _, formatted = _format_messages([human, ai])
+    assistant_content = formatted[-1]["content"]
+    tool_use_block = next(b for b in assistant_content if b["type"] == "tool_use")
+    assert tool_use_block.get("cache_control") == {"type": "ephemeral"}, (
+        "cache_control must be preserved on tool_use blocks during _format_messages"
+    )
+
+
 def test__format_messages_with_cache_control() -> None:
     messages = [
         SystemMessage(


### PR DESCRIPTION
## Summary

Fixes #38398

- `_format_messages` rebuilds `tool_use` content blocks from the structured `tool_calls` field when a matching entry exists (preferred for accuracy). The rebuild discards all extra keys from the original content block, including `cache_control`.
- All other block types (`text`, `thinking`, `server_tool_use`, `mcp_tool_use`) already explicitly preserve `cache_control` — `tool_use` was the only exception.
- Fix: after `_lc_tool_calls_to_anthropic_tool_use_blocks` builds the block, merge any `cache_control` from the original content block.

## Test plan

- [ ] New unit test `test__format_messages_preserves_cache_control_on_tool_use` reproduces the exact scenario from the issue report and confirms `cache_control` survives `_format_messages`.
- [ ] Existing test `test__format_messages_with_tool_use_blocks_and_tool_calls` continues to pass (tool_calls args still preferred over content block args).