### PR TITLE
fix(openai): prevent _construct_responses_api_payload from mutating caller text dict

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4241,10 +4241,8 @@ def _construct_responses_api_payload(
             else:
                 schema_dict = schema
             if schema_dict == {"type": "json_object"}:  # JSON mode
-                if "text" in payload and isinstance(payload["text"], dict):
-                    payload["text"]["format"] = {"type": "json_object"}
-                else:
-                    payload["text"] = {"format": {"type": "json_object"}}
+                existing = payload.get("text") or {}
+                payload["text"] = {**existing, "format": {"type": "json_object"}}
             elif (
                 (
                     response_format := _convert_to_openai_response_format(
@@ -4255,19 +4253,15 @@ def _construct_responses_api_payload(
                 and (response_format["type"] == "json_schema")
             ):
                 format_value = {"type": "json_schema", **response_format["json_schema"]}
-                if "text" in payload and isinstance(payload["text"], dict):
-                    payload["text"]["format"] = format_value
-                else:
-                    payload["text"] = {"format": format_value}
+                existing = payload.get("text") or {}
+                payload["text"] = {**existing, "format": format_value}
             else:
                 pass
 
     verbosity = payload.pop("verbosity", None)
     if verbosity is not None:
-        if "text" in payload and isinstance(payload["text"], dict):
-            payload["text"]["verbosity"] = verbosity
-        else:
-            payload["text"] = {"verbosity": verbosity}
+        existing = payload.get("text") or {}
+        payload["text"] = {**existing, "verbosity": verbosity}
 
     return payload
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1446,6 +1446,46 @@ def test_chat_completions_payload_includes_stop() -> None:
     assert payload["stop"] == ["END"]
 
 
+def test_responses_api_json_mode_does_not_mutate_caller_text_dict() -> None:
+    """_construct_responses_api_payload must not mutate the caller's text dict.
+
+    When response_format={"type": "json_object"} is passed, the Responses API
+    payload builder writes `format` into payload["text"]. If payload["text"] is
+    the same object as model_kwargs["text"] (or the caller's own dict), that
+    write permanently corrupts instance state and leaks into subsequent calls.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38869
+    """
+    from langchain_openai.chat_models.base import _construct_responses_api_payload
+
+    caller_text: dict = {"verbosity": "low"}
+
+    # Simulate the shallow-merge that _get_request_payload does:
+    # payload["text"] is the same object as the caller's dict.
+    payload = {"model": OPENAI_TEST_MODEL, "text": caller_text}
+
+    result = _construct_responses_api_payload(
+        [HumanMessage(content="give me json")],
+        {**payload, "response_format": {"type": "json_object"}},
+    )
+
+    assert result["text"].get("format") == {"type": "json_object"}, (
+        "format should appear in the result payload"
+    )
+    assert "format" not in caller_text, (
+        "_construct_responses_api_payload must not mutate the caller-provided text dict"
+    )
+
+    # A second call WITHOUT response_format must not carry forward the format key.
+    result2 = _construct_responses_api_payload(
+        [HumanMessage(content="just chat")],
+        dict(payload),  # fresh copy of the unchanged caller payload
+    )
+    assert "format" not in (result2.get("text") or {}), (
+        "format from a JSON-mode call must not bleed into a subsequent plain call"
+    )
+
+
 def test_output_version_compat() -> None:
     llm = ChatOpenAI(model="gpt-5", output_version="responses/v1")
     assert llm._use_responses_api({}) is True


### PR DESCRIPTION
## Summary

Fixes #38869

- `_construct_responses_api_payload` writes `format` and `verbosity` directly into `payload[text]` with `payload[text][key] = value`.
- Because `payload` is a shallow merge of `model_kwargs`, `payload[text]` is the **same object** as `self.model_kwargs[text]` and the caller's dict. The in-place write therefore mutates instance state.
- Consequence: a JSON-mode call permanently turns on JSON mode for every later plain call on the same instance (and any other instance sharing the same options dict).
- Fix: replace in-place mutation with copy-on-write (`{**existing, key: val}`) at all three write sites (`json_object` mode, `json_schema` mode, and `verbosity`).

## Test plan

- [ ] New unit test `test_responses_api_json_mode_does_not_mutate_caller_text_dict` directly exercises `_construct_responses_api_payload` and asserts that the caller's `text` dict is unchanged after a JSON-mode call, and that a subsequent plain call does not inherit the `format` key.
- [ ] Existing `test_responses_api_payload_excludes_stop` and related tests continue to pass.