### PR TITLE
feat(huggingface): support non-CUDA accelerators in HuggingFacePipeline via torch.accelerator

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -260,22 +260,25 @@ class HuggingFacePipeline(BaseLLM):
         ):
             import torch
 
-            cuda_device_count = torch.cuda.device_count()
-            if device < -1 or (device >= cuda_device_count):
+            if hasattr(torch, "accelerator"):
+                accelerator_device_count = torch.accelerator.device_count()
+            else:
+                accelerator_device_count = torch.cuda.device_count()
+            if device < -1 or (device >= accelerator_device_count):
                 msg = (
                     f"Got device=={device}, "
-                    f"device is required to be within [-1, {cuda_device_count})"
+                    f"device is required to be within [-1, {accelerator_device_count})"
                 )
                 raise ValueError(msg)
             if device_map is not None and device < 0:
                 device = None
-            if device is not None and device < 0 and cuda_device_count > 0:
+            if device is not None and device < 0 and accelerator_device_count > 0:
                 logger.warning(
-                    "Device has %d GPUs available. "
-                    "Provide device={deviceId} to `from_model_id` to use available"
-                    "GPUs for execution. deviceId is -1 (default) for CPU and "
-                    "can be a positive integer associated with CUDA device id.",
-                    cuda_device_count,
+                    "Device has %d accelerator(s) available. "
+                    "Provide device={deviceId} to `from_model_id` to use an available "
+                    "accelerator for execution. deviceId is -1 (default) for CPU and "
+                    "can be a positive integer associated with the accelerator device id.",
+                    accelerator_device_count,
                 )
         if device is not None and device_map is not None and backend == "openvino":
             logger.warning("Please set device for OpenVINO through: `model_kwargs`")

--- a/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
@@ -1,3 +1,4 @@
+import pytest
 from unittest.mock import MagicMock, patch
 
 from langchain_huggingface import HuggingFacePipeline
@@ -45,3 +46,102 @@ def test_initialization_with_from_model_id(
     )
 
     assert llm.model_id == "mock-model-id"
+
+
+def _make_mock_transformers_modules(mock_pipeline_fn: MagicMock) -> dict:
+    """Return a sys.modules patch dict that stubs out all transformers sub-modules
+    needed by from_model_id without requiring a real PyTorch installation."""
+    mock_model_instance = MagicMock()
+    # Prevent the "device set to None" early-exit path triggered by quantized models.
+    mock_model_instance.is_loaded_in_4bit = False
+    mock_model_instance.is_loaded_in_8bit = False
+
+    mock_transformers = MagicMock()
+    mock_transformers.pipeline = mock_pipeline_fn
+    mock_transformers.AutoModelForCausalLM.from_pretrained.return_value = (
+        mock_model_instance
+    )
+    mock_transformers.AutoModelForSeq2SeqLM.from_pretrained.return_value = (
+        mock_model_instance
+    )
+    return {
+        "transformers": mock_transformers,
+        "transformers.pipelines": MagicMock(),
+    }
+
+
+def test_from_model_id_uses_torch_accelerator_when_available() -> None:
+    """from_model_id uses torch.accelerator.device_count() on PyTorch >= 2.6.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38855:
+    on non-CUDA accelerators (XPU, ROCm) torch.cuda.device_count() returns 0,
+    so a valid device index was incorrectly rejected. The fix prefers
+    torch.accelerator.device_count() when the API is available.
+    """
+    mock_pipe = MagicMock()
+    mock_pipe.task = "text-generation"
+    mock_pipe.model.name_or_path = "mock-model-id"
+    mock_pipeline_fn = MagicMock(return_value=mock_pipe)
+
+    mock_torch = MagicMock()
+    mock_torch.__spec__ = MagicMock()  # required by importlib.util.find_spec
+    mock_torch.cuda.device_count.return_value = 0  # no CUDA devices
+    mock_torch.accelerator.device_count.return_value = 1  # 1 XPU/non-CUDA device
+
+    modules = {"torch": mock_torch, **_make_mock_transformers_modules(mock_pipeline_fn)}
+    with patch.dict("sys.modules", modules):
+        # device=0 is valid for the XPU; must not raise ValueError
+        llm = HuggingFacePipeline.from_model_id(
+            model_id="mock-model-id",
+            task="text-generation",
+            device=0,
+        )
+
+    assert llm.model_id == "mock-model-id"
+    mock_torch.accelerator.device_count.assert_called()
+    mock_torch.cuda.device_count.assert_not_called()
+
+
+def test_from_model_id_falls_back_to_cuda_device_count() -> None:
+    """from_model_id falls back to torch.cuda.device_count() on PyTorch < 2.6."""
+    mock_pipe = MagicMock()
+    mock_pipe.task = "text-generation"
+    mock_pipe.model.name_or_path = "mock-model-id"
+    mock_pipeline_fn = MagicMock(return_value=mock_pipe)
+
+    # spec=["cuda"] means hasattr(mock_torch, "accelerator") returns False
+    mock_torch = MagicMock(spec=["cuda", "__spec__"])
+    mock_torch.__spec__ = MagicMock()  # required by importlib.util.find_spec
+    mock_torch.cuda.device_count.return_value = 1  # 1 CUDA device
+
+    modules = {"torch": mock_torch, **_make_mock_transformers_modules(mock_pipeline_fn)}
+    with patch.dict("sys.modules", modules):
+        llm = HuggingFacePipeline.from_model_id(
+            model_id="mock-model-id",
+            task="text-generation",
+            device=0,
+        )
+
+    assert llm.model_id == "mock-model-id"
+    mock_torch.cuda.device_count.assert_called()
+
+
+def test_from_model_id_raises_for_out_of_range_device() -> None:
+    """from_model_id raises ValueError when device index exceeds available count."""
+    mock_pipe = MagicMock()
+    mock_pipe.task = "text-generation"
+    mock_pipe.model.name_or_path = "mock-model-id"
+    mock_pipeline_fn = MagicMock(return_value=mock_pipe)
+
+    mock_torch = MagicMock()
+    mock_torch.__spec__ = MagicMock()  # required by importlib.util.find_spec
+    mock_torch.accelerator.device_count.return_value = 1  # only device 0 is valid
+
+    modules = {"torch": mock_torch, **_make_mock_transformers_modules(mock_pipeline_fn)}
+    with patch.dict("sys.modules", modules):
+        with pytest.raises(ValueError, match="device is required to be within"):
+            HuggingFacePipeline.from_model_id(
+                model_id="mock-model-id",
+                task="text-generation",
+                device=5,  # out of range
+            )


### PR DESCRIPTION
## Summary

Closes #38855

- `HuggingFacePipeline.from_model_id` used `torch.cuda.device_count()` to validate the `device` argument and to warn about available accelerators.
- On non-CUDA machines (Intel XPU, AMD ROCm), `cuda.device_count()` returns `0`, so a valid `device=0` was incorrectly rejected with a `ValueError`, and the availability warning never fired.
- PyTorch 2.6 introduced `torch.accelerator`, a device-agnostic API that enumerates all accelerator backends.
- Fix: prefer `torch.accelerator.device_count()` when available, fall back to `torch.cuda.device_count()` for PyTorch less than 2.6. Also update the warning message to use generic accelerator language instead of GPU/CUDA.

The change is fully backward-compatible: CUDA behaviour is unchanged, and the `torch.accelerator` path is additive.

## Test plan

- [ ] `test_from_model_id_uses_torch_accelerator_when_available` -- simulates a machine with 0 CUDA devices and 1 XPU device; confirms `device=0` is accepted and `torch.accelerator.device_count()` is called (not `cuda.device_count()`).
- [ ] `test_from_model_id_falls_back_to_cuda_device_count` -- simulates PyTorch before 2.6 (no `torch.accelerator` attribute); confirms fallback to `cuda.device_count()`.
- [ ] `test_from_model_id_raises_for_out_of_range_device` -- confirms `ValueError` is still raised for an out-of-range device index.