### PR TITLE
fix(core): skip tool call creation when streaming args chunk is empty string

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -554,6 +554,11 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
 
         for chunk in self.tool_call_chunks:
             try:
+                if chunk["args"] == "":
+                    # Empty string means the provider has not sent any argument
+                    # bytes yet (mid-stream header chunk). Skip until args arrive;
+                    # zero-arg tools send args="{}" which parse_partial_json handles.
+                    continue
                 args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}
                 if isinstance(args_, dict):
                     tool_calls.append(

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -211,6 +211,48 @@ def test_init_tool_calls() -> None:
     msg.tool_calls = [{"name": "bar", "args": {"c": "d"}, "id": "def"}]
 
 
+def test_streaming_tool_call_empty_args_not_premature() -> None:
+    """init_tool_calls must not create a tool_call when args is empty string.
+
+    Providers such as OpenRouter and deepseek-v3.2 send the first tool-call
+    chunk with args="" (no argument bytes received yet) before streaming the
+    actual JSON. init_tool_calls previously treated args="" identically to
+    args=None, resolving both to {}, so the tool call was fired before its
+    arguments arrived and downstream tool invocations crashed with
+    ValidationError: Field required.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38682
+    """
+    # First chunk: name + id present, but args is empty (still mid-stream)
+    chunk1 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name="get_weather", args="", id="call_abc", index=0
+            )
+        ],
+    )
+    # Before the fix, tool_calls would be non-empty here
+    assert chunk1.tool_calls == [], (
+        "tool_calls must be empty when args='' — arguments have not arrived yet"
+    )
+
+    # Second chunk: args arrive
+    chunk2 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name=None, args='{"city": "Paris"}', id=None, index=0
+            )
+        ],
+    )
+    # After accumulation the merged message should have one complete tool call
+    combined = chunk1 + chunk2
+    assert len(combined.tool_calls) == 1
+    assert combined.tool_calls[0]["name"] == "get_weather"
+    assert combined.tool_calls[0]["args"] == {"city": "Paris"}
+
+
 def test_content_blocks() -> None:
     message = AIMessage(
         "",


### PR DESCRIPTION
## Summary

Fixes #38682

Providers such as OpenRouter and deepseek-v3.2 fragment tool-call arguments across multiple SSE chunks. The first chunk carries the function name and id but args="" (no argument bytes yet). AIMessageChunk.init_tool_calls treated args="" identically to args=None, resolving both to {} immediately. The tool call was created before its arguments arrived, and downstream invocations crashed with ValidationError: Field required.

Root cause in libs/core/langchain_core/messages/ai.py, init_tool_calls:

    # Before: args="" falls into the else branch and becomes {}
    args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}

Fix: add an explicit guard for args=="" before the existing parse_partial_json path. An empty string means the stream is still in progress -- skip the chunk until real argument bytes arrive. Zero-arg tools correctly send args="{}" which parse_partial_json already handles.

    if chunk["args"] == "":
        continue  # mid-stream header chunk, args not yet received
    args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}

## Test plan

- [ ] New unit test test_streaming_tool_call_empty_args_not_premature: asserts tool_calls == [] on a chunk with args="" (the buggy behavior was tool_calls being non-empty), then confirms the accumulated result after a second chunk with real args has exactly one correct tool call.
- [ ] Existing test_init_tool_calls continues to pass.
