### PR TITLE
fix(core): use identity check for cache presence in get_prompts and aupdate_cache

### DIFF
--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -182,7 +182,7 @@ def get_prompts(
 
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = llm_cache.lookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -217,7 +217,7 @@ async def aget_prompts(
     existing_prompts = {}
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = await llm_cache.alookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -288,7 +288,7 @@ async def aupdate_cache(
     for i, result in enumerate(new_results.generations):
         existing_prompts[missing_prompt_idxs[i]] = result
         prompt = prompts[missing_prompt_idxs[i]]
-        if llm_cache:
+        if llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result)
     return new_results.llm_output
 

--- a/libs/core/tests/unit_tests/language_models/llms/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/llms/test_cache.py
@@ -109,3 +109,60 @@ async def test_no_cache_generate_async() -> None:
         assert global_cache._cache == {}
     finally:
         set_llm_cache(None)
+
+
+class SizedCache(BaseCache):
+    """Cache that implements __len__ — common in real-world caching libraries.
+
+    Used to reproduce the bug where get_prompts / aget_prompts tested the cache
+    with a truthiness check (``if llm_cache:``) instead of an identity check
+    (``if llm_cache is not None:``). An empty cache returns len() == 0, which
+    is falsy, so the prompt was silently dropped and generate raised KeyError.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[tuple[str, str], RETURN_VAL_TYPE] = {}
+
+    def lookup(self, prompt: str, llm_string: str) -> RETURN_VAL_TYPE | None:
+        return self._cache.get((prompt, llm_string))
+
+    def update(self, prompt: str, llm_string: str, return_val: RETURN_VAL_TYPE) -> None:
+        self._cache[prompt, llm_string] = return_val
+
+    @override
+    def clear(self, **kwargs: Any) -> None:
+        self._cache = {}
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+
+def test_sized_cache_generate_sync() -> None:
+    """generate must not crash when the cache implements __len__ and starts empty.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38440
+    """
+    cache = SizedCache()
+    assert len(cache) == 0  # empty -> falsy -> would trigger the bug
+    llm = FakeListLLM(cache=cache, responses=["foo", "bar"])
+    output = llm.generate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1
+    # Second call should hit the cache
+    output = llm.generate(["hello"])
+    assert output.generations[0][0].text == "foo"
+
+
+async def test_sized_cache_generate_async() -> None:
+    """agenerate must not crash when the cache implements __len__ and starts empty.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38440
+    """
+    cache = SizedCache()
+    assert len(cache) == 0
+    llm = FakeListLLM(cache=cache, responses=["foo", "bar"])
+    output = await llm.agenerate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1
+    output = await llm.agenerate(["hello"])
+    assert output.generations[0][0].text == "foo"


### PR DESCRIPTION
## Summary

Fixes #38440

Three helpers in `langchain_core.language_models.llms` guard cache usage with a truthiness check (`if llm_cache:`) instead of an identity check (`if llm_cache is not None:`):

- `get_prompts` (sync lookup) — line 185
- `aget_prompts` (async lookup) — line 220
- `aupdate_cache` (async write) — line 291

(`update_cache`, the sync write, already used `if llm_cache is not None:` correctly — line 258.)

When a `BaseCache` subclass implements `__len__` (a common pattern for caches that report their entry count), an **empty** cache has `len() == 0` and is therefore falsy. The lookup loop body is skipped: the prompt is added to neither `existing_prompts` nor `missing_prompts`, so generation is never invoked, and the final `[existing_prompts[i] for i in range(len(prompts))]` raises `KeyError: 0`.

Fix: replace all three `if llm_cache:` guards with `if llm_cache is not None:`.

## Test plan

- [ ] `test_sized_cache_generate_sync` and `test_sized_cache_generate_async` — reproduce the bug using a `SizedCache` that implements `__len__`; assert that `generate`/`agenerate` succeed with an empty cache and correctly populate it on the first call.
- [ ] Existing `test_local_cache_generate_sync` / `test_local_cache_generate_async` continue to pass.
