### PR TITLE
middleware: export PIIMatch from public langchain.agents.middleware package

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -11,7 +11,7 @@ from langchain.agents.middleware.human_in_the_loop import (
 from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddleware
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
-from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
+from langchain.agents.middleware.pii import PIIDetectionError, PIIMatch, PIIMiddleware
 from langchain.agents.middleware.provider_tool_search import ProviderToolSearchMiddleware
 from langchain.agents.middleware.shell_tool import (
     CodexSandboxExecutionPolicy,
@@ -69,6 +69,7 @@ __all__ = [
     "ModelRetryMiddleware",
     "OutputAgentState",
     "PIIDetectionError",
+    "PIIMatch",
     "PIIMiddleware",
     "ProviderToolSearchMiddleware",
     "RedactionRule",

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -2368,4 +2368,13 @@ class TestPIIStreamingEndToEnd:
         assert not seen_email_in_finalized, (
             "raw PII leaked through a subgraph's content-block-finish snapshot"
         )
+
+
+def test_piimatch_exported_from_public_package() -> None:
+    """PIIMatch must be importable from the public langchain.agents.middleware package."""
+    from langchain.agents.middleware import PIIMatch  # noqa: PLC0415
+
+    match = PIIMatch(type="email", value="x@y.com", start=0, end=7)
+    assert match["type"] == "email"
+    assert match["value"] == "x@y.com"
         assert seen_redaction, "transformer never fired at the subgraph scope"


### PR DESCRIPTION
## Summary

Fixes #38718

`PIIMatch` is the `TypedDict` that represents an individual PII detection result. It is used:
- as the return type of all built-in detectors (`detect_email`, `detect_ip`, â€¦)
- as the element type of custom detector callbacks (`Callable[[str], list[PIIMatch]]`)
- in `PIIDetectionError.matches`

The type lives in the private `langchain.agents.middleware._redaction` module and is re-exported by `langchain.agents.middleware.pii`. However, it was **not** included in the public top-level `langchain.agents.middleware.__init__`:

```python
# before
from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
```

This meant users who wanted to annotate custom detector return types had to reach into an internal module:

```python
# workaround users had to use
from langchain.agents.middleware._redaction import PIIMatch  # private path
# or
from langchain.agents.middleware.pii import PIIMatch         # semi-private
```

The fix adds `PIIMatch` to the public import and `__all__` so the canonical import works:

```python
from langchain.agents.middleware import PIIMatch
```

## Test plan

- [ ] `test_piimatch_exported_from_public_package` â€” imports `PIIMatch` directly from `langchain.agents.middleware` and constructs a match dict to confirm the TypedDict is usable.
- [ ] All existing PII middleware tests continue to pass.
