### PR TITLE
fix(langchain): preserve history when summary generation fails

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -1,5 +1,6 @@
 """Summarization middleware."""
 
+import logging
 import uuid
 import warnings
 from collections.abc import Callable, Iterable, Mapping
@@ -29,6 +30,8 @@ from langchain.agents.middleware.types import AgentMiddleware, AgentState, Conte
 from langchain.chat_models import BaseChatModel, init_chat_model
 
 TokenCounter = Callable[[Iterable[MessageLikeRepresentation]], int]
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SUMMARY_PROMPT = """<role>
 Context Extraction Assistant
@@ -394,6 +397,10 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         messages_to_summarize, preserved_messages = self._partition_messages(messages, cutoff_index)
 
         summary = self._create_summary(messages_to_summarize)
+        if summary is None:
+            # Summary generation failed; preserve the original message history
+            # rather than replacing it with an error string and losing context.
+            return None
         new_messages = self._build_new_messages(summary)
 
         return {
@@ -432,6 +439,10 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         messages_to_summarize, preserved_messages = self._partition_messages(messages, cutoff_index)
 
         summary = await self._acreate_summary(messages_to_summarize)
+        if summary is None:
+            # Summary generation failed; preserve the original message history
+            # rather than replacing it with an error string and losing context.
+            return None
         new_messages = self._build_new_messages(summary)
 
         return {
@@ -795,11 +806,16 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         # orphaned tool responses
         return idx
 
-    def _create_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
+    def _create_summary(self, messages_to_summarize: list[AnyMessage]) -> str | None:
         """Generate summary for the given messages.
 
         Args:
             messages_to_summarize: Messages to summarize.
+
+        Returns:
+            The generated summary text, or ``None`` if summary generation
+            failed (so callers can preserve the original message history
+            instead of replacing it with an error string).
         """
         if not messages_to_summarize:
             return "No previous conversation history."
@@ -819,13 +835,23 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             return response.text.strip()
         except Exception as e:
-            return f"Error generating summary: {e!s}"
+            logger.warning(
+                "Failed to generate conversation summary; preserving original "
+                "message history instead of summarizing. Error: %s",
+                e,
+            )
+            return None
 
-    async def _acreate_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
+    async def _acreate_summary(self, messages_to_summarize: list[AnyMessage]) -> str | None:
         """Generate summary for the given messages.
 
         Args:
             messages_to_summarize: Messages to summarize.
+
+        Returns:
+            The generated summary text, or ``None`` if summary generation
+            failed (so callers can preserve the original message history
+            instead of replacing it with an error string).
         """
         if not messages_to_summarize:
             return "No previous conversation history."
@@ -845,7 +871,12 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             return response.text.strip()
         except Exception as e:
-            return f"Error generating summary: {e!s}"
+            logger.warning(
+                "Failed to generate conversation summary; preserving original "
+                "message history instead of summarizing. Error: %s",
+                e,
+            )
+            return None
 
     def _trim_messages_for_summary(self, messages: list[AnyMessage]) -> list[AnyMessage]:
         """Trim messages to fit within summary generation limits."""

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -242,7 +242,7 @@ def test_summarization_middleware_summary_creation() -> None:
 
     middleware_error = SummarizationMiddleware(model=ErrorModel(), trigger=("tokens", 1000))
     summary = middleware_error._create_summary(messages)
-    assert "Error generating summary: Model error" in summary
+    assert summary is None  # failure returns None so history is preserved (#38867)
 
     # Test we raise warning if max_tokens_before_summary or messages_to_keep is specified
     with pytest.warns(DeprecationWarning, match="max_tokens_before_summary is deprecated"):
@@ -938,7 +938,7 @@ async def test_summarization_middleware_async_error_handling() -> None:
     middleware = SummarizationMiddleware(model=ErrorAsyncModel(), trigger=("messages", 5))
     messages: list[AnyMessage] = [HumanMessage(content="test")]
     summary = await middleware._acreate_summary(messages)
-    assert "Error generating summary: Async model error" in summary
+    assert summary is None  # failure returns None so history is preserved (#38867)
 
 
 def test_summarization_middleware_cutoff_at_boundary() -> None:
@@ -2084,3 +2084,99 @@ async def test_create_summary_passes_lc_source_metadata(use_async: bool) -> None
     assert config is not None
     assert "metadata" in config
     assert config["metadata"]["lc_source"] == "summarization"
+
+
+class _AlwaysFailingModel(BaseChatModel):
+    """Chat model whose invoke/ainvoke always raise, simulating a provider outage."""
+
+    @override
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        msg = "429 Too Many Requests (simulated)"
+        raise RuntimeError(msg)
+
+    @override
+    async def _agenerate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        msg = "429 Too Many Requests (simulated)"
+        raise RuntimeError(msg)
+
+    @property
+    def _llm_type(self) -> str:
+        return "failing-fake"
+
+
+def _count_messages(messages: Iterable[MessageLikeRepresentation]) -> int:
+    """Token counter that treats each message as one token (test helper)."""
+    return len(list(messages))
+
+
+def test_before_model_preserves_history_when_summary_fails() -> None:
+    """Summarization must not delete the original history when the summary call fails.
+
+    Regression test for #38867: previously, when the summary model raised (e.g. a
+    transient 429), `_create_summary` returned the error string as if it were a
+    valid summary, and `before_model` then replaced the entire conversation with
+    that error text via `RemoveMessage(id=REMOVE_ALL_MESSAGES)`.
+    """
+    middleware = SummarizationMiddleware(
+        model=_AlwaysFailingModel(),
+        trigger=("messages", 5),
+        keep=("messages", 2),
+        token_counter=_count_messages,
+    )
+    messages: list[AnyMessage] = [
+        msg
+        for i in range(5)
+        for msg in (
+            HumanMessage(content=f"user turn {i}"),
+            AIMessage(content=f"assistant turn {i}"),
+        )
+    ]
+    state = AgentState[Any](messages=messages)
+
+    result = middleware.before_model(state, Runtime())
+
+    # No state update => original history is preserved untouched.
+    assert result is None
+    # The caller's messages are still intact and no RemoveMessage was emitted.
+    assert len(messages) == 10
+    assert not any(isinstance(m, RemoveMessage) for m in messages)
+
+
+async def test_abefore_model_preserves_history_when_summary_fails() -> None:
+    """Async variant: history must be preserved when `_acreate_summary` fails.
+
+    Regression test for #38867.
+    """
+    middleware = SummarizationMiddleware(
+        model=_AlwaysFailingModel(),
+        trigger=("messages", 5),
+        keep=("messages", 2),
+        token_counter=_count_messages,
+    )
+    messages: list[AnyMessage] = [
+        msg
+        for i in range(5)
+        for msg in (
+            HumanMessage(content=f"user turn {i}"),
+            AIMessage(content=f"assistant turn {i}"),
+        )
+    ]
+    state = AgentState[Any](messages=messages)
+
+    result = await middleware.abefore_model(state, Runtime())
+
+    assert result is None
+    assert len(messages) == 10
+    assert not any(isinstance(m, RemoveMessage) for m in messages)


### PR DESCRIPTION
Closes #38867

---

When the summarization model call fails (a transient 429, timeout, auth error, etc.), SummarizationMiddleware currently performs its most destructive action — deleting the entire conversation via RemoveMessage(id=REMOVE_ALL_MESSAGES) — precisely when the constructive step (generating the summary) has already failed. The original history is replaced with the literal string "Error generating summary: <error>", so users silently lose all prior context the moment their provider hiccups, with no exception raised.

This makes _create_summary and _acreate_summary return None on failure (logging the exception at WARNING level instead of smuggling it back as a summary string). before_model and abefore_model now treat a None summary as "summarization did not succeed, leave the state alone" and return None, so the full message history is preserved untouched. The agent simply retries summarization on the next turn once the provider recovers, which is the safe default — a failed compression should never cost the user their data.

The two existing error-path unit tests (which asserted on the error string) are updated to assert None, and I added sync and async regression tests that drive before_model/abefore_model end-to-end with a model that always raises, confirming the original messages survive intact and no RemoveMessage is emitted.

This change is confined to the failure path; the success path is untouched, and no public signatures change.

Disclosure: this contribution was prepared with the assistance of an AI agent.