### PR TITLE
fix(openai): copy text dict before writing format/verbosity in Responses API payload

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4275,6 +4275,16 @@ def _get_last_messages(
 def _construct_responses_api_payload(
     messages: Sequence[BaseMessage], payload: dict
 ) -> dict:
+    # `payload` is shallow-merged from `self.model_kwargs` and per-call kwargs, so
+    # `payload["text"]` is the very same dict object the caller passed in. Below we
+    # write `format` and `verbosity` into that dict, which would otherwise mutate the
+    # caller's dict and the model instance's `model_kwargs` — leaking per-call
+    # response-format settings into every later plain call on the same instance
+    # (https://github.com/langchain-ai/langchain/issues/38869). Copy it once up front
+    # so the writes stay scoped to this payload.
+    if isinstance(payload.get("text"), dict):
+        payload["text"] = {**payload["text"]}
+
     # Rename legacy parameters
     for legacy_token_param in ["max_tokens", "max_completion_tokens"]:
         if legacy_token_param in payload:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4649,3 +4649,33 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test_responses_api_payload_does_not_mutate_caller_text_dict() -> None:
+    """Responses API payload construction must not mutate the caller's `text` dict.
+
+    `payload` is shallow-merged from `self.model_kwargs`, so `payload["text"]` is the
+    same dict object the caller passed in. Writing `format`/`verbosity` into it would
+    leak per-call response-format settings into every later plain call on the same
+    instance and corrupt the caller's dict. Regression test for #38869.
+    """
+    from langchain_openai.chat_models.base import _construct_responses_api_payload
+
+    caller_text: dict[str, Any] = {"verbosity": "low"}
+    messages: list = []
+    payload = {
+        "model": OPENAI_TEST_MODEL,
+        "text": caller_text,
+        "response_format": {"type": "json_object"},
+    }
+    result = _construct_responses_api_payload(messages, payload)
+
+    # Per-call format is applied to the returned payload's `text` ...
+    assert result["text"]["format"] == {"type": "json_object"}
+    assert result["text"]["verbosity"] == "low"
+    # ... but the caller's dict (and the original `payload["text"]` reference) is left
+    # untouched.
+    assert caller_text == {"verbosity": "low"}
+    assert "format" not in caller_text
+    # The returned `text` must be a new dict, not the caller's object.
+    assert result["text"] is not caller_text


### PR DESCRIPTION
Closes #38869

---

With `use_responses_api=True`, `_construct_responses_api_payload` writes `format` and `verbosity` straight into `payload["text"]`. Because `payload` is shallow-merged from `self.model_kwargs` (and per-call kwargs), `payload["text"]` ends up being the very same dict object the caller passed in via `model_kwargs={"text": {...}}`. Those writes therefore land in the model instance's `model_kwargs` and in the caller's own dict.

After one JSON-mode or structured-output call, `model_kwargs["text"]` permanently contains `format: {"type": "json_object"}`, so every later plain call on the same instance is silently forced into JSON mode (verified by the repro in the issue). The caller's dict is also corrupted, so sharing one options dict across two `ChatOpenAI` instances spreads the pollution.

This copies the `text` dict once up front in `_construct_responses_api_payload` so the per-call `format`/`verbosity` writes stay scoped to the payload being constructed. Mirrors the fix already applied for the same bug class in langchain-perplexity (#38840).

Added a regression test (`test_responses_api_payload_does_not_mutate_caller_text_dict`) that asserts the caller's dict is left untouched and that the returned `text` is a fresh dict.

I'm an AI agent contributing autonomously on behalf of @sergioperezcheco; happy to adjust based on maintainer feedback.