### PR TITLE
fix(core): treat empty upstream streams as success in fallbacks stream()/astream()

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -486,6 +486,12 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        # Sentinel used to distinguish an exhausted (legitimately empty) upstream
+        # stream from a real first chunk. `next(stream)` raises `StopIteration`
+        # when the stream is empty, which is a subclass of `Exception` and would
+        # otherwise be caught by `exceptions_to_handle` and treated as a failure.
+        empty_stream_sentinel: Any = object()
+        chunk: Any = empty_stream_sentinel
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -497,7 +503,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    chunk = context.run(next, stream, empty_stream_sentinel)
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -510,6 +516,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         if first_error:
             run_manager.on_chain_error(first_error)
             raise first_error
+
+        # If the chosen runnable produced no chunks at all, the run succeeded
+        # with an empty stream — do not yield anything, but still report a
+        # successful chain end.
+        if chunk is empty_stream_sentinel:
+            run_manager.on_chain_end(None)
+            return
 
         yield chunk
         output: Output | None = chunk
@@ -550,6 +563,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        # Sentinel used to distinguish an exhausted (legitimately empty) upstream
+        # async stream from a real first chunk. `anext(stream)` raises
+        # `StopAsyncIteration` when the stream is empty, which is a subclass of
+        # `Exception` and would otherwise be caught by `exceptions_to_handle`
+        # and treated as a failure.
+        empty_stream_sentinel: Any = object()
+        chunk: Any = empty_stream_sentinel
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -561,7 +581,12 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         child_config,
                         **kwargs,
                     )
-                    chunk = await coro_with_context(anext(stream), context)
+                    try:
+                        chunk = await coro_with_context(anext(stream), context)
+                    except StopAsyncIteration:
+                        # The upstream stream was empty before any chunk was
+                        # produced. This is a successful (empty) result.
+                        chunk = empty_stream_sentinel
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -574,6 +599,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         if first_error:
             await run_manager.on_chain_error(first_error)
             raise first_error
+
+        # If the chosen runnable produced no chunks at all, the run succeeded
+        # with an empty stream — do not yield anything, but still report a
+        # successful chain end.
+        if chunk is empty_stream_sentinel:
+            await run_manager.on_chain_end(None)
+            return
 
         yield chunk
         output: Output | None = chunk

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -318,6 +318,52 @@ async def test_fallbacks_astream() -> None:
         _ = [_ async for _ in runnable.astream({})]
 
 
+def _generate_empty(_: Iterator[Any]) -> Iterator[str]:
+    """A legitimate runnable that decides to yield zero chunks."""
+    return
+    yield  # pragma: no cover  # makes this a generator function
+
+
+async def _agenerate_empty(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    """Async counterpart of `_generate_empty`."""
+    return
+    yield  # pragma: no cover  # makes this a generator function
+
+
+def _generate_fallback_marker(_: Iterator[Any]) -> Iterator[str]:
+    yield "FALLBACK-OUTPUT"
+
+
+async def _agenerate_fallback_marker(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    yield "FALLBACK-OUTPUT"
+
+
+def test_fallbacks_stream_empty_upstream_does_not_trigger_fallback() -> None:
+    # Regression test for https://github.com/langchain-ai/langchain/issues/38892
+    # A legitimately empty upstream stream must NOT be treated as a failure and
+    # must NOT silently fall through to the fallback.
+    runnable = RunnableGenerator(_generate_empty).with_fallbacks(
+        [RunnableGenerator(_generate_fallback_marker)]
+    )
+    assert list(runnable.stream({})) == []
+
+    # And with no fallback configured at all, an empty stream must succeed
+    # instead of raising `RuntimeError: generator raised StopIteration`.
+    runnable_no_fallback = RunnableGenerator(_generate_empty).with_fallbacks([])
+    assert list(runnable_no_fallback.stream({})) == []
+
+
+async def test_fallbacks_astream_empty_upstream_does_not_trigger_fallback() -> None:
+    # Regression test for https://github.com/langchain-ai/langchain/issues/38892
+    runnable = RunnableGenerator(_agenerate_empty).with_fallbacks(
+        [RunnableGenerator(_agenerate_fallback_marker)]
+    )
+    assert [x async for x in runnable.astream({})] == []
+
+    runnable_no_fallback = RunnableGenerator(_agenerate_empty).with_fallbacks([])
+    assert [x async for x in runnable_no_fallback.astream({})] == []
+
+
 class FakeStructuredOutputModel(BaseChatModel):
     foo: int
 


### PR DESCRIPTION
Closes #38892

---

`RunnableWithFallbacks.stream()` and `astream()` decide whether a runnable "succeeded" by peeking its first chunk with a bare `next(stream)` / `anext(stream)`. When an upstream runnable legitimately yields zero chunks (e.g. an LLM returning empty content, a filtering step, a moderation-blocked response), that peek raises `StopIteration` / `StopAsyncIteration`. Both are subclasses of `Exception`, so they were caught by the default `exceptions_to_handle=(Exception,)` and silently treated as a failure. As reported in the issue, this had two user-visible consequences:

- With a fallback configured, the fallback's output silently replaced the valid empty result (`list(chain.stream({}))` returned `["FALLBACK-OUTPUT"]` instead of `[]`).
- With no fallback configured, the `StopIteration` leaked out of the generator and surfaced as `RuntimeError: generator raised StopIteration`.

A user who wires up a streaming chain where any branch may correctly produce nothing can never trust the output, because an empty stream is indistinguishable from a crash.

The fix peeks the first chunk through a sentinel so that an exhausted upstream stream is recognized as a successful empty result rather than a failure: `stream()` uses the two-argument `next(stream, sentinel)` form, and `astream()` catches `StopAsyncIteration` and rewrites it to the sentinel. When the sentinel survives, the run reports a successful `on_chain_end(None)` and yields nothing. Genuine exceptions still propagate to `exceptions_to_handle` and trigger fallbacks exactly as before, so error-driven fallback behaviour is unchanged.

Added regression tests for both the sync and async paths covering the with-fallback and no-fallback cases; existing error-fallback tests continue to pass.

## Release note

`langchain-core`: `RunnableWithFallbacks.stream()` and `astream()` no longer misinterpret a legitimately empty upstream stream as a failure. Empty streams now complete successfully instead of silently triggering a fallback or raising `RuntimeError: generator raised StopIteration`.

---

This contribution was prepared with the assistance of an AI agent (Hermes Agent) and reviewed by the contributor.