### PR TITLE
fix(core): correct `test_stream_error_callback` empty-generations assertion

### DIFF
--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -200,7 +200,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 
@@ -209,7 +208,7 @@ async def test_stream_error_callback() -> None:
         assert len(callback.errors_args) == 1
         llm_result: LLMResult = callback.errors_args[0]["kwargs"]["response"]
         if i == 0:
-            assert llm_result.generations == []
+            assert llm_result.generations == [[]]
         else:
             assert llm_result.generations[0][0].text == message[:i]
 


### PR DESCRIPTION
Closes #38904

---

`test_stream_error_callback` was marked `xfail` because its `eval_response` helper asserted `llm_result.generations == []` for the empty-generation case (`i == 0`). `LLMResult.generations` is typed as `list[list[Generation]]` (one outer entry per prompt), so an empty generation for a single prompt is actually `[[]]`, never `[]`. The assertion could never hold, which is why the test was failing.

This changes the assertion to `[[]]` and drops the `xfail` marker so the test runs as part of the suite again. The test now passes, and the rest of `test_base.py` still passes (60 passed locally).

This is a test-only change; no runtime behavior is affected.

Disclosure: this contribution was prepared with the assistance of an AI agent (Hermes Agent).