### PR TITLE
fix(mistralai): handle index=0 in streaming tool calls

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -325,7 +325,9 @@ def _convert_chunk_to_message_chunk(
             try:
                 tool_call_chunks = []
                 for raw_tool_call in raw_tool_calls:
-                    if not raw_tool_call.get("index") and not raw_tool_call.get("id"):
+                    if raw_tool_call.get("index") is None and not raw_tool_call.get(
+                        "id"
+                    ):
                         tool_call_id = uuid.uuid4().hex[:]
                     else:
                         tool_call_id = raw_tool_call.get("id")

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -1082,6 +1082,60 @@ def test_no_duplicate_tool_calls_when_multiple_tools() -> None:
     assert len(set(ids)) == 2, f"Duplicate tool call IDs found: {ids}"
 
 
+def test_streaming_tool_call_chunks_merge_when_index_is_zero() -> None:
+    """Tool call chunks at index 0 with no provider id must merge into one call.
+
+    Regression test: the index check used truthy evaluation (`not index`),
+    which treated `index=0` the same as a missing index and generated a new
+    random id per chunk, preventing the chunks from merging.
+    """
+    first_chunk = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"name": "search", "arguments": ""},
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    second_chunk = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": '{"q": "weather"}'},
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+    result_1, index, index_type = _convert_chunk_to_message_chunk(
+        first_chunk, AIMessageChunk, -1, "", None
+    )
+    result_2, _, _ = _convert_chunk_to_message_chunk(
+        second_chunk, AIMessageChunk, index, index_type, None
+    )
+
+    assert isinstance(result_1, AIMessageChunk)
+    assert isinstance(result_2, AIMessageChunk)
+    assert result_1.tool_call_chunks[0]["id"] == result_2.tool_call_chunks[0]["id"]
+
+    combined = result_1 + result_2
+    assert isinstance(combined, AIMessageChunk)
+    assert len(combined.tool_calls) == 1
+    assert combined.tool_calls[0]["name"] == "search"
+    assert combined.tool_calls[0]["args"] == {"q": "weather"}
+
+
 def test_profile() -> None:
     model = ChatMistralAI(model="mistral-large-latest")  # type: ignore[call-arg]
     assert model.profile


### PR DESCRIPTION
I looked into this and can confirm the root cause. In `_convert_chunk_to_message_chunk`, the check is:

    if not raw_tool_call.get("index") and not raw_tool_call.get("id"):

Since `not 0` is `True` in Python, a tool call at `index=0` with no `id` is treated as if it has no index, so a fresh random id gets assigned to every chunk. That breaks merging and splits one tool call into several incomplete ones.

Changing it to `raw_tool_call.get("index") is None and not raw_tool_call.get("id")` fixes it — the random-id fallback only kicks in when the index is genuinely missing. I ran the reproduction from this issue against the fix and the chunks now merge into a single `search({"q": "weather"})` call as expected.

I've got the fix plus a regression test ready to go and lint/tests passing locally. Could I be assigned to this? Happy to open the PR once I'm assigned.