### PR TITLE
fix(openai): stop mutating caller's `text` dict in Responses API payload

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4272,6 +4272,26 @@ def _get_last_messages(
     return messages, None
 
 
+def _set_text_payload_field(payload: dict, field: str, value: Any) -> None:
+    """Set ``field`` under the Responses API ``text`` param without mutating the
+    caller's dict.
+
+    ``text`` may have been supplied by the caller via ``model_kwargs={"text": ...}``,
+    in which case ``payload["text"]`` is a reference to the caller's dict. Setting
+    ``payload["text"][field]`` would mutate that dict in place and leak request-
+    specific fields (``format``/``verbosity``) back into the caller's
+    ``model_kwargs`` — a single JSON-mode call would then force JSON mode on every
+    later plain call. Build a fresh ``text`` dict here instead so the caller's
+    object is never touched. See issue #38869.
+    """
+    existing = payload.get("text")
+    if isinstance(existing, dict):
+        new_text = {**existing, field: value}
+    else:
+        new_text = {field: value}
+    payload["text"] = new_text
+
+
 def _construct_responses_api_payload(
     messages: Sequence[BaseMessage], payload: dict
 ) -> dict:
@@ -4354,10 +4374,7 @@ def _construct_responses_api_payload(
             else:
                 schema_dict = schema
             if schema_dict == {"type": "json_object"}:  # JSON mode
-                if "text" in payload and isinstance(payload["text"], dict):
-                    payload["text"]["format"] = {"type": "json_object"}
-                else:
-                    payload["text"] = {"format": {"type": "json_object"}}
+                _set_text_payload_field(payload, "format", {"type": "json_object"})
             elif (
                 (
                     response_format := _convert_to_openai_response_format(
@@ -4368,19 +4385,13 @@ def _construct_responses_api_payload(
                 and (response_format["type"] == "json_schema")
             ):
                 format_value = {"type": "json_schema", **response_format["json_schema"]}
-                if "text" in payload and isinstance(payload["text"], dict):
-                    payload["text"]["format"] = format_value
-                else:
-                    payload["text"] = {"format": format_value}
+                _set_text_payload_field(payload, "format", format_value)
             else:
                 pass
 
     verbosity = payload.pop("verbosity", None)
     if verbosity is not None:
-        if "text" in payload and isinstance(payload["text"], dict):
-            payload["text"]["verbosity"] = verbosity
-        else:
-            payload["text"] = {"verbosity": verbosity}
+        _set_text_payload_field(payload, "verbosity", verbosity)
 
     return payload
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4649,3 +4649,66 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test_responses_api_text_param_not_mutated_by_json_mode() -> None:
+    """A JSON-mode (or verbosity) call must not mutate the caller's ``text`` dict.
+
+    Regression test for #38869: ``model_kwargs={"text": my_dict}`` is passed by
+    reference into the Responses API payload builder. Before the fix, adding
+    ``text.format`` / ``text.verbosity`` mutated that dict in place, so a single
+    JSON-mode call permanently forced JSON mode on every later plain call.
+    """
+    from langchain_openai.chat_models.base import _construct_responses_api_payload
+
+    messages: list = []
+
+    caller_text = {"verbosity": "low"}
+    payload = {
+        "model": OPENAI_TEST_MODEL,
+        "response_format": {"type": "json_object"},
+        "text": caller_text,
+    }
+
+    result = _construct_responses_api_payload(messages, payload)
+
+    # The resulting request should carry format under a fresh text dict...
+    assert result["text"]["format"] == {"type": "json_object"}
+    assert result["text"]["verbosity"] == "low"
+    # ...and the caller's dict must be untouched.
+    assert caller_text == {"verbosity": "low"}
+    # The payload dict's "text" entry should no longer be the caller's dict.
+    assert result["text"] is not caller_text
+
+    # A follow-up plain call on the same caller dict stays JSON-free.
+    payload2 = {
+        "model": OPENAI_TEST_MODEL,
+        "text": caller_text,
+    }
+    result2 = _construct_responses_api_payload(messages, payload2)
+    assert "format" not in result2["text"]
+    assert caller_text == {"verbosity": "low"}
+
+
+def test_responses_api_text_param_not_mutated_by_verbosity() -> None:
+    """Setting ``verbosity`` must not mutate the caller's ``text`` dict either.
+
+    Same bug class as the JSON-mode case in #38869, for the verbosity branch.
+    """
+    from langchain_openai.chat_models.base import _construct_responses_api_payload
+
+    messages: list = []
+
+    caller_text = {"format": {"type": "json_object"}}
+    payload = {
+        "model": OPENAI_TEST_MODEL,
+        "verbosity": "high",
+        "text": caller_text,
+    }
+
+    result = _construct_responses_api_payload(messages, payload)
+
+    assert result["text"]["verbosity"] == "high"
+    assert result["text"]["format"] == {"type": "json_object"}
+    assert caller_text == {"format": {"type": "json_object"}}
+    assert result["text"] is not caller_text


### PR DESCRIPTION
Fixes #38869

ChatOpenAI with use_responses_api=True and model_kwargs={"text": my_dict} mutates the caller's dict in place. When a call adds text.format (JSON mode or json_schema) or text.verbosity, _construct_responses_api_payload does payload["text"][field] = value, which writes straight into the caller's dict since payload["text"] is a reference to it. A single JSON-mode call (e.g. with_structured_output(method="json_mode")) then permanently forces JSON mode on every later plain call made with the same dict, because the leaked format key is never removed.

This replaces all three in-place mutations (json_object, json_schema, verbosity) with a small helper _set_text_payload_field that builds a fresh text dict from the existing fields, so the caller's object is never touched and model_kwargs stays stable across calls. Added two regression tests covering the JSON-mode and verbosity branches, asserting both that the request carries the right fields and that the caller's dict is left unchanged.

Assisted-by: Hermes Agent