### PR TITLE
fix(core): treat empty upstream stream as success in `RunnableWithFallbacks`

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -486,6 +486,15 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        # Sentinel used to distinguish a legitimately empty upstream stream
+        # (runnable succeeded but produced zero chunks) from a `StopIteration`
+        # raised by a failing runnable. Without this, an empty stream is
+        # misinterpreted as a failure and either silently triggers a fallback
+        # (wrong) or leaks a `RuntimeError: generator raised StopIteration`
+        # under PEP 479 when no fallback is configured. See #38892.
+        empty_stream_sentinel: Any = object()
+        chunk: Any = empty_stream_sentinel
+        stream: Iterator[Output] | None = None
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -497,7 +506,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    chunk = context.run(next, stream, empty_stream_sentinel)
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -511,10 +520,16 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             run_manager.on_chain_error(first_error)
             raise first_error
 
+        # The runnable succeeded but produced no chunks. Treat this as a
+        # successful empty stream rather than falling back.
+        if chunk is empty_stream_sentinel:
+            run_manager.on_chain_end(None)
+            return
+
         yield chunk
         output: Output | None = chunk
         try:
-            for chunk in stream:
+            for chunk in stream:  # type: ignore[assignment]
                 yield chunk
                 try:
                     output = output + chunk  # type: ignore[operator]
@@ -550,6 +565,12 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        # Sentinel used to distinguish a legitimately empty upstream stream
+        # (runnable succeeded but produced zero chunks) from a
+        # `StopAsyncIteration` raised by a failing runnable. See `stream` and #38892.
+        empty_stream_sentinel: Any = object()
+        chunk: Any = empty_stream_sentinel
+        stream: AsyncIterator[Output] | None = None
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -561,7 +582,9 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         child_config,
                         **kwargs,
                     )
-                    chunk = await coro_with_context(anext(stream), context)
+                    chunk = await coro_with_context(
+                        anext(stream, empty_stream_sentinel), context
+                    )
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -575,10 +598,16 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             await run_manager.on_chain_error(first_error)
             raise first_error
 
+        # The runnable succeeded but produced no chunks. Treat this as a
+        # successful empty stream rather than falling back.
+        if chunk is empty_stream_sentinel:
+            await run_manager.on_chain_end(None)
+            return
+
         yield chunk
         output: Output | None = chunk
         try:
-            async for chunk in stream:
+            async for chunk in stream:  # type: ignore[assignment]
                 yield chunk
                 try:
                     output = output + chunk  # type: ignore[operator]

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -318,6 +318,49 @@ async def test_fallbacks_astream() -> None:
         _ = [_ async for _ in runnable.astream({})]
 
 
+def _generate_empty(_: Iterator[Any]) -> Iterator[str]:
+    """A runnable that legitimately produces zero chunks."""
+    return
+    yield  # make this a generator function
+
+
+async def _agenerate_empty(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    """An async runnable that legitimately produces zero chunks."""
+    return
+    yield  # make this an async generator function
+
+
+def test_fallbacks_stream_empty_primary_does_not_fallback() -> None:
+    """A primary that produces an empty stream is a success, not a failure.
+
+    Regression test for #38892: `stream()` peeked the first chunk with a bare
+    `next(stream)`, so an empty upstream stream raised `StopIteration` (which
+    becomes `RuntimeError` under PEP 479 inside the generator) and was
+    misinterpreted as a failure — silently triggering the fallback when one
+    was configured, or surfacing a confusing `RuntimeError` when none was.
+    """
+    # With a fallback configured, the empty primary must NOT be replaced.
+    runnable = RunnableGenerator(_generate_empty).with_fallbacks(
+        [RunnableGenerator(_generate)]
+    )
+    assert list(runnable.stream({})) == []
+
+    # With no fallback configured, an empty stream must not raise.
+    runnable_no_fallback = RunnableGenerator(_generate_empty).with_fallbacks([])
+    assert list(runnable_no_fallback.stream({})) == []
+
+
+async def test_fallbacks_astream_empty_primary_does_not_fallback() -> None:
+    """Async variant of `test_fallbacks_stream_empty_primary_does_not_fallback`."""
+    runnable = RunnableGenerator(_agenerate_empty).with_fallbacks(
+        [RunnableGenerator(_agenerate)]
+    )
+    assert [_ async for _ in runnable.astream({})] == []
+
+    runnable_no_fallback = RunnableGenerator(_agenerate_empty).with_fallbacks([])
+    assert [_ async for _ in runnable_no_fallback.astream({})] == []
+
+
 class FakeStructuredOutputModel(BaseChatModel):
     foo: int
 


### PR DESCRIPTION
Closes #38892

---

`RunnableWithFallbacks.stream`/`astream` decided whether the primary runnable succeeded by peeking its first chunk with a bare `next(stream)` / `anext(stream)`. When the primary legitimately produced zero chunks (an empty LLM response, a filtering step that drops everything, a moderation-blocked reply), that bare peek raised `StopIteration`: with a fallback configured the empty stream was silently misread as a failure and replaced by the fallback's output, and without a fallback the `StopIteration` escaped into the generator and surfaced as `RuntimeError: generator raised StopIteration` under PEP 479.

This peeks with a sentinel (`next(stream, sentinel)` / `anext(stream, sentinel)`) instead. A sentinel means the runnable succeeded with an empty stream, so the run ends without yielding and without falling back. The change is local to the empty-first-chunk detection; real failures still raise and trigger fallbacks exactly as before.

Adds regression tests for both sync and async paths, each covering the with-fallback and no-fallback cases. Verified against the issue's reproduction: both previously-broken cases now return `[]`, while failing primaries still fall back, non-empty primaries still stream through, and genuine errors with no fallback still re-raise.

Assisted-by: Hermes Agent