### PR TITLE
fix(langchain): re-raise non-retryable exceptions in `ModelRetryMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -237,8 +237,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -287,8 +287,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -291,7 +291,12 @@ def test_model_retry_succeeds_after_retries() -> None:
 
 
 def test_model_retry_specific_exceptions() -> None:
-    """Test ModelRetryMiddleware only retries specific exception types."""
+    """Test ModelRetryMiddleware only retries specific exception types.
+
+    Non-retryable exceptions are re-raised immediately, matching
+    `ToolRetryMiddleware` (see #38845). `on_failure` only applies once the
+    configured retries for a retryable exception are exhausted.
+    """
     # This model will fail with RuntimeError, which we won't retry
     model = AlwaysFailingModel(error_message="Runtime error", error_type=RuntimeError)
 
@@ -311,15 +316,106 @@ def test_model_retry_specific_exceptions() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
+    # RuntimeError is not retryable, so it is re-raised
+    # even though on_failure="continue"
+    with pytest.raises(RuntimeError, match="Runtime error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
+
+
+def test_model_retry_non_retryable_exception_reraises() -> None:
+    """Non-retryable exceptions are re-raised even when on_failure='continue'.
+
+    Regression test mirroring `test_tool_retry_non_retryable_exception_reraises`
+    on the model side: an exception that does not match `retry_on` must
+    propagate immediately instead of being routed through `on_failure`.
+    This keeps `ModelRetryMiddleware` consistent with `ToolRetryMiddleware`
+    (changed in #38845) and honors `retry_on` as a fatal-vs-transient signal.
+    """
+
+    class NonRetryableModel(FakeToolCallingModel):
+        """Model that always raises a non-retryable TypeError."""
+
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            msg = "non-retryable boom"
+            raise TypeError(msg)
+
+    model = NonRetryableModel()
+
+    # Only retry ValueError — TypeError is not retryable
+    retry = ModelRetryMiddleware(
+        max_retries=2,
+        retry_on=(ValueError,),
+        initial_delay=0.01,
+        jitter=False,
+        on_failure="continue",
     )
 
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-    # RuntimeError should fail immediately (1 attempt only)
-    assert "1 attempt" in ai_messages[-1].content
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[retry],
+        checkpointer=InMemorySaver(),
+    )
+
+    # TypeError does not match retry_on, so it is re-raised
+    # even though on_failure="continue"
+    with pytest.raises(TypeError, match="non-retryable boom"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_model_retry_async_non_retryable_exception_reraises() -> None:
+    """Async path also re-raises non-retryable exceptions under on_failure='continue'."""
+
+    class NonRetryableModel(FakeToolCallingModel):
+        """Model that always raises a non-retryable TypeError."""
+
+        @override
+        def _generate(
+            self,
+            messages: list[BaseMessage],
+            stop: list[str] | None = None,
+            run_manager: CallbackManagerForLLMRun | None = None,
+            **kwargs: Any,
+        ) -> ChatResult:
+            msg = "async non-retryable boom"
+            raise TypeError(msg)
+
+    model = NonRetryableModel()
+
+    retry = ModelRetryMiddleware(
+        max_retries=2,
+        retry_on=(ValueError,),
+        initial_delay=0.01,
+        jitter=False,
+        on_failure="continue",
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[retry],
+        checkpointer=InMemorySaver(),
+    )
+
+    with pytest.raises(TypeError, match="async non-retryable boom"):
+        await agent.ainvoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
 
 def test_model_retry_custom_exception_filter() -> None:
@@ -389,17 +485,17 @@ def test_model_retry_custom_exception_filter() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
+    # First attempt raises retryable error → retried.
+    # Second attempt raises non-retryable error → re-raised (not swallowed),
+    # even though on_failure="continue".
+    with pytest.raises(CustomError, match="Non-retryable error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-
-    # Should retry once (attempt 1 with retry_me=True), then fail on attempt 2 (retry_me=False)
+    # Should have retried once (attempt 1 retryable, attempt 2 non-retryable)
     assert attempt_count["value"] == 2
-    assert "2 attempts" in ai_messages[-1].content
 
 
 def test_model_retry_backoff_timing() -> None:


### PR DESCRIPTION
Closes #38893

---

`ModelRetryMiddleware.wrap_model_call`/`awrap_model_call` routed exceptions that did not match `retry_on` through `_handle_failure`, swallowing them as error `AIMessage`s even under `on_failure="continue"`. This diverged from `ToolRetryMiddleware`, which was changed in #38845 to re-raise non-retryable exceptions immediately, and it violated the `retry_on` contract documented in #38884: a user-supplied `retry_on` is a fatal-vs-transient signal, so an exception the user excluded should surface rather than be turned into an error reply.

The fix mirrors `ToolRetryMiddleware`: when `should_retry_exception` returns `False`, re-raise instead of calling `_handle_failure`. `on_failure` now only applies once the configured retries for a matching exception are exhausted, matching the documented behavior.

A user configuring `retry_on=(ValueError,)` and hitting a `TypeError` previously got an `AIMessage` ("Model call failed after 1 attempt with TypeError: boom") and the agent kept going as if nothing was wrong. After this change the `TypeError` propagates so the caller can actually see the fatal error.

Updates `test_model_retry_specific_exceptions` and `test_model_retry_custom_exception_filter` to assert the re-raise, and adds `test_model_retry_non_retryable_exception_reraises` plus an async counterpart mirroring `test_tool_retry_non_retryable_exception_reraises`. The full `test_model_retry.py`, `test_tool_retry.py`, and `test_structured_output_retry.py` suites pass (66 tests).

## Release note

`ModelRetryMiddleware` now re-raises exceptions that do not match `retry_on` instead of converting them to error `AIMessage`s via `on_failure`. This aligns it with `ToolRetryMiddleware` and makes `retry_on` behave as documented: only matching exceptions are retried and eligible for `on_failure` handling; everything else propagates. If you previously relied on non-retryable exceptions being swallowed as error messages, set `retry_on=(Exception,)` (the default) or add the relevant exception type to `retry_on`.

Assisted-by: Hermes Agent