### PR TITLE
fix(core): correct `test_stream_error_callback` empty-generations assertion

### DIFF
--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -200,7 +200,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 
@@ -209,7 +208,7 @@ async def test_stream_error_callback() -> None:
         assert len(callback.errors_args) == 1
         llm_result: LLMResult = callback.errors_args[0]["kwargs"]["response"]
         if i == 0:
-            assert llm_result.generations == []
+            assert llm_result.generations == [[]]
         else:
             assert llm_result.generations[0][0].text == message[:i]
 


### PR DESCRIPTION
Closes #38904

---

`test_stream_error_callback` was marked `xfail` because its assertion for the `i == 0` case (`llm_result.generations == []`) never holds: `LLMResult.generations` is a list-of-lists (one list of generations per prompt), so an empty generation for a single prompt is `[[]]`, not `[]`. The wrong assertion made the test fail, and rather than investigate it was just flipped to `xfail`.

This removes the `xfail` marker and corrects the assertion to `llm_result.generations == [[]]`, which matches the real shape of an empty generation for one prompt. The test now passes against the full `i in range(len(message))` loop (both sync `stream` and async `astream` paths, with the error callback firing on each chunk index).

No production code changed — this is purely a test correctness fix that un-skips an existing xfailed test.

Assisted-by: Hermes Agent