### PR TITLE
fix(core): treat empty upstream streams as success in `RunnableWithFallbacks`

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -486,6 +486,12 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        # Sentinel used to distinguish an exhausted (legitimately empty) upstream
+        # stream from a real first chunk. `next(stream)` raises `StopIteration`
+        # when the stream is empty, which is a subclass of `Exception` and would
+        # otherwise be caught by `exceptions_to_handle` and treated as a failure.
+        empty_stream_sentinel: Any = object()
+        chunk: Any = empty_stream_sentinel
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -497,7 +503,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    chunk = context.run(next, stream, empty_stream_sentinel)
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -510,6 +516,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         if first_error:
             run_manager.on_chain_error(first_error)
             raise first_error
+
+        # If the chosen runnable produced no chunks at all, the run succeeded
+        # with an empty stream — do not yield anything, but still report a
+        # successful chain end.
+        if chunk is empty_stream_sentinel:
+            run_manager.on_chain_end(None)
+            return
 
         yield chunk
         output: Output | None = chunk
@@ -550,6 +563,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        # Sentinel used to distinguish an exhausted (legitimately empty) upstream
+        # async stream from a real first chunk. `anext(stream)` raises
+        # `StopAsyncIteration` when the stream is empty, which is a subclass of
+        # `Exception` and would otherwise be caught by `exceptions_to_handle`
+        # and treated as a failure.
+        empty_stream_sentinel: Any = object()
+        chunk: Any = empty_stream_sentinel
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -561,7 +581,12 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         child_config,
                         **kwargs,
                     )
-                    chunk = await coro_with_context(anext(stream), context)
+                    try:
+                        chunk = await coro_with_context(anext(stream), context)
+                    except StopAsyncIteration:
+                        # The upstream stream was empty before any chunk was
+                        # produced. This is a successful (empty) result.
+                        chunk = empty_stream_sentinel
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -574,6 +599,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         if first_error:
             await run_manager.on_chain_error(first_error)
             raise first_error
+
+        # If the chosen runnable produced no chunks at all, the run succeeded
+        # with an empty stream — do not yield anything, but still report a
+        # successful chain end.
+        if chunk is empty_stream_sentinel:
+            await run_manager.on_chain_end(None)
+            return
 
         yield chunk
         output: Output | None = chunk

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -318,6 +318,52 @@ async def test_fallbacks_astream() -> None:
         _ = [_ async for _ in runnable.astream({})]
 
 
+def _generate_empty(_: Iterator[Any]) -> Iterator[str]:
+    """A legitimate runnable that decides to yield zero chunks."""
+    return
+    yield  # pragma: no cover  # makes this a generator function
+
+
+async def _agenerate_empty(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    """Async counterpart of `_generate_empty`."""
+    return
+    yield  # pragma: no cover  # makes this a generator function
+
+
+def _generate_fallback_marker(_: Iterator[Any]) -> Iterator[str]:
+    yield "FALLBACK-OUTPUT"
+
+
+async def _agenerate_fallback_marker(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    yield "FALLBACK-OUTPUT"
+
+
+def test_fallbacks_stream_empty_upstream_does_not_trigger_fallback() -> None:
+    # Regression test for https://github.com/langchain-ai/langchain/issues/38892
+    # A legitimately empty upstream stream must NOT be treated as a failure and
+    # must NOT silently fall through to the fallback.
+    runnable = RunnableGenerator(_generate_empty).with_fallbacks(
+        [RunnableGenerator(_generate_fallback_marker)]
+    )
+    assert list(runnable.stream({})) == []
+
+    # And with no fallback configured at all, an empty stream must succeed
+    # instead of raising `RuntimeError: generator raised StopIteration`.
+    runnable_no_fallback = RunnableGenerator(_generate_empty).with_fallbacks([])
+    assert list(runnable_no_fallback.stream({})) == []
+
+
+async def test_fallbacks_astream_empty_upstream_does_not_trigger_fallback() -> None:
+    # Regression test for https://github.com/langchain-ai/langchain/issues/38892
+    runnable = RunnableGenerator(_agenerate_empty).with_fallbacks(
+        [RunnableGenerator(_agenerate_fallback_marker)]
+    )
+    assert [x async for x in runnable.astream({})] == []
+
+    runnable_no_fallback = RunnableGenerator(_agenerate_empty).with_fallbacks([])
+    assert [x async for x in runnable_no_fallback.astream({})] == []
+
+
 class FakeStructuredOutputModel(BaseChatModel):
     foo: int
 


### PR DESCRIPTION
Closes #38892

---

`RunnableWithFallbacks.stream()` / `astream()` peek the first chunk of the primary runnable with a bare `next(stream)` / `anext(stream)` to decide whether the run "succeeded". When the primary legitimately produces zero chunks, that peek raises `StopIteration` / `StopAsyncIteration`. Inside the generator, PEP 479 turns `StopIteration` into `RuntimeError: generator raised StopIteration`, and the `except self.exceptions_to_handle` branch (which defaults to `Exception`) catches it as a failure — so a legitimately empty stream is conflated with an error.

Two concrete consequences, both from the issue report:

1. With a fallback configured, a valid empty primary output is silently replaced by the fallback (e.g. `["FALLBACK-OUTPUT"]`).
2. With no fallback configured, `stream({})` raises `RuntimeError: generator raised StopIteration` instead of returning an empty stream.

Empty streams are a legitimate terminal state (an LLM returning empty content, a filtering step that matches nothing, a moderation-blocked response), not a failure signal.

The fix replaces the bare peek with a sentinel-based one: `next(stream, sentinel)` / a guarded `anext` that returns a unique `empty_stream_sentinel` on `StopAsyncIteration`. The success branch then checks for the sentinel: if the chosen runnable produced no chunks, the run succeeded with an empty stream, so we report a successful chain end and yield nothing. This keeps the existing fallback-on-real-error behavior intact.

Two regression tests cover both reported cases (sync and async): an empty upstream with a fallback does not trigger the fallback, and an empty upstream with no fallback succeeds instead of raising.

Assisted-by: Hermes Agent