### PR TITLE
fix(xai): derive bound client from single root client per side

### DIFF
--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -541,19 +541,15 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
 
         if not (self.client or None):
             sync_specific: dict = {"http_client": self.http_client}
-            self.client = openai.OpenAI(
-                **client_params, **sync_specific
-            ).chat.completions
             self.root_client = openai.OpenAI(**client_params, **sync_specific)
+            self.client = self.root_client.chat.completions
         if not (self.async_client or None):
             async_specific: dict = {"http_client": self.http_async_client}
-            self.async_client = openai.AsyncOpenAI(
-                **client_params, **async_specific
-            ).chat.completions
             self.root_async_client = openai.AsyncOpenAI(
                 **client_params,
                 **async_specific,
             )
+            self.async_client = self.root_async_client.chat.completions
 
         # Enable streaming usage metadata by default
         if self.stream_usage is not False:

--- a/libs/partners/xai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/xai/tests/unit_tests/test_chat_models.py
@@ -217,3 +217,21 @@ def test_metadata_versions() -> None:
     assert "langchain-core" in versions
     assert "langchain-xai" in versions
     assert "langchain-openai" in versions
+
+
+def test_single_openai_client_per_side() -> None:
+    """The bound chat.completions handle shares the root client's transport.
+
+    Regression test for the issue where ``ChatXAI`` constructed two
+    ``openai.OpenAI`` instances (and two ``openai.AsyncOpenAI`` instances) per
+    instantiation, so the bound ``client``/``async_client`` each carried their
+    own httpx transport instead of sharing the root client's. Verify the bound
+    handles are derived from the root clients.
+    """
+    llm = ChatXAI(model=MODEL_NAME)
+    assert llm.root_client is not None
+    assert llm.root_async_client is not None
+    # The bound chat.completions handle must come from the root client so both
+    # fields share one transport per side.
+    assert llm.client is llm.root_client.chat.completions
+    assert llm.async_client is llm.root_async_client.chat.completions


### PR DESCRIPTION
Fixes #38839

---

ChatXAI.validate_environment constructed two openai.OpenAI instances (and two openai.AsyncOpenAI instances) on every instantiation: one to build the bound client/async_client chat.completions handle, and a separate one for root_client/root_async_client. Each carried its own httpx transport, so workloads that build a ChatXAI per request or per config variant paid four connection pools / TLS handshakes per instance and forfeited connection reuse — the same failure mode users hit on AzureChatOpenAI (#32489) and ChatOpenRouter (#38610).

The fix mirrors the in-repo ChatDeepSeek pattern: construct root_client once and derive self.client = self.root_client.chat.completions (likewise on the async side). The bound and root fields now share one transport per side, halving the transports created per instance.

This is the contained half of the fix suggested in #38839. The remaining half — falling back to the cached _get_default_httpx_client/_get_default_async_httpx_client when the caller doesn't supply an http_client, so multiple instances share one default transport like ChatOpenAI does — is a cross-package change (_client_utils lives in langchain-openai) and felt out of scope for this PR; happy to follow up separately.

Added a unit test (test_single_openai_client_per_side) that asserts the bound handle is the root client's chat.completions. It fails against current master (the bound handle is a distinct object with its own transport) and passes with this change. Full libs/partners/xai unit suite (39 tests), ruff check, and ruff format --check are clean.

Assisted-by: Hermes Agent