### PR TITLE
fix(core): treat empty upstream stream as success in RunnableWithFallbacks

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -33,6 +33,26 @@ from langchain_core.utils.pydantic import TypeBaseModel
 if TYPE_CHECKING:
     from langchain_core.callbacks.manager import AsyncCallbackManagerForChainRun
 
+# Sentinel returned by `next(stream, _EMPTY)` / the `_anext_or_empty` helper when
+# the primary stream produced no chunks. An empty stream is a legitimate result
+# (see the `stream`/`astream` overrides below) and must not be confused with a
+# failure, so it is represented distinctly from `None`.
+_EMPTY: Any = object()
+
+
+async def _anext_or_empty(stream: AsyncIterator[Any]) -> Any:
+    """Return the next chunk from an async stream, or `_EMPTY` if it is empty.
+
+    `anext(stream)` raises `StopAsyncIteration` on an empty stream. Inside the
+    async `astream` override we must not let that propagate as an error, because
+    an empty upstream stream is a valid (successful) result, not a fallback
+    trigger.
+    """
+    try:
+        return await anext(stream)
+    except StopAsyncIteration:
+        return _EMPTY
+
 
 class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
     """`Runnable` that can fallback to other `Runnable` objects if it fails.
@@ -486,6 +506,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        chunk: Any = _EMPTY
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -497,7 +518,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    chunk = context.run(next, stream, _EMPTY)
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -511,7 +532,16 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             run_manager.on_chain_error(first_error)
             raise first_error
 
-        yield chunk
+        # An empty upstream stream is a valid result (e.g. an LLM that returns
+        # no content, a filtering step, or a moderation-blocked response), not a
+        # failure. Previously `next(stream)` raised `StopIteration` which leaked
+        # out of this generator as `RuntimeError: generator raised StopIteration`
+        # and, when a fallback was configured, caused the empty primary output to
+        # be silently replaced by the fallback. Treat an empty stream as success.
+        if chunk is _EMPTY:
+            run_manager.on_chain_end(None)
+            return
+        yield cast("Output", chunk)
         output: Output | None = chunk
         try:
             for chunk in stream:
@@ -550,6 +580,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        chunk: Any = _EMPTY
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -561,7 +592,7 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         child_config,
                         **kwargs,
                     )
-                    chunk = await coro_with_context(anext(stream), context)
+                    chunk = await coro_with_context(_anext_or_empty(stream), context)
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -575,7 +606,12 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             await run_manager.on_chain_error(first_error)
             raise first_error
 
-        yield chunk
+        # An empty upstream stream is a valid result, not a failure (see the
+        # matching comment in `stream`). Do not fall back and do not raise.
+        if chunk is _EMPTY:
+            await run_manager.on_chain_end(None)
+            return
+        yield cast("Output", chunk)
         output: Output | None = chunk
         try:
             async for chunk in stream:

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -288,6 +288,31 @@ def test_fallbacks_stream() -> None:
         list(runnable.stream({}))
 
 
+def _generate_empty(_: Iterator[Any]) -> Iterator[str]:
+    """A legitimate runnable that decides to yield zero chunks."""
+    return
+    yield  # pragma: no cover  # makes this a generator function
+
+
+def test_fallbacks_stream_empty_primary_does_not_fallback() -> None:
+    """An empty primary stream is a valid result, not a failure.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38892:
+    a legitimately empty upstream stream must not be replaced by the fallback
+    and must not raise ``RuntimeError: generator raised StopIteration``.
+    """
+    # With a fallback configured: the empty primary output must be preserved.
+    runnable = RunnableGenerator(_generate_empty).with_fallbacks(
+        [RunnableGenerator(_generate)]
+    )
+    assert list(runnable.stream({})) == []
+
+    # Without any fallback: an empty stream must still be returned cleanly
+    # instead of raising.
+    runnable_no_fallback = RunnableGenerator(_generate_empty).with_fallbacks([])
+    assert list(runnable_no_fallback.stream({})) == []
+
+
 async def _agenerate(_: AsyncIterator[Any]) -> AsyncIterator[str]:
     for c in "foo bar":
         yield c
@@ -316,6 +341,29 @@ async def test_fallbacks_astream() -> None:
     )
     with pytest.raises(ValueError, match="delayed error"):
         _ = [_ async for _ in runnable.astream({})]
+
+
+async def _agenerate_empty(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    """A legitimate async runnable that decides to yield zero chunks."""
+    return
+    yield  # pragma: no cover  # makes this a generator function
+
+
+async def test_fallbacks_astream_empty_primary_does_not_fallback() -> None:
+    """An empty primary async stream is a valid result, not a failure.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/38892:
+    a legitimately empty upstream stream must not be replaced by the fallback.
+    """
+    # With a fallback configured: the empty primary output must be preserved.
+    runnable = RunnableGenerator(_agenerate_empty).with_fallbacks(
+        [RunnableGenerator(_agenerate)]
+    )
+    assert [_ async for _ in runnable.astream({})] == []
+
+    # Without any fallback: an empty stream must still be returned cleanly.
+    runnable_no_fallback = RunnableGenerator(_agenerate_empty).with_fallbacks([])
+    assert [_ async for _ in runnable_no_fallback.astream({})] == []
 
 
 class FakeStructuredOutputModel(BaseChatModel):


### PR DESCRIPTION
Closes #38892

---

`RunnableWithFallbacks.stream()` and `astream()` eagerly consume the first chunk of the primary runnable (`next(stream)` / `anext(stream)`) to decide whether a fallback is needed. When the primary runnable legitimately produces zero chunks — an LLM returning empty content, a filtering step that matches nothing, or a moderation-blocked response — that eager read raised `StopIteration`. Because the override is itself a generator, this surfaced in two broken ways: with no fallback configured it became `RuntimeError: generator raised StopIteration`, and with a fallback configured the valid empty output was silently replaced by the fallback output.

An empty stream is a valid result, not a failure, so it should neither raise nor trigger a fallback. This change uses a sentinel (`next(stream, _EMPTY)` in the sync path, an `_anext_or_empty` helper in the async path) to detect an empty primary stream and treat it as success: emit no chunks, call `on_chain_end(None)`, and return without consulting any fallback.

Existing error-triggered fallback behaviour is unchanged: a stream whose first iteration raises an in-scope exception (e.g. `IndexError`, `ValueError`) still falls back exactly as before, because the sentinel default only swallows `StopIteration`/`StopAsyncIteration`.

Regression tests cover both `stream` and `astream`, each asserting that (a) an empty primary with a configured fallback returns `[]` instead of the fallback output, and (b) an empty primary with no fallback returns `[]` instead of raising.

## Release note
`RunnableWithFallbacks.stream()`/`astream()` no longer raise `RuntimeError: generator raised StopIteration` (or silently fall back) when the primary runnable produces an empty stream. An empty upstream stream is now treated as a successful empty result.

Assisted-by: Hermes Agent (Nous Research)