### PR TITLE
fix(core): correct generations assertion in test_stream_error_callback

### DIFF
--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -200,7 +200,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 
@@ -209,7 +208,10 @@ async def test_stream_error_callback() -> None:
         assert len(callback.errors_args) == 1
         llm_result: LLMResult = callback.errors_args[0]["kwargs"]["response"]
         if i == 0:
-            assert llm_result.generations == []
+            # `generations` is a list of per-prompt generation lists; for a
+            # single prompt that produced no chunks before the error this is
+            # `[[]]`, not `[]`.
+            assert llm_result.generations == [[]]
         else:
             assert llm_result.generations[0][0].text == message[:i]
 


### PR DESCRIPTION
Closes #38904

---

`test_stream_error_callback` was marked `xfail(reason="This test is failing due to a bug in the testing code")`. The bug was in the test, not the library: for the `i == 0` case (the model errors on the very first chunk, so no generations are produced for the prompt) the assertion was `llm_result.generations == []`. `LLMResult.generations` is a list of per-prompt generation lists, so the correct value there is `[[]]` (one prompt, zero generations), not `[]`.

Confirmed by running with `--runxfail`, which fails exactly on `assert llm_result.generations == []` with `assert [[]] == []`. The other branch (`i > 0`) is correct and unchanged.

This fixes the assertion and drops the `xfail` marker so the test runs and passes as part of the normal suite. No production code is touched.

Assisted-by: Hermes Agent (Nous Research)