### PR TITLE
fix(core): do not treat an empty primary stream as a fallback trigger

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -486,6 +486,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        # `stream`/`chunk` are bound outside the loop so the type checker can
+        # see they are always assigned before use once the loop exits.
+        stream: Iterator[Output] | None = None
+        chunk: Output | None = None
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -497,7 +501,17 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    chunk = context.run(next, stream)
+            except StopIteration:
+                # The upstream runnable produced a legitimately empty stream.
+                # This is a valid output, not a failure, so do not fall back to
+                # the next runnable and report an empty stream to the caller.
+                # NOTE: must be caught before `exceptions_to_handle`, which
+                # typically includes `Exception` and would otherwise swallow
+                # `StopIteration` (a subclass of `Exception`) and trigger a
+                # spurious fallback.
+                run_manager.on_chain_end(None)
+                return
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -511,10 +525,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             run_manager.on_chain_error(first_error)
             raise first_error
 
-        yield chunk
+        yield chunk  # type: ignore[misc]
         output: Output | None = chunk
         try:
-            for chunk in stream:
+            for chunk in stream:  # type: ignore[union-attr]
                 yield chunk
                 try:
                     output = output + chunk  # type: ignore[operator]
@@ -550,6 +564,8 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         )
         first_error = None
         last_error = None
+        stream: AsyncIterator[Output] | None = None
+        chunk: Output | None = None
         for runnable in self.runnables:
             try:
                 if self.exception_key and last_error is not None:
@@ -562,6 +578,16 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         **kwargs,
                     )
                     chunk = await coro_with_context(anext(stream), context)
+            except StopAsyncIteration:
+                # The upstream runnable produced a legitimately empty stream.
+                # This is a valid output, not a failure, so do not fall back to
+                # the next runnable and report an empty stream to the caller.
+                # NOTE: must be caught before `exceptions_to_handle`, which
+                # typically includes `Exception` and would otherwise swallow
+                # `StopAsyncIteration` (a subclass of `Exception`) and trigger
+                # a spurious fallback.
+                await run_manager.on_chain_end(None)
+                return
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -575,10 +601,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             await run_manager.on_chain_error(first_error)
             raise first_error
 
-        yield chunk
+        yield chunk  # type: ignore[misc]
         output: Output | None = chunk
         try:
-            async for chunk in stream:
+            async for chunk in stream:  # type: ignore[union-attr]
                 yield chunk
                 try:
                     output = output + chunk  # type: ignore[operator]

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -275,6 +275,13 @@ def _generate_delayed_error(_: Iterator[Any]) -> Iterator[str]:
     _error("delayed error")
 
 
+def _generate_empty(_: Iterator[Any]) -> Iterator[str]:
+    # A runnable that legitimately produces zero chunks. Yield is unreachable
+    # but keeps this a generator function.
+    return
+    yield  # pragma: no cover
+
+
 def test_fallbacks_stream() -> None:
     runnable = RunnableGenerator(_generate_immediate_error).with_fallbacks(
         [RunnableGenerator(_generate)]
@@ -286,6 +293,21 @@ def test_fallbacks_stream() -> None:
     )
     with pytest.raises(ValueError, match="delayed error"):
         list(runnable.stream({}))
+
+
+def test_fallbacks_stream_empty_does_not_fallback() -> None:
+    # An empty primary stream is a valid output and must not trigger fallback.
+    primary = RunnableGenerator(_generate_empty)
+    fallback = RunnableGenerator(_generate)
+    runnable = primary.with_fallbacks([fallback])
+    assert list(runnable.stream({})) == []
+
+
+def test_fallbacks_stream_empty_with_no_fallbacks() -> None:
+    # With no fallbacks configured, an empty stream must not raise
+    # RuntimeError: generator raised StopIteration.
+    runnable = RunnableGenerator(_generate_empty).with_fallbacks([])
+    assert list(runnable.stream({})) == []
 
 
 async def _agenerate(_: AsyncIterator[Any]) -> AsyncIterator[str]:
@@ -303,6 +325,13 @@ async def _agenerate_delayed_error(_: AsyncIterator[Any]) -> AsyncIterator[str]:
     _error("delayed error")
 
 
+async def _agenerate_empty(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    # A runnable that legitimately produces zero chunks. Yield is unreachable
+    # but keeps this an async generator function.
+    return
+    yield  # pragma: no cover
+
+
 async def test_fallbacks_astream() -> None:
     runnable = RunnableGenerator(_agenerate_immediate_error).with_fallbacks(
         [RunnableGenerator(_agenerate)]
@@ -316,6 +345,20 @@ async def test_fallbacks_astream() -> None:
     )
     with pytest.raises(ValueError, match="delayed error"):
         _ = [_ async for _ in runnable.astream({})]
+
+
+async def test_fallbacks_astream_empty_does_not_fallback() -> None:
+    # An empty primary stream is a valid output and must not trigger fallback.
+    primary = RunnableGenerator(_agenerate_empty)
+    fallback = RunnableGenerator(_agenerate)
+    runnable = primary.with_fallbacks([fallback])
+    assert [_ async for _ in runnable.astream({})] == []
+
+
+async def test_fallbacks_astream_empty_with_no_fallbacks() -> None:
+    # With no fallbacks configured, an empty stream must not raise.
+    runnable = RunnableGenerator(_agenerate_empty).with_fallbacks([])
+    assert [_ async for _ in runnable.astream({})] == []
 
 
 class FakeStructuredOutputModel(BaseChatModel):


### PR DESCRIPTION
Closes #38892

---

`RunnableWithFallbacks.stream()` and `astream()` peek at the first chunk of each runnable with `next(stream)` / `anext(stream)` to decide whether to fall back. For a runnable that legitimately produces zero chunks (an LLM returning empty content, a filtering step that drops everything, a moderation-blocked response), that call raises `StopIteration` / `StopAsyncIteration`.

Because `exceptions_to_handle` defaults to `(Exception,)` and `StopIteration` subclasses `Exception`, the empty-stream case was misclassified as a recoverable error. With a fallback configured, the fallback silently replaced the valid empty output; with no fallback, the bare `StopIteration` leaked out of the generator and surfaced to the user as `RuntimeError: generator raised StopIteration`.

This catches `StopIteration` / `StopAsyncIteration` before the `exceptions_to_handle` branch, reports the run as successfully ended with no output, and returns an empty stream to the caller. The existing immediate-error and delayed-error paths are unchanged.

## Release note

`RunnableWithFallbacks.stream()` and `astream()` no longer misinterpret a legitimately empty primary stream as a failure. An empty stream is now passed through as `[]` instead of silently triggering a fallback or raising `RuntimeError: generator raised StopIteration`.

This contribution was prepared with the assistance of an AI agent (Hermes Agent).