### PR TITLE
fix(langchain): re-raise non-retryable exceptions in `ModelRetryMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -237,8 +237,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -287,8 +287,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -290,8 +290,14 @@ def test_model_retry_succeeds_after_retries() -> None:
     assert model.attempt == 3
 
 
-def test_model_retry_specific_exceptions() -> None:
-    """Test ModelRetryMiddleware only retries specific exception types."""
+def test_model_retry_non_retryable_exception_reraises() -> None:
+    """Non-retryable exceptions are re-raised even when on_failure='continue'.
+
+    A non-retryable exception (one that does not match ``retry_on``) must
+    propagate immediately instead of being normalized to an ``AIMessage``,
+    mirroring the contract of ``ToolRetryMiddleware`` (see #38845 / #38893).
+    """
+
     # This model will fail with RuntimeError, which we won't retry
     model = AlwaysFailingModel(error_message="Runtime error", error_type=RuntimeError)
 
@@ -311,15 +317,13 @@ def test_model_retry_specific_exceptions() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
-
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-    # RuntimeError should fail immediately (1 attempt only)
-    assert "1 attempt" in ai_messages[-1].content
+    # RuntimeError does not match retry_on, so it is re-raised
+    # even though on_failure="continue"
+    with pytest.raises(RuntimeError, match="Runtime error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
 
 def test_model_retry_custom_exception_filter() -> None:
@@ -389,17 +393,18 @@ def test_model_retry_custom_exception_filter() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
+    # First attempt raises a retryable CustomError (retried), second attempt
+    # raises a non-retryable CustomError which must propagate per the
+    # retry_on contract (see #38845 / #38893), instead of being normalized
+    # to an AIMessage.
+    with pytest.raises(CustomError, match="Non-retryable error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-
-    # Should retry once (attempt 1 with retry_me=True), then fail on attempt 2 (retry_me=False)
+    # Should have attempted twice: once retryable, once non-retryable.
     assert attempt_count["value"] == 2
-    assert "2 attempts" in ai_messages[-1].content
 
 
 def test_model_retry_backoff_timing() -> None:
@@ -573,6 +578,34 @@ async def test_model_retry_async_failing_model() -> None:
     last_msg = ai_messages[-1].content
     assert "failed after 3 attempts" in last_msg
     assert "ValueError" in last_msg
+
+
+@pytest.mark.asyncio
+async def test_model_retry_async_non_retryable_exception_reraises() -> None:
+    """Async path also re-raises non-retryable exceptions instead of normalizing them."""
+
+    model = AlwaysFailingModel(error_message="Runtime error", error_type=RuntimeError)
+
+    retry = ModelRetryMiddleware(
+        max_retries=2,
+        retry_on=(ValueError,),
+        initial_delay=0.01,
+        jitter=False,
+        on_failure="continue",
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[retry],
+        checkpointer=InMemorySaver(),
+    )
+
+    with pytest.raises(RuntimeError, match="Runtime error"):
+        await agent.ainvoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #38893

---

`ModelRetryMiddleware` normalized every non-retryable exception into an `AIMessage` via `on_failure`, diverging from `ToolRetryMiddleware`, which was fixed in #38845 to re-raise exceptions that do not match `retry_on`. As a result, a `TypeError` (or any exception the user excluded from `retry_on`) raised during a model call was silently swallowed into an error `AIMessage` instead of propagating to the caller, so genuinely unexpected failures were hidden from the caller and surfaced to the model as ordinary content.

This aligns `wrap_model_call` and `awrap_model_call` with the tool-side contract established in #38845 and documented in #38884: when `should_retry_exception` returns `False`, the exception is re-raised immediately instead of being routed through `_handle_failure`. `on_failure` now only applies to exceptions that match `retry_on` after retries are exhausted, matching how `ToolRetryMiddleware` behaves.

Two existing tests asserted the old swallowing behavior (`test_model_retry_specific_exceptions` and `test_model_retry_custom_exception_filter`); both are updated to assert that the non-retryable exception propagates, and a new async regression test covers the `awrap_model_call` path. The full middleware unit suite (725 tests) passes.

## Release note

`ModelRetryMiddleware` now re-raises exceptions that do not match `retry_on` instead of converting them to an `AIMessage`, matching `ToolRetryMiddleware`. `on_failure` only applies to exceptions that match `retry_on` after retries are exhausted. To continue normalizing an exception type into an `AIMessage`, include it in `retry_on` (or compose with a dedicated error-handling middleware).

This contribution was developed with the assistance of an AI agent (Hermes Agent).