### PR TITLE
fix(core): treat empty upstream stream/astream as valid in RunnableWithFallbacks

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -497,7 +497,23 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    try:
+                        chunk: Output = context.run(next, stream)
+                    except StopIteration:
+                        # The primary stream produced no chunks at all, which is a
+                        # valid outcome (e.g. an LLM returning empty content, a
+                        # filtering step, or a moderation-blocked response). This is
+                        # not a failure, so we must neither trigger a fallback nor
+                        # surface an error. Drain the (already exhausted) stream to
+                        # avoid "GeneratorExit"-style ResourceWarnings, fire the
+                        # success callbacks, and return an empty stream. Without this
+                        # guard, `StopIteration` (an `Exception` subclass) is caught by
+                        # `except self.exceptions_to_handle` below and treated as a
+                        # failure, silently substituting a fallback's output for the
+                        # primary's valid empty output.
+                        yield from stream
+                        run_manager.on_chain_end(None)
+                        return
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -561,7 +577,23 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         child_config,
                         **kwargs,
                     )
-                    chunk = await coro_with_context(anext(stream), context)
+                    try:
+                        chunk = await coro_with_context(anext(stream), context)
+                    except StopAsyncIteration:
+                        # The primary stream produced no chunks at all, which is a
+                        # valid outcome (e.g. an LLM returning empty content, a
+                        # filtering step, or a moderation-blocked response). This is
+                        # not a failure, so we must neither trigger a fallback nor
+                        # surface an error. Drain the (already exhausted) stream, fire
+                        # the success callbacks, and return an empty stream. Without
+                        # this guard, `StopAsyncIteration` (an `Exception` subclass) is
+                        # caught by `except self.exceptions_to_handle` below and treated
+                        # as a failure, silently substituting a fallback's output for
+                        # the primary's valid empty output.
+                        async for _remaining in stream:
+                            yield _remaining
+                        await run_manager.on_chain_end(None)
+                        return
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -318,6 +318,46 @@ async def test_fallbacks_astream() -> None:
         _ = [_ async for _ in runnable.astream({})]
 
 
+def _generate_empty(_: Iterator[Any]) -> Iterator[str]:
+    # A legitimate runnable that decides to yield no chunks at all (e.g. an LLM
+    # returning empty content, a filtering step, a moderation-blocked response).
+    return
+    yield  # makes this a generator function
+
+
+def test_fallbacks_stream_empty_primary_does_not_trigger_fallback() -> None:
+    # An empty primary stream is a valid result, not a failure, so the fallback
+    # must NOT be invoked. See issue #38892.
+    primary = RunnableGenerator(_generate_empty)
+    runnable = primary.with_fallbacks([RunnableGenerator(_generate)])
+    assert list(runnable.stream({})) == []
+
+
+def test_fallbacks_stream_empty_primary_no_fallbacks_returns_empty() -> None:
+    # Without any fallback configured, an empty primary stream must complete
+    # cleanly instead of raising "RuntimeError: generator raised StopIteration".
+    primary = RunnableGenerator(_generate_empty)
+    runnable = primary.with_fallbacks([])
+    assert list(runnable.stream({})) == []
+
+
+async def _agenerate_empty(_: AsyncIterator[Any]) -> AsyncIterator[str]:
+    return
+    yield  # makes this a generator function
+
+
+async def test_fallbacks_astream_empty_primary_does_not_trigger_fallback() -> None:
+    primary = RunnableGenerator(_agenerate_empty)
+    runnable = primary.with_fallbacks([RunnableGenerator(_agenerate)])
+    assert [c async for c in runnable.astream({})] == []
+
+
+async def test_fallbacks_astream_empty_primary_no_fallbacks_returns_empty() -> None:
+    primary = RunnableGenerator(_agenerate_empty)
+    runnable = primary.with_fallbacks([])
+    assert [c async for c in runnable.astream({})] == []
+
+
 class FakeStructuredOutputModel(BaseChatModel):
     foo: int
 


### PR DESCRIPTION
Closes #38892

---

`RunnableWithFallbacks.stream()`/`astream()` decide whether each runnable "succeeded" by peeking its first chunk with `next(stream)` / `anext(stream)`. When the upstream stream is legitimately empty (an LLM returning empty content, a filtering step, or a moderation-blocked response) that peek raises `StopIteration` / `StopAsyncIteration`, both of which are `Exception` subclasses. With the default `exceptions_to_handle=(Exception,)` that Stop signal was caught and treated exactly like a real runtime failure, which produced two bad outcomes:

1. When a fallback was configured, its output silently replaced the primary's valid empty output, with no error or warning.
2. When no fallback was configured, the `StopIteration` escaped the generator and PEP 479 converted it into `RuntimeError: generator raised StopIteration`.

This guards the first-chunk peek so an exhausted stream completes the run successfully and yields an empty stream, instead of being misclassified as a failure. The non-empty and genuine-error paths are unchanged.

Tests added cover both `stream` and `astream` for the empty-primary case, with and without a fallback, asserting the fallback is not triggered and no error is raised.

## Release note
`RunnableWithFallbacks.stream()`/`astream()` no longer treat a legitimately empty upstream stream as a failure. An empty primary stream now completes the run and yields nothing, instead of silently triggering a fallback (or raising `RuntimeError` when no fallback is configured).

This contribution was prepared with assistance from an AI agent (Hermes Agent).
