### PR TITLE
feat(huggingface): support torch.accelerator device discovery

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -248,7 +248,7 @@ class HuggingFacePipeline(BaseLLM):
             logger.warning(
                 f"Setting the `device` argument to None from {device} to avoid "
                 "the error caused by attempting to move the model that was already "
-                "loaded on the GPU using the Accelerate module to the same or "
+                "loaded on the accelerator using the Accelerate module to the same or "
                 "another device."
             )
             device = None
@@ -260,22 +260,26 @@ class HuggingFacePipeline(BaseLLM):
         ):
             import torch
 
-            cuda_device_count = torch.cuda.device_count()
-            if device < -1 or (device >= cuda_device_count):
+            if hasattr(torch, "accelerator"):
+                accelerator_device_count = torch.accelerator.device_count()
+            else:
+                accelerator_device_count = torch.cuda.device_count()
+
+            if device < -1 or (device >= accelerator_device_count):
                 msg = (
                     f"Got device=={device}, "
-                    f"device is required to be within [-1, {cuda_device_count})"
+                    f"device is required to be within [-1, {accelerator_device_count})"
                 )
                 raise ValueError(msg)
             if device_map is not None and device < 0:
                 device = None
-            if device is not None and device < 0 and cuda_device_count > 0:
+            if device is not None and device < 0 and accelerator_device_count > 0:
                 logger.warning(
-                    "Device has %d GPUs available. "
+                    "Device has %d accelerators available. "
                     "Provide device={deviceId} to `from_model_id` to use available"
-                    "GPUs for execution. deviceId is -1 (default) for CPU and "
-                    "can be a positive integer associated with CUDA device id.",
-                    cuda_device_count,
+                    "accelerators for execution. deviceId is -1 (default) for CPU and "
+                    "can be a positive integer associated with an accelerator device id.",
+                    accelerator_device_count,
                 )
         if device is not None and device_map is not None and backend == "openvino":
             logger.warning("Please set device for OpenVINO through: `model_kwargs`")

--- a/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_huggingface_pipeline.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock, patch
+import pytest
 
 from langchain_huggingface import HuggingFacePipeline
 
@@ -45,3 +46,107 @@ def test_initialization_with_from_model_id(
     )
 
     assert llm.model_id == "mock-model-id"
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+@patch("transformers.AutoModelForCausalLM.from_pretrained")
+@patch("transformers.pipeline")
+@patch("torch.cuda.device_count")
+def test_from_model_id_older_pytorch(
+    mock_device_count: MagicMock, mock_pipeline: MagicMock, mock_model: MagicMock, mock_tokenizer: MagicMock
+) -> None:
+    import torch
+    
+    mock_tokenizer.return_value = MagicMock(pad_token_id=0)
+    mock_model.return_value = MagicMock(is_loaded_in_4bit=False, is_loaded_in_8bit=False)
+    mock_pipe = MagicMock()
+    mock_pipe.task = "text-generation"
+    mock_pipe.model = mock_model.return_value
+    mock_pipeline.return_value = mock_pipe
+
+    # Simulate older PyTorch by deleting 'accelerator' attribute if it exists
+    original_accelerator = None
+    if hasattr(torch, "accelerator"):
+        original_accelerator = torch.accelerator
+        delattr(torch, "accelerator")
+
+    try:
+        mock_device_count.return_value = 2
+
+        # Valid device
+        HuggingFacePipeline.from_model_id(
+            model_id="mock-model-id", task="text-generation", device=0
+        )
+
+        # Invalid device
+        with pytest.raises(ValueError, match="device is required to be within \\[-1, 2\\)"):
+            HuggingFacePipeline.from_model_id(
+                model_id="mock-model-id", task="text-generation", device=2
+            )
+            
+        # device=-1
+        HuggingFacePipeline.from_model_id(
+            model_id="mock-model-id", task="text-generation", device=-1
+        )
+    finally:
+        if original_accelerator is not None:
+            torch.accelerator = original_accelerator
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+@patch("transformers.AutoModelForCausalLM.from_pretrained")
+@patch("transformers.pipeline")
+def test_from_model_id_newer_pytorch(
+    mock_pipeline: MagicMock, mock_model: MagicMock, mock_tokenizer: MagicMock
+) -> None:
+    import torch
+    
+    mock_tokenizer.return_value = MagicMock(pad_token_id=0)
+    mock_model.return_value = MagicMock(is_loaded_in_4bit=False, is_loaded_in_8bit=False)
+    mock_pipe = MagicMock()
+    mock_pipe.task = "text-generation"
+    mock_pipe.model = mock_model.return_value
+    mock_pipeline.return_value = mock_pipe
+
+    mock_accelerator = MagicMock()
+    mock_accelerator.device_count.return_value = 2
+    
+    with patch.object(torch, "accelerator", mock_accelerator, create=True):
+        # Valid device
+        HuggingFacePipeline.from_model_id(
+            model_id="mock-model-id", task="text-generation", device=1
+        )
+
+        # Invalid device
+        with pytest.raises(ValueError, match="device is required to be within \\[-1, 2\\)"):
+            HuggingFacePipeline.from_model_id(
+                model_id="mock-model-id", task="text-generation", device=3
+            )
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+@patch("transformers.AutoModelForCausalLM.from_pretrained")
+@patch("transformers.pipeline")
+@patch("langchain_huggingface.llms.huggingface_pipeline.logger.warning")
+def test_from_model_id_accelerator_warning(
+    mock_warning: MagicMock, mock_pipeline: MagicMock, mock_model: MagicMock, mock_tokenizer: MagicMock
+) -> None:
+    import torch
+    
+    mock_tokenizer.return_value = MagicMock(pad_token_id=0)
+    mock_model.return_value = MagicMock(is_loaded_in_4bit=False, is_loaded_in_8bit=False)
+    mock_pipe = MagicMock()
+    mock_pipe.task = "text-generation"
+    mock_pipe.model = mock_model.return_value
+    mock_pipeline.return_value = mock_pipe
+
+    mock_accelerator = MagicMock()
+    mock_accelerator.device_count.return_value = 2
+    
+    with patch.object(torch, "accelerator", mock_accelerator, create=True):
+        HuggingFacePipeline.from_model_id(
+            model_id="mock-model-id", task="text-generation", device=-1
+        )
+        mock_warning.assert_called_once()
+        assert "Device has %d accelerators available" in mock_warning.call_args[0][0]
+        assert mock_warning.call_args[0][1] == 2


### PR DESCRIPTION
Fixes #
## Summary

This PR updates `HuggingFacePipeline.from_model_id` to use the device-agnostic `torch.accelerator.device_count()` API when available (PyTorch ≥ 2.6), while preserving the existing `torch.cuda.device_count()` fallback for older PyTorch versions.

### Changes

- Prefer `torch.accelerator.device_count()` when available.
- Fall back to `torch.cuda.device_count()` for older PyTorch versions.
- Use accelerator device count for device validation and availability checks.
- Update user-facing warning messages to use generic accelerator terminology instead of CUDA/GPU where appropriate.
- Add unit tests covering both compatibility paths.

### Motivation

This enables correct device validation on non-CUDA accelerator backends (such as Intel XPU) while remaining fully backward compatible with existing CUDA workflows.

Closes #38855 
---

<!-- Keep the `Fixes #xx` keyword at the very top and update the issue number — this auto-closes the issue on merge. Replace this comment with a 1-2 sentence description of your change. No `# Summary` header; the description is the summary. -->

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangChain! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

  - Examples:
    - fix(anthropic): resolve flag parsing error
    - feat(core): add multi-tenant support
    - test(openai): update API usage tests
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langchain/blob/master/.github/workflows/pr_lint.yml#L15-L33

2. PR description:

  - Write 1-2 sentences that make the change easy to understand: who benefits, what problem they had, and how this solves it. Prefer a simple user story over a long summary.
  - The `Fixes #xx` line at the top is **required** for external contributions — update the issue number and keep the keyword. This links your PR to the approved issue and auto-closes it on merge.
  - If there are any breaking changes, please clearly describe them.
  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.

## Release note
<!-- Required for net new features or behavior-changing bugfixes. State the user-visible change in release-note-ready language. Omit this section for chores, refactors, or test-only changes. -->

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

4. How did you verify your code works?

Additional guidelines:

  - All external PRs must link to an issue or discussion where a solution has been approved by a maintainer, and you must be assigned to that issue. PRs without prior approval will be closed.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/
