### PR TITLE
fix(core): stop incremental indexing from re-embedding unchanged docs across batches

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -466,6 +466,7 @@ def index(
     num_updated = 0
     num_deleted = 0
     scoped_full_cleanup_source_ids: set[str] = set()
+    incremental_cleanup_source_ids: set[str] = set()
 
     for doc_batch in _batch(batch_size, doc_iterator):
         # Track original batch size before deduplication
@@ -500,6 +501,8 @@ def index(
                     raise ValueError(msg)
                 if cleanup == "scoped_full":
                     scoped_full_cleanup_source_ids.add(source_id)
+                if cleanup == "incremental":
+                    incremental_cleanup_source_ids.add(source_id)
             # Source IDs cannot be None after for loop above.
             source_ids = cast("Sequence[str]", source_ids)
 
@@ -556,29 +559,24 @@ def index(
             time_at_least=index_start_dt,
         )
 
-        # If source IDs are provided, we can do the deletion incrementally!
-        if cleanup == "incremental":
-            # Get the uids of the documents that were not returned by the loader.
-            # mypy isn't good enough to determine that source IDs cannot be None
-            # here due to a check that's happening above, so we check again.
-            for source_id in source_ids:
-                if source_id is None:
-                    msg = (
-                        "source_id cannot be None at this point. "
-                        "Reached unreachable code."
-                    )
-                    raise AssertionError(msg)
+    # If source IDs are provided, we can do the deletion incrementally!
+    # This is done after all batches have been processed (rather than per
+    # batch) so that documents from a later batch sharing a source_id with
+    # an earlier batch aren't mistaken for stale documents and deleted
+    # before they've been indexed in this same run.
+    if cleanup == "incremental" and incremental_cleanup_source_ids:
+        incremental_cleanup_source_ids_ = list(incremental_cleanup_source_ids)
 
-            source_ids_ = cast("Sequence[str]", source_ids)
-
-            while uids_to_delete := record_manager.list_keys(
-                group_ids=source_ids_, before=index_start_dt, limit=cleanup_batch_size
-            ):
-                # Then delete from vector store.
-                _delete(destination, uids_to_delete)
-                # First delete from record store.
-                record_manager.delete_keys(uids_to_delete)
-                num_deleted += len(uids_to_delete)
+        while uids_to_delete := record_manager.list_keys(
+            group_ids=incremental_cleanup_source_ids_,
+            before=index_start_dt,
+            limit=cleanup_batch_size,
+        ):
+            # Then delete from vector store.
+            _delete(destination, uids_to_delete)
+            # First delete from record store.
+            record_manager.delete_keys(uids_to_delete)
+            num_deleted += len(uids_to_delete)
 
     if cleanup == "full" or (
         cleanup == "scoped_full" and scoped_full_cleanup_source_ids
@@ -816,6 +814,7 @@ async def aindex(
     num_updated = 0
     num_deleted = 0
     scoped_full_cleanup_source_ids: set[str] = set()
+    incremental_cleanup_source_ids: set[str] = set()
 
     async for doc_batch in _abatch(batch_size, async_doc_iterator):
         # Track original batch size before deduplication
@@ -850,6 +849,8 @@ async def aindex(
                     raise ValueError(msg)
                 if cleanup == "scoped_full":
                     scoped_full_cleanup_source_ids.add(source_id)
+                if cleanup == "incremental":
+                    incremental_cleanup_source_ids.add(source_id)
             # Source IDs cannot be None after for loop above.
             source_ids = cast("Sequence[str]", source_ids)
 
@@ -905,31 +906,24 @@ async def aindex(
             time_at_least=index_start_dt,
         )
 
-        # If source IDs are provided, we can do the deletion incrementally!
+    # If source IDs are provided, we can do the deletion incrementally!
+    # This is done after all batches have been processed (rather than per
+    # batch) so that documents from a later batch sharing a source_id with
+    # an earlier batch aren't mistaken for stale documents and deleted
+    # before they've been indexed in this same run.
+    if cleanup == "incremental" and incremental_cleanup_source_ids:
+        incremental_cleanup_source_ids_ = list(incremental_cleanup_source_ids)
 
-        if cleanup == "incremental":
-            # Get the uids of the documents that were not returned by the loader.
-
-            # mypy isn't good enough to determine that source IDs cannot be None
-            # here due to a check that's happening above, so we check again.
-            for source_id in source_ids:
-                if source_id is None:
-                    msg = (
-                        "source_id cannot be None at this point. "
-                        "Reached unreachable code."
-                    )
-                    raise AssertionError(msg)
-
-            source_ids_ = cast("Sequence[str]", source_ids)
-
-            while uids_to_delete := await record_manager.alist_keys(
-                group_ids=source_ids_, before=index_start_dt, limit=cleanup_batch_size
-            ):
-                # Then delete from vector store.
-                await _adelete(destination, uids_to_delete)
-                # First delete from record store.
-                await record_manager.adelete_keys(uids_to_delete)
-                num_deleted += len(uids_to_delete)
+        while uids_to_delete := await record_manager.alist_keys(
+            group_ids=incremental_cleanup_source_ids_,
+            before=index_start_dt,
+            limit=cleanup_batch_size,
+        ):
+            # Then delete from vector store.
+            await _adelete(destination, uids_to_delete)
+            # First delete from record store.
+            await record_manager.adelete_keys(uids_to_delete)
+            num_deleted += len(uids_to_delete)
 
     if cleanup == "full" or (
         cleanup == "scoped_full" and scoped_full_cleanup_source_ids

--- a/libs/core/tests/unit_tests/indexing/test_indexing.py
+++ b/libs/core/tests/unit_tests/indexing/test_indexing.py
@@ -1617,6 +1617,9 @@ def test_incremental_indexing_with_batch_size(
     }
     assert doc_texts == {"1", "2", "3", "4"}
 
+    # Re-indexing the same documents should skip all of them without
+    # redundant deletes and re-adds, even when batch_size < the number of
+    # docs sharing a source_id. (Fixes #32612)
     with patch.object(
         record_manager,
         "get_time",
@@ -1631,9 +1634,9 @@ def test_incremental_indexing_with_batch_size(
             batch_size=2,
             key_encoder="sha256",
         ) == {
-            "num_added": 2,
-            "num_deleted": 2,
-            "num_skipped": 2,
+            "num_added": 0,
+            "num_deleted": 0,
+            "num_skipped": 4,
             "num_updated": 0,
         }
 
@@ -1643,6 +1646,177 @@ def test_incremental_indexing_with_batch_size(
         for uid in vector_store.store
     }
     assert doc_texts == {"1", "2", "3", "4"}
+
+
+def test_incremental_indexing_with_batch_size_no_redundant_work(
+    record_manager: InMemoryRecordManager, vector_store: InMemoryVectorStore
+) -> None:
+    """Regression test for #32612.
+
+    Re-indexing unchanged docs with batch_size < total docs sharing a
+    source_id should not cause redundant deletes and re-adds.
+    """
+    docs = [
+        Document(page_content=str(i), metadata={"source": "same_source"})
+        for i in range(10)
+    ]
+
+    with patch.object(
+        record_manager,
+        "get_time",
+        return_value=datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp(),
+    ):
+        assert index(
+            docs,
+            record_manager,
+            vector_store,
+            cleanup="incremental",
+            source_id_key="source",
+            batch_size=3,
+            key_encoder="sha256",
+        ) == {
+            "num_added": 10,
+            "num_deleted": 0,
+            "num_skipped": 0,
+            "num_updated": 0,
+        }
+
+    with patch.object(
+        record_manager,
+        "get_time",
+        return_value=datetime(2021, 1, 2, tzinfo=timezone.utc).timestamp(),
+    ):
+        assert index(
+            docs,
+            record_manager,
+            vector_store,
+            cleanup="incremental",
+            source_id_key="source",
+            batch_size=3,
+            key_encoder="sha256",
+        ) == {
+            "num_added": 0,
+            "num_deleted": 0,
+            "num_skipped": 10,
+            "num_updated": 0,
+        }
+
+
+async def test_aincremental_indexing_with_batch_size_no_redundant_work(
+    arecord_manager: InMemoryRecordManager, vector_store: InMemoryVectorStore
+) -> None:
+    """Async regression test for #32612.
+
+    Re-indexing unchanged docs with batch_size < total docs sharing a
+    source_id should not cause redundant deletes and re-adds.
+    """
+    docs = [
+        Document(page_content=str(i), metadata={"source": "same_source"})
+        for i in range(10)
+    ]
+
+    with patch.object(
+        arecord_manager,
+        "get_time",
+        return_value=datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp(),
+    ):
+        assert await aindex(
+            docs,
+            arecord_manager,
+            vector_store,
+            cleanup="incremental",
+            source_id_key="source",
+            batch_size=3,
+            key_encoder="sha256",
+        ) == {
+            "num_added": 10,
+            "num_deleted": 0,
+            "num_skipped": 0,
+            "num_updated": 0,
+        }
+
+    with patch.object(
+        arecord_manager,
+        "get_time",
+        return_value=datetime(2021, 1, 2, tzinfo=timezone.utc).timestamp(),
+    ):
+        assert await aindex(
+            docs,
+            arecord_manager,
+            vector_store,
+            cleanup="incremental",
+            source_id_key="source",
+            batch_size=3,
+            key_encoder="sha256",
+        ) == {
+            "num_added": 0,
+            "num_deleted": 0,
+            "num_skipped": 10,
+            "num_updated": 0,
+        }
+
+
+def test_incremental_indexing_with_batch_size_stale_docs_still_cleaned_up(
+    record_manager: InMemoryRecordManager, vector_store: InMemoryVectorStore
+) -> None:
+    """Regression test for #32612.
+
+    Moving incremental cleanup outside the batch loop must not stop it
+    from deleting documents that are genuinely stale (no longer returned
+    by the loader), even when batch_size < total docs sharing a
+    source_id.
+    """
+    docs = [
+        Document(page_content=str(i), metadata={"source": "same_source"})
+        for i in range(6)
+    ]
+
+    with patch.object(
+        record_manager,
+        "get_time",
+        return_value=datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp(),
+    ):
+        assert index(
+            docs,
+            record_manager,
+            vector_store,
+            cleanup="incremental",
+            source_id_key="source",
+            batch_size=3,
+            key_encoder="sha256",
+        ) == {
+            "num_added": 6,
+            "num_deleted": 0,
+            "num_skipped": 0,
+            "num_updated": 0,
+        }
+
+    # Second run only returns half the docs for the same source_id - the
+    # other half should be cleaned up.
+    with patch.object(
+        record_manager,
+        "get_time",
+        return_value=datetime(2021, 1, 2, tzinfo=timezone.utc).timestamp(),
+    ):
+        assert index(
+            docs[:3],
+            record_manager,
+            vector_store,
+            cleanup="incremental",
+            source_id_key="source",
+            batch_size=3,
+            key_encoder="sha256",
+        ) == {
+            "num_added": 0,
+            "num_deleted": 3,
+            "num_skipped": 3,
+            "num_updated": 0,
+        }
+
+    doc_texts = {
+        vector_store.get_by_ids([uid])[0].page_content for uid in vector_store.store
+    }
+    assert doc_texts == {"0", "1", "2"}
 
 
 def test_incremental_delete_with_batch_size(


### PR DESCRIPTION
## Summary

Fixes #32612.

`index()`/`aindex()` ran the incremental-cleanup delete pass **inside** the per-batch loop, querying `record_manager.list_keys(group_ids=source_ids, before=index_start_dt, ...)` using only the current batch's `source_ids`. When `batch_size` splits documents that share a `source_id` across multiple batches, each batch's cleanup pass deletes *any* record under that `source_id` with a stale timestamp — including documents belonging to sibling batches that haven't been reprocessed yet in the same run (their timestamp hasn't been bumped to `index_start_dt` yet).

Net effect: every subsequent call to `index()`/`aindex()` with `cleanup="incremental"` and `batch_size` smaller than the number of docs sharing a `source_id` redundantly deletes and re-adds (re-embeds) documents that never actually changed — wasting embedding calls/GPU time on every run, not just the first.

## Fix

Collect the `source_id`s seen across all batches during the loop, then run the incremental-cleanup delete pass once, after the loop completes (mirroring how `scoped_full`/`full` cleanup already run after the loop). This guarantees every batch has already had its timestamp refreshed before any staleness check runs.

## Test plan

- Updated `test_incremental_indexing_with_batch_size`, which previously asserted the *buggy* behavior (`num_added: 2, num_deleted: 2` on a no-op re-index) as expected output; it now asserts `num_added: 0, num_deleted: 0, num_skipped: 4`.
- Added `test_incremental_indexing_with_batch_size_no_redundant_work` (sync) and `test_aincremental_indexing_with_batch_size_no_redundant_work` (async): 10 docs, one `source_id`, `batch_size=3`; re-indexing unchanged docs now yields `num_skipped: 10` with zero adds/deletes.
- Added `test_incremental_indexing_with_batch_size_stale_docs_still_cleaned_up` to guard against overcorrecting: when a doc genuinely drops out of the source on a later run, it's still deleted.
- Full `libs/core/tests/unit_tests/indexing/test_indexing.py` suite: 48 passed.
- `ruff check` / `ruff format --check` clean on pinned `ruff==0.15.5`; `mypy` clean on pinned `mypy==2.1.0`.