### PR TITLE
fix(core): _TracerCore __copy__/__deepcopy__ return self; tool list mutation; log stream error handling; Anthropic merge corruption

### DIFF
--- a/libs/core/langchain_core/tracers/core.py
+++ b/libs/core/langchain_core/tracers/core.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import traceback
 from abc import ABC, abstractmethod
@@ -556,12 +557,28 @@ class _TracerCore(ABC):
         return retrieval_run
 
     def __deepcopy__(self, memo: dict[int, Any] | None = None) -> _TracerCore:
-        """Return self deepcopied."""
-        return self
+        """Return a deep copy with isolated mutable state."""
+        cls = self.__class__
+        obj = cls.__new__(cls)
+        memo[id(self)] = obj
+        for k, v in self.__dict__.items():
+            if k in ("run_map", "order_map"):
+                setattr(obj, k, copy.deepcopy(v, memo))
+            elif k == "_external_run_ids":
+                setattr(obj, k, copy.deepcopy(v, memo))
+            else:
+                setattr(obj, k, copy.copy(v))
+        return obj
 
     def __copy__(self) -> _TracerCore:
-        """Return self copied."""
-        return self
+        """Return a shallow copy with isolated mutable dicts."""
+        cls = self.__class__
+        obj = cls.__new__(cls)
+        obj.__dict__.update(self.__dict__)
+        obj.run_map = self.run_map.copy()
+        obj.order_map = self.order_map.copy()
+        obj._external_run_ids = self._external_run_ids.copy()
+        return obj
 
     def _end_trace(self, run: Run) -> Coroutine[Any, Any, None] | None:
         """End a trace for a run.

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -1095,7 +1095,8 @@ async def _astream_events_implementation_v2(
             yield event
     except asyncio.CancelledError as exc:
         # Cancel the task if it's still running
-        task.cancel(exc.args[0] if exc.args else None)
+        cancel_msg = exc.args[0] if exc.args and isinstance(exc.args[0], str) else None
+        task.cancel(cancel_msg)
         raise
     finally:
         # Cancel the task if it's still running

--- a/libs/core/langchain_core/tracers/log_stream.py
+++ b/libs/core/langchain_core/tracers/log_stream.py
@@ -316,12 +316,11 @@ class LogStreamCallbackHandler(BaseTracer, _StreamingCallbackHandler[Any]):
         Returns:
             `True` if the patch was sent successfully, `False` if the stream is closed.
         """
-        # We will likely want to wrap this in try / except at some point
-        # to handle exceptions that might arise at run time.
-        # For now we'll let the exception bubble up, and always return
-        # True on the happy path.
-        self.send_stream.send_nowait(RunLogPatch(*ops))
-        return True
+        try:
+            self.send_stream.send_nowait(RunLogPatch(*ops))
+            return True
+        except Exception:
+            return False
 
     async def tap_output_aiter(
         self, run_id: UUID, output: AsyncIterator[T]

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1434,7 +1434,7 @@ def create_agent(
         """Sync model request handler with sequential middleware processing."""
         request = ModelRequest(
             model=model,
-            tools=default_tools,
+            tools=list(default_tools),
             system_message=system_message,
             response_format=initial_response_format,
             messages=state["messages"],
@@ -1482,7 +1482,7 @@ def create_agent(
         """Async model request handler with sequential middleware processing."""
         request = ModelRequest(
             model=model,
-            tools=default_tools,
+            tools=list(default_tools),
             system_message=system_message,
             response_format=initial_response_format,
             messages=state["messages"],

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -289,7 +289,9 @@ def _merge_messages(
 ) -> list[SystemMessage | AIMessage | HumanMessage]:
     """Merge runs of human/tool messages into single human messages with content blocks."""  # noqa: E501
     merged: list = []
+    last_was_tool = False
     for curr in messages:
+        was_tool = isinstance(curr, ToolMessage)
         if isinstance(curr, ToolMessage):
             if (
                 isinstance(curr.content, list)
@@ -328,16 +330,30 @@ def _merge_messages(
                     [tool_result],
                 )
         last = merged[-1] if merged else None
-        if any(
-            all(isinstance(m, c) for m in (curr, last))
-            for c in (SystemMessage, HumanMessage)
-        ):
-            if isinstance(cast("BaseMessage", last).content, str):
-                new_content: list = [
-                    {"type": "text", "text": cast("BaseMessage", last).content},
-                ]
+        if last is not None and isinstance(curr, HumanMessage) and isinstance(last, HumanMessage):
+            if was_tool and not last_was_tool:
+                merged.append(curr)
             else:
-                new_content = copy.copy(cast("list", cast("BaseMessage", last).content))
+                if isinstance(cast("BaseMessage", last).content, str):
+                    new_content: list = [
+                        {"type": "text", "text": cast("BaseMessage", last).content},
+                    ]
+                else:
+                    new_content = copy.copy(cast("list", cast("BaseMessage", last).content))
+                if isinstance(curr.content, str):
+                    new_content.append({"type": "text", "text": curr.content})
+                else:
+                    new_content.extend(curr.content)
+                merged[-1] = curr.model_copy(update={"content": new_content})
+        elif (
+            last is not None
+            and isinstance(last, SystemMessage)
+            and isinstance(curr, SystemMessage)
+        ):
+            if isinstance(last.content, str):
+                new_content = [{"type": "text", "text": last.content}]
+            else:
+                new_content = copy.copy(cast("list", last.content))
             if isinstance(curr.content, str):
                 new_content.append({"type": "text", "text": curr.content})
             else:
@@ -345,6 +361,10 @@ def _merge_messages(
             merged[-1] = curr.model_copy(update={"content": new_content})
         else:
             merged.append(curr)
+        if isinstance(curr, HumanMessage) or isinstance(curr, SystemMessage):
+            last_was_tool = was_tool
+        else:
+            last_was_tool = False
     return merged
 
 


### PR DESCRIPTION
Closes #38958

---

A handful of bugs found while auditing the tracer, agent factory, and Anthropic message formatting code.

1. \_TracerCore.__copy__\ / \__deepcopy__\ returned \self\ instead of an actual copy. Every 'copy' referenced the same instance, so concurrent chain runs corrupted each other's trace data. The fix creates proper new instances.

2. \create_agent()\ built \default_tools\ once. Both closures captured the same list object. Any middleware that mutated \equest.tools\ in place changed the shared list for all subsequent calls. The fix passes \list(default_tools)\ to each request.

3. \LogStreamCallbackHandler.send()\ always returned \True\ even when \send_nowait\ failed. The fix wraps it in try/except.

4. \	ask.cancel(exc.args[0])\ could receive a non-string or missing argument. Fixed with a type guard.

5. Anthropic \_merge_messages\ converted ToolMessage to HumanMessage and then merged it with the preceding user message, corrupting message history. The fix tracks tool origin and skips the merge when a tool result follows a user message.

All existing unit tests pass.