### PR TITLE
fix(langchain): validate `InterruptOnConfig` instead of silently auto-approving

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -213,6 +213,10 @@ class InterruptOnConfig(TypedDict):
     """
 
 
+_INTERRUPT_ON_CONFIG_KEYS = frozenset(InterruptOnConfig.__annotations__)
+"""Valid keys for an `InterruptOnConfig` mapping, derived from the `TypedDict`."""
+
+
 class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
     """Human in the loop middleware."""
 
@@ -255,8 +259,30 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
                     resolved_configs[tool_name] = InterruptOnConfig(
                         allowed_decisions=["approve", "edit", "reject", "respond"]
                     )
-            elif tool_config.get("allowed_decisions"):
-                resolved_configs[tool_name] = tool_config
+                # `False` disables interrupts for the tool (documented auto-approve).
+                continue
+
+            # A mapping expresses intent to gate the tool behind a human. Validate
+            # it loudly: a typo'd key or a missing `allowed_decisions` previously
+            # dropped the entry silently, executing a tool the user explicitly
+            # listed for approval with no interrupt, error, or warning (#38838).
+            # For a safety middleware, raising is the correct failure direction.
+            unknown_keys = set(tool_config) - _INTERRUPT_ON_CONFIG_KEYS
+            if unknown_keys:
+                msg = (
+                    f"Invalid `InterruptOnConfig` for tool {tool_name!r}: unknown "
+                    f"key(s) {sorted(unknown_keys)}. Allowed keys: "
+                    f"{sorted(_INTERRUPT_ON_CONFIG_KEYS)}."
+                )
+                raise ValueError(msg)
+            if not tool_config.get("allowed_decisions"):
+                msg = (
+                    f"Invalid `InterruptOnConfig` for tool {tool_name!r}: "
+                    "`allowed_decisions` must be a non-empty list. To auto-approve "
+                    "this tool, set its value to `False` or omit it instead."
+                )
+                raise ValueError(msg)
+            resolved_configs[tool_name] = tool_config
         self.interrupt_on = resolved_configs
         self.description_prefix = description_prefix
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop.py
@@ -28,6 +28,34 @@ def test_human_in_the_loop_middleware_initialization() -> None:
     assert middleware.description_prefix == "Custom prefix"
 
 
+def test_human_in_the_loop_middleware_typo_key_raises() -> None:
+    """A typo'd key must raise instead of silently disabling the gate (#38838)."""
+    with pytest.raises(ValueError, match=r"delete_database.*unknown key.*allowed_decision"):
+        HumanInTheLoopMiddleware(
+            interrupt_on={"delete_database": {"allowed_decision": ["approve"]}}  # type: ignore[typeddict-unknown-key]
+        )
+
+
+def test_human_in_the_loop_middleware_missing_allowed_decisions_raises() -> None:
+    """A `when`-only config (no `allowed_decisions`) must raise, not auto-approve."""
+    with pytest.raises(ValueError, match=r"delete_database.*allowed_decisions.*non-empty"):
+        HumanInTheLoopMiddleware(
+            interrupt_on={"delete_database": {"when": lambda _req: True}}  # type: ignore[typeddict-item]
+        )
+
+
+def test_human_in_the_loop_middleware_empty_allowed_decisions_raises() -> None:
+    """An empty `allowed_decisions` list must raise instead of being dropped."""
+    with pytest.raises(ValueError, match=r"allowed_decisions.*non-empty"):
+        HumanInTheLoopMiddleware(interrupt_on={"delete_database": {"allowed_decisions": []}})
+
+
+def test_human_in_the_loop_middleware_false_auto_approves() -> None:
+    """`False` still disables interrupts for a tool without raising (unchanged path)."""
+    middleware = HumanInTheLoopMiddleware(interrupt_on={"safe_tool": False})
+    assert middleware.interrupt_on == {}
+
+
 def test_human_in_the_loop_middleware_no_interrupts_needed() -> None:
     """Test HumanInTheLoopMiddleware when no interrupts are needed."""
     middleware = HumanInTheLoopMiddleware(


### PR DESCRIPTION
Fixes #38838

---

`HumanInTheLoopMiddleware` lets you gate risky tools behind a human approval step by listing them in `interrupt_on`. Because `InterruptOnConfig` is a `TypedDict`, nothing checked those mappings at runtime — and the resolution loop kept an entry only when `allowed_decisions` was truthy. Every other mapping was dropped silently.

That meant a one-character typo turned a safety gate into unattended execution:

```python
HumanInTheLoopMiddleware(
    interrupt_on={"delete_database": {"allowed_decision": ["approve"]}}  # missing "s"
)
```

The user's intent is unmistakable — gate `delete_database` behind a human — but the entry vanished, `after_model` returned `None`, and the tool ran with no interrupt, no error, and no warning. The same happened for an empty `allowed_decisions` list and for a config carrying only `when` or `description`. For a safety middleware this is the worst possible failure direction: the misconfiguration disables the protection it was meant to configure, and nothing surfaces it.

Validation now happens at construction. A mapping with unknown keys, or with a missing/empty `allowed_decisions`, raises `ValueError` naming the offending tool and key(s) and pointing at `False` as the documented way to auto-approve. Unknown keys are rejected by name, so a typo is reported as a typo rather than discovered later through its side effect.

`False` (documented auto-approve), `True`, and valid dict configs resolve exactly as before.

**This tightens behavior:** configs that were silently ignored now raise at construction. Anyone affected was already not getting the gate they asked for, so the exception surfaces a pre-existing bug rather than breaking working code. Happy to switch to a warning if maintainers prefer a softer landing.

Tests cover the typo'd key, empty `allowed_decisions`, `when`-only config, unknown extra key, and regression coverage that valid dict/bool configs are unchanged.

## Release note

`HumanInTheLoopMiddleware` now raises `ValueError` at construction when an `interrupt_on` entry is an invalid `InterruptOnConfig` — unknown keys, or a missing or empty `allowed_decisions`. Previously such entries were silently discarded, causing tools explicitly listed for human approval to execute without any interrupt.

---

*This contribution was developed with assistance from an AI coding agent (Claude Code); all changes were reviewed and verified by the author.*
