### PR TITLE
fix(perplexity): copy `extra_body` when building the Responses payload

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -1074,10 +1074,21 @@ class ChatPerplexity(BaseChatModel):
                 payload["tools"] = [_flatten_responses_tool(tool) for tool in value]
                 continue
             if key in _RESPONSES_PASSTHROUGH_KEYS:
-                payload[key] = value
+                if key == "extra_body" and isinstance(value, dict):
+                    # Merge into a *copy* of the caller's dict so payload
+                    # construction never mutates caller-owned state (which would
+                    # otherwise leak per-call params into `model_kwargs` and every
+                    # later request). Merging (rather than overwriting) also keeps
+                    # any keys already routed here alive regardless of the order
+                    # `params` is iterated in.
+                    payload["extra_body"] = {**value, **payload.get("extra_body", {})}
+                else:
+                    payload[key] = value
                 continue
             # Unknown / Perplexity-specific keys: route under extra_body so the
             # SDK forwards them to the Agent API without breaking strict typing.
+            # `setdefault` returns the copy built above (or a fresh dict), so the
+            # write below never touches the caller's `extra_body`.
             extra_body = payload.setdefault("extra_body", {})
             if not isinstance(extra_body, dict):
                 msg = (

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -663,3 +663,52 @@ def test_convert_responses_stream_event_ignores_non_function_items() -> None:
         "item": {"type": "message", "content": "hi"},
     }
     assert _convert_responses_stream_event_to_chunk(event) is None
+
+
+def test_to_responses_payload_does_not_mutate_caller_extra_body() -> None:
+    """Building the payload must not mutate a caller-provided `extra_body` (#38840)."""
+    llm = ChatPerplexity(model="sonar-pro", api_key="test", use_responses_api=True)
+    shared = {"country": "US"}
+    payload = llm._to_responses_payload(
+        [], {"extra_body": shared, "search_mode": "academic"}, user_set_keys=set()
+    )
+    # The caller's dict is untouched...
+    assert shared == {"country": "US"}
+    # ...while the payload carries both the caller key and the routed key.
+    assert payload["extra_body"] == {"country": "US", "search_mode": "academic"}
+
+
+def test_to_responses_payload_does_not_leak_into_model_kwargs() -> None:
+    """A per-call param must not become permanent instance state (#38840).
+
+    `extra_body` set at construction lands in `model_kwargs`, and `_default_params`
+    merges `model_kwargs` by reference. Mutating it in place would bake a one-off
+    per-call key into every later request.
+    """
+    llm = ChatPerplexity(
+        model="sonar-pro",
+        api_key="test",
+        use_responses_api=True,
+        extra_body={"country": "US"},
+    )
+    # One call that routes a per-call-only key under extra_body.
+    params = {**llm._default_params, "search_mode": "academic"}
+    llm._to_responses_payload([], params, user_set_keys=set())
+    # The instance state must not have absorbed search_mode.
+    assert llm.model_kwargs == {"extra_body": {"country": "US"}}
+    # A second call without search_mode must not carry it.
+    p2 = llm._to_responses_payload([], dict(llm._default_params), user_set_keys=set())
+    assert p2.get("extra_body") == {"country": "US"}
+
+
+def test_to_responses_payload_routed_keys_survive_before_extra_body() -> None:
+    """Routed keys survive when they precede `extra_body` in iteration order.
+
+    Regression test for the ordering variant of #38840.
+    """
+    llm = ChatPerplexity(model="sonar-pro", api_key="test", use_responses_api=True)
+    # search_mode is routed under extra_body *before* the passthrough extra_body
+    # key is reached; it must not be dropped by the passthrough assignment.
+    params = {"search_mode": "academic", "extra_body": {"country": "US"}}
+    payload = llm._to_responses_payload([], params, user_set_keys=set())
+    assert payload["extra_body"] == {"country": "US", "search_mode": "academic"}


### PR DESCRIPTION
Fixes #38840

---

When `ChatPerplexity` builds a Responses-route payload, it routes Perplexity-specific keys (`search_mode`, `disable_search`, ...) under `extra_body` so the SDK forwards them without breaking strict typing. The passthrough branch stored the caller's `extra_body` dict **by reference**, and the routing code then wrote into it in place.

That mutates a dict the caller still owns. The consequence compounds: an `extra_body` set at construction lands in `model_kwargs`, and `_default_params` merges `model_kwargs` by reference — so a single per-call parameter such as `search_mode` gets baked into the instance and is silently resent on every subsequent request. A user passing `search_mode` once for one query finds it applied to every later query from that model instance, with nothing in their code to explain it.

There was a second, order-dependent bug in the same spot: any key routed into `extra_body` *before* the passthrough entry was reached got wiped by the overwrite, so whether a routed parameter survived depended on `params` iteration order.

Routed keys are now merged into a **copy** of the caller's dict. Payload construction no longer touches caller-owned state, and routed keys survive regardless of iteration order.

Same defect class as #38779 and #38659.

Tests assert the caller's `extra_body` dict is unchanged after payload construction, that a per-call parameter does not leak into a later request, and that routed keys survive alongside caller-supplied ones.

## Release note

Fixed `ChatPerplexity` mutating the caller's `extra_body` dict when building a Responses payload, which caused per-call parameters such as `search_mode` to be retained on the instance and resent on every subsequent request. Routed keys are now merged into a copy and no longer depend on iteration order to survive.

---

*This contribution was developed with assistance from an AI coding agent (Claude Code); all changes were reviewed and verified by the author.*
