### PR TITLE
fix(core): use materialized `texts_` in default `add_texts` and `aadd_texts`

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -86,7 +86,7 @@ class VectorStore(ABC):
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             if ids is not None:
                 # For backward compatibility
@@ -226,7 +226,7 @@ class VectorStore(ABC):
 
             docs = [
                 Document(id=id_, page_content=text, metadata=metadata_)
-                for text, metadata_, id_ in zip(texts, metadatas_, ids_, strict=False)
+                for text, metadata_, id_ in zip(texts_, metadatas_, ids_, strict=False)
             ]
             return await self.aadd_documents(docs, **kwargs)
         return await run_in_executor(None, self.add_texts, texts, metadatas, **kwargs)

--- a/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_vectorstore.py
@@ -292,3 +292,31 @@ async def test_default_afrom_documents(vs_class: type[VectorStore]) -> None:
     store = await vs_class.afrom_documents([original_document], embeddings, ids=["6"])
     assert original_document.id == "7"  # original document should not be modified
     assert await store.aget_by_ids(["6"]) == [Document(id="6", page_content="baz")]
+
+
+def test_default_add_texts_generator() -> None:
+    """Test default implementation of add_texts with a generator."""
+    store = CustomAddDocumentsVectorstore()
+
+    # Passing a generator
+    texts_gen = (t for t in ["hello", "world"])
+    ids = store.add_texts(texts_gen, ids=["3", "4"])
+    assert ids == ["3", "4"]
+    assert store.get_by_ids(["3", "4"]) == [
+        Document(id="3", page_content="hello"),
+        Document(id="4", page_content="world"),
+    ]
+
+
+async def test_default_aadd_texts_generator() -> None:
+    """Test default implementation of aadd_texts with a generator."""
+    store = CustomAddDocumentsVectorstore()
+
+    # Passing a generator
+    texts_gen = (t for t in ["hello", "world"])
+    ids = await store.aadd_texts(texts_gen, ids=["3", "4"])
+    assert ids == ["3", "4"]
+    assert await store.aget_by_ids(["3", "4"]) == [
+        Document(id="3", page_content="hello"),
+        Document(id="4", page_content="world"),
+    ]


### PR DESCRIPTION
Fixes #37673

---

Fixes a bug where passing a generator as the `texts` parameter to `add_texts` or `aadd_texts` resulted in zero documents being added to the vector store. This occurs because the generator is consumed during the length/validation checks to build `texts_`, but the subsequent document creation loop still references the original exhausted `texts` generator instead of the materialized `texts_` sequence.

### 🛑 Current Buggy Behavior (Generator Exhaustion)

```mermaid
graph TD
    A[texts: Generator] --> B["texts_: List = list(texts) (exhausts generator)"]
    B --> C["zip(texts, metadatas_) (references empty texts)"]
    C --> D["Result: zero documents created & added"]
```

### ✅ Fixed Behavior (Using Materialized Sequence)

```mermaid
graph TD
    A[texts: Generator] --> B["texts_: List = list(texts) (exhausts generator)"]
    B --> C["zip(texts_, metadatas_) (references materialized list)"]
    C --> D["Result: all documents successfully created & added"]
```

### Value / Benefits
1. **Prevents Silent Failure**: Users passing generators (e.g., streaming chunks from document loaders or database cursors) no longer experience silent ingestion failures.
2. **Defensive API Design**: Robustly handles any `Iterable[str]` as documented in the type signature, fulfilling the Python iterator protocol contract.

## Release note
- fix(core): fix generator input exhaustion in `VectorStore.add_texts` and `aadd_texts` default implementations.

### Verification
Added sync and async unit tests:
- `test_default_add_texts_generator`
- `test_default_aadd_texts_generator`

Verified with `make lint` and `uv run pytest tests/unit_tests/vectorstores/test_vectorstore.py` passing locally.
