### PR TITLE
fix(core): don't short-circuit mustache dotted-path lookup on a falsy intermediate

### DIFF
--- a/libs/core/langchain_core/utils/mustache.py
+++ b/libs/core/langchain_core/utils/mustache.py
@@ -389,10 +389,6 @@ def _get_key(
             )
             # For every dot separated key
             for child in key.split("."):
-                # Return an empty string if falsy, with two exceptions
-                # 0 should return 0, and False should return False
-                if resolved_scope in (0, False):
-                    return resolved_scope
                 # Move into the scope
                 if isinstance(resolved_scope, dict):
                     try:

--- a/libs/core/tests/unit_tests/utils/test_mustache.py
+++ b/libs/core/tests/unit_tests/utils/test_mustache.py
@@ -1,0 +1,27 @@
+"""Tests for the vendored mustache renderer."""
+
+from langchain_core.utils.mustache import render
+
+
+def test_dotted_path_through_falsy_intermediate_zero() -> None:
+    # `x` is the scalar 0, which has no member `y`, so `x.y` does not resolve
+    # and should render empty -- not leak the intermediate value `0`.
+    assert render("a{{x.y}}b", {"x": 0}) == "ab"
+
+
+def test_dotted_path_through_falsy_intermediate_false() -> None:
+    assert render("a{{x.y}}b", {"x": False}) == "ab"
+
+
+def test_dotted_path_final_zero_is_rendered() -> None:
+    # When the full path resolves to 0, 0 must still render as "0".
+    assert render("a{{x.y}}b", {"x": {"y": 0}}) == "a0b"
+
+
+def test_dotted_path_final_false_is_rendered() -> None:
+    assert render("a{{x.y}}b", {"x": {"y": False}}) == "aFalseb"
+
+
+def test_top_level_falsy_is_rendered() -> None:
+    assert render("a{{x}}b", {"x": 0}) == "a0b"
+    assert render("a{{x}}b", {"x": False}) == "aFalseb"


### PR DESCRIPTION
Fixes #38967

`langchain_core.utils.mustache._get_key` checked `resolved_scope in (0, False)` at the top of the dotted-path loop, so a middle path segment resolving to `0`/`False` was returned immediately instead of continuing the lookup — making `{{x.y}}` render `"0"`/`"False"` (the value of `x`) instead of `""` when `x` is a falsy scalar with no member `y`. Reproducible example in #38967.

The "`0`/`False` render as themselves" behavior for the final resolved value is already handled by the post-loop check, so this removes only the erroneous in-loop early return, matching the mustache spec and the `chevron` reference the module is adapted from.

Verified the final-value case is unchanged (`{{x.y}}` with `{'x': {'y': 0}}` still returns `'a0b'`, `{{x}}` with `x=0` still `'0'`). Adds `tests/unit_tests/utils/test_mustache.py`; prompt tests + new tests pass (45). Distinct from #38555 (falsy list-section items).