### PR TITLE
feat(langchain): add `DeduplicateToolCallsMiddleware` to collapse parallel tool calls

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -20,6 +20,7 @@ from langchain.agents.middleware.shell_tool import (
     RedactionRule,
     ShellToolMiddleware,
 )
+from langchain.agents.middleware.deduplicate import DeduplicateToolCallsMiddleware
 from langchain.agents.middleware.summarization import SummarizationMiddleware, TriggerClause
 from langchain.agents.middleware.todo import TodoListMiddleware
 from langchain.agents.middleware.tool_call_limit import ToolCallLimitMiddleware
@@ -90,4 +91,5 @@ __all__ = [
     "hook_config",
     "wrap_model_call",
     "wrap_tool_call",
+    "DeduplicateToolCallsMiddleware"
 ]

--- a/libs/langchain_v1/langchain/agents/middleware/deduplicate.py
+++ b/libs/langchain_v1/langchain/agents/middleware/deduplicate.py
@@ -1,0 +1,162 @@
+"""Middleware to deduplicate parallel tool calls."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import AIMessage, BaseMessage
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    AgentState,
+    ContextT,
+    ModelResponse,
+    ResponseT,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ModelRequest
+
+
+def _canonicalize_args(args: Any) -> str:
+    """Canonicalize arguments by sorting keys in any nested dictionaries.
+
+    Args:
+        args: The arguments to canonicalize.
+
+    Returns:
+        A JSON string representation of the arguments with sorted keys.
+    """
+    try:
+        return json.dumps(args, sort_keys=True)
+    except Exception:
+        return str(args)
+
+
+class DeduplicateToolCallsMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
+    """Middleware that deduplicates identical parallel tool calls within a single AIMessage.
+
+    When using tool-calling models, the model may emit duplicate parallel tool calls
+    (same tool name and equivalent arguments, sometimes with reordered JSON keys).
+    This middleware filters out duplicate tool calls, preserving only the first
+    occurrence of each unique tool call in the `AIMessage`.
+
+    Example:
+        ```python
+        from langchain.agents import create_agent
+        from langchain.agents.middleware import DeduplicateToolCallsMiddleware
+
+        agent = create_agent(
+            model=model,
+            tools=tools,
+            middleware=[DeduplicateToolCallsMiddleware()],
+        )
+        ```
+    """
+
+    def _deduplicate_message(self, message: BaseMessage) -> BaseMessage:
+        """Deduplicate tool calls in an AIMessage.
+
+        Args:
+            message: The message to deduplicate.
+
+        Returns:
+            The message with duplicate tool calls removed.
+        """
+        if not isinstance(message, AIMessage):
+            return message
+
+        has_tool_calls = bool(message.tool_calls)
+        has_invalid_tool_calls = bool(getattr(message, "invalid_tool_calls", None))
+
+        if not has_tool_calls and not has_invalid_tool_calls:
+            return message
+
+        seen_keys = set()
+        update_dict: dict[str, Any] = {}
+
+        if has_tool_calls:
+            deduplicated_tool_calls = []
+            for tool_call in message.tool_calls:
+                name = tool_call.get("name") if isinstance(tool_call, dict) else getattr(tool_call, "name", None)
+                args = tool_call.get("args") if isinstance(tool_call, dict) else getattr(tool_call, "args", None)
+                key = (name, _canonicalize_args(args))
+                if key not in seen_keys:
+                    seen_keys.add(key)
+                    deduplicated_tool_calls.append(tool_call)
+            update_dict["tool_calls"] = deduplicated_tool_calls
+
+        if has_invalid_tool_calls:
+            deduplicated_invalid_tool_calls = []
+            for invalid_call in message.invalid_tool_calls:
+                name = (
+                    invalid_call.get("name")
+                    if isinstance(invalid_call, dict)
+                    else getattr(invalid_call, "name", None)
+                )
+                args = (
+                    invalid_call.get("args")
+                    if isinstance(invalid_call, dict)
+                    else getattr(invalid_call, "args", None)
+                )
+                key = (name, _canonicalize_args(args))
+                if key not in seen_keys:
+                    seen_keys.add(key)
+                    deduplicated_invalid_tool_calls.append(invalid_call)
+            update_dict["invalid_tool_calls"] = deduplicated_invalid_tool_calls
+
+        if hasattr(message, "model_copy"):
+            return message.model_copy(update=update_dict)
+        return message.copy(update=update_dict)
+
+    def _deduplicate_response(self, response: ModelResponse[ResponseT]) -> ModelResponse[ResponseT]:
+        """Deduplicate tool calls in the model response result messages.
+
+        Args:
+            response: The original model response.
+
+        Returns:
+            A model response with deduplicated messages.
+        """
+        deduplicated_messages = [self._deduplicate_message(msg) for msg in response.result]
+        return ModelResponse(
+            result=deduplicated_messages,
+            structured_response=response.structured_response,
+        )
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
+    ) -> ModelResponse[ResponseT]:
+        """Intercept model call and deduplicate parallel tool calls in the response.
+
+        Args:
+            request: The model call request.
+            handler: The handler to execute the model call.
+
+        Returns:
+            The model response with deduplicated tool calls.
+        """
+        response = handler(request)
+        return self._deduplicate_response(response)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest[ContextT],
+        handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
+    ) -> ModelResponse[ResponseT]:
+        """Intercept model call and deduplicate parallel tool calls in the response asynchronously.
+
+        Args:
+            request: The model call request.
+            handler: The handler to execute the model call.
+
+        Returns:
+            The model response with deduplicated tool calls.
+        """
+        response = await handler(request)
+        return self._deduplicate_response(response)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_deduplicate.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_deduplicate.py
@@ -1,0 +1,94 @@
+"""Tests for DeduplicateToolCallsMiddleware functionality."""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolCall, InvalidToolCall
+from langchain_core.tools import tool
+
+from langchain.agents.factory import create_agent
+from langchain.agents.middleware import DeduplicateToolCallsMiddleware
+from tests.unit_tests.agents.model import FakeToolCallingModel
+
+
+@tool
+def dummy_tool(query: str, limit: int = 10) -> str:
+    """A dummy tool for testing."""
+    return f"results for {query} with limit {limit}"
+
+
+def test_deduplicate_tool_calls_sync() -> None:
+    """Test sync deduplication of parallel tool calls."""
+    tool_calls = [
+        [
+            ToolCall(name="dummy_tool", args={"query": "test", "limit": 10}, id="call_1"),
+            ToolCall(name="dummy_tool", args={"limit": 10, "query": "test"}, id="call_2"),  # Duplicate (reordered keys)
+            ToolCall(name="dummy_tool", args={"query": "test", "limit": 10}, id="call_3"),  # Duplicate (exact)
+            ToolCall(name="dummy_tool", args={"query": "other", "limit": 10}, id="call_4"),  # Distinct (different query)
+            ToolCall(name="dummy_tool", args={"query": "test", "limit": 5}, id="call_5"),   # Distinct (different limit)
+        ],
+        [],
+    ]
+
+    model = FakeToolCallingModel(tool_calls=tool_calls)
+    agent = create_agent(
+        model=model,
+        tools=[dummy_tool],
+        middleware=[DeduplicateToolCallsMiddleware()],
+    )
+
+    result = agent.invoke({"messages": [HumanMessage("search")]})
+
+    # Find the AI message containing the tool calls
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) >= 1
+
+    # The first AIMessage generated will contain the tool calls
+    deduplicated_calls = ai_messages[0].tool_calls
+    assert len(deduplicated_calls) == 3
+    assert deduplicated_calls[0]["id"] == "call_1"
+    assert deduplicated_calls[1]["id"] == "call_4"
+    assert deduplicated_calls[2]["id"] == "call_5"
+
+
+async def test_deduplicate_tool_calls_async() -> None:
+    """Test async deduplication of parallel tool calls."""
+    tool_calls = [
+        [
+            ToolCall(name="dummy_tool", args={"query": "test"}, id="call_1"),
+            ToolCall(name="dummy_tool", args={"query": "test"}, id="call_2"),
+        ],
+        [],
+    ]
+
+    model = FakeToolCallingModel(tool_calls=tool_calls)
+    agent = create_agent(
+        model=model,
+        tools=[dummy_tool],
+        middleware=[DeduplicateToolCallsMiddleware()],
+    )
+
+    result = await agent.ainvoke({"messages": [HumanMessage("search")]})
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) >= 1
+
+    deduplicated_calls = ai_messages[0].tool_calls
+    assert len(deduplicated_calls) == 1
+    assert deduplicated_calls[0]["id"] == "call_1"
+
+
+def test_deduplicate_invalid_tool_calls() -> None:
+    """Test deduplication of invalid tool calls."""
+    msg = AIMessage(
+        content="",
+        tool_calls=[],
+        invalid_tool_calls=[
+            InvalidToolCall(name="dummy_tool", args="bad json", id="call_1", error="parsing error"),
+            InvalidToolCall(name="dummy_tool", args="bad json", id="call_2", error="parsing error"),
+        ]
+    )
+
+    middleware = DeduplicateToolCallsMiddleware()
+    deduplicated_msg = middleware._deduplicate_message(msg)
+
+    assert isinstance(deduplicated_msg, AIMessage)
+    assert len(deduplicated_msg.invalid_tool_calls) == 1
+    assert deduplicated_msg.invalid_tool_calls[0]["id"] == "call_1"


### PR DESCRIPTION
Fixes #38708

---

Users building agents with `create_agent` sometimes experience duplicate parallel tool calls generated by language models in a single response, leading to redundant side effects and extra execution costs. This PR introduces `DeduplicateToolCallsMiddleware` to collapse duplicate parallel tool calls in model response messages, ensuring each unique tool call is executed exactly once.

## Release note
Add `DeduplicateToolCallsMiddleware` to `langchain.agents.middleware` to collapse duplicate parallel tool calls generated by language models.

***

