### PR TITLE
perf(core): lazily import transformers in get_tokenizer

### DIFF
--- a/libs/core/langchain_core/language_models/base.py
+++ b/libs/core/langchain_core/language_models/base.py
@@ -39,14 +39,6 @@ from langchain_core.runnables import Runnable, RunnableSerializable
 if TYPE_CHECKING:
     from langchain_core.outputs import LLMResult
 
-try:
-    from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
-
-    _HAS_TRANSFORMERS = True
-except ImportError:
-    _HAS_TRANSFORMERS = False
-
-
 class LangSmithParams(TypedDict, total=False):
     """LangSmith parameters for tracing."""
 
@@ -87,13 +79,15 @@ def get_tokenizer() -> Any:
         The GPT-2 tokenizer instance.
 
     """
-    if not _HAS_TRANSFORMERS:
+    try:
+        from transformers import GPT2TokenizerFast  # type: ignore[import-not-found]
+    except ImportError as e:
         msg = (
             "Could not import transformers python package. "
             "This is needed in order to calculate get_token_ids. "
             "Please install it with `pip install transformers`."
         )
-        raise ImportError(msg)
+        raise ImportError(msg) from e
     # create a GPT-2 tokenizer instance
     return GPT2TokenizerFast.from_pretrained("gpt2")
 


### PR DESCRIPTION
Fixes #36835.

Moving the transformers import into `get_tokenizer()` avoids importing the massive `transformers` library unconditionally at the module level when `BaseChatModel` is imported. This significantly reduces application startup time.

Existing tests for `get_num_tokens_from_messages` pass successfully.