### PR TITLE
fix(langchain): re-raise non-retryable exceptions in ModelRetryMiddleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -128,7 +128,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
             retry_on: Either a tuple of exception types to retry on, or a callable
                 that takes an exception and returns `True` if it should be retried.
 
-                Default is to retry on all exceptions.
+                Default is to retry on all exceptions. Exceptions that do not match
+                are re-raised immediately (not converted to an error message).
             on_failure: Behavior when all retries are exhausted.
 
                 Options:
@@ -237,8 +238,10 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable — re-raise immediately so it is
+                    # not converted into an error AIMessage. Matches
+                    # ToolRetryMiddleware after #38845 (#38893).
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -287,8 +290,10 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable — re-raise immediately so it is
+                    # not converted into an error AIMessage. Matches
+                    # ToolRetryMiddleware after #38845 (#38893).
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -311,15 +311,13 @@ def test_model_retry_specific_exceptions() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
-
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-    # RuntimeError should fail immediately (1 attempt only)
-    assert "1 attempt" in ai_messages[-1].content
+    # RuntimeError does not match retry_on, so it is re-raised immediately
+    # even though on_failure="continue" (parity with ToolRetryMiddleware #38845).
+    with pytest.raises(RuntimeError, match="Runtime error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
 
 def test_model_retry_custom_exception_filter() -> None:
@@ -389,17 +387,69 @@ def test_model_retry_custom_exception_filter() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
+    # First attempt raises retryable error → retried.
+    # Second attempt raises non-retryable error → re-raised (not swallowed),
+    # even though on_failure="continue".
+    with pytest.raises(CustomError, match="Non-retryable error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
+
+    # Should have retried once (attempt 1 retryable, attempt 2 non-retryable)
+    assert attempt_count["value"] == 2
+
+
+def test_model_retry_non_retryable_exception_reraises() -> None:
+    """Non-retryable exceptions are re-raised even when on_failure='continue'."""
+    model = AlwaysFailingModel(error_message="boom", error_type=TypeError)
+
+    retry = ModelRetryMiddleware(
+        max_retries=2,
+        retry_on=(ValueError,),
+        initial_delay=0.0,
+        jitter=False,
+        on_failure="continue",
     )
 
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[retry],
+        checkpointer=InMemorySaver(),
+    )
 
-    # Should retry once (attempt 1 with retry_me=True), then fail on attempt 2 (retry_me=False)
-    assert attempt_count["value"] == 2
-    assert "2 attempts" in ai_messages[-1].content
+    with pytest.raises(TypeError, match="boom"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
+
+
+async def test_model_retry_async_non_retryable_exception_reraises() -> None:
+    """Async path also re-raises non-matching exceptions immediately."""
+    model = AlwaysFailingModel(error_message="async boom", error_type=TypeError)
+
+    retry = ModelRetryMiddleware(
+        max_retries=2,
+        retry_on=(ValueError,),
+        initial_delay=0.0,
+        jitter=False,
+        on_failure="continue",
+    )
+
+    agent = create_agent(
+        model=model,
+        tools=[],
+        middleware=[retry],
+        checkpointer=InMemorySaver(),
+    )
+
+    with pytest.raises(TypeError, match="async boom"):
+        await agent.ainvoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test-async-nonretry"}},
+        )
 
 
 def test_model_retry_backoff_timing() -> None:


### PR DESCRIPTION
## Summary
#38845 changed `ToolRetryMiddleware` so exceptions that do not match `retry_on` are re-raised immediately (not handled by `on_failure`). #38884 documented that contract. `ModelRetryMiddleware` still routed non-matching exceptions through `_handle_failure`, so with `on_failure="continue"` they became a fabricated error `AIMessage` and the agent continued.

This mirrors the tool-side fix on the model path.

## Change
- `wrap_model_call` / `awrap_model_call`: bare `raise` when `should_retry_exception` is false
- Align `retry_on` docstring with the tool middleware contract
- Update existing tests that expected swallowed non-retryable errors
- Add sync + async unit tests asserting non-matching exceptions propagate on the first attempt even when `on_failure="continue"`

## Test plan
- [x] Updated `test_model_retry_specific_exceptions` and `test_model_retry_custom_exception_filter` for re-raise semantics
- [x] Added `test_model_retry_non_retryable_exception_reraises`
- [x] Added `test_model_retry_async_non_retryable_exception_reraises`
- [ ] CI unit tests for `libs/langchain_v1`

Fixes #38893
