### PR TITLE
agents(middleware): lazily initialize fallback models (fixes #37642)\…

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -314,14 +314,43 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         """
         super().__init__()
 
-        # Initialize all fallback models
+        # Store model specifications (strings or instances) and prepare a
+        # per-spec cache for lazy instantiation. Preserve the public `models`
+        # attribute as the list of provided specs so external callers can
+        # introspect fallback order without triggering initialization.
         all_models = (first_model, *additional_models)
-        self.models: list[BaseChatModel] = []
+        self.models: list[str | BaseChatModel] = list(all_models)
+
+        # Internal cache: index -> instantiated BaseChatModel. Pre-populate
+        # entries for any provided `BaseChatModel` instances so they bypass
+        # initialization logic and are reused directly.
+        self._model_cache: list[BaseChatModel | None] = []
         for model in all_models:
             if isinstance(model, str):
-                self.models.append(init_chat_model(model))
+                self._model_cache.append(None)
             else:
-                self.models.append(model)
+                self._model_cache.append(model)
+
+    def _resolve(self, index: int) -> BaseChatModel:
+        """Lazily resolve the model at ``index``.
+
+        Initialize and cache the model on first access.
+
+        Args:
+            index: Index into the original `models` list.
+
+        Returns:
+            An instantiated ``BaseChatModel`` corresponding to the spec.
+        """
+        cached = self._model_cache[index]
+        if cached is not None:
+            return cached
+
+        spec = self.models[index]
+        model = init_chat_model(spec) if isinstance(spec, str) else spec
+
+        self._model_cache[index] = model
+        return model
 
     def wrap_model_call(
         self,
@@ -351,7 +380,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         # model cannot accept them (i.e. is not an Anthropic-compatible model).
         # The request is derived outside the try so a sanitizer or `_llm_type`
         # bug surfaces directly instead of being masked as a model failure.
-        for fallback_model in self.models:
+        for idx in range(len(self.models)):
+            fallback_model = self._resolve(idx)
             fallback_request = (
                 request
                 if _supports_anthropic_cache_control(fallback_model)
@@ -393,7 +423,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         # model cannot accept them (i.e. is not an Anthropic-compatible model).
         # The request is derived outside the try so a sanitizer or `_llm_type`
         # bug surfaces directly instead of being masked as a model failure.
-        for fallback_model in self.models:
+        for idx in range(len(self.models)):
+            fallback_model = self._resolve(idx)
             fallback_request = (
                 request
                 if _supports_anthropic_cache_control(fallback_model)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -1067,3 +1067,95 @@ async def test_fallback_sanitizer_error_is_not_masked_async(
 
     with pytest.raises(RuntimeError, match="sanitizer boom"):
         await middleware.awrap_model_call(request, mock_handler)
+
+
+def test_lazy_initialization_does_not_instantiate_on_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No model should be instantiated during middleware construction."""
+    called = False
+
+    def fake_init(_spec: str) -> BaseChatModel:
+        nonlocal called
+        called = True
+        return GenericFakeChatModel(messages=iter([AIMessage(content="lazy")]))
+
+    monkeypatch.setattr(model_fallback_module, "init_chat_model", fake_init)
+
+    # Constructing the middleware must not call `init_chat_model`.
+    ModelFallbackMiddleware("fake:model")
+    assert not called
+
+
+def test_lazy_initialization_and_caching(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First access should initialize once; subsequent uses reuse cached model."""
+    call_count = 0
+
+    def fake_init(_spec: str) -> BaseChatModel:
+        nonlocal call_count
+        call_count += 1
+        return GenericFakeChatModel(messages=iter([AIMessage(content=f"inst{call_count}")]))
+
+    monkeypatch.setattr(model_fallback_module, "init_chat_model", fake_init)
+
+    middleware = ModelFallbackMiddleware("fake:model")
+
+    primary_model = GenericFakeChatModel(messages=iter([AIMessage(content="primary")]))
+    request = _make_request().override(model=primary_model)
+
+    attempts: list[ModelRequest] = []
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        attempts.append(req)
+        if len(attempts) == 1:
+            msg = "Primary failed"
+            raise ValueError(msg)
+        # The fallback should be an instantiated BaseChatModel
+        assert isinstance(req.model, BaseChatModel)
+        return ModelResponse(result=[AIMessage(content="fallback")])
+
+    response = middleware.wrap_model_call(request, mock_handler)
+    assert isinstance(response, ModelResponse)
+    assert call_count == 1
+
+    # Second overall call should reuse cached instance (no extra init)
+    attempts.clear()
+    response = middleware.wrap_model_call(request, mock_handler)
+    assert call_count == 1
+
+
+def test_passing_basechatmodel_is_reused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing a BaseChatModel instance should bypass initialization entirely."""
+    call_count = 0
+
+    def fake_init(_spec: str) -> BaseChatModel:
+        nonlocal call_count
+        call_count += 1
+        return GenericFakeChatModel(messages=iter([AIMessage(content=f"inst{call_count}")]))
+
+    monkeypatch.setattr(model_fallback_module, "init_chat_model", fake_init)
+
+    instance = GenericFakeChatModel(messages=iter([AIMessage(content="fallback instance")]))
+    middleware = ModelFallbackMiddleware(instance)
+
+    # init_chat_model must not have been called
+    assert call_count == 0
+
+    primary_model = GenericFakeChatModel(messages=iter([AIMessage(content="primary")]))
+    request = _make_request().override(model=primary_model)
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        if req.model is primary_model:
+            msg = "Primary failed"
+            raise ValueError(msg)
+        # Ensure the exact instance passed to middleware is used
+        assert req.model is instance
+        return ModelResponse(result=[AIMessage(content="ok")])
+
+    response = middleware.wrap_model_call(request, mock_handler)
+    assert isinstance(response, ModelResponse)
+    assert call_count == 0


### PR DESCRIPTION

Summary
- Replace eager instantiation of fallback chat models with lazy initialization and caching inside `ModelFallbackMiddleware`.
- Store provided model *specifications* (string IDs or `BaseChatModel` instances) in `self.models` and initialize string specs on first use via `init_chat_model()`. Cache instantiated models for reuse.
- Preserve public API and runtime behavior (fallback order, sanitizer logic, exception propagation). `BaseChatModel` instances passed by callers are reused unchanged.

What I changed
- `ModelFallbackMiddleware`:
  - Store model specs instead of eagerly calling `init_chat_model()` in `__init__`.
  - Add `_model_cache` and `_resolve(index)` to lazily initialize and cache models.
  - Use `_resolve()` in `wrap_model_call()` and `awrap_model_call()` to obtain fallback models.
- Tests:
  - Add tests asserting no instantiation at construction, first-access initialization, cached reuse, and unchanged behavior when passing `BaseChatModel` instances.
  - Small test updates for style/type hints per project linting rules.
- Linting/docs:
  - Minor docstring/format changes to satisfy Ruff.

Files modified
- `langchain/agents/middleware/model_fallback.py`
- `tests/unit_tests/agents/middleware/implementations/test_model_fallback.py`

Behavior and compatibility
- No public API changes: `ModelFallbackMiddleware.models` remains available for introspection; it now holds the original specs (strings or instances).
- No change to fallback order, retry semantics, request sanitization, or exception propagation.
- Passing a `BaseChatModel` instance is still supported and bypasses initialization.

Why this fixes #37642
- Previously string model specs were turned into model instances during middleware construction. That could create unnecessary/expensive SDK or network initialization at import/agent creation time.
- The new implementation defers `init_chat_model()` until the first fallback attempt that actually needs the model, avoiding unnecessary work and side effects. Instantiated models are cached, preserving the original behavior on subsequent fallbacks.

Tests & verification
- Lint: `uv run ruff format .` then `uv run ruff check .` — no errors.
- Tests: `python -m pytest tests/unit_tests/agents/middleware/implementations/test_model_fallback.py -q` — all tests pass (33/33).
- I ran those locally in the repo venv; please re-run CI.

Suggested changelog entry
- Unreleased / Changed:
  - `ModelFallbackMiddleware` now lazily initializes fallback models instead of creating them during construction. This reduces unnecessary initialization and side effects while preserving behavior. (Fixes #37642)

Suggested reviewers & labels
- Reviewers: core agents/middleware maintainers (suggest adding whoever owns the agents/middleware area)
- Labels: `type: enhancement`, `area: agents`, `needs: tests`, `priority: low`

How to reproduce locally (maintainers)
1) Create and activate the project venv, install test deps (see pyproject.toml test group).
2) Format & lint:
```powershell
uv run ruff format .
uv run ruff check .
```
3) Run the updated tests:
```powershell
.\.venv\Scripts\python.exe -m pytest tests/unit_tests/agents/middleware/implementations/test_model_fallback.py -q
```

Notes for reviewers
- I deliberately kept `self.models` public and as the original list of specs to avoid surprising API changes and to preserve introspection.
- The `_resolve` helper is private and only used inside the fallback loops.
- No unrelated files or logic were changed; tests and linting are green.
<img width="1393" height="574" alt="Screenshot 2026-07-20 202138" src="https://github.com/user-attachments/assets/50227130-963f-4878-8ba9-21907ffedb8d" />
