### PR TITLE
fix(langchain): handle OpenAI phased responses in ProviderStrategyBinding parsing

### DIFF
--- a/libs/langchain_v1/langchain/agents/structured_output.py
+++ b/libs/langchain_v1/langchain/agents/structured_output.py
@@ -424,6 +424,12 @@ class ProviderStrategyBinding(Generic[SchemaT]):
     def _extract_text_content_from_message(message: AIMessage) -> str:
         """Extract text content from an `AIMessage`.
 
+        When the message contains multiple text blocks (e.g. OpenAI phased
+        responses with ``commentary`` and ``final_answer`` phases), each block
+        is tried individually (last-to-first) as valid JSON.  Only if none of
+        the blocks parse as standalone JSON does the method fall back to
+        concatenating all text blocks.
+
         Args:
             message: The AI message to extract text from
 
@@ -442,6 +448,18 @@ class ProviderStrategyBinding(Generic[SchemaT]):
                     parts.append(c["content"])
             else:
                 parts.append(str(c))
+        # Try each block individually (last-to-first) as valid JSON.
+        # This handles phased responses where only the final block contains
+        # the structured output.
+        for block in reversed(parts):
+            stripped = block.strip()
+            if stripped.startswith("{") and stripped.endswith("}"):
+                try:
+                    json.loads(stripped)
+                    return stripped
+                except json.JSONDecodeError:
+                    continue
+        # Fall back to concatenation for split JSON.
         return "".join(parts)
 
 


### PR DESCRIPTION
When OpenAI returns a phased response with multiple text blocks (`commentary` and `final_answer`), `_extract_text_content_from_message` concatenates all blocks into a single string, producing invalid JSON that fails to parse.

**Root cause:** The method assumes all text blocks should be concatenated. But OpenAI's phased responses contain multiple complete JSON objects — only the `final_answer` block contains the structured output.

**Fix:** Each text block is tried individually (last-to-first) as valid JSON before falling back to concatenation. This correctly handles phased responses where only the final block contains the structured output, while remaining compatible with split-JSON responses from other models.

Fixes #36290