### PR TITLE
fix: prevent in-place mutation of model_kwargs["text"] in Responses API

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4355,7 +4355,7 @@ def _construct_responses_api_payload(
                 schema_dict = schema
             if schema_dict == {"type": "json_object"}:  # JSON mode
                 if "text" in payload and isinstance(payload["text"], dict):
-                    payload["text"]["format"] = {"type": "json_object"}
+                    payload["text"] = {**payload["text"], "format": {"type": "json_object"}}
                 else:
                     payload["text"] = {"format": {"type": "json_object"}}
             elif (
@@ -4369,7 +4369,7 @@ def _construct_responses_api_payload(
             ):
                 format_value = {"type": "json_schema", **response_format["json_schema"]}
                 if "text" in payload and isinstance(payload["text"], dict):
-                    payload["text"]["format"] = format_value
+                    payload["text"] = {**payload["text"], "format": format_value}
                 else:
                     payload["text"] = {"format": format_value}
             else:
@@ -4378,7 +4378,7 @@ def _construct_responses_api_payload(
     verbosity = payload.pop("verbosity", None)
     if verbosity is not None:
         if "text" in payload and isinstance(payload["text"], dict):
-            payload["text"]["verbosity"] = verbosity
+            payload["text"] = {**payload["text"], "verbosity": verbosity}
         else:
             payload["text"] = {"verbosity": verbosity}
 


### PR DESCRIPTION
## Problem

`ChatOpenAI` with the Responses API mutates `model_kwargs["text"]` **in place** when setting JSON mode or verbosity:

```python
payload["text"]["format"] = {"type": "json_object"}
```

Since `payload["text"]` is a reference to `self.model_kwargs["text"]`, this permanently alters the instance's `model_kwargs`. One JSON mode call forces JSON mode on **all subsequent requests** — even those that didn't request it.

## Reproduction

```python
llm = ChatOpenAI(model="gpt-4o", model_kwargs={"text": {"format": {"type": "text"}}})
# First call with response_format triggers JSON mode
llm.invoke("...", response_format={"type": "json_object"})
# Second call WITHOUT response_format still sends JSON mode!
llm.invoke("...")  # ← permanently broken
```

## Fix

Replace in-place key assignment with immutable dict spread:

```python
# Before (mutates shared dict):
payload["text"]["format"] = {"type": "json_object"}

# After (creates new dict):
payload["text"] = {**payload["text"], "format": {"type": "json_object"}}
```

Applied to all three mutation sites: `format` (json_object), `format` (response_format), and `verbosity`.

## Changes

- `libs/partners/openai/langchain_openai/chat_models/base.py`

Fixes #38869