### PR TITLE
fix(core): handle empty streams in RunnableWithFallbacks without triggering fallback

### DIFF
--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -497,7 +497,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    try:
+                        chunk: Output = context.run(next, stream)
+                    except StopIteration:
+                        # Stream is legitimately empty; no output to yield
+                        # and no fallback should be triggered.
+                        first_error = None
+                        break
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -511,7 +517,11 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             run_manager.on_chain_error(first_error)
             raise first_error
 
-        yield chunk
+        try:
+            yield chunk
+        except UnboundLocalError:
+            # All runnables produced empty streams; nothing to yield.
+            return
         output: Output | None = chunk
         try:
             for chunk in stream:
@@ -561,7 +571,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         child_config,
                         **kwargs,
                     )
-                    chunk = await coro_with_context(anext(stream), context)
+                    try:
+                        chunk = await coro_with_context(anext(stream), context)
+                    except StopAsyncIteration:
+                        # Stream is legitimately empty; no output to yield
+                        # and no fallback should be triggered.
+                        first_error = None
+                        break
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -575,7 +591,11 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
             await run_manager.on_chain_error(first_error)
             raise first_error
 
-        yield chunk
+        try:
+            yield chunk
+        except UnboundLocalError:
+            # All runnables produced empty streams; nothing to yield.
+            return
         output: Output | None = chunk
         try:
             async for chunk in stream:


### PR DESCRIPTION
## Problem

When an upstream runnable in a `RunnableWithFallbacks` chain produces a legitimately **empty stream** (yields no chunks), the `next(stream)` call in `stream()` raises `StopIteration`. This exception is caught by `except self.exceptions_to_handle`, causing the fallback mechanism to incorrectly trigger — even though the upstream did not fail.

The same issue exists in `astream()` with `StopAsyncIteration` from `anext(stream)`.

```python
from langchain_core.runnables import RunnableLambda, RunnableWithFallbacks

def empty_stream(input):
    """A runnable that legitimately yields nothing."""
    return iter([])

def fallback(input):
    return iter(["fallback output"])

chain = RunnableLambda(empty_stream).with_fallbacks([RunnableLambda(fallback)])
result = list(chain.stream("hello"))
# Expected: []  (empty stream is valid)
# Actual: ["fallback_output"]  (fallback incorrectly triggered)
```

## Root Cause

In `stream()` (line ~500):
```python
chunk: Output = context.run(next, stream)
```

If the stream is empty, `next()` raises `StopIteration`. Since `StopIteration` is a subclass of `Exception`, it gets caught by `except self.exceptions_to_handle as e:` (which defaults to `(Exception,)`), triggering fallback.

## Fix

Wrap the `next(stream)` / `anext(stream)` call in a nested try/except that catches `StopIteration` / `StopAsyncIteration` separately:

- Empty stream → treat as successful completion (`first_error = None; break`)
- After the loop, guard `yield chunk` with `try/except UnboundLocalError` for the case where all runnables produced empty streams

## Testing

- Empty stream from primary → no fallback triggered, stream yields nothing
- Actual exception from primary → fallback still triggers correctly
- Non-empty stream → behavior unchanged

Fixes #38892