### PR TITLE
fix(langchain): export PIIMatch from langchain.agents.middleware public API

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/__init__.py
+++ b/libs/langchain_v1/langchain/agents/middleware/__init__.py
@@ -11,7 +11,11 @@ from langchain.agents.middleware.human_in_the_loop import (
 from langchain.agents.middleware.model_call_limit import ModelCallLimitMiddleware
 from langchain.agents.middleware.model_fallback import ModelFallbackMiddleware
 from langchain.agents.middleware.model_retry import ModelRetryMiddleware
-from langchain.agents.middleware.pii import PIIDetectionError, PIIMiddleware
+from langchain.agents.middleware.pii import (
+    PIIDetectionError,
+    PIIMatch,
+    PIIMiddleware,
+)
 from langchain.agents.middleware.provider_tool_search import ProviderToolSearchMiddleware
 from langchain.agents.middleware.shell_tool import (
     CodexSandboxExecutionPolicy,
@@ -70,6 +74,7 @@ __all__ = [
     "ModelRetryMiddleware",
     "OutputAgentState",
     "PIIDetectionError",
+    "PIIMatch",
     "PIIMiddleware",
     "ProviderToolSearchMiddleware",
     "RedactionRule",


### PR DESCRIPTION
Fixes #38718

Export `PIIMatch` from `langchain.agents.middleware` so developers can create custom PII detection middleware with public type annotations instead of importing from private internal modules.

## Release note
Exported `PIIMatch` TypedDict in `langchain.agents.middleware` public API.

4. How did you verify your code works?
- Verified `from langchain.agents.middleware import PIIMatch` imports cleanly without `ImportError`.
- Ran `ruff check` and `pytest tests/unit_tests/agents/` across the modified package (all 967 tests passed).

## Social handles (optional)
LinkedIn: https://linkedin.com/in/vishnup22102002