### PR TITLE
fix(anthropic): prevent bind_tools from mutating caller tool_choice dict

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1984,7 +1984,7 @@ class ChatAnthropic(BaseChatModel):
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
-            kwargs["tool_choice"] = tool_choice
+            kwargs["tool_choice"] = tool_choice.copy()
         elif isinstance(tool_choice, str) and tool_choice in ("any", "auto"):
             kwargs["tool_choice"] = {"type": tool_choice}
         elif isinstance(tool_choice, str):

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3780,3 +3780,16 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+def test_bind_tools_does_not_mutate_tool_choice_dict() -> None:
+    """Verify that bind_tools does not mutate caller's tool_choice dictionary."""
+    model = ChatAnthropic(model="claude-3-5-sonnet-20241022", api_key="test")
+    tool_choice = {"type": "tool", "name": "GetWeather"}
+    tool_choice_original = tool_choice.copy()
+
+    model.bind_tools([], tool_choice=tool_choice, parallel_tool_calls=False)
+
+    assert tool_choice == tool_choice_original
+    assert "disable_parallel_tool_use" not in tool_choice
+


### PR DESCRIPTION
Fixes #38779

Prevent `ChatAnthropic.bind_tools()` from mutating caller-provided `tool_choice` dictionaries in-place when configuring parameters like `disable_parallel_tool_use`.

## Release note
Prevented in-place mutation of caller-provided `tool_choice` dictionaries in `ChatAnthropic.bind_tools()`.

4. How did you verify your code works?
- Added regression test `test_bind_tools_does_not_mutate_tool_choice_dict()` in `libs/partners/anthropic/tests/unit_tests/test_chat_models.py`.
- Ran `ruff check` (0 errors) and `pytest tests/unit_tests/test_chat_models.py` (all 127 unit tests passed cleanly).

## Social handles (optional)
LinkedIn: https://linkedin.com/in/vishnup22102002