### PR TITLE
feat(openai): expose vLLM `stop_reason` metadata

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1441,6 +1441,8 @@ class BaseChatOpenAI(BaseChatModel):
 
         if finish_reason := choice.get("finish_reason"):
             generation_info["finish_reason"] = finish_reason
+            if "stop_reason" in choice:
+                generation_info["stop_reason"] = choice["stop_reason"]
             if model_name := chunk.get("model"):
                 generation_info["model_name"] = model_name
             if system_fingerprint := chunk.get("system_fingerprint"):
@@ -1852,6 +1854,8 @@ class BaseChatOpenAI(BaseChatModel):
                 if res.get("finish_reason") is not None
                 else generation_info.get("finish_reason")
             )
+            if "stop_reason" in res:
+                generation_info["stop_reason"] = res["stop_reason"]
             if "logprobs" in res:
                 generation_info["logprobs"] = res["logprobs"]
             gen = ChatGeneration(message=message, generation_info=generation_info)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -621,6 +621,29 @@ def test_openai_stream(mock_openai_completion: list) -> None:
         assert "stream_options" not in call_kwargs[-1]
 
 
+@pytest.mark.parametrize("stop_reason", ["custom stop sequence", 0, None])
+def test_openai_stream_preserves_stop_reason(
+    mock_openai_completion: list[dict], stop_reason: str | int | None
+) -> None:
+    final_choice = next(
+        chunk["choices"][0]
+        for chunk in reversed(mock_openai_completion)
+        if chunk["choices"]
+    )
+    final_choice["stop_reason"] = stop_reason
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    mock_client = MagicMock()
+    mock_client.create.return_value = MockSyncContextManager(mock_openai_completion)
+
+    with patch.object(llm, "client", mock_client):
+        stream = llm.stream("bar")
+        response = next(stream)
+        for chunk in stream:
+            response += chunk
+
+    assert response.response_metadata["stop_reason"] == stop_reason
+
+
 def test_openai_stream_events_v3_lifecycle(mock_openai_completion: list) -> None:
     """`stream_events(version="v3")` on chat completions emits a valid lifecycle."""
     from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
@@ -700,6 +723,25 @@ def test_openai_invoke(mock_client: MagicMock) -> None:
         # headers are not in response_metadata if include_response_headers not set
         assert "headers" not in res.response_metadata
     assert mock_client.with_raw_response.create.called
+
+
+@pytest.mark.parametrize("stop_reason", ["custom stop sequence", 0, None])
+def test_openai_invoke_preserves_stop_reason(
+    mock_client: MagicMock,
+    mock_completion: dict,
+    stop_reason: str | int | None,
+) -> None:
+    mock_completion["choices"][0]["stop_reason"] = stop_reason
+    mock_response = mock_client.with_raw_response.create.return_value
+    mock_response.parse.return_value = openai.types.chat.ChatCompletion.model_validate(
+        mock_completion
+    )
+    llm = ChatOpenAI()
+
+    with patch.object(llm, "client", mock_client):
+        response = llm.invoke("bar")
+
+    assert response.response_metadata["stop_reason"] == stop_reason
 
 
 async def test_openai_ainvoke(mock_async_client: AsyncMock) -> None:


### PR DESCRIPTION
Closes #34307

---

vLLM's OpenAI-compatible Chat Completions responses can include a per-choice `stop_reason`, but `ChatOpenAI` previously copied only `finish_reason`. This left callers unable to identify the specific stop sequence or token that ended a generation.

This change exposes `stop_reason` through `AIMessage.response_metadata` for both streaming and non-streaming Chat Completions. It checks for key presence so valid stop token ID `0` and explicit `None` values are preserved. The shared conversion paths also cover synchronous and asynchronous calls.

Validated with Ruff, formatting and import checks, mypy, and the complete `langchain-openai` unit test suite (544 passed, 1 skipped, 4 xfailed).

## Release note

`ChatOpenAI` now exposes vLLM's per-choice `stop_reason` in response metadata for streaming and non-streaming Chat Completions.

---

This contribution was developed with assistance from an AI coding agent.
