### PR TITLE
fix(openai): correct `gpt-5.3-chat-latest` profile

### DIFF
--- a/libs/partners/openai/langchain_openai/data/_profiles.py
+++ b/libs/partners/openai/langchain_openai/data/_profiles.py
@@ -875,13 +875,6 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "image_tool_message": True,
         "tool_choice": True,
         "tool_call_streaming": True,
-        "reasoning_effort_levels": [
-            "none",
-            "low",
-            "medium",
-            "high",
-            "xhigh",
-        ],
     },
     "gpt-5.3-codex": {
         "name": "GPT-5.3 Codex",

--- a/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
+++ b/libs/partners/openai/langchain_openai/data/profile_augmentations.toml
@@ -73,9 +73,6 @@ reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
 [overrides."gpt-5.2-codex"]
 reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
 
-[overrides."gpt-5.3-chat-latest"]
-reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
-
 [overrides."gpt-5.3-codex"]
 reasoning_effort_levels = ["none", "low", "medium", "high", "xhigh"]
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -167,6 +167,14 @@ def test_profile() -> None:
     assert model.profile["max_input_tokens"] == 272_000
 
 
+def test_gpt_5_3_chat_latest_profile_has_no_reasoning_effort() -> None:
+    model = ChatOpenAI(model="gpt-5.3-chat-latest")
+
+    assert model.profile
+    assert model.profile["reasoning_output"] is False
+    assert "reasoning_effort_levels" not in model.profile
+
+
 def test_function_message_dict_to_function_message() -> None:
     content = json.dumps({"result": "Example #1"})
     name = "test_function"


### PR DESCRIPTION
The `gpt-5.3-chat-latest` OpenAI model profile no longer advertises unsupported configurable reasoning effort levels.

---

`gpt-5.3-chat-latest` is OpenAI's non-reasoning GPT-5.3 Instant model, but its generated LangChain profile advertises configurable `reasoning_effort_levels` while also reporting `reasoning_output=False`. Profile-driven clients can therefore offer settings that the model does not support.

OpenAI's [model page](https://developers.openai.com/api/docs/models/gpt-5.3-chat-latest) identifies this alias as GPT-5.3 Instant. Its [launch announcement](https://openai.com/index/gpt-5-3-instant/) separates Instant from Thinking and Pro, while the [reasoning guide](https://developers.openai.com/api/docs/guides/reasoning) says effort support is model-dependent and must be checked on the relevant model page.