### PR TITLE
fix(core): support positional-only parameters in tools

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -347,7 +347,10 @@ def create_schema_from_function(
         if not has_kwargs and field == "kwargs":
             continue
 
-        if field == "v__duplicate_kwargs":  # Internal pydantic field
+        # Internal virtual fields injected by pydantic's `validate_arguments`;
+        # `v__positional_only` is a catch-all for positional-only parameters and
+        # would otherwise leak into the tool schema as a phantom argument.
+        if field in {"v__duplicate_kwargs", "v__positional_only"}:
             continue
 
         if field not in filter_args_:

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import textwrap
 from collections.abc import Awaitable, Callable
-from inspect import signature
+from inspect import Parameter, signature
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -35,6 +35,42 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 
 if TYPE_CHECKING:
     from langchain_core.messages import ToolCall
+
+
+def _split_positional_only(
+    func: Callable[..., Any], args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Move positional-only parameters from `kwargs` into positional `args`.
+
+    Tool inputs are collected as keyword arguments, but positional-only
+    parameters (PEP 570, e.g. `def f(a, /, b)`) cannot be passed by keyword.
+    Pull them out of `kwargs` in signature order and prepend them to `args` so
+    the wrapped function receives them positionally. Extraction stops at the
+    first positional-only parameter missing from `kwargs`, since a later one
+    cannot fill an earlier positional slot.
+
+    Args:
+        func: The wrapped tool function.
+        args: Positional arguments already destined for `func`.
+        kwargs: Keyword arguments collected from the tool input.
+
+    Returns:
+        The adjusted `(args, kwargs)` pair.
+    """
+    positional_only = [
+        name
+        for name, param in signature(func).parameters.items()
+        if param.kind is Parameter.POSITIONAL_ONLY
+    ]
+    if not positional_only:
+        return args, kwargs
+    extracted: list[Any] = []
+    remaining = dict(kwargs)
+    for name in positional_only:
+        if name not in remaining:
+            break
+        extracted.append(remaining.pop(name))
+    return (*extracted, *args), remaining
 
 
 class StructuredTool(BaseTool):
@@ -94,6 +130,7 @@ class StructuredTool(BaseTool):
                 kwargs["callbacks"] = run_manager.get_child()
             if config_param := _get_runnable_config_param(self.func):
                 kwargs[config_param] = config
+            args, kwargs = _split_positional_only(self.func, args, kwargs)
             return self.func(*args, **kwargs)
         msg = "StructuredTool does not support sync invocation."
         raise NotImplementedError(msg)
@@ -121,6 +158,7 @@ class StructuredTool(BaseTool):
                 kwargs["callbacks"] = run_manager.get_child()
             if config_param := _get_runnable_config_param(self.coroutine):
                 kwargs[config_param] = config
+            args, kwargs = _split_positional_only(self.coroutine, args, kwargs)
             return await self.coroutine(*args, **kwargs)
 
         # If self.coroutine is None, then this will delegate to the default

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -4063,3 +4063,60 @@ def test_tool_call_schema_json_schema_cache_invalidated_on_reassignment() -> Non
     new_schema = new_cls.model_json_schema()
     assert new_schema is not old_schema
     assert new_schema["description"] == "New description for cache test."
+
+
+def test_tool_positional_only_param_not_in_schema() -> None:
+    """Positional-only params must not leak a phantom `v__positional_only` field."""
+
+    @tool
+    def add(a: int, /, b: int) -> int:
+        """Add a and b."""
+        return a + b
+
+    assert "v__positional_only" not in add.args
+    assert set(add.args) == {"a", "b"}
+
+
+def test_tool_invoke_with_positional_only_param() -> None:
+    """A tool with a positional-only parameter can be invoked by name."""
+
+    @tool
+    def add(a: int, /, b: int) -> int:
+        """Add a and b."""
+        return a + b
+
+    assert add.invoke({"a": 1, "b": 2}) == 3
+
+
+def test_tool_invoke_with_multiple_positional_only_params() -> None:
+    """Multiple positional-only params, including a defaulted one, bind correctly."""
+
+    @tool
+    def combine(a: int, b: int, /, c: int = 10) -> int:
+        """Sum a, b and c."""
+        return a + b + c
+
+    assert combine.invoke({"a": 1, "b": 2, "c": 3}) == 6
+    assert combine.invoke({"a": 1, "b": 2}) == 13
+
+
+def test_tool_regular_params_unaffected_by_positional_only_handling() -> None:
+    """Tools with only regular parameters keep working unchanged."""
+
+    @tool
+    def add(a: int, b: int) -> int:
+        """Add a and b."""
+        return a + b
+
+    assert add.invoke({"a": 4, "b": 5}) == 9
+
+
+async def test_tool_ainvoke_with_positional_only_param() -> None:
+    """The async path also routes positional-only params positionally."""
+
+    @tool
+    async def add(a: int, /, b: int) -> int:
+        """Add a and b."""
+        return a + b
+
+    assert await add.ainvoke({"a": 7, "b": 8}) == 15


### PR DESCRIPTION
Closes #39011

---

If you register a tool whose function has a positional-only parameter (PEP 570, `def f(a, /, b)`), two things go wrong today. The generated schema gains a phantom `v__positional_only` argument that does not exist on the function, so an LLM can see a fake parameter and try to fill it. And invoking the tool raises `TypeError: ... got some positional-only arguments passed as keyword arguments`, because tool inputs are always passed by keyword. Positional-only parameters are ordinary valid Python, so a model may generate one or a user may already have one on a function they wrap.

This change fixes both halves:

- `create_schema_from_function` now strips the internal `v__positional_only` field that pydantic's `validate_arguments` injects, alongside the existing `v__duplicate_kwargs` strip, so it no longer leaks into the tool schema.
- `StructuredTool._run` and `_arun` now move positional-only parameters out of the collected keyword arguments and pass them positionally, via a small `_split_positional_only` helper. Extraction stops at the first missing positional-only parameter so a later one can never fill an earlier slot, which keeps defaulted positional-only parameters working.

Tools with only regular parameters are unaffected, and the async path is handled the same way as the sync path.

## Release note

Tools whose functions use positional-only parameters (`def f(a, /, b)`) now generate a clean schema and invoke correctly, instead of exposing a phantom `v__positional_only` argument and raising a `TypeError` on call.

---

_This contribution was prepared with the assistance of an AI agent: the fix and tests were written with agent tooling and reviewed before submission._
