### PR TITLE
fix(core): allow Blob.as_bytes_io() to handle string data

### DIFF
--- a/libs/core/langchain_core/documents/base.py
+++ b/libs/core/langchain_core/documents/base.py
@@ -203,6 +203,8 @@ class Blob(BaseMedia):
         """
         if isinstance(self.data, bytes):
             yield BytesIO(self.data)
+        elif isinstance(self.data, str):
+            yield BytesIO(self.data.encode(self.encoding))
         elif self.data is None and self.path:
             with Path(self.path).open("rb") as f:
                 yield f


### PR DESCRIPTION
Fixes #39017

### Motivation and Context

When a `Blob` is initialized with string data (e.g. `Blob.from_data("hello")` or `Blob(data="hello")`), invoking `blob.as_bytes_io()` currently raises `NotImplementedError: Unable to convert blob` because the method only checks for `isinstance(self.data, bytes)`.

In contrast, `blob.as_bytes()` converts `str` data to `bytes` using `self.data.encode(self.encoding)`.

### Fix

Add `elif isinstance(self.data, str): yield BytesIO(self.data.encode(self.encoding))` to `Blob.as_bytes_io()`.
