### PR TITLE
fix(anthropic): enable structured output for Claude Opus 4.8

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/data/_profiles.py
+++ b/libs/partners/anthropic/langchain_anthropic/data/_profiles.py
@@ -297,7 +297,7 @@ _PROFILES: dict[str, dict[str, Any]] = {
         "video_outputs": False,
         "reasoning_output": True,
         "tool_calling": True,
-        "structured_output": False,
+        "structured_output": True,
         "attachment": True,
         "temperature": False,
         "image_url_inputs": True,

--- a/libs/partners/anthropic/langchain_anthropic/data/profile_augmentations.toml
+++ b/libs/partners/anthropic/langchain_anthropic/data/profile_augmentations.toml
@@ -42,6 +42,7 @@ reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 reasoning_effort_default = "high"
 
 [overrides."claude-opus-4-8"]
+structured_output = true
 reasoning_effort_levels = ["low", "medium", "high", "xhigh", "max"]
 reasoning_effort_default = "high"
 

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -2826,6 +2826,12 @@ def test_auto_append_betas_for_mcp_servers() -> None:
     }
 
 
+def test_claude_opus_4_8_profile_supports_structured_output() -> None:
+    model = ChatAnthropic(model="claude-opus-4-8")
+    assert model.profile
+    assert model.profile["structured_output"] is True
+
+
 def test_profile() -> None:
     model = ChatAnthropic(model="claude-sonnet-4-5-20250929")
     assert model.profile


### PR DESCRIPTION
[Anthropic's structured-output documentation](https://platform.claude.com/docs/en/build-with-claude/structured-outputs) lists `claude-opus-4-8` as supporting native structured output, but `ChatAnthropic` currently reports that capability as disabled.

This updates the Anthropic profile augmentation and regenerates the model profile so `ChatAnthropic(model="claude-opus-4-8").profile["structured_output"]` is `True`.