### PR TITLE
fix(core): empty stream success + deferred tool_calls for args=""

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -554,7 +554,20 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
 
         for chunk in self.tool_call_chunks:
             try:
-                args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}
+                raw_args = chunk["args"]
+                # Empty string means the provider is still streaming tool-call
+                # arguments (common with fragmented SSE). Do not materialize a
+                # tool_call with {} until real args or an explicit null arrive.
+                # None / missing still means "no args object yet" -> {}.
+                if raw_args == "":
+                    if self.chunk_position == "last":
+                        args_: object = {}
+                    else:
+                        continue
+                elif raw_args:
+                    args_ = parse_partial_json(raw_args)
+                else:
+                    args_ = {}
                 if isinstance(args_, dict):
                     tool_calls.append(
                         create_tool_call(

--- a/libs/core/langchain_core/runnables/fallbacks.py
+++ b/libs/core/langchain_core/runnables/fallbacks.py
@@ -497,7 +497,13 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         input,
                         **kwargs,
                     )
-                    chunk: Output = context.run(next, stream)
+                    try:
+                        chunk: Output | None = context.run(next, stream)
+                    except StopIteration:
+                        # Empty stream is a valid successful result (e.g. filtered
+                        # content, empty model response). Do not treat as failure
+                        # or trigger fallbacks.
+                        chunk = None
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -510,6 +516,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         if first_error:
             run_manager.on_chain_error(first_error)
             raise first_error
+
+        if chunk is None:
+            run_manager.on_chain_end(None)
+            return
 
         yield chunk
         output: Output | None = chunk
@@ -561,7 +571,11 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
                         child_config,
                         **kwargs,
                     )
-                    chunk = await coro_with_context(anext(stream), context)
+                    try:
+                        chunk = await coro_with_context(anext(stream), context)
+                    except StopAsyncIteration:
+                        # Empty async stream is a valid successful result.
+                        chunk = None
             except self.exceptions_to_handle as e:
                 first_error = e if first_error is None else first_error
                 last_error = e
@@ -574,6 +588,10 @@ class RunnableWithFallbacks(RunnableSerializable[Input, Output]):
         if first_error:
             await run_manager.on_chain_error(first_error)
             raise first_error
+
+        if chunk is None:
+            await run_manager.on_chain_end(None)
+            return
 
         yield chunk
         output: Output | None = chunk

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -576,3 +576,27 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+
+def test_empty_string_args_do_not_materialize_tool_call() -> None:
+    """Fragmented SSE first chunk with args="" must not create tool_calls (#38682)."""
+    from langchain_core.messages import AIMessageChunk
+
+    chunk = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {"name": "get_weather", "args": "", "id": "call_abc", "index": 0}
+        ],
+    )
+    assert chunk.tool_calls == []
+
+    # Final chunk position may still resolve empty args to {}.
+    last = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            {"name": "get_weather", "args": "", "id": "call_abc", "index": 0}
+        ],
+        chunk_position="last",
+    )
+    assert len(last.tool_calls) == 1
+    assert last.tool_calls[0]["args"] == {}

--- a/libs/core/tests/unit_tests/runnables/test_fallbacks.py
+++ b/libs/core/tests/unit_tests/runnables/test_fallbacks.py
@@ -404,3 +404,47 @@ def test_fallbacks_getattr_runnable_output() -> None:
         for fallback in llm_with_fallbacks_with_tools.fallbacks
     )
     assert llm_with_fallbacks_with_tools.runnable.kwargs["tools"] == []
+
+
+def test_empty_upstream_stream_does_not_trigger_fallback() -> None:
+    """Empty stream is success: must not silently run fallbacks (#38892)."""
+
+    def empty_stream(_input: Any) -> Iterator[str]:
+        return
+        yield  # pragma: no cover
+
+    def fallback_stream(_input: Any) -> Iterator[str]:
+        yield "FALLBACK-OUTPUT"
+
+    chain = RunnableGenerator(empty_stream).with_fallbacks(
+        [RunnableGenerator(fallback_stream)]
+    )
+    assert list(chain.stream({})) == []
+
+
+def test_empty_upstream_stream_without_fallback_returns_empty() -> None:
+    """Empty stream without fallbacks should not raise (#38892)."""
+
+    def empty_stream(_input: Any) -> Iterator[str]:
+        return
+        yield  # pragma: no cover
+
+    chain = RunnableGenerator(empty_stream).with_fallbacks([])
+    assert list(chain.stream({})) == []
+
+
+@pytest.mark.asyncio
+async def test_empty_upstream_astream_does_not_trigger_fallback() -> None:
+    """Async empty stream must not trigger fallbacks (#38892)."""
+
+    async def empty_stream(_input: Any) -> AsyncIterator[str]:
+        if False:  # pragma: no cover
+            yield "x"
+
+    async def fallback_stream(_input: Any) -> AsyncIterator[str]:
+        yield "FALLBACK-OUTPUT"
+
+    chain = RunnableGenerator(empty_stream).with_fallbacks(
+        [RunnableGenerator(fallback_stream)]
+    )
+    assert [c async for c in chain.astream({})] == []


### PR DESCRIPTION
## Summary
Fixes #38892 and #38682.

### #38892
`RunnableWithFallbacks.stream()`/`astream()` used bare `next`/`anext` to peek the first chunk. A legitimately empty upstream stream raised `StopIteration`/`StopAsyncIteration`, which was treated as failure and either triggered fallbacks or raised `RuntimeError: generator raised StopIteration`.

Empty stream is now treated as a successful empty result.

### #38682
`AIMessageChunk.init_tool_calls` treated `args=""` like missing args and materialized `tool_calls` with `{}` on the first SSE fragment. Providers that stream tool-call arguments then invoke tools prematurely.

Empty-string args now skip materialization until a non-empty partial JSON arrives, or `chunk_position=="last"`.

## Test plan
- [x] `tests/unit_tests/runnables/test_fallbacks.py` empty-stream regressions
- [x] `tests/unit_tests/messages/test_ai.py` empty-args regression
- [x] full `test_fallbacks.py` + `test_ai.py` suite green locally