### PR TITLE
fix(core): fix test_stream_error_callback assertion

### DIFF
--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -200,7 +200,6 @@ async def test_async_batch_size(
         assert (cb.traced_runs[0].extra or {}).get("batch_size") == 1
 
 
-@pytest.mark.xfail(reason="This test is failing due to a bug in the testing code")
 async def test_stream_error_callback() -> None:
     message = "test"
 
@@ -209,7 +208,7 @@ async def test_stream_error_callback() -> None:
         assert len(callback.errors_args) == 1
         llm_result: LLMResult = callback.errors_args[0]["kwargs"]["response"]
         if i == 0:
-            assert llm_result.generations == []
+            assert llm_result.generations == [[]]
         else:
             assert llm_result.generations[0][0].text == message[:i]
 


### PR DESCRIPTION
The test `test_stream_error_callback` was marked xfail due to a bug in the testing code.

The assertion `llm_result.generations == []` is incorrect — `generations` is a list of lists (one per prompt), so an empty generation for a single prompt is `[[]]`, not `[]`.

This PR:
- Removes the `@pytest.mark.xfail` marker
- Fixes the assertion to `assert llm_result.generations == [[]]`

Fixes #38904