### PR TITLE
fix(openai): stop mutating shared `model_kwargs["text"]`

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4364,7 +4364,10 @@ def _construct_responses_api_payload(
                 schema_dict = schema
             if schema_dict == {"type": "json_object"}:  # JSON mode
                 if "text" in payload and isinstance(payload["text"], dict):
-                    payload["text"]["format"] = {"type": "json_object"}
+                    payload["text"] = {
+                        **payload["text"],
+                        "format": {"type": "json_object"},
+                    }
                 else:
                     payload["text"] = {"format": {"type": "json_object"}}
             elif (
@@ -4378,7 +4381,7 @@ def _construct_responses_api_payload(
             ):
                 format_value = {"type": "json_schema", **response_format["json_schema"]}
                 if "text" in payload and isinstance(payload["text"], dict):
-                    payload["text"]["format"] = format_value
+                    payload["text"] = {**payload["text"], "format": format_value}
                 else:
                     payload["text"] = {"format": format_value}
             else:
@@ -4387,7 +4390,7 @@ def _construct_responses_api_payload(
     verbosity = payload.pop("verbosity", None)
     if verbosity is not None:
         if "text" in payload and isinstance(payload["text"], dict):
-            payload["text"]["verbosity"] = verbosity
+            payload["text"] = {**payload["text"], "verbosity": verbosity}
         else:
             payload["text"] = {"verbosity": verbosity}
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1825,6 +1825,35 @@ def test_verbosity_parameter_payload() -> None:
     assert payload["text"]["verbosity"] == "high"
 
 
+def test_responses_api_does_not_mutate_model_kwargs_text() -> None:
+    """Structured output must not mutate a shared `model_kwargs["text"]` dict.
+
+    Regression for https://github.com/langchain-ai/langchain/issues/38869: the
+    Responses API payload builder merged `format` into `model_kwargs["text"]` in
+    place, so a single structured-output call left every later request stuck in
+    that format.
+    """
+    llm = ChatOpenAI(
+        model="gpt-5",
+        use_responses_api=True,
+        model_kwargs={"text": {"verbosity": "low"}},
+    )
+    messages = [HumanMessage(content="hello")]
+
+    payload = llm._get_request_payload(
+        messages, response_format={"type": "json_object"}
+    )
+
+    assert payload["text"] == {
+        "verbosity": "low",
+        "format": {"type": "json_object"},
+    }
+    assert llm.model_kwargs == {"text": {"verbosity": "low"}}
+
+    later_payload = llm._get_request_payload(messages)
+    assert later_payload["text"] == {"verbosity": "low"}
+
+
 def test_structured_output_legacy_model() -> None:
     class Output(TypedDict):
         """output."""


### PR DESCRIPTION
Closes #38869

---

Setting `model_kwargs={"text": {...}}` on `ChatOpenAI` (for example to pin `verbosity`) and then making a structured-output call permanently corrupted the model. The first call worked, but every request afterward was silently stuck in the earlier `format`, so a later plain call would keep returning JSON, or a different schema call would carry the wrong `format`.

The cause is a shared-reference mutation. When building a Responses API request, the payload shallow-copies `model_kwargs`, so `payload["text"]` is the *same* nested dict object as `model_kwargs["text"]`. The payload builder then merged `format` (and `verbosity`) into `payload["text"]` in place, which rewrote the caller's `model_kwargs["text"]` and leaked into every subsequent request built from the same instance.

The fix builds a new `text` dict instead of mutating the existing one, so `model_kwargs` is never touched. Behavior for a single request is unchanged; only the cross-call leak is removed.

## Release note

Fixed a bug where using structured output or `verbosity` on a `ChatOpenAI` instance configured with `model_kwargs={"text": {...}}` mutated the shared `model_kwargs`, causing later requests from the same instance to be stuck in a previously used `format`.

---

A regression test asserts that `model_kwargs` is unchanged after a structured-output call and that a later call without a `response_format` does not inherit the leaked `format`.

Disclaimer: this contribution was prepared with the assistance of an AI agent, and reviewed and verified by the contributor.
