### PR TITLE
fix(core): produce UUID document IDs for all `key_encoder` algorithms

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -157,19 +157,19 @@ class IndexingException(LangChainException):
 def _calculate_hash(
     text: str, algorithm: Literal["sha1", "sha256", "sha512", "blake2b"]
 ) -> str:
-    """Return a hexadecimal digest of *text* using *algorithm*."""
+    """Return a UUID derived from the digest of *text* using *algorithm*."""
     if algorithm == "sha1":
-        # Calculate the SHA-1 hash and return it as a UUID.
         digest = hashlib.sha1(text.encode("utf-8"), usedforsecurity=False).hexdigest()
-        return str(uuid.uuid5(NAMESPACE_UUID, digest))
-    if algorithm == "blake2b":
-        return hashlib.blake2b(text.encode("utf-8")).hexdigest()
-    if algorithm == "sha256":
-        return hashlib.sha256(text.encode("utf-8")).hexdigest()
-    if algorithm == "sha512":
-        return hashlib.sha512(text.encode("utf-8")).hexdigest()
-    msg = f"Unsupported hashing algorithm: {algorithm}"  # type: ignore[unreachable]
-    raise ValueError(msg)
+    elif algorithm == "blake2b":
+        digest = hashlib.blake2b(text.encode("utf-8")).hexdigest()
+    elif algorithm == "sha256":
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    elif algorithm == "sha512":
+        digest = hashlib.sha512(text.encode("utf-8")).hexdigest()
+    else:
+        msg = f"Unsupported hashing algorithm: {algorithm}"  # type: ignore[unreachable]
+        raise ValueError(msg)
+    return str(uuid.uuid5(NAMESPACE_UUID, digest))
 
 
 def _get_document_with_hash(
@@ -369,6 +369,7 @@ def index(
             record manager. Useful if you are re-indexing with updated embeddings.
         key_encoder: Hashing algorithm to use for hashing the document content and
             metadata. Options include "blake2b", "sha256", and "sha512".
+            All built-in encoders produce UUID-formatted document IDs.
 
             !!! version-added "Added in `langchain-core` 0.3.66"
 
@@ -708,6 +709,7 @@ async def aindex(
             record manager. Useful if you are re-indexing with updated embeddings.
         key_encoder: Hashing algorithm to use for hashing the document content and
             metadata. Options include "blake2b", "sha256", and "sha512".
+            All built-in encoders produce UUID-formatted document IDs.
 
             !!! version-added "Added in `langchain-core` 0.3.66"
 

--- a/libs/core/tests/unit_tests/indexing/test_indexing.py
+++ b/libs/core/tests/unit_tests/indexing/test_indexing.py
@@ -1,7 +1,9 @@
+import uuid
 from collections.abc import AsyncIterator, Iterable, Iterator, Sequence
 from datetime import datetime, timezone
 from typing import (
     Any,
+    Literal,
 )
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2961,3 +2963,23 @@ async def test_aindex_with_upsert_kwargs(
         # Check other arguments
         assert kwargs["batch_size"] == 100
         assert kwargs["vector_field"] == "embedding"
+
+
+@pytest.mark.parametrize("key_encoder", ["sha1", "sha256", "sha512", "blake2b"])
+def test_document_ids_are_uuids(
+    key_encoder: Literal["sha1", "sha256", "sha512", "blake2b"],
+) -> None:
+    """Test that every built-in key encoder produces a UUID-formatted document ID."""
+    doc = Document(page_content="hello world", metadata={"source": "doc1.txt"})
+    doc_id = _get_document_with_hash(doc, key_encoder=key_encoder).id
+    assert doc_id is not None
+    assert str(uuid.UUID(doc_id)) == doc_id
+
+
+def test_sha1_document_ids_are_unchanged() -> None:
+    """Test that the `sha1` encoder produces the same IDs as previous versions."""
+    doc = Document(page_content="hello world", metadata={"source": "doc1.txt"})
+    assert (
+        _get_document_with_hash(doc, key_encoder="sha1").id
+        == "91bb7324-3dc0-5dad-8c72-0e48a981c88b"
+    )


### PR DESCRIPTION
Fixes #39047

`index()` warns you to move off the default `sha1` key encoder, but all three
encoders it recommends produced raw hex digests instead of UUIDs, so indexing
into Qdrant failed on every call. All four encoders now derive the document ID
the same way `sha1` already did, via a UUIDv5 wrap.

### Release note

`key_encoder="sha256"`, `"sha512"`, and `"blake2b"` now produce UUID-formatted
document IDs in `index()` and `aindex()`, matching `sha1`. These encoders now
work with vector stores that require UUID record IDs, such as Qdrant.

Breaking for existing users of those three encoders, since their document IDs
change. With `cleanup="incremental"` or `"full"` the old IDs are reconciled away
on the next run. With `cleanup=None` there is no reconciliation, so old and new
IDs coexist and previously-indexed documents are duplicated — run once with a
cleanup mode when upgrading. `sha1` output is unchanged.

### Social handles 

Twitter: x.com/KidyeYash