### PR TITLE
fix(qdrant): correct lambda_mult inversion in MMR search

### DIFF
--- a/libs/partners/qdrant/langchain_qdrant/qdrant.py
+++ b/libs/partners/qdrant/langchain_qdrant/qdrant.py
@@ -827,7 +827,7 @@ class QdrantVectorStore(VectorStore):
             collection_name=self.collection_name,
             query=models.NearestQuery(
                 nearest=embedding,
-                mmr=models.Mmr(diversity=lambda_mult, candidates_limit=fetch_k),
+                mmr=models.Mmr(diversity=1.0 - lambda_mult, candidates_limit=fetch_k),
             ),
             query_filter=filter,
             search_params=search_params,

--- a/libs/partners/qdrant/tests/integration_tests/qdrant_vector_store/test_mmr.py
+++ b/libs/partners/qdrant/tests/integration_tests/qdrant_vector_store/test_mmr.py
@@ -63,7 +63,7 @@ def test_qdrant_mmr_search(
         output,
         [
             Document(page_content="foo", metadata={"page": 0}),
-            Document(page_content="bar", metadata={"page": 1}),
+            Document(page_content="baz", metadata={"page": 2}),
         ],
     )
 
@@ -74,6 +74,34 @@ def test_qdrant_mmr_search(
         output,
         [Document(page_content="baz", metadata={"page": 2})],
     )
+
+@pytest.mark.parametrize("location", qdrant_locations())
+def test_qdrant_mmr_lambda_mult_not_inverted(location: str) -> None:
+    """Regression test for GH issue #39052: lambda_mult=1.0 must favor
+    relevance, lambda_mult=0.0 must favor diversity."""
+    texts = [
+        "foo",
+        "foo foo",
+        "completely unrelated topic about penguins",
+    ]
+    docsearch = QdrantVectorStore.from_texts(
+        texts,
+        ConsistentFakeEmbeddings(),
+        location=location,
+        distance=models.Distance.EUCLID,
+    )
+
+    relevance_output = docsearch.max_marginal_relevance_search(
+        "foo", k=2, fetch_k=3, lambda_mult=1.0
+    )
+    relevance_contents = {doc.page_content for doc in relevance_output}
+    assert relevance_contents == {"foo", "foo foo"}
+
+    diversity_output = docsearch.max_marginal_relevance_search(
+        "foo", k=2, fetch_k=3, lambda_mult=0.0
+    )
+    diversity_contents = {doc.page_content for doc in diversity_output}
+    assert "completely unrelated topic about penguins" in diversity_contents
 
 
 # MMR shouldn't work with only sparse retrieval mode


### PR DESCRIPTION
QdrantVectorStore's MMR search passed lambda_mult directly as Qdrant's native diversity param, but Qdrant defines diversity as the inverse of lambda_mult (it computes lambda_ = 1.0 - diversity internally). This meant lambda_mult=0.0 (should mean max diversity) behaved like max relevance, and vice versa.

Fix: invert the value before passing it to Qdrant
(diversity = 1.0 - lambda_mult).

Also corrects a pre-existing test assertion that had unknowingly baked in the inverted behavior, and adds a regression test that checks both ends of the lambda_mult range.

Fixes #39052

Fixes #

---

<!-- Keep the `Fixes #xx` keyword at the very top and update the issue number — this auto-closes the issue on merge. Replace this comment with a 1-2 sentence description of your change. No `# Summary` header; the description is the summary. -->

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangChain! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

  - Examples:
    - fix(anthropic): resolve flag parsing error
    - feat(core): add multi-tenant support
    - test(openai): update API usage tests
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langchain/blob/master/.github/workflows/pr_lint.yml#L15-L33

2. PR description:

  - Write 1-2 sentences that make the change easy to understand: who benefits, what problem they had, and how this solves it. Prefer a simple user story over a long summary.
  - The `Fixes #xx` line at the top is **required** for external contributions — update the issue number and keep the keyword. This links your PR to the approved issue and auto-closes it on merge.
  - If there are any breaking changes, please clearly describe them.
  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.

## Release note
<!-- Required for net new features or behavior-changing bugfixes. State the user-visible change in release-note-ready language. Omit this section for chores, refactors, or test-only changes. -->

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

4. How did you verify your code works?

Additional guidelines:

  - All external PRs must link to an issue or discussion where a solution has been approved by a maintainer, and you must be assigned to that issue. PRs without prior approval will be closed.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/
