### PR TITLE
fix(openai): preserve `reasoning_content` during message conversion

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -217,6 +217,10 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # Also OpenAI returns None for tool invocations
         content = _dict.get("content", "") or ""
         additional_kwargs: dict = {}
+        if "reasoning_content" in _dict and _dict["reasoning_content"] is not None:
+            additional_kwargs["reasoning_content"] = _dict["reasoning_content"]
+        elif "reasoning" in _dict and _dict["reasoning"] is not None:
+            additional_kwargs["reasoning_content"] = _dict["reasoning"]
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
         tool_calls = []
@@ -403,6 +407,14 @@ def _convert_message_to_dict(
         message_dict["role"] = "user"
     elif isinstance(message, AIMessage):
         message_dict["role"] = "assistant"
+        if (
+            api == "chat/completions"
+            and "reasoning_content" in message.additional_kwargs
+            and message.additional_kwargs["reasoning_content"] is not None
+        ):
+            message_dict["reasoning_content"] = message.additional_kwargs[
+                "reasoning_content"
+            ]
         if message.tool_calls or message.invalid_tool_calls:
             message_dict["tool_calls"] = [
                 _lc_tool_call_to_openai_tool_call(tc) for tc in message.tool_calls
@@ -475,6 +487,10 @@ def _convert_delta_to_message_chunk(
     role = cast(str, _dict.get("role"))
     content = cast(str, _dict.get("content") or "")
     additional_kwargs: dict = {}
+    if "reasoning_content" in _dict and _dict["reasoning_content"] is not None:
+        additional_kwargs["reasoning_content"] = _dict["reasoning_content"]
+    elif "reasoning" in _dict and _dict["reasoning"] is not None:
+        additional_kwargs["reasoning_content"] = _dict["reasoning"]
     if _dict.get("function_call"):
         function_call = dict(_dict["function_call"])
         if "name" in function_call and function_call["name"] is None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -77,6 +77,7 @@ from langchain_openai.chat_models.base import (
     OpenAIRefusalError,
     _construct_lc_result_from_responses_api,
     _construct_responses_api_input,
+    _convert_delta_to_message_chunk,
     _convert_dict_to_message,
     _convert_message_to_dict,
     _convert_responses_chunk_to_generation_chunk,
@@ -210,6 +211,36 @@ def test__convert_dict_to_message_ai() -> None:
     assert _convert_message_to_dict(expected_output) == message
 
 
+def test__convert_dict_to_message_ai_with_reasoning_content() -> None:
+    message = {
+        "role": "assistant",
+        "content": "foo",
+        "reasoning_content": "step-by-step",
+    }
+    result = _convert_dict_to_message(message)
+    expected_output = AIMessage(
+        content="foo",
+        additional_kwargs={"reasoning_content": "step-by-step"},
+    )
+    assert result == expected_output
+    assert _convert_message_to_dict(expected_output) == message
+
+
+def test__convert_dict_to_message_ai_maps_reasoning_to_reasoning_content() -> None:
+    message = {"role": "assistant", "content": "foo", "reasoning": "step-by-step"}
+    result = _convert_dict_to_message(message)
+    expected_output = AIMessage(
+        content="foo",
+        additional_kwargs={"reasoning_content": "step-by-step"},
+    )
+    assert result == expected_output
+    assert _convert_message_to_dict(expected_output) == {
+        "role": "assistant",
+        "content": "foo",
+        "reasoning_content": "step-by-step",
+    }
+
+
 def test__convert_dict_to_message_ai_with_name() -> None:
     message = {"role": "assistant", "content": "foo", "name": "test"}
     result = _convert_dict_to_message(message)
@@ -327,6 +358,18 @@ def test__convert_dict_to_message_tool_call() -> None:
         reverted_message_dict["tool_calls"], key=lambda x: x["id"]
     )
     assert reverted_message_dict == message
+
+
+@pytest.mark.parametrize("reasoning_key", ["reasoning_content", "reasoning"])
+def test__convert_delta_to_message_chunk_maps_reasoning_content(
+    reasoning_key: str,
+) -> None:
+    chunk = _convert_delta_to_message_chunk(
+        {"role": "assistant", "content": "foo", reasoning_key: "step-by-step"},
+        AIMessageChunk,
+    )
+    assert isinstance(chunk, AIMessageChunk)
+    assert chunk.additional_kwargs == {"reasoning_content": "step-by-step"}
 
 
 class MockAsyncContextManager:

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -398,7 +398,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -666,7 +666,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -697,7 +697,7 @@ requires-dist = [
 dev = [
     { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
-    { name = "setuptools", specifier = ">=67.6.1,<83.0.0" },
+    { name = "setuptools", specifier = ">=67.6.1,<84.0.0" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
 test = [


### PR DESCRIPTION
Closes #38764

---

## Background

When integrating OpenAI-compatible models that expose reasoning output, such as DeepSeek / GLM / Qwen, providers often return `reasoning_content` or `reasoning` in either normal responses or streaming deltas to carry the model's reasoning text.

However, `langchain-openai` does not currently preserve these fields reliably when converting OpenAI-style responses into LangChain message objects. As a result:

- The provider returns reasoning content, but the application layer cannot read it from `AIMessage` / `AIMessageChunk`
- The frontend cannot distinguish between "answer content" and "reasoning content"
- Application code often has to wrap or subclass the model implementation just to restore this capability

This is the core issue described in [#38764](https://github.com/langchain-ai/langchain/issues/38764).

## Problem

### Input

Streaming deltas may include `reasoning_content`:

```json
{
  "delta": {
    "content": null,
    "function_call": null,
    "refusal": null,
    "role": "assistant",
    "tool_calls": null,
    "reasoning_content": "The"
  },
  "finish_reason": null,
  "index": 0,
  "logprobs": null
}
```

Some compatible providers use `reasoning` instead:

<img width="1964" height="906" alt="image" src="https://github.com/user-attachments/assets/721d5410-4d85-4a28-97ea-4f9dbb0ec56e" />

### Current Issue

After conversion, these fields are not preserved in a stable location that the application layer can read. In practice, downstream code usually receives only the final answer text. As a result, Agent applications cannot surface the reasoning stream, and the frontend may appear unresponsive while waiting, often for more than 10 seconds, making it hard for users to tell whether the system is still thinking or has stalled.

### Expected Behavior

Regardless of whether the provider returns `reasoning_content` or `reasoning`, the value should be normalized and preserved at:

```shell
message.additional_kwargs["reasoning_content"]
```

This gives downstream code a single canonical field to read.

## What This Change Does

This change does three things:

1. Preserves `reasoning_content` during normal assistant message conversion
2. Normalizes the compatibility field `reasoning` to `reasoning_content` during normal assistant message conversion
3. Applies the same preservation and normalization logic during streaming delta conversion

With this change, downstream code can read reasoning text consistently from `additional_kwargs["reasoning_content"]` in both non-streaming and streaming flows.

## Result

### Before

Application code could not read reasoning content from the message object.

<img width="2024" height="1136" alt="image" src="https://github.com/user-attachments/assets/4cf97f06-930d-4e4b-a946-c9ca35d9cc1f" />

### After

Example downstream consumption:

```python
config = {"recursion_limit": recursion_limit()}
final_text = ""
final_reasoning = ""
chunk_count = 0

with dump_file.open("w", encoding="utf-8") as fp:
    for item in agent.stream(
            {"messages": [{"role": "user", "content": prompt}]},
            config=config,
            stream_mode="messages",
    ):
        if not isinstance(item, tuple) or len(item) < 1:
            continue
        message = item[0]
        metadata = item[1] if len(item) > 1 else None
        if not isinstance(message, BaseMessage):
            continue

        if isinstance(message, AIMessageChunk):
            chunk_count += 1
            record = {
                "index": chunk_count,
                "message": serialize_aimessage_chunk(message),
                "metadata": metadata,
            }
            fp.write(json.dumps(record, ensure_ascii=False) + "\n")

            reasoning = message.additional_kwargs.get("reasoning_content") or ""
            if reasoning:
                final_reasoning += reasoning
            final_text += _text_of(message.content)
```

<img width="1980" height="1688" alt="image" src="https://github.com/user-attachments/assets/539c2023-cdb6-4a41-a593-116fc3731266" />

## Design Notes

The goal of this change is not to introduce a new public API. It is to reliably pass through data that providers are already returning into the existing LangChain message objects.

Benefits:

- No change to the existing primary usage flow
- No need for application code to subclass `ChatOpenAI`
- Better support for OpenAI-compatible providers that extend the protocol with reasoning fields
- A consistent access pattern across standard and streaming responses

## Validation

Targeted unit tests were added to cover:

- assistant messages containing `reasoning_content`: preserved and round-trippable after conversion
- assistant messages containing `reasoning`: normalized to `reasoning_content`
- streaming deltas containing `reasoning_content`: preserved
- streaming deltas containing `reasoning`: normalized to `reasoning_content`

In addition, this was verified in a real application project: the packaged `langchain-openai` wheel could be installed into an external project, and the updated behavior worked as expected.

## Compatibility

This change is intentionally minimal in scope:

- No new public API
- No changes to the existing call pattern
- Only preserves provider-returned data on the message object
- Normalizes `reasoning` to `reasoning_content` for compatible providers, reducing branching in downstream code

The main area to watch is the assistant message serialization / deserialization path, to ensure this does not affect the existing standard `chat/completions` conversion logic.

## Release note

Improved `langchain-openai` by preserving reasoning text returned by OpenAI-compatible models in both standard and streaming responses, and exposing it consistently as `reasoning_content`.