### PR TITLE
fix(core): raise on `vectors`/`texts` length mismatch in `InMemoryVectorStore`

### DIFF
--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -201,13 +201,20 @@ class InMemoryVectorStore(VectorStore):
             )
             raise ValueError(msg)
 
+        if len(vectors) != len(texts):
+            msg = (
+                f"vectors must be the same length as texts. "
+                f"Got {len(vectors)} vectors and {len(texts)} texts."
+            )
+            raise ValueError(msg)
+
         id_iterator: Iterator[str | None] = (
             iter(ids) if ids else iter(doc.id for doc in documents)
         )
 
         ids_ = []
 
-        for doc, vector in zip(documents, vectors, strict=False):
+        for doc, vector in zip(documents, vectors, strict=True):
             doc_id = next(id_iterator)
             doc_id_ = doc_id or str(uuid.uuid4())
             ids_.append(doc_id_)
@@ -234,12 +241,19 @@ class InMemoryVectorStore(VectorStore):
             )
             raise ValueError(msg)
 
+        if len(vectors) != len(texts):
+            msg = (
+                f"vectors must be the same length as texts. "
+                f"Got {len(vectors)} vectors and {len(texts)} texts."
+            )
+            raise ValueError(msg)
+
         id_iterator: Iterator[str | None] = (
             iter(ids) if ids else iter(doc.id for doc in documents)
         )
         ids_: list[str] = []
 
-        for doc, vector in zip(documents, vectors, strict=False):
+        for doc, vector in zip(documents, vectors, strict=True):
             doc_id = next(id_iterator)
             doc_id_ = doc_id or str(uuid.uuid4())
             ids_.append(doc_id_)

--- a/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
@@ -5,9 +5,27 @@ import pytest
 from langchain_tests.integration_tests.vectorstores import VectorStoreIntegrationTests
 
 from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
 from langchain_core.embeddings.fake import DeterministicFakeEmbedding
 from langchain_core.vectorstores import InMemoryVectorStore
 from tests.unit_tests.stubs import _any_id_document
+
+
+class _TruncatingEmbedding(Embeddings):
+    """Embedding function that returns one fewer vector than requested."""
+
+    def __init__(self, size: int = 3) -> None:
+        self.size = size
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        vectors = DeterministicFakeEmbedding(size=self.size).embed_documents(texts)
+        return vectors[:-1]
+
+    def embed_query(self, text: str) -> list[float]:
+        return DeterministicFakeEmbedding(size=self.size).embed_query(text)
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_documents(texts)
 
 
 class TestInMemoryStandard(VectorStoreIntegrationTests):
@@ -209,8 +227,8 @@ async def test_inmemory_get_by_ids() -> None:
 async def test_inmemory_call_embeddings_async() -> None:
     embeddings_mock = Mock(
         wraps=DeterministicFakeEmbedding(size=3),
-        aembed_documents=AsyncMock(),
-        aembed_query=AsyncMock(),
+        aembed_documents=AsyncMock(return_value=[[0.1, 0.2, 0.3]] * 3),
+        aembed_query=AsyncMock(return_value=[0.1, 0.2, 0.3]),
     )
     store = InMemoryVectorStore(embedding=embeddings_mock)
 
@@ -220,3 +238,29 @@ async def test_inmemory_call_embeddings_async() -> None:
     # Ensure the async embedding function is called
     assert embeddings_mock.aembed_documents.await_count == 1
     assert embeddings_mock.aembed_query.await_count == 1
+
+
+def test_add_documents_raises_on_vector_count_mismatch() -> None:
+    """Test add_documents raises when embed_documents returns too few vectors."""
+    store = InMemoryVectorStore(embedding=_TruncatingEmbedding())
+    documents = [
+        Document(page_content="foo"),
+        Document(page_content="bar"),
+        Document(page_content="baz"),
+    ]
+
+    with pytest.raises(ValueError, match="vectors must be the same length as texts"):
+        store.add_documents(documents)
+
+
+async def test_aadd_documents_raises_on_vector_count_mismatch() -> None:
+    """Test aadd_documents raises when aembed_documents returns too few vectors."""
+    store = InMemoryVectorStore(embedding=_TruncatingEmbedding())
+    documents = [
+        Document(page_content="foo"),
+        Document(page_content="bar"),
+        Document(page_content="baz"),
+    ]
+
+    with pytest.raises(ValueError, match="vectors must be the same length as texts"):
+        await store.aadd_documents(documents)


### PR DESCRIPTION
Closes #36745

---

If a custom `Embeddings.embed_documents` (or `aembed_documents`) implementation
returns fewer vectors than the number of input texts — for example due to a bug,
a provider-side truncation, or a partial batch failure that isn't itself
error-raising — `InMemoryVectorStore.add_documents` and `aadd_documents` would
silently drop the trailing documents instead of surfacing the problem. This is
because the internal `zip(documents, vectors, strict=False)` truncates to the
shorter sequence rather than raising, and there was no explicit length check
beforehand (unlike the existing check for `ids`).

Callers had no signal that documents were missing from the store, which made
this bug easy to miss until similarity search silently failed to return
documents that were supposedly added.

This adds an explicit length check for `vectors` against `texts`, mirroring
the existing `ids` validation, in both `add_documents` and `aadd_documents`.
The `zip` calls are also switched to `strict=True` as a defense-in-depth
backstop against future length mismatches.

## Release note

`InMemoryVectorStore.add_documents` and `aadd_documents` now raise a
`ValueError` if the configured embedding function returns a different number
of vectors than the number of input documents, instead of silently dropping
the extra documents.

---

This contribution was prepared with the assistance of an AI coding agent
(Claude), with all changes reviewed and verified by a human before submission.