### PR TITLE
fix(core): clear usage callback when the block exits via an exception

### DIFF
--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -114,6 +114,8 @@ def get_usage_metadata_callback(
     )
     register_configure_hook(usage_metadata_callback_var, inheritable=True)
     cb = UsageMetadataCallbackHandler()
-    usage_metadata_callback_var.set(cb)
-    yield cb
-    usage_metadata_callback_var.set(None)
+    token = usage_metadata_callback_var.set(cb)
+    try:
+        yield cb
+    finally:
+        usage_metadata_callback_var.reset(token)

--- a/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
+++ b/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
@@ -1,3 +1,4 @@
+import contextlib
 from typing import Any
 
 from langchain_core.callbacks import (
@@ -120,3 +121,76 @@ async def test_usage_callback_async() -> None:
     callback = UsageMetadataCallbackHandler()
     _ = await llm.abatch(["Message 1", "Message 2"], config={"callbacks": [callback]})
     assert callback.usage_metadata == {"test_model": total_1_2}
+
+
+def test_usage_callback_stops_tracking_when_block_raises() -> None:
+    """The callback must stop collecting when the `with` block exits via an exception.
+
+    Without a `try`/`finally` the context variable is never cleared, so model calls
+    made after the block keep accumulating into the callback.
+    """
+    messages = [
+        AIMessage("Response 1", usage_metadata=usage1),
+        AIMessage("Response 2", usage_metadata=usage2),
+    ]
+    llm = FakeChatModelWithResponseMetadata(
+        messages=iter(messages), model_name="test_model"
+    )
+
+    with contextlib.suppress(RuntimeError), get_usage_metadata_callback() as cb:
+        _ = llm.invoke("Message 1")
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    _ = llm.invoke("Message 2")
+
+    assert cb.usage_metadata == {"test_model": usage1}
+
+
+async def test_usage_callback_stops_tracking_when_block_raises_async() -> None:
+    """Async variant of the exception-path cleanup check."""
+    messages = [
+        AIMessage("Response 1", usage_metadata=usage1),
+        AIMessage("Response 2", usage_metadata=usage2),
+    ]
+    llm = FakeChatModelWithResponseMetadata(
+        messages=iter(messages), model_name="test_model"
+    )
+
+    with contextlib.suppress(RuntimeError), get_usage_metadata_callback() as cb:
+        _ = await llm.ainvoke("Message 1")
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    _ = await llm.ainvoke("Message 2")
+
+    assert cb.usage_metadata == {"test_model": usage1}
+
+
+def test_nested_usage_callbacks_keep_tracking_in_outer_scope() -> None:
+    """An outer block keeps tracking across and after a nested block.
+
+    Each `get_usage_metadata_callback()` call installs its own context variable, so
+    both handlers are attached while nested: the inner block sees only its own call,
+    and the outer block accounts for everything that happened inside it.
+    """
+    messages = [
+        AIMessage("Response 1", usage_metadata=usage1),
+        AIMessage("Response 2", usage_metadata=usage2),
+        AIMessage("Response 3", usage_metadata=usage3),
+    ]
+    llm = FakeChatModelWithResponseMetadata(
+        messages=iter(messages), model_name="test_model"
+    )
+
+    with get_usage_metadata_callback() as outer:
+        _ = llm.invoke("Message 1")
+        with get_usage_metadata_callback() as inner:
+            _ = llm.invoke("Message 2")
+        # Leaving the nested block must not stop the outer one.
+        _ = llm.invoke("Message 3")
+
+    assert inner.usage_metadata == {"test_model": usage2}
+    assert outer.usage_metadata == {
+        "test_model": add_usage(add_usage(usage1, usage2), usage3)
+    }


### PR DESCRIPTION
Closes #38989

---

Someone tracking token spend per operation wraps their work in `get_usage_metadata_callback()`. If anything inside that block raises — a rate limit, a parsing error, a bug in their own chain — the callback is never unregistered, and every model call they make *afterwards* keeps accumulating into it. Their next reported token count is silently inflated, with no error to hint at why.

The context manager set the context variable, yielded, and then cleared it, with nothing guaranteeing the cleanup:

```python
usage_metadata_callback_var.set(cb)
yield cb
usage_metadata_callback_var.set(None)  # skipped when the block raises
```

From the issue's reproduction, a block that raises after one 3-token call and then makes one more call reports `6` where it should report `3`.

This switches to the token + `try`/`finally` pattern that the sibling context managers in `langchain_core.tracers.context` (`tracing_v2_enabled`, `collect_runs`) already use, so the variable is restored on every exit path — normal, exception, or early `break`/`return`. Using `reset(token)` rather than `set(None)` also restores whatever was previously in scope instead of unconditionally blanking it.

No signature or public API change; the only behavioral difference is on the path that was previously leaking.

## Release note

Fixed `get_usage_metadata_callback` continuing to record usage after its `with` block exited via an exception, which inflated token counts for subsequent model calls.

## Notes for review

Three tests added: the sync and async exception paths, plus one pinning the nesting semantics. Worth a look at that third one — because each call installs its own context variable, both handlers stay attached while nested, so an inner block sees only its own call while the outer block accounts for everything inside it. That behavior is unchanged by this fix; I added the test so it does not regress silently.
