### PR TITLE
fix(core): stop usage_metadata_callback tracking when block raises

### DIFF
--- a/libs/core/langchain_core/callbacks/usage.py
+++ b/libs/core/langchain_core/callbacks/usage.py
@@ -115,5 +115,7 @@ def get_usage_metadata_callback(
     register_configure_hook(usage_metadata_callback_var, inheritable=True)
     cb = UsageMetadataCallbackHandler()
     usage_metadata_callback_var.set(cb)
-    yield cb
-    usage_metadata_callback_var.set(None)
+    try:
+        yield cb
+    finally:
+        usage_metadata_callback_var.set(None)

--- a/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
+++ b/libs/core/tests/unit_tests/callbacks/test_usage_callback.py
@@ -1,4 +1,7 @@
+from itertools import cycle
 from typing import Any
+
+import pytest
 
 from langchain_core.callbacks import (
     UsageMetadataCallbackHandler,
@@ -120,3 +123,20 @@ async def test_usage_callback_async() -> None:
     callback = UsageMetadataCallbackHandler()
     _ = await llm.abatch(["Message 1", "Message 2"], config={"callbacks": [callback]})
     assert callback.usage_metadata == {"test_model": total_1_2}
+
+
+def test_usage_callback_stops_tracking_after_exception() -> None:
+    # Regression test for https://github.com/langchain-ai/langchain/issues/38989
+    # If the `with` block exits via an exception, the callback must stop tracking
+    # so later model calls are not attributed to the (already-exited) context.
+    llm = FakeChatModelWithResponseMetadata(
+        messages=cycle([AIMessage("Hi", usage_metadata=usage1)]),
+        model_name="test_model",
+    )
+
+    with pytest.raises(RuntimeError), get_usage_metadata_callback() as cb:  # noqa: PT012
+        _ = llm.invoke("in block")  # tracked
+        raise RuntimeError
+
+    _ = llm.invoke("outside block")  # must NOT be tracked
+    assert cb.usage_metadata == {"test_model": usage1}


### PR DESCRIPTION
**Fixes #38989**

### Description

`get_usage_metadata_callback` reset the context variable *after* the `yield` without a `try`/`finally`:

```python
usage_metadata_callback_var.set(cb)
yield cb
usage_metadata_callback_var.set(None)  # skipped when the with-block raises
```

If the `with` block exits via an exception, the reset line is skipped, the callback stays registered, and model calls made **after** the block keep accumulating into it — silent, incorrect token accounting. This wraps the `yield` in `try`/`finally`, matching the sibling context managers in `langchain_core.tracers.context`.

### Reproduction (before → after)

```python
try:
    with get_usage_metadata_callback() as cb:
        llm.invoke("in block")     # tracked: 3 tokens
        raise RuntimeError
except RuntimeError:
    pass
llm.invoke("outside block")        # should NOT be tracked
print(cb.usage_metadata["fake"]["total_tokens"])
```
Before: `6`  ·  After: `3`

### Tests

Added `test_usage_callback_stops_tracking_after_exception` in `tests/unit_tests/callbacks/test_usage_callback.py` — it raises inside the block and asserts a later call is not attributed to the exited context. Fails on `master`, passes with this change. Full `test_usage_callback.py` suite green; `ruff check`/`ruff format` clean.