### PR TITLE
fix(core): return NotImplemented from Runnable.__or__/__ror__ for unsupported operands

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -662,9 +662,15 @@ class Runnable(ABC, Generic[Input, Output]):
             other: Another `Runnable` or a `Runnable`-like object.
 
         Returns:
-            A new `Runnable`.
+            A new `Runnable`, or `NotImplemented` if `other` is not a
+            `Runnable`-like object, so the interpreter can try
+            `type(other).__ror__`.
         """
-        return RunnableSequence(self, coerce_to_runnable(other))
+        try:
+            coerced_other = coerce_to_runnable(other)
+        except TypeError:
+            return NotImplemented
+        return RunnableSequence(self, coerced_other)
 
     @overload
     def __ror__(
@@ -705,9 +711,15 @@ class Runnable(ABC, Generic[Input, Output]):
             other: Another `Runnable` or a `Runnable`-like object.
 
         Returns:
-            A new `Runnable`.
+            A new `Runnable`, or `NotImplemented` if `other` is not a
+            `Runnable`-like object, so the interpreter can try
+            `type(other).__or__`.
         """
-        return RunnableSequence(coerce_to_runnable(other), self)
+        try:
+            coerced_other = coerce_to_runnable(other)
+        except TypeError:
+            return NotImplemented
+        return RunnableSequence(coerced_other, self)
 
     def pipe(
         self,

--- a/libs/core/tests/unit_tests/runnables/test_runnable_operators.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_operators.py
@@ -1,0 +1,48 @@
+"""Tests for ``Runnable.__or__`` / ``Runnable.__ror__`` operator protocol.
+
+Regression tests for https://github.com/langchain-ai/langchain/issues/39075:
+when the other operand is not ``Runnable``-like, the dunder must return
+``NotImplemented`` (per the Python data model) so the interpreter can try the
+other operand's reflected operator, instead of raising ``TypeError`` directly.
+"""
+
+import pytest
+
+from langchain_core.runnables import RunnableLambda
+
+
+class _ForeignRor:
+    """Third-party object that defines the reflected ``__ror__``."""
+
+    def __ror__(self, other: object) -> tuple[str, str]:
+        return ("foreign_ror", type(other).__name__)
+
+
+class _ForeignOr:
+    """Third-party object that defines ``__or__``."""
+
+    def __or__(self, other: object) -> tuple[str, str]:
+        return ("foreign_or", type(other).__name__)
+
+
+def test_or_defers_to_foreign_ror() -> None:
+    chain = RunnableLambda(lambda x: x * 2)
+    assert chain | _ForeignRor() == ("foreign_ror", "RunnableLambda")
+
+
+def test_ror_defers_to_foreign_or() -> None:
+    chain = RunnableLambda(lambda x: x * 2)
+    assert _ForeignOr() | chain == ("foreign_or", "RunnableLambda")
+
+
+def test_or_returns_not_implemented_for_unsupported() -> None:
+    chain = RunnableLambda(lambda x: x * 2)
+    assert chain.__or__(42) is NotImplemented
+    assert chain.__ror__(42) is NotImplemented
+
+
+def test_or_still_raises_for_genuinely_unsupported_operand() -> None:
+    chain = RunnableLambda(lambda x: x * 2)
+    # neither operand handles the op -> the interpreter raises TypeError
+    with pytest.raises(TypeError):
+        _ = chain | 42


### PR DESCRIPTION
**Fixes #39075**

### Description

`Runnable.__or__` / `__ror__` called `coerce_to_runnable(other)` directly, so when `other` was not `Runnable`-like they propagated its `TypeError`. Per the [Python data model](https://docs.python.org/3/reference/datamodel.html#object.__ror__), a binary dunder that can't handle an operand should return `NotImplemented` so the interpreter can try the other operand's reflected method.

Because the operator raised instead, `chain | obj` never consulted `type(obj).__ror__`, and `obj | chain` never consulted `type(obj).__or__` — diverging from builtins/stdlib (`int`, `set`, `dict`, `pathlib.Path`) and from what static type checkers already assume for `|`.

Both dunders now catch the coercion `TypeError` and return `NotImplemented`. When neither operand handles the operation, the interpreter still raises `TypeError` (`unsupported operand type(s) for |`).

### Behavior (before → after)

```python
chain = RunnableLambda(lambda x: x * 2)

class Foreign:
    def __ror__(self, other): return ("foreign", type(other).__name__)

chain | Foreign()
# before: TypeError from coerce_to_runnable
# after:  ('foreign', 'RunnableLambda')  ← Foreign.__ror__ consulted
```

### Tests

New `tests/unit_tests/runnables/test_runnable_operators.py`:
- `__or__`/`__ror__` defer to a third-party `__ror__`/`__or__`;
- both return `NotImplemented` for unsupported operands;
- a genuinely unsupported operand still raises `TypeError`.

`ruff check` / `ruff format` clean; `mypy` clean on the changed module. (The pre-existing `test_combining_sequences` snapshot test fails identically on `master` in this environment due to partner-package versions — unrelated to this change.)