### PR TITLE
fix(openai): do not mutate model_kwargs["text"] in Responses API payload

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4349,6 +4349,13 @@ def _construct_responses_api_payload(
         else:
             payload["tool_choice"] = tool_choice
 
+    # Copy any caller-provided ``text`` options before mutating them below, so we
+    # don't modify the user's ``model_kwargs["text"]`` dict in place. Mutating it
+    # would corrupt the caller's dict and leak structured-output/verbosity
+    # settings into subsequent calls that reuse the same model instance.
+    if isinstance(payload.get("text"), dict):
+        payload["text"] = dict(payload["text"])
+
     # Structured output
     if schema := payload.pop("response_format", None):
         # For pydantic + non-streaming case, we use responses.parse.

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1418,6 +1418,32 @@ def test_nested_structured_output_strict() -> None:
     llm.with_structured_output(JokeWithEvaluation, method="json_schema")
 
 
+def test__get_request_payload_does_not_mutate_text_model_kwargs() -> None:
+    # Regression test for https://github.com/langchain-ai/langchain/issues/38869
+    # The Responses API payload builder must not mutate the caller's
+    # ``model_kwargs["text"]`` dict in place, otherwise structured-output settings
+    # leak into subsequent calls that reuse the same model instance.
+    text_opts = {"verbosity": "low"}
+    llm = ChatOpenAI(
+        model="gpt-4.1",
+        use_responses_api=True,
+        model_kwargs={"text": text_opts},
+    )
+
+    payload1 = llm._get_request_payload(
+        "give me json", response_format={"type": "json_object"}
+    )
+    # the structured-output request still gets the format applied...
+    assert payload1["text"] == {"verbosity": "low", "format": {"type": "json_object"}}
+    # ...but the caller's dict and the model's model_kwargs are untouched.
+    assert text_opts == {"verbosity": "low"}
+    assert llm.model_kwargs["text"] == {"verbosity": "low"}
+
+    # a subsequent plain call must not inherit the previous call's format.
+    payload2 = llm._get_request_payload("just chat normally")
+    assert payload2["text"] == {"verbosity": "low"}
+
+
 def test__get_request_payload() -> None:
     llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
     messages: list = [


### PR DESCRIPTION
**Fixes #38869**

### Description

In `_construct_responses_api_payload`, structured output and verbosity were applied by mutating `payload["text"]` in place:

```python
payload["text"]["format"] = ...
payload["text"]["verbosity"] = ...
```

`payload["text"]` is the same object as the caller's `model_kwargs["text"]`. So a structured-output request:
1. mutated the caller's own dict, and
2. because the `ChatOpenAI` instance reuses `model_kwargs`, **leaked** the injected `format` into every later call on that instance — including plain calls with no `response_format`.

This copies `payload["text"]` once (`payload["text"] = dict(payload["text"])`) before the structured-output / verbosity blocks, so the request payload is built correctly while the caller's `model_kwargs["text"]` is left untouched.

### Before → after

```python
opts = {"verbosity": "low"}
llm = ChatOpenAI(model="gpt-4.1", api_key="test", use_responses_api=True, model_kwargs={"text": opts})
llm._get_request_payload("json", response_format={"type": "json_object"})
# before: opts == {"verbosity": "low", "format": {"type": "json_object"}}   (mutated!)
# after:  opts == {"verbosity": "low"}
llm._get_request_payload("plain")["text"]
# before: {"verbosity": "low", "format": {"type": "json_object"}}  (leaked)
# after:  {"verbosity": "low"}
```

### Tests

Added `test__get_request_payload_does_not_mutate_text_model_kwargs` in `tests/unit_tests/chat_models/test_base.py`: asserts the structured call still applies `format`, the caller's dict and `model_kwargs["text"]` are unchanged, and a following plain call does not inherit the format. `ruff check`/`format` clean.