### PR TITLE
fix(perplexity): do not mutate caller's extra_body in _to_responses_payload

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -1078,8 +1078,8 @@ class ChatPerplexity(BaseChatModel):
                 continue
             # Unknown / Perplexity-specific keys: route under extra_body so the
             # SDK forwards them to the Agent API without breaking strict typing.
-            extra_body = payload.setdefault("extra_body", {})
-            if not isinstance(extra_body, dict):
+            extra_body = payload.get("extra_body")
+            if extra_body is not None and not isinstance(extra_body, dict):
                 msg = (
                     "`extra_body` must be a dict to forward Perplexity-specific "
                     f"parameters to the Responses API, got "
@@ -1087,7 +1087,11 @@ class ChatPerplexity(BaseChatModel):
                     f"user-set key {key!r}."
                 )
                 raise TypeError(msg)
+            # Copy so we never mutate a caller-provided `extra_body` dict in place
+            # (it may be shared via `model_kwargs` and reused across calls).
+            extra_body = dict(extra_body or {})
             extra_body[key] = value
+            payload["extra_body"] = extra_body
         # When the caller selected a preset, defer model selection to it: the
         # Agent API rejects bare Chat-Completions model names like `sonar-pro`
         # outright when `model` is set, even if a preset is also present.

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
@@ -1036,3 +1036,41 @@ def test_responses_completed_event_sets_model_name() -> None:
     chunk = _convert_responses_stream_event_to_chunk(event)
     assert chunk is not None
     assert chunk.message.response_metadata["model_name"] == "sonar-pro"
+
+
+def test_to_responses_payload_does_not_mutate_extra_body() -> None:
+    # Regression test for https://github.com/langchain-ai/langchain/issues/38840
+    # Routing Perplexity-specific keys under `extra_body` must not mutate a
+    # caller-provided `extra_body` dict in place (it may be reused across calls).
+    llm = ChatPerplexity(model="sonar-pro", api_key="test", use_responses_api=True)
+
+    shared = {"country": "US"}
+    payload = llm._to_responses_payload(
+        [], {"extra_body": shared, "search_mode": "academic"}, user_set_keys=set()
+    )
+
+    # the payload still forwards the routed key...
+    assert payload["extra_body"] == {"country": "US", "search_mode": "academic"}
+    # ...but the caller's dict is left untouched.
+    assert shared == {"country": "US"}
+
+
+def test_to_responses_payload_does_not_leak_across_calls() -> None:
+    # A routed key from one call must not persist into a later call that reuses
+    # the same instance's `model_kwargs["extra_body"]`.
+    llm = ChatPerplexity(
+        model="sonar-pro",
+        api_key="test",
+        use_responses_api=True,
+        extra_body={"country": "US"},
+    )
+
+    llm._to_responses_payload(
+        [], {**llm._default_params, "search_mode": "academic"}, user_set_keys=set()
+    )
+    assert llm.model_kwargs == {"extra_body": {"country": "US"}}
+
+    payload2 = llm._to_responses_payload(
+        [], dict(llm._default_params), user_set_keys=set()
+    )
+    assert payload2.get("extra_body") == {"country": "US"}


### PR DESCRIPTION
**Fixes #38840**

### Description

In `ChatPerplexity._to_responses_payload`, Perplexity-specific keys are routed under `extra_body` via:

```python
extra_body = payload.setdefault("extra_body", {})
...
extra_body[key] = value
```

`extra_body` is a passthrough key, so `payload["extra_body"]` is the **caller's own dict** (typically shared through `model_kwargs`). Assigning into it therefore:
1. mutated the caller's dict in place, and
2. leaked the routed keys into later calls on the same instance (which rebuilds params from `{**self._default_params, ...}`).

The fix builds a fresh copy of `extra_body` before adding routed keys, so the payload is correct while the caller's dict is left untouched. The existing non-dict `extra_body` `TypeError` guard is preserved.

### Before → after

```python
llm = ChatPerplexity(model="sonar-pro", api_key="test", use_responses_api=True)
shared = {"country": "US"}
llm._to_responses_payload([], {"extra_body": shared, "search_mode": "academic"}, user_set_keys=set())
# before: shared == {"country": "US", "search_mode": "academic"}   (mutated)
# after:  shared == {"country": "US"}
```

### Tests

Added to `tests/unit_tests/test_chat_models_responses.py`:
- `test_to_responses_payload_does_not_mutate_extra_body` — payload gets the routed key, caller's dict unchanged;
- `test_to_responses_payload_does_not_leak_across_calls` — a routed key from one call doesn't persist into the next.

Existing `extra_body` tests (passthrough preserved, non-dict raises `TypeError`) still pass. `ruff check`/`format` clean.