### PR TITLE
fix(core): make all index() key encoders produce valid UUID document ids

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -157,19 +157,24 @@ class IndexingException(LangChainException):
 def _calculate_hash(
     text: str, algorithm: Literal["sha1", "sha256", "sha512", "blake2b"]
 ) -> str:
-    """Return a hexadecimal digest of *text* using *algorithm*."""
+    """Return a deterministic UUID string derived from *text* using *algorithm*."""
+    encoded = text.encode("utf-8")
     if algorithm == "sha1":
-        # Calculate the SHA-1 hash and return it as a UUID.
-        digest = hashlib.sha1(text.encode("utf-8"), usedforsecurity=False).hexdigest()
-        return str(uuid.uuid5(NAMESPACE_UUID, digest))
-    if algorithm == "blake2b":
-        return hashlib.blake2b(text.encode("utf-8")).hexdigest()
-    if algorithm == "sha256":
-        return hashlib.sha256(text.encode("utf-8")).hexdigest()
-    if algorithm == "sha512":
-        return hashlib.sha512(text.encode("utf-8")).hexdigest()
-    msg = f"Unsupported hashing algorithm: {algorithm}"  # type: ignore[unreachable]
-    raise ValueError(msg)
+        digest = hashlib.sha1(encoded, usedforsecurity=False).hexdigest()
+    elif algorithm == "blake2b":
+        digest = hashlib.blake2b(encoded).hexdigest()
+    elif algorithm == "sha256":
+        digest = hashlib.sha256(encoded).hexdigest()
+    elif algorithm == "sha512":
+        digest = hashlib.sha512(encoded).hexdigest()
+    else:
+        msg = f"Unsupported hashing algorithm: {algorithm}"  # type: ignore[unreachable]
+        raise ValueError(msg)
+    # Wrap the digest in a UUID so the resulting id is a valid UUID for every
+    # vector store (e.g. Qdrant requires point ids to be UUIDs). Previously only
+    # the "sha1" branch did this; "blake2b"/"sha256"/"sha512" returned the raw
+    # hex digest, which broke indexing into stores that validate UUIDs.
+    return str(uuid.uuid5(NAMESPACE_UUID, digest))
 
 
 def _get_document_with_hash(

--- a/libs/core/tests/unit_tests/indexing/test_indexing.py
+++ b/libs/core/tests/unit_tests/indexing/test_indexing.py
@@ -1,3 +1,4 @@
+import uuid
 from collections.abc import AsyncIterator, Iterable, Iterator, Sequence
 from datetime import datetime, timezone
 from typing import (
@@ -17,6 +18,7 @@ from langchain_core.indexing.api import (
     IndexingException,
     _abatch,
     _batch,
+    _calculate_hash,
     _get_document_with_hash,
 )
 from langchain_core.indexing.in_memory import InMemoryDocumentIndex
@@ -2961,3 +2963,19 @@ async def test_aindex_with_upsert_kwargs(
         # Check other arguments
         assert kwargs["batch_size"] == 100
         assert kwargs["vector_field"] == "embedding"
+
+
+@pytest.mark.parametrize("algorithm", ["sha1", "sha256", "sha512", "blake2b"])
+def test_calculate_hash_returns_valid_uuid(algorithm: str) -> None:
+    """All built-in key encoders must produce valid UUID strings.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/39047:
+    previously only ``sha1`` wrapped its digest in a UUID, while
+    ``sha256``/``sha512``/``blake2b`` returned raw hex digests, which are not
+    valid UUIDs and broke indexing into stores such as Qdrant.
+    """
+    hash_ = _calculate_hash("hello world", algorithm=algorithm)  # type: ignore[arg-type]
+    # Must be parseable as a UUID (raises ValueError otherwise).
+    assert str(uuid.UUID(hash_)) == hash_
+    # Deterministic.
+    assert _calculate_hash("hello world", algorithm=algorithm) == hash_  # type: ignore[arg-type]


### PR DESCRIPTION
**Fixes #39047**

### Description

`_calculate_hash` (used by `index()`/`aindex()` to derive document ids) wrapped the digest in `uuid.uuid5(...)` **only** for the `"sha1"` encoder:

```python
if algorithm == "sha1":
    digest = hashlib.sha1(...).hexdigest()
    return str(uuid.uuid5(NAMESPACE_UUID, digest))   # UUID
if algorithm == "blake2b":
    return hashlib.blake2b(...).hexdigest()           # raw hex, NOT a UUID
if algorithm == "sha256":
    return hashlib.sha256(...).hexdigest()            # raw hex
if algorithm == "sha512":
    return hashlib.sha512(...).hexdigest()            # raw hex
```

The built-in warning tells users to move off `sha1` to `blake2b`/`sha256`/`sha512`, but those return raw hex digests — not valid UUIDs — so indexing into stores that require UUID point ids (e.g. Qdrant) fails with `ValueError: Point id ... is not a valid UUID`.

This derives the id via `uuid.uuid5(NAMESPACE_UUID, digest)` for **all** algorithms, so every built-in `key_encoder` yields a consistent, valid UUID — matching what `sha1` already did.

### Note on compatibility

This changes the generated ids for `blake2b`/`sha256`/`sha512`. That's consistent with the documented expectation that *"when changing the key encoder, you must change the index as well"* — and those encoders were unusable with UUID-validating stores before this fix.

### Tests

Added a parametrized `test_calculate_hash_returns_valid_uuid` covering all four algorithms (valid UUID + deterministic). Existing indexing suite (`test_indexing.py`, `test_hashed_document.py`, 49 tests) still passes; `ruff check`/`format` clean.