### PR TITLE
fix(agents): stream-then-join model calls so token callbacks fire

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -1403,6 +1403,55 @@ def create_agent(
             )
         return request.model.bind(**request.model_settings), None
 
+    def _coerce_model_output_message(output: Any) -> AIMessage:
+        """Normalize streamed chunks to a concrete AIMessage."""
+        if isinstance(output, AIMessage) and not type(output).__name__.endswith("Chunk"):
+            return output
+        # AIMessageChunk (and sums thereof) expose the same fields; rebuild so
+        # downstream handlers that type-check AIMessage keep working.
+        if isinstance(output, AIMessage):
+            return AIMessage(
+                content=output.content,
+                additional_kwargs=dict(output.additional_kwargs or {}),
+                response_metadata=dict(output.response_metadata or {}),
+                id=getattr(output, "id", None),
+                tool_calls=list(getattr(output, "tool_calls", []) or []),
+                invalid_tool_calls=list(getattr(output, "invalid_tool_calls", []) or []),
+                usage_metadata=getattr(output, "usage_metadata", None),
+                name=getattr(output, "name", None),
+            )
+        msg = f"Model returned unexpected type: {type(output)!r}"
+        raise TypeError(msg)
+
+    def _invoke_model_with_token_streaming(
+        model_: Any, messages: list[Any]
+    ) -> AIMessage:
+        """Invoke model via stream-then-join so token callbacks fire.
+
+        Agent planning needs the full message, but calling `invoke`/`ainvoke`
+        alone skips token-level streaming callbacks (`on_llm_new_token`) even
+        when the underlying chat model has streaming enabled. Accumulate
+        `stream`/`astream` chunks into a single message instead.
+        """
+        output: Any = None
+        for chunk in model_.stream(messages):
+            output = chunk if output is None else output + chunk
+        if output is None:
+            # Some models yield nothing on stream; fall back to a single shot.
+            output = model_.invoke(messages)
+        return _coerce_model_output_message(output)
+
+    async def _ainvoke_model_with_token_streaming(
+        model_: Any, messages: list[Any]
+    ) -> AIMessage:
+        """Async counterpart of `_invoke_model_with_token_streaming`."""
+        output: Any = None
+        async for chunk in model_.astream(messages):
+            output = chunk if output is None else output + chunk
+        if output is None:
+            output = await model_.ainvoke(messages)
+        return _coerce_model_output_message(output)
+
     def _execute_model_sync(request: ModelRequest[ContextT]) -> ModelResponse:
         """Execute model and return response.
 
@@ -1416,7 +1465,7 @@ def create_agent(
         if request.system_message:
             messages = [request.system_message, *messages]
 
-        output = model_.invoke(messages)
+        output = _invoke_model_with_token_streaming(model_, messages)
         if name:
             output.name = name
 
@@ -1464,7 +1513,7 @@ def create_agent(
         if request.system_message:
             messages = [request.system_message, *messages]
 
-        output = await model_.ainvoke(messages)
+        output = await _ainvoke_model_with_token_streaming(model_, messages)
         if name:
             output.name = name
 

--- a/libs/langchain_v1/tests/unit_tests/agents/test_token_callbacks_on_ainvoke.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_token_callbacks_on_ainvoke.py
@@ -1,0 +1,53 @@
+"""Regression for token callbacks during agent ainvoke (issue #37878).
+
+`create_agent` model execution used `invoke`/`ainvoke`, which never emits
+`on_llm_new_token`. Planning still needs the full message, so we stream-then-join.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+
+from langchain.agents import create_agent
+
+
+class TokenTracker(BaseCallbackHandler):
+    def __init__(self) -> None:
+        self.tokens: list[str] = []
+
+    def on_llm_new_token(self, token: str, **kwargs: object) -> None:
+        self.tokens.append(token)
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_emits_on_llm_new_token() -> None:
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="Hello world")]))
+    agent = create_agent(model, tools=[])
+    tracker = TokenTracker()
+
+    result = await agent.ainvoke(
+        {"messages": [HumanMessage("hi")]},
+        config={"callbacks": [tracker]},
+    )
+
+    assert tracker.tokens, "expected on_llm_new_token during agent.ainvoke"
+    assert "".join(tracker.tokens) == "Hello world"
+    assert result["messages"][-1].content == "Hello world"
+
+
+def test_invoke_emits_on_llm_new_token() -> None:
+    model = GenericFakeChatModel(messages=iter([AIMessage(content="Hello world")]))
+    agent = create_agent(model, tools=[])
+    tracker = TokenTracker()
+
+    result = agent.invoke(
+        {"messages": [HumanMessage("hi")]},
+        config={"callbacks": [tracker]},
+    )
+
+    assert tracker.tokens, "expected on_llm_new_token during agent.invoke"
+    assert "".join(tracker.tokens) == "Hello world"
+    assert result["messages"][-1].content == "Hello world"


### PR DESCRIPTION
## Summary

Fixes #37878

`create_agent` model execution used `invoke`/`ainvoke`, so `on_llm_new_token` never fired during `agent.ainvoke` / `agent.invoke` even when the underlying chat model supports streaming.

Planning still needs the full `AIMessage`, so this change **streams then joins** chunks (with invoke fallback if the stream is empty), then runs the existing structured-output handling unchanged.

## Test plan

- [x] Isolated: `GenericFakeChatModel` emits `['Hello',' ','world']` via `on_llm_new_token` on both `ainvoke` and `invoke`
- [x] Tool-calling path with `FakeToolCallingModel` still completes
- [x] Unit file: `tests/unit_tests/agents/test_token_callbacks_on_ainvoke.py`

## Note

Assignment requested on #37878. If require-issue-link auto-closes this, please assign me and I will reopen — branch is ready.