### PR TITLE
feat(huggingface): support `endpoint_url` in `HuggingFaceEndpointEmbeddings`

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface_endpoint.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from typing import Any
+from urllib.parse import urlparse
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.utils import from_env
@@ -10,6 +11,18 @@ from typing_extensions import Self
 
 DEFAULT_MODEL = "sentence-transformers/all-mpnet-base-v2"
 VALID_TASKS = ("feature-extraction",)
+
+
+def _is_huggingface_hosted_url(url: str | None) -> bool:
+    """True if url is HF-hosted (huggingface.co or hf.space)."""
+    if not url:
+        return False
+    hostname = (urlparse(url).hostname or "").lower()
+    return (
+        hostname == "huggingface.co"
+        or hostname == "hf.space"
+        or hostname.endswith((".huggingface.co", ".hf.space"))
+    )
 
 
 class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
@@ -39,6 +52,9 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
     model: str | None = None
     """Model name to use."""
 
+    endpoint_url: str | None = None
+    """Endpoint URL to use."""
+
     provider: str | None = None
     """Name of the provider to use for inference with the model specified in
         `repo_id`. e.g. "sambanova". if not specified, defaults to HF Inference API.
@@ -65,6 +81,13 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
     @model_validator(mode="after")
     def validate_environment(self) -> Self:
         """Validate that api key and python package exists in environment."""
+        if sum([bool(self.model), bool(self.repo_id), bool(self.endpoint_url)]) > 1:
+            msg = (
+                "Please specify either `model` OR `repo_id` OR `endpoint_url`, "
+                "not more than one."
+            )
+            raise ValueError(msg)
+
         for field_name in ("model", "repo_id"):
             value = getattr(self, field_name)
             if value and value.startswith(("http://", "https://")):
@@ -74,6 +97,8 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
         huggingfacehub_api_token = self.huggingfacehub_api_token or os.getenv(
             "HF_TOKEN"
         )
+        if self.endpoint_url and not _is_huggingface_hosted_url(self.endpoint_url):
+            huggingfacehub_api_token = None
 
         try:
             from huggingface_hub import (  # type: ignore[import]
@@ -81,7 +106,10 @@ class HuggingFaceEndpointEmbeddings(BaseModel, Embeddings):
                 InferenceClient,
             )
 
-            if self.model:
+            if self.endpoint_url:
+                self.model = self.endpoint_url
+                self.repo_id = self.endpoint_url
+            elif self.model:
                 self.repo_id = self.model
             elif self.repo_id:
                 self.model = self.repo_id

--- a/libs/partners/huggingface/tests/unit_tests/test_huggingface_endpoint_embeddings.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_huggingface_endpoint_embeddings.py
@@ -1,0 +1,152 @@
+"""Tests for HuggingFaceEndpointEmbeddings with custom endpoint_url."""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_huggingface.embeddings.huggingface_endpoint import (
+    HuggingFaceEndpointEmbeddings,
+    _is_huggingface_hosted_url,
+)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("http://localhost:8081/", False),
+        ("http://127.0.0.1:8080", False),
+        ("http://my-tgi.internal/", False),
+        ("https://api.inference-api.azure-api.net/", False),
+        ("https://abc.huggingface.co/inference", True),
+        ("https://xyz.hf.space/", True),
+    ],
+)
+def test_is_huggingface_hosted_url(
+    url: str | None,
+    expected: bool,  # noqa: FBT001
+) -> None:
+    """Verify Hugging Face hosted URL checking behavior."""
+    assert _is_huggingface_hosted_url(url) is expected
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_local_endpoint_does_not_pass_api_key(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """With a local endpoint_url we don't pass token/api_key."""
+    mock_inference_client.return_value = MagicMock()
+    mock_async_client.return_value = MagicMock()
+
+    HuggingFaceEndpointEmbeddings(  # type: ignore[call-arg]
+        endpoint_url="http://localhost:8081/",
+    )
+
+    mock_inference_client.assert_called_once()
+    call_kwargs = mock_inference_client.call_args[1]
+    assert call_kwargs.get("token") is None
+    assert call_kwargs.get("model") == "http://localhost:8081/"
+
+    mock_async_client.assert_called_once()
+    async_call_kwargs = mock_async_client.call_args[1]
+    assert async_call_kwargs.get("token") is None
+    assert async_call_kwargs.get("model") == "http://localhost:8081/"
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_huggingface_hosted_endpoint_keeps_api_key(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """HF-hosted endpoint_url still gets the token."""
+    mock_inference_client.return_value = MagicMock()
+    mock_async_client.return_value = MagicMock()
+
+    HuggingFaceEndpointEmbeddings(  # type: ignore[call-arg]
+        endpoint_url="https://abc.huggingface.co/inference",
+        huggingfacehub_api_token="hf_xxx",  # noqa: S106
+    )
+
+    call_kwargs = mock_inference_client.call_args[1]
+    assert call_kwargs.get("token") == "hf_xxx"
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_mutual_exclusivity_validation(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """Verify that model, repo_id, and endpoint_url are mutually exclusive."""
+    mock_inference_client.return_value = MagicMock()
+    mock_async_client.return_value = MagicMock()
+
+    # Specifying both model and endpoint_url should raise ValueError
+    with pytest.raises(ValueError, match="Please specify either"):
+        HuggingFaceEndpointEmbeddings(  # type: ignore[call-arg]
+            model="sentence-transformers/all-mpnet-base-v2",
+            endpoint_url="http://localhost:8081/",
+        )
+
+    # Specifying both repo_id and endpoint_url should raise ValueError
+    with pytest.raises(ValueError, match="Please specify either"):
+        HuggingFaceEndpointEmbeddings(  # type: ignore[call-arg]
+            repo_id="sentence-transformers/all-mpnet-base-v2",
+            endpoint_url="http://localhost:8081/",
+        )
+
+    # Specifying all three should raise ValueError
+    with pytest.raises(ValueError, match="Please specify either"):
+        HuggingFaceEndpointEmbeddings(  # type: ignore[call-arg]
+            model="sentence-transformers/all-mpnet-base-v2",
+            repo_id="sentence-transformers/all-mpnet-base-v2",
+            endpoint_url="http://localhost:8081/",
+        )
+
+
+@patch("huggingface_hub.AsyncInferenceClient")
+@patch("huggingface_hub.InferenceClient")
+def test_sync_and_async_embedding_inference(
+    mock_inference_client: MagicMock,
+    mock_async_client: MagicMock,
+) -> None:
+    """Test sync and async clients feature_extraction calls and result extraction."""
+    import numpy as np
+
+    # Mock responses for feature_extraction
+    mock_sync_instance = MagicMock()
+    mock_sync_instance.feature_extraction.return_value = np.array([[0.1, 0.2, 0.3]])
+    mock_inference_client.return_value = mock_sync_instance
+
+    mock_async_instance = MagicMock()
+
+    async def mock_async_feature_extraction(*args: Any, **kwargs: Any) -> np.ndarray:
+        return np.array([[0.4, 0.5, 0.6]])
+
+    mock_async_instance.feature_extraction = mock_async_feature_extraction
+    mock_async_client.return_value = mock_async_instance
+
+    embeddings = HuggingFaceEndpointEmbeddings(  # type: ignore[call-arg]
+        endpoint_url="http://localhost:8081/",
+    )
+
+    # Test embed_documents / embed_query
+    sync_res = embeddings.embed_query("hello")
+    assert sync_res == [0.1, 0.2, 0.3]
+    mock_sync_instance.feature_extraction.assert_called_once_with(
+        text=["hello"],
+    )
+
+    # Test aembed_documents / aembed_query
+    import asyncio
+
+    async def run_async_test() -> list[float]:
+        return await embeddings.aembed_query("world")
+
+    async_res = asyncio.run(run_async_test())
+    assert async_res == [0.4, 0.5, 0.6]

--- a/libs/partners/huggingface/uv.lock
+++ b/libs/partners/huggingface/uv.lock
@@ -484,7 +484,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "python_full_version < '3.15'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -519,43 +519,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -623,7 +623,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -966,17 +966,17 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/31/10ac88f3357fc276dc8a64e8880c82e80e7459326ae1d0a211b40abf6665/ipython-8.37.0.tar.gz", hash = "sha256:ca815841e1a41a1e6b73a0b08f3038af9b2252564d01fc405356d34033012216", size = 5606088, upload-time = "2025-05-31T16:39:09.613Z" }
 wheels = [
@@ -998,17 +998,17 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/71/a86262bf5a68bf211bcc71fe302af7e05f18a2852fdc610a854d20d085e6/ipython-9.5.0.tar.gz", hash = "sha256:129c44b941fe6d9b82d36fc7a7c18127ddb1d6f02f78f867f402e2e3adde3113", size = 4389137, upload-time = "2025-08-29T12:15:21.519Z" }
 wheels = [
@@ -1020,7 +1020,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1202,7 +1202,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.9"
+version = "1.5.1"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -1233,7 +1233,7 @@ requires-dist = [
 dev = [
     { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
-    { name = "setuptools", specifier = ">=67.6.1,<83.0.0" },
+    { name = "setuptools", specifier = ">=67.6.1,<84.0.0" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
 test = [
@@ -3252,7 +3252,7 @@ resolution-markers = [
     "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -3318,7 +3318,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and platform_python_implementation != 'PyPy'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4c/3b/546a6f0bfe791bbb7f8d591613454d15097e53f906308ec6f7c1ce588e8e/scipy-1.16.2.tar.gz", hash = "sha256:af029b153d243a80afb6eabe40b0a07f8e35c9adc269c019f364ad747f826a6b", size = 30580599, upload-time = "2025-09-11T17:48:08.271Z" }
 wheels = [


### PR DESCRIPTION
Closes #39072

---

Currently, `HuggingFaceEndpointEmbeddings` does not support self-hosted or custom deployed Hugging Face-compatible embedding services via a direct URL, as the `model` and `repo_id` fields are validated to reject URLs.

This PR adds an optional `endpoint_url` parameter to `HuggingFaceEndpointEmbeddings`, aligning it with the existing `HuggingFaceEndpoint` LLM integration.

### Proposed Changes
- Added an `endpoint_url` field to `HuggingFaceEndpointEmbeddings`.
- Enforced mutual exclusivity between `model`, `repo_id`, and `endpoint_url` (raises `ValueError` if more than one is specified).
- Implemented `_is_huggingface_hosted_url` helper to determine if the endpoint is local or HF-hosted, avoiding sending the `huggingfacehub_api_token` to local/custom endpoints (preventing auth/egress errors).
- Added comprehensive unit tests under `tests/unit_tests/test_huggingface_endpoint_embeddings.py` covering standard and async client initialization, token exclusion, and validations.

## Release note
- feat(huggingface): support `endpoint_url` parameter in `HuggingFaceEndpointEmbeddings` to connect with custom and self-hosted inference endpoints.

