### PR TITLE
fix(indexing): use single timestamp per batch in InMemoryRecordManager.update()

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -296,12 +296,13 @@ class InMemoryRecordManager(RecordManager):
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+        update_time = self.get_time()
+        if time_at_least and time_at_least > update_time:
+            msg = "time_at_least must be in the past"
+            raise ValueError(msg)
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
-                msg = "time_at_least must be in the past"
-                raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            self.records[key] = {"group_id": group_id, "updated_at": update_time}
 
     async def aupdate(
         self,


### PR DESCRIPTION
## Problem
`InMemoryRecordManager.update()` called `get_time()` once per document 
inside the loop, so documents in the same batch received slightly 
different timestamps.

During full/incremental cleanup, `list_keys(before=index_start_dt)` 
would miss documents whose timestamps drifted past `index_start_dt`, 
resulting in fewer deletions than expected (e.g. 800-900 instead of 1000).

## Fix
Capture `get_time()` once before the loop and apply it to all records 
in the batch, ensuring consistent timestamps within a single update call.

## Tests
- Fixes `test_full_cleanup_with_different_batchsize`
- Fixes `test_aincremental_cleanup_with_different_batchsize`
- All other indexing tests continue to pass
