### PR TITLE
fix(core): normalize same-index `tool_call_chunks` in `AIMessageChunk`

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -539,6 +539,20 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = tool_call_chunks
 
             return self
+        if (
+            len(self.tool_call_chunks) > 1
+            and (raw_tool_calls := merge_lists([], self.tool_call_chunks))
+            and len(raw_tool_calls) != len(self.tool_call_chunks)
+        ):
+            self.tool_call_chunks = [
+                create_tool_call_chunk(
+                    name=rtc.get("name"),
+                    args=rtc.get("args"),
+                    id=rtc.get("id"),
+                    index=rtc.get("index"),
+                )
+                for rtc in raw_tool_calls
+            ]
         tool_calls = []
         invalid_tool_calls = []
 

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -985,6 +985,34 @@ def test_merge_tool_calls_parallel_same_index() -> None:
     assert [m["id"] for m in merged] == ["id_a", "id_b", "id_c"]
 
 
+def test_same_index_tool_call_chunks_merge_in_delta() -> None:
+    """Test for #36627: same-index tool call chunks packed in a single delta."""
+    first = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(name="search", args="", id="id1", index=0),
+            create_tool_call_chunk(name=None, args="{", id=None, index=0),
+        ],
+    )
+
+    merged = first + AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(name=None, args='"query": "bar"}', id=None, index=0)
+        ],
+    )
+
+    assert merged.tool_call_chunks == [
+        create_tool_call_chunk(
+            name="search", args='{"query": "bar"}', id="id1", index=0
+        )
+    ]
+    assert merged.tool_calls == [
+        create_tool_call(name="search", args={"query": "bar"}, id="id1")
+    ]
+    assert merged.invalid_tool_calls == []
+
+
 def test_tool_message_serdes() -> None:
     message = ToolMessage(
         "foo", artifact={"bar": {"baz": 123}}, tool_call_id="1", status="error"


### PR DESCRIPTION
Closes #36627

When a single streamed delta contains multiple `tool_call_chunks` that share the same `index` (e.g. one fragment with name and id, another with leading argument bytes), `init_tool_calls` previously processed them independently without normalization. This caused continuations to become blank `tool_calls` while original fragments fell into `invalid_tool_calls`.

This change normalizes `self.tool_call_chunks` in `init_tool_calls` using `merge_lists` before parsing, matching the existing behavior of `add_ai_message_chunks`.

Signed-off-by: cyforkk <1139009771@qq.com>
