### PR TITLE
fix(core): snapshot timestamp once in `InMemoryRecordManager.update`

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -296,12 +296,17 @@ class InMemoryRecordManager(RecordManager):
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+        # Snapshot the timestamp once so every record in the batch shares it.
+        # Calling get_time() per key yielded slightly different timestamps and
+        # could drop records from cleanup queries that compare against a single
+        # index_start_dt (see #39087).
+        now = self.get_time()
+        if time_at_least and time_at_least > now:
+            msg = "time_at_least must be in the past"
+            raise ValueError(msg)
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
-                msg = "time_at_least must be in the past"
-                raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            self.records[key] = {"group_id": group_id, "updated_at": now}
 
     async def aupdate(
         self,

--- a/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
+++ b/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
@@ -145,6 +145,27 @@ async def test_aupdate_timestamp(manager: InMemoryRecordManager) -> None:
     ) == ["key1"]
 
 
+def test_update_batch_shares_single_timestamp(manager: InMemoryRecordManager) -> None:
+    """All records in one update() call must share the same updated_at value.
+
+    Previously get_time() was called per key inside the loop, so a batch could
+    end up with slightly different timestamps. See #39087.
+    """
+    call_count = 0
+
+    def increasing_time() -> float:
+        nonlocal call_count
+        call_count += 1
+        # Each call returns a strictly larger timestamp.
+        return float(1_000_000 + call_count)
+
+    with patch.object(manager, "get_time", side_effect=increasing_time):
+        manager.update(["key1", "key2", "key3"])
+
+    timestamps = {record["updated_at"] for record in manager.records.values()}
+    assert timestamps == {1_000_001.0}
+
+
 def test_exists(manager: InMemoryRecordManager) -> None:
     """Test checking if keys exist in the database."""
     # Insert records


### PR DESCRIPTION
Closes #39087

---

`InMemoryRecordManager.update` called `get_time()` inside the per-key loop, so every record in a batch received a slightly different `updated_at` value. Cleanup queries compare records against a single `index_start_dt`, and records whose `updated_at` landed just after that cutoff got excluded — causing flaky, timing-dependent deletions during indexing with `cleanup="full"`.

This snapshots the timestamp once before the loop so the whole batch shares the same value. The `time_at_least` validation also moved out of the loop since it only needs to run once per call.

Added a regression test that mocks `get_time` to return a strictly increasing value on every call; before the fix the three keys would get three distinct timestamps, after the fix they share the first one.

Assisted-by: Hermes Agent

## Release note

`InMemoryRecordManager.update` now assigns a single consistent timestamp to all records in a batch instead of calling `get_time()` per key, fixing timing-dependent record loss during indexing cleanup.