### PR TITLE
fix(core): wrap all `key_encoder` hashes in uuid5 for UUID-shaped IDs

### DIFF
--- a/libs/core/langchain_core/indexing/api.py
+++ b/libs/core/langchain_core/indexing/api.py
@@ -157,19 +157,25 @@ class IndexingException(LangChainException):
 def _calculate_hash(
     text: str, algorithm: Literal["sha1", "sha256", "sha512", "blake2b"]
 ) -> str:
-    """Return a hexadecimal digest of *text* using *algorithm*."""
+    """Return a deterministic UUID derived from *text* using *algorithm*.
+
+    All algorithms wrap their raw digest in ``uuid.uuid5(NAMESPACE_UUID, ...)``
+    so that document IDs are valid UUIDs regardless of the chosen hash. Some
+    vector stores (e.g. Qdrant) require point IDs to be UUIDs, and the raw
+    hex digests produced by blake2b/sha256/sha512 are not UUID-shaped.
+    """
     if algorithm == "sha1":
-        # Calculate the SHA-1 hash and return it as a UUID.
         digest = hashlib.sha1(text.encode("utf-8"), usedforsecurity=False).hexdigest()
-        return str(uuid.uuid5(NAMESPACE_UUID, digest))
-    if algorithm == "blake2b":
-        return hashlib.blake2b(text.encode("utf-8")).hexdigest()
-    if algorithm == "sha256":
-        return hashlib.sha256(text.encode("utf-8")).hexdigest()
-    if algorithm == "sha512":
-        return hashlib.sha512(text.encode("utf-8")).hexdigest()
-    msg = f"Unsupported hashing algorithm: {algorithm}"  # type: ignore[unreachable]
-    raise ValueError(msg)
+    elif algorithm == "blake2b":
+        digest = hashlib.blake2b(text.encode("utf-8")).hexdigest()
+    elif algorithm == "sha256":
+        digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+    elif algorithm == "sha512":
+        digest = hashlib.sha512(text.encode("utf-8")).hexdigest()
+    else:
+        msg = f"Unsupported hashing algorithm: {algorithm}"  # type: ignore[unreachable]
+        raise ValueError(msg)
+    return str(uuid.uuid5(NAMESPACE_UUID, digest))
 
 
 def _get_document_with_hash(

--- a/libs/core/tests/unit_tests/indexing/test_hashed_document.py
+++ b/libs/core/tests/unit_tests/indexing/test_hashed_document.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Literal
 
 from langchain_core.documents import Document
@@ -49,6 +50,23 @@ def test_hashing() -> None:
             document, key_encoder=key_encoder
         )
         assert different_hashed_document.id != hashed_document.id
+
+
+def test_all_key_encoders_produce_uuids() -> None:
+    """Every built-in key encoder must produce a valid UUID string.
+
+    Vector stores like Qdrant validate that point IDs are UUIDs; raw hex
+    digests from sha256/sha512/blake2b are not UUID-shaped and would be
+    rejected at insert time.
+    """
+    document = Document(
+        page_content="Lorem ipsum dolor sit amet", metadata={"key": "value"}
+    )
+    for key_encoder in ("sha1", "sha256", "sha512", "blake2b"):
+        hashed = _get_document_with_hash(document, key_encoder=key_encoder)
+        # Must parse as a UUID (raises ValueError otherwise).
+        parsed = uuid.UUID(hashed.id)
+        assert str(parsed) == hashed.id
 
 
 def test_hashing_custom_key_encoder() -> None:


### PR DESCRIPTION
Closes #39047

---

`index()` accepts a `key_encoder` argument ("sha1", "sha256", "sha512", "blake2b") and its own deprecation warning recommends switching off the default sha1 to a stronger algorithm. But only the sha1 branch of `_calculate_hash` wrapped its digest in `uuid.uuid5`; the other three returned the raw hexdigest (64 or 128 chars). Stores like Qdrant validate that point IDs are UUIDs, so following the warning's advice made `index()` fail on every insert — `ValueError: Point id ... is not a valid UUID`.

This change routes all four branches through `uuid.uuid5(NAMESPACE_UUID, digest)`, so every built-in encoder produces a valid UUID regardless of algorithm. sha1 IDs are unchanged. The IDs produced by sha256/sha512/blake2b change from raw hex to UUID form — for users already indexing with one of those encoders and `cleanup=None`, the next run will add the new-format IDs alongside the old ones (duplicate documents); with `cleanup="incremental"` or `"full"` the stale IDs are reconciled automatically on the next run.

Added a unit test (`test_all_key_encoders_produce_uuids`) that parses the ID from each encoder with `uuid.UUID` to guard against regressions.

Co-authored-by: Hermes Agent <agent@nousresearch.com>