### PR TITLE
fix(core): `InMemoryRecordManager.update()` uses a single timestamp per batch

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -296,12 +296,13 @@ class InMemoryRecordManager(RecordManager):
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+        current_time = self.get_time()
+        if time_at_least and time_at_least > current_time:
+            msg = "time_at_least must be in the past"
+            raise ValueError(msg)
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
-                msg = "time_at_least must be in the past"
-                raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            self.records[key] = {"group_id": group_id, "updated_at": current_time}
 
     async def aupdate(
         self,

--- a/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
+++ b/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
@@ -277,3 +277,37 @@ async def test_adelete_keys(amanager: InMemoryRecordManager) -> None:
     # Check if the deleted keys are no longer in the database
     remaining_keys = await amanager.alist_keys()
     assert remaining_keys == ["key3"]
+
+
+def test_update_batch_shares_single_timestamp(manager: InMemoryRecordManager) -> None:
+    """Regression test for #39087.
+
+    All keys written in a single update() call must share the same timestamp.
+    Previously, get_time() was called once per key inside the loop, so keys
+    inserted at the end of a large batch could receive timestamps later than
+    index_start_dt, preventing them from being cleaned up by the indexer.
+    """
+    timestamps: list[float] = []
+    original_get_time = manager.get_time
+
+    call_count = 0
+
+    def counting_get_time() -> float:
+        nonlocal call_count
+        call_count += 1
+        t = original_get_time()
+        timestamps.append(t)
+        return t
+
+    manager.get_time = counting_get_time  # type: ignore[method-assign]
+
+    keys = [f"key{i}" for i in range(100)]
+    manager.update(keys)
+
+    # get_time() must be called exactly once for the whole batch, not per key.
+    assert call_count == 1, (
+        f"get_time() was called {call_count} times; expected 1 (once per batch)"
+    )
+    # All stored timestamps must be identical.
+    stored = [manager.records[k]["updated_at"] for k in keys]
+    assert len(set(stored)) == 1, "all keys in a batch must share the same timestamp"


### PR DESCRIPTION
Closes #39087

---

`InMemoryRecordManager.update()` was calling `self.get_time()` inside the `for` loop — once per document key. When updating a large batch, each key received a slightly different (monotonically increasing) timestamp. The indexer records `index_start_dt` before the batch, then at cleanup time excludes any document whose `updated_at` exceeds that cutoff. Documents at the tail of a large batch (those given timestamps after `index_start_dt`) therefore escape cleanup, leaving stale records in the store.

The fix snapshots `get_time()` once before the loop and uses that single value for every record in the batch. The `time_at_least` guard is moved out of the loop for the same reason — it is a batch-level precondition, not a per-document check.

A regression test (`test_update_batch_shares_single_timestamp`) verifies that `get_time()` is called exactly once per `update()` invocation and that all keys in the batch share an identical `updated_at` value.

> ⚠️ This PR was developed with the assistance of an AI coding agent.