### PR TITLE
Fix typo in Visitor._validate_func error message: 'comparators' -> 'operators'

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
Fixes #36701

In `Visitor._validate_func`, when an invalid operator is passed the error message reads "Allowed comparators are ..." but it is actually validating operators (the variable is `allowed_operators`). This is a copy-paste typo from the comparator branch just below; it should say "operators".

Repro from the issue:
```python
from langchain_core.structured_query import Visitor, Operator
class V(Visitor):
    allowed_comparators = ()
    allowed_operators = (Operator.AND,)
v = V()
v._validate_func(Operator.OR)  # -> "Allowed comparators are ..." (should be operators)
```

Fixes #36701