### PR TITLE
release(fireworks): 1.5.2

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/_version.py
+++ b/libs/partners/fireworks/langchain_fireworks/_version.py
@@ -1,3 +1,3 @@
 """Version information for `langchain-fireworks`."""
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/libs/partners/fireworks/pyproject.toml
+++ b/libs/partners/fireworks/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
-version = "1.5.1"
+version = "1.5.2"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.5.1,<2.0.0",

--- a/libs/partners/fireworks/uv.lock
+++ b/libs/partners/fireworks/uv.lock
@@ -813,7 +813,7 @@ typing = [
 
 [[package]]
 name = "langchain-fireworks"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Bump `langchain-fireworks` from 1.5.1 to 1.5.2 to ship the model profile refreshes landed since the last release.