### PR TITLE
fix(ci): repair model profile refresh workflow expressions

### DIFF
--- a/.github/workflows/refresh_model_profiles.yml
+++ b/.github/workflows/refresh_model_profiles.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   resolve-providers:
     name: resolve providers
-    if: github.repository_owner == "langchain-ai"
+    if: github.repository_owner == 'langchain-ai'
     runs-on: ubuntu-latest
     outputs:
       providers: ${{ steps.resolve.outputs.providers }}
@@ -57,7 +57,8 @@ jobs:
         env:
           # Scheduled runs have no inputs — default to all providers.
           PROVIDER: ${{ github.event_name == 'workflow_dispatch' && inputs.provider || 'all' }}
-          PROVIDERS_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs.providers-override || '' }}
+          # Bracket access required: bare `inputs.providers-override` is parsed as subtraction.
+          PROVIDERS_OVERRIDE: ${{ github.event_name == 'workflow_dispatch' && inputs['providers-override'] || '' }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
#39094 left the model profile refresh workflow invalid, so it failed immediately on push with no jobs (e.g. https://github.com/langchain-ai/langchain/actions/runs/30287294147).

---

GitHub Actions expressions only allow single-quoted string literals. The new job condition used double quotes:

```yaml
if: github.repository_owner == "langchain-ai"
```

That failed workflow validation before any job could start:

> Unexpected symbol: `"langchain-ai"`

Also switched the hyphenated input to bracket access so `providers-override` is not parsed as subtraction (`inputs.providers - override`).