### PR TITLE
fix(core): rebuild incomplete args_schema instead of silently exposing no tool arguments

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1601,10 +1601,33 @@ def get_all_basemodel_annotations(
 
     Returns:
         `dict` of field names to their type annotations.
+
+    Raises:
+        NameError: If the model has unresolved forward references that cannot be
+            resolved by rebuilding the model.
     """
     orig_bases: tuple[type, ...]
     # cls has no subscript: cls = FooBar
     if isinstance(cls, type):
+        if is_pydantic_v2_subclass(cls) and not cls.__pydantic_complete__:
+            # The model has unresolved forward references (e.g. a nested model
+            # annotated with a type that was not yet defined when the model was
+            # created). An incomplete model degrades `inspect.signature` to
+            # `(**data: Any)`, which would make the introspection below silently
+            # return no annotations and, downstream, make the tool expose no
+            # arguments to the model. Try resolving the references now; if they
+            # are still unresolvable, fail loudly to match the `NameError` raised
+            # when the unresolved name appears directly in a tool's signature.
+            try:
+                cls.model_rebuild()
+            except NameError as exc:
+                msg = (
+                    f"Unable to resolve the type annotations of {cls.__name__!r}:"
+                    f" {exc}. Make sure every referenced type (including forward"
+                    " references in nested models) is defined, or call"
+                    f" `model_rebuild()` on {cls.__name__!r} once it is."
+                )
+                raise NameError(msg) from exc
         fields = get_fields(cls)
         alias_map = {field.alias: name for name, field in fields.items() if field.alias}
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2459,6 +2459,55 @@ def test_get_all_basemodel_annotations_aliases() -> None:
     assert actual == {"a": int, "b": int}
 
 
+class _ForwardRefContainer(BaseModel):
+    """Refers to `_ForwardRefRow` (defined below) via a forward reference."""
+
+    rows: list["_ForwardRefRow"] = []
+
+
+@tool
+def _forward_ref_tool(real_arg: str, container: _ForwardRefContainer) -> str:
+    """A tool whose schema is incomplete at creation time."""
+    return "ok"
+
+
+class _ForwardRefRow(BaseModel):
+    name: str
+
+
+def test_incomplete_args_schema_rebuilt_on_introspection() -> None:
+    """Incomplete `args_schema` is rebuilt instead of silently exposing no args.
+
+    `_forward_ref_tool` was decorated before `_ForwardRefRow` was defined, so its
+    generated `args_schema` was incomplete at creation time.
+    https://github.com/langchain-ai/langchain/issues/39099
+    """
+    assert list(_forward_ref_tool.args) == ["real_arg", "container"]
+
+    params = convert_to_openai_tool(_forward_ref_tool)["function"]["parameters"]
+    assert set(params["properties"]) == {"real_arg", "container"}
+    assert params["required"] == ["real_arg", "container"]
+
+
+def test_unresolvable_args_schema_raises_name_error() -> None:
+    """A genuinely unresolvable `args_schema` fails loudly on introspection.
+
+    This matches the `NameError` raised when the unresolved name appears
+    directly in the tool's signature.
+    """
+
+    class Unresolvable(BaseModel):
+        rows: list["MissingRow"] = []  # noqa: F821
+
+    @tool
+    def unresolvable_tool(real_arg: str, container: Unresolvable) -> str:
+        """A tool whose schema can never be resolved."""
+        return "ok"
+
+    with pytest.raises(NameError, match="MissingRow"):
+        _ = unresolvable_tool.tool_call_schema
+
+
 def test_tool_annotations_preserved() -> None:
     """Test that annotations are preserved when creating a tool."""
 


### PR DESCRIPTION
Fixes #39099

## What

A tool whose `args_schema` is a pydantic model with an unresolved forward reference (`__pydantic_complete__ == False`) silently advertised zero parameters to the model, while `invoke()` still validated against the full schema. The model had no way to supply required arguments.

`get_all_basemodel_annotations()` now calls `model_rebuild()` on incomplete pydantic v2 models before introspection, which resolves the common "referenced model defined later" case correctly. If the reference is genuinely unresolvable, a contextual `NameError` is raised naming the model, matching the existing hard error for unresolved names directly in a tool signature. No more silent empty schemas.

Placed in `get_all_basemodel_annotations` rather than `tool_call_schema` so injected-arg detection paths are fixed as well.

## Tests

- `test_incomplete_args_schema_rebuilt_on_introspection`: issue repro; asserts correct args and `convert_to_openai_tool` output (fails on main with empty properties)
- `test_unresolvable_args_schema_raises_name_error`: unresolvable ref raises `NameError` mentioning the missing model

Full libs/core unit suite: 2167 passed, no new failures. `ruff check` clean.

Credit to @jgabriellacerda for the report in #39099.
