### PR TITLE
fix(anthropic): strip id from system text blocks before sending

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -490,7 +490,15 @@ def _format_messages(
             if isinstance(message.content, list):
                 system = [
                     (
-                        block
+                        # Allowlist the keys Anthropic accepts on a system text
+                        # block. create_text_block() mints an `id` (e.g.
+                        # "lc_<uuid4>") that the API rejects with
+                        # "system.0.id: Extra inputs are not permitted" (#39100).
+                        {
+                            k: v
+                            for k, v in block.items()
+                            if k in ("type", "text", "cache_control", "citations")
+                        }
                         if isinstance(block, dict)
                         else {"type": "text", "text": block}
                     )

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3942,3 +3942,46 @@ def test_langsmith_gateway_provider_base_url_uses_provider_key(
     llm = ChatAnthropic(model=MODEL_NAME)
     assert llm.anthropic_api_url == "https://api.anthropic.com"
     assert llm.anthropic_api_key.get_secret_value() == "provider-key"
+
+
+def test__format_messages_strips_id_from_system_text_blocks() -> None:
+    """Regression test for #39100.
+
+    create_text_block() mints an `id` (e.g. "lc_<uuid4>") on the block. The
+    Anthropic API rejects an `id` on a system text block with
+    "system.0.id: Extra inputs are not permitted", so _format_messages must
+    strip it while keeping the keys the API does accept (cache_control,
+    citations).
+    """
+    from langchain_core.messages.content import create_text_block
+
+    block = create_text_block("You are a helpful assistant.")
+    assert "id" in block  # precondition: the helper mints an id
+
+    system = SystemMessage(content_blocks=[block])  # type: ignore[misc]
+    formatted_system, _ = _format_messages([system, HumanMessage("hi")])  # type: ignore[misc]
+
+    assert isinstance(formatted_system, list)
+    formatted_block = formatted_system[0]
+    assert "id" not in formatted_block
+    assert formatted_block["type"] == "text"
+    assert formatted_block["text"] == "You are a helpful assistant."
+
+
+def test__format_messages_keeps_cache_control_on_system_text_blocks() -> None:
+    """The system block allowlist must preserve cache_control."""
+    system = SystemMessage(  # type: ignore[misc]
+        content_blocks=[
+            {
+                "type": "text",
+                "text": "cached system",
+                "cache_control": {"type": "ephemeral"},
+                "id": "lc_should_be_dropped",
+            }
+        ]
+    )
+    formatted_system, _ = _format_messages([system, HumanMessage("hi")])  # type: ignore[misc]
+
+    formatted_block = formatted_system[0]
+    assert formatted_block["cache_control"] == {"type": "ephemeral"}
+    assert "id" not in formatted_block


### PR DESCRIPTION
## Summary

Fixes #39100

`create_text_block()` mints an `id` (e.g. `"lc_<uuid4>"`) on the block. For a `SystemMessage` built from `content_blocks`, `_format_messages` forwarded the dict **verbatim**, so the `id` reached Anthropic's `system` parameter and the request failed with:

```
system.0.id: Extra inputs are not permitted
```

## Fix

Allowlist the keys Anthropic accepts on a system text block — `type`, `text`, `cache_control`, `citations` — the **same allowlist already used for text blocks in regular message content** (chat_models.py:600-617). The `id` is dropped while `cache_control` and `citations` are preserved.

## Tests

Added two unit tests in `tests/unit_tests/test_chat_models.py`:

- [x] `test__format_messages_strips_id_from_system_text_blocks` — the `id` minted by `create_text_block()` is stripped from a system block.
- [x] `test__format_messages_keeps_cache_control_on_system_text_blocks` — `cache_control` survives the allowlist.

```
$ pytest tests/unit_tests/test_chat_models.py -q
148 passed
```

Verified both new tests **fail** on the unfixed code and **pass** with the fix.