### PR TITLE
fix(core): call get_time() once per update() batch instead of per key

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -293,15 +293,22 @@ class InMemoryRecordManager(RecordManager):
                 ids.
             ValueError: If time_at_least is in the future.
         """
+
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+        # Fetch the timestamp once per batch instead of once per key so that
+        # all records written in the same update() call share a single,
+        # consistent timestamp. Calling get_time() per-key allowed the
+        # timestamp to drift across a large batch, which caused
+        # list_keys(before=...) to miss records during cleanup (see #39087).
+        update_time = self.get_time()
+        if time_at_least and time_at_least > update_time:
+            msg = "time_at_least must be in the past"
+            raise ValueError(msg)
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
-                msg = "time_at_least must be in the past"
-                raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            self.records[key] = {"group_id": group_id, "updated_at": update_time}
 
     async def aupdate(
         self,

--- a/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
+++ b/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
@@ -277,3 +277,63 @@ async def test_adelete_keys(amanager: InMemoryRecordManager) -> None:
     # Check if the deleted keys are no longer in the database
     remaining_keys = await amanager.alist_keys()
     assert remaining_keys == ["key3"]
+
+
+def test_update_uses_single_timestamp_for_entire_batch(
+    manager: InMemoryRecordManager,
+) -> None:
+    """Regression test for #39087.
+
+    update() used to call get_time() once per key inside the loop, so
+    records written in the same update() call could end up with different
+    'updated_at' timestamps whenever get_time() drifted between calls.
+    This test simulates that drift and confirms get_time() is only
+    consulted once per update() call, so every key in the batch ends up
+    with the exact same timestamp.
+    """
+    drifting_timestamps = iter(
+        [
+            datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp(),
+            datetime(2021, 1, 2, tzinfo=timezone.utc).timestamp(),
+            datetime(2021, 1, 3, tzinfo=timezone.utc).timestamp(),
+        ]
+    )
+
+    with patch.object(
+        manager, "get_time", side_effect=lambda: next(drifting_timestamps)
+    ):
+        manager.update(["key1", "key2", "key3"])
+
+    updated_ats = {
+        manager.records[key]["updated_at"] for key in ["key1", "key2", "key3"]
+    }
+
+    # Before the fix, this would contain three distinct timestamps
+    # (one per get_time() call inside the loop).
+    assert len(updated_ats) == 1
+    assert updated_ats == {datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp()}
+
+
+async def test_aupdate_uses_single_timestamp_for_entire_batch(
+    amanager: InMemoryRecordManager,
+) -> None:
+    """Async counterpart of test_update_uses_single_timestamp_for_entire_batch."""
+    drifting_timestamps = iter(
+        [
+            datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp(),
+            datetime(2021, 1, 2, tzinfo=timezone.utc).timestamp(),
+            datetime(2021, 1, 3, tzinfo=timezone.utc).timestamp(),
+        ]
+    )
+
+    with patch.object(
+        amanager, "get_time", side_effect=lambda: next(drifting_timestamps)
+    ):
+        await amanager.aupdate(["key1", "key2", "key3"])
+
+    updated_ats = {
+        amanager.records[key]["updated_at"] for key in ["key1", "key2", "key3"]
+    }
+
+    assert len(updated_ats) == 1
+    assert updated_ats == {datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp()}


### PR DESCRIPTION
Fixes #39087

## Problem

`InMemoryRecordManager.update()` called `self.get_time()` once **per
key** inside the loop, instead of once per batch. On large batches,
`get_time()` could return slightly different values across
iterations, so records written in the same `update()` call ended up
with inconsistent `updated_at` timestamps.

This broke `list_keys(before=..., after=...)`, which assumes all
records from the same indexing run share a consistent timestamp.
During `cleanup="full"` / `cleanup="incremental"`, some stale
documents ended up with a timestamp just past `index_start_dt` and
were skipped during cleanup, causing fewer deletions than expected
(observed as `num_deleted` varying between ~800-900 instead of 1000
in the reproduction from the issue).

## Fix

Call `get_time()` once before the loop in `update()`, and reuse that
single timestamp for every key in the batch. The `time_at_least`
check is also moved out of the loop since it only needs to run once
against the batch's timestamp.

## Tests

Added two regression tests to
`tests/unit_tests/indexing/test_in_memory_record_manager.py`:
- `test_update_uses_single_timestamp_for_entire_batch`
- `test_aupdate_uses_single_timestamp_for_entire_batch`

Both simulate `get_time()` drifting between calls (via
`patch.object` with `side_effect`) and assert that every key in a
single `update()`/`aupdate()` call ends up with the exact same
`updated_at` timestamp.

Full `tests/unit_tests/indexing/` suite passes with this change,
aside from two pre-existing failures
(`test_index_into_document_index`, `test_aindex_into_document_index`)
that are unrelated to this fix and reproduce identically on `main`
without this change — likely a separate `time.time()` resolution
issue in `InMemoryDocumentIndex`, will file separately.