### PR TITLE
fix(core): handle empty string in gateway env vars

### DIFF
--- a/libs/core/langchain_core/utils/_gateway.py
+++ b/libs/core/langchain_core/utils/_gateway.py
@@ -65,7 +65,8 @@ def _resolve_gateway_base_url(provider_path: str) -> str | None:
     base URL:
 
     - ``true`` / ``1`` / ``yes`` -> the default gateway host.
-    - ``false`` / ``0`` / ``no`` / unset -> the gateway is disabled (None).
+    - ``false`` / ``0`` / ``no`` / unset / empty -> the gateway is disabled
+      (None).
     - anything else -> treated as a custom gateway base URL.
 
     The provider-specific path is appended in all enabled cases.
@@ -79,7 +80,7 @@ def _resolve_gateway_base_url(provider_path: str) -> str | None:
         disabled.
     """
     raw = os.getenv(_LANGSMITH_GATEWAY_ENV)
-    if raw is None or raw.lower() in _FALSE_VALUES:
+    if not raw or raw.lower() in _FALSE_VALUES:
         return None
     base = (
         _LANGSMITH_GATEWAY_DEFAULT_BASE

--- a/libs/core/tests/unit_tests/utils/test_gateway.py
+++ b/libs/core/tests/unit_tests/utils/test_gateway.py
@@ -63,6 +63,13 @@ def test_base_url_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     assert _resolve_gateway_base_url(_PATH) is None
 
 
+def test_base_url_empty_is_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An empty value (e.g. ``export LANGSMITH_GATEWAY=`` or a blank .env entry)
+    # disables the gateway rather than being treated as a custom base URL.
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "")
+    assert _resolve_gateway_base_url(_PATH) is None
+
+
 def test_base_url_custom(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_GATEWAY", "https://eu.gateway.example.com/")
     assert (


### PR DESCRIPTION
Treats `LANGSMITH_GATEWAY=""` the same as unset.