### PR TITLE
fix(core): fall back to `LANGSMITH_API_KEY` for gateway

### DIFF
--- a/libs/core/langchain_core/utils/_gateway.py
+++ b/libs/core/langchain_core/utils/_gateway.py
@@ -108,9 +108,9 @@ def _resolve_gateway_config(
       > ``default_base_url``.
     - **api_key:** explicit ``api_key`` (returned unchanged) > the gateway key if
       the base URL came from the gateway, otherwise the provider key > the other.
-      The gateway key uses ``LANGSMITH_GATEWAY_API_KEY`` with
-      ``LANGSMITH_API_KEY`` as a fallback and is only a candidate when the gateway
-      is enabled.
+      The gateway key uses ``LANGSMITH_GATEWAY_API_KEY`` when the gateway is
+      enabled, with ``LANGSMITH_API_KEY`` as a fallback only when the base URL came
+      from the gateway.
 
     The provenance flip on the key means an ``OPENAI_API_KEY``-style provider key
     is preferred whenever the caller pointed the base URL at a non-gateway
@@ -150,10 +150,12 @@ def _resolve_gateway_config(
         resolved_api_key: Any = api_key
     else:
         gateway_api_key = (
-            _first_env((_LANGSMITH_GATEWAY_API_KEY_ENV, _LANGSMITH_API_KEY_ENV))
+            os.getenv(_LANGSMITH_GATEWAY_API_KEY_ENV)
             if gateway_base_url is not None
             else None
         )
+        if not gateway_api_key and base_url_from_gateway:
+            gateway_api_key = os.getenv(_LANGSMITH_API_KEY_ENV)
         provider_api_key = _first_env(api_key_env)
         chosen = (
             (gateway_api_key or provider_api_key)

--- a/libs/core/langchain_core/utils/_gateway.py
+++ b/libs/core/langchain_core/utils/_gateway.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 _LANGSMITH_GATEWAY_ENV = "LANGSMITH_GATEWAY"
 _LANGSMITH_GATEWAY_API_KEY_ENV = "LANGSMITH_GATEWAY_API_KEY"
+_LANGSMITH_API_KEY_ENV = "LANGSMITH_API_KEY"
 _LANGSMITH_GATEWAY_DEFAULT_BASE = "https://gateway.smith.langchain.com"
 
 _TRUE_VALUES = ("true", "1", "yes")
@@ -107,7 +108,9 @@ def _resolve_gateway_config(
       > ``default_base_url``.
     - **api_key:** explicit ``api_key`` (returned unchanged) > the gateway key if
       the base URL came from the gateway, otherwise the provider key > the other.
-      The gateway key is only a candidate when the gateway is enabled.
+      The gateway key uses ``LANGSMITH_GATEWAY_API_KEY`` with
+      ``LANGSMITH_API_KEY`` as a fallback and is only a candidate when the gateway
+      is enabled.
 
     The provenance flip on the key means an ``OPENAI_API_KEY``-style provider key
     is preferred whenever the caller pointed the base URL at a non-gateway
@@ -147,7 +150,7 @@ def _resolve_gateway_config(
         resolved_api_key: Any = api_key
     else:
         gateway_api_key = (
-            os.getenv(_LANGSMITH_GATEWAY_API_KEY_ENV)
+            _first_env((_LANGSMITH_GATEWAY_API_KEY_ENV, _LANGSMITH_API_KEY_ENV))
             if gateway_base_url is not None
             else None
         )

--- a/libs/core/tests/unit_tests/utils/test_gateway.py
+++ b/libs/core/tests/unit_tests/utils/test_gateway.py
@@ -168,6 +168,17 @@ def test_provider_base_url_uses_provider_key(
     assert config.api_key.get_secret_value() == "provider-key"
 
 
+def test_provider_base_url_does_not_use_langsmith_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "langsmith-key")
+    monkeypatch.setenv(_BASE_ENV, "https://api.openai.com/v1")
+    config = _config()
+    assert config.base_url == "https://api.openai.com/v1"
+    assert config.api_key is None
+
+
 def test_provider_base_url_falls_back_to_gateway_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/core/tests/unit_tests/utils/test_gateway.py
+++ b/libs/core/tests/unit_tests/utils/test_gateway.py
@@ -25,6 +25,7 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     for var in (
         "LANGSMITH_GATEWAY",
         "LANGSMITH_GATEWAY_API_KEY",
+        "LANGSMITH_API_KEY",
         _BASE_ENV,
         _KEY_ENV,
     ):
@@ -87,6 +88,26 @@ def test_gateway_on_with_gateway_key(monkeypatch: pytest.MonkeyPatch) -> None:
     config = _config()
     assert config.base_url == _DEFAULT_GATEWAY
     assert config.base_url_from_gateway is True
+    assert isinstance(config.api_key, SecretStr)
+    assert config.api_key.get_secret_value() == "gateway-key"
+
+
+def test_gateway_on_falls_back_to_langsmith_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "langsmith-key")
+    config = _config()
+    assert config.base_url == _DEFAULT_GATEWAY
+    assert isinstance(config.api_key, SecretStr)
+    assert config.api_key.get_secret_value() == "langsmith-key"
+
+
+def test_gateway_key_beats_langsmith_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "langsmith-key")
+    config = _config()
     assert isinstance(config.api_key, SecretStr)
     assert config.api_key.get_secret_value() == "gateway-key"
 


### PR DESCRIPTION
Gateway users who already configure `LANGSMITH_API_KEY` currently need to duplicate it as `LANGSMITH_GATEWAY_API_KEY`. Gateway-derived credential resolution now falls back to the standard LangSmith key while preserving the dedicated gateway key's broader precedence and preventing the standard key from reaching provider-overridden endpoints.

## Release note
LangSmith gateway authentication now falls back to `LANGSMITH_API_KEY` when the gateway supplies the resolved base URL and `LANGSMITH_GATEWAY_API_KEY` is unset.

Made by [Open SWE](https://openswe.vercel.app/agents/5fe1d3be-dc10-4640-fec8-27ddc0e3827e)