### PR TITLE
fix(openai): omit non-msg_ ids for synthetic AI messages in Responses API input

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4659,7 +4659,11 @@ def _construct_responses_api_input(
                                     "content": [new_block],
                                     "role": "assistant",
                                 }
-                                if store is not False:
+                                if (
+                                    store is not False
+                                    and isinstance(msg_id, str)
+                                    and msg_id.startswith("msg_")
+                                ):
                                     new_item["id"] = msg_id
                                 if phase is not None:
                                     new_item["phase"] = phase

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3066,6 +3066,42 @@ def test__construct_responses_api_input_store_enabled_keeps_item_ids(
     ]
 
 
+@pytest.mark.parametrize("store", [None, True])
+def test__construct_responses_api_input_omits_non_msg_ids_for_synthetic_messages(
+    store: bool | None,
+) -> None:
+    """Synthetic AI messages (e.g. from `create_text_block`) use `lc_*` IDs.
+
+    OpenAI's Responses API only accepts assistant message item IDs that start
+    with `msg_`, so we must omit invalid IDs instead of forwarding them.
+    """
+    ai_message = AIMessage(
+        content=[
+            {
+                "type": "text",
+                "text": "Paris is the capital of France.",
+                "id": "lc_fdbf5210-33f1-4cb1-90b4-2f5ec390cc83",
+            },
+        ],
+    )
+
+    result = _construct_responses_api_input([ai_message], store=store)
+
+    assert result == [
+        {
+            "type": "message",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Paris is the capital of France.",
+                    "annotations": [],
+                }
+            ],
+            "role": "assistant",
+        },
+    ]
+
+
 def test__construct_responses_api_input_store_false_keeps_full_tool_call_items() -> (
     None
 ):


### PR DESCRIPTION
Closes #39113

---

When "store" is not "False", "_construct_responses_api_input" was assigning any "id" found on assistant content blocks to the generated Responses API input item. Content-block factories such as "create_text_block" assign "lc_*" IDs to synthetic blocks; OpenAI rejects these with:

> Invalid 'input[2].id': 'lc_...'. Expected an ID that begins with 'msg'.

The fix only preserves the item-level "id" when it is a string starting with "msg_", matching real OpenAI assistant message IDs. Synthetic messages now omit the "id" (consistent with the existing "store=False" path).

Added a unit test covering "store=None" and "store=True".