### PR TITLE
fix: add path validation in check_diff.py...

### DIFF
--- a/.github/scripts/check_diff.py
+++ b/.github/scripts/check_diff.py
@@ -165,6 +165,8 @@ def _get_pydantic_test_configs(
             core_max_pydantic_minor = package["version"].split(".")[1]
             break
 
+    if ".." in Path(dir_).parts:
+        raise ValueError(f"Invalid directory path: {dir_}")
     with open(f"./{dir_}/uv.lock", "rb") as f:
         dir_uv_lock_data = tomllib.load(f)
 


### PR DESCRIPTION
## Summary
Address high severity security finding in `.github/scripts/check_diff.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | utils.custom.path-traversal-open |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `utils.custom.path-traversal-open` |
| **File** | `.github/scripts/check_diff.py:168` |
| **Assessment** | Pattern match — needs manual review |

**Description**: User-controlled input used in file path for open() without sanitization. This can allow path traversal attacks to read arbitrary files.


## Evidence

**Scanner confirmation**: semgrep rule `utils.custom.path-traversal-open` matched this pattern as utils.custom.path-traversal-open.

## Changes
- `.github/scripts/check_diff.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
