### PR TITLE
fix(langchain): fix exception swallowing in model retry and fallback middleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -19,6 +19,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.tools import BaseTool
+from langgraph.errors import GraphBubbleUp
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
@@ -344,6 +345,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         last_exception: Exception
         try:
             return handler(request)
+        except GraphBubbleUp:
+            raise
         except Exception as e:
             last_exception = e
 
@@ -359,6 +362,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             try:
                 return handler(fallback_request.override(model=fallback_model))
+            except GraphBubbleUp:
+                raise
             except Exception as e:
                 last_exception = e
                 continue
@@ -386,6 +391,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         last_exception: Exception
         try:
             return await handler(request)
+        except GraphBubbleUp:
+            raise
         except Exception as e:
             last_exception = e
 
@@ -401,6 +408,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             try:
                 return await handler(fallback_request.override(model=fallback_model))
+            except GraphBubbleUp:
+                raise
             except Exception as e:
                 last_exception = e
                 continue

--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -7,6 +7,7 @@ import time
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage
+from langgraph.errors import GraphBubbleUp
 
 from langchain.agents.middleware._retry import (
     OnFailure,
@@ -128,7 +129,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
             retry_on: Either a tuple of exception types to retry on, or a callable
                 that takes an exception and returns `True` if it should be retried.
 
-                Default is to retry on all exceptions.
+                Default is to retry on all exceptions. Exceptions that do not match
+                propagate immediately and are not handled by `on_failure`.
             on_failure: Behavior when all retries are exhausted.
 
                 Options:
@@ -232,13 +234,15 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
         for attempt in range(self.max_retries + 1):
             try:
                 return handler(request)
+            except GraphBubbleUp:
+                raise
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -282,13 +286,15 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
         for attempt in range(self.max_retries + 1):
             try:
                 return await handler(request)
+            except GraphBubbleUp:
+                raise
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -11,6 +11,8 @@ from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.tools import BaseTool, tool
+from langgraph.errors import ParentCommand
+from langgraph.types import Command
 from typing_extensions import override
 
 from langchain.agents.factory import create_agent
@@ -1067,3 +1069,44 @@ async def test_fallback_sanitizer_error_is_not_masked_async(
 
     with pytest.raises(RuntimeError, match="sanitizer boom"):
         await middleware.awrap_model_call(request, mock_handler)
+
+
+def test_model_fallback_reraises_graph_bubble_up() -> None:
+    """GraphBubbleUp signals (e.g. ParentCommand) must propagate, not be retried or caught."""
+    primary_model = FakeToolCallingModel()
+    fallback_model = FakeToolCallingModel()
+    middleware = ModelFallbackMiddleware(fallback_model)
+    request = _make_request().override(model=primary_model)
+
+    calls = 0
+
+    def mock_handler(req: ModelRequest) -> ModelResponse: 
+        nonlocal calls
+        calls += 1
+        raise ParentCommand(Command(goto="some_node"))
+
+    with pytest.raises(ParentCommand):
+        middleware.wrap_model_call(request, mock_handler)
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_model_fallback_async_reraises_graph_bubble_up() -> None:
+    """GraphBubbleUp signals (e.g. ParentCommand) must propagate (async)."""
+    primary_model = FakeToolCallingModel()
+    fallback_model = FakeToolCallingModel()
+    middleware = ModelFallbackMiddleware(fallback_model)
+    request = _make_request().override(model=primary_model)
+
+    calls = 0
+
+    async def mock_handler(req: ModelRequest) -> ModelResponse:  
+        nonlocal calls
+        calls += 1
+        raise ParentCommand(Command(goto="some_node"))
+
+    with pytest.raises(ParentCommand):
+        await middleware.awrap_model_call(request, mock_handler)
+
+    assert calls == 1

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -1080,7 +1080,7 @@ def test_model_fallback_reraises_graph_bubble_up() -> None:
 
     calls = 0
 
-    def mock_handler(req: ModelRequest) -> ModelResponse: 
+    def mock_handler(req: ModelRequest) -> ModelResponse:  # noqa: ARG001
         nonlocal calls
         calls += 1
         raise ParentCommand(Command(goto="some_node"))
@@ -1101,7 +1101,7 @@ async def test_model_fallback_async_reraises_graph_bubble_up() -> None:
 
     calls = 0
 
-    async def mock_handler(req: ModelRequest) -> ModelResponse:  
+    async def mock_handler(req: ModelRequest) -> ModelResponse:  # noqa: ARG001
         nonlocal calls
         calls += 1
         raise ParentCommand(Command(goto="some_node"))

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -703,7 +703,7 @@ def test_model_retry_reraises_graph_bubble_up() -> None:
 
     calls = 0
 
-    def handler(request: ModelRequest) -> ModelResponse: 
+    def handler(request: ModelRequest) -> ModelResponse:  # noqa: ARG001
         nonlocal calls
         calls += 1
         raise ParentCommand(Command(goto="some_node"))
@@ -728,7 +728,7 @@ async def test_model_retry_async_reraises_graph_bubble_up() -> None:
 
     calls = 0
 
-    async def handler(request: ModelRequest) -> ModelResponse:  
+    async def handler(request: ModelRequest) -> ModelResponse:  # noqa: ARG001
         nonlocal calls
         calls += 1
         raise ParentCommand(Command(goto="some_node"))

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -9,6 +9,8 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.errors import ParentCommand
+from langgraph.types import Command
 from pydantic import Field
 from typing_extensions import override
 
@@ -311,15 +313,11 @@ def test_model_retry_specific_exceptions() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
-
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-    # RuntimeError should fail immediately (1 attempt only)
-    assert "1 attempt" in ai_messages[-1].content
+    with pytest.raises(RuntimeError, match="Runtime error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
 
 def test_model_retry_custom_exception_filter() -> None:
@@ -389,17 +387,14 @@ def test_model_retry_custom_exception_filter() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
+    with pytest.raises(CustomError, match="Non-retryable error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-
-    # Should retry once (attempt 1 with retry_me=True), then fail on attempt 2 (retry_me=False)
+    # Should have retried once (attempt 1 retryable, attempt 2 non-retryable)
     assert attempt_count["value"] == 2
-    assert "2 attempts" in ai_messages[-1].content
 
 
 def test_model_retry_backoff_timing() -> None:
@@ -700,3 +695,52 @@ def test_model_retry_multiple_middleware_composition() -> None:
     ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
     assert len(ai_messages) >= 1
     assert "Hello" in ai_messages[-1].content
+
+
+def test_model_retry_reraises_graph_bubble_up() -> None:
+    """GraphBubbleUp signals (e.g. ParentCommand) must propagate, not be retried."""
+    middleware = ModelRetryMiddleware(max_retries=3, initial_delay=0.01, jitter=False)
+
+    calls = 0
+
+    def handler(request: ModelRequest) -> ModelResponse: 
+        nonlocal calls
+        calls += 1
+        raise ParentCommand(Command(goto="some_node"))
+
+    request = ModelRequest(
+        model=FakeToolCallingModel(),
+        messages=[],
+        state={"messages": []},
+        runtime=None,
+    )
+
+    with pytest.raises(ParentCommand):
+        middleware.wrap_model_call(request, handler)
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_model_retry_async_reraises_graph_bubble_up() -> None:
+    """GraphBubbleUp signals (e.g. ParentCommand) must propagate, not be retried (async)."""
+    middleware = ModelRetryMiddleware(max_retries=3, initial_delay=0.01, jitter=False)
+
+    calls = 0
+
+    async def handler(request: ModelRequest) -> ModelResponse:  
+        nonlocal calls
+        calls += 1
+        raise ParentCommand(Command(goto="some_node"))
+
+    request = ModelRequest(
+        model=FakeToolCallingModel(),
+        messages=[],
+        state={"messages": []},
+        runtime=None,
+    )
+
+    with pytest.raises(ParentCommand):
+        await middleware.awrap_model_call(request, handler)
+
+    assert calls == 1


### PR DESCRIPTION
Fixes #39121 
---

this pr fixes issue where model retry and fallback middleware were catching langraph control signals like graph interrupts, which caused human in the loop flows to break. the change made allows these signals to go correctly and makes sure non retryable errors are raised immediately instead of being wrapped as error messages

## Release note
fix(langchain): prevent model retry and fallback middleware from swallowing graph interrupts and non retryable errors.

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - ran ruff linting and formatting success fully
  - ran all 57 unit tests in `test_model_retry.py` and `test_model_fallback.py`; all passed

4. How did you verify your code works?

i added unit tests to verify GraphBubbleUp signals are propagated correctly and that non retryable errors are raised immedately. i ran pytest locally and confirmed that all 57 tests passed.

## Social handles (optional)
Twitter: @Saniya_Gupte12  
LinkedIn: https://www.linkedin.com/in/saniya-milind-gupte/