### PR TITLE
fix(core): make InMemoryRecordManager.get_time strictly increasing

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import math
 import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -251,6 +252,8 @@ class InMemoryRecordManager(RecordManager):
         # of {'group_id': group_id, 'updated_at': timestamp}
         self.records: dict[str, _Record] = {}
         self.namespace = namespace
+        # Last timestamp handed out by `get_time()`; see the note there.
+        self._last_time = 0.0
 
     def create_schema(self) -> None:
         """In-memory schema creation is simply ensuring the structure is initialized."""
@@ -260,7 +263,22 @@ class InMemoryRecordManager(RecordManager):
 
     @override
     def get_time(self) -> float:
-        return time.time()
+        """Return a strictly increasing timestamp.
+
+        ``RecordManager`` requires the timestamp to be monotonically increasing,
+        and ``list_keys(before=...)`` treats the cutoff as exclusive
+        (``updated_at >= before`` is skipped). ``time.time()`` has a coarse
+        resolution on some platforms — roughly 15.6 ms on Windows — so
+        consecutive calls can return the same value. Records that end up sharing
+        a timestamp with a later cutoff are then silently skipped by ``full``
+        cleanup, making the number of deleted records depend on where the clock
+        tick happens to fall.
+        """
+        now = time.time()
+        if now <= self._last_time:
+            now = math.nextafter(self._last_time, math.inf)
+        self._last_time = now
+        return now
 
     @override
     async def aget_time(self) -> float:

--- a/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
+++ b/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
@@ -25,6 +25,28 @@ async def amanager() -> InMemoryRecordManager:
     return record_manager
 
 
+def test_get_time_is_strictly_increasing(manager: InMemoryRecordManager) -> None:
+    """`get_time` must never return the same timestamp twice.
+
+    `RecordManager` documents the timestamp as monotonically increasing, and
+    `list_keys(before=...)` treats the cutoff as exclusive (`updated_at >=
+    before` is skipped). So records that share a timestamp with a later cutoff
+    are silently skipped by `full` cleanup.
+
+    `time.time()` is patched to a constant here to emulate a coarse clock. Real
+    resolution varies by platform — around 15.6 ms on Windows — so without
+    patching this would pass on Linux and hide the defect.
+    """
+    with patch("time.time", return_value=1234.5):
+        timestamps = [manager.get_time() for _ in range(10)]
+
+    assert timestamps == sorted(timestamps), "timestamps must not go backwards"
+    assert len(set(timestamps)) == len(timestamps), (
+        "get_time() returned duplicate timestamps, so records sharing one can "
+        "escape `before=` cleanup"
+    )
+
+
 def test_update(manager: InMemoryRecordManager) -> None:
     """Test updating records in the database."""
     # no keys should be present in the set


### PR DESCRIPTION
﻿**Description:** `InMemoryRecordManager.get_time()` returned `time.time()` directly, which is not guaranteed to advance between calls. That breaks the documented monotonic contract and makes `full` cleanup skip records, leaving five indexing tests non-deterministic.

**Issue:** none filed — found while running `libs/core` unit tests.

### The defect

`RecordManager` documents the timestamp as monotonically increasing:

> `It's important to get this from the server to ensure a monotonic clock`

and `InMemoryRecordManager.list_keys` treats `before` as an **exclusive** cutoff:

```python
if before and data["updated_at"] >= before:
    continue
```

`update()` stamps each record with its own `get_time()` call:

```python
self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
```

`time.time()` resolution is platform dependent — roughly 15.6 ms on Windows — so a bulk index run writes many records sharing one timestamp. When a later `index_start_dt` lands on that same tick, `index(..., cleanup="full")` never lists those records and `num_deleted` silently under-counts.

### Evidence

Running the four `*_cleanup_with_different_batchsize` tests **in isolation**, three consecutive times:

```
run 1 : 1 failed, 3 passed
run 2 : 3 failed, 1 passed
run 3 : 2 failed, 2 passed
```

with assertions like `num_deleted` of `800` where `1000` was expected. Isolation rules out cross-test ordering.

After the change, six consecutive runs:

```
run 1..6 : 4 passed
```

Across the full `libs/core` unit suite these five tests go from failing to passing:

```
tests/unit_tests/indexing/test_indexing.py::test_full_cleanup_with_different_batchsize
tests/unit_tests/indexing/test_indexing.py::test_incremental_cleanup_with_different_batchsize
tests/unit_tests/indexing/test_indexing.py::test_aincremental_cleanup_with_different_batchsize
tests/unit_tests/indexing/test_indexing.py::test_index_into_document_index
tests/unit_tests/indexing/test_indexing.py::test_aindex_into_document_index
```

No test regressed. `test_rate_limiting.py::test_rate_limit_stream` is also intermittent here, but I verified it fails with **and** without this change (4/5 vs 2/5 over five runs), so it is a separate timing-sensitive test and not affected by this PR.

### The change

Track the last timestamp handed out and step to the next representable float when the clock has not advanced, so `get_time()` is strictly increasing while still tracking wall-clock time.

The regression test patches `time.time` to a constant deliberately: real resolution is fine-grained on Linux, so an unpatched test would pass on CI and hide the defect.

I am happy to take a different approach if you would prefer one — for example making `before` inclusive, or having `update()` reuse a single timestamp for the batch. This felt like the smallest change consistent with the documented contract, but it is your call.

### Add tests and docs

Added `test_get_time_is_strictly_increasing` in `tests/unit_tests/indexing/test_in_memory_record_manager.py`. It fails on `master` with `get_time() returned duplicate timestamps` and passes with the change.

### Lint and test

```
ruff check                     -> All checks passed!
ruff format --check            -> 2 files already formatted
mypy langchain_core/indexing/base.py -> Success: no issues found
pytest tests/unit_tests/indexing/test_in_memory_record_manager.py -> 10 passed
```
