### PR TITLE
Add RecursiveJsonSplitter length_function

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/json.py
+++ b/libs/text-splitters/langchain_text_splitters/json.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import Any
+from typing import Any, Callable
 
 from langchain_core.documents import Document
 
@@ -27,7 +27,10 @@ class RecursiveJsonSplitter:
     """
 
     def __init__(
-        self, max_chunk_size: int = 2000, min_chunk_size: int | None = None
+        self,
+        max_chunk_size: int = 2000,
+        min_chunk_size: int | None = None,
+        length_function: Callable[[dict[str, Any]], int] | None = None,
     ) -> None:
         """Initialize the chunk size configuration for text processing.
 
@@ -49,6 +52,7 @@ class RecursiveJsonSplitter:
             if min_chunk_size is not None
             else max(max_chunk_size - 200, 50)
         )
+        self._length_function = length_function or self._json_size
 
     @staticmethod
     def _json_size(data: dict[str, Any]) -> int:
@@ -94,8 +98,8 @@ class RecursiveJsonSplitter:
         if isinstance(data, dict) and data:
             for key, value in data.items():
                 new_path = [*current_path, key]
-                chunk_size = self._json_size(chunks[-1])
-                size = self._json_size({key: value})
+                chunk_size = self._length_function(chunks[-1])
+                size = self._length_function({key: value})
                 remaining = self.max_chunk_size - chunk_size
 
                 if size < remaining:

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3380,6 +3380,23 @@ def test_split_json_with_lists() -> None:
     assert len(texts_list) >= len(texts)
 
 
+def test_split_json_length_function() -> None:
+    """Test json text splitter with a custom length function."""
+    data: dict[str, Any] = {
+        "a": "x" * 80,
+        "b": "y" * 80,
+    }
+
+    default_splitter = RecursiveJsonSplitter(max_chunk_size=100)
+    custom_splitter = RecursiveJsonSplitter(
+        max_chunk_size=100,
+        length_function=lambda json_data: len(json_data),
+    )
+
+    assert len(default_splitter.split_json(data)) > 1
+    assert custom_splitter.split_json(data) == [data]
+
+
 def test_split_json_many_calls() -> None:
     x = {"a": 1, "b": 2}
     y = {"c": 3, "d": 4}


### PR DESCRIPTION
## Summary

Add an optional `length_function` parameter to `RecursiveJsonSplitter` so callers can override the JSON size heuristic used during chunking.

## Why

`TextSplitter` classes already expose a length hook, but `RecursiveJsonSplitter` was hard-wired to `_json_size`. That made custom chunk sizing awkward and forced subclassing or monkeypatching for tokenizer-based sizing.

## What changed

- Added `length_function` to `RecursiveJsonSplitter.__init__`.
- Routed chunk-size checks through the configured length function, defaulting to the existing `_json_size` behavior.
- Added a regression test that verifies a custom length function changes splitting behavior.

## Validation

- Dependency-free smoke test of the modified splitter logic using a local module load and stub `Document` class.
- Confirmed the default splitter still splits the sample payload while the custom length function keeps it in one chunk.

## Notes

This stays intentionally narrow and only touches `langchain-text-splitters`.
