### PR TITLE
fix(core): fix InMemoryRecordManager.update() inconsistent per-document timestamps

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -296,12 +296,16 @@ class InMemoryRecordManager(RecordManager):
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
-        for index, key in enumerate(keys):
-            group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
+        if time_at_least is not None:
+            now = time_at_least
+            if time_at_least > self.get_time():
                 msg = "time_at_least must be in the past"
                 raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+        else:
+            now = self.get_time()
+        for index, key in enumerate(keys):
+            group_id = group_ids[index] if group_ids else None
+            self.records[key] = {"group_id": group_id, "updated_at": now}
 
     async def aupdate(
         self,
@@ -659,3 +663,4 @@ class DocumentIndex(BaseRetriever):
             ids,
             **kwargs,
         )
+

--- a/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
+++ b/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
@@ -95,6 +95,32 @@ def test_update_timestamp(manager: InMemoryRecordManager) -> None:
     ) == ["key1"]
 
 
+def test_update_multiple_keys_consistent_timestamp(
+    manager: InMemoryRecordManager,
+) -> None:
+    """Test that updating multiple keys uses a single timestamp for all keys.
+
+    Previously, get_time() was called once per key inside the update()
+    loop, causing documents in the same batch to get slightly different
+    timestamps. This led to incomplete cleanup during indexing since
+    list_keys(before=...) could miss some documents.
+    """
+    timestamps = iter(
+        [
+            datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp(),
+            datetime(2021, 1, 2, tzinfo=timezone.utc).timestamp(),
+            datetime(2021, 1, 3, tzinfo=timezone.utc).timestamp(),
+        ]
+    )
+    with patch.object(manager, "get_time", side_effect=lambda: next(timestamps)):
+        manager.update(["key1", "key2", "key3"])
+
+    # All records should share the first timestamp value, not one per key
+    expected_ts = datetime(2021, 1, 1, tzinfo=timezone.utc).timestamp()
+    for key in ["key1", "key2", "key3"]:
+        assert manager.records[key]["updated_at"] == expected_ts
+
+
 async def test_aupdate_timestamp(manager: InMemoryRecordManager) -> None:
     """Test updating records in the database."""
     # no keys should be present in the set


### PR DESCRIPTION
Closes #39087

---

InMemoryRecordManager.update() called self.get_time() once per key inside the loop, giving each document in the same batch a slightly different timestamp. During indexing cleanup with \ull\ or \incremental\ strategy, \list_keys(before=index_start_dt)\ used these inconsistent timestamps via \>=\ comparison, causing documents to be missed by the cleanup query. The exact number of missed documents varied between runs due to timing.

This fix uses \	ime_at_least\ as the actual timestamp for all keys in the batch when provided (aligned with \index_start_dt\ from the \index()\ function), ensuring all records in the same indexing run share the same timestamp. When \	ime_at_least\ is not provided, it falls back to a single \get_time()\ call for the entire batch.

A regression test is added to verify that \update()\ with multiple keys uses a single consistent timestamp for all keys.