### PR TITLE
fix(core): use `is not None` instead of truthiness check for cache in LLM and chat model helpers

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1872,9 +1872,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         # We should check the cache unless it's explicitly set to False
         # A None cache means we should use the default global cache
         # if it's configured.
-        check_cache = self.cache or self.cache is None
+        check_cache = self.cache is not False
         if check_cache:
-            if llm_cache:
+            if llm_cache is not None:
                 llm_string = self._get_llm_string(stop=stop, **kwargs)
                 normalized_messages = [
                     (
@@ -2016,7 +2016,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 **result.llm_output,
                 **result.generations[0].message.response_metadata,
             }
-        if check_cache and llm_cache:
+        if check_cache and llm_cache is not None:
             llm_cache.update(prompt, llm_string, result.generations)
         return result
 
@@ -2031,9 +2031,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         # We should check the cache unless it's explicitly set to False
         # A None cache means we should use the default global cache
         # if it's configured.
-        check_cache = self.cache or self.cache is None
+        check_cache = self.cache is not False
         if check_cache:
-            if llm_cache:
+            if llm_cache is not None:
                 llm_string = self._get_llm_string(stop=stop, **kwargs)
                 normalized_messages = [
                     (
@@ -2173,7 +2173,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 **result.llm_output,
                 **result.generations[0].message.response_metadata,
             }
-        if check_cache and llm_cache:
+        if check_cache and llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result.generations)
         return result
 

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -182,7 +182,7 @@ def get_prompts(
 
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = llm_cache.lookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -217,7 +217,7 @@ async def aget_prompts(
     existing_prompts = {}
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = await llm_cache.alookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
@@ -288,7 +288,7 @@ async def aupdate_cache(
     for i, result in enumerate(new_results.generations):
         existing_prompts[missing_prompt_idxs[i]] = result
         prompt = prompts[missing_prompt_idxs[i]]
-        if llm_cache:
+        if llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result)
     return new_results.llm_output
 

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_cache.py
@@ -506,6 +506,52 @@ def test_cache_key_ignores_message_id_sync() -> None:
     assert len(local_cache._cache) == 1
 
 
+class SizedCache(BaseCache):
+    """Cache that implements __len__, making an empty instance falsy."""
+
+    def __init__(self) -> None:
+        self._cache: dict[tuple[str, str], RETURN_VAL_TYPE] = {}
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def lookup(self, prompt: str, llm_string: str) -> RETURN_VAL_TYPE | None:
+        return self._cache.get((prompt, llm_string))
+
+    def update(self, prompt: str, llm_string: str, return_val: RETURN_VAL_TYPE) -> None:
+        self._cache[prompt, llm_string] = return_val
+
+    @override
+    def clear(self, **kwargs: Any) -> None:
+        self._cache = {}
+
+
+def test_sized_cache_invoke_sync() -> None:
+    """invoke() must not skip caching when cache implements __len__."""
+    cache = SizedCache()
+    assert len(cache) == 0
+
+    chat_model = FakeListChatModel(cache=cache, responses=["hello", "goodbye"])
+    assert chat_model.invoke("How are you?").content == "hello"
+    assert len(cache) == 1
+
+    assert chat_model.invoke("How are you?").content == "hello"
+    assert len(cache) == 1
+
+
+async def test_sized_cache_invoke_async() -> None:
+    """ainvoke() must not skip caching when cache implements __len__."""
+    cache = SizedCache()
+    assert len(cache) == 0
+
+    chat_model = FakeListChatModel(cache=cache, responses=["hello", "goodbye"])
+    assert (await chat_model.ainvoke("How are you?")).content == "hello"
+    assert len(cache) == 1
+
+    assert (await chat_model.ainvoke("How are you?")).content == "hello"
+    assert len(cache) == 1
+
+
 async def test_cache_key_ignores_message_id_async() -> None:
     """Test that message IDs are stripped from cache keys (async).
 

--- a/libs/core/tests/unit_tests/language_models/llms/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/llms/test_cache.py
@@ -109,3 +109,62 @@ async def test_no_cache_generate_async() -> None:
         assert global_cache._cache == {}
     finally:
         set_llm_cache(None)
+
+
+class SizedCache(BaseCache):
+    """Cache that implements __len__, making an empty instance falsy.
+
+    This exercises the `is not None` guard — a truthiness check (`if llm_cache:`)
+    would skip lookups when the cache is empty, silently dropping prompts from
+    both `existing_prompts` and `missing_prompts` and causing a KeyError later.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[tuple[str, str], RETURN_VAL_TYPE] = {}
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def lookup(self, prompt: str, llm_string: str) -> RETURN_VAL_TYPE | None:
+        return self._cache.get((prompt, llm_string))
+
+    def update(self, prompt: str, llm_string: str, return_val: RETURN_VAL_TYPE) -> None:
+        self._cache[prompt, llm_string] = return_val
+
+    @override
+    def clear(self, **kwargs: Any) -> None:
+        self._cache = {}
+
+
+def test_sized_cache_generate_sync() -> None:
+    """generate() must not raise KeyError when cache implements __len__."""
+    cache = SizedCache()
+    assert len(cache) == 0  # falsy — would break under the old truthiness check
+
+    llm = FakeListLLM(cache=cache, responses=["foo", "bar"])
+
+    # First call: cache miss → LLM called, result stored
+    output = llm.generate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1
+
+    # Second call: cache hit → same result returned, LLM NOT called again
+    output = llm.generate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1  # still 1 — no new entry
+
+
+async def test_sized_cache_generate_async() -> None:
+    """agenerate() must not raise KeyError when cache implements __len__."""
+    cache = SizedCache()
+    assert len(cache) == 0
+
+    llm = FakeListLLM(cache=cache, responses=["foo", "bar"])
+
+    output = await llm.agenerate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1
+
+    output = await llm.agenerate(["hello"])
+    assert output.generations[0][0].text == "foo"
+    assert len(cache) == 1


### PR DESCRIPTION
Closes #38440

---

Any `BaseCache` that implements `__len__` is falsy when empty. The old truthiness guards (`if llm_cache:`) silently skipped cache lookups on the first call, leaving prompts untracked in both `existing_prompts` and `missing_prompts`, which then raised `KeyError: 0` during result assembly.

**LLM path** (`get_prompts`, `aget_prompts`, `aupdate_cache`): three `if llm_cache:` guards changed to `if llm_cache is not None:`, matching the already-correct sync `update_cache`.

**Chat model path** (`_generate_with_cache`, `_agenerate_with_cache`):
- `check_cache = self.cache or self.cache is None` → `check_cache = self.cache is not False` so an empty sized cache is not treated as "caching disabled".
- Lookup and write guards updated to `is not None` in both sync and async variants.

Behavior is unchanged for the common case — caches without `__len__`/`__bool__` remain truthy. Regression tests use a `SizedCache` fixture mirroring the issue reproducer, covering `generate`/`agenerate` and `invoke`/`ainvoke`.

> AI-assisted contribution.

Made with [Cursor](https://cursor.com)