### PR TITLE
chore(infra): expand credential coverage in root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,29 @@ celerybeat.pid
 *.key
 *.crt
 credentials.json
+# SSH private keys (no file extension, so *.key never matches them)
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+*_rsa
+*_dsa
+*_ecdsa
+*_ed25519
+!*.pub
+
+# Keystores
+*.p12
+*.pfx
+*.jks
+
+# Tokens, cookie jars, and git credential stores
+token.json
+Cookies
+Cookies.db
+cookies.sqlite
+cookies.txt
+.git-credentials
 .venv*
 venv*
 env/


### PR DESCRIPTION
The root `.gitignore` covers `.env` files, `*.pem`/`*.key`/`*.crt`, and `credentials.json`, but a number of common local credential files are still stageable and easy to commit by accident — especially SSH private keys, which usually have no extension, so the existing `*.key` pattern never matches `id_rsa` or `id_ed25519`.

This adds ignores, all within the existing `# Environments` section, for:

- **SSH private keys** — `id_rsa` / `id_dsa` / `id_ecdsa` / `id_ed25519` and their `*_rsa` / `*_dsa` / `*_ecdsa` / `*_ed25519` counterparts. A `!*.pub` negation keeps public keys (e.g. `id_rsa.pub`, `deploy_ed25519.pub`) committable, since those are not secrets and are sometimes checked in deliberately.
- **Keystores** — `*.p12`, `*.pfx`, `*.jks`.
- **Tokens, cookie jars, and git credential stores** — `token.json`, `Cookies`, `Cookies.db`, `cookies.sqlite`, `cookies.txt`, `.git-credentials`.

No source files are touched; this only narrows what `git add` will stage.

## Verification

`git check-ignore` is authoritative here (grepping the file is not, since patterns can come from multiple files).

Newly ignored (all `IGNORED`):

```text
IGNORED      id_rsa
IGNORED      id_dsa
IGNORED      id_ecdsa
IGNORED      id_ed25519
IGNORED      mykey_rsa
IGNORED      deploy_ed25519
IGNORED      x.p12
IGNORED      x.pfx
IGNORED      x.jks
IGNORED      token.json
IGNORED      Cookies
IGNORED      cookies.sqlite
IGNORED      cookies.txt
IGNORED      .git-credentials
```

Deliberately still committable (all NOT ignored):

```text
ok  id_rsa.pub
ok  deploy_ed25519.pub
ok  .env.example
```

The `!*.pub` negation is placed after the key patterns so it is not re-matched, and `.env.example`'s existing `!.env.example` negation is earlier in the file than every new pattern, so neither is re-ignored. Finally, `git ls-files | git check-ignore --stdin` prints nothing, confirming no already-tracked file is newly shadowed.
