### PR TITLE
fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 LangChain is a framework for building agents and LLM-powered applications. It helps you chain together interoperable components and third-party integrations to simplify AI application development — all while future-proofing decisions as the underlying technology evolves.
 
 > [!TIP]
-> Just getting started? Check out **[Deep Agents](http://docs.langchain.com/oss/python/deepagents/)** — a higher-level package built on LangChain for agents that have built-in capabilites for common usage patterns such as planning, subagents, file system usage, and more.
+> Just getting started? Check out **[Deep Agents](http://docs.langchain.com/oss/python/deepagents/)** — a higher-level package built on LangChain for agents that have built-in capabilities for common usage patterns such as planning, subagents, file system usage, and more.
 
 ## Quickstart
 

--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1582,7 +1582,7 @@ def _is_injected_arg_type(
         injected_type = InjectedToolArg
 
     # if the type is an Annotated type, check if annotated metadata
-    # is an intance or subclass of the injected type
+    # is an instance or subclass of the injected type
     return any(
         isinstance(arg, injected_type)
         or (isinstance(arg, type) and issubclass(arg, injected_type))

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
@@ -724,7 +724,7 @@ def test_stream_reasoning_summary(
     )
     message_1 = {
         "role": "user",
-        "content": "What was the third tallest buliding in the year 2000?",
+        "content": "What was the third tallest building in the year 2000?",
     }
     response_1: BaseMessage
     if use_v2_stream:


### PR DESCRIPTION
ran codespell out of curiosity and found a couple typos:

   - `capabilites` → `capabilities` in the readme
   - `intance` → `instance` in a docstring
   - `buliding` → `building` in a test

   this is my first pr, so let me know if I should do anything differently