### PR TITLE
fix(openai): strip `lc_` IDs from synthetic AIMessage content blocks in Responses API input

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4659,7 +4659,11 @@ def _construct_responses_api_input(
                                     "content": [new_block],
                                     "role": "assistant",
                                 }
-                                if store is not False:
+                                if (
+                                    store is not False
+                                    and msg_id
+                                    and not msg_id.startswith("lc_")
+                                ):
                                     new_item["id"] = msg_id
                                 if phase is not None:
                                     new_item["phase"] = phase

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -31,6 +31,7 @@ from langchain_core.messages.ai import UsageMetadata
 from langchain_core.messages.block_translators.openai import (
     _convert_from_v03_ai_message,
 )
+from langchain_core.messages.content import create_text_block
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.runnables import RunnableLambda
 from langchain_core.runnables.base import RunnableBinding, RunnableSequence
@@ -3064,6 +3065,89 @@ def test__construct_responses_api_input_store_enabled_keeps_item_ids(
             "id": "msg_123",
         },
     ]
+
+
+def test__construct_responses_api_input_strips_lc_id_from_synthetic_message() -> None:
+    """Synthetic AIMessage built with create_text_block() should not leak lc_ IDs.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/39113.
+    create_text_block() auto-generates an id prefixed with 'lc_'. When forwarded
+    to the OpenAI Responses API, this causes a 400 because the API requires
+    message IDs to begin with 'msg_'.
+    """
+    ai_message = AIMessage(
+        content_blocks=[
+            create_text_block("The capital of France is Paris."),
+        ],
+    )
+    # Verify the block has an lc_ prefixed ID (the root cause).
+    assert isinstance(ai_message.content, list)
+    block = ai_message.content[0]
+    assert isinstance(block, dict)
+    assert block["id"].startswith("lc_")
+
+    result = _construct_responses_api_input([ai_message])
+
+    # The lc_ ID must NOT appear on the emitted message item.
+    assert len(result) == 1
+    assert result[0]["type"] == "message"
+    assert result[0]["role"] == "assistant"
+    assert "id" not in result[0]
+    assert result[0]["content"] == [
+        {
+            "type": "output_text",
+            "text": "The capital of France is Paris.",
+            "annotations": [],
+        }
+    ]
+
+
+def test__construct_responses_api_input_preserves_valid_msg_id() -> None:
+    """Valid msg_ prefixed IDs must still be forwarded to the Responses API."""
+    ai_message = AIMessage(
+        content=[
+            {"type": "text", "text": "Hello!", "id": "msg_abc123"},
+        ],
+        response_metadata={"id": "resp_abc"},
+    )
+
+    result = _construct_responses_api_input([ai_message])
+
+    assert len(result) == 1
+    assert result[0]["id"] == "msg_abc123"
+
+
+def test__construct_responses_api_input_synthetic_conversation_round_trip() -> None:
+    """End-to-end test: synthetic multi-turn conversation with lc_ IDs.
+
+    Reproduces the exact scenario from issue #39113.
+    """
+    messages: list[BaseMessage] = [
+        SystemMessage(
+            content_blocks=[create_text_block("You are a helpful assistant.")]
+        ),
+        HumanMessage(
+            content_blocks=[create_text_block("What is the capital of France?")]
+        ),
+        AIMessage(
+            content_blocks=[create_text_block("The capital of France is Paris.")]
+        ),
+        HumanMessage(content_blocks=[create_text_block("And of Italy?")]),
+    ]
+
+    result = _construct_responses_api_input(messages)
+
+    # Verify no lc_ IDs leaked into any item.
+    for item in result:
+        item_id = item.get("id")
+        assert item_id is None or not item_id.startswith("lc_"), (
+            f"LangChain-internal ID leaked into Responses API input: {item_id}"
+        )
+
+    # The assistant message should not have an 'id' field.
+    assistant_items = [i for i in result if i.get("role") == "assistant"]
+    assert len(assistant_items) == 1
+    assert "id" not in assistant_items[0]
 
 
 def test__construct_responses_api_input_store_false_keeps_full_tool_call_items() -> (

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -398,7 +398,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -666,7 +666,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.5.0"
+version = "1.5.2"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -697,7 +697,7 @@ requires-dist = [
 dev = [
     { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
-    { name = "setuptools", specifier = ">=67.6.1,<83.0.0" },
+    { name = "setuptools", specifier = ">=67.6.1,<84.0.0" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
 test = [


### PR DESCRIPTION
Closes #39113
Description
This PR fixes a bug where passing synthetic conversation histories to ChatOpenAI (when use_responses_api=True) raises an openai.BadRequestError: 400 - Expected an ID that begins with 'msg'.

Root Cause: When developers construct synthetic messages using create_text_block(), LangChain auto-generates internal identifiers prefixed with lc_ (e.g., "lc_fdbf5210..."). Previously, _construct_responses_api_input() in langchain-openai blindly forwarded these lc_ IDs into the OpenAI Responses API payload. Because OpenAI strictly enforces that message IDs must start with "msg_", the API rejected the payload.

Fix: In _construct_responses_api_input, we now explicitly verify that the message ID does not start with the LangChain internal "lc_" prefix before assigning it to the payload. If it does, the ID is stripped, allowing OpenAI to successfully process the request (it will generate a new valid ID on its end).

Legitimate OpenAI IDs (like "msg_123xyz") are still preserved, ensuring store=True thread tracking continues to work perfectly.
This is conceptually identical to how Anthropic's version of this bug (#39100) was fixed in #39101.
Note: This PR was authored with the assistance of an AI coding agent.

Release note
Fixed an issue in langchain-openai where passing synthetic AIMessage content blocks to the OpenAI Responses API would crash with a 400 Bad Request error due to invalid lc_ internal IDs.
Testing
Added 3 new unit tests to test_base.py to ensure:

Synthetic lc_ prefixed IDs are correctly stripped from the payload.
Valid msg_ prefixed IDs are safely preserved (regression guard).
The exact multi-turn synthetic conversation scenario from the issue report successfully round-trips through the payload generator without leaking internal IDs.
