### PR TITLE
fix(openai): redact MCP `authorization`

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -2045,10 +2045,18 @@ class BaseChatOpenAI(BaseChatModel):
             **self._default_params,
             **kwargs,
         }
-        # Redact headers from built-in remote MCP tool invocations
+        # Redact credentials from built-in remote MCP tool invocations
         if (tools := params.get("tools")) and isinstance(tools, list):
+            sensitive_fields = ("headers", "authorization")
             params["tools"] = [
-                ({**tool, "headers": "**REDACTED**"} if "headers" in tool else tool)
+                {
+                    **tool,
+                    **{
+                        field: "**REDACTED**"
+                        for field in sensitive_fields
+                        if field in tool
+                    },
+                }
                 if isinstance(tool, dict) and tool.get("type") == "mcp"
                 else tool
                 for tool in tools

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3447,25 +3447,31 @@ def test_mcp_tracing() -> None:
             "server_label": "deepwiki",
             "server_url": "https://mcp.deepwiki.com/mcp",
             "require_approval": "always",
-            "headers": {"Authorization": "Bearer PLACEHOLDER"},
+            "headers": {"Authorization": "Bearer HEADER_SECRET"},
+            "authorization": "Bearer AUTHORIZATION_SECRET",
         }
     ]
     with patch.object(llm, "root_client", mock_client):
         llm_with_tools = llm.bind_tools(tools)
         _ = llm_with_tools.invoke([input_message], config={"callbacks": [tracer]})
 
-    # Test headers are not traced
+    # Test credentials are not traced
     assert len(tracer.chat_model_start_inputs) == 1
     invocation_params = tracer.chat_model_start_inputs[0]["kwargs"]["invocation_params"]
-    for tool in invocation_params["tools"]:
-        if "headers" in tool:
-            assert tool["headers"] == "**REDACTED**"
-    for substring in ["Authorization", "Bearer", "PLACEHOLDER"]:
+    assert invocation_params["tools"][0]["headers"] == "**REDACTED**"
+    assert invocation_params["tools"][0]["authorization"] == "**REDACTED**"
+    for substring in [
+        "Authorization",
+        "Bearer",
+        "HEADER_SECRET",
+        "AUTHORIZATION_SECRET",
+    ]:
         assert substring not in str(tracer.chat_model_start_inputs)
 
-    # Test headers are correctly propagated to request
+    # Test credentials are correctly propagated to request
     payload = llm_with_tools._get_request_payload([input_message], tools=tools)  # type: ignore[attr-defined]
-    assert payload["tools"][0]["headers"]["Authorization"] == "Bearer PLACEHOLDER"
+    assert payload["tools"][0]["headers"]["Authorization"] == "Bearer HEADER_SECRET"
+    assert payload["tools"][0]["authorization"] == "Bearer AUTHORIZATION_SECRET"
 
 
 def test_compat_responses_v03() -> None:


### PR DESCRIPTION
MCP tools can provide credentials through either `headers` or the sibling `authorization` field. `ChatOpenAI` previously removed `headers` from callback and tracing invocation parameters but left `authorization` intact, allowing that credential to reach configured callbacks or LangSmith traces.

This change redacts both credential fields when constructing invocation metadata while preserving the original values in the OpenAI request payload. The regression test covers callback redaction and request propagation for both forms.

## Release note

`ChatOpenAI` now redacts MCP tool `authorization` credentials from callback and tracing invocation metadata.

This contribution was prepared with AI-agent assistance.


Thanks [@liyander](https://github.com/liyander) for raising this issue. 