### PR TITLE
fix(core): forward kwargs in `RouterRunnable`

### DIFF
--- a/libs/core/langchain_core/runnables/router.py
+++ b/libs/core/langchain_core/runnables/router.py
@@ -114,7 +114,7 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
             raise ValueError(msg)
 
         runnable = self.runnables[key]
-        return runnable.invoke(actual_input, config)
+        return runnable.invoke(actual_input, config, **kwargs)
 
     @override
     async def ainvoke(
@@ -130,7 +130,7 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
             raise ValueError(msg)
 
         runnable = self.runnables[key]
-        return await runnable.ainvoke(actual_input, config)
+        return await runnable.ainvoke(actual_input, config, **kwargs)
 
     @override
     def batch(
@@ -219,7 +219,7 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
             raise ValueError(msg)
 
         runnable = self.runnables[key]
-        yield from runnable.stream(actual_input, config)
+        yield from runnable.stream(actual_input, config, **kwargs)
 
     @override
     async def astream(
@@ -235,5 +235,5 @@ class RouterRunnable(RunnableSerializable[RouterInput, Output]):
             raise ValueError(msg)
 
         runnable = self.runnables[key]
-        async for output in runnable.astream(actual_input, config):
+        async for output in runnable.astream(actual_input, config, **kwargs):
             yield output

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -2953,6 +2953,23 @@ async def test_router_runnable_async() -> None:
     assert result2 == ["4", "2"]
 
 
+async def test_router_runnable_forwards_kwargs() -> None:
+    """Test that every router execution mode forwards keyword arguments."""
+
+    def add_suffix(value: str, *, suffix: str) -> str:
+        return f"{value}{suffix}"
+
+    router = RouterRunnable({"suffix": RunnableLambda(add_suffix)})
+    router_input = {"key": "suffix", "input": "value"}
+
+    assert router.invoke(router_input, suffix="!") == "value!"
+    assert list(router.stream(router_input, suffix="!")) == ["value!"]
+    assert await router.ainvoke(router_input, suffix="!") == "value!"
+    assert [chunk async for chunk in router.astream(router_input, suffix="!")] == [
+        "value!"
+    ]
+
+
 @freeze_time("2023-01-01")
 def test_higher_order_lambda_runnable(
     mocker: MockerFixture, snapshot: SnapshotAssertion


### PR DESCRIPTION
`RouterRunnable` accepted keyword arguments but silently dropped them on `invoke`, `ainvoke`, `stream`, and `astream`. This made routed runnables that require keyword arguments fail outside batch execution.

The four methods now forward keyword arguments consistently with `batch` and `abatch`. A regression test covers synchronous, asynchronous, and streaming execution.

## Release note

`RouterRunnable` now forwards keyword arguments consistently across invocation and streaming methods.
