### PR TITLE
chore(devcontainer): add devcontainer lock file

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.8",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2",
+      "integrity": "sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #

---

Adds the devcontainer lock file used by the repository's devcontainer configuration so contributors use a reproducible development container image. The file was generated by the devcontainer tooling and should be updated by maintainers when the devcontainer definition changes.

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

## Release note
N/A

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

4. How did you verify your code works?
N/A — this is a devcontainer lock file change only.