### PR TITLE
feat(exa): add Contents, Answer, and Agent tools

### DIFF
--- a/libs/partners/exa/README.md
+++ b/libs/partners/exa/README.md
@@ -25,3 +25,7 @@ View the [documentation](https://docs.langchain.com/oss/python/integrations/prov
 
 - [LangChain Academy](https://academy.langchain.com/) — comprehensive, free courses on LangChain libraries and products, made by the LangChain team
 - [Code of Conduct](https://github.com/langchain-ai/langchain/?tab=coc-ov-file) — community guidelines and standards
+
+## Exa tools
+
+The package exports first-class `ExaSearchResults`, `ExaContents`, `ExaAnswer`, and `ExaAgent` tools. `ExaContents`, `ExaAnswer`, and `ExaAgent` return snake_case dicts. `ExaFindSimilarResults` is deprecated (Exa's `/findSimilar` is deprecated) and remains only for compatibility — prefer `ExaSearchResults`.

--- a/libs/partners/exa/langchain_exa/__init__.py
+++ b/libs/partners/exa/langchain_exa/__init__.py
@@ -7,9 +7,18 @@ from exa_py.api import (
 
 from langchain_exa._version import __version__
 from langchain_exa.retrievers import ExaSearchRetriever
-from langchain_exa.tools import ExaFindSimilarResults, ExaSearchResults
+from langchain_exa.tools import (
+    ExaAgent,
+    ExaAnswer,
+    ExaContents,
+    ExaFindSimilarResults,
+    ExaSearchResults,
+)
 
 __all__ = [
+    "ExaAgent",
+    "ExaAnswer",
+    "ExaContents",
     "ExaFindSimilarResults",
     "ExaSearchResults",
     "ExaSearchRetriever",

--- a/libs/partners/exa/langchain_exa/_utilities.py
+++ b/libs/partners/exa/langchain_exa/_utilities.py
@@ -1,17 +1,70 @@
 import os  # type: ignore[import-not-found]
+import warnings
+from typing import Any
 
-from exa_py import Exa
+from exa_py import AsyncExa, Exa
 from langchain_core.utils import convert_to_secret_str
+
+_CONTENT_KEYS = ("text", "highlights", "summary")
+
+
+def build_contents_options(
+    *,
+    text: Any = None,
+    highlights: Any = None,
+    summary: Any = None,
+    livecrawl: Any = None,
+    max_age_hours: int | None = None,
+) -> dict[str, Any]:
+    """Build content options; defaults to text when none are set."""
+    options = {
+        "text": text,
+        "highlights": highlights,
+        "summary": summary,
+        "livecrawl": livecrawl,
+        "max_age_hours": max_age_hours,
+    }
+    selected = {key: value for key, value in options.items() if value is not None}
+    if not any(key in selected for key in _CONTENT_KEYS):
+        selected["text"] = True
+    return selected
+
+
+def warn_if_use_autoprompt(use_autoprompt: bool | None) -> None:  # noqa: FBT001
+    """Warn that ``use_autoprompt`` is deprecated; use ``type="auto"``."""
+    if use_autoprompt is not None:
+        warnings.warn(
+            "`use_autoprompt` is deprecated and no longer sent to Exa; "
+            'use `type="auto"` instead.',
+            DeprecationWarning,
+            stacklevel=3,
+        )
 
 
 def initialize_client(values: dict) -> dict:
     """Initialize the client."""
     exa_api_key = values.get("exa_api_key") or os.environ.get("EXA_API_KEY") or ""
     values["exa_api_key"] = convert_to_secret_str(exa_api_key)
+    if values.get("client") is not None and values.get("async_client") is not None:
+        return values
     args = {
         "api_key": values["exa_api_key"].get_secret_value(),
     }
     if values.get("exa_base_url"):
         args["base_url"] = values["exa_base_url"]
-    values["client"] = Exa(**args)
+    if values.get("client") is None:
+        values["client"] = Exa(**args)
+        values["client"].headers["x-exa-integration"] = (
+            "langchain-ai/langchain-exa-integration"
+        )
+    if values.get("async_client") is None:
+        async_args: dict[str, str] = {
+            "api_key": values["exa_api_key"].get_secret_value()
+        }
+        if values.get("exa_base_url"):
+            async_args["api_base"] = values["exa_base_url"]
+        values["async_client"] = AsyncExa(**async_args)
+        values["async_client"].headers["x-exa-integration"] = (
+            "langchain-ai/langchain-exa-integration"
+        )
     return values

--- a/libs/partners/exa/langchain_exa/retrievers.py
+++ b/libs/partners/exa/langchain_exa/retrievers.py
@@ -14,7 +14,11 @@ from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
 from pydantic import Field, SecretStr, model_validator
 
-from langchain_exa._utilities import initialize_client
+from langchain_exa._utilities import (
+    build_contents_options,
+    initialize_client,
+    warn_if_use_autoprompt,
+)
 
 
 def _get_metadata(result: Any) -> dict[str, Any]:
@@ -54,22 +58,27 @@ class ExaSearchRetriever(BaseRetriever):
     end_published_date: str | None = None
     """The end date for when the document was published (in YYYY-MM-DD format)."""
     use_autoprompt: bool | None = None
-    """Whether to use autoprompt for the search."""
+    """Deprecated and no longer sent to Exa; use `type="auto"` instead."""
     type: str = "auto"
     """The type of search, 'auto', 'deep', or 'fast'. Default: auto"""
     highlights: HighlightsContentsOptions | bool | None = None
-    """Whether to set the page content to the highlights of the results."""
-    text_contents_options: TextContentsOptions | dict[str, Any] | Literal[True] = True
+    """Whether to include highlights of the results."""
+    text_contents_options: (
+        TextContentsOptions | dict[str, Any] | Literal[True] | None
+    ) = None
     """How to set the page content of the results. Can be True or a dict with options
-    like max_characters."""
+    like max_characters. Requested by default when no other content option is set."""
     livecrawl: Literal["always", "fallback", "never"] | None = None
     """Option to crawl live webpages if content is not in the index. Options: "always",
-    "fallback", "never"."""
+    "fallback", "never". Prefer `max_age_hours` for freshness."""
+    max_age_hours: int | None = None
+    """The maximum age of cached content in hours."""
     summary: bool | dict[str, str] | None = None
     """Whether to include a summary of the content. Can be a boolean or a dict with a
     custom query."""
 
     client: Exa = Field(default=None)  # type: ignore[assignment]
+    async_client: Any = Field(default=None)
     exa_api_key: SecretStr = Field(default=SecretStr(""))
     exa_base_url: str | None = None
 
@@ -79,32 +88,52 @@ class ExaSearchRetriever(BaseRetriever):
         """Validate the environment."""
         return initialize_client(values)
 
+    def _search_kwargs(self) -> dict[str, Any]:
+        """Build the keyword arguments shared by the sync and async paths."""
+        warn_if_use_autoprompt(self.use_autoprompt)
+        return {
+            "num_results": self.k,
+            "include_domains": self.include_domains,
+            "exclude_domains": self.exclude_domains,
+            "start_crawl_date": self.start_crawl_date,
+            "end_crawl_date": self.end_crawl_date,
+            "start_published_date": self.start_published_date,
+            "end_published_date": self.end_published_date,
+            "contents": build_contents_options(
+                text=self.text_contents_options,
+                highlights=self.highlights,
+                summary=self.summary,
+                livecrawl=self.livecrawl,
+                max_age_hours=self.max_age_hours,
+            ),
+            "type": self.type,
+        }
+
     def _get_relevant_documents(
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun
     ) -> list[Document]:
-        response = self.client.search_and_contents(  # type: ignore[call-overload]
+        response = self.client.search(  # type: ignore[call-overload]
             query,
-            num_results=self.k,
-            text=self.text_contents_options,
-            highlights=self.highlights,
-            include_domains=self.include_domains,
-            exclude_domains=self.exclude_domains,
-            start_crawl_date=self.start_crawl_date,
-            end_crawl_date=self.end_crawl_date,
-            start_published_date=self.start_published_date,
-            end_published_date=self.end_published_date,
-            use_autoprompt=self.use_autoprompt,
-            livecrawl=self.livecrawl,
-            summary=self.summary,
-            type=self.type,
+            **self._search_kwargs(),
         )  # type: ignore[call-overload, misc]
-
-        results = response.results
 
         return [
             Document(
-                page_content=(result.text),
+                page_content=(result.text or ""),
                 metadata=_get_metadata(result),
             )
-            for result in results
+            for result in response.results
+        ]
+
+    async def _aget_relevant_documents(
+        self, query: str, *, run_manager: Any
+    ) -> list[Document]:
+        """Use the asynchronous Exa SDK."""
+        response = await self.async_client.search(query, **self._search_kwargs())
+        return [
+            Document(
+                page_content=(result.text or ""),
+                metadata=_get_metadata(result),
+            )
+            for result in response.results
         ]

--- a/libs/partners/exa/langchain_exa/tools.py
+++ b/libs/partners/exa/langchain_exa/tools.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+import warnings
 from typing import Any, Literal
 
 from exa_py import Exa  # type: ignore[untyped-import]
@@ -13,9 +15,13 @@ from langchain_core.callbacks import (
     CallbackManagerForToolRun,
 )
 from langchain_core.tools import BaseTool
-from pydantic import Field, SecretStr, model_validator
+from pydantic import BaseModel, Field, SecretStr, model_validator
 
-from langchain_exa._utilities import initialize_client
+from langchain_exa._utilities import (
+    build_contents_options,
+    initialize_client,
+    warn_if_use_autoprompt,
+)
 
 
 class ExaSearchResults(BaseTool):  # type: ignore[override]
@@ -31,7 +37,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
 
     Instantiation:
         ```python
-        from langchain-exa import ExaSearchResults
+        from langchain_exa import ExaSearchResults
 
         tool = ExaSearchResults()
         ```
@@ -90,6 +96,7 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
         "Output is a JSON array of the query results"
     )
     client: Exa = Field(default=None)  # type: ignore[assignment]
+    async_client: Any = Field(default=None)
     exa_api_key: SecretStr = Field(default=SecretStr(""))
 
     @model_validator(mode="before")
@@ -115,8 +122,9 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
         end_published_date: str | None = None,
         use_autoprompt: bool | None = None,  # noqa: FBT001
         livecrawl: Literal["always", "fallback", "never"] | None = None,
+        max_age_hours: int | None = None,
         summary: bool | dict[str, str] | None = None,  # noqa: FBT001
-        type: Literal["auto", "deep", "fast"] | None = None,  # noqa: A002
+        type: Literal["auto", "deep", "fast"] = "auto",  # noqa: A002
         run_manager: CallbackManagerForToolRun | None = None,
     ) -> list[dict] | str:
         # TODO: rename `type` to something else, as it is a reserved keyword
@@ -133,42 +141,98 @@ class ExaSearchResults(BaseTool):  # type: ignore[override]
             end_crawl_date: The end date for the crawl (in YYYY-MM-DD format).
             start_published_date: The start date for when the document was published (in YYYY-MM-DD format).
             end_published_date: The end date for when the document was published (in YYYY-MM-DD format).
-            use_autoprompt: Whether to use autoprompt for the search.
-            livecrawl: Option to crawl live webpages if content is not in the index. Options: "always", "fallback", "never"
+            use_autoprompt: Deprecated and no longer sent to Exa; use `type="auto"`.
+            livecrawl: Option to crawl live webpages if content is not in the index. Options: "always", "fallback", "never".
+                Prefer `max_age_hours` for freshness.
+            max_age_hours: The maximum age of cached content in hours. This is the recommended
+                freshness control.
             summary: Whether to include a summary of the content. Can be a boolean or a dict with a custom query.
-            type: The type of search, 'auto', 'deep', or 'fast'.
+            type: The type of search, 'auto', 'deep', or 'fast'. Default: "auto".
             run_manager: The run manager for callbacks.
 
         """  # noqa: E501
+        warn_if_use_autoprompt(use_autoprompt)
         try:
-            return self.client.search_and_contents(
+            return self.client.search(  # type: ignore[call-overload, return-value]
                 query,
                 num_results=num_results,
-                text=text_contents_options,
-                highlights=highlights,
                 include_domains=include_domains,
                 exclude_domains=exclude_domains,
                 start_crawl_date=start_crawl_date,
                 end_crawl_date=end_crawl_date,
                 start_published_date=start_published_date,
                 end_published_date=end_published_date,
-                use_autoprompt=use_autoprompt,
-                livecrawl=livecrawl,
-                summary=summary,
+                contents=build_contents_options(  # type: ignore[arg-type]
+                    text=text_contents_options,
+                    highlights=highlights,
+                    summary=summary,
+                    livecrawl=livecrawl,
+                    max_age_hours=max_age_hours,
+                ),
                 type=type,
             )  # type: ignore[call-overload, misc]
         except Exception as e:
             return repr(e)
 
+    async def _arun(
+        self,
+        query: str,
+        num_results: int = 10,
+        text_contents_options: TextContentsOptions  # noqa: FBT001
+        | dict[str, Any]
+        | bool
+        | None = None,
+        highlights: HighlightsContentsOptions | bool | None = None,  # noqa: FBT001
+        include_domains: list[str] | None = None,
+        exclude_domains: list[str] | None = None,
+        start_crawl_date: str | None = None,
+        end_crawl_date: str | None = None,
+        start_published_date: str | None = None,
+        end_published_date: str | None = None,
+        use_autoprompt: bool | None = None,  # noqa: FBT001
+        livecrawl: Literal["always", "fallback", "never"] | None = None,
+        max_age_hours: int | None = None,
+        summary: bool | dict[str, str] | None = None,  # noqa: FBT001
+        type: Literal["auto", "deep", "fast"] = "auto",  # noqa: A002
+        run_manager: Any = None,
+    ) -> Any:
+        """Use the asynchronous Exa SDK."""
+        warn_if_use_autoprompt(use_autoprompt)
+        try:
+            return await self.async_client.search(
+                query,
+                num_results=num_results,
+                include_domains=include_domains,
+                exclude_domains=exclude_domains,
+                start_crawl_date=start_crawl_date,
+                end_crawl_date=end_crawl_date,
+                start_published_date=start_published_date,
+                end_published_date=end_published_date,
+                contents=build_contents_options(
+                    text=text_contents_options,
+                    highlights=highlights,
+                    summary=summary,
+                    livecrawl=livecrawl,
+                    max_age_hours=max_age_hours,
+                ),
+                type=type,
+            )
+        except Exception as e:
+            return repr(e)
+
 
 class ExaFindSimilarResults(BaseTool):  # type: ignore[override]
-    """Tool that queries the Metaphor Search API and gets back json."""
+    """Deprecated wrapper around Exa's ``/findSimilar`` endpoint.
+
+    Exa has deprecated ``/findSimilar`` (and ``find_similar_and_contents`` in
+    exa-py). Prefer :class:`ExaSearchResults` for new code. This tool remains
+    for compatibility and emits a :class:`DeprecationWarning` when used.
+    """
 
     name: str = "exa_find_similar_results_json"
     description: str = (
-        "A wrapper around Exa Find Similar. "
-        "Input should be an Exa-optimized query. "
-        "Output is a JSON array of the query results"
+        "Deprecated. Prefer exa_search_results_json. "
+        "Finds pages similar to a URL via Exa's deprecated /findSimilar endpoint."
     )
     client: Exa = Field(default=None)  # type: ignore[assignment]
     exa_api_key: SecretStr = Field(default=SecretStr(""))
@@ -221,6 +285,12 @@ class ExaFindSimilarResults(BaseTool):  # type: ignore[override]
             run_manager: The run manager for callbacks.
 
         """  # noqa: E501
+        warnings.warn(
+            "ExaFindSimilarResults is deprecated; Exa's /findSimilar endpoint is "
+            "deprecated. Prefer ExaSearchResults.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         try:
             return self.client.find_similar_and_contents(
                 url,
@@ -240,3 +310,253 @@ class ExaFindSimilarResults(BaseTool):  # type: ignore[override]
             )  # type: ignore[call-overload, misc]
         except Exception as e:
             return repr(e)
+
+
+class ExaContentsInput(BaseModel):
+    """Arguments for extracting contents from URLs."""
+
+    urls: list[str] = Field(description="URLs to extract contents from.")
+    text: bool | dict[str, Any] | None = None
+    highlights: bool | dict[str, Any] | None = None
+    summary: bool | dict[str, Any] | None = None
+    max_age_hours: int | None = Field(default=None, ge=0)
+
+
+class ExaAnswerInput(BaseModel):
+    """Arguments for asking Exa a grounded question."""
+
+    query: str
+    text: bool | None = True
+    output_schema: dict[str, Any] | None = None
+    system_prompt: str | None = None
+    user_location: str | None = None
+
+
+class ExaAgentInput(BaseModel):
+    """Arguments for running Exa's asynchronous Agent workflow."""
+
+    query: str
+    input: dict[str, Any] | None = None
+    output_schema: dict[str, Any] | None = None
+    effort: Literal["low", "medium", "high", "xhigh", "auto"] | None = None
+    previous_run_id: str | None = None
+    data_sources: list[dict[str, Any]] | None = None
+    timeout_ms: int = Field(default=3600000, ge=1)
+    poll_interval: int = Field(default=1000, ge=1)
+
+
+def _to_dict(value: Any) -> Any:
+    """Normalize Exa SDK responses to plain snake_case dicts."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {key: _to_dict(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_to_dict(item) for item in value]
+    if hasattr(value, "model_dump"):
+        return _to_dict(value.model_dump(by_alias=False))
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return _to_dict(dataclasses.asdict(value))
+    return value
+
+
+class _ExaBaseTool(BaseTool):  # type: ignore[override]
+    client: Exa = Field(default=None)  # type: ignore[assignment]
+    async_client: Any = Field(default=None)
+    exa_api_key: SecretStr = Field(default=SecretStr(""))
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_environment(cls, values: dict) -> Any:
+        return initialize_client(values)
+
+
+class ExaContents(_ExaBaseTool):
+    """Extract text, highlights, or summaries from URLs with Exa.
+
+    Returns a snake_case dict (``results``, ``statuses``, …).
+
+    ```python
+    from langchain_exa import ExaContents
+
+    tool = ExaContents()
+    result = tool.invoke({"urls": ["https://exa.ai"]})
+    print(result["results"], result["statuses"])
+    ```
+    """
+
+    name: str = "exa_contents"
+    description: str = "Extract contents from one or more URLs using Exa."
+    args_schema: type[BaseModel] = ExaContentsInput
+
+    def _run(
+        self,
+        urls: list[str],
+        *,
+        text: bool | dict[str, Any] | None = None,
+        highlights: bool | dict[str, Any] | None = None,
+        summary: bool | dict[str, Any] | None = None,
+        max_age_hours: int | None = None,
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> Any:
+        options = build_contents_options(
+            text=text,
+            highlights=highlights,
+            summary=summary,
+            max_age_hours=max_age_hours,
+        )
+        return _to_dict(self.client.get_contents(urls, **options))
+
+    async def _arun(
+        self,
+        urls: list[str],
+        *,
+        text: bool | dict[str, Any] | None = None,
+        highlights: bool | dict[str, Any] | None = None,
+        summary: bool | dict[str, Any] | None = None,
+        max_age_hours: int | None = None,
+        run_manager: Any = None,
+    ) -> Any:
+        client: Any = self.async_client or self.client
+        options = build_contents_options(
+            text=text,
+            highlights=highlights,
+            summary=summary,
+            max_age_hours=max_age_hours,
+        )
+        result = await client.get_contents(urls, **options)
+        return _to_dict(result)
+
+
+class ExaAnswer(_ExaBaseTool):
+    """Answer a question with grounded Exa citations.
+
+    Returns a snake_case dict (``answer``, ``citations``, ``cost_dollars``).
+
+    ```python
+    from langchain_exa import ExaAnswer
+
+    answer = ExaAnswer().invoke({"query": "What is Exa?"})
+    print(answer["answer"], answer["citations"])
+    ```
+    """
+
+    name: str = "exa_answer"
+    description: str = (
+        "Answer a question with a grounded answer and citations from Exa."
+    )
+    args_schema: type[BaseModel] = ExaAnswerInput
+
+    def _run(
+        self,
+        query: str,
+        *,
+        text: bool | None = True,
+        output_schema: dict[str, Any] | None = None,
+        system_prompt: str | None = None,
+        user_location: str | None = None,
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> Any:
+        return _to_dict(
+            self.client.answer(
+                query,
+                text=text,
+                output_schema=output_schema,
+                system_prompt=system_prompt,
+                user_location=user_location,
+            )
+        )
+
+    async def _arun(
+        self,
+        query: str,
+        *,
+        text: bool | None = True,
+        output_schema: dict[str, Any] | None = None,
+        system_prompt: str | None = None,
+        user_location: str | None = None,
+        run_manager: Any = None,
+    ) -> Any:
+        client: Any = self.async_client or self.client
+        result = await client.answer(
+            query,
+            text=text,
+            output_schema=output_schema,
+            system_prompt=system_prompt,
+            user_location=user_location,
+        )
+        return _to_dict(result)
+
+
+class ExaAgent(_ExaBaseTool):
+    """Run Exa's asynchronous multi-step Agent and poll to completion.
+
+    Returns a snake_case dict (``status``, ``stop_reason``, ``cost_dollars``, …).
+
+    ```python
+    from langchain_exa import ExaAgent
+
+    result = ExaAgent().invoke({"query": "Find the latest Exa product updates"})
+    print(result["status"], result.get("output"))
+    ```
+    """
+
+    name: str = "exa_agent"
+    description: str = "Run Exa Agent for a long-running, multi-step grounded workflow."
+    args_schema: type[BaseModel] = ExaAgentInput
+
+    def _run(
+        self,
+        query: str,
+        input: dict[str, Any] | None = None,  # noqa: A002
+        *,
+        output_schema: dict[str, Any] | None = None,
+        effort: Literal["low", "medium", "high", "xhigh", "auto"] | None = None,
+        previous_run_id: str | None = None,
+        data_sources: list[dict[str, Any]] | None = None,
+        timeout_ms: int = 3600000,
+        poll_interval: int = 1000,
+        run_manager: CallbackManagerForToolRun | None = None,
+    ) -> Any:
+        create_kwargs: dict[str, Any] = {
+            "query": query,
+            "input": input,
+            "output_schema": output_schema,
+            "effort": effort,
+            "previous_run_id": previous_run_id,
+            "data_sources": data_sources,
+        }
+        run = self.client.agent.runs.create(**create_kwargs)
+        result = self.client.agent.runs.poll_until_finished(
+            run.id, timeout_ms=timeout_ms, poll_interval=poll_interval
+        )
+        return _to_dict(result)
+
+    async def _arun(
+        self,
+        query: str,
+        input: dict[str, Any] | None = None,  # noqa: A002
+        *,
+        output_schema: dict[str, Any] | None = None,
+        effort: Literal["low", "medium", "high", "xhigh", "auto"] | None = None,
+        previous_run_id: str | None = None,
+        data_sources: list[dict[str, Any]] | None = None,
+        timeout_ms: int = 3600000,
+        poll_interval: int = 1000,
+        run_manager: Any = None,
+    ) -> Any:
+        client: Any = self.async_client or self.client
+        run = await client.agent.runs.create(
+            query=query,
+            input=input,
+            output_schema=output_schema,
+            effort=effort,
+            previous_run_id=previous_run_id,
+            data_sources=data_sources,
+        )
+        result = await client.agent.runs.poll_until_finished(
+            run.id,
+            timeout_ms=timeout_ms,
+            poll_interval=poll_interval,
+        )
+        return _to_dict(result)

--- a/libs/partners/exa/pyproject.toml
+++ b/libs/partners/exa/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.4.7,<2.0.0",
-    "exa-py>=1.0.8,<2.0.0"
+    "exa-py>=2.15.0,<3.0.0"
 ]
 
 [project.urls]

--- a/libs/partners/exa/tests/unit_tests/test_imports.py
+++ b/libs/partners/exa/tests/unit_tests/test_imports.py
@@ -3,6 +3,9 @@
 from langchain_exa import __all__  # type: ignore[import-not-found, import-not-found]
 
 EXPECTED_ALL = [
+    "ExaAgent",
+    "ExaAnswer",
+    "ExaContents",
     "ExaSearchResults",
     "ExaSearchRetriever",
     "HighlightsContentsOptions",

--- a/libs/partners/exa/tests/unit_tests/test_search.py
+++ b/libs/partners/exa/tests/unit_tests/test_search.py
@@ -1,0 +1,254 @@
+"""Unit tests for Exa search tools and retrievers."""
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from exa_py import AsyncExa, Exa
+from pydantic import BaseModel, ConfigDict, Field
+
+from langchain_exa import (
+    ExaAgent,
+    ExaAnswer,
+    ExaContents,
+    ExaFindSimilarResults,
+    ExaSearchResults,
+    ExaSearchRetriever,
+)
+
+
+def _response() -> SimpleNamespace:
+    return SimpleNamespace(
+        results=[
+            SimpleNamespace(
+                text="content",
+                title="title",
+                url="https://example.com",
+                id="id",
+                score=1.0,
+                published_date=None,
+                author=None,
+                highlights=None,
+                highlight_scores=None,
+                summary=None,
+            )
+        ]
+    )
+
+
+def test_search_tool_defaults_and_freshness() -> None:
+    """The search tool defaults to text content and automatic search."""
+    client = Exa(api_key="test")
+    search = MagicMock(return_value=_response())
+    setattr(client, "search", search)
+    tool = ExaSearchResults(client=client)
+
+    tool.invoke({"query": "test", "max_age_hours": 24})
+
+    search.assert_called_once()
+    kwargs = search.call_args.kwargs
+    assert kwargs["contents"]["text"] is True
+    assert kwargs["type"] == "auto"
+    assert kwargs["contents"]["max_age_hours"] == 24
+
+
+def test_search_tool_forwards_independent_content_options() -> None:
+    """Content options are independent, so each requested option is forwarded."""
+    client = Exa(api_key="test")
+    search = MagicMock(return_value=_response())
+    setattr(client, "search", search)
+    tool = ExaSearchResults(client=client)
+
+    tool.invoke(
+        {
+            "query": "test",
+            "text_contents_options": True,
+            "highlights": True,
+            "summary": True,
+        }
+    )
+
+    contents = search.call_args.kwargs["contents"]
+    assert contents["text"] is True
+    assert contents["highlights"] is True
+    assert contents["summary"] is True
+
+
+def test_search_tool_requests_only_highlights() -> None:
+    """Asking for highlights alone does not add an unrequested text option."""
+    client = Exa(api_key="test")
+    search = MagicMock(return_value=_response())
+    setattr(client, "search", search)
+    tool = ExaSearchResults(client=client)
+
+    tool.invoke({"query": "test", "highlights": True})
+
+    contents = search.call_args.kwargs["contents"]
+    assert contents["highlights"] is True
+    assert "text" not in contents
+
+
+def test_search_tool_warns_on_use_autoprompt() -> None:
+    """`use_autoprompt` is accepted but deprecated and never sent to Exa."""
+    client = Exa(api_key="test")
+    search = MagicMock(return_value=_response())
+    setattr(client, "search", search)
+    tool = ExaSearchResults(client=client)
+
+    with pytest.warns(DeprecationWarning, match="use_autoprompt"):
+        tool.invoke({"query": "test", "use_autoprompt": True})
+
+    assert "use_autoprompt" not in search.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_search_tool_async() -> None:
+    """The search tool uses the asynchronous Exa client."""
+    async_client = AsyncExa(api_key="test")
+    search = AsyncMock(return_value=_response())
+    setattr(async_client, "search", search)
+    tool = ExaSearchResults(async_client=async_client)
+
+    await tool.ainvoke({"query": "test", "max_age_hours": 12})
+
+    search.assert_awaited_once()
+    assert search.await_args is not None
+    kwargs = search.await_args.kwargs
+    assert kwargs["contents"]["max_age_hours"] == 12
+
+
+def test_retriever_defaults_and_freshness() -> None:
+    """The retriever passes automatic search and freshness options."""
+    client = Exa(api_key="test")
+    search = MagicMock(return_value=_response())
+    setattr(client, "search", search)
+    retriever = ExaSearchRetriever(client=client, max_age_hours=48)
+
+    assert retriever.invoke("test")[0].page_content == "content"
+
+    kwargs = search.call_args.kwargs
+    assert kwargs["contents"]["text"] is True
+    assert kwargs["type"] == "auto"
+    assert kwargs["contents"]["max_age_hours"] == 48
+
+
+@pytest.mark.asyncio
+async def test_retriever_async() -> None:
+    """The retriever uses the asynchronous Exa client."""
+    async_client = AsyncExa(api_key="test")
+    search = AsyncMock(return_value=_response())
+    setattr(async_client, "search", search)
+    retriever = ExaSearchRetriever(async_client=async_client)
+
+    docs = await retriever.ainvoke("test")
+
+    assert docs[0].page_content == "content"
+    search.assert_awaited_once()
+
+
+@dataclass
+class _AnswerResponse:
+    answer: str
+    citations: list[object] = field(default_factory=list)
+    cost_dollars: object | None = None
+
+
+@dataclass
+class _ContentsResponse:
+    results: list[object] = field(default_factory=list)
+    statuses: list[object] = field(default_factory=list)
+
+
+class _AgentRun(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    id: str
+    status: str
+    stop_reason: str | None = Field(default=None, alias="stopReason")
+    cost_dollars: dict[str, float] | None = Field(default=None, alias="costDollars")
+    output: dict[str, object] | None = None
+
+
+def test_contents_answer_and_agent_tools() -> None:
+    """New tools normalize SDK responses to snake_case dicts."""
+    client = Exa(api_key="test")
+    contents = MagicMock(return_value=_ContentsResponse())
+    answer = MagicMock(return_value=_AnswerResponse(answer="yes"))
+    run = SimpleNamespace(id="run-1")
+    finished = _AgentRun(
+        id="run-1",
+        status="completed",
+        stopReason="completed",
+        costDollars={"total": 0.01},
+        output={},
+    )
+    create = MagicMock(return_value=run)
+    poll = MagicMock(return_value=finished)
+    setattr(client, "get_contents", contents)
+    setattr(client, "answer", answer)
+    setattr(
+        client,
+        "agent",
+        SimpleNamespace(runs=SimpleNamespace(create=create, poll_until_finished=poll)),
+    )
+
+    contents_result = ExaContents(client=client).invoke(
+        {"urls": ["https://example.com"]}
+    )
+    answer_result = ExaAnswer(client=client).invoke({"query": "test"})
+    agent_result = ExaAgent(client=client).invoke({"query": "test"})
+
+    assert contents_result["statuses"] == []
+    assert answer_result["answer"] == "yes"
+    assert answer_result["citations"] == []
+    assert agent_result["status"] == "completed"
+    assert agent_result["stop_reason"] == "completed"
+    assert agent_result["cost_dollars"] == {"total": 0.01}
+    assert "stopReason" not in agent_result
+    assert "costDollars" not in agent_result
+    contents.assert_called_once()
+    answer.assert_called_once()
+    create.assert_called_once()
+    poll.assert_called_once()
+    assert contents.call_args.kwargs == {"text": True}
+
+
+def test_find_similar_emits_deprecation_warning() -> None:
+    """Find Similar remains available but warns that callers should prefer Search."""
+    client = Exa(api_key="test")
+    find_similar = MagicMock(return_value=_response())
+    setattr(client, "find_similar_and_contents", find_similar)
+    tool = ExaFindSimilarResults(client=client)
+
+    with pytest.warns(DeprecationWarning, match="ExaFindSimilarResults"):
+        tool.invoke({"url": "https://example.com", "num_results": 2})
+
+    find_similar.assert_called_once()
+
+
+def test_contents_forwards_independent_options() -> None:
+    """Contents forwards each requested option without dropping any."""
+    client = Exa(api_key="test")
+    get_contents = MagicMock(return_value={"results": [], "statuses": []})
+    setattr(client, "get_contents", get_contents)
+
+    ExaContents(client=client).invoke(
+        {"urls": ["https://example.com"], "highlights": True, "summary": True}
+    )
+
+    assert get_contents.call_args.kwargs == {"highlights": True, "summary": True}
+
+
+def test_retriever_requests_only_highlights() -> None:
+    """The retriever honours an explicit highlights-only request."""
+    client = Exa(api_key="test")
+    search = MagicMock(return_value=_response())
+    setattr(client, "search", search)
+    retriever = ExaSearchRetriever(client=client, highlights=True)
+
+    retriever.invoke("test")
+
+    contents = search.call_args.kwargs["contents"]
+    assert contents["highlights"] is True
+    assert "text" not in contents

--- a/libs/partners/exa/uv.lock
+++ b/libs/partners/exa/uv.lock
@@ -263,16 +263,20 @@ wheels = [
 
 [[package]]
 name = "exa-py"
-version = "1.9.0"
+version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "httpcore" },
+    { name = "httpx" },
     { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/6e/58f0676c64494e2154a58f08843b0466ca07cbd62960d50e94478b03cb57/exa_py-1.9.0.tar.gz", hash = "sha256:a4ba76f9b44072248cf3369e88bb801061da2ba713b7f712b155ad62660b27de", size = 12115, upload-time = "2025-03-11T17:53:59.333Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/a3/dabad8d3dbdb50d2ad49f426cc3e1fb47a0d0fd6ba10fbb27219c9bef684/exa_py-2.16.0.tar.gz", hash = "sha256:dce0db698720b1b7b39b58a1a17ad65fcc5969ee47f810cff5bcc836aeb0f777", size = 63530, upload-time = "2026-07-02T01:04:38.797Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/da/555713b4269858f4fed4bfd70d1d34de3a1bdafa9b2f3e4efefab43d4a6f/exa_py-1.9.0-py3-none-any.whl", hash = "sha256:3aace8d0cf0d1e3a70839f22e45d1296ce259b5fa50262ebfa85a0fe8e9cf778", size = 12533, upload-time = "2025-03-11T17:53:58.395Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/c8/69d100ed12f8493ab8b9d03bf20cd0080a3a60dec4abadb1782cc4f91969/exa_py-2.16.0-py3-none-any.whl", hash = "sha256:cf726f801d6e4be25f38275a6318b536445a92077450a11cb3d7e493ea77ecc2", size = 86866, upload-time = "2026-07-02T01:04:37.451Z" },
 ]
 
 [[package]]
@@ -459,7 +463,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.9"
+version = "1.5.3"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -490,7 +494,7 @@ requires-dist = [
 dev = [
     { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
-    { name = "setuptools", specifier = ">=67.6.1,<83.0.0" },
+    { name = "setuptools", specifier = ">=67.6.1,<84.0.0" },
 ]
 lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
 test = [
@@ -549,7 +553,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "exa-py", specifier = ">=1.0.8,<2.0.0" },
+    { name = "exa-py", specifier = ">=2.15.0,<3.0.0" },
     { name = "langchain-core", editable = "../../core" },
 ]
 
@@ -614,7 +618,7 @@ requires-dist = [
     { name = "pytest-recording" },
     { name = "pytest-socket", specifier = ">=0.7.0,<1.0.0" },
     { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
+    { name = "vcrpy", specifier = ">=8.2.1,<9.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1399,6 +1403,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #37701

Upgrade `langchain-exa` to `exa-py` 2.x and add Contents, Answer, and Agent tools so LangChain users can access the current Exa API while preserving existing Search and retriever workflows. Search and the retriever now use the 2.x Contents API internally; `ExaFindSimilarResults` remains available but is deprecated in favor of Search.

Verified with `make format`, `make lint`, and `make test` in `libs/partners/exa`, plus live Exa API checks for the new tools.

## Social handles (optional)
Twitter: @yoimnotkesku