### PR TITLE
fix(core): evaluate get_time() once per batch in InMemoryRecordManage…

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -296,12 +296,17 @@ class InMemoryRecordManager(RecordManager):
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+
+        # Get the timestamp once for the entire batch update
+        current_time = self.get_time()
+
+        if time_at_least and time_at_least > current_time:
+            msg = "time_at_least must be in the past"
+            raise ValueError(msg)
+
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
-                msg = "time_at_least must be in the past"
-                raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            self.records[key] = {"group_id": group_id, "updated_at": current_time}
 
     async def aupdate(
         self,

--- a/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
+++ b/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
@@ -277,3 +277,18 @@ async def test_adelete_keys(amanager: InMemoryRecordManager) -> None:
     # Check if the deleted keys are no longer in the database
     remaining_keys = await amanager.alist_keys()
     assert remaining_keys == ["key3"]
+
+
+def test_in_memory_record_manager_batch_update_consistent_timestamp() -> None:
+    """Ensure all records updated in a single batch share the exact same timestamp."""
+    record_manager = InMemoryRecordManager(namespace="test_namespace")
+    record_manager.create_schema()
+
+    keys = ["key1", "key2", "key3"]
+    record_manager.update(keys)
+
+    records = record_manager.records
+    timestamps = {records[k]["updated_at"] for k in keys}
+
+    # All records in the batch must share 1 unique timestamp
+    assert len(timestamps) == 1


### PR DESCRIPTION
Fixes #39099

Evaluating get_time() inside the document iteration loop in InMemoryRecordManager.update() caused records in the same batch to receive different timestamps when execution crossed high-resolution clock ticks. Moving self.get_time() outside the loop ensures all records in a single batch share an identical timestamp for atomic cleanup.

Release note

Fix timestamp inconsistency in InMemoryRecordManager.update() by evaluating batch timestamps once per call.

How did you verify your code works?

Added unit test test_in_memory_record_manager_batch_update_consistent_timestamp in libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py to confirm all updated keys share a single timestamp. Verified that all existing unit tests pass via pytest.