### PR TITLE
fix(ci): replace invalid Actions pin with the commit SHA it resolves to

### DIFF
--- a/.github/workflows/_refresh_model_profiles.yml
+++ b/.github/workflows/_refresh_model_profiles.yml
@@ -119,7 +119,7 @@ jobs:
           fi
 
       - name: "🐍 Set up Python + uv"
-        uses: astral-sh/setup-uv@0ca8f610542aa7f4acaf39e65cf4eb3c35091883 # v7
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7
         with:
           version: "0.5.25"
           python-version: "3.12"

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: "📦 Install UV Package Manager"
-        uses: astral-sh/setup-uv@0ca8f610542aa7f4acaf39e65cf4eb3c35091883 # v7
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7
         with:
           # Pinned to 3.13.11 to work around CodSpeed walltime segfault on 3.13.12+
           # See: https://github.com/CodSpeedHQ/pytest-codspeed/issues/106
@@ -76,7 +76,7 @@ jobs:
         working-directory: ${{ matrix.job-configs.working-directory }}
 
       - name: "⚡ Run Benchmarks: ${{ matrix.job-configs.working-directory }}"
-        uses: CodSpeedHQ/action@a50965600eafa04edcd6717761f55b77e52aafbd # v4
+        uses: CodSpeedHQ/action@281164b0f014a4e7badd2c02cecad9b595b70537 # v4
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: |


### PR DESCRIPTION
## Problem

These workflow `uses:` pins are invalid as written. Each item below shows the current value, why it is wrong, and the correct ref that must be used instead.

### 1. `.github/workflows/_refresh_model_profiles.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@0ca8f610542aa7f4acaf39e65cf4eb3c35091883 # v7
```

**Why this is wrong:**

- `0ca8f610542aa7f4acaf39e65cf4eb3c35091883` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v7`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v7` points to**: `5a095e7a2014a4212f075830d4f7277575a9d098`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7
```

### 2. `.github/workflows/codspeed.yml`

**Current (invalid):**

```yaml
uses: astral-sh/setup-uv@0ca8f610542aa7f4acaf39e65cf4eb3c35091883 # v7
```

**Why this is wrong:**

- `0ca8f610542aa7f4acaf39e65cf4eb3c35091883` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v7`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v7` points to**: `5a095e7a2014a4212f075830d4f7277575a9d098`.

**Correct pin:**

```yaml
uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7
```

### 3. `.github/workflows/codspeed.yml`

**Current (invalid):**

```yaml
uses: CodSpeedHQ/action@a50965600eafa04edcd6717761f55b77e52aafbd # v4
```

**Why this is wrong:**

- `a50965600eafa04edcd6717761f55b77e52aafbd` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v4`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v4` points to**: `281164b0f014a4e7badd2c02cecad9b595b70537`.

**Correct pin:**

```yaml
uses: CodSpeedHQ/action@281164b0f014a4e7badd2c02cecad9b595b70537 # v4
```

## Test plan

- [ ] Each updated `uses:` ref resolves as a commit via the GitHub Commits API
- [ ] Relevant CI jobs on this branch look healthy
