### PR TITLE
fix(exa): handle missing optional result metadata

### DIFF
--- a/libs/partners/exa/langchain_exa/retrievers.py
+++ b/libs/partners/exa/langchain_exa/retrievers.py
@@ -27,12 +27,9 @@ def _get_metadata(result: Any) -> dict[str, Any]:
         "published_date": result.published_date,
         "author": result.author,
     }
-    if getattr(result, "highlights"):
-        metadata["highlights"] = result.highlights
-    if getattr(result, "highlight_scores"):
-        metadata["highlight_scores"] = result.highlight_scores
-    if getattr(result, "summary"):
-        metadata["summary"] = result.summary
+    for attribute in ("highlights", "highlight_scores", "summary"):
+        if value := getattr(result, attribute, None):
+            metadata[attribute] = value
     return metadata
 
 

--- a/libs/partners/exa/tests/unit_tests/test_retrievers.py
+++ b/libs/partners/exa/tests/unit_tests/test_retrievers.py
@@ -1,0 +1,41 @@
+"""Unit tests for the Exa retriever."""
+
+from types import SimpleNamespace
+from typing import Any
+
+from langchain_exa.retrievers import _get_metadata
+
+
+def _make_result(**optional_metadata: Any) -> SimpleNamespace:
+    return SimpleNamespace(
+        title="Example",
+        url="https://example.com",
+        id="result-1",
+        score=0.95,
+        published_date="2024-01-01",
+        author="Author",
+        **optional_metadata,
+    )
+
+
+def test_get_metadata_omits_missing_optional_attributes() -> None:
+    """Test that missing optional result attributes are omitted."""
+    assert _get_metadata(_make_result()) == {
+        "title": "Example",
+        "url": "https://example.com",
+        "id": "result-1",
+        "score": 0.95,
+        "published_date": "2024-01-01",
+        "author": "Author",
+    }
+
+
+def test_get_metadata_includes_available_optional_attributes() -> None:
+    """Test that available optional attributes are retained independently."""
+    metadata = _get_metadata(
+        _make_result(highlights=["Excerpt"], summary="A short summary")
+    )
+
+    assert metadata["highlights"] == ["Excerpt"]
+    assert metadata["summary"] == "A short summary"
+    assert "highlight_scores" not in metadata


### PR DESCRIPTION
Fixes #39167

---

Exa search responses can omit `highlights`, `highlight_scores`, and `summary` when callers do not request those optional fields. `ExaSearchRetriever` previously accessed each attribute without a default, so an otherwise valid result could raise `AttributeError` instead of becoming a `Document`.

This change safely skips absent optional attributes while retaining available values and all required metadata. Regression tests cover results with no optional attributes and results where only some optional attributes are present.

## Release note

`ExaSearchRetriever` now handles Exa search results that omit optional highlight or summary metadata instead of raising `AttributeError`.

This contribution was created with assistance from an AI coding agent.