### PR TITLE
feat(text-splitters): add length_function parameter to RecursiveJsonSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/json.py
+++ b/libs/text-splitters/langchain_text_splitters/json.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import copy
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from langchain_core.documents import Document
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 class RecursiveJsonSplitter:
@@ -27,7 +30,11 @@ class RecursiveJsonSplitter:
     """
 
     def __init__(
-        self, max_chunk_size: int = 2000, min_chunk_size: int | None = None
+        self,
+        max_chunk_size: int = 2000,
+        min_chunk_size: int | None = None,
+        *,
+        length_function: Callable[[dict[str, Any]], int] | None = None,
     ) -> None:
         """Initialize the chunk size configuration for text processing.
 
@@ -41,6 +48,8 @@ class RecursiveJsonSplitter:
 
                 If `None`, defaults to the maximum chunk size minus 200, with a lower
                 bound of 50.
+            length_function: A function that measures the length of a JSON object.
+                If `None`, defaults to `self._json_size`.
         """
         super().__init__()
         self.max_chunk_size = max_chunk_size
@@ -48,6 +57,9 @@ class RecursiveJsonSplitter:
             min_chunk_size
             if min_chunk_size is not None
             else max(max_chunk_size - 200, 50)
+        )
+        self._length_function: Callable[[dict[str, Any]], int] = (
+            length_function or self._json_size
         )
 
     @staticmethod
@@ -94,13 +106,15 @@ class RecursiveJsonSplitter:
         if isinstance(data, dict) and data:
             for key, value in data.items():
                 new_path = [*current_path, key]
-                chunk_size = self._json_size(chunks[-1])
-                size = self._json_size({key: value})
-                remaining = self.max_chunk_size - chunk_size
+                chunk_size = self._length_function(chunks[-1])
 
-                if size < remaining:
+                tentative_chunk = copy.deepcopy(chunks[-1])
+                self._set_nested_dict(tentative_chunk, new_path, value)
+                tentative_size = self._length_function(tentative_chunk)
+
+                if tentative_size < self.max_chunk_size:
                     # Add item to current chunk
-                    self._set_nested_dict(chunks[-1], new_path, value)
+                    chunks[-1] = tentative_chunk
                 else:
                     if chunk_size >= self.min_chunk_size:
                         # Chunk is big enough, start a new chunk

--- a/libs/text-splitters/langchain_text_splitters/json.py
+++ b/libs/text-splitters/langchain_text_splitters/json.py
@@ -124,7 +124,17 @@ class RecursiveJsonSplitter:
                     self._json_split(value, new_path, chunks)
         # Handle leaf values and empty dicts
         elif current_path:
-            self._set_nested_dict(chunks[-1], current_path, data)
+            tentative_chunk = copy.deepcopy(chunks[-1])
+            self._set_nested_dict(tentative_chunk, current_path, data)
+            tentative_size = self._length_function(tentative_chunk)
+
+            if tentative_size < self.max_chunk_size:
+                chunks[-1] = tentative_chunk
+            else:
+                # Current chunk is full, start a new one with this leaf
+                new_chunk: dict[str, Any] = {}
+                self._set_nested_dict(new_chunk, current_path, data)
+                chunks.append(new_chunk)
         return chunks
 
     def split_json(

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3333,6 +3333,34 @@ def test_happy_path_splitting_with_duplicate_header_tag() -> None:
     assert docs[3].metadata["Header 1"] == "Foo"
 
 
+def test_recursive_json_splitter_with_length_function() -> None:
+    """Test json text splitter with a custom length function."""
+
+    def custom_length(data: dict[str, Any]) -> int:
+        return len(json.dumps(data)) * 100
+
+    # Max chunk size is 1000.
+    # Empty dict length = 2 * 100 = 200
+    # {"a": 1} length = 8 * 100 = 800
+    # {"b": 2} length = 8 * 100 = 800
+    # First item ("a": 1) will be added to the first chunk because it fits.
+    # Second item ("b": 2) won't fit in the remaining 200, so it will start a new chunk.
+    splitter = RecursiveJsonSplitter(max_chunk_size=1000, length_function=custom_length)
+
+    test_data: dict[str, Any] = {
+        "a": 1,
+        "b": 2,
+    }
+
+    chunks = splitter.split_json(test_data)
+
+    # Without the custom length function, {"a": 1, "b": 2} (length ~16)
+    # would easily fit in a single 1000 max_chunk_size chunk.
+    assert len(chunks) == 2
+    assert chunks[0] == {"a": 1}
+    assert chunks[1] == {"b": 2}
+
+
 def test_split_json() -> None:
     """Test json text splitter."""
     max_chunk = 800

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -4401,3 +4401,24 @@ def test_character_text_splitter_chunk_size_effect(
         keep_separator=False,
     )
     assert splitter.split_text(text) == expected
+
+
+def test_split_json_non_additive_length_function() -> None:
+    """Test json text splitter with a non-additive length function (e.g. tokenizers)."""
+
+    def non_additive_size(data: dict[str, Any]) -> int:
+        """Mock non-additive size function which breaks the additive fit check."""
+        return len(json.dumps(obj=data)) ** 2
+
+    max_chunk_size = 2000
+    splitter = RecursiveJsonSplitter(
+        max_chunk_size=max_chunk_size,
+        min_chunk_size=50,
+        length_function=non_additive_size,
+    )
+    data: dict[str, str] = {f"k{i}": f"v{i}" for i in range(20)}
+    chunks = splitter.split_json(data)
+
+    sizes = [non_additive_size(c) for c in chunks]
+    oversized_chunks = [s for s in sizes if s > max_chunk_size]
+    assert len(oversized_chunks) == 0, f"Oversized chunks: {oversized_chunks}"


### PR DESCRIPTION
Closes #39128

This PR adds an optional `length_function` parameter to `RecursiveJsonSplitter`, allowing users to provide custom chunk size measurement logic (e.g. token counting) instead of the default `len(json.dumps(data))`.

### Changes

**`langchain_text_splitters/json.py`**
- Added `length_function: Callable[[dict[str, Any]], int] | None = None` keyword argument to `__init__`, falling back to `self._json_size` when not provided.
- Replaced hardcoded `self._json_size` calls in `_json_split` with `self._length_function`.
- Removed the additive size assumption in the **dict branch** — now tentatively merges, measures the actual result, and reverts on overflow.
- Applied the same tentative-merge-and-measure pattern to the **leaf branch** (`elif current_path:`), ensuring non-additive size functions (like tokenizers) don't produce oversized chunks.

**`tests/unit_tests/test_text_splitters.py`**
- Added `test_recursive_json_splitter_with_length_function` — verifies custom length function drives chunk splitting.
- Added `test_split_json_non_additive_length_function` — verifies chunks respect `max_chunk_size` with a non-additive size function (simulating tokenizer behavior).

### Testing
- Backward compatible — existing usage without `length_function` is unaffected.
- Passed `make format` and `make lint`.
- All tests pass with no regressions.
