### PR TITLE
fix(perplexity): surface num_search_queries and forward cost from usage

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -38,6 +38,7 @@ from langchain_core.messages import (
     ToolMessageChunk,
 )
 from langchain_core.messages.ai import (
+    InputTokenDetails,
     OutputTokenDetails,
     UsageMetadata,
     subtract_usage,
@@ -95,6 +96,13 @@ def _create_usage_metadata(token_usage: dict) -> UsageMetadata:
     output_tokens = token_usage.get("completion_tokens", 0)
     total_tokens = token_usage.get("total_tokens", input_tokens + output_tokens)
 
+    # Build input_token_details for Perplexity-specific fields.
+    # num_search_queries drives per-query billing on Perplexity and must be
+    # visible to cost calculators.
+    input_token_details: InputTokenDetails = {}
+    if (num_search_queries := token_usage.get("num_search_queries")) is not None:
+        input_token_details["num_search_queries"] = num_search_queries  # type: ignore[typeddict-unknown-key]
+
     # Build output_token_details for Perplexity-specific fields
     output_token_details: OutputTokenDetails = {}
     if (reasoning := token_usage.get("reasoning_tokens")) is not None:
@@ -102,12 +110,15 @@ def _create_usage_metadata(token_usage: dict) -> UsageMetadata:
     if (citation_tokens := token_usage.get("citation_tokens")) is not None:
         output_token_details["citation_tokens"] = citation_tokens  # type: ignore[typeddict-unknown-key]
 
-    return UsageMetadata(
+    usage = UsageMetadata(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
         output_token_details=output_token_details,
     )
+    if input_token_details:
+        usage["input_token_details"] = input_token_details
+    return usage
 
 
 _RESPONSES_ONLY_ARGS = frozenset(
@@ -1427,6 +1438,8 @@ class ChatPerplexity(BaseChatModel):
             response_metadata["num_search_queries"] = num_search_queries
         if search_context_size := usage_dict.get("search_context_size"):
             response_metadata["search_context_size"] = search_context_size
+        if cost := usage_dict.get("cost"):
+            response_metadata["cost"] = cost
 
         message = AIMessage(
             content=response.choices[0].message.content,
@@ -1496,6 +1509,8 @@ class ChatPerplexity(BaseChatModel):
             response_metadata["num_search_queries"] = num_search_queries
         if search_context_size := usage_dict.get("search_context_size"):
             response_metadata["search_context_size"] = search_context_size
+        if cost := usage_dict.get("cost"):
+            response_metadata["cost"] = cost
 
         message = AIMessage(
             content=response.choices[0].message.content,

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -176,6 +176,48 @@ def test_create_usage_metadata_basic() -> None:
     assert usage_metadata["total_tokens"] == 30
     assert usage_metadata["output_token_details"]["reasoning"] == 0
     assert usage_metadata["output_token_details"]["citation_tokens"] == 0  # type: ignore[typeddict-item]
+    assert "input_token_details" not in usage_metadata
+
+
+def test_create_usage_metadata_with_search_queries() -> None:
+    """Test _create_usage_metadata includes num_search_queries in input_token_details.
+
+    `num_search_queries` drives per-query billing and must be surfaced in
+    `input_token_details` so that LangSmith can compute accurate call costs.
+    """
+    token_usage = {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+        "num_search_queries": 3,
+        "reasoning_tokens": 5,
+        "citation_tokens": 15,
+    }
+
+    usage_metadata = _create_usage_metadata(token_usage)
+
+    assert usage_metadata["input_tokens"] == 10
+    assert usage_metadata["output_tokens"] == 20
+    assert usage_metadata["total_tokens"] == 30
+    # num_search_queries drives per-query billing and must be in input_token_details
+    assert usage_metadata["input_token_details"]["num_search_queries"] == 3  # type: ignore[typeddict-item]
+    assert usage_metadata["output_token_details"]["reasoning"] == 5
+    assert usage_metadata["output_token_details"]["citation_tokens"] == 15  # type: ignore[typeddict-item]
+
+
+def test_create_usage_metadata_zero_search_queries() -> None:
+    """Test _create_usage_metadata with num_search_queries=0."""
+    token_usage = {
+        "prompt_tokens": 5,
+        "completion_tokens": 10,
+        "total_tokens": 15,
+        "num_search_queries": 0,
+    }
+
+    usage_metadata = _create_usage_metadata(token_usage)
+
+    # Zero is a valid value — still included so callers can distinguish 0 from absent
+    assert usage_metadata["input_token_details"]["num_search_queries"] == 0  # type: ignore[typeddict-item]
 
 
 def test_perplexity_invoke_includes_num_search_queries(mocker: MockerFixture) -> None:
@@ -220,6 +262,127 @@ def test_perplexity_invoke_includes_num_search_queries(mocker: MockerFixture) ->
     assert result.response_metadata["num_search_queries"] == 3
     assert result.response_metadata["search_context_size"] == "high"
     assert result.response_metadata["model_name"] == "test-model"
+    patcher.assert_called_once()
+
+
+def test_num_search_queries_flows_into_usage_metadata(
+    mocker: MockerFixture,
+) -> None:
+    """Smoke test: num_search_queries from the API response reaches usage_metadata.
+
+    Verifies the full path: API response -> _create_usage_metadata ->
+    `AIMessage.usage_metadata.input_token_details["num_search_queries"]`.
+    Previously `num_search_queries` was only stored in `response_metadata`,
+    making it invisible to LangSmith's cost calculator.
+    """
+    llm = ChatPerplexity(model="sonar-pro", timeout=30)
+
+    mock_usage = MagicMock()
+    mock_usage.model_dump.return_value = {
+        "prompt_tokens": 100,
+        "completion_tokens": 50,
+        "total_tokens": 150,
+        "num_search_queries": 3,
+        "citation_tokens": 20,
+        "reasoning_tokens": 0,
+        "cost": {
+            "input_tokens_cost": 0.0001,
+            "output_tokens_cost": 0.00005,
+            "total_cost": 0.03015,
+            "citation_tokens_cost": 0.00002,
+            "reasoning_tokens_cost": None,
+            "request_cost": None,
+            "search_queries_cost": 0.015,
+        },
+    }
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(content="Paris is the capital.", tool_calls=None),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.model = "sonar-pro"
+    mock_response.usage = mock_usage
+    mock_response.citations = None
+    mock_response.images = None
+    mock_response.related_questions = None
+    mock_response.search_results = None
+    mock_response.videos = None
+    mock_response.reasoning_steps = None
+
+    patcher = mocker.patch.object(
+        llm.client.chat.completions, "create", return_value=mock_response
+    )
+
+    result = llm.invoke("What is the capital of France?")
+
+    assert result.usage_metadata is not None
+    # num_search_queries must be in input_token_details for LangSmith cost tracking
+    assert "input_token_details" in result.usage_metadata
+    assert result.usage_metadata["input_token_details"]["num_search_queries"] == 3  # type: ignore[typeddict-item]
+    # citation_tokens and reasoning must still be in output_token_details
+    assert result.usage_metadata["output_token_details"]["citation_tokens"] == 20  # type: ignore[typeddict-item]
+    assert result.usage_metadata["output_token_details"]["reasoning"] == 0
+    # token counts correct
+    assert result.usage_metadata["input_tokens"] == 100
+    assert result.usage_metadata["output_tokens"] == 50
+    assert result.usage_metadata["total_tokens"] == 150
+    # The API-returned cost breakdown must be in response_metadata so callers
+    # can read the exact cost Perplexity charged (incl. search_queries_cost)
+    assert result.response_metadata["cost"]["total_cost"] == 0.03015
+    assert result.response_metadata["cost"]["search_queries_cost"] == 0.015
+    patcher.assert_called_once()
+
+
+def test_cost_absent_when_reasoning_mode_enabled(mocker: MockerFixture) -> None:
+    """Smoke test: missing cost field (e.g. reasoning mode) does not raise.
+
+    Some providers (e.g. OpenRouter) omit the cost object from the usage
+    payload when reasoning mode is enabled. The integration must degrade
+    gracefully — no KeyError, no crash — and simply omit 'cost' from
+    `response_metadata`.
+    """
+    llm = ChatPerplexity(model="sonar-reasoning-pro", timeout=30)
+
+    mock_usage = MagicMock()
+    mock_usage.model_dump.return_value = {
+        "prompt_tokens": 200,
+        "completion_tokens": 80,
+        "total_tokens": 280,
+        "reasoning_tokens": 60,
+        "num_search_queries": 2,
+    }
+
+    mock_response = MagicMock()
+    mock_response.choices = [
+        MagicMock(
+            message=MagicMock(content="Reasoned answer.", tool_calls=None),
+            finish_reason="stop",
+        )
+    ]
+    mock_response.model = "sonar-reasoning-pro"
+    mock_response.usage = mock_usage
+    mock_response.citations = None
+    mock_response.images = None
+    mock_response.related_questions = None
+    mock_response.search_results = None
+    mock_response.videos = None
+    mock_response.reasoning_steps = None
+
+    patcher = mocker.patch.object(
+        llm.client.chat.completions, "create", return_value=mock_response
+    )
+
+    result = llm.invoke("Explain quantum entanglement.")
+
+    # Must not raise — cost simply absent from response_metadata
+    assert "cost" not in result.response_metadata
+    # Other fields still correct
+    assert result.usage_metadata is not None
+    assert result.usage_metadata["input_token_details"]["num_search_queries"] == 2  # type: ignore[typeddict-item]
+    assert result.usage_metadata["output_token_details"]["reasoning"] == 60
     patcher.assert_called_once()
 
 


### PR DESCRIPTION
Fixes #31647

---

### Problem

LangSmith shows inaccurate costs for Perplexity API calls. Two gaps in `ChatPerplexity` caused this:

1. `num_search_queries` — which drives Perplexity's per-search-query billing — was only placed in `response_metadata`/`generation_info`, so `UsageMetadata` (the shape LangSmith's cost calculator reads) never saw it.
2. Perplexity's SDK already returns its own `Cost` object (with `input_tokens_cost`, `output_tokens_cost`, `search_queries_cost`, `reasoning_tokens_cost`, `total_cost`), but it was being silently discarded.

### Solution

- Surface `num_search_queries` in `UsageMetadata.input_token_details` so downstream cost calculators can read it.
- Forward Perplexity's `Cost` object into `response_metadata["cost"]` when present, degrading gracefully when absent (e.g. proxied via OpenRouter with reasoning mode enabled).

No hardcoded pricing tables are introduced; the fix only forwards the raw data Perplexity already returns.

### Changes

- `_create_usage_metadata` now populates `input_token_details["num_search_queries"]` when the field is present (including `0`).
- `_generate` and `_agenerate` forward `usage.cost` into `response_metadata["cost"]`.

### Release note

`ChatPerplexity` now exposes `num_search_queries` in `usage_metadata.input_token_details` and forwards the Perplexity-provided `cost` object to `response_metadata["cost"]`, enabling accurate cost tracking in LangSmith.

---

> This PR was authored with the assistance of AI agents.
