### PR TITLE
fix(core): don't mutate caller-provided `structured_output_kwargs` in…

### DIFF
--- a/libs/core/langchain_core/prompts/structured.py
+++ b/libs/core/langchain_core/prompts/structured.py
@@ -69,7 +69,7 @@ class StructuredPrompt(ChatPromptTemplate):
                 f"{schema_}"
             )
             raise ValueError(err_msg)
-        structured_output_kwargs = structured_output_kwargs or {}
+        structured_output_kwargs = dict(structured_output_kwargs or {})
         for k in set(kwargs).difference(get_pydantic_field_names(self.__class__)):
             structured_output_kwargs[k] = kwargs.pop(k)
         super().__init__(

--- a/libs/core/tests/unit_tests/prompts/test_structured.py
+++ b/libs/core/tests/unit_tests/prompts/test_structured.py
@@ -138,6 +138,33 @@ def test_structured_prompt_template_format() -> None:
     ]
 
 
+def test_structured_prompt_does_not_mutate_structured_output_kwargs() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+    }
+    shared_options = {"method": "json_schema"}
+
+    first = StructuredPrompt.from_messages_and_schema(
+        [("human", "one")],
+        schema,
+        structured_output_kwargs=shared_options,
+        strict=True,
+    )
+    second = StructuredPrompt(
+        [("human", "two")],
+        schema,
+        structured_output_kwargs=shared_options,
+    )
+
+    assert shared_options == {"method": "json_schema"}
+    assert first.structured_output_kwargs == {  # type: ignore[attr-defined]
+        "method": "json_schema",
+        "strict": True,
+    }
+    assert "strict" not in second.structured_output_kwargs
+
+
 def test_structured_prompt_template_empty_vars() -> None:
     with pytest.raises(ChevronError, match="empty tag"):
         StructuredPrompt(


### PR DESCRIPTION
Fixes #39169



'StructuredPrompt.__init__' reused the caller-owned 'structured_output_kwargs'
dict in place and merged extra keyword arguments (like `strict`) directly
into it. This meant constructing one 'StructuredPrompt' could silently
mutate a dict the caller still held a reference to — so a second prompt
built later from the same dict would unexpectedly inherit options it was
never given.

The fix takes a shallow copy of `structured_output_kwargs` before merging,
so the caller's dict is left untouched while the prompt still gets the
correct merged options forwarded through `pipe()` to
`with_structured_output()`.

# Release note

`StructuredPrompt` no longer mutates a caller-provided `structured_output_kwargs`
dictionary when merging in additional keyword arguments.

