### PR TITLE
fix(openai): surface Responses API stream failures

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -5097,7 +5097,19 @@ def _convert_responses_chunk_to_generation_chunk(
         response = _coerce_chunk_response(chunk.response)
         id = response.id
         response_metadata["id"] = response.id  # Backwards compatibility
-    elif chunk.type in ("response.completed", "response.incomplete"):
+    elif chunk.type == "error":
+        # An `error` event carries no `response` object -- only `code`, `message`
+        # and `param` -- so it cannot go through the terminal-response branch
+        # below. Without this, the event fell through to the final `else` and was
+        # discarded, leaving a failed stream indistinguishable from a successful
+        # one.
+        msg = f"{chunk.code}: {chunk.message}" if chunk.code else chunk.message
+        raise ValueError(msg)
+    elif chunk.type in (
+        "response.completed",
+        "response.incomplete",
+        "response.failed",
+    ):
         response = _coerce_chunk_response(chunk.response)
         msg = cast(
             AIMessage,

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
@@ -13,6 +13,8 @@ from openai.types.responses import (
     ResponseContentPartAddedEvent,
     ResponseContentPartDoneEvent,
     ResponseCreatedEvent,
+    ResponseErrorEvent,
+    ResponseFailedEvent,
     ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent,
     ResponseFunctionToolCallItem,
@@ -30,6 +32,7 @@ from openai.types.responses import (
     ResponseTextDoneEvent,
 )
 from openai.types.responses.response import Response
+from openai.types.responses.response_error import ResponseError
 from openai.types.responses.response_output_text import ResponseOutputText
 from openai.types.responses.response_reasoning_item import Summary
 from openai.types.responses.response_reasoning_summary_part_added_event import (
@@ -1158,3 +1161,85 @@ def test_responses_stream_tolerates_unknown_literal_drift() -> None:
             full = chunk if full is None else full + chunk
     assert isinstance(full, AIMessageChunk)
     assert full.id == "resp_123"
+
+
+def _in_progress_stream_head() -> ResponseCreatedEvent:
+    """Return a `response.created` event copied from the canonical fixture."""
+    created = copy.deepcopy(responses_stream[0])
+    assert isinstance(created, ResponseCreatedEvent)
+    return created
+
+
+def test_responses_stream_surfaces_response_failed_event() -> None:
+    """A stream ending in `response.failed` must raise, not look successful.
+
+    Regression test for #39039: `response.failed` fell through the converter's
+    final `else` branch and was discarded, so a failed stream was
+    indistinguishable from a completed one and the error never reached the
+    caller.
+    """
+    created = _in_progress_stream_head()
+    failed_response = created.response.model_copy(
+        update={
+            "status": "failed",
+            "error": ResponseError(
+                code="server_error",
+                message="The model failed to generate a response.",
+            ),
+        }
+    )
+    stream = [
+        created,
+        ResponseFailedEvent(
+            response=failed_response, sequence_number=1, type="response.failed"
+        ),
+    ]
+
+    llm = ChatOpenAI(model=MODEL, use_responses_api=True)
+    mock_client = MagicMock()
+
+    def mock_create(*args: Any, **kwargs: Any) -> MockSyncContextManager:
+        return MockSyncContextManager(stream)
+
+    mock_client.responses.create = mock_create
+
+    with (
+        patch.object(llm, "root_client", mock_client),
+        pytest.raises(ValueError, match="server_error"),
+    ):
+        for _ in llm.stream("test"):
+            pass
+
+
+def test_responses_stream_surfaces_error_event() -> None:
+    """A top-level `error` event must raise rather than be discarded.
+
+    Unlike `response.failed`, an `error` event carries no `response` object --
+    only `code`, `message` and `param` -- so it cannot be routed through the
+    terminal-response branch and needs handling of its own.
+    """
+    stream = [
+        _in_progress_stream_head(),
+        ResponseErrorEvent(
+            type="error",
+            code="rate_limit_exceeded",
+            message="Rate limit reached for gpt-5.4.",
+            param=None,
+            sequence_number=1,
+        ),
+    ]
+
+    llm = ChatOpenAI(model=MODEL, use_responses_api=True)
+    mock_client = MagicMock()
+
+    def mock_create(*args: Any, **kwargs: Any) -> MockSyncContextManager:
+        return MockSyncContextManager(stream)
+
+    mock_client.responses.create = mock_create
+
+    with (
+        patch.object(llm, "root_client", mock_client),
+        pytest.raises(ValueError, match="rate_limit_exceeded"),
+    ):
+        for _ in llm.stream("test"):
+            pass


### PR DESCRIPTION
Fixes #39039

---

If a Responses API stream fails server-side, you currently can't tell. The stream
ends, you get a truncated or empty message back, and nothing raises — so a failed
call is indistinguishable from a successful one. You find out later, from a wrong
answer or a confusing downstream error, rather than at the point of failure.

The Responses API has four terminal stream events. The streaming converter
recognized only `response.completed` and `response.incomplete`; `response.failed`
and `error` fell through its final `else` branch and were silently dropped.

`response.failed` now raises the provider's error. An `error` event carries no
`response` object — only `code`, `message` and `param` — so it is handled
separately. Both align streaming with the non-streaming path, which has always
raised when a response carries an error.

**`response.failed` raises even with no error payload.** `error` is
`Optional[ResponseError]` on `Response`, so a failed event is not guaranteed to
carry one, and keying off the error payload alone would leave that case looking
exactly like success — the same defect, surviving the fix that appears to close
it. Nothing upstream prevents it either: the SDK raises `APIError` only on a
top-level `error` key in the SSE payload, while `response.failed` nests `error`
under `response`. Verified end to end over a real SSE transport with `error`
omitted, with `error: null`, and with a drifted `status` literal.

## Please review carefully

This intentionally changes behavior: calls that previously ended quietly on a
server-side failure now raise `ValueError`. That's the point of the fix, but
anyone relying on the silent-success behavior is affected. `ValueError` matches
what the non-streaming path already raises, so no new exception type is
introduced.

One gap from the issue is deliberately left alone: a stream that ends with **no**
terminal event at all is still treated as successful. Fixing that means deciding
what "the stream just stopped" should mean — plausibly different for a dropped
connection than for a server that simply stopped — which felt like a maintainer
call rather than something to settle inside a bugfix. Happy to take it here or as
a follow-up.

## Release note

`ChatOpenAI` with the Responses API now raises when a stream terminates with a
`response.failed` or `error` event, instead of ending silently and returning a
partial message as though the call had succeeded.

---

*Disclaimer: this contribution was developed with AI-agent assistance. The
behavior described above was verified by running the code, including the real-SSE
and structured-output paths, not by inspection alone.*
