### PR TITLE
fix(core): redact streaming callback options

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -737,7 +737,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             )
 
             params = self._get_invocation_params(stop=stop, **kwargs)
-            options = {"stop": stop, **kwargs, **ls_structured_output_format_dict}
+            options = {
+                "stop": stop,
+                **{key: params[key] for key in kwargs if key in params},
+                **ls_structured_output_format_dict,
+            }
             inheritable_metadata = {
                 **(config.get("metadata") or {}),
                 **self._get_ls_params_with_defaults(stop=stop, **kwargs),
@@ -866,7 +870,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         )
 
         params = self._get_invocation_params(stop=stop, **kwargs)
-        options = {"stop": stop, **kwargs, **ls_structured_output_format_dict}
+        options = {
+            "stop": stop,
+            **{key: params[key] for key in kwargs if key in params},
+            **ls_structured_output_format_dict,
+        }
         inheritable_metadata = {
             **(config.get("metadata") or {}),
             **self._get_ls_params_with_defaults(stop=stop, **kwargs),
@@ -1001,7 +1009,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         )
 
         params = self._get_invocation_params(stop=stop, **kwargs)
-        options = {"stop": stop, **kwargs, **ls_structured_output_format_dict}
+        options = {
+            "stop": stop,
+            **{key: params[key] for key in kwargs if key in params},
+            **ls_structured_output_format_dict,
+        }
         inheritable_metadata = {
             **(config.get("metadata") or {}),
             **self._get_ls_params_with_defaults(stop=stop, **kwargs),
@@ -1135,7 +1147,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         )
 
         params = self._get_invocation_params(stop=stop, **kwargs)
-        options = {"stop": stop, **kwargs, **ls_structured_output_format_dict}
+        options = {
+            "stop": stop,
+            **{key: params[key] for key in kwargs if key in params},
+            **ls_structured_output_format_dict,
+        }
         inheritable_metadata = {
             **(config.get("metadata") or {}),
             **self._get_ls_params_with_defaults(stop=stop, **kwargs),

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 from langsmith.env import get_langchain_env_var_metadata
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from typing_extensions import Self, override
 
 from langchain_core._api import LangChainDeprecationWarning
@@ -446,6 +446,88 @@ class StreamingModel(NoStreamingModel):
         **kwargs: Any,
     ) -> Iterator[ChatGenerationChunk]:
         yield ChatGenerationChunk(message=AIMessageChunk(content="stream"))
+
+
+class SanitizingStreamingModel(StreamingModel):
+    received_secrets: list[str] = Field(default_factory=list)
+
+    @override
+    def _get_invocation_params(
+        self, stop: list[str] | None = None, **kwargs: Any
+    ) -> dict[str, Any]:
+        params = super()._get_invocation_params(stop=stop, **kwargs)
+        if "secret" in params:
+            params["secret"] = "**REDACTED**"
+        return params
+
+    @override
+    def _stream(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        self.received_secrets.append(kwargs["secret"])
+        yield from super()._stream(messages, stop, run_manager, **kwargs)
+
+
+class ModelStartTracer(FakeTracer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.start_kwargs: list[dict[str, Any]] = []
+
+    @override
+    def on_chat_model_start(self, *args: Any, **kwargs: Any) -> Run:
+        self.start_kwargs.append(kwargs)
+        return super().on_chat_model_start(*args, **kwargs)
+
+
+@pytest.mark.parametrize("stream_events", [False, True])
+def test_streaming_options_use_sanitized_invocation_params(
+    *, stream_events: bool
+) -> None:
+    model = SanitizingStreamingModel()
+    tracer = ModelStartTracer()
+
+    if stream_events:
+        stream = model.stream_events(
+            [], version="v3", config={"callbacks": [tracer]}, secret="raw-secret"
+        )
+        _ = stream.output
+    else:
+        list(model.stream([], config={"callbacks": [tracer]}, secret="raw-secret"))
+
+    assert model.received_secrets == ["raw-secret"]
+    assert tracer.start_kwargs[0]["invocation_params"]["secret"] == "**REDACTED**"
+    assert tracer.start_kwargs[0]["options"]["secret"] == "**REDACTED**"
+    assert "raw-secret" not in str(tracer.start_kwargs)
+
+
+@pytest.mark.parametrize("stream_events", [False, True])
+async def test_async_streaming_options_use_sanitized_invocation_params(
+    *, stream_events: bool
+) -> None:
+    model = SanitizingStreamingModel()
+    tracer = ModelStartTracer()
+
+    if stream_events:
+        stream = await model.astream_events(
+            [], version="v3", config={"callbacks": [tracer]}, secret="raw-secret"
+        )
+        _ = await stream
+    else:
+        _ = [
+            chunk
+            async for chunk in model.astream(
+                [], config={"callbacks": [tracer]}, secret="raw-secret"
+            )
+        ]
+
+    assert model.received_secrets == ["raw-secret"]
+    assert tracer.start_kwargs[0]["invocation_params"]["secret"] == "**REDACTED**"
+    assert tracer.start_kwargs[0]["options"]["secret"] == "**REDACTED**"
+    assert "raw-secret" not in str(tracer.start_kwargs)
 
 
 @pytest.mark.parametrize("disable_streaming", [True, False, "tool_calling"])


### PR DESCRIPTION
Credential-bearing model kwargs can be sanitized by an integration's `_get_invocation_params`, but streaming callbacks also received the original kwargs through `options`. This could expose remote MCP credentials to callback handlers and persisted LangSmith traces even when `invocation_params` was redacted.

Streaming and v3 streaming-event callbacks now construct `options` from the integration-sanitized invocation parameters while the model invocation continues to receive the original values. Sync and async regression coverage verifies both callback redaction and provider propagation.

## Release note

Streaming chat-model callbacks no longer receive unsanitized invocation options when an integration redacts sensitive parameters.

This contribution was prepared with AI-agent assistance.