### PR TITLE
fix(core): copy structured_output_kwargs to avoid mutating caller dict

### DIFF
--- a/libs/core/langchain_core/prompts/structured.py
+++ b/libs/core/langchain_core/prompts/structured.py
@@ -69,7 +69,11 @@ class StructuredPrompt(ChatPromptTemplate):
                 f"{schema_}"
             )
             raise ValueError(err_msg)
-        structured_output_kwargs = structured_output_kwargs or {}
+        # Create a copy to avoid mutating the caller's original dictionary.
+        if structured_output_kwargs is None:
+            structured_output_kwargs = {}
+        else:
+            structured_output_kwargs = dict(structured_output_kwargs)
         for k in set(kwargs).difference(get_pydantic_field_names(self.__class__)):
             structured_output_kwargs[k] = kwargs.pop(k)
         super().__init__(

--- a/libs/core/tests/unit_tests/prompts/test_structured.py
+++ b/libs/core/tests/unit_tests/prompts/test_structured.py
@@ -145,3 +145,27 @@ def test_structured_prompt_template_empty_vars() -> None:
             schema={"type": "object", "properties": {}, "title": "foo"},
             template_format="mustache",
         )
+
+
+def test_structured_prompt_does_not_mutate_input_kwargs() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+    }
+    shared_options = {"method": "json_schema"}
+
+    StructuredPrompt.from_messages_and_schema(
+        [("human", "one")],
+        schema,
+        structured_output_kwargs=shared_options,
+        strict=True,
+    )
+
+    assert shared_options == {"method": "json_schema"}
+
+    second = StructuredPrompt(
+        [("human", "two")],
+        schema,
+        structured_output_kwargs=shared_options,
+    )
+    assert "strict" not in second.structured_output_kwargs


### PR DESCRIPTION
Fixes #39169

StructuredPrompt currently mutates the caller's `structured_output_kwargs` dictionary when extra kwargs (like `strict=True`) are passed. This causes unintended side effects when the same dict is reused for multiple prompts.

The fix copies the dict before merging extra kwargs, preserving the caller's original object. A regression test is included.

## Release note
Bugfix: `StructuredPrompt` no longer mutates caller-provided `structured_output_kwargs` dictionaries.

## How verified
- Added regression test `test_structured_prompt_does_not_mutate_input_kwargs`
- Ran `make format`, `make lint`, `make test` - all passing
- Manually reproduced the bug and verified the fix works