### PR TITLE
fix(text-splitters): raise TypeError on invalid non-dict input in RecursiveJsonSplitter

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/json.py
+++ b/libs/text-splitters/langchain_text_splitters/json.py
@@ -128,6 +128,22 @@ class RecursiveJsonSplitter:
         Returns:
             A list of JSON chunks.
         """
+        if not isinstance(json_data, dict):
+            if isinstance(json_data, list) and convert_lists:
+                pass
+            elif isinstance(json_data, list):
+                msg = (
+                    "Unexpected input type: list. Pass convert_lists=True to "
+                    "split top-level lists."
+                )
+                raise TypeError(msg)
+            else:
+                msg = (
+                    f"Unexpected input type: {type(json_data).__name__}. "
+                    "Expected dict."
+                )
+                raise TypeError(msg)
+
         if convert_lists:
             chunks = self._json_split(self._list_to_dict_preprocessing(json_data))
         else:

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3504,6 +3504,24 @@ def test_split_json_empty_dict_value_in_large_payload() -> None:
     assert found_empty, "Empty dict value was lost during splitting"
 
 
+def test_split_json_invalid_input_types() -> None:
+    """Test that split_json raises TypeError for invalid non-dict top-level inputs."""
+    splitter = RecursiveJsonSplitter(max_chunk_size=300)
+
+    # List without convert_lists=True should raise TypeError
+    with pytest.raises(TypeError, match="convert_lists=True"):
+        splitter.split_json([{"a": 1}])
+
+    # List with convert_lists=True should succeed
+    res = splitter.split_json([{"a": 1}], convert_lists=True)
+    assert res == [{"0": {"a": 1}}]
+
+    # Non-dict/non-list types should raise TypeError
+    for invalid in ["hello world", 123, True, None]:
+        with pytest.raises(TypeError, match="Unexpected input type"):
+            splitter.split_json(invalid)  # type: ignore[arg-type]
+
+
 def test_powershell_code_splitter_short_code() -> None:
     splitter = RecursiveCharacterTextSplitter.from_language(
         Language.POWERSHELL, chunk_size=60, chunk_overlap=0


### PR DESCRIPTION
Fixes #39192

When `RecursiveJsonSplitter.split_json()` receives non-dict top-level input (such as a list without `convert_lists=True`, a string, int, or bool), it previously returned `[]` silently and discarded all input data. This change adds explicit type validation so `TypeError` is raised with helpful guidance instead of silently discarding input.

## Release note
Fix `RecursiveJsonSplitter.split_json()` silently returning empty list on invalid non-dict top-level input by raising `TypeError`.