### PR TITLE
fix(langchain): propagate model middleware control flow

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -19,6 +19,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.tools import BaseTool
+from langgraph.errors import GraphBubbleUp
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
@@ -344,6 +345,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         last_exception: Exception
         try:
             return handler(request)
+        except GraphBubbleUp:
+            raise
         except Exception as e:
             last_exception = e
 
@@ -359,6 +362,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             try:
                 return handler(fallback_request.override(model=fallback_model))
+            except GraphBubbleUp:
+                raise
             except Exception as e:
                 last_exception = e
                 continue
@@ -386,6 +391,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         last_exception: Exception
         try:
             return await handler(request)
+        except GraphBubbleUp:
+            raise
         except Exception as e:
             last_exception = e
 
@@ -401,6 +408,8 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
             )
             try:
                 return await handler(fallback_request.override(model=fallback_model))
+            except GraphBubbleUp:
+                raise
             except Exception as e:
                 last_exception = e
                 continue

--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -7,6 +7,7 @@ import time
 from typing import TYPE_CHECKING
 
 from langchain_core.messages import AIMessage
+from langgraph.errors import GraphBubbleUp
 
 from langchain.agents.middleware._retry import (
     OnFailure,
@@ -128,7 +129,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
             retry_on: Either a tuple of exception types to retry on, or a callable
                 that takes an exception and returns `True` if it should be retried.
 
-                Default is to retry on all exceptions.
+                Default is to retry on all exceptions. Exceptions that do not match
+                propagate immediately.
             on_failure: Behavior when all retries are exhausted.
 
                 Options:
@@ -232,13 +234,15 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
         for attempt in range(self.max_retries + 1):
             try:
                 return handler(request)
+            except GraphBubbleUp:
+                raise
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -282,13 +286,15 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
         for attempt in range(self.max_retries + 1):
             try:
                 return await handler(request)
+            except GraphBubbleUp:
+                raise
             except Exception as exc:
                 attempts_made = attempt + 1  # attempt is 0-indexed
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, handle failure immediately
-                    return self._handle_failure(exc, attempts_made)
+                    # Exception is not retryable, re-raise immediately
+                    raise
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:

--- a/libs/langchain_v1/langchain/agents/middleware/model_retry.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_retry.py
@@ -129,8 +129,7 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
             retry_on: Either a tuple of exception types to retry on, or a callable
                 that takes an exception and returns `True` if it should be retried.
 
-                Default is to retry on all exceptions. Exceptions that do not match
-                propagate immediately.
+                Default is to retry on all exceptions.
             on_failure: Behavior when all retries are exhausted.
 
                 Options:
@@ -241,8 +240,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, re-raise immediately
-                    raise
+                    # Exception is not retryable, handle failure immediately
+                    return self._handle_failure(exc, attempts_made)
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:
@@ -293,8 +292,8 @@ class ModelRetryMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
 
                 # Check if we should retry this exception
                 if not should_retry_exception(exc, self.retry_on):
-                    # Exception is not retryable, re-raise immediately
-                    raise
+                    # Exception is not retryable, handle failure immediately
+                    return self._handle_failure(exc, attempts_made)
 
                 # Check if we have more retries left
                 if attempt < self.max_retries:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -11,6 +11,7 @@ from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.tools import BaseTool, tool
+from langgraph.errors import GraphInterrupt
 from typing_extensions import override
 
 from langchain.agents.factory import create_agent
@@ -214,6 +215,48 @@ def _assert_request_is_sanitized(request: ModelRequest) -> None:
     assert "cache_control" not in dict_tool
     dict_tool_extras = dict_tool.get("extras")
     assert dict_tool_extras == {"defer_loading": True}
+
+
+@pytest.mark.parametrize("interrupt_stage", ["primary", "fallback"])
+def test_model_fallback_reraises_graph_bubble_up(interrupt_stage: str) -> None:
+    """Graph control-flow signals propagate from primary and fallback calls."""
+    fallback_model = GenericFakeChatModel(messages=iter([]))
+    middleware = ModelFallbackMiddleware(fallback_model)
+    calls = 0
+
+    def handler(_request: ModelRequest) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if interrupt_stage == "fallback" and calls == 1:
+            msg = "try fallback"
+            raise ValueError(msg)
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        middleware.wrap_model_call(_make_request(), handler)
+
+    assert calls == (2 if interrupt_stage == "fallback" else 1)
+
+
+@pytest.mark.parametrize("interrupt_stage", ["primary", "fallback"])
+async def test_model_fallback_async_reraises_graph_bubble_up(interrupt_stage: str) -> None:
+    """Async graph signals propagate from primary and fallback calls."""
+    fallback_model = GenericFakeChatModel(messages=iter([]))
+    middleware = ModelFallbackMiddleware(fallback_model)
+    calls = 0
+
+    async def handler(_request: ModelRequest) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        if interrupt_stage == "fallback" and calls == 1:
+            msg = "try fallback"
+            raise ValueError(msg)
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        await middleware.awrap_model_call(_make_request(), handler)
+
+    assert calls == (2 if interrupt_stage == "fallback" else 1)
 
 
 def test_fallback_sanitizes_cache_markers_sync() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -9,6 +9,7 @@ from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.errors import GraphInterrupt
 from pydantic import Field
 from typing_extensions import override
 
@@ -311,15 +312,11 @@ def test_model_retry_specific_exceptions() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
-
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-    # RuntimeError should fail immediately (1 attempt only)
-    assert "1 attempt" in ai_messages[-1].content
+    with pytest.raises(RuntimeError, match="Runtime error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
 
 def test_model_retry_custom_exception_filter() -> None:
@@ -389,17 +386,73 @@ def test_model_retry_custom_exception_filter() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    result = agent.invoke(
-        {"messages": [HumanMessage("Hello")]},
-        {"configurable": {"thread_id": "test"}},
-    )
+    with pytest.raises(CustomError, match="Non-retryable error"):
+        agent.invoke(
+            {"messages": [HumanMessage("Hello")]},
+            {"configurable": {"thread_id": "test"}},
+        )
 
-    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
-    assert len(ai_messages) >= 1
-
-    # Should retry once (attempt 1 with retry_me=True), then fail on attempt 2 (retry_me=False)
     assert attempt_count["value"] == 2
-    assert "2 attempts" in ai_messages[-1].content
+
+
+def test_model_retry_reraises_graph_bubble_up() -> None:
+    """Graph control-flow signals propagate without retrying."""
+    retry = ModelRetryMiddleware(max_retries=3, initial_delay=0, jitter=False)
+    calls = 0
+    request = ModelRequest(model=FakeToolCallingModel(), messages=[])
+
+    def handler(_request: ModelRequest) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        retry.wrap_model_call(request, handler)
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_model_retry_async_reraises_graph_bubble_up() -> None:
+    """Async graph control-flow signals propagate without retrying."""
+    retry = ModelRetryMiddleware(max_retries=3, initial_delay=0, jitter=False)
+    calls = 0
+    request = ModelRequest(model=FakeToolCallingModel(), messages=[])
+
+    async def handler(_request: ModelRequest) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        raise GraphInterrupt
+
+    with pytest.raises(GraphInterrupt):
+        await retry.awrap_model_call(request, handler)
+
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_model_retry_async_reraises_non_retryable_exception() -> None:
+    """Async exceptions excluded by `retry_on` propagate immediately."""
+    retry = ModelRetryMiddleware(
+        max_retries=3,
+        retry_on=(ValueError,),
+        initial_delay=0,
+        jitter=False,
+        on_failure="continue",
+    )
+    calls = 0
+    request = ModelRequest(model=FakeToolCallingModel(), messages=[])
+
+    async def handler(_request: ModelRequest) -> ModelResponse:
+        nonlocal calls
+        calls += 1
+        msg = "not retryable"
+        raise TypeError(msg)
+
+    with pytest.raises(TypeError, match="not retryable"):
+        await retry.awrap_model_call(request, handler)
+
+    assert calls == 1
 
 
 def test_model_retry_backoff_timing() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_retry.py
@@ -312,11 +312,15 @@ def test_model_retry_specific_exceptions() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    with pytest.raises(RuntimeError, match="Runtime error"):
-        agent.invoke(
-            {"messages": [HumanMessage("Hello")]},
-            {"configurable": {"thread_id": "test"}},
-        )
+    result = agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        {"configurable": {"thread_id": "test"}},
+    )
+
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) >= 1
+    # RuntimeError should fail immediately (1 attempt only)
+    assert "1 attempt" in ai_messages[-1].content
 
 
 def test_model_retry_custom_exception_filter() -> None:
@@ -386,13 +390,17 @@ def test_model_retry_custom_exception_filter() -> None:
         checkpointer=InMemorySaver(),
     )
 
-    with pytest.raises(CustomError, match="Non-retryable error"):
-        agent.invoke(
-            {"messages": [HumanMessage("Hello")]},
-            {"configurable": {"thread_id": "test"}},
-        )
+    result = agent.invoke(
+        {"messages": [HumanMessage("Hello")]},
+        {"configurable": {"thread_id": "test"}},
+    )
 
+    ai_messages = [m for m in result["messages"] if isinstance(m, AIMessage)]
+    assert len(ai_messages) >= 1
+
+    # Should retry once (attempt 1 with retry_me=True), then fail on attempt 2 (retry_me=False)
     assert attempt_count["value"] == 2
+    assert "2 attempts" in ai_messages[-1].content
 
 
 def test_model_retry_reraises_graph_bubble_up() -> None:
@@ -425,31 +433,6 @@ async def test_model_retry_async_reraises_graph_bubble_up() -> None:
         raise GraphInterrupt
 
     with pytest.raises(GraphInterrupt):
-        await retry.awrap_model_call(request, handler)
-
-    assert calls == 1
-
-
-@pytest.mark.asyncio
-async def test_model_retry_async_reraises_non_retryable_exception() -> None:
-    """Async exceptions excluded by `retry_on` propagate immediately."""
-    retry = ModelRetryMiddleware(
-        max_retries=3,
-        retry_on=(ValueError,),
-        initial_delay=0,
-        jitter=False,
-        on_failure="continue",
-    )
-    calls = 0
-    request = ModelRequest(model=FakeToolCallingModel(), messages=[])
-
-    async def handler(_request: ModelRequest) -> ModelResponse:
-        nonlocal calls
-        calls += 1
-        msg = "not retryable"
-        raise TypeError(msg)
-
-    with pytest.raises(TypeError, match="not retryable"):
         await retry.awrap_model_call(request, handler)
 
     assert calls == 1


### PR DESCRIPTION
Closes #38837
Closes #39121

---

`ModelRetryMiddleware` and `ModelFallbackMiddleware` now propagate LangGraph control-flow signals instead of retrying, converting, or falling back on them. Focused sync and async tests cover primary, retry, and fallback paths.

Made by [Open SWE](https://openswe.vercel.app/agents/9b98355b-188d-4208-8016-e360a4edd028)