### PR TITLE
fix(perplexity): preserve caller `extra_body`

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -1074,7 +1074,7 @@ class ChatPerplexity(BaseChatModel):
                 payload["tools"] = [_flatten_responses_tool(tool) for tool in value]
                 continue
             if key in _RESPONSES_PASSTHROUGH_KEYS:
-                payload[key] = value
+                payload[key] = dict(value) if isinstance(value, dict) else value
                 continue
             # Unknown / Perplexity-specific keys: route under extra_body so the
             # SDK forwards them to the Agent API without breaking strict typing.

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
@@ -814,15 +814,17 @@ def test_to_responses_payload_raises_for_non_dict_extra_body() -> None:
 
 def test_to_responses_payload_preserves_existing_extra_body() -> None:
     llm = ChatPerplexity(model="sonar-pro", api_key="test")
+    extra_body = {"caller_set": True}
     payload = llm._to_responses_payload(
         [{"role": "user", "content": "hi"}],
         {
             "model": "sonar-pro",
-            "extra_body": {"caller_set": True},
+            "extra_body": extra_body,
             "search_mode": "academic",
         },
     )
     assert payload["extra_body"] == {"caller_set": True, "search_mode": "academic"}
+    assert extra_body == {"caller_set": True}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #38840

---

`ChatPerplexity` could mutate caller-owned `extra_body` while routing Responses API parameters, leaking per-call options into later requests. Copying dictionary passthrough values keeps payload construction isolated.

Made by [Open SWE](https://openswe.vercel.app/agents/5570bd8f-e852-22d9-6ef6-d90d549352e7)