### PR TITLE
fix(openai): preserve Responses `text` options

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -4357,6 +4357,9 @@ def _construct_responses_api_payload(
         else:
             payload["tool_choice"] = tool_choice
 
+    if isinstance(payload.get("text"), dict):
+        payload["text"] = payload["text"].copy()
+
     # Structured output
     if schema := payload.pop("response_format", None):
         # For pydantic + non-streaming case, we use responses.parse.

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -1825,6 +1825,22 @@ def test_verbosity_parameter_payload() -> None:
     assert payload["text"]["verbosity"] == "high"
 
 
+def test_responses_payload_does_not_mutate_text_model_kwargs() -> None:
+    text = {"verbosity": "low"}
+    llm = ChatOpenAI(
+        model="gpt-5",
+        api_key=SecretStr("test"),
+        use_responses_api=True,
+        model_kwargs={"text": text},
+    )
+
+    payload = llm._get_request_payload("hello", response_format={"type": "json_object"})
+
+    assert payload["text"]["format"] == {"type": "json_object"}
+    assert text == {"verbosity": "low"}
+    assert llm._get_request_payload("hello")["text"] == {"verbosity": "low"}
+
+
 def test_structured_output_legacy_model() -> None:
     class Output(TypedDict):
         """output."""


### PR DESCRIPTION
Closes #38869

---

`ChatOpenAI` could mutate caller-owned `model_kwargs["text"]` while building Responses payloads, causing format settings to leak across calls. Copying the nested options before request-specific updates keeps caller state unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/5570bd8f-e852-22d9-6ef6-d90d549352e7)