### PR TITLE
docs(openai): add multi-model gateway example for ChatOpenAI base_url

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -3275,7 +3275,7 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
 
         `ChatOpenAI` can be used with OpenAI-compatible APIs like
         [LM Studio](https://lmstudio.ai/), [vLLM](https://github.com/vllm-project/vllm),
-        [Ollama](https://ollama.com/), and others.
+        [Ollama](https://ollama.com/), multi-model gateways, and others.
 
         To use custom parameters specific to these providers, use the `extra_body` parameter.
 
@@ -3305,6 +3305,23 @@ class ChatOpenAI(BaseChatOpenAI):  # type: ignore[override]
                 extra_body={"use_beam_search": True, "best_of": 4},
             )
             ```
+
+        !!! example "Multi-model gateway (e.g. DaoXE)"
+
+            Point `base_url` at any OpenAI-compatible gateway. Use a key and model ID
+            issued by that endpoint (not an official OpenAI key unless the gateway
+            accepts one).
+
+            ```python
+            model = ChatOpenAI(
+                base_url="https://api.daoxe.com/v1",
+                api_key="...",  # key from the gateway
+                model="gpt-4o-mini",  # model ID the gateway serves
+            )
+            ```
+
+            You can also set `OPENAI_API_BASE=https://api.daoxe.com/v1` instead of
+            passing `base_url` explicitly.
 
     ??? info "`model_kwargs` vs `extra_body`"
 


### PR DESCRIPTION
## Summary

`ChatOpenAI` already supports OpenAI-compatible endpoints via `base_url` / `OPENAI_API_BASE` (see existing LM Studio and vLLM examples). This PR adds one more concrete example for multi-model gateways, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`).

Docs only — docstring example under the existing "OpenAI-compatible APIs" section. No runtime behavior change.

## Why

Users frequently point `ChatOpenAI` at multi-model OpenAI-compatible gateways. Documenting that path next to local runtimes (LM Studio / vLLM) makes the existing `base_url` support easier to discover.

## Changes

- Extended the `ChatOpenAI` class docstring with a multi-model gateway example
- Notes that the key and model ID must come from that endpoint
- Mentions `OPENAI_API_BASE` as an alternative to the `base_url` kwarg

## Release note

N/A — documentation only.

## Test plan

- [ ] Docstring renders in API reference
- [ ] Example is optional / not required
- [ ] No invented product numbers

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>