### PR TITLE
fix(core): don't raise `KeyError` on malformed Anthropic content blocks

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/anthropic.py
+++ b/libs/core/langchain_core/messages/block_translators/anthropic.py
@@ -8,6 +8,16 @@ from langchain_core.messages import AIMessage, AIMessageChunk
 from langchain_core.messages import content as types
 
 
+def _has_all(mapping: dict[str, Any], *keys: str) -> bool:
+    """Whether `mapping` carries every one of `keys`.
+
+    Used to check that a provider-shaped block actually contains the fields its
+    variant requires before converting it, so malformed input falls through to
+    the `non_standard` branch instead of raising `KeyError`.
+    """
+    return all(key in mapping for key in keys)
+
+
 def _populate_extras(
     standard_block: types.ContentBlock, block: dict[str, Any], known_fields: set[str]
 ) -> types.ContentBlock:
@@ -55,40 +65,43 @@ def _convert_to_v1_from_anthropic_input(
         for block in blocks:
             block_type = block.get("type")
 
+            source = block.get("source")
+
             if (
                 block_type == "document"
-                and "source" in block
-                and "type" in block["source"]
+                and isinstance(source, dict)
+                and "type" in source
             ):
-                if block["source"]["type"] == "base64":
+                source_type = source["type"]
+                if source_type == "base64" and _has_all(source, "data", "media_type"):
                     file_block: types.FileContentBlock = {
                         "type": "file",
-                        "base64": block["source"]["data"],
-                        "mime_type": block["source"]["media_type"],
+                        "base64": source["data"],
+                        "mime_type": source["media_type"],
                     }
                     _populate_extras(file_block, block, {"type", "source"})
                     yield file_block
 
-                elif block["source"]["type"] == "url":
+                elif source_type == "url" and _has_all(source, "url"):
                     file_block = {
                         "type": "file",
-                        "url": block["source"]["url"],
+                        "url": source["url"],
                     }
                     _populate_extras(file_block, block, {"type", "source"})
                     yield file_block
 
-                elif block["source"]["type"] == "file":
+                elif source_type == "file" and _has_all(source, "file_id"):
                     file_block = {
                         "type": "file",
-                        "id": block["source"]["file_id"],
+                        "id": source["file_id"],
                     }
                     _populate_extras(file_block, block, {"type", "source"})
                     yield file_block
 
-                elif block["source"]["type"] == "text":
+                elif source_type == "text" and _has_all(source, "data"):
                     plain_text_block: types.PlainTextContentBlock = {
                         "type": "text-plain",
-                        "text": block["source"]["data"],
+                        "text": source["data"],
                         "mime_type": block.get("media_type", "text/plain"),
                     }
                     _populate_extras(plain_text_block, block, {"type", "source"})
@@ -98,31 +111,30 @@ def _convert_to_v1_from_anthropic_input(
                     yield {"type": "non_standard", "value": block}
 
             elif (
-                block_type == "image"
-                and "source" in block
-                and "type" in block["source"]
+                block_type == "image" and isinstance(source, dict) and "type" in source
             ):
-                if block["source"]["type"] == "base64":
+                source_type = source["type"]
+                if source_type == "base64" and _has_all(source, "data", "media_type"):
                     image_block: types.ImageContentBlock = {
                         "type": "image",
-                        "base64": block["source"]["data"],
-                        "mime_type": block["source"]["media_type"],
+                        "base64": source["data"],
+                        "mime_type": source["media_type"],
                     }
                     _populate_extras(image_block, block, {"type", "source"})
                     yield image_block
 
-                elif block["source"]["type"] == "url":
+                elif source_type == "url" and _has_all(source, "url"):
                     image_block = {
                         "type": "image",
-                        "url": block["source"]["url"],
+                        "url": source["url"],
                     }
                     _populate_extras(image_block, block, {"type", "source"})
                     yield image_block
 
-                elif block["source"]["type"] == "file":
+                elif source_type == "file" and _has_all(source, "file_id"):
                     image_block = {
                         "type": "image",
-                        "id": block["source"]["file_id"],
+                        "id": source["file_id"],
                     }
                     _populate_extras(image_block, block, {"type", "source"})
                     yield image_block
@@ -142,7 +154,9 @@ def _convert_to_v1_from_anthropic_input(
 def _convert_citation_to_v1(citation: dict[str, Any]) -> types.Annotation:
     citation_type = citation.get("type")
 
-    if citation_type == "web_search_result_location":
+    if citation_type == "web_search_result_location" and _has_all(
+        citation, "cited_text", "url"
+    ):
         url_citation: types.Citation = {
             "type": "citation",
             "cited_text": citation["cited_text"],
@@ -164,7 +178,7 @@ def _convert_citation_to_v1(citation: dict[str, Any]) -> types.Annotation:
         "content_block_location",
         "page_location",
         "search_result_location",
-    }:
+    } and _has_all(citation, "cited_text"):
         document_citation: types.Citation = {
             "type": "citation",
             "cited_text": citation["cited_text"],

--- a/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_anthropic.py
@@ -1,5 +1,18 @@
-from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
+from typing import Any
+
+import pytest
+
+from langchain_core.messages import (
+    AIMessage,
+    AIMessageChunk,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
 from langchain_core.messages import content as types
+from langchain_core.messages.block_translators.anthropic import (
+    _convert_citation_to_v1,
+)
 
 
 def test_convert_to_v1_from_anthropic() -> None:
@@ -507,3 +520,68 @@ def test_convert_to_v1_from_anthropic_input() -> None:
     ]
 
     assert message.content_blocks == expected
+
+
+@pytest.mark.parametrize(
+    "block",
+    [
+        # `source.type` present, but the field that variant requires is missing.
+        {"type": "image", "source": {"type": "base64"}},
+        {"type": "image", "source": {"type": "base64", "data": "<data>"}},
+        {"type": "image", "source": {"type": "url"}},
+        {"type": "image", "source": {"type": "file"}},
+        {"type": "document", "source": {"type": "base64"}},
+        {"type": "document", "source": {"type": "base64", "data": "<data>"}},
+        {"type": "document", "source": {"type": "url"}},
+        {"type": "document", "source": {"type": "file"}},
+        {"type": "document", "source": {"type": "text"}},
+        # `source` isn't a mapping at all.
+        {"type": "image", "source": "not-a-mapping"},
+        {"type": "document", "source": 0},
+    ],
+)
+def test_anthropic_input_block_missing_required_field_does_not_raise(
+    block: dict[str, Any],
+) -> None:
+    """Malformed Anthropic-shaped blocks degrade instead of raising `KeyError`.
+
+    `content_blocks` runs the Anthropic input translator over every message,
+    whichever provider produced it, so a block that merely looks Anthropic-shaped
+    must not be able to crash the property.
+    """
+    for message in (
+        HumanMessage(content=[block]),
+        SystemMessage(content=[block]),
+        AIMessage(content=[block]),
+        ToolMessage(content=[block], tool_call_id="call_1"),
+    ):
+        blocks = message.content_blocks
+        assert len(blocks) == 1
+        parsed = blocks[0]
+        # Left verbatim or wrapped as non-standard — either way, nothing is lost.
+        if parsed["type"] == "non_standard":
+            assert parsed["value"] == block
+        else:
+            assert parsed == block
+
+
+@pytest.mark.parametrize(
+    "citation",
+    [
+        {"type": "web_search_result_location"},
+        {"type": "web_search_result_location", "cited_text": "foo"},
+        {"type": "web_search_result_location", "url": "<url>"},
+        {"type": "char_location"},
+        {"type": "content_block_location"},
+        {"type": "page_location"},
+        {"type": "search_result_location"},
+    ],
+)
+def test_anthropic_citation_missing_required_field_does_not_raise(
+    citation: dict[str, Any],
+) -> None:
+    """A citation missing `cited_text` (or `url`) falls back to non-standard."""
+    assert _convert_citation_to_v1(citation) == {
+        "type": "non_standard_annotation",
+        "value": citation,
+    }


### PR DESCRIPTION
Closes #38667

---

If you build a `HumanMessage` or `ToolMessage` out of JSON you didn't write — a chat service taking multimodal content from a client, or history replayed from a checkpoint or shared store — reading `.content_blocks` on it can crash your process with an uncaught `KeyError`.

`content_blocks` runs a fixed pipeline of provider translators over *every* message, regardless of which provider actually produced it. The Anthropic input translator claims any dict that merely looks Anthropic-shaped: type `document` or `image` with a `source` dict carrying a recognized `type`. Once inside that branch, it read the field each variant needs by direct indexing — the `base64` variant read `data` and `media_type`, `url` read `url`, `file` read `file_id`. A block that names a variant but omits its field therefore raised, out of a property that is documented as a safe read-only view over arbitrary message content. No `allow_dangerous_*` flag, no real model call, no elevated privileges — just control over the shape of `content`.

The fix checks those fields before converting and falls through to the `non_standard` branch when they're missing, which is what this module already does for shapes it doesn't recognize. Two smaller holes in the same code path get the same treatment: a `source` that isn't a mapping at all is now treated as unrecognized rather than subscripted, and the two citation branches check `cited_text` (and `url`) before reading them.

Well-formed blocks are untouched — the existing round-trip test over the full document/image variant matrix passes unchanged.

## Note for reviewers

There is a second, separate instance of this class of bug that I deliberately left alone: a `{"type": "non_standard"}` block with no `value` key still raises `KeyError: 'value'`, and it fails earlier in the pipeline, in the v0 multimodal translator. Every translator in the pipeline unwraps `non_standard` blocks with the same unguarded `block["value"]`, so fixing it properly means touching all of them. That felt like a different change from the one this issue describes — happy to open a separate issue or fold it in here, whichever you prefer.

## Release note

`BaseMessage.content_blocks` no longer raises `KeyError` on Anthropic-shaped `image` or `document` blocks that omit the field their `source.type` requires. Such blocks are now surfaced as `non_standard` instead, consistent with how other unrecognized shapes are handled.

---

*Disclaimer: an AI coding agent was used while preparing this change. I reviewed the diff, ran the reproduction from the issue against both trees, and verified the new tests fail without the fix (17 failures) and pass with it. `make test`, `make lint` and `mypy` are clean for `langchain-core`.*
