### PR TITLE
fix(openai): reuse cached httpx clients in Azure chat/LLM/embeddings classes

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -17,6 +17,10 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 from langchain_openai.chat_models.base import BaseChatOpenAI, _get_default_model_profile
 
 if TYPE_CHECKING:
@@ -687,11 +691,19 @@ class AzureChatOpenAI(BaseChatOpenAI):
             client_params["max_retries"] = self.max_retries
 
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(self.azure_endpoint, self.request_timeout)
+            }
             self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
             self.client = self.root_client.chat.completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                )
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (

--- a/libs/partners/openai/langchain_openai/embeddings/azure.py
+++ b/libs/partners/openai/langchain_openai/embeddings/azure.py
@@ -10,6 +10,10 @@ from langchain_core.utils import from_env, secret_from_env
 from pydantic import Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 from langchain_openai.embeddings.base import OpenAIEmbeddings
 
 
@@ -206,13 +210,21 @@ class AzureOpenAIEmbeddings(OpenAIEmbeddings):  # type: ignore[override]
             "default_query": self.default_query,
         }
         if not self.client:
-            sync_specific: dict = {"http_client": self.http_client}
+            sync_specific: dict = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(self.azure_endpoint, self.request_timeout)
+            }
             self.client = openai.AzureOpenAI(
                 **client_params,  # type: ignore[arg-type]
                 **sync_specific,
             ).embeddings
         if not self.async_client:
-            async_specific: dict = {"http_client": self.http_async_client}
+            async_specific: dict = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                )
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (

--- a/libs/partners/openai/langchain_openai/llms/azure.py
+++ b/libs/partners/openai/langchain_openai/llms/azure.py
@@ -13,6 +13,10 @@ from pydantic import Field, SecretStr, model_validator
 from typing_extensions import Self
 
 from langchain_openai._version import __version__
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+)
 from langchain_openai.llms.base import BaseOpenAI
 
 logger = logging.getLogger(__name__)
@@ -182,13 +186,21 @@ class AzureOpenAI(BaseOpenAI):
             "default_query": self.default_query,
         }
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(self.azure_endpoint, self.request_timeout)
+            }
             self.client = openai.AzureOpenAI(
                 **client_params,
                 **sync_specific,  # type: ignore[arg-type]
             ).completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.azure_endpoint, self.request_timeout
+                )
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -4,6 +4,7 @@ import os
 import warnings
 from unittest import mock
 
+import httpx
 import openai
 import pytest
 from langchain_core.messages import HumanMessage
@@ -50,6 +51,59 @@ def test_initialize_more() -> None:
     ls_params = llm._get_ls_params()
     assert ls_params.get("ls_provider") == "azure"
     assert ls_params.get("ls_model_name") == "gpt-35-turbo-0125"
+
+
+def test_azure_client_caching() -> None:
+    """Test that the underlying httpx client is cached and reused."""
+    llm1 = AzureChatOpenAI(  # type: ignore[call-arg]
+        azure_deployment="35-turbo-dev",
+        openai_api_version="2023-05-15",
+        azure_endpoint="my-base-url",
+        api_key=SecretStr("test"),
+    )
+    llm2 = AzureChatOpenAI(  # type: ignore[call-arg]
+        azure_deployment="35-turbo-dev",
+        openai_api_version="2023-05-15",
+        azure_endpoint="my-base-url",
+        api_key=SecretStr("test"),
+    )
+    assert llm1.root_client._client is llm2.root_client._client
+    assert llm1.root_async_client._client is llm2.root_async_client._client
+
+    llm3 = AzureChatOpenAI(  # type: ignore[call-arg]
+        azure_deployment="35-turbo-dev",
+        openai_api_version="2023-05-15",
+        azure_endpoint="other-base-url",
+        api_key=SecretStr("test"),
+    )
+    assert llm1.root_client._client is not llm3.root_client._client
+
+    llm4 = AzureChatOpenAI(  # type: ignore[call-arg]
+        azure_deployment="35-turbo-dev",
+        openai_api_version="2023-05-15",
+        azure_endpoint="my-base-url",
+        api_key=SecretStr("test"),
+        timeout=3,
+    )
+    assert llm1.root_client._client is not llm4.root_client._client
+
+    llm5 = AzureChatOpenAI(  # type: ignore[call-arg]
+        azure_deployment="35-turbo-dev",
+        openai_api_version="2023-05-15",
+        azure_endpoint="my-base-url",
+        api_key=SecretStr("test"),
+        timeout=httpx.Timeout(timeout=60.0, connect=5.0),
+    )
+    assert llm1.root_client._client is not llm5.root_client._client
+
+    llm6 = AzureChatOpenAI(  # type: ignore[call-arg]
+        azure_deployment="35-turbo-dev",
+        openai_api_version="2023-05-15",
+        azure_endpoint="my-base-url",
+        api_key=SecretStr("test"),
+        http_client=httpx.Client(),
+    )
+    assert llm1.root_client._client is not llm6.root_client._client
 
 
 def test_profile_resolves_from_model_name() -> None:

--- a/libs/partners/openai/tests/unit_tests/embeddings/test_azure_embeddings.py
+++ b/libs/partners/openai/tests/unit_tests/embeddings/test_azure_embeddings.py
@@ -15,6 +15,38 @@ def test_initialize_azure_openai() -> None:
     assert embeddings.model == "text-embedding-large"
 
 
+def test_azure_client_caching() -> None:
+    """Test that the underlying httpx client is cached and reused."""
+    embeddings1 = AzureOpenAIEmbeddings(  # type: ignore[call-arg]
+        model="text-embedding-large",
+        api_key="xyz",  # type: ignore[arg-type]
+        azure_endpoint="my-base-url",
+        azure_deployment="35-turbo-dev",
+        openai_api_version="2023-05-15",
+    )
+    embeddings2 = AzureOpenAIEmbeddings(  # type: ignore[call-arg]
+        model="text-embedding-large",
+        api_key="xyz",  # type: ignore[arg-type]
+        azure_endpoint="my-base-url",
+        azure_deployment="35-turbo-dev",
+        openai_api_version="2023-05-15",
+    )
+    assert embeddings1.client._client._client is embeddings2.client._client._client
+    assert (
+        embeddings1.async_client._client._client
+        is embeddings2.async_client._client._client
+    )
+
+    embeddings3 = AzureOpenAIEmbeddings(  # type: ignore[call-arg]
+        model="text-embedding-large",
+        api_key="xyz",  # type: ignore[arg-type]
+        azure_endpoint="other-base-url",
+        azure_deployment="35-turbo-dev",
+        openai_api_version="2023-05-15",
+    )
+    assert embeddings1.client._client._client is not embeddings3.client._client._client
+
+
 def test_initialize_azure_openai_with_base_set() -> None:
     with mock.patch.dict(os.environ, {"OPENAI_API_BASE": "https://api.openai.com"}):
         embeddings = AzureOpenAIEmbeddings(  # type: ignore[call-arg, call-arg]

--- a/libs/partners/openai/tests/unit_tests/llms/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/llms/test_azure.py
@@ -3,6 +3,32 @@ from typing import Any
 from langchain_openai import AzureOpenAI
 
 
+def test_azure_client_caching() -> None:
+    """Test that the underlying httpx client is cached and reused."""
+    llm1 = AzureOpenAI(
+        openai_api_key="secret-api-key",  # type: ignore[call-arg]
+        azure_endpoint="endpoint",
+        api_version="version",
+        azure_deployment="gpt-35-turbo-instruct",
+    )
+    llm2 = AzureOpenAI(
+        openai_api_key="secret-api-key",  # type: ignore[call-arg]
+        azure_endpoint="endpoint",
+        api_version="version",
+        azure_deployment="gpt-35-turbo-instruct",
+    )
+    assert llm1.client._client._client is llm2.client._client._client
+    assert llm1.async_client._client._client is llm2.async_client._client._client
+
+    llm3 = AzureOpenAI(
+        openai_api_key="secret-api-key",  # type: ignore[call-arg]
+        azure_endpoint="other-endpoint",
+        api_version="version",
+        azure_deployment="gpt-35-turbo-instruct",
+    )
+    assert llm1.client._client._client is not llm3.client._client._client
+
+
 def test_azure_model_param(monkeypatch: Any) -> None:
     monkeypatch.delenv("OPENAI_API_BASE", raising=False)
     llm = AzureOpenAI(


### PR DESCRIPTION
Fixes #32489

---

`AzureChatOpenAI`, `AzureOpenAI` (LLM), and `AzureOpenAIEmbeddings` all created a brand-new `httpx.Client`/`AsyncClient` on every instantiation instead of reusing a shared one. This wastes TCP/TLS connections and adds latency for anyone who creates many short-lived instances of these classes (e.g. per-request in a web server).

`BaseChatOpenAI` already solves this for plain `ChatOpenAI` by falling back to the cached `_get_default_httpx_client` / `_get_default_async_httpx_client` helpers (from `langchain_openai.chat_models._client_utils`) whenever the user hasn't supplied an explicit `http_client`/`http_async_client`. The three Azure classes never adopted that pattern — they just passed `self.http_client` straight through, which defaults to `None`, so the underlying `openai` SDK built a fresh client every time.

This PR applies the same `self.http_client or _get_default_httpx_client(...)` fallback to all three Azure classes, keyed on `azure_endpoint` and `request_timeout` (matching how these classes construct their Azure `base_url`), and adds unit tests asserting that instances with identical configuration share the same underlying `httpx` client while instances with a different endpoint, timeout, or explicitly-provided `http_client` do not.

## Release note

`AzureChatOpenAI`, `AzureOpenAI`, and `AzureOpenAIEmbeddings` now reuse a cached `httpx` client across instances with identical configuration, instead of creating a new one on every instantiation, matching the existing behavior of `ChatOpenAI`.

---

_Disclaimer: this change was drafted with the assistance of an AI coding agent (Claude), reviewed and verified by me before submission._
