### PR TITLE
fix(core): close internally created event loops in streaming tracers

### DIFF
--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import weakref
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -40,7 +41,7 @@ from langchain_core.tracers.log_stream import (
     RunLog,
     _astream_log_implementation,
 )
-from langchain_core.tracers.memory_stream import _MemoryStream
+from langchain_core.tracers.memory_stream import _close_loop_quietly, _MemoryStream
 from langchain_core.utils.aiter import aclosing
 from langchain_core.utils.uuid import uuid7
 
@@ -142,7 +143,13 @@ class _AstreamEventsCallbackHandler(
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:
+            # On Python 3.14+ there is no implicit current loop in a sync context,
+            # so we have to create one to back the memory stream. Since nothing
+            # else references this loop, register a finalizer so it is closed
+            # when this handler is garbage collected; otherwise the loop's
+            # `__del__` emits `ResourceWarning: unclosed event loop` at GC time.
             loop = asyncio.new_event_loop()
+            weakref.finalize(self, _close_loop_quietly, loop)
         memory_stream = _MemoryStream[StreamEvent](loop)
         self.send_stream = memory_stream.get_send_stream()
         self.receive_stream = memory_stream.get_receive_stream()

--- a/libs/core/langchain_core/tracers/event_stream.py
+++ b/libs/core/langchain_core/tracers/event_stream.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-import weakref
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -41,7 +40,7 @@ from langchain_core.tracers.log_stream import (
     RunLog,
     _astream_log_implementation,
 )
-from langchain_core.tracers.memory_stream import _close_loop_quietly, _MemoryStream
+from langchain_core.tracers.memory_stream import _get_or_create_loop, _MemoryStream
 from langchain_core.utils.aiter import aclosing
 from langchain_core.utils.uuid import uuid7
 
@@ -140,17 +139,7 @@ class _AstreamEventsCallbackHandler(
             exclude_tags=exclude_tags,
         )
 
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            # On Python 3.14+ there is no implicit current loop in a sync context,
-            # so we have to create one to back the memory stream. Since nothing
-            # else references this loop, register a finalizer so it is closed
-            # when this handler is garbage collected; otherwise the loop's
-            # `__del__` emits `ResourceWarning: unclosed event loop` at GC time.
-            loop = asyncio.new_event_loop()
-            weakref.finalize(self, _close_loop_quietly, loop)
-        memory_stream = _MemoryStream[StreamEvent](loop)
+        memory_stream = _MemoryStream[StreamEvent](_get_or_create_loop(self))
         self.send_stream = memory_stream.get_send_stream()
         self.receive_stream = memory_stream.get_receive_stream()
 

--- a/libs/core/langchain_core/tracers/log_stream.py
+++ b/libs/core/langchain_core/tracers/log_stream.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import copy
 import threading
+import weakref
 from collections import defaultdict
 from pprint import pformat
 from typing import (
@@ -26,7 +27,7 @@ from langchain_core.outputs import ChatGenerationChunk, GenerationChunk
 from langchain_core.runnables import RunnableConfig, ensure_config
 from langchain_core.tracers._streaming import _StreamingCallbackHandler
 from langchain_core.tracers.base import BaseTracer
-from langchain_core.tracers.memory_stream import _MemoryStream
+from langchain_core.tracers.memory_stream import _close_loop_quietly, _MemoryStream
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator, Sequence
@@ -290,7 +291,13 @@ class LogStreamCallbackHandler(BaseTracer, _StreamingCallbackHandler[Any]):
         try:
             loop = asyncio.get_event_loop()
         except RuntimeError:
+            # On Python 3.14+ there is no implicit current loop in a sync context,
+            # so we have to create one to back the memory stream. Since nothing
+            # else references this loop, register a finalizer so it is closed
+            # when this handler is garbage collected; otherwise the loop's
+            # `__del__` emits `ResourceWarning: unclosed event loop` at GC time.
             loop = asyncio.new_event_loop()
+            weakref.finalize(self, _close_loop_quietly, loop)
         memory_stream = _MemoryStream[RunLogPatch](loop)
         self.lock = threading.Lock()
         self.send_stream = memory_stream.get_send_stream()

--- a/libs/core/langchain_core/tracers/log_stream.py
+++ b/libs/core/langchain_core/tracers/log_stream.py
@@ -6,7 +6,6 @@ import asyncio
 import contextlib
 import copy
 import threading
-import weakref
 from collections import defaultdict
 from pprint import pformat
 from typing import (
@@ -27,7 +26,7 @@ from langchain_core.outputs import ChatGenerationChunk, GenerationChunk
 from langchain_core.runnables import RunnableConfig, ensure_config
 from langchain_core.tracers._streaming import _StreamingCallbackHandler
 from langchain_core.tracers.base import BaseTracer
-from langchain_core.tracers.memory_stream import _close_loop_quietly, _MemoryStream
+from langchain_core.tracers.memory_stream import _get_or_create_loop, _MemoryStream
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator, Sequence
@@ -288,17 +287,7 @@ class LogStreamCallbackHandler(BaseTracer, _StreamingCallbackHandler[Any]):
         self.exclude_types = exclude_types
         self.exclude_tags = exclude_tags
 
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            # On Python 3.14+ there is no implicit current loop in a sync context,
-            # so we have to create one to back the memory stream. Since nothing
-            # else references this loop, register a finalizer so it is closed
-            # when this handler is garbage collected; otherwise the loop's
-            # `__del__` emits `ResourceWarning: unclosed event loop` at GC time.
-            loop = asyncio.new_event_loop()
-            weakref.finalize(self, _close_loop_quietly, loop)
-        memory_stream = _MemoryStream[RunLogPatch](loop)
+        memory_stream = _MemoryStream[RunLogPatch](_get_or_create_loop(self))
         self.lock = threading.Lock()
         self.send_stream = memory_stream.get_send_stream()
         self.receive_stream = memory_stream.get_receive_stream()

--- a/libs/core/langchain_core/tracers/memory_stream.py
+++ b/libs/core/langchain_core/tracers/memory_stream.py
@@ -44,8 +44,10 @@ def _get_or_create_loop(owner: object) -> AbstractEventLoop:
     """Get the current event loop, creating one if this thread has none.
 
     Args:
-        owner: Object whose lifetime bounds a loop created here. A loop created
-            by this function is closed once `owner` is garbage collected.
+        owner: Object whose lifetime bounds a loop created here.
+
+            A loop created by this function is closed once `owner` is
+            garbage collected.
 
     Returns:
         The event loop to back a `_MemoryStream` with.

--- a/libs/core/langchain_core/tracers/memory_stream.py
+++ b/libs/core/langchain_core/tracers/memory_stream.py
@@ -10,6 +10,7 @@ code.
 
 import asyncio
 import contextlib
+import weakref
 from asyncio import AbstractEventLoop, Queue
 from collections.abc import AsyncIterator
 from typing import Any, Generic, TypeVar
@@ -18,14 +19,51 @@ T = TypeVar("T")
 
 
 def _close_loop_quietly(loop: AbstractEventLoop) -> None:
-    """Close an event loop, swallowing any errors raised during shutdown.
+    """Close an event loop that was created internally, as a finalizer callback.
 
-    Used as a `weakref.finalize` callback for loops that LangChain created
-    internally; closing must never raise because finalizers run at GC time.
+    Errors are suppressed rather than logged. `weakref.finalize` defaults to
+    `atexit=True`, so this can run during interpreter shutdown, where `logging`
+    may already be torn down. Python routes finalizer exceptions to
+    `sys.unraisablehook` rather than propagating them, so suppressing here only
+    avoids dumping a traceback to stderr at a nondeterministic moment, which is
+    the same kind of noise this cleanup exists to remove. If `close()` does
+    fail, the loop's own `__del__` still emits
+    `ResourceWarning: unclosed event loop`, so the leak stays detectable.
+
+    Args:
+        loop: The event loop to close. A running loop is left alone.
     """
-    if not loop.is_closed():
-        with contextlib.suppress(Exception):
-            loop.close()
+    if loop.is_running():
+        # `close()` would raise; leave the `ResourceWarning` as the signal.
+        return
+    with contextlib.suppress(Exception):
+        loop.close()
+
+
+def _get_or_create_loop(owner: object) -> AbstractEventLoop:
+    """Get the current event loop, creating one if this thread has none.
+
+    Args:
+        owner: Object whose lifetime bounds a loop created here. A loop created
+            by this function is closed once `owner` is garbage collected.
+
+    Returns:
+        The event loop to back a `_MemoryStream` with.
+    """
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        # No loop is set on this thread. That is always the case in a sync
+        # context on Python 3.14+, where `get_event_loop()` no longer creates
+        # one implicitly, and on any version in a non-main thread.
+        #
+        # This loop is ours: unlike one returned by `get_event_loop()`, no
+        # caller owns it, so close it once `owner` dies. Otherwise the loop's
+        # `__del__` emits `ResourceWarning: unclosed event loop` at whatever
+        # nondeterministic point GC happens to run.
+        loop = asyncio.new_event_loop()
+        weakref.finalize(owner, _close_loop_quietly, loop)
+        return loop
 
 
 class _SendStream(Generic[T]):

--- a/libs/core/langchain_core/tracers/memory_stream.py
+++ b/libs/core/langchain_core/tracers/memory_stream.py
@@ -9,11 +9,23 @@ code.
 """
 
 import asyncio
+import contextlib
 from asyncio import AbstractEventLoop, Queue
 from collections.abc import AsyncIterator
 from typing import Any, Generic, TypeVar
 
 T = TypeVar("T")
+
+
+def _close_loop_quietly(loop: AbstractEventLoop) -> None:
+    """Close an event loop, swallowing any errors raised during shutdown.
+
+    Used as a `weakref.finalize` callback for loops that LangChain created
+    internally; closing must never raise because finalizers run at GC time.
+    """
+    if not loop.is_closed():
+        with contextlib.suppress(Exception):
+            loop.close()
 
 
 class _SendStream(Generic[T]):

--- a/libs/core/tests/unit_tests/tracers/test_memory_stream.py
+++ b/libs/core/tests/unit_tests/tracers/test_memory_stream.py
@@ -1,13 +1,17 @@
 import asyncio
 import gc
 import math
+import threading
 import time
-import warnings
-from collections.abc import AsyncIterator
+import weakref
+from collections.abc import AsyncIterator, Callable
+from typing import Any, TypeVar
 
 from langchain_core.tracers.event_stream import _AstreamEventsCallbackHandler
 from langchain_core.tracers.log_stream import LogStreamCallbackHandler
-from langchain_core.tracers.memory_stream import _MemoryStream
+from langchain_core.tracers.memory_stream import _close_loop_quietly, _MemoryStream
+
+T = TypeVar("T")
 
 
 async def test_same_event_loop() -> None:
@@ -144,36 +148,104 @@ async def test_closed_stream() -> None:
     assert [chunk async for chunk in reader] == []
 
 
-def test_sync_handler_construction_does_not_leak_event_loop() -> None:
+def _run_in_thread(fn: Callable[[], T]) -> T:
+    """Run `fn` in a worker thread and return its result.
+
+    Two reasons for the thread: a worker thread never has an implicit current
+    event loop on any supported Python version, which is what forces the
+    `asyncio.new_event_loop()` fallback in `_get_or_create_loop`; and event loop
+    policy state is thread-local, so any loop set here cannot leak into the rest
+    of the test session and change which branch later tests take.
+    """
+    result: list[T] = []
+    thread = threading.Thread(target=lambda: result.append(fn()))
+    thread.start()
+    thread.join()
+    assert len(result) == 1, "worker thread raised before returning (see stderr)"
+    return result[0]
+
+
+def _make_handlers() -> list[Any]:
+    """Construct one handler of each streaming type from a sync context."""
+    return [_AstreamEventsCallbackHandler(), LogStreamCallbackHandler()]
+
+
+def test_internally_created_event_loop_is_closed() -> None:
     """Regression test for `ResourceWarning: unclosed event loop` at GC time.
 
     When a streaming callback handler is constructed from a synchronous context
-    on Python 3.14+ (where `asyncio.get_event_loop()` raises if no loop is
-    set), the handler falls back to `asyncio.new_event_loop()`. That loop must
-    be closed when the handler is garbage collected; otherwise the loop's
-    `__del__` emits a `ResourceWarning` that can surface inside whatever test
-    happens to be running when GC fires, causing flaky failures such as
-    `test_chat_prompt_template_variable_names`.
-    """
-    # Force the no-current-loop branch regardless of what the surrounding
-    # test session (pytest-asyncio) has set up on this thread.
-    asyncio.set_event_loop(None)
-    try:
-        handler_events = _AstreamEventsCallbackHandler()
-        handler_log = LogStreamCallbackHandler(auto_close=False)
-    finally:
-        asyncio.set_event_loop(None)
+    with no current event loop, it falls back to `asyncio.new_event_loop()`.
+    That loop must be closed once the handler is garbage collected; otherwise
+    the loop's `__del__` emits a `ResourceWarning` at whatever nondeterministic
+    point GC runs. Landing inside a `warnings.catch_warnings(record=True)`
+    block turns the leak into an order-dependent flaky failure.
 
-    with warnings.catch_warnings(record=True) as record:
-        warnings.simplefilter("always")
-        del handler_events
-        del handler_log
+    Asserts the loop is positively closed rather than merely that no warning
+    appeared, so the test cannot pass vacuously if the handler stops being
+    collectible (e.g. via a global registry or a reference cycle).
+    """
+    handlers = _run_in_thread(_make_handlers)
+    loops = [handler.send_stream._reader_loop for handler in handlers]
+    assert len(loops) == 2
+    assert all(not loop.is_closed() for loop in loops)
+
+    refs = [weakref.ref(handler) for handler in handlers]
+    handlers.clear()
+    gc.collect()
+
+    assert all(ref() is None for ref in refs), (
+        "handlers were not collected, so the assertion below would be vacuous"
+    )
+    assert all(loop.is_closed() for loop in loops), (
+        "finalizer did not close the internally created event loop"
+    )
+
+
+def test_caller_owned_event_loop_is_not_closed() -> None:
+    """A loop we did not create must be left alone when the handler is GCed.
+
+    The complement of `test_internally_created_event_loop_is_closed`, and the
+    more dangerous half to get wrong: closing a loop the caller owns would
+    break user code at an arbitrary GC point, silently, since
+    `_close_loop_quietly` suppresses errors.
+    """
+
+    def construct() -> tuple[asyncio.AbstractEventLoop, list[Any]]:
+        caller_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(caller_loop)
+        return caller_loop, _make_handlers()
+
+    caller_loop, handlers = _run_in_thread(construct)
+    try:
+        assert all(
+            handler.send_stream._reader_loop is caller_loop for handler in handlers
+        ), "handlers did not adopt the caller's loop, so this test proves nothing"
+
+        handlers.clear()
         gc.collect()
 
-    unclosed_loop_warnings = [
-        w for w in record if "unclosed event loop" in str(w.message)
-    ]
-    assert unclosed_loop_warnings == [], (
-        f"Expected no `unclosed event loop` ResourceWarnings, got: "
-        f"{[str(w.message) for w in unclosed_loop_warnings]}"
-    )
+        assert not caller_loop.is_closed(), (
+            "a caller-owned event loop must not be closed when the handler that "
+            "borrowed it is garbage collected"
+        )
+    finally:
+        caller_loop.close()
+
+
+def test_close_loop_quietly_leaves_running_loop_open() -> None:
+    """A running loop cannot be closed, so the finalizer must not try."""
+
+    async def close_self_while_running() -> bool:
+        loop = asyncio.get_running_loop()
+        _close_loop_quietly(loop)
+        return loop.is_closed()
+
+    loop = asyncio.new_event_loop()
+    try:
+        assert loop.run_until_complete(close_self_while_running()) is False
+    finally:
+        loop.close()
+
+    # Idempotent on an already-closed loop.
+    _close_loop_quietly(loop)
+    assert loop.is_closed()

--- a/libs/core/tests/unit_tests/tracers/test_memory_stream.py
+++ b/libs/core/tests/unit_tests/tracers/test_memory_stream.py
@@ -1,8 +1,12 @@
 import asyncio
+import gc
 import math
 import time
+import warnings
 from collections.abc import AsyncIterator
 
+from langchain_core.tracers.event_stream import _AstreamEventsCallbackHandler
+from langchain_core.tracers.log_stream import LogStreamCallbackHandler
 from langchain_core.tracers.memory_stream import _MemoryStream
 
 
@@ -138,3 +142,38 @@ async def test_closed_stream() -> None:
     await writer.aclose()
 
     assert [chunk async for chunk in reader] == []
+
+
+def test_sync_handler_construction_does_not_leak_event_loop() -> None:
+    """Regression test for `ResourceWarning: unclosed event loop` at GC time.
+
+    When a streaming callback handler is constructed from a synchronous context
+    on Python 3.14+ (where `asyncio.get_event_loop()` raises if no loop is
+    set), the handler falls back to `asyncio.new_event_loop()`. That loop must
+    be closed when the handler is garbage collected; otherwise the loop's
+    `__del__` emits a `ResourceWarning` that can surface inside whatever test
+    happens to be running when GC fires, causing flaky failures such as
+    `test_chat_prompt_template_variable_names`.
+    """
+    # Force the no-current-loop branch regardless of what the surrounding
+    # test session (pytest-asyncio) has set up on this thread.
+    asyncio.set_event_loop(None)
+    try:
+        handler_events = _AstreamEventsCallbackHandler()
+        handler_log = LogStreamCallbackHandler(auto_close=False)
+    finally:
+        asyncio.set_event_loop(None)
+
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        del handler_events
+        del handler_log
+        gc.collect()
+
+    unclosed_loop_warnings = [
+        w for w in record if "unclosed event loop" in str(w.message)
+    ]
+    assert unclosed_loop_warnings == [], (
+        f"Expected no `unclosed event loop` ResourceWarnings, got: "
+        f"{[str(w.message) for w in unclosed_loop_warnings]}"
+    )


### PR DESCRIPTION
Fixed a resource leak in the `astream_events` and `astream_log` streaming tracers: when constructed from synchronous code on Python 3.14+, an internally created event loop was never closed, causing a `ResourceWarning: unclosed event loop` to be emitted at garbage-collection time (and intermittent failures of warning-sensitive tests such as `test_chat_prompt_template_variable_names`). The loop is now closed when the handler is garbage collected.