### PR TITLE
fix(core): allow unsized iterables in ContextThreadPoolExecutor.map

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -633,27 +633,18 @@ class ContextThreadPoolExecutor(ThreadPoolExecutor):
         *iterables: Iterable[Any],
         **kwargs: Any,
     ) -> Iterator[T]:
-        """Map a function to multiple iterables.
+        """Map a function over iterables, copying context to each call.
 
         Args:
             fn: The function to map.
             *iterables: The iterables to map over.
-            timeout: The timeout for the map.
-            chunksize: The chunksize for the map.
+            **kwargs: Additional arguments to pass to `ThreadPoolExecutor.map`,
+                such as `timeout` and `chunksize`.
 
         Returns:
-            The iterator for the mapped function.
+            An iterator over the results, in the order the iterables were given.
         """
-        contexts = [copy_context() for _ in range(len(iterables[0]))]  # type: ignore[arg-type]
-
-        def _wrapped_fn(*args: Any) -> T:
-            return contexts.pop().run(fn, *args)
-
-        return super().map(
-            _wrapped_fn,
-            *iterables,
-            **kwargs,
-        )
+        return super().map(fn, *iterables, **kwargs)
 
 
 @contextmanager

--- a/libs/core/tests/unit_tests/runnables/test_context_executor.py
+++ b/libs/core/tests/unit_tests/runnables/test_context_executor.py
@@ -1,0 +1,49 @@
+"""Tests for ContextThreadPoolExecutor."""
+from contextvars import ContextVar
+
+from langchain_core.runnables.config import ContextThreadPoolExecutor
+
+
+def test_context_thread_pool_executor_map_with_generator() -> None:
+    """Test that ContextThreadPoolExecutor.map() works with generators."""
+
+    def values():
+        yield from range(3)
+
+    with ContextThreadPoolExecutor(max_workers=2) as executor:
+        result = list(executor.map(lambda x: x * 2, values()))
+
+    assert result == [0, 2, 4]
+
+
+def test_context_thread_pool_executor_map_preserves_context() -> None:
+    """Test that context variables are still passed to worker threads."""
+    test_var: ContextVar[str] = ContextVar("test_var", default="not_set")
+    test_var.set("caller_value")
+
+    def get_var_and_multiply(x: int) -> str:
+        return f"{test_var.get()}_{x}"
+
+    def values():
+        yield from range(2)
+
+    with ContextThreadPoolExecutor(max_workers=1) as executor:
+        result = list(executor.map(get_var_and_multiply, values()))
+
+    assert result == ["caller_value_0", "caller_value_1"]
+
+
+def test_context_thread_pool_executor_map_with_list() -> None:
+    """Test that ContextThreadPoolExecutor.map() still works with lists."""
+    with ContextThreadPoolExecutor(max_workers=2) as executor:
+        result = list(executor.map(lambda x: x * 2, [0, 1, 2]))
+
+    assert result == [0, 2, 4]
+
+
+def test_context_thread_pool_executor_map_with_multiple_iterables() -> None:
+    """Test shortest-iterable behavior is preserved with multiple iterables."""
+    with ContextThreadPoolExecutor(max_workers=2) as executor:
+        result = list(executor.map(lambda x, y: x + y, [1, 2, 3], [10, 20]))
+
+    assert result == [11, 22]


### PR DESCRIPTION
Delegates to ThreadPoolExecutor.map() via super(), which submits each call through self.submit() and picks up the existing context-copying override. Removes the eager len(iterables[0]) precomputation that rejected generators and other unsized iterables.

Fixes #39211

Fixes #

---

<!-- Keep the `Fixes #xx` keyword at the very top and update the issue number — this auto-closes the issue on merge. Replace this comment with a 1-2 sentence description of your change. No `# Summary` header; the description is the summary. -->

Read the full contributing guidelines: https://docs.langchain.com/oss/python/contributing/overview

> **All contributions must be in English.** See the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy).

If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!

Thank you for contributing to LangChain! Follow these steps to have your pull request considered as ready for review.

1. PR title: Should follow the format: TYPE(SCOPE): DESCRIPTION

  - Examples:
    - fix(anthropic): resolve flag parsing error
    - feat(core): add multi-tenant support
    - test(openai): update API usage tests
  - Allowed TYPE and SCOPE values: https://github.com/langchain-ai/langchain/blob/master/.github/workflows/pr_lint.yml#L15-L33

2. PR description:

  - Write 1-2 sentences that make the change easy to understand: who benefits, what problem they had, and how this solves it. Prefer a simple user story over a long summary.
  - The `Fixes #xx` line at the top is **required** for external contributions — update the issue number and keep the keyword. This links your PR to the approved issue and auto-closes it on merge.
  - If there are any breaking changes, please clearly describe them.
  - If this PR depends on another PR being merged first, please include "Depends on #PR_NUMBER" in the description.

## Release note
<!-- Required for net new features or behavior-changing bugfixes. State the user-visible change in release-note-ready language. Omit this section for chores, refactors, or test-only changes. -->

3. Run `make format`, `make lint` and `make test` from the root of the package(s) you've modified.

  - We will not consider a PR unless these three are passing in CI.

4. How did you verify your code works?

Additional guidelines:

  - All external PRs must link to an issue or discussion where a solution has been approved by a maintainer, and you must be assigned to that issue. PRs without prior approval will be closed.
  - PRs should not touch more than one package unless absolutely necessary.
  - Do not update the `uv.lock` files or add dependencies to `pyproject.toml` files (even optional ones) unless you have explicit permission to do so by a maintainer.

## Social handles (optional)
<!-- If you'd like a shoutout on release, add your socials below -->
Twitter: @
LinkedIn: https://linkedin.com/in/
