### PR TITLE
feat(langchain): add LangSmith provider to `init_chat_model`

### DIFF
--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -328,7 +328,7 @@ def init_chat_model(
             - `baseten`                 -> [`langchain-baseten`](https://docs.langchain.com/oss/python/integrations/providers/baseten)
             - `litellm`                 -> [`langchain-litellm`](https://docs.langchain.com/oss/python/integrations/providers/litellm)
             - `meta`                    -> [`langchain-meta`](https://pypi.org/project/langchain-meta)
-            - `langsmith`               -> [`langchain-openai`](https://docs.langchain.com/oss/python/integrations/providers/openai)
+            - `langsmith`               -> [`langchain-openai`](https://docs.langchain.com/langsmith/llm-gateway)
 
         configurable_fields: Which model parameters are configurable at runtime:
 

--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -18,7 +18,25 @@ from langchain_core.language_models import BaseChatModel, LanguageModelInput
 from langchain_core.messages import AIMessage, AnyMessage
 from langchain_core.prompt_values import ChatPromptValueConcrete, StringPromptValue
 from langchain_core.runnables import Runnable, RunnableConfig, ensure_config
+from langchain_core.utils._gateway import _apply_gateway_config
 from typing_extensions import override
+
+_LANGSMITH_GATEWAY_DEFAULT_BASE = "https://gateway.smith.langchain.com/v1"
+
+
+def _init_langsmith(cls: type[BaseChatModel], **kwargs: Any) -> BaseChatModel:
+    _apply_gateway_config(
+        kwargs,
+        cls,
+        base_url_field="openai_api_base",
+        api_key_field="openai_api_key",
+        provider_path="v1",
+        api_key_env=("LANGSMITH_GATEWAY_API_KEY", "LANGSMITH_API_KEY"),
+        default_base_url=_LANGSMITH_GATEWAY_DEFAULT_BASE,
+    )
+    kwargs["use_responses_api"] = True
+    return cls(**kwargs)
+
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Iterator, Sequence
@@ -64,6 +82,7 @@ _BUILTIN_PROVIDERS: dict[str, tuple[str, str, Callable[..., BaseChatModel]]] = {
         "ChatWatsonx",
         lambda cls, model, **kwargs: cls(model_id=model, **kwargs),
     ),
+    "langsmith": ("langchain_openai", "ChatOpenAI", _init_langsmith),
     "litellm": ("langchain_litellm", "ChatLiteLLM", _call),
     "meta": ("langchain_meta", "ChatMetaModel", _call),
     "mistralai": ("langchain_mistralai", "ChatMistralAI", _call),
@@ -309,6 +328,7 @@ def init_chat_model(
             - `baseten`                 -> [`langchain-baseten`](https://docs.langchain.com/oss/python/integrations/providers/baseten)
             - `litellm`                 -> [`langchain-litellm`](https://docs.langchain.com/oss/python/integrations/providers/litellm)
             - `meta`                    -> [`langchain-meta`](https://pypi.org/project/langchain-meta)
+            - `langsmith`               -> [`langchain-openai`](https://docs.langchain.com/oss/python/integrations/providers/openai)
 
         configurable_fields: Which model parameters are configurable at runtime:
 

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 version = "1.3.14"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.9,<2.0.0",
+    "langchain-core>=1.5.3,<2.0.0",
     "langgraph>=1.2.5,<1.3.0",
     "pydantic>=2.7.4,<3.0.0",
 ]

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -76,6 +76,15 @@ def test_init_chat_model_langsmith_defaults() -> None:
 
 
 @pytest.mark.requires("langchain_openai")
+@mock.patch.dict(os.environ, {"LANGSMITH_API_KEY": "langsmith-key"}, clear=True)
+def test_init_chat_model_langsmith_api_key_fallback() -> None:
+    model = cast("ChatOpenAI", init_chat_model("langsmith:moonshotai/kimi-k3"))
+
+    assert isinstance(model.openai_api_key, SecretStr)
+    assert model.openai_api_key.get_secret_value() == "langsmith-key"
+
+
+@pytest.mark.requires("langchain_openai")
 @mock.patch.dict(
     os.environ,
     {

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -80,6 +80,7 @@ def test_init_chat_model_langsmith_defaults() -> None:
 def test_init_chat_model_langsmith_api_key_fallback() -> None:
     model = cast("ChatOpenAI", init_chat_model("langsmith:moonshotai/kimi-k3"))
 
+    assert model.openai_api_base == "https://gateway.smith.langchain.com/v1"
     assert isinstance(model.openai_api_key, SecretStr)
     assert model.openai_api_key.get_secret_value() == "langsmith-key"
 

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -1,5 +1,5 @@
 import os
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 from unittest import mock
 
 import pytest
@@ -13,6 +13,7 @@ from langchain.chat_models.base import _BUILTIN_PROVIDERS, _attempt_infer_model_
 
 if TYPE_CHECKING:
     from langchain_core.language_models import BaseChatModel
+    from langchain_openai import ChatOpenAI
 
 OPENAI_TEST_MODEL = "gpt-5.5"
 
@@ -53,6 +54,74 @@ def test_init_chat_model(model_name: str, model_provider: str | None) -> None:
         api_key="foo",
     )
     assert llm1.dict() == llm2.dict()
+
+
+@pytest.mark.requires("langchain_openai")
+@mock.patch.dict(
+    os.environ,
+    {
+        "LANGSMITH_GATEWAY_API_KEY": "gateway-key",
+        "LANGSMITH_API_KEY": "langsmith-key",
+    },
+    clear=True,
+)
+def test_init_chat_model_langsmith_defaults() -> None:
+    model = cast("ChatOpenAI", init_chat_model("langsmith:moonshotai/kimi-k3"))
+
+    assert model.model_name == "moonshotai/kimi-k3"
+    assert model.openai_api_base == "https://gateway.smith.langchain.com/v1"
+    assert isinstance(model.openai_api_key, SecretStr)
+    assert model.openai_api_key.get_secret_value() == "gateway-key"
+    assert model.use_responses_api is True
+
+
+@pytest.mark.requires("langchain_openai")
+@mock.patch.dict(
+    os.environ,
+    {
+        "LANGSMITH_GATEWAY": "https://eu.gateway.example.com/",
+        "LANGSMITH_API_KEY": "langsmith-key",
+    },
+    clear=True,
+)
+def test_init_chat_model_langsmith_custom_gateway() -> None:
+    model = cast(
+        "ChatOpenAI",
+        init_chat_model(
+            "moonshotai/kimi-k3",
+            model_provider="langsmith",
+            use_responses_api=False,
+        ),
+    )
+
+    assert model.openai_api_base == "https://eu.gateway.example.com/v1"
+    assert isinstance(model.openai_api_key, SecretStr)
+    assert model.openai_api_key.get_secret_value() == "langsmith-key"
+    assert model.use_responses_api is True
+
+
+@pytest.mark.requires("langchain_openai")
+@mock.patch.dict(
+    os.environ,
+    {
+        "LANGSMITH_GATEWAY": "https://eu.gateway.example.com",
+        "LANGSMITH_GATEWAY_API_KEY": "gateway-key",
+    },
+    clear=True,
+)
+def test_init_chat_model_langsmith_explicit_config() -> None:
+    model = cast(
+        "ChatOpenAI",
+        init_chat_model(
+            "langsmith:moonshotai/kimi-k3",
+            base_url="https://apac.gateway.example.com/v1",
+            api_key="explicit-key",
+        ),
+    )
+
+    assert model.openai_api_base == "https://apac.gateway.example.com/v1"
+    assert isinstance(model.openai_api_key, SecretStr)
+    assert model.openai_api_key.get_secret_value() == "explicit-key"
 
 
 def test_init_chat_model_rejects_model_object() -> None:

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -192,7 +192,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.96.0"
+version = "0.120.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -204,9 +204,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/7e/672f533dee813028d2c699bfd2a7f52c9118d7353680d9aa44b9e23f717f/anthropic-0.96.0.tar.gz", hash = "sha256:9de947b737f39452f68aa520f1c2239d44119c9b73b0fb6d4e6ca80f00279ee6", size = 658210, upload-time = "2026-04-16T14:28:02.846Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/10/4ca013cb166f226bd89e0aeb0fcaff94f45ddf716d4925ce89475d3c587b/anthropic-0.120.2.tar.gz", hash = "sha256:9722efc10c27a30a69f5338ddacdb35bc6a64297a4e4ba729bf83af873d5fb3a", size = 1008421, upload-time = "2026-07-28T17:38:26.986Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/5a/72f33204064b6e87601a71a6baf8d855769f8a0c1eaae8d06a1094872371/anthropic-0.96.0-py3-none-any.whl", hash = "sha256:9a6e335a354602a521cd9e777e92bfd46ba6e115bf9bbfe6135311e8fb2015b2", size = 635930, upload-time = "2026-04-16T14:28:01.436Z" },
+    { url = "https://files.pythonhosted.org/packages/63/af/0f5db57b9397a0f3b7fc204cbef143401a7cadaf982330f97f1ce3d39f34/anthropic-0.120.2-py3-none-any.whl", hash = "sha256:0f0bc2b381dc0eb41c8d886b815d79c2041cd2374f83aed36f574b6dc9c579c1", size = 1022851, upload-time = "2026-07-28T17:38:25.466Z" },
 ]
 
 [[package]]
@@ -2093,7 +2093,7 @@ requires-dist = [
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity", "meta"]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.15.0,<0.17.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.26,<1.6.0" },
     { name = "langchain-openai", editable = "../partners/openai" },
@@ -2123,7 +2123,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.5.0"
+version = "1.5.3"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2133,13 +2133,13 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.96.0,<1.0.0" },
+    { name = "anthropic", specifier = ">=0.120.0,<1.0.0" },
     { name = "langchain-core", editable = "../core" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.13.1,<0.17.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.5,<1.6" },
     { name = "defusedxml", specifier = ">=0.7.1,<1.0.0" },
@@ -2263,7 +2263,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.5.0"
+version = "1.5.3"
 source = { editable = "../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -2294,9 +2294,9 @@ requires-dist = [
 dev = [
     { name = "grandalf", specifier = ">=0.8.0,<1.0.0" },
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
-    { name = "setuptools", specifier = ">=67.6.1,<83.0.0" },
+    { name = "setuptools", specifier = ">=67.6.1,<84.0.0" },
 ]
-lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.15.0,<0.17.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.18,<1.6.0" },
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -2465,7 +2465,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },
@@ -2482,7 +2482,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = []
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.13.1,<0.17.0" }]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain", editable = "." },
@@ -2572,11 +2572,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.15.0,<0.17.0" }]
 test = []
 test-integration = []
 typing = [
-    { name = "mypy", specifier = ">=2.1.0,<2.2.0" },
+    { name = "mypy", specifier = ">=2.1.0,<2.4.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
 ]
 
@@ -2593,7 +2593,7 @@ requires-dist = [{ name = "langchain-core", editable = "../core" }]
 
 [package.metadata.requires-dev]
 dev = [{ name = "jupyter", specifier = ">=1.0.0,<2.0.0" }]
-lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.15.0,<0.17.0" }]
 test = [
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },


### PR DESCRIPTION
## Description
Users can now select `langsmith:<model>` to route `ChatOpenAI` through the LangSmith gateway's Responses API. The provider reuses the shared gateway resolver for custom URLs and credential precedence.

## Release Note
`init_chat_model` now supports the `langsmith` provider prefix for LangSmith Gateway models.

## Test Plan
- [x] Added unit coverage for defaults, environment fallbacks, custom URLs, and explicit overrides.

Made by [Open SWE](https://openswe.vercel.app/agents/5bbf7cfb-ee93-9966-e83d-e24cd477bf53)