### PR TITLE
fix(core): accept generator inputs in ContextThreadPoolExecutor.map

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -644,16 +644,11 @@ class ContextThreadPoolExecutor(ThreadPoolExecutor):
         Returns:
             The iterator for the mapped function.
         """
-        contexts = [copy_context() for _ in range(len(iterables[0]))]  # type: ignore[arg-type]
-
-        def _wrapped_fn(*args: Any) -> T:
-            return contexts.pop().run(fn, *args)
-
-        return super().map(
-            _wrapped_fn,
-            *iterables,
-            **kwargs,
-        )
+        # Delegate to `Executor.map`, which submits each item via `self.submit`
+        # and therefore inherits the per-item context copying implemented there.
+        # This also accepts unsized iterables such as generators, matching
+        # `ThreadPoolExecutor.map` semantics.
+        return super().map(fn, *iterables, **kwargs)
 
 
 @contextmanager

--- a/libs/core/tests/unit_tests/runnables/test_config.py
+++ b/libs/core/tests/unit_tests/runnables/test_config.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from contextvars import copy_context
+from contextvars import ContextVar, copy_context
 from typing import Any, cast
 
 import pytest
@@ -15,6 +15,7 @@ from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain_core.runnables import RunnableBinding, RunnablePassthrough
 from langchain_core.runnables.config import (
+    ContextThreadPoolExecutor,
     RunnableConfig,
     _get_langsmith_inheritable_metadata_from_config,
     _merge_metadata_dicts,
@@ -323,6 +324,46 @@ async def test_run_in_executor() -> None:
 
     with pytest.raises(RuntimeError):
         await run_in_executor(None, raises_stop_iter)
+
+
+def test_context_thread_pool_executor_map_with_generator() -> None:
+    """map() should accept unsized iterables like stdlib ThreadPoolExecutor.map.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/39211.
+    """
+    with ContextThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda x: x * 2, (i for i in range(10))))
+
+    assert results == [i * 2 for i in range(10)]
+
+
+def test_context_thread_pool_executor_map_with_multiple_generators() -> None:
+    with ContextThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda a, b: a + b, (i for i in range(5)), (j for j in range(5))))
+
+    assert results == [i + i for i in range(5)]
+
+
+def test_context_thread_pool_executor_map_shortest_iterable_wins() -> None:
+    with ContextThreadPoolExecutor(max_workers=2) as executor:
+        results = list(
+            executor.map(lambda a, b: a + b, (i for i in range(5)), [10, 20])
+        )
+
+    assert results == [10, 21]
+
+
+def test_context_thread_pool_executor_map_copies_context() -> None:
+    ctx_var: ContextVar[int] = ContextVar("map_ctx_var", default=0)
+    ctx_var.set(42)
+
+    def read_ctx(x: int) -> int:
+        return x + ctx_var.get()
+
+    with ContextThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(read_ctx, [1, 2, 3]))
+
+    assert results == [43, 44, 45]
 
 
 class TestMergeMetadataDicts:


### PR DESCRIPTION
﻿## Summary
ContextThreadPoolExecutor.map rejected generator inputs, breaking runnables that stream results via generators. Accept generator inputs and iterate them lazily so callables returning generators are mapped like any other iterable.

Fixes #39229

## Test plan
Adds unit coverage in libs/core/tests/unit_tests/runnables/test_config.py.
