### PR TITLE
fix(core): prefer provider-assigned message id in streamed message-start

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -58,6 +58,7 @@ from langchain_protocol.protocol import (
 
 from langchain_core.messages import AIMessageChunk, BaseMessage
 from langchain_core.utils._merge import merge_dicts
+from langchain_core.utils.utils import LC_AUTO_PREFIX, LC_ID_PREFIX
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Iterator
@@ -527,6 +528,33 @@ def _isolate_usage(usage: UsageInfo | None) -> UsageInfo | None:
 # ---------------------------------------------------------------------------
 
 
+def _streamed_message_id(msg: BaseMessage, message_id: str | None) -> str | None:
+    """Resolve a streaming `message-start` id, preferring the provider's.
+
+    On the streaming path `message_id` is the run-derived placeholder
+    (`lc_run--<run_id>`) that the stream driver assigns at
+    `on_chat_model_start` — before any provider has replied, so it is the only
+    id available at that point. A provider that names its own message should
+    still win: OpenAI's Responses API sends `resp_…` on `response.created`,
+    ahead of the first token, and that is the id the assembled `AIMessage` ends
+    up carrying, because `add_ai_message_chunks` ranks provider ids above
+    `lc_run-*`/`lc_*` ones.
+
+    Applying the same precedence here keeps the streamed protocol id and the
+    resulting message id in agreement. Without it they diverge for the whole
+    stream, so a consumer that addresses a message by the id it was streamed
+    under cannot match it to the persisted message.
+
+    Only the live-chunk paths use this. `message_to_events` replays an already
+    finalized message, where an explicit `message_id` is a caller override and
+    must keep winning.
+    """
+    provider_id = getattr(msg, "id", None)
+    if provider_id and not provider_id.startswith((LC_ID_PREFIX, LC_AUTO_PREFIX)):
+        return provider_id
+    return message_id if message_id is not None else provider_id
+
+
 def _build_message_start(
     msg: BaseMessage,
     message_id: str | None,
@@ -649,7 +677,7 @@ def chunks_to_events(
 
         if not started:
             started = True
-            yield _build_message_start(msg, message_id)
+            yield _build_message_start(msg, _streamed_message_id(msg, message_id))
 
         for key, block in _iter_protocol_blocks(msg):
             if key not in blocks:
@@ -729,7 +757,7 @@ async def achunks_to_events(
 
         if not started:
             started = True
-            yield _build_message_start(msg, message_id)
+            yield _build_message_start(msg, _streamed_message_id(msg, message_id))
 
         for key, block in _iter_protocol_blocks(msg):
             if key not in blocks:

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -171,6 +171,49 @@ def test_chunks_to_events_text_only() -> None:
     assert "finish_reason" not in _event_metadata(finish)
 
 
+def test_chunks_to_events_prefers_provider_message_id() -> None:
+    """A provider-assigned id wins over the run-derived placeholder.
+
+    The stream driver passes `lc_run--<run_id>` (assigned at
+    `on_chat_model_start`, before the provider replies). OpenAI's Responses API
+    names the message `resp_…` on `response.created`, and that is the id the
+    assembled `AIMessage` keeps, so `message-start` must report it too.
+    """
+    chunks = [
+        ChatGenerationChunk(message=AIMessageChunk(content="Hi", id="resp_abc123")),
+    ]
+
+    events = list(
+        chunks_to_events(iter(chunks), message_id="lc_run--0199-4abc-8def-1234")
+    )
+
+    start = cast("MessageStartData", events[0])
+    assert start["event"] == "message-start"
+    assert start["id"] == "resp_abc123"
+
+
+def test_chunks_to_events_keeps_placeholder_when_provider_gives_no_id() -> None:
+    """Providers that never name the message keep the run-derived placeholder."""
+    chunks = [ChatGenerationChunk(message=AIMessageChunk(content="Hi"))]
+
+    events = list(chunks_to_events(iter(chunks), message_id="lc_run--0199-4abc"))
+
+    start = cast("MessageStartData", events[0])
+    assert start["id"] == "lc_run--0199-4abc"
+
+
+def test_chunks_to_events_placeholder_wins_over_auto_generated_chunk_id() -> None:
+    """An `lc_`-prefixed chunk id is auto-generated, not provider-assigned."""
+    chunks = [
+        ChatGenerationChunk(message=AIMessageChunk(content="Hi", id="lc_generated")),
+    ]
+
+    events = list(chunks_to_events(iter(chunks), message_id="lc_run--0199-4abc"))
+
+    start = cast("MessageStartData", events[0])
+    assert start["id"] == "lc_run--0199-4abc"
+
+
 def test_chunks_to_events_empty_iterator() -> None:
     """No chunks means no events."""
     assert list(chunks_to_events(iter([]))) == []


### PR DESCRIPTION
## Problem

On the streaming path, the `message-start` event reports LangChain's run-derived
placeholder id even when the provider has already named the message. The streamed
id and the resulting `AIMessage.id` then disagree for the whole stream.

`chunks_to_events` forces the caller-supplied `message_id` onto the event:

```python
# _compat_bridge.py, _build_message_start
resolved_id = message_id if message_id is not None else getattr(msg, "id", None)
```

The chunk's own id is consulted only when the caller passes `None`, which never
happens here — `_iter_v2_events` always passes `stream.message_id`, and the driver
sets that at `on_chat_model_start`:

```python
stream.set_message_id("-".join((LC_ID_PREFIX, str(run_manager.run_id))))
```

That fires *before the request is sent*, so the placeholder is the only id available
at that moment. But a provider can name its message moments later and well before the
first token: OpenAI's Responses API sends `resp_…` on `response.created`, and
`langchain_openai` already puts it on every `AIMessageChunk`. Because
`add_ai_message_chunks` ranks provider ids above `lc_run-*`/`lc_*`, that is the id the
assembled message ends up with:

```python
# messages/ai.py
# Ranks are defined by the order of preference. Higher is better:
# 2. Provider-assigned IDs (non lc_* and non lc_run-*)
# 1. lc_run-* IDs
```

So the two disagree — `message-start` says `lc_run--019fca47-…`, the persisted message
says `resp_06e5d87…`.

## Impact

Anything that addresses a message by the id it was streamed under cannot match it to
the persisted message:

- Feedback / scoring a specific turn after the fact
- Regeneration and branching from a given message
- `on_chain_end` message dedupe in `langgraph/pregel/_messages.py`, which matches the
  `message-start` id against the finalized message the node returns and comments:
  *"otherwise the messages projection double-counts: once from streaming, once from
  the chain output"*

`langchain_openai` emits no `message-start` events of its own (`grep -rn "message-start"`
returns nothing there), so it has no way to correct this from the integration side —
every other layer in the chain speaks the event.

## Change

Apply the precedence `add_ai_message_chunks` already uses: a provider-assigned id wins
over an auto-generated one.

Scoped to the live-chunk paths (`chunks_to_events` / `achunks_to_events`).
`message_to_events` replays an already finalized message, where an explicit
`message_id` is a deliberate caller override and keeps winning — covered by the
existing `test_message_to_events_message_id_override`.

## Tests

Three new cases in `test_compat_bridge.py`:

- provider id wins over the `lc_run--` placeholder
- placeholder is kept when the provider supplies no id
- placeholder wins over an `lc_`-prefixed (auto-generated) chunk id

`libs/core`: 291 passed, 2 xfailed. `ruff check` and `ruff format --check` clean.

---

Patch prepared with Claude Code.
