### PR TITLE
fix(text-splitters): raise TypeError for non-dict input in RecursiveJsonSplitter.split_json

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/json.py
+++ b/libs/text-splitters/langchain_text_splitters/json.py
@@ -128,6 +128,18 @@ class RecursiveJsonSplitter:
         Returns:
             A list of JSON chunks.
         """
+        if json_data is None:
+            return []
+        if isinstance(json_data, list) and not convert_lists:
+            raise TypeError(
+                "split_json() received a list as top-level input. "
+                "Use convert_lists=True to convert lists to dicts first, "
+                "or pass a dict."
+            )
+        if not isinstance(json_data, (dict, list)):
+            raise TypeError(
+                f"split_json() expected a dict or list, got {type(json_data).__name__}"
+            )
         if convert_lists:
             chunks = self._json_split(self._list_to_dict_preprocessing(json_data))
         else:

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3504,6 +3504,42 @@ def test_split_json_empty_dict_value_in_large_payload() -> None:
     assert found_empty, "Empty dict value was lost during splitting"
 
 
+def test_split_json_list_without_convert_lists_raises() -> None:
+    """split_json([]) without convert_lists should raise TypeError."""
+    splitter = RecursiveJsonSplitter()
+    with pytest.raises(TypeError, match="received a list"):
+        splitter.split_json([])
+
+
+def test_split_json_list_with_convert_lists() -> None:
+    """split_json([]) with convert_lists=True should work (returns converted list)."""
+    splitter = RecursiveJsonSplitter()
+    result = splitter.split_json([], convert_lists=True)
+    # Empty list converted to empty dict -> split_json returns []
+    assert result == []
+
+
+def test_split_json_string_raises() -> None:
+    """split_json('hello') should raise TypeError."""
+    splitter = RecursiveJsonSplitter()
+    with pytest.raises(TypeError, match="expected a dict or list"):
+        splitter.split_json("hello")
+
+
+def test_split_json_int_raises() -> None:
+    """split_json(123) should raise TypeError."""
+    splitter = RecursiveJsonSplitter()
+    with pytest.raises(TypeError, match="expected a dict or list"):
+        splitter.split_json(123)
+
+
+def test_split_json_bool_raises() -> None:
+    """split_json(True) should raise TypeError."""
+    splitter = RecursiveJsonSplitter()
+    with pytest.raises(TypeError, match="expected a dict or list"):
+        splitter.split_json(True)
+
+
 def test_powershell_code_splitter_short_code() -> None:
     splitter = RecursiveCharacterTextSplitter.from_language(
         Language.POWERSHELL, chunk_size=60, chunk_overlap=0


### PR DESCRIPTION
Fixes #39192

split_json silently returns [] for non-dict top-level input instead of raising. Regression from PR #35079.

Add type validation: None returns [], list without convert_lists raises TypeError, non-dict/non-list raises TypeError.

Added 5 tests. All 13 split_json tests pass.