### PR TITLE
fix(core): preserve scalar values in dict prompt lists

### DIFF
--- a/libs/core/langchain_core/prompts/dict.py
+++ b/libs/core/langchain_core/prompts/dict.py
@@ -137,6 +137,10 @@ def _get_input_variables(
                     input_variables += get_template_variables(x, template_format)
                 elif isinstance(x, dict):
                     input_variables += _get_input_variables(x, template_format)
+                elif isinstance(x, (list, tuple)):
+                    input_variables += _get_input_variables(
+                        {"_nested": x}, template_format
+                    )
     return list(set(input_variables))
 
 
@@ -145,12 +149,20 @@ def _insert_input_variables(
     inputs: dict[str, Any],
     template_format: Literal["f-string", "mustache"],
 ) -> dict[str, Any]:
-    formatted: dict[str, Any] = {}
     formatter = DEFAULT_FORMATTER_MAPPING[template_format]
+
+    def format_value(value: Any) -> Any:
+        if isinstance(value, str):
+            return formatter(value, **inputs)
+        if isinstance(value, dict):
+            return _insert_input_variables(value, inputs, template_format)
+        if isinstance(value, (list, tuple)):
+            return type(value)(format_value(item) for item in value)
+        return value
+
+    formatted: dict[str, Any] = {}
     for k, v in template.items():
-        if isinstance(v, str):
-            formatted[k] = formatter(v, **inputs)
-        elif isinstance(v, dict):
+        if isinstance(v, dict):
             if k == "image_url" and "path" in v:
                 msg = (
                     "Specifying image inputs via file path in environments with "
@@ -159,17 +171,7 @@ def _insert_input_variables(
                     "misuse."
                 )
                 warnings.warn(msg, stacklevel=2)
-            formatted[k] = _insert_input_variables(v, inputs, template_format)
-        elif isinstance(v, (list, tuple)):
-            formatted_v: list[str | dict[str, Any]] = []
-            for x in v:
-                if isinstance(x, str):
-                    formatted_v.append(formatter(x, **inputs))
-                elif isinstance(x, dict):
-                    formatted_v.append(
-                        _insert_input_variables(x, inputs, template_format)
-                    )
-            formatted[k] = type(v)(formatted_v)
+            formatted[k] = format_value(v)
         else:
-            formatted[k] = v
+            formatted[k] = format_value(v)
     return formatted

--- a/libs/core/tests/unit_tests/prompts/test_dict.py
+++ b/libs/core/tests/unit_tests/prompts/test_dict.py
@@ -23,6 +23,19 @@ def test__dict_message_prompt_template_fstring() -> None:
     assert actual == expected
 
 
+def test_dict_prompt_template_preserves_and_formats_nested_list_values() -> None:
+    prompt = DictPromptTemplate(
+        template={
+            "content": ["{text}", 1, {"nested": [True, "{text}"]}, [[None, 2]]]
+        },
+        template_format="f-string",
+    )
+
+    assert prompt.format(text="hello") == {
+        "content": ["hello", 1, {"nested": [True, "hello"]}, [[None, 2]]]
+    }
+
+
 def test_deserialize_legacy() -> None:
     ser = {
         "type": "constructor",


### PR DESCRIPTION
## Summary
- preserve scalar and nested list values when formatting DictPromptTemplate
- recurse through nested lists and tuples while still formatting string leaves
- add regression coverage for mixed provider-style content blocks

## Problem
DictPromptTemplate silently removed integers, booleans, None, and nested lists whenever they appeared inside a list or tuple. This could corrupt tool-use payloads, scores, IDs, and other structured Agent message content before it reached the model.

## Solution
Use one recursive value formatter for strings, dictionaries, lists, tuples, and pass-through scalars. This keeps existing string substitution and dictionary handling while making list behavior lossless.

## Tests
- python -m compileall / AST parse passed
- Focused pytest collection was attempted, but the monorepo runtime still lacks additional optional dependencies (uuid_utils); no external API or model calls were made.

## Scope and risk
One prompt formatting helper and one focused unit test. No changes to template syntax, serialization, or model integrations.

Closes #39152