### PR TITLE
core: fix typo in Visitor._validate_func error message

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
# What does this PR do?

Fixes a copy-paste typo in `Visitor._validate_func` (`libs/core/langchain_core/structured_query.py`): when an invalid operator is passed, the error message incorrectly says "Allowed comparators are ..." instead of "Allowed operators are ...".

This matches what the method actually validates and avoids confusion for users debugging disallowed operators.

Fixes #36701