### PR TITLE
fix(langchain): clear stale `structured_response` between checkpointed turns

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -193,6 +193,8 @@ def _normalize_to_model_response(
 def _build_commands(
     model_response: ModelResponse,
     middleware_commands: list[Command[Any]] | None = None,
+    *,
+    has_structured_output: bool = False,
 ) -> list[Command[Any]]:
     """Build a list of Commands from a model response and middleware commands.
 
@@ -204,6 +206,10 @@ def _build_commands(
             structured output.
         middleware_commands: Commands accumulated from middleware layers during
             composition (inner-first ordering).
+        has_structured_output: Whether the agent was configured with a
+            `response_format`. When `True` and no structured response was
+            produced, `structured_response` is explicitly cleared to avoid a
+            stale value from a previous checkpointed turn.
 
     Returns:
         List of `Command` objects ready to be returned from a model node.
@@ -212,6 +218,8 @@ def _build_commands(
 
     if model_response.structured_response is not None:
         state["structured_response"] = model_response.structured_response
+    elif has_structured_output:
+        state["structured_response"] = None
 
     for cmd in middleware_commands or []:
         if cmd.goto:
@@ -1443,12 +1451,15 @@ def create_agent(
             runtime=runtime,
         )
 
+        has_structured_output = initial_response_format is not None
         if wrap_model_call_handler is None:
             model_response = _execute_model_sync(request)
-            return _build_commands(model_response)
+            return _build_commands(model_response, has_structured_output=has_structured_output)
 
         result = wrap_model_call_handler(request, _execute_model_sync)
-        return _build_commands(result.model_response, result.commands)
+        return _build_commands(
+            result.model_response, result.commands, has_structured_output=has_structured_output
+        )
 
     async def _execute_model_async(request: ModelRequest[ContextT]) -> ModelResponse:
         """Execute model asynchronously and return response.
@@ -1491,12 +1502,15 @@ def create_agent(
             runtime=runtime,
         )
 
+        has_structured_output = initial_response_format is not None
         if awrap_model_call_handler is None:
             model_response = await _execute_model_async(request)
-            return _build_commands(model_response)
+            return _build_commands(model_response, has_structured_output=has_structured_output)
 
         result = await awrap_model_call_handler(request, _execute_model_async)
-        return _build_commands(result.model_response, result.commands)
+        return _build_commands(
+            result.model_response, result.commands, has_structured_output=has_structured_output
+        )
 
     # Use sync or async based on model capabilities
     graph.add_node("model", RunnableCallable(model_node, amodel_node, trace=False))
@@ -1880,8 +1894,8 @@ def _make_model_to_tools_edge(
         if pending_tool_calls:
             return [Send("tools", [tool_call]) for tool_call in pending_tool_calls]
 
-        # 5. If there is a structured response, exit the loop
-        if "structured_response" in state:
+        # 5. If a fresh structured response was produced this call, exit the loop
+        if state.get("structured_response") is not None:
             return end_destination
 
         # 6. AIMessage has tool calls, but there are no pending tool calls which suggests
@@ -1907,8 +1921,8 @@ def _make_model_to_model_edge(
                 end_destination=end_destination,
             )
 
-        # 2. Exit condition: A structured response was generated
-        if "structured_response" in state:
+        # 2. Exit condition: a fresh structured response was generated this call
+        if state.get("structured_response") is not None:
             return end_destination
 
         # 3. Default: Continue the loop, there may have been an issue with structured

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -11,7 +11,7 @@ from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import HumanMessage
-from langchain_core.runnables import Runnable
+from langchain_core.runnables import Runnable, RunnableConfig
 from langgraph.checkpoint.memory import InMemorySaver
 from pydantic import BaseModel, Field, field_validator
 from typing_extensions import TypedDict, override
@@ -720,7 +720,7 @@ class TestResponseFormatAsToolStrategy:
             response_format=ToolStrategy(Answer, handle_errors=True),
             checkpointer=InMemorySaver(),
         )
-        thread = {"configurable": {"thread_id": "test-thread"}}
+        thread: RunnableConfig = {"configurable": {"thread_id": "test-thread"}}
 
         response_1 = agent.invoke({"messages": [HumanMessage("say hi")]}, config=thread)
         response_2 = agent.invoke({"messages": [HumanMessage("say bye")]}, config=thread)

--- a/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_response_format.py
@@ -12,7 +12,8 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import HumanMessage
 from langchain_core.runnables import Runnable
-from pydantic import BaseModel, Field
+from langgraph.checkpoint.memory import InMemorySaver
+from pydantic import BaseModel, Field, field_validator
 from typing_extensions import TypedDict, override
 
 from langchain.agents import create_agent
@@ -683,6 +684,49 @@ class TestResponseFormatAsToolStrategy:
             match=r".*WeatherBaseModel.*",
         ):
             agent.invoke({"messages": [HumanMessage("What's the weather?")]})
+
+    def test_structured_response_not_stale_across_checkpointed_turns(self) -> None:
+        """Test that a checkpointed turn doesn't reuse a previous turn's response.
+
+        Regression test for a bug where the routing edges checked for
+        `structured_response` key *presence* rather than freshness, so a turn whose
+        first attempt failed validation (and needed a retry) would exit early with
+        the previous turn's stale `structured_response` still sitting in the
+        checkpointed state.
+        """
+
+        class Answer(BaseModel):
+            text: str
+
+            @field_validator("text")
+            @classmethod
+            def not_bad(cls, v: str) -> str:
+                if v == "BAD":
+                    msg = "bad sentinel"
+                    raise ValueError(msg)
+                return v
+
+        tool_calls = [
+            [{"name": "Answer", "id": "1", "args": {"text": "Hi"}}],
+            [{"name": "Answer", "id": "2", "args": {"text": "BAD"}}],
+            [{"name": "Answer", "id": "3", "args": {"text": "Bye"}}],
+        ]
+
+        model = FakeToolCallingModel(tool_calls=tool_calls)
+
+        agent = create_agent(
+            model,
+            [],
+            response_format=ToolStrategy(Answer, handle_errors=True),
+            checkpointer=InMemorySaver(),
+        )
+        thread = {"configurable": {"thread_id": "test-thread"}}
+
+        response_1 = agent.invoke({"messages": [HumanMessage("say hi")]}, config=thread)
+        response_2 = agent.invoke({"messages": [HumanMessage("say bye")]}, config=thread)
+
+        assert response_1["structured_response"] == Answer(text="Hi")
+        assert response_2["structured_response"] == Answer(text="Bye")
 
 
 class TestResponseFormatAsProviderStrategy:


### PR DESCRIPTION
Closes #36957

---

With a checkpointer, `_build_commands` only wrote `structured_response` into state when the model call produced one, so a value persisted from a prior turn stuck around in the checkpoint. The routing edges (`_make_model_to_tools_edge`, `_make_model_to_model_edge`) only checked `"structured_response" in state` (key presence), so a turn whose first model call failed structured-output validation and needed a retry would exit the loop early using the previous turn's stale value instead of continuing to retry.

`_build_commands` now explicitly clears `structured_response` to `None` when the agent has a `response_format` configured but the current call didn't produce one, and the routing edges check `state.get("structured_response") is not None` for freshness rather than mere key presence.

Co-authored-by: @Kcstring 