### PR TITLE
fix(anthropic): add missing reasoning/thinking token count to `UsageMetadata`

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -30,6 +30,7 @@ from langchain_core.messages import (
     AIMessageChunk,
     BaseMessage,
     HumanMessage,
+    OutputTokenDetails,
     SystemMessage,
     ToolCall,
     ToolMessage,
@@ -2530,6 +2531,17 @@ def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
         "cache_read": getattr(anthropic_usage, "cache_read_input_tokens", None),
         "cache_creation": getattr(anthropic_usage, "cache_creation_input_tokens", None),
     }
+    output_token_details: dict = {
+        "reasoning": getattr(
+            getattr(
+                anthropic_usage,
+                "output_tokens_details",
+                None,
+            ),
+            "thinking_tokens",
+            None,
+        )
+    }
 
     # Add cache TTL information if provided (5-minute and 1-hour ephemeral cache)
     cache_creation = getattr(anthropic_usage, "cache_creation", None)
@@ -2561,11 +2573,21 @@ def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
     )
     output_tokens = getattr(anthropic_usage, "output_tokens", 0) or 0
 
-    return UsageMetadata(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        total_tokens=input_tokens + output_tokens,
-        input_token_details=InputTokenDetails(
+    usage_metadata = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "input_token_details": InputTokenDetails(
             **{k: v for k, v in input_token_details.items() if v is not None},
         ),
-    )
+    }
+
+    filtered_output_token_details = {
+        k: v for k, v in output_token_details.items() if v is not None
+    }
+    if filtered_output_token_details:
+        usage_metadata["output_token_details"] = OutputTokenDetails(
+            **filtered_output_token_details
+        )
+
+    return UsageMetadata(**usage_metadata)

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1870,6 +1870,35 @@ def test_usage_metadata_cache_creation_ttl() -> None:
     assert details["cache_creation"] == 10
 
 
+def test_usage_metadata_with_reasoning_tokens() -> None:
+    """Test _create_usage_metadata with reasoning tokens."""
+
+    class OutputTokensDetails(BaseModel):
+        thinking_tokens: int = 20
+
+    class UsageWithReasoning(BaseModel):
+        input_tokens: int = 100
+        output_tokens: int = 50
+        output_tokens_details: OutputTokensDetails | None
+
+    # Case 1: output_tokens_details present
+    result = _create_usage_metadata(
+        UsageWithReasoning(output_tokens_details=OutputTokensDetails())
+    )
+    assert result["input_tokens"] == 100
+    assert result["output_tokens"] == 50
+    assert result["total_tokens"] == 150
+    details = dict(result.get("output_token_details") or {})
+    assert details["reasoning"] == 20
+
+    # Case 2: output_tokens_details is None
+    result = _create_usage_metadata(UsageWithReasoning(output_tokens_details=None))
+    assert result["input_tokens"] == 100
+    assert result["output_tokens"] == 50
+    assert result["total_tokens"] == 150
+    assert "output_token_details" not in result
+
+
 class FakeTracer(BaseTracer):
     """Fake tracer to capture inputs to `chat_model_start`."""
 


### PR DESCRIPTION
Fixes #39249 

---

Adds the thinking token count exposed by the Anthropic API to the standardized `UsageMetadata` struct in `AIMessage`s returned by `ChatAnthropic`.

Backward compatibility to older models who do not expose this metric is guaranteed by `getattr` with defaults and filtering `None`-values.