### PR TITLE
fix(core): forward `feedback_config` through `EvaluatorCallbackHandler._log_evaluation_feedback`

### DIFF
--- a/libs/core/langchain_core/tracers/evaluation.py
+++ b/libs/core/langchain_core/tracers/evaluation.py
@@ -199,6 +199,7 @@ class EvaluatorCallbackHandler(BaseTracer):
                 source_info=source_info_,
                 source_run_id=res.source_run_id or source_run_id,
                 feedback_source_type=langsmith.schemas.FeedbackSourceType.MODEL,
+                feedback_config=res.feedback_config,
             )
         return results
 

--- a/libs/core/tests/unit_tests/tracers/test_evaluation.py
+++ b/libs/core/tests/unit_tests/tracers/test_evaluation.py
@@ -1,0 +1,53 @@
+"""Tests for EvaluatorCallbackHandler."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from langsmith.evaluation.evaluator import EvaluationResult
+
+from langchain_core.tracers.evaluation import EvaluatorCallbackHandler
+from langchain_core.tracers.schemas import Run
+
+
+def _make_run() -> Run:
+    """Create a minimal Run for evaluator tests."""
+    return Run(
+        name="test-run",
+        run_type="chain",
+        outputs={"output": "test"},
+    )
+
+
+def test_log_evaluation_feedback_forwards_feedback_config() -> None:
+    """`feedback_config` from the EvaluationResult is passed to create_feedback."""
+    client = MagicMock()
+    handler = EvaluatorCallbackHandler(evaluators=[], client=client)
+    run = _make_run()
+    result = EvaluationResult(
+        key="sentiment",
+        value="positive",
+        feedback_config={"criteria": "sentiment", "threshold": 0.5},
+    )
+
+    handler._log_evaluation_feedback(result, run)
+
+    client.create_feedback.assert_called_once()
+    kwargs = client.create_feedback.call_args.kwargs
+    assert kwargs["feedback_config"] == {
+        "criteria": "sentiment",
+        "threshold": 0.5,
+    }
+
+
+def test_log_evaluation_feedback_none_feedback_config() -> None:
+    """A missing `feedback_config` forwards `None` (no-op, no TypeError)."""
+    client = MagicMock()
+    handler = EvaluatorCallbackHandler(evaluators=[], client=client)
+    run = _make_run()
+    result = EvaluationResult(key="sentiment", value="positive")
+
+    handler._log_evaluation_feedback(result, run)
+
+    client.create_feedback.assert_called_once()
+    assert client.create_feedback.call_args.kwargs["feedback_config"] is None


### PR DESCRIPTION
## Summary

`EvaluatorCallbackHandler._log_evaluation_feedback` calls `client.create_feedback(...)` without passing `feedback_config` from the `EvaluationResult`, so any dict the user puts in `EvaluationResult.feedback_config` is silently dropped before the API call.

Reported in #31802.

## Fix

Add a single keyword argument:

```python
feedback_config=res.feedback_config,
```

to the `create_feedback` call, matching the `feedback_config` parameter already accepted by `langsmith.Client.create_feedback`.

## Tests

This patch adds the first unit-test coverage of `EvaluatorCallbackHandler` (`libs/core/tests/unit_tests/tracers/test_evaluation.py`):

- `test_log_evaluation_feedback_forwards_feedback_config` — asserts the dict is forwarded verbatim.
- `test_log_evaluation_feedback_defaults_feedback_config_to_none` — asserts `None` stays `None` when not set.

Both pass, plus the 84 existing `tests/unit_tests/tracers/` tests still pass.

Fixes #31802.