### PR TITLE
fix(anthropic): include reasoning tokens in usage_metadata

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -36,7 +36,11 @@ from langchain_core.messages import (
     is_data_content_block,
 )
 from langchain_core.messages import content as types
-from langchain_core.messages.ai import InputTokenDetails, UsageMetadata
+from langchain_core.messages.ai import (
+    InputTokenDetails,
+    OutputTokenDetails,
+    UsageMetadata,
+)
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
 from langchain_core.output_parsers import (
     JsonOutputKeyToolsParser,
@@ -2561,7 +2565,19 @@ def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
     )
     output_tokens = getattr(anthropic_usage, "output_tokens", 0) or 0
 
-    return UsageMetadata(
+    # Extract reasoning (thinking) token count, if provided. Anthropic reports this
+    # as a decomposition of `output_tokens` (not additive) via
+    # `output_tokens_details.thinking_tokens`.
+    output_token_details: dict = {}
+    output_tokens_details = getattr(anthropic_usage, "output_tokens_details", None)
+    if output_tokens_details:
+        if isinstance(output_tokens_details, BaseModel):
+            output_tokens_details = output_tokens_details.model_dump()
+        thinking_tokens = output_tokens_details.get("thinking_tokens")
+        if thinking_tokens is not None:
+            output_token_details["reasoning"] = thinking_tokens
+
+    usage_metadata = UsageMetadata(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=input_tokens + output_tokens,
@@ -2569,3 +2585,8 @@ def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
             **{k: v for k, v in input_token_details.items() if v is not None},
         ),
     )
+    if output_token_details:
+        usage_metadata["output_token_details"] = OutputTokenDetails(
+            **output_token_details
+        )
+    return usage_metadata

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1744,6 +1744,43 @@ def test_usage_metadata_standardization() -> None:
     assert result["total_tokens"] == 0
 
 
+def test_usage_metadata_reasoning_tokens() -> None:
+    """Reasoning tokens surfaced via `output_tokens_details.thinking_tokens` should
+    be mapped to `output_token_details.reasoning`.
+    """
+
+    class OutputTokensDetailsModel(BaseModel):
+        thinking_tokens: int = 140
+
+    class UsageModelWithThinking(BaseModel):
+        input_tokens: int = 70
+        output_tokens: int = 190
+        cache_read_input_tokens: int = 0
+        cache_creation_input_tokens: int = 0
+        output_tokens_details: OutputTokensDetailsModel = OutputTokensDetailsModel()
+
+    result = _create_usage_metadata(UsageModelWithThinking())
+    assert result["output_tokens"] == 190
+    assert result.get("output_token_details") == {"reasoning": 140}
+
+    # No `output_tokens_details` at all (older/other providers, or absent field)
+    class UsageModelNoDetails(BaseModel):
+        input_tokens: int = 10
+        output_tokens: int = 5
+
+    result_no_details = _create_usage_metadata(UsageModelNoDetails())
+    assert "output_token_details" not in result_no_details
+
+    # `output_tokens_details` explicitly `None`
+    class UsageModelNoneDetails(BaseModel):
+        input_tokens: int = 10
+        output_tokens: int = 5
+        output_tokens_details: OutputTokensDetailsModel | None = None
+
+    result_none_details = _create_usage_metadata(UsageModelNoneDetails())
+    assert "output_token_details" not in result_none_details
+
+
 def test_usage_metadata_cache_creation_ttl() -> None:
     """Test _create_usage_metadata with granular cache_creation TTL fields."""
 


### PR DESCRIPTION
Fixes #39249

---

`ChatAnthropic` wasn't reporting reasoning token usage: when extended thinking was enabled, `AIMessage.usage_metadata` never included the `output_token_details.reasoning` count, for both `invoke` and `stream`, this adds that field, sourced from Anthropic's `output_tokens_details.thinking_tokens`

## Release note

`ChatAnthropic.usage_metadata` now includes `output_token_details.reasoning` when the API reports thinking-token usage

## How I verified this

Ran `make format`, `make lint` and `make test` in `libs/partners/anthropic` — all pass, including a new unit test (`test_usage_metadata_reasoning_tokens`) covering the fix, also reproduced the original issue's script against a live API call with extended thinking enabled and confirmed `usage_metadata["output_token_details"]["reasoning"]` is now populated for both `invoke` and `stream`, where before the fix that key was absent in both cases.