### PR TITLE
fix(anthropic): include reasoning tokens in output_token_details usage metadata (#39249)

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -36,7 +36,11 @@ from langchain_core.messages import (
     is_data_content_block,
 )
 from langchain_core.messages import content as types
-from langchain_core.messages.ai import InputTokenDetails, UsageMetadata
+from langchain_core.messages.ai import (
+    InputTokenDetails,
+    OutputTokenDetails,
+    UsageMetadata,
+)
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
 from langchain_core.output_parsers import (
     JsonOutputKeyToolsParser,
@@ -2561,6 +2565,27 @@ def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
     )
     output_tokens = getattr(anthropic_usage, "output_tokens", 0) or 0
 
+    output_token_details: dict = {}
+    raw_output_details = getattr(anthropic_usage, "output_tokens_details", None)
+    if raw_output_details is not None:
+        if isinstance(raw_output_details, BaseModel):
+            raw_output_details = raw_output_details.model_dump()
+        if isinstance(raw_output_details, dict):
+            reasoning = raw_output_details.get("thinking_tokens")
+            if reasoning is None:
+                reasoning = raw_output_details.get("reasoning_tokens")
+            if reasoning is not None:
+                output_token_details["reasoning"] = reasoning
+
+    if "reasoning" not in output_token_details:
+        thinking = getattr(anthropic_usage, "thinking_tokens", None)
+        if thinking is not None:
+            output_token_details["reasoning"] = thinking
+
+    filtered_output_token_details = {
+        k: v for k, v in output_token_details.items() if v is not None
+    }
+
     return UsageMetadata(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
@@ -2568,4 +2593,7 @@ def _create_usage_metadata(anthropic_usage: BaseModel) -> UsageMetadata:
         input_token_details=InputTokenDetails(
             **{k: v for k, v in input_token_details.items() if v is not None},
         ),
+        output_token_details=OutputTokenDetails(**filtered_output_token_details)
+        if filtered_output_token_details
+        else OutputTokenDetails(),
     )

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1744,6 +1744,38 @@ def test_usage_metadata_standardization() -> None:
     assert result["total_tokens"] == 0
 
 
+def test_usage_metadata_reasoning_tokens() -> None:
+    """Test _create_usage_metadata populates output_token_details['reasoning']."""
+
+    class OutputTokensDetailsModel(BaseModel):
+        thinking_tokens: int = 150
+
+    class UsageWithThinkingDetails(BaseModel):
+        input_tokens: int = 50
+        output_tokens: int = 200
+        output_tokens_details: OutputTokensDetailsModel = OutputTokensDetailsModel()
+
+    res1 = _create_usage_metadata(UsageWithThinkingDetails())
+    assert res1["output_tokens"] == 200
+    assert res1["output_token_details"] == {"reasoning": 150}
+
+    class UsageWithThinkingDict(BaseModel):
+        input_tokens: int = 50
+        output_tokens: int = 200
+        output_tokens_details: dict = {"thinking_tokens": 120}
+
+    res2 = _create_usage_metadata(UsageWithThinkingDict())
+    assert res2["output_token_details"] == {"reasoning": 120}
+
+    class UsageWithDirectThinking(BaseModel):
+        input_tokens: int = 50
+        output_tokens: int = 200
+        thinking_tokens: int = 90
+
+    res3 = _create_usage_metadata(UsageWithDirectThinking())
+    assert res3["output_token_details"] == {"reasoning": 90}
+
+
 def test_usage_metadata_cache_creation_ttl() -> None:
     """Test _create_usage_metadata with granular cache_creation TTL fields."""
 


### PR DESCRIPTION
### Fixes Issue
Fixes #39249: Reasoning tokens not reported in `usage_metadata`

### Summary of Changes
- Updated `_create_usage_metadata` in `langchain_anthropic/chat_models.py` to parse `output_tokens_details.thinking_tokens` (and direct `thinking_tokens` attribute).
- Populates `UsageMetadata.output_token_details["reasoning"]` on `AIMessage` and `AIMessageChunk`.
- Added unit test `test_usage_metadata_reasoning_tokens` in `tests/unit_tests/test_chat_models.py`.

### Verification
Verified against `anthropic` SDK:
- Extracted `thinking_tokens` from `output_tokens_details` model or dict.
- `UsageMetadata["output_token_details"]["reasoning"]` correctly populated across invoke and streaming tests.