### PR TITLE
fix(huggingface): support Pydantic schemas in \with_structured_output"

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,9 +47,11 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
+from langchain_core.output_parsers.base import OutputParserLike
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
+    PydanticToolsParser,
     make_invalid_tool_call,
     parse_tool_call,
 )
@@ -1109,9 +1111,17 @@ class ChatHuggingFace(BaseChatModel):
 
                 - An OpenAI function/tool schema,
                 - A JSON Schema,
-                - A `TypedDict` class
+                - A `TypedDict` class,
+                - Or a Pydantic class.
 
-                Pydantic class is currently supported.
+                If `schema` is a Pydantic class then the model output will be a
+                Pydantic instance of that class, and the model-generated fields
+                will be validated by the Pydantic class. Otherwise the model
+                output will be a dict and will not be validated.
+
+                See `langchain_core.utils.function_calling.convert_to_openai_tool`
+                for more on how to properly specify types and descriptions of
+                schema fields when specifying a Pydantic or `TypedDict` class.
 
             method: The method for steering model generation, one of:
 
@@ -1175,11 +1185,14 @@ class ChatHuggingFace(BaseChatModel):
                 },
             )
             if is_pydantic_schema:
-                msg = "Pydantic schema is not supported for function calling"
-                raise NotImplementedError(msg)
-            output_parser: JsonOutputKeyToolsParser | JsonOutputParser = (
-                JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
-            )
+                output_parser: OutputParserLike = PydanticToolsParser(
+                    tools=[schema],  # type: ignore[list-item]
+                    first_tool_only=True,  # type: ignore[list-item]
+                )
+            else:
+                output_parser = JsonOutputKeyToolsParser(
+                    key_name=tool_name, first_tool_only=True
+                )
         elif method == "json_schema":
             if schema is None:
                 msg = (
@@ -1195,7 +1208,11 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1204,7 +1221,11 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            output_parser = (
+                PydanticOutputParser(pydantic_object=schema)  # type: ignore[arg-type]
+                if is_pydantic_schema
+                else JsonOutputParser()
+            )
         else:
             msg = (
                 f"Unrecognized method argument. Expected one of 'function_calling' or "

--- a/libs/partners/huggingface/tests/integration_tests/test_standard.py
+++ b/libs/partners/huggingface/tests/integration_tests/test_standard.py
@@ -29,10 +29,7 @@ class TestHuggingFaceEndpoint(ChatModelIntegrationTests):
     def model(self, request: Any) -> BaseChatModel:
         return self.chat_model_class(**self.chat_model_params)  # type: ignore[call-arg]
 
-    @pytest.mark.xfail(
-        reason=("Overrding, testing only typed dict and json schema structured output")
-    )
-    @pytest.mark.parametrize("schema_type", ["typeddict", "json_schema"])
+    @pytest.mark.parametrize("schema_type", ["pydantic", "typeddict", "json_schema"])
     def test_structured_output(
         self,
         model: BaseChatModel,
@@ -40,10 +37,7 @@ class TestHuggingFaceEndpoint(ChatModelIntegrationTests):
     ) -> None:
         super().test_structured_output(model, schema_type)
 
-    @pytest.mark.xfail(
-        reason=("Overrding, testing only typed dict and json schema structured output")
-    )
-    @pytest.mark.parametrize("schema_type", ["typeddict", "json_schema"])
+    @pytest.mark.parametrize("schema_type", ["pydantic", "typeddict", "json_schema"])
     async def test_structured_output_async(
         self,
         model: BaseChatModel,
@@ -51,11 +45,9 @@ class TestHuggingFaceEndpoint(ChatModelIntegrationTests):
     ) -> None:
         super().test_structured_output(model, schema_type)
 
-    @pytest.mark.xfail(reason=("Pydantic structured output is not supported"))
     def test_structured_output_pydantic_2_v1(self, model: BaseChatModel) -> None:
         super().test_structured_output_pydantic_2_v1(model)
 
-    @pytest.mark.xfail(reason=("Pydantic structured output is not supported"))
     def test_structured_output_optional_param(self, model: BaseChatModel) -> None:
         super().test_structured_output_optional_param(model)
 

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -9,8 +10,9 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from langchain_core.outputs import ChatResult
+from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
@@ -402,3 +404,200 @@ def test_init_chat_model_huggingface() -> None:
         # The important part is that the code path doesn't raise ValidationError
         # about missing 'llm' field, which was the original bug
         pytest.skip(f"Skipping test due to model download/initialization error: {e}")
+
+
+class _Joke(BaseModel):
+    """A joke with a setup and a punchline."""
+
+    setup: str = Field(description="The setup of the joke")
+    punchline: str = Field(description="The punchline of the joke")
+
+
+@pytest.fixture
+def structured_output_chat() -> ChatHuggingFace:
+    """A ChatHuggingFace instance that can be used for structured output tests."""
+    empty_llm = Mock(spec=HuggingFaceEndpoint)
+    empty_llm.repo_id = "test/model"
+    empty_llm.model = "test/model"
+    with patch(
+        "langchain_huggingface.chat_models.huggingface.ChatHuggingFace._resolve_model_id"
+    ):
+        return ChatHuggingFace(llm=empty_llm)
+
+
+def test_with_structured_output_pydantic_function_calling(
+    structured_output_chat: ChatHuggingFace,
+) -> None:
+    """Test that Pydantic schemas are supported with function calling."""
+    structured_llm = structured_output_chat.with_structured_output(_Joke)
+    with patch.object(
+        ChatHuggingFace,
+        "_generate",
+        return_value=ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "_Joke",
+                                "args": {
+                                    "setup": "Why did the chicken cross the road?",
+                                    "punchline": "To get to the other side.",
+                                },
+                                "id": "call_1",
+                            }
+                        ],
+                    )
+                )
+            ]
+        ),
+    ):
+        result = structured_llm.invoke("Tell me a joke.")
+    assert isinstance(result, _Joke)
+    assert result.setup == "Why did the chicken cross the road?"
+    assert result.punchline == "To get to the other side."
+
+
+def test_with_structured_output_pydantic_json_mode(
+    structured_output_chat: ChatHuggingFace,
+) -> None:
+    """Test that Pydantic schemas are supported with json mode."""
+    structured_llm = structured_output_chat.with_structured_output(
+        _Joke, method="json_mode"
+    )
+    with patch.object(
+        ChatHuggingFace,
+        "_generate",
+        return_value=ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content=json.dumps(
+                            {
+                                "setup": "Why did the chicken cross the road?",
+                                "punchline": "To get to the other side.",
+                            }
+                        )
+                    )
+                )
+            ]
+        ),
+    ):
+        result = structured_llm.invoke("Tell me a joke.")
+    assert isinstance(result, _Joke)
+    assert result.setup == "Why did the chicken cross the road?"
+    assert result.punchline == "To get to the other side."
+
+
+def test_with_structured_output_pydantic_json_schema(
+    structured_output_chat: ChatHuggingFace,
+) -> None:
+    """Test that Pydantic schemas are supported with json schema mode."""
+    structured_llm = structured_output_chat.with_structured_output(
+        _Joke, method="json_schema"
+    )
+    with patch.object(
+        ChatHuggingFace,
+        "_generate",
+        return_value=ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content=json.dumps(
+                            {
+                                "setup": "Why did the chicken cross the road?",
+                                "punchline": "To get to the other side.",
+                            }
+                        )
+                    )
+                )
+            ]
+        ),
+    ):
+        result = structured_llm.invoke("Tell me a joke.")
+    assert isinstance(result, _Joke)
+    assert result.setup == "Why did the chicken cross the road?"
+    assert result.punchline == "To get to the other side."
+
+
+def test_with_structured_output_dict_function_calling(
+    structured_output_chat: ChatHuggingFace,
+) -> None:
+    """Test that dict schemas still return dicts with function calling."""
+    schema = {
+        "name": "_Joke",
+        "description": "A joke with a setup and a punchline.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "setup": {"type": "string"},
+                "punchline": {"type": "string"},
+            },
+            "required": ["setup", "punchline"],
+        },
+    }
+    structured_llm = structured_output_chat.with_structured_output(schema)
+    with patch.object(
+        ChatHuggingFace,
+        "_generate",
+        return_value=ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "_Joke",
+                                "args": {
+                                    "setup": "Why did the chicken cross the road?",
+                                    "punchline": "To get to the other side.",
+                                },
+                                "id": "call_1",
+                            }
+                        ],
+                    )
+                )
+            ]
+        ),
+    ):
+        result = structured_llm.invoke("Tell me a joke.")
+    assert isinstance(result, dict)
+    assert result["setup"] == "Why did the chicken cross the road?"
+    assert result["punchline"] == "To get to the other side."
+
+
+def test_with_structured_output_include_raw_pydantic(
+    structured_output_chat: ChatHuggingFace,
+) -> None:
+    """Test that include_raw returns the raw message and parsed output."""
+    structured_llm = structured_output_chat.with_structured_output(
+        _Joke, include_raw=True
+    )
+    with patch.object(
+        ChatHuggingFace,
+        "_generate",
+        return_value=ChatResult(
+            generations=[
+                ChatGeneration(
+                    message=AIMessage(
+                        content="",
+                        tool_calls=[
+                            {
+                                "name": "_Joke",
+                                "args": {
+                                    "setup": "Why did the chicken cross the road?",
+                                    "punchline": "To get to the other side.",
+                                },
+                                "id": "call_1",
+                            }
+                        ],
+                    )
+                )
+            ]
+        ),
+    ):
+        result = structured_llm.invoke("Tell me a joke.")
+    assert isinstance(result["raw"], AIMessage)
+    assert isinstance(result["parsed"], _Joke)
+    assert result["parsing_error"] is None


### PR DESCRIPTION
Fixes #32197

`ChatHuggingFace.with_structured_output()` documented support for Pydantic schemas, but the implementation did not handle them consistently. Passing a Pydantic model with `function_calling` raised `NotImplementedError`, while `json_mode` and `json_schema` returned unvalidated dictionaries. This change adds full Pydantic support across all structured output methods by parsing and validating model outputs into Pydantic instances, while preserving the existing behavior for dict, JSON Schema, and TypedDict inputs.

## Release note

`ChatHuggingFace.with_structured_output()` now supports Pydantic output schemas for `function_calling`, `json_mode`, and `json_schema`. When a Pydantic model is provided, the model output is parsed and validated into an instance of that model instead of raising `NotImplementedError` or returning an unvalidated dictionary.

## How did you verify your code works?

- Added unit tests covering Pydantic support for `function_calling`, `json_mode`, and `json_schema`.
- Added regression tests for dict schemas and `include_raw=True`.
- Updated the integration test overrides so Pydantic structured output is exercised as a supported schema type.
- Ran the relevant test suite to verify the new behavior and ensure existing functionality remains unchanged.
