### PR TITLE
fix(langchain): inconsistencies between `PIIMiddleware`'s state hooks

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/pii.py
+++ b/libs/langchain_v1/langchain/agents/middleware/pii.py
@@ -54,11 +54,8 @@ def _redact_tool_call_list(
 ) -> tuple[list[Any], bool]:
     """Walk a list of tool-call (or invalid-tool-call) dicts.
 
-    Returns `(new_list, changed)`. Each element's `args` is run through
-    `_redact_value` regardless of its type — `tool_call.args` is a dict,
-    `invalid_tool_call.args` is a raw JSON string, and `_redact_value`
-    handles both shapes uniformly. If nothing changed, returns the input
-    list and `changed=False`.
+    Returns `(new_list, changed)`. Redacts each element's `args` (dict or JSON
+    string) via `_redact_value`. If nothing changes, returns the original list.
     """
     if not calls:
         return calls or [], False
@@ -80,25 +77,13 @@ def _redact_tool_call_list(
 def _redact_value(rule: ResolvedRedactionRule, value: Any) -> Any:
     """Recursively redact PII in string leaves of a nested structure.
 
-    Returns a new value where every `str` leaf that contains PII has
-    been replaced (or emptied under `block`). Non-string leaves and
-    the structure itself are preserved.
+    Returns a copy with PII redacted from string values while preserving the
+    original structure.
 
-    `BaseMessage` payloads (typically `ToolMessage` from
-    `tool-finished.output`, or any message reached via the `values`
-    channel, or a message acted on directly by a state-level hook)
-    return a fresh copy with `.content` redacted plus
-    `AIMessage.tool_calls[*].args` / `invalid_tool_calls[*].args`
-    walked. The original object stays intact unless the caller applies
-    the returned copy.
-
-    Scope mirrors the pre-streaming state-level surfaces:
-    `.content` (string or list-of-content-blocks) and `tool_calls`
-    args. Other message attributes (`additional_kwargs`,
-    `response_metadata`, `ToolMessage.artifact`) are intentionally
-    not walked here — they aren't scrubbed in graph state by the
-    existing hooks, so scrubbing them on the wire would create
-    a wire/state divergence.
+    For `BaseMessage`s, redacts `.content` and
+    `AIMessage.tool_calls[*].args`/`invalid_tool_calls[*].args`. Other message
+    fields are intentionally left untouched to match the existing state-level
+    redaction behavior.
     """
     if isinstance(value, str):
         if not value:
@@ -107,7 +92,7 @@ def _redact_value(rule: ResolvedRedactionRule, value: Any) -> Any:
         if not matches:
             return value
         # `apply_strategy` raises `PIIDetectionError` under `block`
-        # — the run fails immediately rather than buffering until a
+        #  the run fails immediately rather than buffering until a
         # state-level hook can raise.
         return apply_strategy(value, matches, rule.strategy)
     if isinstance(value, BaseMessage):
@@ -143,12 +128,9 @@ def _redact_base_message(rule: ResolvedRedactionRule, value: _MessageT) -> _Mess
         if redacted_content != content:
             update["content"] = redacted_content
 
-    # `AIMessage.tool_calls` and `.invalid_tool_calls` carry PII in
-    # `args` independently of `.content`. `tool_call.args` is a
-    # dict; `invalid_tool_call.args` is a raw JSON string —
-    # `_redact_value` handles both shapes via the recursion. This also
-    # covers tool-call-only messages (`content == ""`) since it runs
-    # unconditionally, not just when `.content` is truthy.
+    # Redact `AIMessage.tool_calls[*].args` and
+    # `invalid_tool_calls[*].args` independently of `.content`. This also
+    # covers tool-call-only messages (`content == ""`).
     if isinstance(value, AIMessage):
         new_tc_list, tc_changed = _redact_tool_call_list(rule, value.tool_calls)
         if tc_changed:
@@ -725,9 +707,8 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                     break
 
             if last_user_idx is not None and last_user_msg is not None:
-                # `_redact_base_message` is the same recursive redactor the
-                # streaming transformer uses, so structured content stays
-                # structured and other message attributes are preserved.
+                # Reuse the same recursive redactor as the streaming transformer, preserving
+                # structured content and other message attributes.
                 updated_message = _redact_base_message(self._resolved_rule, last_user_msg)
                 if updated_message is not last_user_msg:
                     new_messages[last_user_idx] = updated_message
@@ -817,10 +798,8 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
         if last_ai_idx is None or last_ai_msg is None:
             return None
 
-        # `_redact_base_message` walks `.content` (string or structured
-        # content blocks) and `tool_calls[*].args` regardless of whether
-        # `.content` is empty, so tool-call-only assistant messages are
-        # still checked for PII in their tool-call arguments.
+        # `_redact_base_message` redacts both `.content` and `tool_calls[*].args`,
+        # including tool-call-only messages with empty `.content`.
         updated_message = _redact_base_message(self._resolved_rule, last_ai_msg)
         if updated_message is last_ai_msg:
             return None

--- a/libs/langchain_v1/langchain/agents/middleware/pii.py
+++ b/libs/langchain_v1/langchain/agents/middleware/pii.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 
-from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langgraph.stream import StreamTransformer
 from typing_extensions import override
 
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
     from langgraph.stream._types import ProtocolEvent
 
 
+_MessageT = TypeVar("_MessageT", bound=BaseMessage)
+
 _DEFAULT_STREAM_LOOKBACK = 128
 """Default trailing-buffer size for cross-delta PII detection.
 
@@ -45,6 +47,119 @@ before any text is released downstream. 128 comfortably covers the built-in
 detectors (the credit-card regex tops out at 19 characters; URLs and emails
 are typically well under 100) while bounding first-token latency.
 """
+
+
+def _redact_tool_call_list(
+    rule: ResolvedRedactionRule, calls: list[Any] | None
+) -> tuple[list[Any], bool]:
+    """Walk a list of tool-call (or invalid-tool-call) dicts.
+
+    Returns `(new_list, changed)`. Each element's `args` is run through
+    `_redact_value` regardless of its type — `tool_call.args` is a dict,
+    `invalid_tool_call.args` is a raw JSON string, and `_redact_value`
+    handles both shapes uniformly. If nothing changed, returns the input
+    list and `changed=False`.
+    """
+    if not calls:
+        return calls or [], False
+    new_calls: list[Any] = []
+    changed = False
+    for tc in calls:
+        if isinstance(tc, dict) and "args" in tc and tc["args"] is not None:
+            redacted = _redact_value(rule, tc["args"])
+            if redacted != tc["args"]:
+                new_tc = dict(tc)
+                new_tc["args"] = redacted
+                new_calls.append(new_tc)
+                changed = True
+                continue
+        new_calls.append(tc)
+    return new_calls, changed
+
+
+def _redact_value(rule: ResolvedRedactionRule, value: Any) -> Any:
+    """Recursively redact PII in string leaves of a nested structure.
+
+    Returns a new value where every `str` leaf that contains PII has
+    been replaced (or emptied under `block`). Non-string leaves and
+    the structure itself are preserved.
+
+    `BaseMessage` payloads (typically `ToolMessage` from
+    `tool-finished.output`, or any message reached via the `values`
+    channel, or a message acted on directly by a state-level hook)
+    return a fresh copy with `.content` redacted plus
+    `AIMessage.tool_calls[*].args` / `invalid_tool_calls[*].args`
+    walked. The original object stays intact unless the caller applies
+    the returned copy.
+
+    Scope mirrors the pre-streaming state-level surfaces:
+    `.content` (string or list-of-content-blocks) and `tool_calls`
+    args. Other message attributes (`additional_kwargs`,
+    `response_metadata`, `ToolMessage.artifact`) are intentionally
+    not walked here — they aren't scrubbed in graph state by the
+    existing hooks, so scrubbing them on the wire would create
+    a wire/state divergence.
+    """
+    if isinstance(value, str):
+        if not value:
+            return value
+        matches = rule.detector(value)
+        if not matches:
+            return value
+        # `apply_strategy` raises `PIIDetectionError` under `block`
+        # — the run fails immediately rather than buffering until a
+        # state-level hook can raise.
+        return apply_strategy(value, matches, rule.strategy)
+    if isinstance(value, BaseMessage):
+        return _redact_base_message(rule, value)
+    if isinstance(value, dict):
+        return {k: _redact_value(rule, v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_value(rule, v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_redact_value(rule, v) for v in value)
+    return value
+
+
+def _redact_base_message(rule: ResolvedRedactionRule, value: _MessageT) -> _MessageT:
+    """Return a fresh copy of `value` with PII-carrying surfaces redacted.
+
+    Shared by the streaming transformer and the state-level
+    `before_model` / `after_model` hooks so both paths redact the same
+    message surfaces the same way. Returns `value` unchanged (same
+    object) when nothing needs redacting.
+    """
+    update: dict[str, Any] = {}
+
+    content = value.content
+    if isinstance(content, str) and content:
+        matches = rule.detector(content)
+        if matches:
+            update["content"] = apply_strategy(content, matches, rule.strategy)
+    elif isinstance(content, list) and content:
+        # Structured content-blocks shape:
+        # `[{"type": "text", "text": "..."}, {"type": "tool_call", ...}, ...]`.
+        redacted_content = _redact_value(rule, content)
+        if redacted_content != content:
+            update["content"] = redacted_content
+
+    # `AIMessage.tool_calls` and `.invalid_tool_calls` carry PII in
+    # `args` independently of `.content`. `tool_call.args` is a
+    # dict; `invalid_tool_call.args` is a raw JSON string —
+    # `_redact_value` handles both shapes via the recursion. This also
+    # covers tool-call-only messages (`content == ""`) since it runs
+    # unconditionally, not just when `.content` is truthy.
+    if isinstance(value, AIMessage):
+        new_tc_list, tc_changed = _redact_tool_call_list(rule, value.tool_calls)
+        if tc_changed:
+            update["tool_calls"] = new_tc_list
+        new_inv_list, inv_changed = _redact_tool_call_list(rule, value.invalid_tool_calls)
+        if inv_changed:
+            update["invalid_tool_calls"] = new_inv_list
+
+    if not update:
+        return value
+    return value.model_copy(update=update)
 
 
 class _PIIStreamTransformer(StreamTransformer):
@@ -131,7 +246,7 @@ class _PIIStreamTransformer(StreamTransformer):
         # `_redact_base_message` raises `PIIDetectionError` via
         # `apply_strategy` before we get here.
         if isinstance(payload, BaseMessage):
-            redacted = self._redact_base_message(payload)
+            redacted = _redact_base_message(self._rule, payload)
             if redacted is not payload:
                 params["data"] = (redacted, metadata)
             return True
@@ -217,105 +332,13 @@ class _PIIStreamTransformer(StreamTransformer):
         elif isinstance(delta, (dict, list)):
             data["delta"] = self._redact_value(delta)
 
-    def _redact_tool_call_list(self, calls: list[Any] | None) -> tuple[list[Any], bool]:
-        """Walk a list of tool-call (or invalid-tool-call) dicts.
-
-        Returns `(new_list, changed)`. Each element's `args` is run
-        through `_redact_value` regardless of its type — `tool_call.args`
-        is a dict, `invalid_tool_call.args` is a raw JSON string, and
-        `_redact_value` handles both shapes uniformly. If nothing
-        changed, returns the input list and `changed=False`.
-        """
-        if not calls:
-            return calls or [], False
-        new_calls: list[Any] = []
-        changed = False
-        for tc in calls:
-            if isinstance(tc, dict) and "args" in tc and tc["args"] is not None:
-                redacted = self._redact_value(tc["args"])
-                if redacted != tc["args"]:
-                    new_tc = dict(tc)
-                    new_tc["args"] = redacted
-                    new_calls.append(new_tc)
-                    changed = True
-                    continue
-            new_calls.append(tc)
-        return new_calls, changed
-
     def _redact_value(self, value: Any) -> Any:
-        """Recursively redact PII in string leaves of a nested structure.
+        """Recursively redact PII using this transformer's resolved rule.
 
-        Returns a new value where every `str` leaf that contains PII has
-        been replaced (or emptied under `block`). Non-string leaves and
-        the structure itself are preserved.
-
-        `BaseMessage` payloads (typically `ToolMessage` from
-        `tool-finished.output`, or any message reached via the `values`
-        channel) return a fresh copy with `.content` redacted plus
-        `AIMessage.tool_calls[*].args` / `invalid_tool_calls[*].args`
-        walked. The original object stays intact for state-level
-        enforcers (`after_model`, `before_model` with
-        `apply_to_tool_results`) to act on independently.
-
-        Scope mirrors the pre-streaming state-level surfaces:
-        `.content` (string or list-of-content-blocks) and `tool_calls`
-        args. Other message attributes (`additional_kwargs`,
-        `response_metadata`, `ToolMessage.artifact`) are intentionally
-        not walked here — they aren't scrubbed in graph state by the
-        existing hooks, so scrubbing them on the wire would create
-        a wire/state divergence.
+        Thin wrapper around the module-level `_redact_value` shared with
+        `PIIMiddleware.before_model` / `after_model`.
         """
-        if isinstance(value, str):
-            if not value:
-                return value
-            matches = self._rule.detector(value)
-            if not matches:
-                return value
-            # `apply_strategy` raises `PIIDetectionError` under `block`
-            # — the run fails immediately rather than buffering until a
-            # state-level hook can raise.
-            return apply_strategy(value, matches, self._rule.strategy)
-        if isinstance(value, BaseMessage):
-            return self._redact_base_message(value)
-        if isinstance(value, dict):
-            return {k: self._redact_value(v) for k, v in value.items()}
-        if isinstance(value, list):
-            return [self._redact_value(v) for v in value]
-        if isinstance(value, tuple):
-            return tuple(self._redact_value(v) for v in value)
-        return value
-
-    def _redact_base_message(self, value: BaseMessage) -> BaseMessage:
-        """Return a fresh copy of `value` with PII-carrying surfaces redacted."""
-        update: dict[str, Any] = {}
-
-        content = value.content
-        if isinstance(content, str) and content:
-            matches = self._rule.detector(content)
-            if matches:
-                update["content"] = apply_strategy(content, matches, self._rule.strategy)
-        elif isinstance(content, list) and content:
-            # Structured content-blocks shape:
-            # `[{"type": "text", "text": "..."}, {"type": "tool_call", ...}, ...]`.
-            redacted_content = self._redact_value(content)
-            if redacted_content != content:
-                update["content"] = redacted_content
-
-        # `AIMessage.tool_calls` and `.invalid_tool_calls` carry PII in
-        # `args` independently of `.content`. `tool_call.args` is a
-        # dict; `invalid_tool_call.args` is a raw JSON string —
-        # `_redact_value` handles both shapes via the recursion.
-        if isinstance(value, AIMessage):
-            new_tc_list, tc_changed = self._redact_tool_call_list(value.tool_calls)
-            if tc_changed:
-                update["tool_calls"] = new_tc_list
-            new_inv_list, inv_changed = self._redact_tool_call_list(value.invalid_tool_calls)
-            if inv_changed:
-                update["invalid_tool_calls"] = new_inv_list
-
-        if not update:
-            return value
-        return value.model_copy(update=update)
+        return _redact_value(self._rule, value)
 
     def _mutate_delta(self, payload: dict[str, Any], run_id: str) -> None:
         delta = payload.get("delta")
@@ -660,14 +683,6 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
         """Name of the middleware."""
         return f"{self.__class__.__name__}[{self.pii_type}]"
 
-    def _process_content(self, content: str) -> tuple[str, list[PIIMatch]]:
-        """Apply the configured redaction rule to the provided content."""
-        matches = self.detector(content)
-        if not matches:
-            return content, []
-        sanitized = apply_strategy(content, matches, self.strategy)
-        return sanitized, matches
-
     @hook_config(can_jump_to=["end"])
     @override
     def before_model(
@@ -709,18 +724,12 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                     last_user_idx = i
                     break
 
-            if last_user_idx is not None and last_user_msg and last_user_msg.content:
-                # Detect PII in message content
-                content = str(last_user_msg.content)
-                new_content, matches = self._process_content(content)
-
-                if matches:
-                    updated_message: AnyMessage = HumanMessage(
-                        content=new_content,
-                        id=last_user_msg.id,
-                        name=last_user_msg.name,
-                    )
-
+            if last_user_idx is not None and last_user_msg is not None:
+                # `_redact_base_message` is the same recursive redactor the
+                # streaming transformer uses, so structured content stays
+                # structured and other message attributes are preserved.
+                updated_message = _redact_base_message(self._resolved_rule, last_user_msg)
+                if updated_message is not last_user_msg:
                     new_messages[last_user_idx] = updated_message
                     any_modified = True
 
@@ -738,26 +747,10 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                 for i in range(last_ai_idx + 1, len(messages)):
                     msg = messages[i]
                     if isinstance(msg, ToolMessage):
-                        tool_msg = msg
-                        if not tool_msg.content:
-                            continue
-
-                        content = str(tool_msg.content)
-                        new_content, matches = self._process_content(content)
-
-                        if not matches:
-                            continue
-
-                        # Create updated tool message
-                        updated_message = ToolMessage(
-                            content=new_content,
-                            id=tool_msg.id,
-                            name=tool_msg.name,
-                            tool_call_id=tool_msg.tool_call_id,
-                        )
-
-                        new_messages[i] = updated_message
-                        any_modified = True
+                        updated_message = _redact_base_message(self._resolved_rule, msg)
+                        if updated_message is not msg:
+                            new_messages[i] = updated_message
+                            any_modified = True
 
         if any_modified:
             return {"messages": new_messages}
@@ -821,23 +814,16 @@ class PIIMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT])
                 last_ai_idx = i
                 break
 
-        if last_ai_idx is None or not last_ai_msg or not last_ai_msg.content:
+        if last_ai_idx is None or last_ai_msg is None:
             return None
 
-        # Detect PII in message content
-        content = str(last_ai_msg.content)
-        new_content, matches = self._process_content(content)
-
-        if not matches:
+        # `_redact_base_message` walks `.content` (string or structured
+        # content blocks) and `tool_calls[*].args` regardless of whether
+        # `.content` is empty, so tool-call-only assistant messages are
+        # still checked for PII in their tool-call arguments.
+        updated_message = _redact_base_message(self._resolved_rule, last_ai_msg)
+        if updated_message is last_ai_msg:
             return None
-
-        # Create updated message
-        updated_message = AIMessage(
-            content=new_content,
-            id=last_ai_msg.id,
-            name=last_ai_msg.name,
-            tool_calls=last_ai_msg.tool_calls,
-        )
 
         # Return updated messages
         new_messages = list(messages)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -508,6 +508,59 @@ class TestPIIMiddlewareIntegration:
         assert exc_info.value.pii_type == "email"
         assert len(exc_info.value.matches) == 1
 
+    def test_after_model_redacts_tool_call_only_ai_message(self) -> None:
+        """`after_model` must redact `tool_calls[*].args`, even with empty `.content`.
+
+        Regression test for the state hook previously skipping
+        `AIMessage(content="", tool_calls=[...])` entirely because it
+        only checked `last_ai_msg.content` for truthiness.
+        """
+        middleware = PIIMiddleware("email", strategy="redact", apply_to_output=True)
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                ToolCall(name="send_email", args={"to": "alice@example.com"}, id="c1"),
+            ],
+        )
+        state = AgentState[Any](messages=[HumanMessage("hi"), msg])
+
+        result = middleware.after_model(state, Runtime())
+
+        assert result is not None
+        redacted = result["messages"][-1]
+        assert redacted.tool_calls[0]["args"] == {"to": "[REDACTED_EMAIL]"}
+
+    def test_before_model_preserves_structured_content_blocks(self) -> None:
+        """`before_model` must keep structured content as a list of blocks.
+
+        Regression test for the state hook previously calling
+        `str(message.content)`, which stringified content-block lists
+        into a Python repr instead of redacting the text in place.
+        """
+        middleware = PIIMiddleware("email", strategy="redact", apply_to_input=True)
+        msg = HumanMessage(content=[{"type": "text", "text": "Reach me at alice@example.com"}])
+        state = AgentState[Any](messages=[msg])
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        redacted = result["messages"][0]
+        assert isinstance(redacted.content, list)
+        assert redacted.content[0]["text"] == "Reach me at [REDACTED_EMAIL]"
+
+    def test_after_model_preserves_structured_content_blocks(self) -> None:
+        """`after_model` must keep structured content as a list of blocks."""
+        middleware = PIIMiddleware("email", strategy="redact", apply_to_output=True)
+        msg = AIMessage(content=[{"type": "text", "text": "My email is ai@example.com"}])
+        state = AgentState[Any](messages=[HumanMessage("hi"), msg])
+
+        result = middleware.after_model(state, Runtime())
+
+        assert result is not None
+        redacted = result["messages"][-1]
+        assert isinstance(redacted.content, list)
+        assert redacted.content[0]["text"] == "My email is [REDACTED_EMAIL]"
+
     def test_with_agent(self) -> None:
         """Test PIIMiddleware integrated with create_agent."""
         model = FakeToolCallingModel()


### PR DESCRIPTION
Closes #37659

Fixes two inconsistencies between `PIIMiddleware`'s state hooks and the recursive redactor introduced for streaming in #37616:

- Tool-call-only `AIMessage`s (`content == ""`) were skipped, leaving `tool_calls[*].args` unredacted.
- Structured content blocks were stringified instead of being redacted in place.

`before_model` and `after_model` now reuse the shared `_redact_base_message` helper, so tool-call arguments are always redacted and structured content is preserved.