### PR TITLE
fix(langchain): persist `ClearToolUsesEdit` clears via `after_model`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/context_editing.py
+++ b/libs/langchain_v1/langchain/agents/middleware/context_editing.py
@@ -10,9 +10,8 @@ chat model.
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Iterable, Sequence
-from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Literal
 
 from langchain_core.messages import (
     AIMessage,
@@ -21,19 +20,18 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from langchain_core.messages.utils import count_tokens_approximately
-from typing_extensions import Protocol, override
+from langgraph.types import Command
+from typing_extensions import Protocol
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
     AgentState,
     ContextT,
+    ExtendedModelResponse,
     ModelRequest,
     ModelResponse,
     ResponseT,
 )
-
-if TYPE_CHECKING:
-    from langgraph.runtime import Runtime
 
 DEFAULT_TOOL_PLACEHOLDER = "[cleared]"
 
@@ -191,7 +189,10 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
     """Automatically prune tool results to manage context size.
 
     The middleware applies a sequence of edits when the total input token count exceeds
-    configured thresholds.
+    configured thresholds. Messages an edit changes are persisted back to agent
+    state (via a `Command` update), so a configured checkpointer observes the
+    same cleared tool results the model saw, and subsequent turns' idempotency
+    checks (e.g. `ClearToolUsesEdit`'s `cleared` flag) see accurate history.
 
     Currently the `ClearToolUsesEdit` strategy is supported, aligning with Anthropic's
     `clear_tool_uses_20250919` behavior [(read more)](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool).
@@ -224,7 +225,7 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
         self,
         request: ModelRequest[ContextT],
         handler: Callable[[ModelRequest[ContextT]], ModelResponse[ResponseT]],
-    ) -> ModelResponse[ResponseT] | AIMessage:
+    ) -> ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]:
         """Apply context edits before invoking the model via handler.
 
         Args:
@@ -234,34 +235,27 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
 
         Returns:
             The result of invoking the handler with potentially edited messages.
+            When an edit changes any message, the changed messages are also
+            returned as a `Command` update so the checkpointer persists them
+            (see `_with_persisted_edits`).
         """
         if not request.messages:
             return handler(request)
 
-        if self.token_count_method == "approximate":  # noqa: S105
+        count_tokens = self._make_token_counter(request)
 
-            def count_tokens(messages: Sequence[BaseMessage]) -> int:
-                return count_tokens_approximately(messages)
-
-        else:
-            system_msg = [request.system_message] if request.system_message else []
-
-            def count_tokens(messages: Sequence[BaseMessage]) -> int:
-                return request.model.get_num_tokens_from_messages(
-                    system_msg + list(messages), request.tools
-                )
-
-        edited_messages = deepcopy(list(request.messages))
+        edited_messages = list(request.messages)
         for edit in self.edits:
             edit.apply(edited_messages, count_tokens=count_tokens)
 
-        return handler(request.override(messages=edited_messages))
+        response = handler(request.override(messages=edited_messages))
+        return self._with_persisted_edits(response, request.messages, edited_messages)
 
     async def awrap_model_call(
         self,
         request: ModelRequest[ContextT],
         handler: Callable[[ModelRequest[ContextT]], Awaitable[ModelResponse[ResponseT]]],
-    ) -> ModelResponse[ResponseT] | AIMessage:
+    ) -> ModelResponse[ResponseT] | AIMessage | ExtendedModelResponse[ResponseT]:
         """Apply context edits before invoking the model via handler.
 
         Args:
@@ -271,10 +265,24 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
 
         Returns:
             The result of invoking the handler with potentially edited messages.
+            When an edit changes any message, the changed messages are also
+            returned as a `Command` update so the checkpointer persists them
+            (see `_with_persisted_edits`).
         """
         if not request.messages:
             return await handler(request)
 
+        count_tokens = self._make_token_counter(request)
+
+        edited_messages = list(request.messages)
+        for edit in self.edits:
+            edit.apply(edited_messages, count_tokens=count_tokens)
+
+        response = await handler(request.override(messages=edited_messages))
+        return self._with_persisted_edits(response, request.messages, edited_messages)
+
+    def _make_token_counter(self, request: ModelRequest[ContextT]) -> TokenCounter:
+        """Build the token counter for `request`, per `self.token_count_method`."""
         if self.token_count_method == "approximate":  # noqa: S105
 
             def count_tokens(messages: Sequence[BaseMessage]) -> int:
@@ -288,80 +296,39 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
                     system_msg + list(messages), request.tools
                 )
 
-        edited_messages = deepcopy(list(request.messages))
-        for edit in self.edits:
-            edit.apply(edited_messages, count_tokens=count_tokens)
+        return count_tokens
 
-        return await handler(request.override(messages=edited_messages))
+    @staticmethod
+    def _with_persisted_edits(
+        response: ModelResponse[ResponseT],
+        original_messages: Sequence[AnyMessage],
+        edited_messages: Sequence[AnyMessage],
+    ) -> ModelResponse[ResponseT] | ExtendedModelResponse[ResponseT]:
+        """Wrap `response` with a `Command` persisting any messages edits changed.
 
-    @override
-    def after_model(
-        self,
-        state: AgentState[Any],
-        runtime: Runtime[ContextT],
-    ) -> dict[str, Any] | None:
-        """Persist context edits so the checkpointer observes cleared tool results.
-
-        `wrap_model_call` only edits a deep copy for the outgoing model
-        request, so a persistent checkpointer never sees the placeholder
-        content or the `cleared` flag `ClearToolUsesEdit.apply` sets — every
-        subsequent turn re-loads the full, never-cleared history, and the
-        trigger check (`count_tokens(messages) <= trigger`) stays permanently
-        false once first crossed. Re-running the edits here against the real
-        state and returning the changed messages lets the checkpointer store
-        the placeholders, so the next turn's raw token count reflects them
-        and the `cleared` flag can actually skip already-cleared messages.
-
-        Args:
-            state: The current agent state.
-            runtime: The langgraph runtime.
-
-        Returns:
-            Updated state with cleared tool results persisted, or `None` if
-                no edit changed anything.
+        `edited_messages` is built from a shallow copy of `original_messages`,
+        so edits that don't touch a given message leave that slot referencing
+        the identical object; only messages `ClearToolUsesEdit.apply` actually
+        replaced (via `model_copy`) differ by identity. Persisting exactly
+        those messages — decided using the same `count_tokens` as the request
+        that was actually sent to the model — keeps the checkpointer's view
+        consistent with what the model saw, regardless of `token_count_method`.
+        Without this, a persistence pass that recomputed edits with a
+        different counter could disagree with `wrap_model_call`'s decision
+        and either skip persisting a clear that was applied, or persist one
+        that wasn't.
         """
-        return self._persist_edits(state["messages"])
-
-    async def aafter_model(
-        self,
-        state: AgentState[Any],
-        runtime: Runtime[ContextT],
-    ) -> dict[str, Any] | None:
-        """Persist context edits so the checkpointer observes cleared tool results.
-
-        Args:
-            state: The current agent state.
-            runtime: The langgraph runtime.
-
-        Returns:
-            Updated state with cleared tool results persisted, or `None` if
-                no edit changed anything.
-        """
-        return self.after_model(state, runtime)
-
-    def _persist_edits(self, messages: list[AnyMessage]) -> dict[str, Any] | None:
-        """Re-apply edits to a copy of `messages` and diff for a state update.
-
-        Uses `count_tokens_approximately` regardless of `token_count_method`
-        since no chat model is available outside of a model call; this only
-        affects the persistence decision, not the token counting used to
-        build the outgoing model request in `wrap_model_call`.
-        """
-        if not messages:
-            return None
-
-        edited_messages = list(messages)
-        for edit in self.edits:
-            edit.apply(edited_messages, count_tokens=count_tokens_approximately)
-
         changed = [
             new_msg
-            for old_msg, new_msg in zip(messages, edited_messages, strict=True)
+            for old_msg, new_msg in zip(original_messages, edited_messages, strict=True)
             if new_msg is not old_msg
         ]
         if not changed:
-            return None
-        return {"messages": changed}
+            return response
+        return ExtendedModelResponse(
+            model_response=response,
+            command=Command(update={"messages": changed}),
+        )
 
 
 __all__ = [

--- a/libs/langchain_v1/langchain/agents/middleware/context_editing.py
+++ b/libs/langchain_v1/langchain/agents/middleware/context_editing.py
@@ -317,7 +317,18 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
         different counter could disagree with `wrap_model_call`'s decision
         and either skip persisting a clear that was applied, or persist one
         that wasn't.
+
+        `ContextEdit.apply` is only required to mutate `messages` in place —
+        custom strategies are free to insert or remove entries, not just
+        replace them one-for-one. A same-length assumption would either raise
+        (pairing up mismatched indices) or silently mismatch messages, so this
+        only persists when the edit preserved length; otherwise the edited
+        request still reaches the model exactly as before, just without the
+        persistence benefit for that edit.
         """
+        if len(original_messages) != len(edited_messages):
+            return response
+
         changed = [
             new_msg
             for old_msg, new_msg in zip(original_messages, edited_messages, strict=True)

--- a/libs/langchain_v1/langchain/agents/middleware/context_editing.py
+++ b/libs/langchain_v1/langchain/agents/middleware/context_editing.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Iterable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from langchain_core.messages import (
     AIMessage,
@@ -21,7 +21,7 @@ from langchain_core.messages import (
     ToolMessage,
 )
 from langchain_core.messages.utils import count_tokens_approximately
-from typing_extensions import Protocol
+from typing_extensions import Protocol, override
 
 from langchain.agents.middleware.types import (
     AgentMiddleware,
@@ -31,6 +31,9 @@ from langchain.agents.middleware.types import (
     ModelResponse,
     ResponseT,
 )
+
+if TYPE_CHECKING:
+    from langgraph.runtime import Runtime
 
 DEFAULT_TOOL_PLACEHOLDER = "[cleared]"
 
@@ -290,6 +293,75 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
             edit.apply(edited_messages, count_tokens=count_tokens)
 
         return await handler(request.override(messages=edited_messages))
+
+    @override
+    def after_model(
+        self,
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Persist context edits so the checkpointer observes cleared tool results.
+
+        `wrap_model_call` only edits a deep copy for the outgoing model
+        request, so a persistent checkpointer never sees the placeholder
+        content or the `cleared` flag `ClearToolUsesEdit.apply` sets — every
+        subsequent turn re-loads the full, never-cleared history, and the
+        trigger check (`count_tokens(messages) <= trigger`) stays permanently
+        false once first crossed. Re-running the edits here against the real
+        state and returning the changed messages lets the checkpointer store
+        the placeholders, so the next turn's raw token count reflects them
+        and the `cleared` flag can actually skip already-cleared messages.
+
+        Args:
+            state: The current agent state.
+            runtime: The langgraph runtime.
+
+        Returns:
+            Updated state with cleared tool results persisted, or `None` if
+                no edit changed anything.
+        """
+        return self._persist_edits(state["messages"])
+
+    async def aafter_model(
+        self,
+        state: AgentState[Any],
+        runtime: Runtime[ContextT],
+    ) -> dict[str, Any] | None:
+        """Persist context edits so the checkpointer observes cleared tool results.
+
+        Args:
+            state: The current agent state.
+            runtime: The langgraph runtime.
+
+        Returns:
+            Updated state with cleared tool results persisted, or `None` if
+                no edit changed anything.
+        """
+        return self.after_model(state, runtime)
+
+    def _persist_edits(self, messages: list[AnyMessage]) -> dict[str, Any] | None:
+        """Re-apply edits to a copy of `messages` and diff for a state update.
+
+        Uses `count_tokens_approximately` regardless of `token_count_method`
+        since no chat model is available outside of a model call; this only
+        affects the persistence decision, not the token counting used to
+        build the outgoing model request in `wrap_model_call`.
+        """
+        if not messages:
+            return None
+
+        edited_messages = list(messages)
+        for edit in self.edits:
+            edit.apply(edited_messages, count_tokens=count_tokens_approximately)
+
+        changed = [
+            new_msg
+            for old_msg, new_msg in zip(messages, edited_messages, strict=True)
+            if new_msg is not old_msg
+        ]
+        if not changed:
+            return None
+        return {"messages": changed}
 
 
 __all__ = [

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
@@ -9,24 +9,32 @@ from langchain_core.messages import (
     AIMessage,
     AnyMessage,
     BaseMessage,
+    HumanMessage,
     MessageLikeRepresentation,
+    ToolCall,
     ToolMessage,
 )
+from langchain_core.tools import tool
+from langgraph.checkpoint.memory import InMemorySaver
 from typing_extensions import override
 
+from langchain.agents.factory import create_agent
 from langchain.agents.middleware.context_editing import (
     ClearToolUsesEdit,
     ContextEditingMiddleware,
 )
 from langchain.agents.middleware.types import (
     AgentState,
+    ExtendedModelResponse,
     ModelRequest,
     ModelResponse,
 )
+from tests.unit_tests.agents.model import FakeToolCallingModel
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from langchain_core.runnables import RunnableConfig
     from langgraph.runtime import Runtime
 
 
@@ -276,11 +284,16 @@ def _fake_runtime() -> Runtime:
     return cast("Runtime", object())
 
 
-def test_after_model_persists_cleared_tool_result() -> None:
-    """`after_model` must return a state update so the checkpointer sees the clear.
+def test_wrap_model_call_persists_edit_matching_model_request() -> None:
+    """The persisted `Command` must reuse the exact edit decided for the real request.
 
-    Regression test for the `cleared` idempotency flag being discarded
-    because `wrap_model_call` only ever edits a `deepcopy`.
+    Regression test for a review comment on #37815: a persistence pass that
+    recomputed the edit with a *different* token counter than the one used
+    to build the outgoing model request could disagree about which messages
+    to clear (e.g. under `token_count_method="model"`, where the model's
+    exact count over messages + system prompt + tools can differ from the
+    approximate, messages-only count). Persisting the identical objects that
+    were actually sent to the model rules that out structurally.
     """
     tool_call_id = "call-1"
     ai_message = AIMessage(
@@ -289,30 +302,65 @@ def test_after_model_persists_cleared_tool_result() -> None:
     )
     tool_message = ToolMessage(content="x" * 200, tool_call_id=tool_call_id)
 
-    state = cast("AgentState[Any]", {"messages": [ai_message, tool_message]})
+    _state, request = _make_state_and_request([ai_message, tool_message])
     middleware = ContextEditingMiddleware(
         edits=[ClearToolUsesEdit(trigger=50, keep=0, placeholder="[cleared]")],
+        token_count_method="model",  # noqa: S106
     )
 
-    result = middleware.after_model(state, _fake_runtime())
+    captured_request: ModelRequest | None = None
 
-    assert result is not None
-    updated_tool_message = result["messages"][0]
-    assert isinstance(updated_tool_message, ToolMessage)
-    assert updated_tool_message.id == tool_message.id
-    assert updated_tool_message.content == "[cleared]"
-    assert updated_tool_message.response_metadata["context_editing"]["cleared"] is True
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        nonlocal captured_request
+        captured_request = req
+        return ModelResponse(result=[AIMessage(content="mock response")])
 
-    # The original state's messages are untouched (new object returned).
+    result = middleware.wrap_model_call(request, mock_handler)
+
+    assert captured_request is not None
+    sent_tool_message = captured_request.messages[1]
+    assert isinstance(sent_tool_message, ToolMessage)
+    assert sent_tool_message.content == "[cleared]"
+
+    assert isinstance(result, ExtendedModelResponse)
+    assert result.command is not None
+    assert result.command.update is not None
+    persisted = result.command.update["messages"]
+    assert len(persisted) == 1
+    # The persisted message is the identical object sent to the model, not a
+    # second, independently-decided copy.
+    assert persisted[0] is sent_tool_message
+
+    # The original state's messages are untouched.
     assert tool_message.content == "x" * 200
 
 
-def test_after_model_is_idempotent_across_turns() -> None:
+def test_wrap_model_call_returns_plain_response_when_no_edit_applied() -> None:
+    """Below trigger, `wrap_model_call` must not wrap the response in a `Command`."""
+    tool_call_id = "call-1"
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[{"id": tool_call_id, "name": "search", "args": {}}],
+    )
+    tool_message = ToolMessage(content="12345", tool_call_id=tool_call_id)
+
+    _state, request = _make_state_and_request([ai_message, tool_message])
+    middleware = ContextEditingMiddleware(edits=[ClearToolUsesEdit(trigger=50)])
+
+    def mock_handler(_req: ModelRequest) -> ModelResponse:
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    result = middleware.wrap_model_call(request, mock_handler)
+
+    assert isinstance(result, ModelResponse)
+
+
+def test_persisted_edit_is_idempotent_across_turns() -> None:
     """Once persisted, a later turn must not re-clear an already-cleared message.
 
-    Simulates the checkpointer round trip: apply `after_model`'s state
-    update back onto the message list (as `add_messages` would), then run
-    `after_model` again on the grown conversation.
+    Simulates the checkpointer round trip: apply `wrap_model_call`'s
+    persisted `Command` update back onto the message list (as `add_messages`
+    would), then run `wrap_model_call` again on the grown conversation.
     """
     tool_call_id = "call-1"
     ai_message = AIMessage(
@@ -325,18 +373,24 @@ def test_after_model_is_idempotent_across_turns() -> None:
         edits=[ClearToolUsesEdit(trigger=50, keep=0, placeholder="[cleared]")],
     )
 
-    state = cast("AgentState[Any]", {"messages": [ai_message, tool_message]})
-    first_result = middleware.after_model(state, _fake_runtime())
-    assert first_result is not None
+    def mock_handler(_req: ModelRequest) -> ModelResponse:
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    _state, request = _make_state_and_request([ai_message, tool_message])
+    first_result = middleware.wrap_model_call(request, mock_handler)
+    assert isinstance(first_result, ExtendedModelResponse)
+    assert first_result.command is not None
+    assert first_result.command.update is not None
 
     # Apply the persisted update, as the checkpointer/`add_messages` would.
-    messages = list(state["messages"])
-    messages[1] = first_result["messages"][0]
-    state = cast("AgentState[Any]", {"messages": messages})
+    messages = list(request.messages)
+    messages[1] = first_result.command.update["messages"][0]
 
-    # A second call against the already-persisted, cleared state changes nothing.
-    second_result = middleware.after_model(state, _fake_runtime())
-    assert second_result is None
+    # A second call against the already-persisted, cleared conversation
+    # changes nothing further.
+    _state, second_request = _make_state_and_request(cast("list[Any]", messages))
+    second_result = middleware.wrap_model_call(second_request, mock_handler)
+    assert isinstance(second_result, ModelResponse)
 
 
 async def test_no_edit_when_below_trigger_async() -> None:
@@ -531,3 +585,54 @@ async def test_exclude_tools_prevents_clearing_async() -> None:
 
     assert isinstance(calc_tool, ToolMessage)
     assert calc_tool.content == "[cleared]"
+
+
+def test_end_to_end_with_checkpointer_clears_persist_across_turns() -> None:
+    """End-to-end regression test for #37815 against a real checkpointer.
+
+    Mirrors the issue's repro: each turn appends a large tool result to a
+    persistent (`InMemorySaver`-backed) conversation. Once the trigger is
+    crossed, older tool results must show up as cleared *in the checkpointed
+    state itself* — not just in the transient request sent to the model —
+    and stay cleared rather than needing to be reprocessed every turn.
+    """
+
+    @tool
+    def big_tool(query: str) -> str:  # noqa: ARG001
+        """Return a large payload."""
+        return "x" * 2_000
+
+    model = FakeToolCallingModel(
+        tool_calls=[
+            call
+            for i in range(4)
+            for call in (
+                [ToolCall(name="big_tool", args={"query": f"q{i}"}, id=f"call_{i}")],
+                [],
+            )
+        ]
+    )
+    middleware = ContextEditingMiddleware(
+        edits=[ClearToolUsesEdit(trigger=100, keep=1, placeholder="[cleared]")],
+    )
+    agent = create_agent(
+        model=model,
+        tools=[big_tool],
+        middleware=[middleware],
+        checkpointer=InMemorySaver(),
+    )
+    config: RunnableConfig = {"configurable": {"thread_id": "context-editing-e2e"}}
+
+    for turn in range(4):
+        agent.invoke({"messages": [HumanMessage(f"turn {turn}")]}, config=config)
+
+    final_state = agent.get_state(config).values
+    tool_messages = [m for m in final_state["messages"] if isinstance(m, ToolMessage)]
+
+    assert len(tool_messages) == 4
+    # All but the most recent tool result are cleared *in checkpointed state*.
+    assert [m.content for m in tool_messages[:-1]] == ["[cleared]"] * 3
+    assert tool_messages[-1].content == "x" * 2_000
+    assert all(
+        m.response_metadata.get("context_editing", {}).get("cleared") for m in tool_messages[:-1]
+    )

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
@@ -276,6 +276,69 @@ def _fake_runtime() -> Runtime:
     return cast("Runtime", object())
 
 
+def test_after_model_persists_cleared_tool_result() -> None:
+    """`after_model` must return a state update so the checkpointer sees the clear.
+
+    Regression test for the `cleared` idempotency flag being discarded
+    because `wrap_model_call` only ever edits a `deepcopy`.
+    """
+    tool_call_id = "call-1"
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[{"id": tool_call_id, "name": "search", "args": {}}],
+    )
+    tool_message = ToolMessage(content="x" * 200, tool_call_id=tool_call_id)
+
+    state = cast("AgentState[Any]", {"messages": [ai_message, tool_message]})
+    middleware = ContextEditingMiddleware(
+        edits=[ClearToolUsesEdit(trigger=50, keep=0, placeholder="[cleared]")],
+    )
+
+    result = middleware.after_model(state, _fake_runtime())
+
+    assert result is not None
+    updated_tool_message = result["messages"][0]
+    assert isinstance(updated_tool_message, ToolMessage)
+    assert updated_tool_message.id == tool_message.id
+    assert updated_tool_message.content == "[cleared]"
+    assert updated_tool_message.response_metadata["context_editing"]["cleared"] is True
+
+    # The original state's messages are untouched (new object returned).
+    assert tool_message.content == "x" * 200
+
+
+def test_after_model_is_idempotent_across_turns() -> None:
+    """Once persisted, a later turn must not re-clear an already-cleared message.
+
+    Simulates the checkpointer round trip: apply `after_model`'s state
+    update back onto the message list (as `add_messages` would), then run
+    `after_model` again on the grown conversation.
+    """
+    tool_call_id = "call-1"
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[{"id": tool_call_id, "name": "search", "args": {}}],
+    )
+    tool_message = ToolMessage(content="x" * 200, tool_call_id=tool_call_id)
+
+    middleware = ContextEditingMiddleware(
+        edits=[ClearToolUsesEdit(trigger=50, keep=0, placeholder="[cleared]")],
+    )
+
+    state = cast("AgentState[Any]", {"messages": [ai_message, tool_message]})
+    first_result = middleware.after_model(state, _fake_runtime())
+    assert first_result is not None
+
+    # Apply the persisted update, as the checkpointer/`add_messages` would.
+    messages = list(state["messages"])
+    messages[1] = first_result["messages"][0]
+    state = cast("AgentState[Any]", {"messages": messages})
+
+    # A second call against the already-persisted, cleared state changes nothing.
+    second_result = middleware.after_model(state, _fake_runtime())
+    assert second_result is None
+
+
 async def test_no_edit_when_below_trigger_async() -> None:
     """Test async version of context editing with no edit when below trigger."""
     tool_call_id = "call-1"

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
@@ -355,6 +355,48 @@ def test_wrap_model_call_returns_plain_response_when_no_edit_applied() -> None:
     assert isinstance(result, ModelResponse)
 
 
+def test_wrap_model_call_skips_persistence_for_length_changing_edit() -> None:
+    """A length-changing custom `ContextEdit` must not crash persistence.
+
+    Regression test for a review comment on #37815: `ContextEdit.apply` is
+    only required to mutate the message list in place — it isn't required to
+    preserve length (e.g. a custom strategy could `messages.pop(0)`). Pairing
+    up messages by index to detect changes would previously raise
+    `ValueError` from a length-mismatched `zip(..., strict=True)`. The edited,
+    shortened request must still reach the model, just without persistence
+    for that edit.
+    """
+
+    class DropFirstMessageEdit:
+        """Custom edit that removes the oldest message instead of replacing it."""
+
+        def apply(self, messages: list[AnyMessage], *, count_tokens: Any) -> None:
+            del count_tokens
+            if messages:
+                messages.pop(0)
+
+    ai_message = AIMessage(content="", tool_calls=[])
+    tool_message = ToolMessage(content="x" * 200, tool_call_id="call-1")
+
+    _state, request = _make_state_and_request([ai_message, tool_message])
+    middleware = ContextEditingMiddleware(edits=[DropFirstMessageEdit()])
+
+    captured_request: ModelRequest | None = None
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        nonlocal captured_request
+        captured_request = req
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    result = middleware.wrap_model_call(request, mock_handler)
+
+    assert captured_request is not None
+    # The model still receives the shortened request.
+    assert captured_request.messages == [tool_message]
+    # No persistence is attempted for a length-changing edit.
+    assert isinstance(result, ModelResponse)
+
+
 def test_persisted_edit_is_idempotent_across_turns() -> None:
     """Once persisted, a later turn must not re-clear an already-cleared message.
 


### PR DESCRIPTION
Closes #37815

`ContextEditingMiddleware` edited only the outgoing model request, so `ClearToolUsesEdit` changes were never persisted to the checkpointer.

`wrap_model_call`/`awrap_model_call` now persist the exact edited messages via `ExtendedModelResponse` + `Command`, ensuring checkpointed state matches what the model saw. Length-changing custom edits safely fall back to the existing non-persisted behavior.