### PR TITLE
fix(langchain): cutoff fixes in `SummarizationMiddleware`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -11,6 +11,7 @@ from langchain_core.messages import (
     AnyMessage,
     MessageLikeRepresentation,
     RemoveMessage,
+    SystemMessage,
     ToolMessage,
 )
 from langchain_core.messages.human import HumanMessage
@@ -767,14 +768,35 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
 
     @staticmethod
     def _find_safe_cutoff_point(messages: list[AnyMessage], cutoff_index: int) -> int:
-        """Find a safe cutoff point that doesn't split AI/Tool message pairs.
+        """Find a safe cutoff point that doesn't split AI/Tool message pairs or turns.
 
         If the message at `cutoff_index` is a `ToolMessage`, search backward for the
-        `AIMessage` containing the corresponding `tool_calls` and adjust the cutoff to
-        include it. This ensures tool call requests and responses stay together.
+        `AIMessage`(s) containing the corresponding `tool_calls` and adjust the cutoff
+        to include them, walking back until *every* `tool_call_id` in the run is
+        covered by a preserved `AIMessage` (not just the first match). This ensures
+        tool call requests and responses stay together even when a mixed run of
+        `ToolMessage`s originates from non-contiguous `AIMessage`s.
 
-        Falls back to advancing forward past `ToolMessage` objects only if no matching
-        `AIMessage` is found (edge case).
+        Falls back to advancing forward past `ToolMessage` objects only if full
+        coverage is never reached (edge case).
+
+        Finally, if the resulting cutoff would split an in-progress assistant turn
+        that contains an Anthropic extended-thinking block (`thinking` or
+        `redacted_thinking` content block), the cutoff is snapped back to the start
+        of that turn so the required thinking block stays with the tool calls/results
+        it precedes.
+        """
+        cutoff_index = SummarizationMiddleware._find_tool_pair_safe_cutoff(messages, cutoff_index)
+        return SummarizationMiddleware._snap_cutoff_past_open_thinking_turn(messages, cutoff_index)
+
+    @staticmethod
+    def _find_tool_pair_safe_cutoff(messages: list[AnyMessage], cutoff_index: int) -> int:
+        """Adjust `cutoff_index` so it never separates a `ToolMessage` from its `AIMessage`.
+
+        If `cutoff_index` lands on a `ToolMessage`, search backward, accumulating
+        matches, until every `tool_call_id` in the consecutive `ToolMessage` run is
+        covered by some preserved `AIMessage`. Falls back to advancing past the
+        `ToolMessage` run if full coverage is never found.
         """
         if cutoff_index >= len(messages) or not isinstance(messages[cutoff_index], ToolMessage):
             return cutoff_index
@@ -788,18 +810,72 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
                 tool_call_ids.add(tool_msg.tool_call_id)
             idx += 1
 
-        # Search backward for AIMessage with matching tool_calls
+        # Search backward for the AIMessage(s) with matching tool_calls, accumulating
+        # coverage until every tool_call_id has a home rather than stopping at the
+        # first (possibly partial) match.
+        covered_ids: set[str] = set()
+        earliest_index = cutoff_index
         for i in range(cutoff_index - 1, -1, -1):
             msg = messages[i]
             if isinstance(msg, AIMessage) and msg.tool_calls:
                 ai_tool_call_ids = {tc.get("id") for tc in msg.tool_calls if tc.get("id")}
-                if tool_call_ids & ai_tool_call_ids:
-                    # Found the AIMessage - move cutoff to include it
-                    return i
+                matched_ids = tool_call_ids & ai_tool_call_ids
+                if matched_ids:
+                    covered_ids |= matched_ids
+                    earliest_index = i
+                    if covered_ids >= tool_call_ids:
+                        return earliest_index
 
-        # Fallback: no matching AIMessage found, advance past ToolMessages to avoid
+        if covered_ids >= tool_call_ids:
+            return earliest_index
+
+        # Fallback: no full coverage found, advance past ToolMessages to avoid
         # orphaned tool responses
         return idx
+
+    @staticmethod
+    def _snap_cutoff_past_open_thinking_turn(messages: list[AnyMessage], cutoff_index: int) -> int:
+        """Snap `cutoff_index` back to the start of an open turn with thinking blocks.
+
+        An assistant turn starts right after a `HumanMessage`/`SystemMessage` (or at
+        the start of the conversation) and stays open across `AIMessage`/`ToolMessage`
+        exchanges until an `AIMessage` with no `tool_calls` completes it. If
+        `cutoff_index` would split such an open turn, and any `AIMessage` being
+        summarized away within that turn carries an Anthropic extended-thinking
+        block, the cutoff is moved back to the turn's start so the thinking block
+        stays with the tool calls/results it precedes, as Anthropic requires.
+        """
+        if cutoff_index <= 0 or cutoff_index >= len(messages):
+            return cutoff_index
+
+        turn_start = cutoff_index
+        while turn_start > 0:
+            previous_message = messages[turn_start - 1]
+            if isinstance(previous_message, (HumanMessage, SystemMessage)):
+                break
+            if isinstance(previous_message, AIMessage) and not previous_message.tool_calls:
+                break
+            turn_start -= 1
+
+        if turn_start >= cutoff_index:
+            return cutoff_index
+
+        has_thinking_block = any(
+            isinstance(msg, AIMessage) and SummarizationMiddleware._has_thinking_block(msg)
+            for msg in messages[turn_start:cutoff_index]
+        )
+        return turn_start if has_thinking_block else cutoff_index
+
+    @staticmethod
+    def _has_thinking_block(message: AIMessage) -> bool:
+        """Check whether `message` carries an Anthropic extended-thinking block."""
+        content = message.content
+        if not isinstance(content, list):
+            return False
+        return any(
+            isinstance(block, dict) and block.get("type") in {"thinking", "redacted_thinking"}
+            for block in content
+        )
 
     def _create_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
         """Generate summary for the given messages.

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -844,6 +844,13 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         if cutoff_index <= 0 or cutoff_index >= len(messages):
             return cutoff_index
 
+        # A cutoff that already lands on a HumanMessage/SystemMessage is itself a
+        # turn boundary right after the preceding (completed) assistant turn -
+        # there's nothing open to preserve, so leave it alone rather than scanning
+        # backward into that already-finished turn.
+        if isinstance(messages[cutoff_index], (HumanMessage, SystemMessage)):
+            return cutoff_index
+
         turn_start = cutoff_index
         while turn_start > 0:
             previous_message = messages[turn_start - 1]

--- a/libs/langchain_v1/langchain/agents/middleware/summarization.py
+++ b/libs/langchain_v1/langchain/agents/middleware/summarization.py
@@ -837,13 +837,9 @@ class SummarizationMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
     def _snap_cutoff_past_open_thinking_turn(messages: list[AnyMessage], cutoff_index: int) -> int:
         """Snap `cutoff_index` back to the start of an open turn with thinking blocks.
 
-        An assistant turn starts right after a `HumanMessage`/`SystemMessage` (or at
-        the start of the conversation) and stays open across `AIMessage`/`ToolMessage`
-        exchanges until an `AIMessage` with no `tool_calls` completes it. If
-        `cutoff_index` would split such an open turn, and any `AIMessage` being
-        summarized away within that turn carries an Anthropic extended-thinking
-        block, the cutoff is moved back to the turn's start so the thinking block
-        stays with the tool calls/results it precedes, as Anthropic requires.
+        If the cutoff would split an unfinished assistant turn containing Anthropic
+        `thinking`/`redacted_thinking` blocks, move it to the turn's start so the
+        thinking stays with the associated tool calls and results.
         """
         if cutoff_index <= 0 or cutoff_index >= len(messages):
             return cutoff_index

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -1017,6 +1017,40 @@ def test_summarization_middleware_find_safe_cutoff_point_no_snap_without_thinkin
     assert middleware._find_safe_cutoff_point(messages, 3) == 3
 
 
+def test_summarization_middleware_find_safe_cutoff_point_closed_turn_not_reopened() -> None:
+    """A cutoff already on a Human/System boundary must not be pulled backward.
+
+    `Human -> AI(thinking+tool) -> Tool -> Human` with the cutoff on the final
+    `HumanMessage` is already a safe boundary right after a *completed* assistant
+    turn. Scanning backward from there (as opposed to refusing to scan at all)
+    would walk through that finished turn and, because it contains a thinking
+    block, incorrectly pull the cutoff back to the earlier `AIMessage` - retaining
+    an old turn beyond the configured retention budget.
+    """
+    model = FakeToolCallingModel()
+    middleware = SummarizationMiddleware(
+        model=model, trigger=("messages", 10), keep=("messages", 2)
+    )
+
+    def thinking_block(text: str) -> dict[str, str]:
+        return {"type": "thinking", "thinking": text, "signature": "sig"}
+
+    messages: list[AnyMessage] = [
+        HumanMessage(content="first request", id="h0"),  # index 0
+        AIMessage(
+            content=[thinking_block("plan")],
+            tool_calls=[{"name": "get_data", "args": {}, "id": "call_get"}],
+            id="a1",
+        ),  # index 1
+        ToolMessage(content="raw data", tool_call_id="call_get", id="t1"),  # index 2
+        HumanMessage(content="second request", id="h1"),  # index 3 - naive cutoff, closed turn
+    ]
+
+    # The candidate cutoff (index 3) already sits right after the completed turn
+    # (index 1-2). It must be returned unchanged, not pulled back to index 1.
+    assert middleware._find_safe_cutoff_point(messages, 3) == 3
+
+
 def test_summarization_middleware_zero_and_negative_target_tokens() -> None:
     """Test handling of edge cases with target token calculations."""
     # Test with very small fraction that rounds to zero

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_summarization.py
@@ -807,9 +807,12 @@ def test_summarization_middleware_find_safe_cutoff_point() -> None:
     assert middleware._find_safe_cutoff_point(messages, 0) == 0
     assert middleware._find_safe_cutoff_point(messages, 1) == 1
 
-    # Starting at ToolMessage with matching AIMessage moves back to include it
-    # ToolMessage at index 2 has tool_call_id="call1" which matches AIMessage at index 1
-    assert middleware._find_safe_cutoff_point(messages, 2) == 1
+    # Starting at ToolMessage index 2 pulls in the consecutive ToolMessage run
+    # (call1, call2). call1 is covered by the AIMessage at index 1, but call2 has no
+    # matching AIMessage anywhere in the conversation, so full coverage is never
+    # reached and we fall back to advancing past the entire ToolMessage run rather
+    # than leaving the unfixable orphan (call2) in the preserved window.
+    assert middleware._find_safe_cutoff_point(messages, 2) == 4
 
     # Starting at orphan ToolMessage (no matching AIMessage) falls back to advancing
     # ToolMessage at index 3 has tool_call_id="call2" with no matching AIMessage
@@ -885,6 +888,133 @@ def test_summarization_cutoff_moves_backward_to_include_ai_message() -> None:
     assert isinstance(messages[result], AIMessage)
     assert messages[result].tool_calls  # type: ignore[union-attr]
     assert messages[result].tool_calls[0]["id"] == "call_abc"  # type: ignore[union-attr]
+
+
+def test_summarization_middleware_find_safe_cutoff_point_mixed_pair_full_coverage() -> None:
+    """Regression test for #38352.
+
+    In a mixed `ToolMessage` run where one `tool_call_id` is covered by a surviving
+    `AIMessage` and another's originating `AIMessage` is further back, the cutoff
+    must keep walking backward until *every* id in the run is covered, rather than
+    short-circuiting on the first (partial) match and leaving an orphan
+    `ToolMessage` in the preserved window.
+    """
+    model = FakeToolCallingModel()
+    middleware = SummarizationMiddleware(
+        model=model, trigger=("messages", 10), keep=("messages", 3)
+    )
+
+    messages: list[AnyMessage] = [
+        HumanMessage(content="hi", id="h0"),  # index 0
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "old_tool", "args": {}, "id": "X"}],
+            id="a_old",
+        ),  # index 1
+        ToolMessage(content="old result for X", tool_call_id="X", id="t_old_x"),  # index 2
+        AIMessage(
+            content="",
+            tool_calls=[{"name": "new_tool", "args": {}, "id": "Y"}],
+            id="a_new",
+        ),  # index 3
+        ToolMessage(content="duplicated X reply", tool_call_id="X", id="t_orphan_x"),  # index 4
+        ToolMessage(content="result for Y", tool_call_id="Y", id="t_y"),  # index 5
+        HumanMessage(content="next", id="h_next"),  # index 6
+    ]
+
+    # Naive target cutoff (len(messages) - keep = 7 - 3 = 4) lands on the ToolMessage
+    # run [X, Y]. Y is covered by the AIMessage at index 3, but X's originating
+    # AIMessage is at index 1 - the cutoff must walk back that far for full coverage.
+    result = middleware._find_safe_cutoff(messages, messages_to_keep=3)
+    assert result == 1
+
+    preserved = messages[result:]
+    ai_tool_call_ids = {
+        tc.get("id")
+        for msg in preserved
+        if isinstance(msg, AIMessage) and msg.tool_calls
+        for tc in msg.tool_calls
+        if tc.get("id")
+    }
+    tool_message_ids = {
+        msg.tool_call_id for msg in preserved if isinstance(msg, ToolMessage) and msg.tool_call_id
+    }
+    assert tool_message_ids <= ai_tool_call_ids, "no orphan ToolMessage should survive the cutoff"
+
+
+def test_summarization_middleware_find_safe_cutoff_point_preserves_thinking_turn() -> None:
+    """Regression test for #34794.
+
+    When the naive cutoff would split an in-progress assistant turn (a multi-step
+    tool-calling loop that hasn't produced a final, tool-call-free `AIMessage` yet),
+    and an earlier `AIMessage` in that turn carries an Anthropic extended-thinking
+    block, the cutoff must snap back to the start of the turn so the thinking block
+    stays with the tool calls/results it precedes.
+    """
+    model = FakeToolCallingModel()
+    middleware = SummarizationMiddleware(
+        model=model, trigger=("messages", 10), keep=("messages", 2)
+    )
+
+    def thinking_block(text: str) -> dict[str, str]:
+        return {"type": "thinking", "thinking": text, "signature": "sig"}
+
+    messages: list[AnyMessage] = [
+        HumanMessage(content="Get data, process it, format it", id="h0"),  # index 0, turn start
+        AIMessage(
+            content=[thinking_block("plan to fetch data")],
+            tool_calls=[{"name": "get_data", "args": {}, "id": "call_get"}],
+            id="a1",
+        ),  # index 1
+        ToolMessage(content="raw data", tool_call_id="call_get", id="t1"),  # index 2
+        AIMessage(
+            content=[thinking_block("plan to process data")],
+            tool_calls=[{"name": "process_data", "args": {}, "id": "call_process"}],
+            id="a2",
+        ),  # index 3 - naive cutoff lands here
+        ToolMessage(content="processed data", tool_call_id="call_process", id="t2"),  # index 4
+        AIMessage(
+            content=[thinking_block("plan to format output")],
+            tool_calls=[{"name": "format_output", "args": {}, "id": "call_format"}],
+            id="a3",
+        ),  # index 5
+        ToolMessage(content="formatted output", tool_call_id="call_format", id="t3"),  # index 6
+    ]
+
+    # The naive cutoff (index 3) is itself a safe AI/Tool boundary, so without
+    # turn-awareness it would be returned unchanged, splitting off the thinking
+    # block on the AIMessage at index 1 from the tool loop it belongs to.
+    result = middleware._find_safe_cutoff_point(messages, 3)
+
+    assert result == 1
+    assert isinstance(messages[result], AIMessage)
+
+
+def test_summarization_middleware_find_safe_cutoff_point_no_snap_without_thinking() -> None:
+    """A cutoff mid tool-loop is left alone when no thinking blocks are involved."""
+    model = FakeToolCallingModel()
+    middleware = SummarizationMiddleware(
+        model=model, trigger=("messages", 10), keep=("messages", 2)
+    )
+
+    messages: list[AnyMessage] = [
+        HumanMessage(content="Get data, process it, format it", id="h0"),
+        AIMessage(
+            content="plan to fetch data",
+            tool_calls=[{"name": "get_data", "args": {}, "id": "call_get"}],
+            id="a1",
+        ),
+        ToolMessage(content="raw data", tool_call_id="call_get", id="t1"),
+        AIMessage(
+            content="plan to process data",
+            tool_calls=[{"name": "process_data", "args": {}, "id": "call_process"}],
+            id="a2",
+        ),
+        ToolMessage(content="processed data", tool_call_id="call_process", id="t2"),
+    ]
+
+    # No thinking blocks anywhere, so the naive (already-safe) cutoff is unchanged.
+    assert middleware._find_safe_cutoff_point(messages, 3) == 3
 
 
 def test_summarization_middleware_zero_and_negative_target_tokens() -> None:


### PR DESCRIPTION
Closes #38352, #34794

Both issues stem from `_find_safe_cutoff_point`, so they're fixed together.

- The helper now walks back until all pending `tool_call_id`s are covered, preventing orphaned `ToolMessage`s in mixed tool-call runs #38352.
- The cutoff is now snapped back to the start of an unfinished assistant turn containing `thinking`/`redacted_thinking` blocks, preventing Anthropic thinking blocks from being separated from their associated tool calls and results #34794.