### PR TITLE
fix(anthropic): drop top-level `oneOf`/`anyOf`/`allOf` in `convert_to_anthropic_tool`

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2388,6 +2388,37 @@ class ChatAnthropic(BaseChatModel):
         return response.input_tokens
 
 
+_TOP_LEVEL_SCHEMA_COMPOSITION_KEYS = ("oneOf", "anyOf", "allOf")
+
+
+def _drop_top_level_schema_composition(
+    tool_name: str, input_schema: dict[str, Any]
+) -> dict[str, Any]:
+    """Drop `oneOf`/`anyOf`/`allOf` from the root of a tool's `input_schema`.
+
+    The Anthropic API rejects tool schemas carrying these keywords at the top
+    level (nested under `properties` is fine), failing the whole request. MCP
+    servers and root-`Union` Pydantic models can emit such schemas. Rather than
+    attempt a lossy rewrite of the union, we drop the root combinator keys and
+    keep the sibling `type`/`properties`/`description`, so the tool's call
+    shape is unchanged and it accepts a superset of the original inputs.
+    """
+    dropped = [k for k in _TOP_LEVEL_SCHEMA_COMPOSITION_KEYS if k in input_schema]
+    if not dropped:
+        return input_schema
+    warnings.warn(
+        f"Tool {tool_name!r} has a top-level {'/'.join(dropped)} in its "
+        "input_schema, which the Anthropic API does not support. Dropping it; "
+        "the tool will accept a superset of the original inputs.",
+        stacklevel=4,
+    )
+    return {
+        key: value
+        for key, value in input_schema.items()
+        if key not in _TOP_LEVEL_SCHEMA_COMPOSITION_KEYS
+    }
+
+
 def convert_to_anthropic_tool(
     tool: Mapping[str, Any] | type | Callable | BaseTool,
     *,
@@ -2421,11 +2452,16 @@ def convert_to_anthropic_tool(
     ):
         # Anthropic tool format
         anthropic_formatted = AnthropicTool(tool)  # type: ignore[misc]
+        anthropic_formatted["input_schema"] = _drop_top_level_schema_composition(
+            anthropic_formatted["name"], anthropic_formatted["input_schema"]
+        )
     else:
         oai_formatted = convert_to_openai_tool(tool, strict=strict)["function"]
         anthropic_formatted = AnthropicTool(
             name=oai_formatted["name"],
-            input_schema=oai_formatted["parameters"],
+            input_schema=_drop_top_level_schema_composition(
+                oai_formatted["name"], oai_formatted["parameters"]
+            ),
         )
         if "description" in oai_formatted:
             anthropic_formatted["description"] = oai_formatted["description"]

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -647,6 +647,72 @@ def test_convert_to_anthropic_tool(
         assert actual == expected
 
 
+def test_convert_to_anthropic_tool_drops_top_level_composition() -> None:
+    """Top-level `oneOf`/`anyOf`/`allOf` are dropped from the root input_schema.
+
+    The Anthropic API rejects tool schemas carrying these keywords at the top
+    level. See https://github.com/langchain-ai/langchain/issues/39271.
+    """
+    raw_tool = {
+        "name": "notion_create_attachment",
+        "description": "Create an attachment",
+        "input_schema": {
+            "type": "object",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"content": {"type": "string"}},
+                    "required": ["content"],
+                },
+                {
+                    "type": "object",
+                    "properties": {"source_url": {"type": "string"}},
+                    "required": ["source_url"],
+                },
+            ],
+        },
+    }
+    with pytest.warns(UserWarning, match="top-level anyOf"):
+        actual = convert_to_anthropic_tool(raw_tool)
+    assert actual["input_schema"] == {"type": "object"}
+
+
+def test_convert_to_anthropic_tool_keeps_nested_composition() -> None:
+    """Combinators nested under `properties` are valid and left untouched."""
+    raw_tool = {
+        "name": "search",
+        "description": "Search",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "value": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+            },
+            "required": ["value"],
+        },
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning expected
+        actual = convert_to_anthropic_tool(raw_tool)
+    assert actual["input_schema"] == raw_tool["input_schema"]
+
+
+def test_convert_to_anthropic_tool_no_composition_no_warning() -> None:
+    """A plain object schema is passed through unchanged and without warning."""
+    raw_tool = {
+        "name": "plain",
+        "description": "Plain tool",
+        "input_schema": {
+            "type": "object",
+            "properties": {"a": {"type": "string"}},
+            "required": ["a"],
+        },
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning expected
+        actual = convert_to_anthropic_tool(raw_tool)
+    assert actual["input_schema"] == raw_tool["input_schema"]
+
+
 def test__format_messages_with_tool_calls() -> None:
     system = SystemMessage("fuzz")  # type: ignore[misc]
     human = HumanMessage("foo")  # type: ignore[misc]


### PR DESCRIPTION
Fixes #39271

`langchain-anthropic` now drops top-level `oneOf`/`anyOf`/`allOf` from tool `input_schema` (which the Anthropic API rejects) and emits a warning, instead of failing the request with a 400.

---

## Why

Agents using Anthropic models with certain MCP tools were failing on every tool-calling request with a 400:

```
tools.N.custom.input_schema: input_schema does not support oneOf, allOf, or anyOf at the top level
```

Anthropic's API (like OpenAI's) rejects tool `input_schema` values that carry `oneOf`/`anyOf`/`allOf` at the top level — nested under `properties` is fine. This is a long-standing rule, not a new change. The proximate trigger is that Notion's hosted MCP server (`mcp.notion.com/mcp`) deployed a change ~Aug 5 that put a top-level combinator into a tool schema (makenotion/notion-mcp-server#340, makenotion/notion-mcp-server#341; confirmed against the live server: `notion-create-attachment` has a root `anyOf`).

`convert_to_anthropic_tool` forwards schemas verbatim with no top-level-combinator handling, and `langchain-mcp-adapters` builds `StructuredTool`s directly from MCP schemas, so these reach the API unmodified. Any MCP server (or root-`Union` Pydantic model) emitting a root combinator hard-fails the whole request.

## What this does

In `convert_to_anthropic_tool`, drop `oneOf`/`anyOf`/`allOf` **only at the schema root** (keeping sibling `type`/`properties`/`description`), leave nested combinators untouched, and emit a `UserWarning` naming the tool and the dropped keys.

This applies no matter how the tool is supplied. `convert_to_anthropic_tool` accepts two kinds of input, and the root combinator could sneak in through either:

- A dict already in Anthropic's native format (`{"name", "description", "input_schema"}`), which is passed through as-is. This is how MCP-style dict tools arrive.
- A Pydantic model, Python function, or `BaseTool`, which is first converted via `convert_to_openai_tool` and whose `parameters` become the `input_schema`. This is how `langchain-mcp-adapters` `StructuredTool`s and root-`Union` models arrive.

Previously neither route removed a top-level combinator; now both do.

This mirrors the fix opencode shipped for the same incident (anomalyco/opencode#39826). The call shape is unchanged — the tool accepts a superset of the original inputs — so it is non-breaking, and a relaxed-but-working tool beats a hard 400. There is no lossless client-side rewrite of a multi-element root union.

## Out of scope (follow-up)

OpenAI rejects the same root combinators (plus top-level `enum`/`const`/`not`), so a shared cross-provider normalization — whether in `langchain-core`, per-partner converters, or `langchain-mcp-adapters` — needs per-provider rules and is a separate issue.
