### PR TITLE
fix(anthropic): handle tool schemas with unsupported top-level composition

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/__init__.py
+++ b/libs/partners/anthropic/langchain_anthropic/__init__.py
@@ -3,7 +3,6 @@
 from langchain_anthropic._version import __version__
 from langchain_anthropic.chat_models import (
     ChatAnthropic,
-    UnsupportedToolSchemaWarning,
     convert_to_anthropic_tool,
 )
 from langchain_anthropic.llms import AnthropicLLM
@@ -11,7 +10,6 @@ from langchain_anthropic.llms import AnthropicLLM
 __all__ = [
     "AnthropicLLM",
     "ChatAnthropic",
-    "UnsupportedToolSchemaWarning",
     "__version__",
     "convert_to_anthropic_tool",
 ]

--- a/libs/partners/anthropic/langchain_anthropic/__init__.py
+++ b/libs/partners/anthropic/langchain_anthropic/__init__.py
@@ -3,6 +3,7 @@
 from langchain_anthropic._version import __version__
 from langchain_anthropic.chat_models import (
     ChatAnthropic,
+    UnsupportedToolSchemaWarning,
     convert_to_anthropic_tool,
 )
 from langchain_anthropic.llms import AnthropicLLM
@@ -10,6 +11,7 @@ from langchain_anthropic.llms import AnthropicLLM
 __all__ = [
     "AnthropicLLM",
     "ChatAnthropic",
+    "UnsupportedToolSchemaWarning",
     "__version__",
     "convert_to_anthropic_tool",
 ]

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2473,13 +2473,13 @@ class ChatAnthropic(BaseChatModel):
         return response.input_tokens
 
 
-_TOP_LEVEL_SCHEMA_COMPOSITION_KEYS = ("oneOf", "anyOf", "allOf")
+_TOP_LEVEL_SCHEMA_COMPOSITION_KEYS = ("oneOf", "anyOf")
 
 
 def _drop_unsupported_root_composition_tools(
     tools: Sequence[Mapping[str, Any]],
 ) -> tuple[list[Mapping[str, Any]], set[str]]:
-    """Drop tools whose root `input_schema` uses `oneOf`/`anyOf`/`allOf`.
+    """Drop tools whose root `input_schema` uses `oneOf`/`anyOf`.
 
     The Anthropic API rejects these at request validation, failing the entire
     request. A tool is dropped only if its `input_schema` is a mapping carrying

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2086,6 +2086,7 @@ class ChatAnthropic(BaseChatModel):
             else convert_to_anthropic_tool(tool, strict=strict)
             for tool in tools
         ]
+        formatted_tools = _drop_unsupported_root_composition_tools(formatted_tools)
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):
@@ -2386,6 +2387,52 @@ class ChatAnthropic(BaseChatModel):
             **kwargs,
         )
         return response.input_tokens
+
+
+class UnsupportedToolSchemaWarning(UserWarning):
+    """A tool was dropped because its `input_schema` is unsupported by Anthropic.
+
+    The Anthropic API rejects custom tool schemas that carry `oneOf`, `anyOf`,
+    or `allOf` at the top level (nested under `properties` is fine). Such
+    schemas are valid JSON Schema and permitted by the MCP spec (SEP-2106), so
+    some MCP servers emit them. Rather than fail the whole request with a 400,
+    the offending tool is dropped and this warning is emitted.
+    """
+
+
+_TOP_LEVEL_SCHEMA_COMPOSITION_KEYS = ("oneOf", "anyOf", "allOf")
+
+
+def _drop_unsupported_root_composition_tools(
+    tools: list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool],
+) -> list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool]:
+    """Drop custom tools whose root `input_schema` uses `oneOf`/`anyOf`/`allOf`.
+
+    The Anthropic API rejects these at request validation, failing the entire
+    request. Built-in (server-side) tools and tools without a root combinator
+    are kept unchanged. A [warning][UnsupportedToolSchemaWarning] names each
+    dropped tool.
+    """
+    kept: list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool] = []
+    for tool in tools:
+        input_schema = tool.get("input_schema") if isinstance(tool, Mapping) else None
+        dropped_keys = (
+            [k for k in _TOP_LEVEL_SCHEMA_COMPOSITION_KEYS if k in input_schema]
+            if isinstance(input_schema, dict)
+            else []
+        )
+        if not dropped_keys:
+            kept.append(tool)
+            continue
+        tool_name = tool.get("name") if isinstance(tool, Mapping) else None
+        warnings.warn(
+            f"Dropping tool {tool_name!r}: its input_schema has a "
+            f"top-level {'/'.join(dropped_keys)}, which the Anthropic API does "
+            "not support. The tool will not be available to the model.",
+            UnsupportedToolSchemaWarning,
+            stacklevel=3,
+        )
+    return kept
 
 
 def convert_to_anthropic_tool(

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2086,7 +2086,9 @@ class ChatAnthropic(BaseChatModel):
             else convert_to_anthropic_tool(tool, strict=strict)
             for tool in tools
         ]
-        formatted_tools = _drop_unsupported_root_composition_tools(formatted_tools)
+        formatted_tools, dropped_tool_names = _drop_unsupported_root_composition_tools(
+            formatted_tools
+        )
 
         # Reconcile tool_choice with the filtered list: a forced choice for a
         # dropped tool, or "any" with no remaining tools, still produces a 400.
@@ -2106,13 +2108,19 @@ class ChatAnthropic(BaseChatModel):
                     t.get("name") for t in formatted_tools if isinstance(t, Mapping)
                 }
                 if choice_name not in available:
-                    msg = (
-                        f"tool_choice references {choice_name!r}, but that tool "
-                        "was dropped because its input_schema uses a top-level "
-                        "oneOf/anyOf/allOf, which the Anthropic API does not "
-                        "support. Remove the forced tool_choice or fix the "
-                        "tool's schema."
-                    )
+                    if choice_name in dropped_tool_names:
+                        msg = (
+                            f"tool_choice references {choice_name!r}, but that tool "
+                            "was dropped because its input_schema uses a top-level "
+                            "oneOf/anyOf/allOf, which the Anthropic API does not "
+                            "support. Remove the forced tool_choice or fix the "
+                            "tool's schema."
+                        )
+                    else:
+                        msg = (
+                            f"tool_choice references {choice_name!r}, but no bound "
+                            "tool has that name. Choose one of the bound tools."
+                        )
                     raise ValueError(msg)
             elif choice_type == "any" and not formatted_tools:
                 msg = (
@@ -2441,15 +2449,16 @@ _TOP_LEVEL_SCHEMA_COMPOSITION_KEYS = ("oneOf", "anyOf", "allOf")
 
 def _drop_unsupported_root_composition_tools(
     tools: list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool],
-) -> list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool]:
+) -> tuple[list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool], set[str]]:
     """Drop custom tools whose root `input_schema` uses `oneOf`/`anyOf`/`allOf`.
 
     The Anthropic API rejects these at request validation, failing the entire
     request. Built-in (server-side) tools and tools without a root combinator
     are kept unchanged. A [warning][UnsupportedToolSchemaWarning] names each
-    dropped tool.
+    dropped tool. Returns the retained tools and the names of dropped tools.
     """
     kept: list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool] = []
+    dropped_tool_names: set[str] = set()
     for tool in tools:
         input_schema = tool.get("input_schema") if isinstance(tool, Mapping) else None
         dropped_keys = (
@@ -2461,6 +2470,8 @@ def _drop_unsupported_root_composition_tools(
             kept.append(tool)
             continue
         tool_name = tool.get("name") if isinstance(tool, Mapping) else None
+        if isinstance(tool_name, str):
+            dropped_tool_names.add(tool_name)
         warnings.warn(
             f"Dropping tool {tool_name!r}: its input_schema has a "
             f"top-level {'/'.join(dropped_keys)}, which the Anthropic API does "
@@ -2468,7 +2479,7 @@ def _drop_unsupported_root_composition_tools(
             UnsupportedToolSchemaWarning,
             stacklevel=3,
         )
-    return kept
+    return kept, dropped_tool_names
 
 
 def convert_to_anthropic_tool(

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2103,7 +2103,18 @@ class ChatAnthropic(BaseChatModel):
                     choice_type = tool_choice
                 else:
                     choice_type, choice_name = "tool", tool_choice
-            if choice_type == "tool" and choice_name is not None:
+            # Thinking discards forced choices before the request is sent, so
+            # they need not refer to a tool that remains after filtering.
+            thinking_discards_forced_choice = (
+                self.thinking is not None
+                and self.thinking.get("type") in ("enabled", "adaptive")
+                and choice_type in ("any", "tool")
+            )
+            if (
+                not thinking_discards_forced_choice
+                and choice_type == "tool"
+                and choice_name is not None
+            ):
                 available = {
                     t.get("name") for t in formatted_tools if isinstance(t, Mapping)
                 }
@@ -2122,7 +2133,11 @@ class ChatAnthropic(BaseChatModel):
                             "tool has that name. Choose one of the bound tools."
                         )
                     raise ValueError(msg)
-            elif choice_type == "any" and not formatted_tools:
+            elif (
+                not thinking_discards_forced_choice
+                and choice_type == "any"
+                and not formatted_tools
+            ):
                 msg = (
                     "tool_choice='any' requires at least one available tool, but "
                     "all tools were dropped because their input_schema uses a "

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -11,7 +11,7 @@ import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from functools import cached_property
 from operator import itemgetter
-from typing import Any, Final, Literal, cast
+from typing import Any, Final, Literal, TypeGuard, cast
 
 import anthropic
 from langchain_core.callbacks import (
@@ -175,7 +175,7 @@ _ANTHROPIC_EXTRA_FIELDS: set[str] = {
 """Valid Anthropic-specific extra fields"""
 
 
-def _is_builtin_tool(tool: Any) -> bool:
+def _is_builtin_tool(tool: Any) -> TypeGuard[dict[str, Any]]:
     """Check if a tool is a built-in (server-side) Anthropic tool.
 
     `tool` must be a `dict` and have a `type` key starting with one of the known
@@ -2044,6 +2044,15 @@ class ChatAnthropic(BaseChatModel):
                 See the [docs](https://docs.langchain.com/oss/python/integrations/chat/anthropic#strict-tool-use) for more info.
             kwargs: Any additional parameters are passed directly to `bind`.
 
+        Raises:
+            ValueError: If every tool in `tools` was dropped for using top-level
+                schema composition, leaving the model with no callable tool.
+            ValueError: If `tool_choice` forces tool use (a specific tool, or
+                `'any'`) while any tool was dropped, since the forced tool may be
+                unreachable. Does not apply when `thinking` is enabled, as the
+                forced choice is discarded before the request is sent.
+            ValueError: If `tool_choice` is neither a `dict`, a `str`, nor `None`.
+
         Example:
             ```python
             from langchain_anthropic import ChatAnthropic
@@ -2080,7 +2089,7 @@ class ChatAnthropic(BaseChatModel):
         # Allows built-in tools either by their:
         # - Raw `dict` format
         # - Extracting extras["provider_tool_definition"] if provided on a BaseTool
-        formatted_tools = [
+        formatted_tools: list[Mapping[str, Any]] = [
             tool
             if _is_builtin_tool(tool)
             else convert_to_anthropic_tool(tool, strict=strict)
@@ -2090,9 +2099,28 @@ class ChatAnthropic(BaseChatModel):
             formatted_tools
         )
 
-        # Reconcile tool_choice with the filtered list: a forced choice for a
-        # dropped tool, or "any" with no remaining tools, still produces a 400.
-        if tool_choice:
+        # Dropping salvages a request when usable tools remain. If every tool was
+        # dropped there is nothing to salvage: the caller asked for a model with
+        # tools and would get one that cannot call any, so fail loudly instead of
+        # letting it surface later as a tool call that never happens.
+        if tools and not formatted_tools:
+            msg = (
+                f"All {len(tools)} bound tool(s) use a top-level "
+                f"{'/'.join(_TOP_LEVEL_SCHEMA_COMPOSITION_KEYS)} in their "
+                f"input_schema, which the Anthropic API rejects: "
+                f"{sorted(dropped_tool_names)}. No tool is left for the model to "
+                "call. If you control the schema, move the combinator under "
+                "`properties`; for structured output, `with_structured_output(..., "
+                "method='json_schema')` accepts these schemas directly. Otherwise "
+                "these tools cannot be used with Anthropic -- bind a subset that "
+                "excludes them, or raise it with the tool's author."
+            )
+            raise ValueError(msg)
+
+        # Reconcile tool_choice with the filtered list: forcing a tool that was
+        # dropped, or forcing tool use at all when the set the caller depends on
+        # has silently shrunk, still produces a 400 or a stuck agent loop.
+        if tool_choice and dropped_tool_names:
             choice_type: str | None = None
             choice_name: str | None = None
             if isinstance(tool_choice, dict):
@@ -2110,41 +2138,34 @@ class ChatAnthropic(BaseChatModel):
                 and self.thinking.get("type") in ("enabled", "adaptive")
                 and choice_type in ("any", "tool")
             )
-            if (
-                not thinking_discards_forced_choice
-                and choice_type == "tool"
-                and choice_name is not None
-            ):
-                available = {
-                    t.get("name") for t in formatted_tools if isinstance(t, Mapping)
-                }
-                if choice_name not in available:
-                    if choice_name in dropped_tool_names:
-                        msg = (
-                            f"tool_choice references {choice_name!r}, but that tool "
-                            "was dropped because its input_schema uses a top-level "
-                            "oneOf/anyOf/allOf, which the Anthropic API does not "
-                            "support. Remove the forced tool_choice or fix the "
-                            "tool's schema."
-                        )
-                    else:
-                        msg = (
-                            f"tool_choice references {choice_name!r}, but no bound "
-                            "tool has that name. Choose one of the bound tools."
-                        )
+            if not thinking_discards_forced_choice:
+                if choice_type == "tool" and choice_name in dropped_tool_names:
+                    msg = (
+                        f"tool_choice forces {choice_name!r}, but that tool was "
+                        "dropped because its input_schema uses a top-level "
+                        f"{'/'.join(_TOP_LEVEL_SCHEMA_COMPOSITION_KEYS)}, which "
+                        "the Anthropic API rejects. Stop forcing it, or -- if you "
+                        "control the schema -- move the combinator under "
+                        "`properties`. For structured output, "
+                        "`with_structured_output(..., method='json_schema')` "
+                        "accepts these schemas directly."
+                    )
                     raise ValueError(msg)
-            elif (
-                not thinking_discards_forced_choice
-                and choice_type == "any"
-                and not formatted_tools
-            ):
-                msg = (
-                    "tool_choice='any' requires at least one available tool, but "
-                    "all tools were dropped because their input_schema uses a "
-                    "top-level oneOf/anyOf/allOf, which the Anthropic API does "
-                    "not support."
-                )
-                raise ValueError(msg)
+                if choice_type == "any":
+                    # Forcing tool use means the caller depends on a specific
+                    # reachable tool set, so losing any member of it is fatal --
+                    # not just losing all of them.
+                    msg = (
+                        "tool_choice='any' forces the model to call a tool, but "
+                        f"{sorted(dropped_tool_names)} were dropped because their "
+                        "input_schema uses a top-level "
+                        f"{'/'.join(_TOP_LEVEL_SCHEMA_COMPOSITION_KEYS)}, which "
+                        "the Anthropic API rejects, so the model can no longer "
+                        "call them. Use tool_choice='auto' to proceed with the "
+                        "remaining tools, or -- if you control the schema -- move "
+                        "the combinator under `properties`."
+                    )
+                    raise ValueError(msg)
 
         if not tool_choice:
             pass
@@ -2428,7 +2449,11 @@ class ChatAnthropic(BaseChatModel):
         if isinstance(formatted_system, str):
             kwargs["system"] = formatted_system
         if tools:
-            kwargs["tools"] = [convert_to_anthropic_tool(tool) for tool in tools]
+            # Filter the same schemas `bind_tools` drops, so counting tokens and
+            # sending a request agree on which tools the API will accept.
+            kwargs["tools"], _ = _drop_unsupported_root_composition_tools(
+                [convert_to_anthropic_tool(tool) for tool in tools]
+            )
         if self.context_management is not None:
             kwargs["context_management"] = self.context_management
 
@@ -2452,33 +2477,46 @@ _TOP_LEVEL_SCHEMA_COMPOSITION_KEYS = ("oneOf", "anyOf", "allOf")
 
 
 def _drop_unsupported_root_composition_tools(
-    tools: list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool],
-) -> tuple[list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool], set[str]]:
-    """Drop custom tools whose root `input_schema` uses `oneOf`/`anyOf`/`allOf`.
+    tools: Sequence[Mapping[str, Any]],
+) -> tuple[list[Mapping[str, Any]], set[str]]:
+    """Drop tools whose root `input_schema` uses `oneOf`/`anyOf`/`allOf`.
 
     The Anthropic API rejects these at request validation, failing the entire
-    request. Built-in (server-side) tools and tools without a root combinator
-    are kept unchanged. A `UserWarning` names each dropped tool. Returns the
-    retained tools and the names of dropped tools.
+    request. A tool is dropped only if its `input_schema` is a mapping carrying
+    a root combinator, so built-in (server-side) tools -- which have no
+    `input_schema` -- and tools whose combinators are nested under `properties`
+    are passed through as the same objects, unmodified.
+
+    A `UserWarning` is emitted per dropped tool.
+
+    Args:
+        tools: Already-formatted tool definitions, as built by `bind_tools`.
+
+    Returns:
+        The retained tools, and the names of the dropped tools. A dropped tool
+        with no string `name` contributes no entry to the name set.
     """
-    kept: list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool] = []
+    kept: list[Mapping[str, Any]] = []
     dropped_tool_names: set[str] = set()
     for tool in tools:
-        input_schema = tool.get("input_schema") if isinstance(tool, Mapping) else None
-        dropped_keys = (
+        input_schema = tool.get("input_schema")
+        offending_keys = (
             [k for k in _TOP_LEVEL_SCHEMA_COMPOSITION_KEYS if k in input_schema]
-            if isinstance(input_schema, dict)
+            if isinstance(input_schema, Mapping)
             else []
         )
-        if not dropped_keys:
+        if not offending_keys:
             kept.append(tool)
             continue
-        tool_name = tool.get("name") if isinstance(tool, Mapping) else None
+        tool_name = tool.get("name")
         if isinstance(tool_name, str):
             dropped_tool_names.add(tool_name)
+            described = repr(tool_name)
+        else:
+            described = "with no name"
         warnings.warn(
-            f"Dropping tool {tool_name!r}: its input_schema has a "
-            f"top-level {'/'.join(dropped_keys)}, which the Anthropic API does "
+            f"Dropping tool {described}: its input_schema has a "
+            f"top-level {'/'.join(offending_keys)}, which the Anthropic API does "
             "not support. The tool will not be available to the model.",
             stacklevel=3,
         )

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2087,6 +2087,42 @@ class ChatAnthropic(BaseChatModel):
             for tool in tools
         ]
         formatted_tools = _drop_unsupported_root_composition_tools(formatted_tools)
+
+        # Reconcile tool_choice with the filtered list: a forced choice for a
+        # dropped tool, or "any" with no remaining tools, still produces a 400.
+        if tool_choice:
+            choice_type: str | None = None
+            choice_name: str | None = None
+            if isinstance(tool_choice, dict):
+                choice_type = tool_choice.get("type")
+                choice_name = tool_choice.get("name")
+            elif isinstance(tool_choice, str):
+                if tool_choice in ("any", "auto"):
+                    choice_type = tool_choice
+                else:
+                    choice_type, choice_name = "tool", tool_choice
+            if choice_type == "tool" and choice_name is not None:
+                available = {
+                    t.get("name") for t in formatted_tools if isinstance(t, Mapping)
+                }
+                if choice_name not in available:
+                    msg = (
+                        f"tool_choice references {choice_name!r}, but that tool "
+                        "was dropped because its input_schema uses a top-level "
+                        "oneOf/anyOf/allOf, which the Anthropic API does not "
+                        "support. Remove the forced tool_choice or fix the "
+                        "tool's schema."
+                    )
+                    raise ValueError(msg)
+            elif choice_type == "any" and not formatted_tools:
+                msg = (
+                    "tool_choice='any' requires at least one available tool, but "
+                    "all tools were dropped because their input_schema uses a "
+                    "top-level oneOf/anyOf/allOf, which the Anthropic API does "
+                    "not support."
+                )
+                raise ValueError(msg)
+
         if not tool_choice:
             pass
         elif isinstance(tool_choice, dict):

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -2433,17 +2433,6 @@ class ChatAnthropic(BaseChatModel):
         return response.input_tokens
 
 
-class UnsupportedToolSchemaWarning(UserWarning):
-    """A tool was dropped because its `input_schema` is unsupported by Anthropic.
-
-    The Anthropic API rejects custom tool schemas that carry `oneOf`, `anyOf`,
-    or `allOf` at the top level (nested under `properties` is fine). Such
-    schemas are valid JSON Schema and permitted by the MCP spec (SEP-2106), so
-    some MCP servers emit them. Rather than fail the whole request with a 400,
-    the offending tool is dropped and this warning is emitted.
-    """
-
-
 _TOP_LEVEL_SCHEMA_COMPOSITION_KEYS = ("oneOf", "anyOf", "allOf")
 
 
@@ -2454,8 +2443,8 @@ def _drop_unsupported_root_composition_tools(
 
     The Anthropic API rejects these at request validation, failing the entire
     request. Built-in (server-side) tools and tools without a root combinator
-    are kept unchanged. A [warning][UnsupportedToolSchemaWarning] names each
-    dropped tool. Returns the retained tools and the names of dropped tools.
+    are kept unchanged. A `UserWarning` names each dropped tool. Returns the
+    retained tools and the names of dropped tools.
     """
     kept: list[Mapping[str, Any] | Callable | BaseTool | AnthropicTool] = []
     dropped_tool_names: set[str] = set()
@@ -2476,7 +2465,6 @@ def _drop_unsupported_root_composition_tools(
             f"Dropping tool {tool_name!r}: its input_schema has a "
             f"top-level {'/'.join(dropped_keys)}, which the Anthropic API does "
             "not support. The tool will not be available to the model.",
-            UnsupportedToolSchemaWarning,
             stacklevel=3,
         )
     return kept, dropped_tool_names

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3924,6 +3924,40 @@ def test_bind_tools_drops_forced_tool_choice_when_thinking_enabled() -> None:
     assert len(w) == 1
 
 
+@pytest.mark.parametrize(
+    "thinking",
+    [
+        pytest.param({"type": "enabled", "budget_tokens": 5000}, id="enabled"),
+        pytest.param({"type": "adaptive"}, id="adaptive"),
+    ],
+)
+def test_bind_tools_drops_forced_choice_for_filtered_tool_when_thinking_enabled(
+    thinking: dict[str, Any],
+) -> None:
+    """Thinking takes precedence over forced-choice validation."""
+    chat_model = ChatAnthropic(
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+        thinking=thinking,
+    )
+    unsupported_tool = {
+        "name": "unsupported_tool",
+        "description": "A tool with an unsupported root schema composition.",
+        "input_schema": {"oneOf": [{"type": "string"}, {"type": "number"}]},
+    }
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = chat_model.bind_tools(
+            [unsupported_tool], tool_choice="unsupported_tool"
+        )
+
+    assert "tool_choice" not in cast("RunnableBinding", result).kwargs
+    assert len(w) == 2
+    assert "unsupported_tool" in str(w[0].message)
+    assert "thinking is enabled" in str(w[1].message)
+
+
 def test_bind_tools_drops_forced_tool_choice_when_adaptive_thinking() -> None:
     """Adaptive thinking has the same forced tool_choice restriction as enabled."""
     chat_model = ChatAnthropic(

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -33,7 +33,6 @@ from langchain_anthropic import ChatAnthropic
 from langchain_anthropic._version import __version__
 from langchain_anthropic.chat_models import (
     _TOOL_CALL_ID_PATTERN,
-    UnsupportedToolSchemaWarning,
     _create_usage_metadata,
     _format_image,
     _format_messages,
@@ -1662,7 +1661,7 @@ def test_bind_tools_drops_top_level_composition() -> None:
             ],
         },
     }
-    with pytest.warns(UnsupportedToolSchemaWarning, match="notion_create_attachment"):
+    with pytest.warns(UserWarning, match="notion_create_attachment"):
         chat_model_with_tools = chat_model.bind_tools([valid_tool, invalid_tool])
 
     bound = cast("RunnableBinding", chat_model_with_tools).kwargs["tools"]
@@ -1720,7 +1719,7 @@ def test_bind_tools_dropped_tool_forced_by_tool_choice_raises() -> None:
         anthropic_api_key="secret-api-key",
     )
     with (
-        pytest.warns(UnsupportedToolSchemaWarning),
+        pytest.warns(UserWarning, match="Dropping tool"),
         pytest.raises(ValueError, match="tool_choice references 'attach'"),
     ):
         chat_model.bind_tools(
@@ -1736,7 +1735,7 @@ def test_bind_tools_dropped_tool_forced_by_tool_choice_raises() -> None:
         )
     # Bare-string tool_choice naming the dropped tool raises too.
     with (
-        pytest.warns(UnsupportedToolSchemaWarning),
+        pytest.warns(UserWarning, match="Dropping tool"),
         pytest.raises(ValueError, match="tool_choice references 'attach'"),
     ):
         chat_model.bind_tools([_composition_tool("attach")], tool_choice="attach")
@@ -1768,7 +1767,7 @@ def test_bind_tools_any_with_all_tools_dropped_raises() -> None:
         anthropic_api_key="secret-api-key",
     )
     with (
-        pytest.warns(UnsupportedToolSchemaWarning),
+        pytest.warns(UserWarning, match="Dropping tool"),
         pytest.raises(ValueError, match="tool_choice='any' requires at least one"),
     ):
         chat_model.bind_tools([_composition_tool("attach")], tool_choice="any")

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -33,6 +33,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_anthropic._version import __version__
 from langchain_anthropic.chat_models import (
     _TOOL_CALL_ID_PATTERN,
+    UnsupportedToolSchemaWarning,
     _create_usage_metadata,
     _format_image,
     _format_messages,
@@ -1620,6 +1621,78 @@ def test_anthropic_bind_tools_does_not_mutate_tool_choice() -> None:
         "name": "GetWeather",
         "disable_parallel_tool_use": True,
     }
+
+
+def test_bind_tools_drops_top_level_composition() -> None:
+    """Tools with a root `oneOf`/`anyOf`/`allOf` are dropped with a warning.
+
+    The Anthropic API rejects tool schemas carrying these keywords at the top
+    level, failing the whole request. MCP servers can emit them. See
+    https://github.com/langchain-ai/langchain/issues/39271.
+    """
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    valid_tool = {
+        "name": "search",
+        "description": "Search",
+        "input_schema": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    }
+    invalid_tool = {
+        "name": "notion_create_attachment",
+        "description": "Create an attachment",
+        "input_schema": {
+            "type": "object",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"content": {"type": "string"}},
+                    "required": ["content"],
+                },
+                {
+                    "type": "object",
+                    "properties": {"source_url": {"type": "string"}},
+                    "required": ["source_url"],
+                },
+            ],
+        },
+    }
+    with pytest.warns(UnsupportedToolSchemaWarning, match="notion_create_attachment"):
+        chat_model_with_tools = chat_model.bind_tools([valid_tool, invalid_tool])
+
+    bound = cast("RunnableBinding", chat_model_with_tools).kwargs["tools"]
+    assert [t["name"] for t in bound] == ["search"]
+
+
+def test_bind_tools_keeps_nested_composition_without_warning() -> None:
+    """Combinators nested under `properties` are valid and left untouched."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    tool = {
+        "name": "search",
+        "description": "Search",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "value": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+            },
+            "required": ["value"],
+        },
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning expected
+        chat_model_with_tools = chat_model.bind_tools([tool])
+
+    bound = cast("RunnableBinding", chat_model_with_tools).kwargs["tools"]
+    assert [t["name"] for t in bound] == ["search"]
+    assert bound[0]["input_schema"] == tool["input_schema"]
 
 
 def test_fine_grained_tool_streaming_beta() -> None:

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1695,6 +1695,59 @@ def test_bind_tools_keeps_nested_composition_without_warning() -> None:
     assert bound[0]["input_schema"] == tool["input_schema"]
 
 
+def _composition_tool(name: str) -> dict:
+    """A tool whose root `input_schema` uses a top-level `anyOf` (unsupported)."""
+    return {
+        "name": name,
+        "description": "Unsupported root composition.",
+        "input_schema": {
+            "type": "object",
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"content": {"type": "string"}},
+                    "required": ["content"],
+                }
+            ],
+        },
+    }
+
+
+def test_bind_tools_dropped_tool_forced_by_tool_choice_raises() -> None:
+    """A forced `tool_choice` for a dropped tool raises locally, not a 400."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    with (
+        pytest.warns(UnsupportedToolSchemaWarning),
+        pytest.raises(ValueError, match="tool_choice references 'attach'"),
+    ):
+        chat_model.bind_tools(
+            [_composition_tool("attach")],
+            tool_choice={"type": "tool", "name": "attach"},
+        )
+    # Bare-string tool_choice naming the dropped tool raises too.
+    with (
+        pytest.warns(UnsupportedToolSchemaWarning),
+        pytest.raises(ValueError, match="tool_choice references 'attach'"),
+    ):
+        chat_model.bind_tools([_composition_tool("attach")], tool_choice="attach")
+
+
+def test_bind_tools_any_with_all_tools_dropped_raises() -> None:
+    """`tool_choice='any'` with no remaining tools raises locally, not a 400."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    with (
+        pytest.warns(UnsupportedToolSchemaWarning),
+        pytest.raises(ValueError, match="tool_choice='any' requires at least one"),
+    ):
+        chat_model.bind_tools([_composition_tool("attach")], tool_choice="any")
+
+
 def test_fine_grained_tool_streaming_beta() -> None:
     """Test that fine-grained tool streaming beta can be enabled."""
     # Test with betas parameter at initialization

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1625,7 +1625,7 @@ def test_anthropic_bind_tools_does_not_mutate_tool_choice() -> None:
 
 
 def test_bind_tools_drops_top_level_composition() -> None:
-    """Tools with a root `oneOf`/`anyOf`/`allOf` are dropped with a warning.
+    """Tools with a root `oneOf`/`anyOf` are dropped with a warning.
 
     The Anthropic API rejects tool schemas carrying these keywords at the top
     level, failing the whole request. MCP servers can emit them. See
@@ -1697,10 +1697,10 @@ def test_bind_tools_keeps_nested_composition_without_warning() -> None:
 
 
 def _composition_tool(name: str, keyword: str = "anyOf") -> dict:
-    """A tool whose root `input_schema` uses a top-level combinator (unsupported)."""
+    """A tool whose root `input_schema` uses a top-level combinator."""
     return {
         "name": name,
-        "description": "Unsupported root composition.",
+        "description": "Root schema composition.",
         "input_schema": {
             "type": "object",
             keyword: [
@@ -1723,7 +1723,7 @@ def _plain_tool(name: str) -> dict:
     }
 
 
-@pytest.mark.parametrize("keyword", ["oneOf", "anyOf", "allOf"])
+@pytest.mark.parametrize("keyword", ["oneOf", "anyOf"])
 def test_bind_tools_drops_each_root_combinator(keyword: str) -> None:
     """Every combinator in the unsupported set is filtered and named in the warning."""
     chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
@@ -1739,6 +1739,22 @@ def test_bind_tools_drops_each_root_combinator(keyword: str) -> None:
         "search"
     ]
     assert "attach" in str(record[0].message)
+
+
+def test_bind_tools_keeps_root_all_of_without_warning() -> None:
+    """A root `allOf` schema is supported and remains available to the model."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    tool = _composition_tool("attach", "allOf")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        bound = chat_model.bind_tools([tool])
+
+    bound_tools = cast("RunnableBinding", bound).kwargs["tools"]
+    assert [tool["name"] for tool in bound_tools] == ["attach"]
+    assert bound_tools[0]["input_schema"] == tool["input_schema"]
 
 
 def test_bind_tools_warning_names_every_offending_combinator() -> None:

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -6,6 +6,7 @@ import copy
 import os
 import warnings
 from collections.abc import Callable
+from types import SimpleNamespace
 from typing import Any, Literal, cast
 from unittest.mock import MagicMock, patch
 
@@ -26,7 +27,7 @@ from langchain_core.runnables import RunnableBinding
 from langchain_core.tools import BaseTool, tool
 from langchain_core.tracers.base import BaseTracer
 from langchain_core.tracers.schemas import Run
-from pydantic import BaseModel, Field, SecretStr, ValidationError
+from pydantic import BaseModel, Field, RootModel, SecretStr, ValidationError
 from pytest import CaptureFixture, MonkeyPatch
 
 from langchain_anthropic import ChatAnthropic
@@ -34,6 +35,7 @@ from langchain_anthropic._version import __version__
 from langchain_anthropic.chat_models import (
     _TOOL_CALL_ID_PATTERN,
     _create_usage_metadata,
+    _drop_unsupported_root_composition_tools,
     _format_image,
     _format_messages,
     _is_builtin_tool,
@@ -1694,14 +1696,14 @@ def test_bind_tools_keeps_nested_composition_without_warning() -> None:
     assert bound[0]["input_schema"] == tool["input_schema"]
 
 
-def _composition_tool(name: str) -> dict:
-    """A tool whose root `input_schema` uses a top-level `anyOf` (unsupported)."""
+def _composition_tool(name: str, keyword: str = "anyOf") -> dict:
+    """A tool whose root `input_schema` uses a top-level combinator (unsupported)."""
     return {
         "name": name,
         "description": "Unsupported root composition.",
         "input_schema": {
             "type": "object",
-            "anyOf": [
+            keyword: [
                 {
                     "type": "object",
                     "properties": {"content": {"type": "string"}},
@@ -1712,7 +1714,102 @@ def _composition_tool(name: str) -> dict:
     }
 
 
-def test_bind_tools_dropped_tool_forced_by_tool_choice_raises() -> None:
+def _plain_tool(name: str) -> dict:
+    """A tool with a supported root `input_schema`."""
+    return {
+        "name": name,
+        "description": "Supported.",
+        "input_schema": {"type": "object", "properties": {}},
+    }
+
+
+@pytest.mark.parametrize("keyword", ["oneOf", "anyOf", "allOf"])
+def test_bind_tools_drops_each_root_combinator(keyword: str) -> None:
+    """Every combinator in the unsupported set is filtered and named in the warning."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    with pytest.warns(UserWarning, match=f"top-level {keyword}") as record:
+        bound = chat_model.bind_tools(
+            [_plain_tool("search"), _composition_tool("attach", keyword)]
+        )
+
+    assert [t["name"] for t in cast("RunnableBinding", bound).kwargs["tools"]] == [
+        "search"
+    ]
+    assert "attach" in str(record[0].message)
+
+
+def test_bind_tools_warning_names_every_offending_combinator() -> None:
+    """A schema with several root combinators reports all of them."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    tool = _composition_tool("attach")
+    tool["input_schema"]["oneOf"] = [{"type": "object", "properties": {}}]
+    with pytest.warns(UserWarning, match="top-level oneOf/anyOf"):
+        chat_model.bind_tools([_plain_tool("search"), tool])
+
+
+def test_bind_tools_passes_builtin_tools_through_unfiltered() -> None:
+    """Built-in server-side tools have no `input_schema` and are never dropped."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    builtin = {"type": "mcp_toolset", "mcp_server_name": "notion"}
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # no warning expected
+        bound = chat_model.bind_tools([builtin])
+
+    assert cast("RunnableBinding", bound).kwargs["tools"] == [builtin]
+
+
+def test_drop_unsupported_tools_describes_unnamed_tool() -> None:
+    """A dropped tool with no `name` is described, not rendered as `None`.
+
+    Exercised on the helper directly: `convert_to_anthropic_tool` rejects a
+    nameless tool before `bind_tools` could ever reach this branch.
+    """
+    unnamed = _composition_tool("attach")
+    del unnamed["name"]
+    with pytest.warns(UserWarning, match="Dropping tool with no name") as record:
+        kept, dropped_names = _drop_unsupported_root_composition_tools([unnamed])
+
+    assert kept == []
+    assert dropped_names == set()
+    assert "None" not in str(record[0].message)
+
+
+def test_bind_tools_all_tools_dropped_raises() -> None:
+    """No usable tool remains, so there is nothing to salvage by dropping."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    with (
+        pytest.warns(UserWarning, match="Dropping tool"),
+        pytest.raises(ValueError, match="All 1 bound tool"),
+    ):
+        chat_model.bind_tools([_composition_tool("attach")])
+
+
+def test_bind_tools_no_tools_does_not_claim_tools_were_dropped() -> None:
+    """An empty tool list is not a dropped tool list, and must not say so."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    bound = chat_model.bind_tools([], tool_choice="any")
+    assert cast("RunnableBinding", bound).kwargs["tools"] == []
+
+
+@pytest.mark.parametrize("tool_choice", ["attach", {"type": "tool", "name": "attach"}])
+def test_bind_tools_dropped_tool_forced_by_tool_choice_raises(
+    tool_choice: str | dict,
+) -> None:
     """A dropped forced tool raises locally even when valid tools remain."""
     chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
         model=MODEL_NAME,
@@ -1720,57 +1817,130 @@ def test_bind_tools_dropped_tool_forced_by_tool_choice_raises() -> None:
     )
     with (
         pytest.warns(UserWarning, match="Dropping tool"),
-        pytest.raises(ValueError, match="tool_choice references 'attach'"),
+        pytest.raises(ValueError, match="tool_choice forces 'attach'"),
     ):
         chat_model.bind_tools(
-            [
-                {
-                    "name": "search",
-                    "description": "Search.",
-                    "input_schema": {"type": "object", "properties": {}},
-                },
-                _composition_tool("attach"),
-            ],
-            tool_choice={"type": "tool", "name": "attach"},
-        )
-    # Bare-string tool_choice naming the dropped tool raises too.
-    with (
-        pytest.warns(UserWarning, match="Dropping tool"),
-        pytest.raises(ValueError, match="tool_choice references 'attach'"),
-    ):
-        chat_model.bind_tools([_composition_tool("attach")], tool_choice="attach")
-
-
-def test_bind_tools_unknown_forced_tool_choice_raises() -> None:
-    """An unknown forced tool reports that it was never bound."""
-    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
-        model=MODEL_NAME,
-        anthropic_api_key="secret-api-key",
-    )
-    with pytest.raises(ValueError, match="no bound tool has that name"):
-        chat_model.bind_tools(
-            [
-                {
-                    "name": "search",
-                    "description": "Search.",
-                    "input_schema": {"type": "object", "properties": {}},
-                },
-            ],
-            tool_choice="attach",
+            [_plain_tool("search"), _composition_tool("attach")],
+            tool_choice=tool_choice,
         )
 
 
-def test_bind_tools_any_with_all_tools_dropped_raises() -> None:
-    """`tool_choice='any'` with no remaining tools raises locally, not a 400."""
+@pytest.mark.parametrize("tool_choice", ["any", {"type": "any"}])
+def test_bind_tools_partial_drop_under_forced_any_raises(
+    tool_choice: str | dict,
+) -> None:
+    """Forcing tool use depends on the whole tool set, so losing any member is fatal.
+
+    Under `create_agent`'s `ToolStrategy`, `tool_choice='any'` plus a dropped
+    structured-output tool would otherwise loop until `GraphRecursionError`.
+    """
     chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
         model=MODEL_NAME,
         anthropic_api_key="secret-api-key",
     )
     with (
         pytest.warns(UserWarning, match="Dropping tool"),
-        pytest.raises(ValueError, match="tool_choice='any' requires at least one"),
+        pytest.raises(ValueError, match="tool_choice='any' forces the model"),
     ):
-        chat_model.bind_tools([_composition_tool("attach")], tool_choice="any")
+        chat_model.bind_tools(
+            [_plain_tool("search"), _composition_tool("attach")],
+            tool_choice=tool_choice,
+        )
+
+
+def test_bind_tools_unknown_forced_tool_choice_is_left_to_the_api() -> None:
+    """Names the client can't see are not rejected locally.
+
+    `mcp_toolset` tools expose no per-tool `name` -- the names live on the MCP
+    server -- so a forced choice naming one is only resolvable server-side.
+    """
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    bound = chat_model.bind_tools(
+        [{"type": "mcp_toolset", "mcp_server_name": "notion"}],
+        tool_choice="notion_create_attachment",
+    )
+    assert cast("RunnableBinding", bound).kwargs["tool_choice"] == {
+        "type": "tool",
+        "name": "notion_create_attachment",
+    }
+
+
+def test_with_structured_output_root_combinator_raises_actionable_error() -> None:
+    """A root-combinator schema fails at bind time, naming the real remedy."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+
+    class _Left(BaseModel):
+        a: int
+
+    class _Right(BaseModel):
+        b: str
+
+    class _Either(RootModel):
+        root: _Left | _Right
+
+    with (
+        pytest.warns(UserWarning, match="Dropping tool"),
+        pytest.raises(ValueError, match="method='json_schema'"),
+    ):
+        chat_model.with_structured_output(_Either, method="function_calling")
+
+
+def test_with_structured_output_root_combinator_raises_when_thinking_enabled() -> None:
+    """The thinking path must not degrade to a toolless request and a wrong error.
+
+    Without the bind-time raise, this spends an API call and then reports the
+    failure as a `thinking` limitation rather than a schema problem.
+    """
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+        thinking={"type": "enabled", "budget_tokens": 1024},
+    )
+
+    class _Left(BaseModel):
+        a: int
+
+    class _Right(BaseModel):
+        b: str
+
+    class _Either(RootModel):
+        root: _Left | _Right
+
+    with (
+        pytest.warns(UserWarning, match="Dropping tool"),
+        pytest.raises(ValueError, match="All 1 bound tool"),
+    ):
+        chat_model.with_structured_output(_Either, method="function_calling")
+
+
+def test_get_num_tokens_from_messages_filters_unsupported_tools() -> None:
+    """Token counting and sending agree on which tools the API will accept."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    counted: dict[str, Any] = {}
+
+    def _count_tokens(**kwargs: Any) -> Any:
+        counted.update(kwargs)
+        return SimpleNamespace(input_tokens=42)
+
+    with (
+        patch.object(chat_model._client.messages, "count_tokens", _count_tokens),
+        pytest.warns(UserWarning, match="Dropping tool"),
+    ):
+        chat_model.get_num_tokens_from_messages(
+            [HumanMessage("hi")],
+            tools=[_plain_tool("search"), _composition_tool("attach")],
+        )
+
+    assert [t["name"] for t in counted["tools"]] == ["search"]
 
 
 def test_fine_grained_tool_streaming_beta() -> None:
@@ -3934,7 +4104,12 @@ def test_bind_tools_drops_forced_tool_choice_when_thinking_enabled() -> None:
 def test_bind_tools_drops_forced_choice_for_filtered_tool_when_thinking_enabled(
     thinking: dict[str, Any],
 ) -> None:
-    """Thinking takes precedence over forced-choice validation."""
+    """Thinking takes precedence over forced-choice validation.
+
+    Thinking discards a forced `tool_choice` before the request is sent, so the
+    choice need not survive filtering. A usable tool must remain, though --
+    otherwise the all-tools-dropped guard applies regardless of thinking.
+    """
     chat_model = ChatAnthropic(
         model=MODEL_NAME,
         anthropic_api_key="secret-api-key",
@@ -3949,10 +4124,14 @@ def test_bind_tools_drops_forced_choice_for_filtered_tool_when_thinking_enabled(
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         result = chat_model.bind_tools(
-            [unsupported_tool], tool_choice="unsupported_tool"
+            [_plain_tool("search"), unsupported_tool],
+            tool_choice="unsupported_tool",
         )
 
     assert "tool_choice" not in cast("RunnableBinding", result).kwargs
+    assert [t["name"] for t in cast("RunnableBinding", result).kwargs["tools"]] == [
+        "search"
+    ]
     assert len(w) == 2
     assert "unsupported_tool" in str(w[0].message)
     assert "thinking is enabled" in str(w[1].message)

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -1714,7 +1714,7 @@ def _composition_tool(name: str) -> dict:
 
 
 def test_bind_tools_dropped_tool_forced_by_tool_choice_raises() -> None:
-    """A forced `tool_choice` for a dropped tool raises locally, not a 400."""
+    """A dropped forced tool raises locally even when valid tools remain."""
     chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
         model=MODEL_NAME,
         anthropic_api_key="secret-api-key",
@@ -1724,7 +1724,14 @@ def test_bind_tools_dropped_tool_forced_by_tool_choice_raises() -> None:
         pytest.raises(ValueError, match="tool_choice references 'attach'"),
     ):
         chat_model.bind_tools(
-            [_composition_tool("attach")],
+            [
+                {
+                    "name": "search",
+                    "description": "Search.",
+                    "input_schema": {"type": "object", "properties": {}},
+                },
+                _composition_tool("attach"),
+            ],
             tool_choice={"type": "tool", "name": "attach"},
         )
     # Bare-string tool_choice naming the dropped tool raises too.
@@ -1733,6 +1740,25 @@ def test_bind_tools_dropped_tool_forced_by_tool_choice_raises() -> None:
         pytest.raises(ValueError, match="tool_choice references 'attach'"),
     ):
         chat_model.bind_tools([_composition_tool("attach")], tool_choice="attach")
+
+
+def test_bind_tools_unknown_forced_tool_choice_raises() -> None:
+    """An unknown forced tool reports that it was never bound."""
+    chat_model = ChatAnthropic(  # type: ignore[call-arg, call-arg]
+        model=MODEL_NAME,
+        anthropic_api_key="secret-api-key",
+    )
+    with pytest.raises(ValueError, match="no bound tool has that name"):
+        chat_model.bind_tools(
+            [
+                {
+                    "name": "search",
+                    "description": "Search.",
+                    "input_schema": {"type": "object", "properties": {}},
+                },
+            ],
+            tool_choice="attach",
+        )
 
 
 def test_bind_tools_any_with_all_tools_dropped_raises() -> None:

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -343,7 +343,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -587,7 +587,7 @@ requires-dist = [
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity", "meta"]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.15.0,<0.17.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.26,<1.6.0" },
     { name = "langchain-openai", editable = "../openai" },
@@ -663,7 +663,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.13.1,<0.17.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.5,<1.6" },
     { name = "defusedxml", specifier = ">=0.7.1,<1.0.0" },
@@ -690,7 +690,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.5.2"
+version = "1.5.3"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -723,7 +723,7 @@ dev = [
     { name = "jupyter", specifier = ">=1.0.0,<2.0.0" },
     { name = "setuptools", specifier = ">=67.6.1,<84.0.0" },
 ]
-lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.15.0,<0.17.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.18,<1.6.0" },
     { name = "freezegun", specifier = ">=1.2.2,<2.0.0" },
@@ -798,11 +798,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.15.0,<0.16.0" }]
+lint = [{ name = "ruff", specifier = ">=0.15.0,<0.17.0" }]
 test = []
 test-integration = []
 typing = [
-    { name = "mypy", specifier = ">=2.1.0,<2.2.0" },
+    { name = "mypy", specifier = ">=2.1.0,<2.4.0" },
     { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
 ]
 


### PR DESCRIPTION
`ChatAnthropic.bind_tools` no longer fails an entire tool-calling request because one bound tool has an `input_schema` that the Anthropic API will not accept.

Related #39271

[Related JS PR](https://github.com/langchain-ai/langchainjs/pull/11310)

---

`ChatAnthropic` now preserves tools that use root-level `allOf` schemas while continuing to filter unsupported root-level `oneOf` and `anyOf` schemas.

## Why

The MCP specification [(SEP-2106)](https://modelcontextprotocol.io/seps/2106-json-schema-2020-12) permits root-level JSON Schema composition in a tool `inputSchema`. Anthropic accepts root `allOf` as a schema merge, but rejects root `oneOf` and `anyOf` during tool validation.

An MCP server can therefore emit a spec-compliant tool schema that Anthropic refuses. Previously, LangChain forwarded that schema unchanged, so a single incompatible tool prevented every tool in the request from being used.

## What this does

Any tool whose root `input_schema` carries `oneOf` or `anyOf` is dropped with a `UserWarning` naming the tool and offending keyword. The remaining tools bind normally, so one incompatible schema no longer costs the caller the whole tool list. Root `allOf` schemas are preserved, as are combinators nested under `properties` and built-in server-side tools without an `input_schema`.

Dropping is appropriate only when a usable tool remains. Two cases raise `ValueError` at bind time instead:

- **Every tool was dropped.** Binding a model to an empty tool list makes tool calling silently unavailable.
- **A forced `tool_choice` can no longer be honored.** A specific dropped tool, or `tool_choice="any"` after the tool set shrank, can leave an agent depending on an unreachable tool. This does not apply when `thinking` is enabled, because the forced choice is already discarded before the request is sent.

Error messages name the affected tools and distinguish remedies for schemas the caller controls from third-party MCP schemas. For structured output, they point to `with_structured_output(..., method="json_schema")` where appropriate.

`get_num_tokens_from_messages` applies the same `oneOf`/`anyOf` filtering as `bind_tools`, keeping token counting consistent with request binding.