### PR TITLE
fix(core): parse tool call args strictly once the stream has ended

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -552,9 +552,14 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 )
             )
 
+        # Once the stream has ended, tool call arguments must be complete,
+        # valid JSON. Parsing them partially here would silently discard
+        # truncated arguments and surface the result as a well-formed tool
+        # call, so parse strictly and route failures to ``invalid_tool_calls``.
+        parse_args = json.loads if self.chunk_position == "last" else parse_partial_json
         for chunk in self.tool_call_chunks:
             try:
-                args_ = parse_partial_json(chunk["args"]) if chunk["args"] else {}
+                args_ = parse_args(chunk["args"]) if chunk["args"] else {}
                 if isinstance(args_, dict):
                     tool_calls.append(
                         create_tool_call(

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -576,3 +576,100 @@ def test_content_blocks_reasoning_extraction() -> None:
     content_blocks = message.content_blocks
     assert len(content_blocks) == 1
     assert content_blocks[0]["type"] == "text"
+
+
+def test_truncated_tool_call_args_on_last_chunk_are_invalid() -> None:
+    """A stream cut mid-arguments must not yield a valid tool call.
+
+    Partial parsing is correct *during* a stream, but once the stream has ended
+    the arguments are final. Parsing them partially silently drops the missing
+    arguments -- including any with defaults, such as ``confirm`` or ``dry_run``
+    -- and presents the result as a complete call.
+    """
+    chunk = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name="transfer_funds",
+                args='{"to": "alice", "amount": 100, "conf',
+                id="call_1",
+                index=0,
+            )
+        ],
+        chunk_position="last",
+    )
+
+    assert chunk.tool_calls == []
+    assert len(chunk.invalid_tool_calls) == 1
+    assert chunk.invalid_tool_calls[0]["name"] == "transfer_funds"
+    assert chunk.invalid_tool_calls[0]["args"] == '{"to": "alice", "amount": 100, "conf'
+    assert chunk.invalid_tool_calls[0]["id"] == "call_1"
+
+
+def test_complete_tool_call_args_on_last_chunk_still_parse() -> None:
+    """Well-formed arguments on the final chunk are unaffected."""
+    chunk = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name="transfer_funds",
+                args='{"to": "alice", "amount": 100, "confirm": true}',
+                id="call_1",
+                index=0,
+            )
+        ],
+        chunk_position="last",
+    )
+
+    assert chunk.invalid_tool_calls == []
+    assert len(chunk.tool_calls) == 1
+    assert chunk.tool_calls[0]["args"] == {
+        "to": "alice",
+        "amount": 100,
+        "confirm": True,
+    }
+
+
+def test_partial_tool_call_args_mid_stream_still_parse_partially() -> None:
+    """Mid-stream chunks keep partial parsing, so streaming UIs are unchanged."""
+    chunk = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name="transfer_funds",
+                args='{"to": "alice", "amount": 100, "conf',
+                id="call_1",
+                index=0,
+            )
+        ],
+        # no chunk_position -> stream still in progress
+    )
+
+    assert chunk.invalid_tool_calls == []
+    assert len(chunk.tool_calls) == 1
+    assert chunk.tool_calls[0]["args"] == {"to": "alice", "amount": 100}
+
+
+def test_accumulated_stream_ending_truncated_is_invalid() -> None:
+    """The realistic path: chunks accumulate, then the stream ends truncated."""
+    c1 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(
+                name="transfer_funds", args='{"to": "ali', id="call_1", index=0
+            )
+        ],
+    )
+    c2 = AIMessageChunk(
+        content="",
+        tool_call_chunks=[
+            create_tool_call_chunk(name=None, args='ce", "conf', id=None, index=0)
+        ],
+        chunk_position="last",
+    )
+
+    merged = c1 + c2
+
+    assert merged.tool_calls == []
+    assert len(merged.invalid_tool_calls) == 1
+    assert merged.invalid_tool_calls[0]["args"] == '{"to": "alice", "conf'


### PR DESCRIPTION
Fixes #39275

# PR: parse tool-call arguments strictly once the stream has ended

**Repo:** `langchain-ai/langchain` · **Package:** `langchain-core` · **File:** `libs/core/langchain_core/messages/ai.py`

## Problem

`AIMessageChunk.init_tool_calls` runs every tool-call chunk's `args` through `parse_partial_json` — **including the final chunk of a stream**. Partial parsing is correct *while* a stream is in flight, but once it has ended the arguments are final. If the stream was truncated mid-arguments, partial parsing silently discards the missing arguments and produces a **well-formed tool call**, with `invalid_tool_calls` left empty. Nothing signals that anything was lost.

The practical consequence: required parameters fail loudly downstream, but **parameters with defaults are silently filled in** — which in practice means safety-oriented flags like `confirm`, `dry_run`, or `force` take their default rather than the value the model actually produced.

## Reproduction

Truncating `'{"to": "alice", "amount": 100, "confirm": true, "dry_run": false}'` to `'{"to": "alice", "amount": 100, "conf'` on a chunk with `chunk_position="last"`:

```
before:  tool_calls        -> {'to': 'alice', 'amount': 100}
         invalid_tool_calls -> []          # nothing reported

after:   tool_calls        -> []
         invalid_tool_calls -> [{'name': 'transfer_funds',
                                 'args': '{"to": "alice", "amount": 100, "conf', ...}]
```

Full script in `repro.py`.

## The change

Select the parser based on whether the stream has ended, leaving everything else untouched:

```python
parse_args = json.loads if self.chunk_position == "last" else parse_partial_json
```

`json` is already imported in this module, so the diff adds no imports and is 22 lines including the comment.

## Why this shape

Two sibling paths in this same repo already treat truncated tool-call arguments as invalid rather than parsing them partially — `langchain_core/messages/tool.py` (`default_tool_parser`) and the v0 compat bridge. This change makes `AIMessageChunk` consistent with them, so it's a consistency fix rather than a behavior proposal.

Mid-stream behavior is deliberately unchanged: streaming UIs that render partial arguments as they arrive continue to work exactly as before. Only the terminal chunk is parsed strictly.

## Tests

Four tests added to `libs/core/tests/unit_tests/messages/test_ai.py`:

- `test_truncated_tool_call_args_on_last_chunk_are_invalid` — the bug. **Fails on `main`.**
- `test_accumulated_stream_ending_truncated_is_invalid` — same via chunk accumulation, the realistic path. **Fails on `main`.**
- `test_complete_tool_call_args_on_last_chunk_still_parse` — control.
- `test_partial_tool_call_args_mid_stream_still_parse_partially` — control, guards the streaming-UI behavior.

Verified: 2 fail before the change and all 4 pass after. The existing suite is unaffected — `tests/unit_tests/messages/` is 210 passed, and the wider `tests/unit_tests/` run shows an identical pass/fail set before and after (12 pre-existing failures unrelated to this area, caused by a missing optional `langchain_tests` dependency in my environment).

## Scope note

This PR does **not** address the separate performance issue in the same function: because `init_tool_calls` is an `@model_validator(mode="after")`, it re-parses the entire accumulated arguments string on every chunk, so streaming aggregation is O(n²) in chunk count. I measured ~3.8× time per doubling of chunk count (2,000 chunks ≈ 78 KB took ~7.3s), and confirmed **this change does not improve it** — the intermediate `parse_partial_json` calls still dominate. Happy to open that as a separate issue; it needs a different fix (incremental parsing or deferring population), and bundling it here would muddy an otherwise minimal correctness change.
