### PR TITLE
release(anthropic): 1.5.4

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/_version.py
+++ b/libs/partners/anthropic/langchain_anthropic/_version.py
@@ -1,3 +1,3 @@
 """Version information for `langchain-anthropic`."""
 
-__version__ = "1.5.3"
+__version__ = "1.5.4"

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
-version = "1.5.3"
+version = "1.5.4"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "anthropic>=0.120.0,<1.0.0",

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -617,7 +617,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.5.3"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Changes since 1.5.3:

- `ChatAnthropic` now exposes a `user_profile_id` convenience attribute (#39148)
- Fixed `tool_choice` being overridden instead of preserving the caller's value (#39206)
- Fixed handling of tool schemas with unsupported top-level composition (#39273)