### PR TITLE
fix(evaluation): use last-match for verdict extraction in scoring, comparison, and QA evaluators

### DIFF
--- a/libs/langchain/langchain_classic/evaluation/comparison/eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/comparison/eval_chain.py
@@ -127,12 +127,11 @@ class PairwiseStringResultOutputParser(BaseOutputParser[dict]):
             ValueError: If the verdict is invalid.
 
         """
-        match = _FIND_DOUBLE_BRACKETS.search(text)
+        matches = _FIND_DOUBLE_BRACKETS.findall(text)
 
-        if match:
-            verdict = match.group(1)
+        verdict = matches[-1] if matches else None
 
-        if not match or verdict not in {"A", "B", "C"}:
+        if not matches or verdict not in {"A", "B", "C"}:
             msg = (
                 f"Invalid output: {text}. "
                 "Output must contain a double bracketed string\

--- a/libs/langchain/langchain_classic/evaluation/qa/eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/qa/eval_chain.py
@@ -24,11 +24,14 @@ from langchain_classic.schema import RUN_KEY
 
 
 def _get_score(text: str) -> tuple[str, int] | None:
-    match = re.search(r"grade:\s*(correct|incorrect)", text.strip(), re.IGNORECASE)
-    if match:
-        if match.group(1).upper() == "CORRECT":
+    matches = re.findall(
+        r"grade:\s*(correct|incorrect)", text.strip(), re.IGNORECASE
+    )
+    if matches:
+        grade = matches[-1].upper()
+        if grade == "CORRECT":
             return "CORRECT", 1
-        if match.group(1).upper() == "INCORRECT":
+        if grade == "INCORRECT":
             return "INCORRECT", 0
     try:
         first_word = (

--- a/libs/langchain/langchain_classic/evaluation/scoring/eval_chain.py
+++ b/libs/langchain/langchain_classic/evaluation/scoring/eval_chain.py
@@ -128,12 +128,11 @@ class ScoreStringResultOutputParser(BaseOutputParser[dict]):
             ValueError: If the verdict is invalid.
 
         """
-        match = _FIND_DOUBLE_BRACKETS.search(text)
+        matches = _FIND_DOUBLE_BRACKETS.findall(text)
 
-        if match:
-            verdict = match.group(1)
+        verdict = matches[-1] if matches else None
 
-        if not match or verdict not in [*list("123456789"), "10"]:
+        if not matches or verdict not in [*list("123456789"), "10"]:
             msg = (
                 f"Invalid output: {text}. "
                 "Output must contain a double bracketed string\


### PR DESCRIPTION
## Summary

Three LLM-as-judge evaluators in `langchain_classic.evaluation` extract verdicts using first-match parsing. Because the output under evaluation is interpolated into the judge prompt without fencing, a model that embeds a verdict token (`[[10]]`, `[[A]]`, `GRADE: correct`) in its own answer can have that token captured when the judge echoes the answer.

| Evaluator | File | Current | Fix |
|---|---|---|---|
| ScoreStringEval | `scoring/eval_chain.py:131` | `_FIND_DOUBLE_BRACKETS.search(text)` | `findall(text)[-1]` |
| PairwiseStringEval | `comparison/eval_chain.py:130` | `_FIND_DOUBLE_BRACKETS.search(text)` | `findall(text)[-1]` |
| QAEvalChain | `qa/eval_chain.py:27` | `re.search(r"grade:\s*(correct\|incorrect)")` | `re.findall(...)[-1]` |

## Fix

Replace `.search()` (first-match) with `.findall()[-1]` (last-match). The judge's own verdict is the last verdict token in a well-formed response, so last-match binds the verdict to the judge rather than to echoed text.

This mirrors the convention used by inspect_ai (`DEFAULT_GRADE_PATTERN` uses a greedy prefix for last-match) and openai/evals (`cot_classify` reverses lines).

## Verification

- `ruff check`: all checks passed
- 3 files changed, 13 insertions, 12 deletions
- No existing logic changed beyond the extraction match direction