### PR TITLE
fix(core): handle falsy LLM and chat model caches

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1888,9 +1888,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         # We should check the cache unless it's explicitly set to False
         # A None cache means we should use the default global cache
         # if it's configured.
-        check_cache = self.cache or self.cache is None
+        check_cache = self.cache is not False
         if check_cache:
-            if llm_cache:
+            if llm_cache is not None:
                 llm_string = self._get_llm_string(stop=stop, **kwargs)
                 normalized_messages = [
                     (
@@ -2032,7 +2032,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 **result.llm_output,
                 **result.generations[0].message.response_metadata,
             }
-        if check_cache and llm_cache:
+        if check_cache and llm_cache is not None:
             llm_cache.update(prompt, llm_string, result.generations)
         return result
 
@@ -2047,9 +2047,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         # We should check the cache unless it's explicitly set to False
         # A None cache means we should use the default global cache
         # if it's configured.
-        check_cache = self.cache or self.cache is None
+        check_cache = self.cache is not False
         if check_cache:
-            if llm_cache:
+            if llm_cache is not None:
                 llm_string = self._get_llm_string(stop=stop, **kwargs)
                 normalized_messages = [
                     (
@@ -2189,7 +2189,7 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                 **result.llm_output,
                 **result.generations[0].message.response_metadata,
             }
-        if check_cache and llm_cache:
+        if check_cache and llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result.generations)
         return result
 

--- a/libs/core/langchain_core/language_models/llms.py
+++ b/libs/core/langchain_core/language_models/llms.py
@@ -182,13 +182,13 @@ def get_prompts(
 
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = llm_cache.lookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
-            else:
-                missing_prompts.append(prompt)
-                missing_prompt_idxs.append(i)
+                continue
+        missing_prompts.append(prompt)
+        missing_prompt_idxs.append(i)
     return existing_prompts, llm_string, missing_prompt_idxs, missing_prompts
 
 
@@ -217,13 +217,13 @@ async def aget_prompts(
     existing_prompts = {}
     llm_cache = _resolve_cache(cache=cache)
     for i, prompt in enumerate(prompts):
-        if llm_cache:
+        if llm_cache is not None:
             cache_val = await llm_cache.alookup(prompt, llm_string)
             if isinstance(cache_val, list):
                 existing_prompts[i] = cache_val
-            else:
-                missing_prompts.append(prompt)
-                missing_prompt_idxs.append(i)
+                continue
+        missing_prompts.append(prompt)
+        missing_prompt_idxs.append(i)
     return existing_prompts, llm_string, missing_prompt_idxs, missing_prompts
 
 
@@ -288,7 +288,7 @@ async def aupdate_cache(
     for i, result in enumerate(new_results.generations):
         existing_prompts[missing_prompt_idxs[i]] = result
         prompt = prompts[missing_prompt_idxs[i]]
-        if llm_cache:
+        if llm_cache is not None:
             await llm_cache.aupdate(prompt, llm_string, result)
     return new_results.llm_output
 

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_cache.py
@@ -38,6 +38,10 @@ class InMemoryCache(BaseCache):
         """Clear cache."""
         self._cache = {}
 
+    def __len__(self) -> int:
+        """Return the number of cached entries."""
+        return len(self._cache)
+
 
 def test_local_cache_sync() -> None:
     """Test that the local cache is being populated but not the global one."""

--- a/libs/core/tests/unit_tests/language_models/llms/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/llms/test_cache.py
@@ -27,6 +27,10 @@ class InMemoryCache(BaseCache):
         """Clear cache."""
         self._cache = {}
 
+    def __len__(self) -> int:
+        """Return the number of cached entries."""
+        return len(self._cache)
+
 
 async def test_local_cache_generate_async() -> None:
     global_cache = InMemoryCache()


### PR DESCRIPTION
## Summary

fixes #38440

If a cache implementation implements `__len__`, it will be falsy when empty which causes some awkward behavior with chat model/llm caches. (we haven't seen this before with other cache implementations because they often implement caches for networked storage where `__len__` is not implemented)

* fixes a condition where we weren't populating from global cache if a cache wasn't specified in chat model configuration
* fixes a condition where we could never populate the cache if it was empty (adding identity check instead of truthiness check)
* this also fixes a condition in chat_models.py/llms.py where we weren't fully populating the lists that informed cached results. All results if not cached will be added to the missing accumulator, not based on the `if llm_cache` condition
