### PR TITLE
fix(langchain): preserve final repeated schema ordering

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -436,7 +436,11 @@ def _resolve_schemas(schemas: list[type]) -> tuple[type, type, type]:
     same field is declared by multiple schemas.  Duplicates are harmless — a type
     that appears more than once is processed at its last position.
     """
-    schema_hints = {schema: _get_schema_type_hints(schema) for schema in schemas}
+    schema_hints = {}
+    for schema in schemas:
+        # Reinsert duplicates so dict iteration reflects their final position.
+        schema_hints.pop(schema, None)
+        schema_hints[schema] = _get_schema_type_hints(schema)
     return (
         _resolve_schema(schema_hints, "StateSchema", None),
         _resolve_schema(schema_hints, "InputSchema", "input"),

--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -436,7 +436,7 @@ def _resolve_schemas(schemas: list[type]) -> tuple[type, type, type]:
     same field is declared by multiple schemas.  Duplicates are harmless — a type
     that appears more than once is processed at its last position.
     """
-    schema_hints = {}
+    schema_hints: dict[type, dict[str, Any]] = {}
     for schema in schemas:
         # Reinsert duplicates so dict iteration reflects their final position.
         schema_hints.pop(schema, None)

--- a/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_state_schema.py
@@ -302,6 +302,10 @@ def test_last_schema_wins_for_conflicting_field() -> None:
     hints = get_type_hints(resolved, include_extras=True)
     assert get_args(hints["shared_field"])[1] == "last"
 
+    resolved, _, _ = factory._resolve_schemas([LastState, MiddleState, LastState])
+    hints = get_type_hints(resolved, include_extras=True)
+    assert get_args(hints["shared_field"])[1] == "last"
+
 
 def test_get_schema_type_hints_cache_hits_for_reused_schema() -> None:
     """Test repeated schema resolution reuses cached type hints for the same schema."""


### PR DESCRIPTION
## Summary

fixes #38720

the way we assume cache equality works using dict assignment - if the same schema appears multiple times in middleware + top level definition (e.g. `[LastState, MiddleState, LastState]`, LastState being whats passed into create_agent state_schema), the order isn't actually respected because dictionary iteration doesn't guarantee order preservation when reassigning keys. (python 3.7+)

This fixes by iterating through all schemas, popping them from the hints dictionary and reinserting them so that the last occurrence is preserved.
