### PR TITLE
fix(anthropic): clearer error when no credentials are configured

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -895,9 +895,10 @@ def _raise_if_authentication_error(e: TypeError) -> None:
         msg = (
             "Anthropic authentication failed: no API key or authorization "
             "credentials were provided. Set the ANTHROPIC_API_KEY environment "
-            "variable, pass api_key=... to ChatAnthropic, provide credentials "
-            'via default_headers={"Authorization": ...}, or configure the '
-            "LangSmith gateway (LANGSMITH_GATEWAY and LANGSMITH_GATEWAY_API_KEY)."
+            "variable, pass api_key=... to ChatAnthropic, or provide "
+            'credentials via default_headers={"Authorization": ...}. If you '
+            "are routing through the LangSmith gateway, set LANGSMITH_GATEWAY "
+            "and LANGSMITH_GATEWAY_API_KEY."
         )
         raise TypeError(msg) from e
 

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -889,6 +889,19 @@ class AnthropicContextOverflowError(anthropic.BadRequestError, ContextOverflowEr
     """BadRequestError raised when input exceeds Anthropic's context limit."""
 
 
+def _raise_if_authentication_error(e: TypeError) -> None:
+    """Re-raise anthropic SDK's missing-credentials `TypeError` with guidance."""
+    if "Could not resolve authentication method" in str(e):
+        msg = (
+            "Anthropic authentication failed: no API key or authorization "
+            "credentials were provided. Set the ANTHROPIC_API_KEY environment "
+            "variable, pass api_key=... to ChatAnthropic, provide credentials "
+            'via default_headers={"Authorization": ...}, or configure the '
+            "LangSmith gateway (LANGSMITH_GATEWAY and LANGSMITH_GATEWAY_API_KEY)."
+        )
+        raise TypeError(msg) from e
+
+
 def _handle_anthropic_bad_request(e: anthropic.BadRequestError) -> None:
     """Handle Anthropic BadRequestError."""
     if "prompt is too long" in e.message:
@@ -1593,14 +1606,22 @@ class ChatAnthropic(BaseChatModel):
         return {k: v for k, v in payload.items() if v is not None}
 
     def _create(self, payload: dict) -> Any:
-        if "betas" in payload:
-            return self._client.beta.messages.create(**payload)
-        return self._client.messages.create(**payload)
+        try:
+            if "betas" in payload:
+                return self._client.beta.messages.create(**payload)
+            return self._client.messages.create(**payload)
+        except TypeError as e:
+            _raise_if_authentication_error(e)
+            raise
 
     async def _acreate(self, payload: dict) -> Any:
-        if "betas" in payload:
-            return await self._async_client.beta.messages.create(**payload)
-        return await self._async_client.messages.create(**payload)
+        try:
+            if "betas" in payload:
+                return await self._async_client.beta.messages.create(**payload)
+            return await self._async_client.messages.create(**payload)
+        except TypeError as e:
+            _raise_if_authentication_error(e)
+            raise
 
     def _stream(
         self,

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -4567,3 +4567,65 @@ def test_langsmith_gateway_provider_base_url_uses_provider_key(
     llm = ChatAnthropic(model=MODEL_NAME)
     assert llm.anthropic_api_url == "https://api.anthropic.com"
     assert llm.anthropic_api_key.get_secret_value() == "provider-key"
+
+
+_MISSING_CREDENTIALS_TYPE_ERROR = TypeError(
+    "Could not resolve authentication method. Expected one of api_key, "
+    "auth_token, or credentials to be set. Or for one of the `X-Api-Key` or "
+    "`Authorization` headers to be explicitly omitted"
+)
+
+
+def _clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+
+
+def test_missing_credentials_error_sync(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing credentials raise a `TypeError` with LangChain guidance."""
+    _clear_auth_env(monkeypatch)
+    llm = ChatAnthropic(model=MODEL_NAME)
+
+    with (  # noqa: PT012
+        patch.object(llm._client.messages, "create") as mock_create,
+        pytest.raises(TypeError, match="ANTHROPIC_API_KEY") as exc_info,
+    ):
+        mock_create.side_effect = _MISSING_CREDENTIALS_TYPE_ERROR
+        llm.invoke([HumanMessage(content="test")])
+
+    assert exc_info.value.__cause__ is _MISSING_CREDENTIALS_TYPE_ERROR
+
+
+async def test_missing_credentials_error_async(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing credentials raise a `TypeError` with LangChain guidance (async)."""
+    _clear_auth_env(monkeypatch)
+    llm = ChatAnthropic(model=MODEL_NAME)
+
+    with (  # noqa: PT012
+        patch.object(llm._async_client.messages, "create") as mock_create,
+        pytest.raises(TypeError, match="ANTHROPIC_API_KEY") as exc_info,
+    ):
+        mock_create.side_effect = _MISSING_CREDENTIALS_TYPE_ERROR
+        await llm.ainvoke([HumanMessage(content="test")])
+
+    assert exc_info.value.__cause__ is _MISSING_CREDENTIALS_TYPE_ERROR
+
+
+def test_unrelated_type_error_propagates_unchanged() -> None:
+    """A `TypeError` not about authentication is re-raised as-is."""
+    llm = ChatAnthropic(model=MODEL_NAME)
+    unrelated_error = TypeError("some unrelated client error")
+
+    with (  # noqa: PT012
+        patch.object(llm._client.messages, "create") as mock_create,
+        pytest.raises(TypeError) as exc_info,
+    ):
+        mock_create.side_effect = unrelated_error
+        llm.invoke([HumanMessage(content="test")])
+
+    assert exc_info.value is unrelated_error


### PR DESCRIPTION
`ChatAnthropic` now raises a clear, actionable `TypeError` when a call is made without any Anthropic credentials configured. The message points users to `ANTHROPIC_API_KEY`, the `api_key=` parameter, `default_headers`, and the LangSmith gateway, replacing the anthropic SDK's internal "Could not resolve authentication method" error. The original error remains available via exception chaining.

---

Users who construct `ChatAnthropic` without credentials currently get a confusing failure on their first call. The model builds fine with no API key — `anthropic_api_key` defaults to an empty `SecretStr`, and the raw anthropic SDK accepts it at construction — so the error only surfaces on the first `invoke()`/`stream()`, deep inside the anthropic SDK's header validation:

```
TypeError: "Could not resolve authentication method. Expected one of api_key,
auth_token, or credentials to be set. Or for one of the `X-Api-Key` or
`Authorization` headers to be explicitly omitted"
```

That message never mentions `ANTHROPIC_API_KEY`, `api_key=`, or the LangSmith gateway — the things a LangChain user actually needs to fix — and the traceback points into the anthropic SDK rather than at the missing configuration.

This PR catches that specific `TypeError` at the call site in `ChatAnthropic._create`/`_acreate` (covering both the beta and non-beta `messages.create` paths) and re-raises it, chained `from e`, with LangChain-specific guidance:

```
Anthropic authentication failed: no API key or authorization credentials
were provided. Set the ANTHROPIC_API_KEY environment variable, pass
api_key=... to ChatAnthropic, or provide credentials via
default_headers={"Authorization": ...}. If you are routing through the
LangSmith gateway, set LANGSMITH_GATEWAY and LANGSMITH_GATEWAY_API_KEY.
```

Matching is done on the message substring, so unrelated `TypeError`s propagate unchanged. There is deliberately no construction-time validation or warning: key-less setups are legitimate (LangSmith gateway routing, `default_headers` with an explicit `Authorization` header, or a user-supplied `http_client` that injects auth), so the error still surfaces only at call time, exactly as before — just with an actionable message.