### PR TITLE
fix(openai): reuse cached default httpx client in AzureChatOpenAI

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/azure.py
+++ b/libs/partners/openai/langchain_openai/chat_models/azure.py
@@ -17,6 +17,11 @@ from langchain_core.utils.pydantic import is_basemodel_subclass
 from pydantic import BaseModel, Field, SecretStr, model_validator
 from typing_extensions import Self
 
+from langchain_openai.chat_models._client_utils import (
+    _get_default_async_httpx_client,
+    _get_default_httpx_client,
+    _resolve_socket_options,
+)
 from langchain_openai.chat_models.base import BaseChatOpenAI, _get_default_model_profile
 
 if TYPE_CHECKING:
@@ -686,12 +691,27 @@ class AzureChatOpenAI(BaseChatOpenAI):
         if self.max_retries is not None:
             client_params["max_retries"] = self.max_retries
 
+        resolved_socket_options = _resolve_socket_options(self.http_socket_options)
         if not self.client:
-            sync_specific = {"http_client": self.http_client}
+            sync_specific = {
+                "http_client": self.http_client
+                or _get_default_httpx_client(
+                    self.openai_api_base,
+                    self.request_timeout,
+                    resolved_socket_options,
+                ),
+            }
             self.root_client = openai.AzureOpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
             self.client = self.root_client.chat.completions
         if not self.async_client:
-            async_specific = {"http_client": self.http_async_client}
+            async_specific = {
+                "http_client": self.http_async_client
+                or _get_default_async_httpx_client(
+                    self.openai_api_base,
+                    self.request_timeout,
+                    resolved_socket_options,
+                ),
+            }
 
             if self.azure_ad_async_token_provider:
                 client_params["azure_ad_token_provider"] = (

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_azure.py
@@ -340,3 +340,23 @@ def test_create_chat_result_avoids_parsed_model_dump_warning() -> None:
     assert result.generations[0].message.additional_kwargs["parsed"] == ModelOutput(
         output="Paris"
     )
+
+def test_azure_chat_openai_reuses_default_httpx_client() -> None:
+    """Identically configured AzureChatOpenAI instances share one httpx client.
+
+    Mirrors ChatOpenAI behavior and guards against regressing #39294.
+    """
+    llm1 = AzureChatOpenAI(
+        azure_deployment="35-turbo-dev",
+        azure_endpoint="my-base-url",
+        api_key=SecretStr("test"),
+        api_version="2023-05-15",
+    )
+    llm2 = AzureChatOpenAI(
+        azure_deployment="35-turbo-dev",
+        azure_endpoint="my-base-url",
+        api_key=SecretStr("test"),
+        api_version="2023-05-15",
+    )
+    assert llm1.root_client._client is llm2.root_client._client
+    assert llm1.root_async_client._client is llm2.root_async_client._client


### PR DESCRIPTION
Fixes #39294

`AzureChatOpenAI.validate_environment` passed `http_client=None` straight into `openai.AzureOpenAI` when no custom client was configured, so every instantiation created a brand-new underlying `httpx.Client`/`AsyncClient`. `ChatOpenAI` already reuses a cached default client via `_get_default_httpx_client` / `_get_default_async_httpx_client`.

Mirror the base implementation in the Azure path: fall back to the cached default httpx clients, keyed by base URL, timeout, and socket options. Two identically configured `AzureChatOpenAI` instances now share the same underlying client, and a regression test asserts the reuse.