### PR TITLE
fix(core): correct operator validation error wording

### DIFF
--- a/libs/core/langchain_core/structured_query.py
+++ b/libs/core/langchain_core/structured_query.py
@@ -29,7 +29,7 @@ class Visitor(ABC):
         ):
             msg = (
                 f"Received disallowed operator {func}. Allowed "
-                f"comparators are {self.allowed_operators}"
+                f"operators are {self.allowed_operators}"
             )
             raise ValueError(msg)
         if (


### PR DESCRIPTION
## Summary
Correct the copy-paste wording in `Visitor._validate_func` so disallowed operators report allowed operators rather than comparators.

## Tests
- `git diff --check`
- Python 3.12 direct behavioral assertion for `Visitor._validate_func(Operator.OR)`

Closes #36701