### PR TITLE
fix(core): preserve flat tool args schema for `RootModel` runnables

### DIFF
--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -4,7 +4,7 @@ import inspect
 from collections.abc import Callable
 from typing import Any, Literal, cast, get_type_hints, overload
 
-from pydantic import BaseModel, Field, create_model
+from pydantic import BaseModel, Field, RootModel, create_model
 
 from langchain_core.callbacks import Callbacks
 from langchain_core.runnables import Runnable
@@ -469,13 +469,25 @@ def convert_runnable_to_tool(
     def invoke_wrapper(callbacks: Callbacks | None = None, **kwargs: Any) -> Any:
         return runnable.invoke(kwargs, config={"callbacks": callbacks})
 
+    input_schema_cls = runnable.input_schema
+    is_root_model = isinstance(input_schema_cls, type) and issubclass(
+        input_schema_cls, RootModel
+    )
     if (
         arg_types is None
         and schema.get("type") == "object"
         and schema.get("properties")
+        and not is_root_model
     ):
-        args_schema = runnable.input_schema
+        args_schema = input_schema_cls
     else:
+        # `Runnable`s whose input type is a `TypedDict` (e.g. a compiled
+        # `StateGraph`) expose `input_schema` as a `pydantic.RootModel`. Using it
+        # directly as `args_schema` would advertise the input nested under a
+        # synthetic `root` key, which doesn't match the flat top-level fields
+        # the runnable actually expects. Building the schema from the runnable's
+        # type hints instead keeps the advertised schema and the invocation
+        # payload in the same shape.
         args_schema = _get_schema_from_runnable_and_arg_types(
             runnable, name, arg_types=arg_types
         )

--- a/libs/core/langchain_core/tools/convert.py
+++ b/libs/core/langchain_core/tools/convert.py
@@ -470,6 +470,8 @@ def convert_runnable_to_tool(
         return runnable.invoke(kwargs, config={"callbacks": callbacks})
 
     input_schema_cls = runnable.input_schema
+    # Detect `RootModel` input schemas so we don't use them directly as the tool
+    # args schema.
     is_root_model = isinstance(input_schema_cls, type) and issubclass(
         input_schema_cls, RootModel
     )
@@ -481,13 +483,6 @@ def convert_runnable_to_tool(
     ):
         args_schema = input_schema_cls
     else:
-        # `Runnable`s whose input type is a `TypedDict` (e.g. a compiled
-        # `StateGraph`) expose `input_schema` as a `pydantic.RootModel`. Using it
-        # directly as `args_schema` would advertise the input nested under a
-        # synthetic `root` key, which doesn't match the flat top-level fields
-        # the runnable actually expects. Building the schema from the runnable's
-        # type hints instead keeps the advertised schema and the invocation
-        # payload in the same shape.
         args_schema = _get_schema_from_runnable_and_arg_types(
             runnable, name, arg_types=arg_types
         )

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, RootModel, ValidationError
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import ValidationError as ValidationErrorV1
 from typing_extensions import TypedDict, override
@@ -1757,6 +1757,58 @@ def test_convert_from_runnable_dict() -> None:
         {"a": 3, "b": [1, 2]}, config={"configurable": {"foo": "not-bar"}}
     )
     assert result == "6"
+
+
+def test_convert_from_runnable_root_model_input_schema() -> None:
+    """`as_tool` should not advertise a `TypedDict` input nested under `root`.
+
+    Some `Runnable`s (e.g. a compiled `langgraph` `StateGraph`) expose a
+    `pydantic.RootModel` as `input_schema` even though `get_input_jsonschema`
+    reports a flat object schema. See:
+    https://github.com/langchain-ai/langchain/issues/38713
+    """
+
+    class Args(TypedDict):
+        foo: str
+        bar: str
+
+    class _RootModelInputRunnable(RunnableLambda[Args, str]):
+        @override
+        def get_input_schema(
+            self, config: RunnableConfig | None = None
+        ) -> TypeBaseModel:
+            return RootModel[Args]
+
+        @override
+        def get_input_jsonschema(
+            self, config: RunnableConfig | None = None
+        ) -> dict[str, Any]:
+            return {
+                "type": "object",
+                "properties": {
+                    "foo": {"type": "string"},
+                    "bar": {"type": "string"},
+                },
+                "required": ["foo", "bar"],
+            }
+
+    def f(x: Args) -> str:
+        return f"{x['foo']} {x['bar']}"
+
+    runnable = _RootModelInputRunnable(f)
+    as_tool = runnable.as_tool(name="my_tool", description="Example tool.")
+
+    assert as_tool.args_schema is not None
+    assert isinstance(as_tool.args_schema, type)
+    assert not issubclass(as_tool.args_schema, RootModel)
+
+    oai_schema = convert_to_openai_tool(as_tool)
+    parameters = oai_schema["function"]["parameters"]
+    assert parameters["properties"].keys() == {"foo", "bar"}
+    assert "root" not in parameters["properties"]
+
+    result = as_tool.invoke({"foo": "hello", "bar": "world"})
+    assert result == "hello world"
 
 
 def test_convert_from_runnable_other() -> None:

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -1765,7 +1765,6 @@ def test_convert_from_runnable_root_model_input_schema() -> None:
     Some `Runnable`s (e.g. a compiled `langgraph` `StateGraph`) expose a
     `pydantic.RootModel` as `input_schema` even though `get_input_jsonschema`
     reports a flat object schema. See:
-    https://github.com/langchain-ai/langchain/issues/38713
     """
 
     class Args(TypedDict):


### PR DESCRIPTION
Closes #38713

Fixes `Runnable.as_tool()` advertising `TypedDict` inputs under a synthetic `root` key.

When a runnable's `input_schema` is a `RootModel` (e.g. compiled `StateGraph`s), the tool schema is now built from the runnable's type hints instead, keeping the advertised schema consistent with the flat input the runnable actually expects.

Co-authored-by: @ashusnapx <ashu.kumarexam@gmail.com>
Thanks @zyf722 for raising this!