### PR TITLE
fix(core): serialize empty list tool results

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1441,7 +1441,14 @@ def _normalize_message_content(obj: Any) -> str | list[MessageContentBlock] | No
     # Validate lazily before materializing: `all` short-circuits on the first
     # invalid element, so a large non-content sequence (e.g. `range(10**12)`)
     # falls back to stringification without allocating it.
-    if isinstance(obj, Sequence) and all(_is_message_content_block(e) for e in obj):
+    # An empty sequence is ambiguous (it could be an empty list of content
+    # blocks or a generic empty result), so treat it as non-content and let
+    # it fall through to `_stringify` for a serialized `"[]"`.
+    if (
+        isinstance(obj, Sequence)
+        and obj
+        and all(_is_message_content_block(e) for e in obj)
+    ):
         return list(obj)
     return None
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -2355,8 +2355,11 @@ def test__is_message_content_block(obj: Any, *, expected: bool) -> None:
         ("foo", True),
         (valid_tool_result_blocks, True),
         (tuple(valid_tool_result_blocks), True),
-        ([], True),  # empty sequences are vacuously valid content
-        ((), True),
+        # Empty sequences are ambiguous (could be a genuine empty result rather
+        # than an empty list of content blocks), so they are not treated as
+        # message content and get serialized instead. See issue #30578.
+        ([], False),
+        ((), False),
         (invalid_tool_result_blocks, False),
         (tuple(invalid_tool_result_blocks), False),
         (({"type": "text", "text": "ok"}, {"text": "bad"}), False),  # mixed
@@ -4113,12 +4116,16 @@ def test_format_output_list_with_non_mixin_element() -> None:
 
 
 def test_format_output_empty_list() -> None:
-    """An empty list is vacuously valid content and wrapped unchanged."""
+    """An empty list result is serialized, not treated as empty content.
+
+    See issue #30578: an unserialized empty list is indistinguishable from a
+    `ToolMessage` with no content blocks at all.
+    """
     result = _format_output(
         [], artifact=None, tool_call_id="0", name="t", status="success"
     )
     assert isinstance(result, ToolMessage)
-    assert result.content == []
+    assert result.content == "[]"
     assert result.tool_call_id == "0"
 
 


### PR DESCRIPTION
Closes #30578

Fixes tools returning an empty list producing a `ToolMessage` with no content instead of `"[]"`.

Empty lists are now treated as non-content and passed through the existing JSON serialization path, making their behavior consistent with other list results.