### PR TITLE
fix(core): use a single timestamp per batch in InMemoryRecordManager.update

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -296,12 +296,18 @@ class InMemoryRecordManager(RecordManager):
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+        # Compute the timestamp once for the whole batch so that every key
+        # upserted in this call gets the exact same `updated_at` value.
+        # Calling `get_time()` per key allowed timestamps to drift across a
+        # batch, which could cause `list_keys(before=...)` to inconsistently
+        # include/exclude keys that were updated in the same logical batch.
+        update_time = self.get_time()
+        if time_at_least and time_at_least > update_time:
+            msg = "time_at_least must be in the past"
+            raise ValueError(msg)
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
-                msg = "time_at_least must be in the past"
-                raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            self.records[key] = {"group_id": group_id, "updated_at": update_time}
 
     async def aupdate(
         self,

--- a/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
+++ b/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
@@ -145,6 +145,36 @@ async def test_aupdate_timestamp(manager: InMemoryRecordManager) -> None:
     ) == ["key1"]
 
 
+def test_update_uses_single_timestamp_for_batch(
+    manager: InMemoryRecordManager,
+) -> None:
+    """All keys upserted in a single `update()` call must share one timestamp.
+
+    Regression test: `get_time()` used to be called once per key inside the
+    update loop, so keys in the same batch could receive different
+    timestamps. That drift could cause `list_keys(before=...)` to miss some
+    keys that were logically updated together, breaking cleanup logic that
+    relies on a stable "as of" cutoff for a batch.
+    """
+    call_count = 0
+    real_get_time = manager.get_time
+
+    def fake_get_time() -> float:
+        nonlocal call_count
+        call_count += 1
+        return real_get_time()
+
+    with patch.object(manager, "get_time", side_effect=fake_get_time):
+        manager.update(["key1", "key2", "key3"])
+
+    # get_time() should be invoked exactly once for the whole batch.
+    assert call_count == 1
+
+    records = manager.records
+    timestamps = {records[key]["updated_at"] for key in ("key1", "key2", "key3")}
+    assert len(timestamps) == 1
+
+
 def test_exists(manager: InMemoryRecordManager) -> None:
     """Test checking if keys exist in the database."""
     # Insert records


### PR DESCRIPTION
Fixes #39087

## Root cause
`InMemoryRecordManager.update()` called `self.get_time()` once per key inside its loop, so keys upserted in the same logical batch could receive slightly different `updated_at` timestamps. This drift made `list_keys(before=...)` inconsistently include/exclude keys from the same batch, causing indexing cleanup (`index(..., cleanup="full"/"incremental")`) to under-delete stale records.

## Fix
Compute the timestamp once before the loop and reuse it for every key and for the `time_at_least` check, mirroring how a single "as of" cutoff should apply to an entire batch. Mirrors existing single-timestamp-per-batch semantics used in `SQLRecordManager`.

## Verification
Added a regression test asserting `get_time()` is called exactly once per `update()` call and all keys in a batch share one timestamp. Full `tests/unit_tests/indexing/` suite passes (pre-existing unrelated failures confirmed via `git stash` comparison against master).