### PR TITLE
fix(openai): respect custom base URL for Responses API routing

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -123,6 +123,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    PrivateAttr,
     SecretStr,
     ValidationError,
     field_validator,
@@ -615,6 +616,12 @@ def _model_prefers_responses_api(model_name: str | None) -> bool:
     return model_name.startswith(_RESPONSES_API_ONLY_PREFIXES) or "codex" in model_name
 
 
+def _is_standard_openai_url(url: str | None) -> bool:
+    if not url:
+        return True
+    return urlparse(url).hostname == "api.openai.com"
+
+
 _BM = TypeVar("_BM", bound=BaseModel)
 _DictOrPydanticClass: TypeAlias = dict[str, Any] | type[_BM] | type
 _DictOrPydantic: TypeAlias = dict | _BM
@@ -629,6 +636,8 @@ class BaseChatOpenAI(BaseChatModel):
     `reasoning_content`) are not extracted. Use a provider-specific subclass for
     full provider support.
     """
+
+    _base_url_from_gateway: bool = PrivateAttr(default=False)
 
     client: Any = Field(default=None, exclude=True)
 
@@ -1222,6 +1231,7 @@ class BaseChatOpenAI(BaseChatModel):
         self.openai_api_base = _gateway_config.base_url
         self.openai_api_key = _gateway_config.api_key
         _base_url_from_gateway = _gateway_config.base_url_from_gateway
+        self._base_url_from_gateway = _base_url_from_gateway
 
         # Enable stream_usage by default if using default base URL and client,
         # or when the base URL was set by the LangSmith gateway (which proxies
@@ -1757,6 +1767,13 @@ class BaseChatOpenAI(BaseChatModel):
             generation_info = {"headers": dict(raw_response.headers)}
         return self._create_chat_result(response, generation_info)
 
+    @property
+    def _is_custom_base_url(self) -> bool:
+        if getattr(self, "_base_url_from_gateway", False):
+            return False
+        base_url = self.openai_api_base or os.environ.get("OPENAI_BASE_URL")
+        return not _is_standard_openai_url(base_url)
+
     def _use_responses_api(self, payload: dict) -> bool:
         if isinstance(self.use_responses_api, bool):
             return self.use_responses_api
@@ -1767,7 +1784,10 @@ class BaseChatOpenAI(BaseChatModel):
             or self.reasoning is not None
             or self.truncation is not None
             or self.use_previous_response_id
-            or _model_prefers_responses_api(self.model_name)
+            or (
+                not self._is_custom_base_url
+                and _model_prefers_responses_api(self.model_name)
+            )
         ):
             return True
         return _use_responses_api(payload)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4303,6 +4303,80 @@ def test_model_prefers_responses_api() -> None:
     assert not _model_prefers_responses_api(None)
 
 
+@pytest.mark.parametrize(
+    ("base_url", "expected_api"),
+    [
+        (None, "responses"),
+        ("https://api.openai.com/v1", "responses"),
+        ("https://api.openai.com/v1/", "responses"),
+        ("http://localhost:8000/v1", "chat"),
+        ("https://api.openai.com.example.com/v1", "chat"),
+        ("https://api.openai.com.evil.example/v1", "chat"),
+        ("https://api.openai.com-proxy.example/v1", "chat"),
+    ],
+)
+def test_custom_base_url_responses_api_routing(
+    base_url: str | None, expected_api: str
+) -> None:
+    kwargs: dict[str, Any] = {"model": "gpt-5.3-codex", "api_key": "test"}
+    if base_url:
+        kwargs["base_url"] = base_url
+
+    llm = ChatOpenAI(**kwargs)
+    payload = llm._get_request_payload([HumanMessage(content="hello")])
+
+    if expected_api == "responses":
+        assert llm._use_responses_api({}) is True
+        assert "input" in payload
+        assert "messages" not in payload
+    else:
+        assert llm._use_responses_api({}) is False
+        assert "messages" in payload
+        assert "input" not in payload
+
+
+@pytest.mark.parametrize(
+    ("use_responses_api", "expected_key"),
+    [
+        (True, "input"),
+        (False, "messages"),
+    ],
+)
+def test_custom_base_url_explicit_use_responses_api(
+    use_responses_api: bool, expected_key: str
+) -> None:
+    llm = ChatOpenAI(
+        model="gpt-5.3-codex",
+        base_url="http://localhost:8000/v1",
+        api_key="test",
+        use_responses_api=use_responses_api,
+    )
+    assert llm._use_responses_api({}) is use_responses_api
+    payload = llm._get_request_payload([HumanMessage(content="hello")])
+    assert expected_key in payload
+
+
+def test_custom_base_url_responses_api_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:8000/v1")
+    llm = ChatOpenAI(model="gpt-5.3-codex", api_key="test")
+    assert llm._use_responses_api({}) is False
+    payload = llm._get_request_payload([HumanMessage(content="hello")])
+    assert "messages" in payload
+    assert "input" not in payload
+
+
+def test_custom_base_url_with_responses_features() -> None:
+    llm = ChatOpenAI(
+        model="gpt-5.3-codex",
+        base_url="http://localhost:8000/v1",
+        api_key="test",
+        reasoning={"effort": "low"},
+    )
+    assert llm._use_responses_api({}) is True
+
+
 def test_openai_structured_output_refusal_handling_responses_api() -> None:
     """
     Test that _oai_structured_outputs_parser raises OpenAIRefusalError


### PR DESCRIPTION
Fixes #39320

## Summary

`ChatOpenAI` automatically selects the Responses API for Codex and other Responses-API-only model names.

When a custom OpenAI-compatible `base_url` is configured, model-name detection could still force requests to `/v1/responses`, even when the custom endpoint only supports `/v1/chat/completions`.

This change prevents model-name detection alone from automatically selecting the Responses API when using a custom base URL.

Explicit Responses API configuration continues to take precedence.

## Changes

- Detect whether `ChatOpenAI` is using the standard OpenAI endpoint or a custom base URL.
- Skip automatic model-name-based Responses API routing for custom endpoints.
- Preserve explicit `use_responses_api=True` and `use_responses_api=False`.
- Preserve routing triggered by Responses API-specific features.
- Add regression coverage for custom base URLs and `OPENAI_BASE_URL`.
- Add coverage for OpenAI lookalike domains to ensure they are treated as custom endpoints.

## Tests

- `243 passed` in `tests/unit_tests/chat_models/test_base.py`
- `ruff check` passed
- `ruff format --check` passed

AI tooling was used to assist with investigation and implementation.