### PR TITLE
fix(core): compat with pydantic 2.14

### DIFF
--- a/libs/core/langchain_core/load/serializable.py
+++ b/libs/core/langchain_core/load/serializable.py
@@ -73,13 +73,13 @@ def try_neq_default(value: Any, key: str, model: BaseModel) -> bool:
 
 def _get_field_default(field: FieldInfo) -> Any:
     # Pydantic 2.14+ returns ``PydanticUndefined`` (rather than ``None``) from
-    # ``get_default()`` for an un-called ``default_factory``; call the factory to get
-    # the real default so factory-defaulted fields are not treated as non-default.
+    # ``get_default()`` for an un-called ``default_factory``. Restore the historical
+    # ``None`` so a factory-defaulted field at its default is still treated as
+    # unchanged. The factory is intentionally not called: ``get_default()`` keeps
+    # ``call_default_factory=False`` precisely because factories may have side effects.
     default = field.get_default()
     if default is PydanticUndefined and field.default_factory is not None:
-        # ``validated_data={}`` supports factories that accept the validated data;
-        # zero-argument factories ignore it.
-        return field.get_default(call_default_factory=True, validated_data={})
+        return None
     return default
 
 

--- a/libs/core/langchain_core/load/serializable.py
+++ b/libs/core/langchain_core/load/serializable.py
@@ -12,6 +12,7 @@ from typing import (
 
 from pydantic import BaseModel, ConfigDict
 from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 from typing_extensions import NotRequired, override
 
 logger = logging.getLogger(__name__)
@@ -70,14 +71,31 @@ def try_neq_default(value: Any, key: str, model: BaseModel) -> bool:
     return _try_neq_default(value, field)
 
 
+def _get_field_default(field: FieldInfo) -> Any:
+    # Pydantic 2.14+ returns ``PydanticUndefined`` (rather than ``None``) from
+    # ``get_default()`` for an un-called ``default_factory``; call the factory to get
+    # the real default so factory-defaulted fields are not treated as non-default.
+    default = field.get_default()
+    if default is PydanticUndefined and field.default_factory is not None:
+        # ``validated_data={}`` supports factories that accept the validated data;
+        # zero-argument factories ignore it.
+        return field.get_default(call_default_factory=True, validated_data={})
+    return default
+
+
 def _try_neq_default(value: Any, field: FieldInfo) -> bool:
     # Handle edge case: inequality of two objects does not evaluate to a bool (e.g. two
     # Pandas DataFrames).
     try:
-        return bool(field.get_default() != value)
+        default = _get_field_default(field)
+    except Exception as _:
+        # A raising default_factory means we cannot compare; treat as non-default.
+        return True
+    try:
+        return bool(default != value)
     except Exception as _:
         try:
-            return all(field.get_default() != value)
+            return all(default != value)
         except Exception as _:
             try:
                 return value is not field.default

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -25,6 +25,7 @@ from langchain_core.prompts import (
 )
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain_core.tracers import log_stream
+from langchain_core.utils import from_env
 
 OPENAI_TEST_MODEL = "gpt-5.5"
 
@@ -146,14 +147,19 @@ def test__is_field_useful() -> None:
     assert not _is_field_useful(foo, "y", foo.y)
 
 
-def test_try_neq_default_none_factory() -> None:
-    """A `None`-valued `default_factory` field at its default is not flagged as changed.
+def test_try_neq_default_none_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An env-backed `default_factory` at its `None` default is not flagged as changed.
 
-    Regression test for issue #39157.
+    Mirrors the real `output_version` field on chat models
+    (`Field(default_factory=from_env(..., default=None))`). Regression test for issue
+    #39157.
     """
+    monkeypatch.delenv("LC_TEST_OUTPUT_VERSION", raising=False)
 
     class Model(BaseModel):
-        none_factory: str | None = Field(default_factory=lambda: None)
+        none_factory: str | None = Field(
+            default_factory=from_env("LC_TEST_OUTPUT_VERSION", default=None)
+        )
 
     field = Model.model_fields["none_factory"]
     assert not _try_neq_default(None, field)
@@ -168,10 +174,14 @@ def test_try_neq_default_simulating_pydantic_2_14(
     Pydantic 2.14+ returns the sentinel (instead of `None`) for an un-called
     `default_factory`; this forces that behavior on the current pydantic.
     """
+    monkeypatch.delenv("LC_TEST_OUTPUT_VERSION", raising=False)
+    monkeypatch.delenv("LC_TEST_STR", raising=False)
 
     class Model(BaseModel):
-        none_factory: str | None = Field(default_factory=lambda: None)
-        str_factory: str = Field(default_factory=lambda: "v1")
+        none_factory: str | None = Field(
+            default_factory=from_env("LC_TEST_OUTPUT_VERSION", default=None)
+        )
+        str_factory: str = Field(default_factory=from_env("LC_TEST_STR", default="v1"))
 
     real_get_default = FieldInfo.get_default
 

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -5,6 +5,8 @@ from typing import Any
 
 import pytest
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
 
 from langchain_core._api import LangChainDeprecationWarning
 from langchain_core._api.deprecation import LangChainPendingDeprecationWarning
@@ -13,7 +15,7 @@ from langchain_core.load import InitValidator, Serializable, dumpd, dumps, load,
 from langchain_core.load.load import (
     _get_default_allowed_class_paths,
 )
-from langchain_core.load.serializable import _is_field_useful
+from langchain_core.load.serializable import _is_field_useful, _try_neq_default
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration, Generation
 from langchain_core.prompts import (
@@ -142,6 +144,71 @@ def test__is_field_useful() -> None:
     foo = Foo(x=default_x, y=default_y, z=ArrayObj())
     assert not _is_field_useful(foo, "x", foo.x)
     assert not _is_field_useful(foo, "y", foo.y)
+
+
+def test_try_neq_default_none_factory() -> None:
+    """A `None`-valued `default_factory` field at its default is not flagged as changed.
+
+    Regression test for issue #39157.
+    """
+
+    class Model(BaseModel):
+        none_factory: str | None = Field(default_factory=lambda: None)
+
+    field = Model.model_fields["none_factory"]
+    assert not _try_neq_default(None, field)
+    assert _try_neq_default("set", field)
+
+
+def test_try_neq_default_simulating_pydantic_2_14(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Factory defaults are resolved when `get_default()` returns `PydanticUndefined`.
+
+    Pydantic 2.14+ returns the sentinel (instead of `None`) for an un-called
+    `default_factory`; this forces that behavior on the current pydantic.
+    """
+
+    class Model(BaseModel):
+        none_factory: str | None = Field(default_factory=lambda: None)
+        str_factory: str = Field(default_factory=lambda: "v1")
+
+    real_get_default = FieldInfo.get_default
+
+    def fake_get_default(self: FieldInfo, **kwargs: Any) -> Any:
+        if self.default_factory is not None and not kwargs.get("call_default_factory"):
+            return PydanticUndefined
+        return real_get_default(self, **kwargs)
+
+    monkeypatch.setattr(FieldInfo, "get_default", fake_get_default)
+
+    fields = Model.model_fields
+    assert fields["none_factory"].get_default() is PydanticUndefined
+    assert not _try_neq_default(None, fields["none_factory"])
+    assert not _try_neq_default("v1", fields["str_factory"])
+    assert _try_neq_default("set", fields["none_factory"])
+
+
+def test_try_neq_default_raising_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A `default_factory` that raises is treated as non-default (simulating 2.14)."""
+
+    def _boom() -> str:
+        msg = "factory error"
+        raise RuntimeError(msg)
+
+    class Model(BaseModel):
+        boom: str = Field(default_factory=_boom)
+
+    real_get_default = FieldInfo.get_default
+
+    def fake_get_default(self: FieldInfo, **kwargs: Any) -> Any:
+        if self.default_factory is not None and not kwargs.get("call_default_factory"):
+            return PydanticUndefined
+        return real_get_default(self, **kwargs)
+
+    monkeypatch.setattr(FieldInfo, "get_default", fake_get_default)
+
+    assert _try_neq_default("anything", Model.model_fields["boom"])
 
 
 class Foo(Serializable):

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -169,19 +169,22 @@ def test_try_neq_default_none_factory(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_try_neq_default_simulating_pydantic_2_14(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Factory defaults are resolved when `get_default()` returns `PydanticUndefined`.
+    """A `None`-factory default is still recognized when `get_default()` is undefined.
 
-    Pydantic 2.14+ returns the sentinel (instead of `None`) for an un-called
-    `default_factory`; this forces that behavior on the current pydantic.
+    Pydantic 2.14+ returns `PydanticUndefined` (instead of `None`) for an un-called
+    `default_factory`; this forces that behavior on the current pydantic. The factory
+    must not be invoked, so the sentinel is mapped back to `None` for comparison.
     """
     monkeypatch.delenv("LC_TEST_OUTPUT_VERSION", raising=False)
-    monkeypatch.delenv("LC_TEST_STR", raising=False)
+
+    called = False
+
+    def _factory() -> None:
+        nonlocal called
+        called = True
 
     class Model(BaseModel):
-        none_factory: str | None = Field(
-            default_factory=from_env("LC_TEST_OUTPUT_VERSION", default=None)
-        )
-        str_factory: str = Field(default_factory=from_env("LC_TEST_STR", default="v1"))
+        none_factory: str | None = Field(default_factory=_factory)
 
     real_get_default = FieldInfo.get_default
 
@@ -192,33 +195,12 @@ def test_try_neq_default_simulating_pydantic_2_14(
 
     monkeypatch.setattr(FieldInfo, "get_default", fake_get_default)
 
-    fields = Model.model_fields
-    assert fields["none_factory"].get_default() is PydanticUndefined
-    assert not _try_neq_default(None, fields["none_factory"])
-    assert not _try_neq_default("v1", fields["str_factory"])
-    assert _try_neq_default("set", fields["none_factory"])
-
-
-def test_try_neq_default_raising_factory(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A `default_factory` that raises is treated as non-default (simulating 2.14)."""
-
-    def _boom() -> str:
-        msg = "factory error"
-        raise RuntimeError(msg)
-
-    class Model(BaseModel):
-        boom: str = Field(default_factory=_boom)
-
-    real_get_default = FieldInfo.get_default
-
-    def fake_get_default(self: FieldInfo, **kwargs: Any) -> Any:
-        if self.default_factory is not None and not kwargs.get("call_default_factory"):
-            return PydanticUndefined
-        return real_get_default(self, **kwargs)
-
-    monkeypatch.setattr(FieldInfo, "get_default", fake_get_default)
-
-    assert _try_neq_default("anything", Model.model_fields["boom"])
+    field = Model.model_fields["none_factory"]
+    assert field.get_default() is PydanticUndefined
+    assert not _try_neq_default(None, field)
+    assert _try_neq_default("set", field)
+    # The factory must never be re-executed during comparison (possible side effects).
+    assert called is False
 
 
 class Foo(Serializable):


### PR DESCRIPTION
Resolves https://github.com/langchain-ai/langchain/issues/39157.

In pydantic 2.14, fields with a default factory will return `PydanticUndefined` as the default instead of `None`.

LangChain `Serializable` compares field values with their defaults to determine if they should be hidden from serialization. So currently, in a pydantic 2.14 environment, fields with default (factory) `None` that are unset will get added to the serialized representation.

Here we account for `PydanticUndefined` in `Serializable`, so that factories returning `None` that are unspecified remain out of the serialized representation in pydantic 2.14. We restore `None` default values in this case.

Alternatively, we can invoke the factory function to determine the default and compare with the given value. This would allow us to hide all defaults from the serialized representation. These factories can have mutations and side-effects, though, which is why this alternative was not pursued. It can be pursued in the future if desired. For now we keep behavior unchanged from pre-2.14.

Will give co-authorship to @alwaysprince05 (https://github.com/langchain-ai/langchain/pull/39196).