### PR TITLE
fix(core): ignore empty-string tool-call `id` and `name` deltas

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -336,9 +336,9 @@ def _accumulate(state: CompatBlock | None, delta: CompatBlock) -> CompatBlock:
                 state[key] = value
     elif btype in {"tool_call_chunk", "server_tool_call_chunk"} and dtype == btype:
         state["args"] = (state.get("args", "") or "") + (delta.get("args") or "")
-        if delta.get("id") is not None:
+        if delta.get("id") not in (None, ""):
             state["id"] = delta["id"]
-        if delta.get("name") is not None:
+        if delta.get("name") not in (None, ""):
             state["name"] = delta["name"]
     elif btype == dtype and "data" in delta:
         state["data"] = (state.get("data", "") or "") + (delta.get("data") or "")

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -294,8 +294,8 @@ def test_chunks_to_events_tool_call_multichunk() -> None:
                 tool_call_chunks=[
                     {
                         "index": 0,
-                        "id": None,
-                        "name": None,
+                        "id": "",
+                        "name": "",
                         "args": ' "test"}',
                         "type": "tool_call_chunk",
                     }
@@ -319,6 +319,8 @@ def test_chunks_to_events_tool_call_multichunk() -> None:
     assert len(finish_events) == 1
     finalized = cast("ToolCall", finish_events[0]["content"])
     assert finalized["type"] == "tool_call"
+    assert finalized["id"] == "tc1"
+    assert finalized["name"] == "search"
     assert finalized["args"] == {"q": "test"}
 
     # No provider finish_reason in the fixture chunks — the bridge does


### PR DESCRIPTION
Tool-call continuation handling now ignores empty-string `id` `name` deltas so previously collected valid values are preserved.