### PR TITLE
fix: preserve tool call metadata across continuations

### DIFF
--- a/libs/core/langchain_core/utils/_merge.py
+++ b/libs/core/langchain_core/utils/_merge.py
@@ -43,6 +43,12 @@ def merge_dicts(left: dict[str, Any], *others: dict[str, Any]) -> dict[str, Any]
                 )
                 raise TypeError(msg)
             elif isinstance(merged[right_k], str):
+                # Empty-string id/name values from continuation chunks should not
+                # overwrite already accumulated valid values.
+                if right_k in {"id", "name"} and right_v == "":
+                    if merged[right_k] == "":
+                        continue
+                    continue
                 # TODO: Add below special handling for 'type' key in 0.3 and remove
                 # merge_lists 'type' logic.
                 #

--- a/libs/core/tests/unit_tests/test_messages.py
+++ b/libs/core/tests/unit_tests/test_messages.py
@@ -985,6 +985,24 @@ def test_merge_tool_calls_parallel_same_index() -> None:
     assert [m["id"] for m in merged] == ["id_a", "id_b", "id_c"]
 
 
+def test_merge_tool_calls_empty_continuation_id_name() -> None:
+    """Continuation chunks with empty id/name must not clobber accumulated values."""
+    first = create_tool_call_chunk(name="tool1", args="", id="id1", index=0)
+    continuation = create_tool_call_chunk(name="", args='{"key": ', id="", index=0)
+    final_args = create_tool_call_chunk(name="", args='"value"}', id="", index=0)
+    merged = merge_lists([first], [continuation], [final_args])
+    assert merged is not None
+    assert merged == [
+        {
+            "name": "tool1",
+            "args": '{"key": "value"}',
+            "id": "id1",
+            "index": 0,
+            "type": "tool_call_chunk",
+        }
+    ]
+
+
 def test_tool_message_serdes() -> None:
     message = ToolMessage(
         "foo", artifact={"bar": {"baz": 123}}, tool_call_id="1", status="error"


### PR DESCRIPTION
Fixes #39335

Preserves accumulated tool-call id and name values when continuation chunks carry empty strings. Adds a focused regression test for streamed parallel tool-call merging.

local verification not run; relying on upstream CI