### PR TITLE
fix(gitignore): ignore temporary build artifacts and uv cache directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,6 @@ virtualenv/
 scratch/
 
 .langgraph_api/
+.uv/
+*.tmp
+.nx/


### PR DESCRIPTION
## Description
Adds `.uv/`, `*.tmp`, and `.nx/` to root `.gitignore` to prevent tracking temporary build artifacts and package manager caches.