### PR TITLE
docs(security): add security vulnerability disclosure policy SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+LangChain actively supports the latest release of `langchain-core` and major packages with security updates.
+
+| Package | Version | Supported |
+| --- | --- | --- |
+| langchain-core | 0.3.x / 1.x | :white_check_mark: |
+| langchain | 0.3.x / 1.x | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability within LangChain, please do NOT report it through a public GitHub issue.
+
+Please report security issues privately:
+- Email security issues to: [security@langchain.dev](mailto:security@langchain.dev)
+- Include steps to reproduce, affected packages/versions, and potential impact.
+
+### Response Timeline
+- We will acknowledge receipt of your vulnerability report within 48 hours.
+- We will provide regular status updates regarding investigation and resolution.


### PR DESCRIPTION
## Description
Adds a standard `SECURITY.md` policy defining supported package versions and private security vulnerability disclosure guidelines.