### PR TITLE
fix #37686 preserve non-ASCII tool call chunk args

### DIFF
--- a/libs/core/langchain_core/messages/ai.py
+++ b/libs/core/langchain_core/messages/ai.py
@@ -520,7 +520,7 @@ class AIMessageChunk(AIMessage, BaseMessageChunk):
                 self.tool_call_chunks = [
                     create_tool_call_chunk(
                         name=tc["name"],
-                        args=json.dumps(tc["args"]),
+                        args=json.dumps(tc["args"], ensure_ascii=False),
                         id=tc["id"],
                         index=None,
                     )

--- a/libs/core/tests/unit_tests/messages/test_ai.py
+++ b/libs/core/tests/unit_tests/messages/test_ai.py
@@ -105,6 +105,28 @@ def test_serdes_message_chunk() -> None:
     assert load(actual, allowed_objects=[AIMessageChunk]) == chunk
 
 
+def test_ai_message_chunk_preserves_non_ascii_tool_call_args() -> None:
+    chunk = AIMessageChunk(
+        content="",
+        tool_calls=[
+            create_tool_call(
+                name="echo",
+                args={"text": "你好", "emoji": "🚀"},
+                id="call_1",
+            )
+        ],
+    )
+
+    assert chunk.tool_call_chunks == [
+        create_tool_call_chunk(
+            name="echo",
+            args='{"text": "你好", "emoji": "🚀"}',
+            id="call_1",
+            index=None,
+        )
+    ]
+
+
 def test_add_usage_both_none() -> None:
     result = add_usage(None, None)
     assert result == UsageMetadata(input_tokens=0, output_tokens=0, total_tokens=0)


### PR DESCRIPTION
Fixes #37686

---

Preserve non-ASCII tool arguments when `AIMessageChunk` backfills `tool_call_chunks` from `tool_calls`. This keeps generated tool-call chunks readable and consistent with the original arguments.

## Release note

`AIMessageChunk` now preserves non-ASCII characters when generating `tool_call_chunks` from tool calls.

## How did you verify your code works?

- Added a regression test for Chinese and emoji tool arguments.
- Ran `uv run --group test pytest tests/unit_tests/messages/test_ai.py` (`17 passed`).
