### PR TITLE
fix(perplexity): capture num_search_queries in usage_metadata for cost tracking

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -101,6 +101,8 @@ def _create_usage_metadata(token_usage: dict) -> UsageMetadata:
         output_token_details["reasoning"] = reasoning
     if (citation_tokens := token_usage.get("citation_tokens")) is not None:
         output_token_details["citation_tokens"] = citation_tokens  # type: ignore[typeddict-unknown-key]
+    if (num_search_queries := token_usage.get("num_search_queries")) is not None:
+        output_token_details["num_search_queries"] = num_search_queries  # type: ignore[typeddict-unknown-key]
 
     return UsageMetadata(
         input_tokens=input_tokens,
@@ -350,10 +352,16 @@ def _convert_responses_usage(usage: Any) -> UsageMetadata | None:
     total_tokens = _get_attr(usage, "total_tokens", None)
     if total_tokens is None:
         total_tokens = input_tokens + output_tokens
+
+    output_token_details: OutputTokenDetails = {}
+    if (num_search_queries := _get_attr(usage, "num_search_queries", None)) is not None:
+        output_token_details["num_search_queries"] = num_search_queries  # type: ignore[typeddict-unknown-key]
+
     return UsageMetadata(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
+        output_token_details=output_token_details,
     )
 
 

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -167,6 +167,7 @@ def test_create_usage_metadata_basic() -> None:
         "total_tokens": 30,
         "reasoning_tokens": 0,
         "citation_tokens": 0,
+        "num_search_queries": 3,
     }
 
     usage_metadata = _create_usage_metadata(token_usage)
@@ -176,6 +177,20 @@ def test_create_usage_metadata_basic() -> None:
     assert usage_metadata["total_tokens"] == 30
     assert usage_metadata["output_token_details"]["reasoning"] == 0
     assert usage_metadata["output_token_details"]["citation_tokens"] == 0  # type: ignore[typeddict-item]
+    assert usage_metadata["output_token_details"]["num_search_queries"] == 3  # type: ignore[typeddict-item]
+
+
+def test_create_usage_metadata_without_search_queries() -> None:
+    """Test _create_usage_metadata omits num_search_queries when absent."""
+    token_usage = {
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+    }
+
+    usage_metadata = _create_usage_metadata(token_usage)
+
+    assert "num_search_queries" not in usage_metadata.get("output_token_details", {})
 
 
 def test_perplexity_invoke_includes_num_search_queries(mocker: MockerFixture) -> None:
@@ -220,6 +235,10 @@ def test_perplexity_invoke_includes_num_search_queries(mocker: MockerFixture) ->
     assert result.response_metadata["num_search_queries"] == 3
     assert result.response_metadata["search_context_size"] == "high"
     assert result.response_metadata["model_name"] == "test-model"
+    # num_search_queries must also flow through to usage_metadata so downstream
+    # cost trackers (LangSmith, Braintrust) can compute accurate Perplexity costs
+    assert result.usage_metadata is not None
+    assert result.usage_metadata["output_token_details"]["num_search_queries"] == 3  # type: ignore[typeddict-item]
     patcher.assert_called_once()
 
 


### PR DESCRIPTION
Closes #31647

---

Perplexity pricing depends on search query count. The `num_search_queries` field was captured in `response_metadata` and `generation_info`, but not in `UsageMetadata.output_token_details`, which is what downstream cost trackers (LangSmith, Braintrust) read to compute spend. This caused Perplexity costs to be underreported by up to an order of magnitude.

**Fix:** Added `num_search_queries` to `output_token_details` in `_create_usage_metadata` (Chat Completions) and `_convert_responses_usage` (Responses API), following the existing `citation_tokens` pattern.

## Release note

`ChatPerplexity` now includes `num_search_queries` in `UsageMetadata.output_token_details` for both API paths. Downstream cost trackers can now compute accurate Perplexity spend.

## Test plan

- Updated `test_create_usage_metadata_basic` to assert `num_search_queries` in `output_token_details`
- Added `test_create_usage_metadata_without_search_queries` for the absent case
- Updated `test_perplexity_invoke_includes_num_search_queries` to assert flow through to `usage_metadata`
- Full suite: 153 passed, 1 skipped, 0 failed

## Disclaimer

Developed with AI assistance (Claude Code). All code reviewed and verified by the author.