### PR TITLE
Fix tool-call delta empty string overwriting id/name in streaming

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -336,9 +336,11 @@ def _accumulate(state: CompatBlock | None, delta: CompatBlock) -> CompatBlock:
                 state[key] = value
     elif btype in {"tool_call_chunk", "server_tool_call_chunk"} and dtype == btype:
         state["args"] = (state.get("args", "") or "") + (delta.get("args") or "")
-        if delta.get("id") is not None:
+        # Treat empty-string id/name as absent so they don't overwrite
+        # previously set values during streaming (GH-39335).
+        if delta.get("id"):
             state["id"] = delta["id"]
-        if delta.get("name") is not None:
+        if delta.get("name"):
             state["name"] = delta["name"]
     elif btype == dtype and "data" in delta:
         state["data"] = (state.get("data", "") or "") + (delta.get("data") or "")

--- a/libs/core/langchain_core/language_models/chat_model_stream.py
+++ b/libs/core/langchain_core/language_models/chat_model_stream.py
@@ -73,8 +73,13 @@ def _merge_block_delta_into_store(
     """Shallow-merge a block-delta snapshot into an indexed chunk store."""
     existing = store.get(idx, {})
     for key, value in fields.items():
-        if value is not None:
-            existing[key] = value
+        if value is None:
+            continue
+        # Treat empty-string id/name as absent so they don't overwrite
+        # previously set values during streaming (GH-39335).
+        if key in {"id", "name"} and value == "":
+            continue
+        existing[key] = value
     store[idx] = existing
 
 

--- a/libs/core/tests/unit_tests/language_models/test_tool_call_empty_string_fix.py
+++ b/libs/core/tests/unit_tests/language_models/test_tool_call_empty_string_fix.py
@@ -1,0 +1,133 @@
+"""Tests for GH-39335: empty string tool-call delta should not overwrite id/name.
+
+When streaming tool calls, some providers send deltas with empty string
+id/name ("") after the initial chunk that carried the real values.
+These empty strings must not clobber previously accumulated state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from langchain_core.language_models.chat_model_stream import (
+    _merge_block_delta_into_store,
+    _merge_chunk_into_store,
+)
+from langchain_core.language_models._compat_bridge import _accumulate
+
+
+# ---------------------------------------------------------------------------
+# _merge_block_delta_into_store (chat_model_stream.py)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeBlockDeltaIntoStoreEmptyString:
+    """Empty string id/name must not overwrite existing values."""
+
+    def test_empty_string_id_does_not_overwrite(self) -> None:
+        store: dict[int, dict] = {}
+        # First delta: real id
+        _merge_block_delta_into_store(store, 0, {"id": "tc_1", "name": "my_tool", "args": ""})
+        assert store[0]["id"] == "tc_1"
+        # Second delta: empty string id should NOT overwrite
+        _merge_block_delta_into_store(store, 0, {"id": "", "name": "", "args": '{"x":'})
+        assert store[0]["id"] == "tc_1"
+        assert store[0]["name"] == "my_tool"
+
+    def test_empty_string_name_does_not_overwrite(self) -> None:
+        store: dict[int, dict] = {}
+        _merge_block_delta_into_store(store, 0, {"id": "tc_2", "name": "search", "args": ""})
+        _merge_block_delta_into_store(store, 0, {"id": "", "name": "", "args": '{"q":'})
+        assert store[0]["name"] == "search"
+
+    def test_none_still_does_not_overwrite(self) -> None:
+        store: dict[int, dict] = {}
+        _merge_block_delta_into_store(store, 0, {"id": "tc_3", "name": "calc", "args": ""})
+        _merge_block_delta_into_store(store, 0, {"id": None, "name": None, "args": "1"})
+        assert store[0]["id"] == "tc_3"
+        assert store[0]["name"] == "calc"
+
+    def test_non_empty_values_still_merge(self) -> None:
+        """Non-empty id/name on first delta should be stored normally."""
+        store: dict[int, dict] = {}
+        _merge_block_delta_into_store(store, 0, {"id": "tc_4", "name": "fetch", "args": ""})
+        assert store[0]["id"] == "tc_4"
+        assert store[0]["name"] == "fetch"
+
+    def test_args_still_concatenated(self) -> None:
+        """Args should still be concatenated even when id/name are empty."""
+        store: dict[int, dict] = {}
+        _merge_block_delta_into_store(store, 0, {"id": "tc_5", "name": "run", "args": '{"a"'})
+        _merge_block_delta_into_store(store, 0, {"id": "", "name": "", "args": ': 1}'})
+        assert store[0]["args"] == '{"a": 1}'
+        assert store[0]["id"] == "tc_5"
+        assert store[0]["name"] == "run"
+
+
+# ---------------------------------------------------------------------------
+# _merge_chunk_into_store (chat_model_stream.py)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeChunkIntoStoreEmptyString:
+    """The legacy merge path should also be safe (it already uses .get() truthiness)."""
+
+    def test_empty_string_id_does_not_overwrite(self) -> None:
+        store: dict[int, dict] = {}
+        _merge_chunk_into_store(store, 0, {"id": "tc_1", "name": "my_tool", "args": ""})
+        _merge_chunk_into_store(store, 0, {"id": "", "name": "", "args": '{"x":'})
+        assert store[0]["id"] == "tc_1"
+        assert store[0]["name"] == "my_tool"
+
+
+# ---------------------------------------------------------------------------
+# _accumulate (_compat_bridge.py)
+# ---------------------------------------------------------------------------
+
+
+class TestAccumulateEmptyString:
+    """_accumulate should not let empty string id/name clobber state."""
+
+    def test_empty_string_id_does_not_overwrite(self) -> None:
+        state = {"type": "tool_call_chunk", "id": "tc_1", "name": "search", "args": ""}
+        delta = {"type": "tool_call_chunk", "id": "", "name": "", "args": '{"q":'}
+        result = _accumulate(state, delta)
+        assert result["id"] == "tc_1"
+        assert result["name"] == "search"
+        assert result["args"] == '{"q":'
+
+    def test_empty_string_name_does_not_overwrite(self) -> None:
+        state = {"type": "tool_call_chunk", "id": "tc_2", "name": "calc", "args": ""}
+        delta = {"type": "tool_call_chunk", "id": "", "name": "", "args": "1+1"}
+        result = _accumulate(state, delta)
+        assert result["name"] == "calc"
+
+    def test_server_tool_call_chunk_same_behavior(self) -> None:
+        state = {"type": "server_tool_call_chunk", "id": "stc_1", "name": "exec", "args": ""}
+        delta = {"type": "server_tool_call_chunk", "id": "", "name": "", "args": "code"}
+        result = _accumulate(state, delta)
+        assert result["id"] == "stc_1"
+        assert result["name"] == "exec"
+        assert result["args"] == "code"
+
+    def test_non_empty_id_still_overwrites(self) -> None:
+        """A real (non-empty) id on a later delta should still be picked up."""
+        state = {"type": "tool_call_chunk", "id": None, "name": None, "args": ""}
+        delta = {"type": "tool_call_chunk", "id": "tc_late", "name": "late_tool", "args": ""}
+        result = _accumulate(state, delta)
+        assert result["id"] == "tc_late"
+        assert result["name"] == "late_tool"
+
+    def test_none_id_does_not_overwrite(self) -> None:
+        state = {"type": "tool_call_chunk", "id": "tc_3", "name": "tool", "args": ""}
+        delta = {"type": "tool_call_chunk", "id": None, "name": None, "args": "x"}
+        result = _accumulate(state, delta)
+        assert result["id"] == "tc_3"
+        assert result["name"] == "tool"
+
+    def test_args_still_concatenated(self) -> None:
+        state = {"type": "tool_call_chunk", "id": "tc_4", "name": "run", "args": '{"a"'}
+        delta = {"type": "tool_call_chunk", "id": "", "name": "", "args": ': 1}'}
+        result = _accumulate(state, delta)
+        assert result["args"] == '{"a": 1}'
+        assert result["id"] == "tc_4"


### PR DESCRIPTION
## Summary

Fixes #39335

When streaming tool calls, some providers send deltas where `id` and `name` arrive as empty strings (`""`) on subsequent chunks after the initial chunk that carried the real values. The merge logic checked `if value is not None` / `if delta.get("id") is not None`, which lets empty strings pass through and overwrite previously accumulated values.

## Changes

### `libs/core/langchain_core/language_models/chat_model_stream.py`
In `_merge_block_delta_into_store`, added a guard to skip empty-string `id` and `name` values, treating them the same as `None`.

### `libs/core/langchain_core/language_models/_compat_bridge.py`
In `_accumulate`, changed the `is not None` checks to truthiness checks for `id` and `name` on tool-call chunks so empty strings are skipped.

## Tests

Added `libs/core/tests/unit_tests/language_models/test_tool_call_empty_string_fix.py` covering:
- Empty string `id`/`name` does not overwrite existing values in `_merge_block_delta_into_store`
- Empty string `id`/`name` does not overwrite in `_merge_chunk_into_store` (legacy path)
- Empty string `id`/`name` does not overwrite in `_accumulate` (compat bridge)
- `None` values still correctly skip (existing behavior preserved)
- Non-empty values still merge correctly
- `args` concatenation still works regardless of `id`/`name` state
- Both `tool_call_chunk` and `server_tool_call_chunk` types are covered

## Impact

This is a minimal, targeted fix that only changes behavior for the specific case of empty-string `id`/`name` values on tool-call chunks. All other merge behavior is unchanged.