### PR TITLE
fix(core): remove excluded tool call blocks from message content

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -14,7 +14,7 @@ import inspect
 import json
 import logging
 import math
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Collection, Iterable, Sequence
 from functools import partial, wraps
 from typing import (
     TYPE_CHECKING,
@@ -853,6 +853,43 @@ def _runnable_support(
     return cast("_RunnableSupportCallable[_P, _R_co]", wrapped)
 
 
+_TOOL_CALL_BLOCK_ID_KEYS: dict[str, str] = {
+    # Anthropic-style blocks.
+    "tool_use": "id",
+    # LangChain standard content blocks.
+    "tool_call": "id",
+    # OpenAI Responses-style blocks.
+    "function_call": "call_id",
+}
+"""Maps a tool call content block type to the key holding its tool call ID."""
+
+
+def _is_excluded_tool_call_block(
+    content_block: Any, exclude_tool_calls: Collection[str]
+) -> bool:
+    """Whether a content block represents a tool call that should be excluded.
+
+    Tool calls are represented differently depending on the provider, so a block is
+    matched against whichever key that provider uses to carry the tool call ID.
+
+    Args:
+        content_block: A single entry from a message's content list.
+        exclude_tool_calls: The tool call IDs being excluded.
+
+    Returns:
+        `True` if the block is a tool call block whose ID is excluded.
+    """
+    if not isinstance(content_block, dict):
+        return False
+    block_type = content_block.get("type")
+    if not isinstance(block_type, str):
+        return False
+    id_key = _TOOL_CALL_BLOCK_ID_KEYS.get(block_type)
+    if id_key is None:
+        return False
+    return content_block.get(id_key) in exclude_tool_calls
+
+
 @_runnable_support
 def filter_messages(
     messages: Iterable[MessageLikeRepresentation] | PromptValue,
@@ -966,15 +1003,14 @@ def filter_messages(
                     continue
 
                 content = msg.content
-                # handle Anthropic content blocks
+                # Drop the content blocks representing the excluded tool calls, so
+                # that content stays consistent with tool_calls.
                 if isinstance(msg.content, list):
                     content = [
                         content_block
                         for content_block in msg.content
-                        if (
-                            not isinstance(content_block, dict)
-                            or content_block.get("type") != "tool_use"
-                            or content_block.get("id") not in exclude_tool_calls
+                        if not _is_excluded_tool_call_block(
+                            content_block, exclude_tool_calls
                         )
                     ]
 

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -269,6 +269,132 @@ def test_filter_message_exclude_tool_calls_content_blocks() -> None:
     assert messages == messages_model_copy
 
 
+def test_filter_message_exclude_tool_calls_openai_content_blocks() -> None:
+    """OpenAI Responses blocks carry the tool call ID under `call_id`."""
+    tool_calls = [
+        {"name": "foo", "id": "1", "args": {}, "type": "tool_call"},
+        {"name": "bar", "id": "2", "args": {}, "type": "tool_call"},
+    ]
+    messages = [
+        HumanMessage("foo", name="blah", id="1"),
+        AIMessage("foo-response", name="blah", id="2"),
+        HumanMessage("bar", name="blur", id="3"),
+        AIMessage(
+            [
+                {"text": "bar-response", "type": "text"},
+                {
+                    "type": "function_call",
+                    "call_id": "1",
+                    "name": "foo",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "2",
+                    "name": "bar",
+                    "arguments": "{}",
+                },
+            ],
+            tool_calls=tool_calls,
+            id="4",
+        ),
+        ToolMessage("baz", tool_call_id="1", id="5"),
+        ToolMessage("qux", tool_call_id="2", id="6"),
+    ]
+    messages_model_copy = [m.model_copy(deep=True) for m in messages]
+
+    # the excluded function_call block is dropped alongside its tool call
+    expected = messages[:4] + messages[-1:]
+    expected[3] = expected[3].model_copy(
+        update={
+            "tool_calls": [tool_calls[1]],
+            "content": [
+                {"text": "bar-response", "type": "text"},
+                {
+                    "type": "function_call",
+                    "call_id": "2",
+                    "name": "bar",
+                    "arguments": "{}",
+                },
+            ],
+        }
+    )
+    actual = filter_messages(messages, exclude_tool_calls=["1"])
+    assert expected == actual
+
+    # assert that we didn't mutate the original messages
+    assert messages == messages_model_copy
+
+
+def test_filter_message_exclude_tool_calls_standard_content_blocks() -> None:
+    """Standard content blocks carry the tool call ID under `id`."""
+    tool_calls = [
+        {"name": "foo", "id": "1", "args": {}, "type": "tool_call"},
+        {"name": "bar", "id": "2", "args": {}, "type": "tool_call"},
+    ]
+    messages = [
+        HumanMessage("foo", name="blah", id="1"),
+        AIMessage("foo-response", name="blah", id="2"),
+        HumanMessage("bar", name="blur", id="3"),
+        AIMessage(
+            [
+                {"text": "bar-response", "type": "text"},
+                {"type": "tool_call", "id": "1", "name": "foo", "args": {}},
+                {"type": "tool_call", "id": "2", "name": "bar", "args": {}},
+            ],
+            tool_calls=tool_calls,
+            id="4",
+        ),
+        ToolMessage("baz", tool_call_id="1", id="5"),
+        ToolMessage("qux", tool_call_id="2", id="6"),
+    ]
+    messages_model_copy = [m.model_copy(deep=True) for m in messages]
+
+    # the excluded tool_call block is dropped alongside its tool call
+    expected = messages[:4] + messages[-1:]
+    expected[3] = expected[3].model_copy(
+        update={
+            "tool_calls": [tool_calls[1]],
+            "content": [
+                {"text": "bar-response", "type": "text"},
+                {"type": "tool_call", "id": "2", "name": "bar", "args": {}},
+            ],
+        }
+    )
+    actual = filter_messages(messages, exclude_tool_calls=["1"])
+    assert expected == actual
+
+    # assert that we didn't mutate the original messages
+    assert messages == messages_model_copy
+
+
+def test_filter_message_exclude_tool_calls_preserves_unrelated_blocks() -> None:
+    """Blocks that aren't tool calls are kept even when their ID is excluded."""
+    messages = [
+        AIMessage(
+            [
+                {"type": "text", "text": "hi"},
+                # Not a tool call block, so the matching `id` is irrelevant.
+                {"type": "image", "id": "1"},
+                {"name": "foo", "type": "tool_use", "id": "1"},
+                {"name": "bar", "type": "tool_use", "id": "2"},
+            ],
+            tool_calls=[
+                {"name": "foo", "id": "1", "args": {}, "type": "tool_call"},
+                {"name": "bar", "id": "2", "args": {}, "type": "tool_call"},
+            ],
+            id="1",
+        ),
+    ]
+
+    actual = filter_messages(messages, exclude_tool_calls=["1"])
+    assert actual[0].content == [
+        {"type": "text", "text": "hi"},
+        {"type": "image", "id": "1"},
+        {"name": "bar", "type": "tool_use", "id": "2"},
+    ]
+
+
 _MESSAGES_TO_TRIM = [
     SystemMessage("This is a 4 token text."),
     HumanMessage("This is a 4 token text.", id="first"),


### PR DESCRIPTION
Closes #36492

---

Someone trimming a conversation before replaying it to a model reaches for `filter_messages(..., exclude_tool_calls=[...])` to drop a tool call they no longer want in context. Today that only half works: the tool call disappears from `AIMessage.tool_calls`, but the content block describing the very same call is left behind. The message then carries a tool call in its content that it claims not to have, and the excluded call reaches the provider anyway.

The filter recognized only Anthropic-style `tool_use` blocks, matched on `id`. Two other representations can appear in `AIMessage.content` and were missed:

- OpenAI Responses `function_call` blocks, which carry the ID under `call_id` — the case in the issue.
- Standard `tool_call` blocks, which carry it under `id`. These sit in content directly under `output_version="v1"`, and `AIMessage` populates `tool_calls` from them when built via `content_blocks`.

Both are the same defect, and the standard block is the going-forward format, so fixing only the reported case would have left the newer path broken.

The inline type check is replaced with a mapping from block type to the key holding its tool call ID, and a helper that matches a block using whichever key its provider uses. A block is dropped only when it is a recognized tool call block *and* its ID is excluded, so unrelated blocks survive even if some other field collides with an excluded ID. Existing `tool_use` behavior is unchanged.

Adding a provider convention later is now a one-line entry in the mapping rather than another clause in the comprehension.

## Release note

`filter_messages` with `exclude_tool_calls` now also removes OpenAI Responses `function_call` content blocks and standard `tool_call` content blocks for excluded tool calls, instead of only Anthropic-style `tool_use` blocks. Message content is no longer left inconsistent with `tool_calls`.

---

*Disclaimer: this contribution was prepared with the assistance of an AI coding agent. The change and its test coverage were reviewed and verified locally by me.*
