### PR TITLE
fix(core): finalize chain-group run on cancellation (BaseException)

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -123,7 +123,10 @@ def trace_as_chain_group(
     )
     try:
         yield group_cm
-    except Exception as e:
+    # Catch BaseException so a cancellation (asyncio.CancelledError) or a
+    # KeyboardInterrupt / SystemExit still finalizes the run via on_chain_error
+    # instead of leaving it pending forever; the error is recorded and re-raised.
+    except BaseException as e:
         if not group_cm.ended:
             run_manager.on_chain_error(e)
         raise
@@ -206,7 +209,11 @@ async def atrace_as_chain_group(
     )
     try:
         yield group_cm
-    except Exception as e:
+    # Catch BaseException so a cancellation (asyncio.CancelledError, common when an
+    # ASGI/WebSocket client disconnects) or a KeyboardInterrupt / SystemExit still
+    # finalizes the run via on_chain_error instead of leaving it pending forever;
+    # the error is recorded and re-raised.
+    except BaseException as e:
         if not group_cm.ended:
             await run_manager.on_chain_error(e)
         raise

--- a/libs/core/tests/unit_tests/callbacks/test_trace_group_cancellation.py
+++ b/libs/core/tests/unit_tests/callbacks/test_trace_group_cancellation.py
@@ -1,0 +1,75 @@
+"""Regression tests for chain-group tracing finalization on cancellation.
+
+`trace_as_chain_group` / `atrace_as_chain_group` used to catch only ``Exception``,
+so a ``BaseException`` such as ``asyncio.CancelledError`` (raised when an
+ASGI/WebSocket client disconnects) slipped past both the ``except`` and the
+``else`` branch, and the group's run was never finalized - it stayed pending.
+
+See https://github.com/langchain-ai/langchain/issues/39163.
+"""
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from langchain_core.callbacks import AsyncCallbackHandler, BaseCallbackHandler
+from langchain_core.callbacks.manager import (
+    atrace_as_chain_group,
+    trace_as_chain_group,
+)
+
+
+class _NonException(BaseException):
+    """A BaseException that is not an Exception (like asyncio.CancelledError)."""
+
+
+def test_trace_as_chain_group_finalizes_run_on_base_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class Recorder(BaseCallbackHandler):
+        def on_chain_error(self, error: BaseException, **kwargs: Any) -> None:
+            events.append("error")
+
+        def on_chain_end(self, outputs: Any, **kwargs: Any) -> None:
+            events.append("end")
+
+    # The context managers only open a run when tracing is enabled; short-circuit
+    # the trace-callback lookup so a run is created without a real LangChainTracer.
+    monkeypatch.setattr(
+        "langchain_core.tracers.context._get_trace_callbacks",
+        lambda *args, **kwargs: [Recorder()],
+    )
+
+    with pytest.raises(_NonException):
+        with trace_as_chain_group("test_group"):
+            raise _NonException
+
+    # The run is finalized as an error, not left pending, and not double-ended.
+    assert events == ["error"]
+
+
+async def test_atrace_as_chain_group_finalizes_run_on_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+
+    class Recorder(AsyncCallbackHandler):
+        async def on_chain_error(self, error: BaseException, **kwargs: Any) -> None:
+            events.append("error")
+
+        async def on_chain_end(self, outputs: Any, **kwargs: Any) -> None:
+            events.append("end")
+
+    monkeypatch.setattr(
+        "langchain_core.tracers.context._get_trace_callbacks",
+        lambda *args, **kwargs: [Recorder()],
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        async with atrace_as_chain_group("test_group"):
+            raise asyncio.CancelledError
+
+    assert events == ["error"]


### PR DESCRIPTION
**Fixes #39163**

## Problem

`trace_as_chain_group` and `atrace_as_chain_group` finalize the group's run like this:

```python
try:
    yield group_cm
except Exception as e:
    if not group_cm.ended:
        run_manager.on_chain_error(e)   # await ... in the async version
    raise
else:
    if not group_cm.ended:
        run_manager.on_chain_end({})
```

`asyncio.CancelledError` derives from `BaseException`, not `Exception`, so when the body is cancelled it slips past the `except` **and** skips the `else` (an exception is propagating). Neither `on_chain_error` nor `on_chain_end` runs, so the parent run is never finalized and stays pending in the tracer. This happens routinely in ASGI / WebSocket apps: when a client disconnects, the serving task is cancelled and every open chain group leaks a pending run. `KeyboardInterrupt` / `SystemExit` have the same shape.

## Fix

Widen the boundary to `BaseException` in both context managers. The error is still recorded via `on_chain_error` and then re-raised, so cancellation still propagates unchanged — the only difference is that the run is now closed out instead of left hanging.

## Tests

`libs/core/tests/unit_tests/callbacks/test_trace_group_cancellation.py` covers both the sync manager (with a non-`Exception` `BaseException`) and the async manager (with `asyncio.CancelledError`), asserting `on_chain_error` fires and the exception re-raises. Both tests fail on `master` and pass with this change.
