### PR TITLE
fix(core): raise ValueError when embedding count mismatches documents in InMemoryVectorStore

### DIFF
--- a/libs/core/langchain_core/vectorstores/in_memory.py
+++ b/libs/core/langchain_core/vectorstores/in_memory.py
@@ -201,13 +201,24 @@ class InMemoryVectorStore(VectorStore):
             )
             raise ValueError(msg)
 
+        # check against embedding model returning wrong number of vectors
+        if len(vectors) != len(documents):
+            msg = (
+                f"Embedding model returned {len(vectors)} vectors"
+                f"for {len(documents)} documents."
+                f"The number of embeddings must match with the number of documents."
+                f"This can happen when embedding provider truncates "
+                f"input or embedding implementation has an error."
+            )
+            raise ValueError(msg)
+
         id_iterator: Iterator[str | None] = (
             iter(ids) if ids else iter(doc.id for doc in documents)
         )
 
         ids_ = []
 
-        for doc, vector in zip(documents, vectors, strict=False):
+        for doc, vector in zip(documents, vectors, strict=True):
             doc_id = next(id_iterator)
             doc_id_ = doc_id or str(uuid.uuid4())
             ids_.append(doc_id_)
@@ -231,6 +242,17 @@ class InMemoryVectorStore(VectorStore):
             msg = (
                 f"ids must be the same length as texts. "
                 f"Got {len(ids)} ids and {len(texts)} texts."
+            )
+            raise ValueError(msg)
+
+        # check against embedding model returning wrong number of vectors
+        if isinstance(vectors, list) and len(vectors) != len(documents):
+            msg = (
+                f"Embedding model returned {len(vectors)} vectors"
+                f"for {len(documents)} documents."
+                f"The number of embeddings must match with the number of documents."
+                f"This can happen when embedding provider truncates "
+                f"input or embedding implementation has an error."
             )
             raise ValueError(msg)
 

--- a/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
+++ b/libs/core/tests/unit_tests/vectorstores/test_in_memory.py
@@ -5,6 +5,7 @@ import pytest
 from langchain_tests.integration_tests.vectorstores import VectorStoreIntegrationTests
 
 from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
 from langchain_core.embeddings.fake import DeterministicFakeEmbedding
 from langchain_core.vectorstores import InMemoryVectorStore
 from tests.unit_tests.stubs import _any_id_document
@@ -220,3 +221,94 @@ async def test_inmemory_call_embeddings_async() -> None:
     # Ensure the async embedding function is called
     assert embeddings_mock.aembed_documents.await_count == 1
     assert embeddings_mock.aembed_query.await_count == 1
+
+
+class _ShortEmbeddings(Embeddings):
+    """Returns one vector less than the document count."""
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[0.1, 0.2, 0.3] for _ in texts[:-1]]
+
+    def embed_query(self, _text: str) -> list[float]:
+        return [0.1, 0.2, 0.3]
+
+
+class _CorrectEmbeddings(Embeddings):
+    """Returns correct number of embedding vectors.
+
+    Vectors count equal document count.
+    """
+
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+    def embed_query(self, _text: str) -> list[float]:
+        return [0.1, 0.2, 0.3]
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_documents(texts)
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return self.embed_query(text)
+
+
+class _ShortEmbeddingsAsync(Embeddings):
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[0.1, 0.2, 0.3] for _ in texts[:1]]
+
+    def embed_query(self, _text: str) -> list[float]:
+        return [0.1, 0.2, 0.3]
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_documents(texts)
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return self.embed_query(text)
+
+
+def test_add_documents_raises_embedding_count_mismatch() -> None:
+    """add_documents must raise ValueError when embed_documents returns fewer vectors.
+
+    Documents must not be silently dropped when embedding count mismatches.
+    """
+    store = InMemoryVectorStore(embedding=_ShortEmbeddings())
+    docs = [
+        Document(page_content="foo"),
+        Document(page_content="boo"),
+        Document(page_content="bar"),
+    ]
+
+    with pytest.raises(ValueError, match="Embedding model returned"):
+        store.add_documents(docs)
+
+
+async def test_aadd_documents_raises_embedding_count_mismatch() -> None:
+    """add_documents must raise ValueError when embedding count mismatches.
+
+    Embedding count less than document count, should not silently drop documents.
+    """
+    store = InMemoryVectorStore(embedding=_ShortEmbeddingsAsync())
+    docs = [
+        Document(page_content="foo"),
+        Document(page_content="boo"),
+        Document(page_content="bar"),
+    ]
+
+    with pytest.raises(ValueError, match="Embedding model returned"):
+        await store.aadd_documents(docs)
+
+
+def test_add_documents_success_embedding_count_match() -> None:
+    """add_documents must succeed when embedding count matches document count.
+
+    Ensures the fix does not break the happy path.
+    """
+    store = InMemoryVectorStore(embedding=_CorrectEmbeddings())
+    docs = [
+        Document(page_content="foo"),
+        Document(page_content="boo"),
+        Document(page_content="bar"),
+    ]
+    ids = store.add_documents(docs)
+    assert len(ids) == 3
+    assert len(store.store) == 3


### PR DESCRIPTION
Fixes #36745 
When "InMemoryVectorStore" is used, there could be chances of silently losing documents when the 
embedding model returned fewer vectors than documents —  because the "zip(strict=False)" 
loop would truncate without any error or warning. 
This adds an explicit count check in both "add_documents" and "aadd_documents" that raises a 
`ValueError` on mismatch.

## Release note
No release note needed - only bug fix 

## How did you verify your code works?
Ran existing unit tests — 38 passed, 0 failed:
uv run pytest tests/unit_tests/vectorstores/test_in_memory.py -v
Added 3 regression tests covering sync mismatch, async mismatch, and success path.

LinkedIn : https://www.linkedin.com/in/parvathy-m-r-0b2391176/

