### PR TITLE
fix(openai): filter invalid tool calls from content

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/_compat.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_compat.py
@@ -165,7 +165,7 @@ def _convert_from_v1_to_chat_completions(message: AIMessage) -> AIMessage:
                 if block_type == "text":
                     # Strip annotations
                     new_content.append({"type": "text", "text": block["text"]})
-                elif block_type in ("reasoning", "tool_call"):
+                elif block_type in ("reasoning", "tool_call", "invalid_tool_call"):
                     pass
                 else:
                     new_content.append(block)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3644,6 +3644,13 @@ def test_compat_responses_v03_apply_patch_tool_outputs() -> None:
                         "args": {"location": "San Francisco"},
                     },
                     {
+                        "type": "invalid_tool_call",
+                        "id": "call_234",
+                        "name": "get_weather",
+                        "args": '{"location":',
+                        "error": "Failed to parse tool call arguments as JSON",
+                    },
+                    {
                         "type": "text",
                         "text": "Hello, world!",
                         "annotations": [
@@ -3653,11 +3660,29 @@ def test_compat_responses_v03_apply_patch_tool_outputs() -> None:
                 ],
                 id="chatcmpl-123",
                 response_metadata={"model_provider": "openai", "model_name": "gpt-4.1"},
+                invalid_tool_calls=[
+                    InvalidToolCall(
+                        id="call_234",
+                        name="get_weather",
+                        args='{"location":',
+                        error="Failed to parse tool call arguments as JSON",
+                        type="invalid_tool_call",
+                    )
+                ],
             ),
             AIMessage(
                 [{"type": "text", "text": "Hello, world!"}],
                 id="chatcmpl-123",
                 response_metadata={"model_provider": "openai", "model_name": "gpt-4.1"},
+                invalid_tool_calls=[
+                    InvalidToolCall(
+                        id="call_234",
+                        name="get_weather",
+                        args='{"location":',
+                        error="Failed to parse tool call arguments as JSON",
+                        type="invalid_tool_call",
+                    )
+                ],
             ),
         )
     ],
@@ -3668,6 +3693,7 @@ def test_convert_from_v1_to_chat_completions(
     result = _convert_from_v1_to_chat_completions(message_v1)
     assert result == expected
     assert result.tool_calls == message_v1.tool_calls  # tool calls remain cached
+    assert result.invalid_tool_calls == message_v1.invalid_tool_calls
 
     # Check no mutation
     assert message_v1 != result


### PR DESCRIPTION
Malformed tool calls represented in the v1 output format could leak `invalid_tool_call` blocks into Chat Completions assistant content, causing OpenAI-compatible endpoints to reject the request. This filters those blocks alongside normal tool-call blocks while preserving `AIMessage.invalid_tool_calls` for the existing OpenAI tool-call serializer.

Covered by the focused v1-to-Chat-Completions conversion test.

Made by [Open SWE](https://openswe.vercel.app/agents/f90691c8-b4a1-1c21-0d3d-9b4554db1d7c)