### PR TITLE
docs: fix non-existent model in README quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ uv add langchain
 ```python
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model("openai:gpt-5.5")
+model = init_chat_model("openai:gpt-4o")
 result = model.invoke("Hello, world!")
 ```
 


### PR DESCRIPTION
gpt-5.5 does not exist as OpenAI model, quickstart fails with model not found. Use gpt-4o which is the current stable default.

Fixes #TBD