### PR TITLE
fix(core): validate batch_iterate size to reject zero and negative values

### DIFF
--- a/libs/core/langchain_core/utils/iter.py
+++ b/libs/core/langchain_core/utils/iter.py
@@ -214,7 +214,12 @@ def batch_iterate(size: int | None, iterable: Iterable[T]) -> Iterator[list[T]]:
 
     Yields:
         The batches of the iterable.
+
+    Raises:
+        ValueError: If size is not None and <= 0.
     """
+    if size is not None and size <= 0:
+        raise ValueError("size must be > 0 or None")
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))


### PR DESCRIPTION
Sync utility silently returned empty iterator for size=0, inconsistent with abatch_iterate which now raises. Add explicit validation for both to fail fast with clear ValueError.

Fixes #TBD