### PR TITLE
fix: detect completion marker when preceded by command output without trailing newline

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -265,7 +265,11 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
+            if source == "stdout" and marker in data:
+                prefix, _, remainder = data.partition(marker)
+                # Preserve any command output that preceded the marker on the same line.
+                if prefix:
+                    collected.append(prefix)
                 _, _, status = data.partition(" ")
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.


### PR DESCRIPTION
## Summary

Fixes `ShellSession` incorrectly reporting timeout when a command produces stdout without a trailing newline.

Closes #39363

## Problem

`ShellSession._collect_output()` uses `data.startswith(marker)` to detect command completion. When a command like `printf 'hello'` runs, its output and the completion marker are concatenated on a single line by `readline()`:

```
hello__LC_SHELL_DONE__<uuid> 0
```

Since `data.startswith(marker)` is `False` (the data starts with `hello`, not the marker), the session doesn't recognize completion and waits until timeout.

## Fix

Changed `data.startswith(marker)` to `marker in data` and extracts any preceding command output from the prefix. This correctly handles:
- `printf 'hello'` → output: `hello`, exit code: 0
- `echo -n test` → output: `test`, exit code: 0
- Commands with normal trailing newlines (no behavior change)

## Test

Added `test_shell_session_command_without_trailing_newline` regression test that verifies `printf 'hello-without-newline'` completes successfully with correct output and exit code.