### PR TITLE
fix(core): accept generators and unsized iterables in ContextThreadPoolExecutor.map (#39211)

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -644,14 +644,17 @@ class ContextThreadPoolExecutor(ThreadPoolExecutor):
         Returns:
             The iterator for the mapped function.
         """
-        contexts = [copy_context() for _ in range(len(iterables[0]))]  # type: ignore[arg-type]
+        first, *rest = iterables
+        first_list = list(first)
+        contexts = [copy_context() for _ in first_list]
 
         def _wrapped_fn(*args: Any) -> T:
             return contexts.pop().run(fn, *args)
 
         return super().map(
             _wrapped_fn,
-            *iterables,
+            first_list,
+            *rest,
             **kwargs,
         )
 

--- a/libs/core/tests/unit_tests/runnables/test_config.py
+++ b/libs/core/tests/unit_tests/runnables/test_config.py
@@ -1,6 +1,7 @@
 import json
 import uuid
-from contextvars import copy_context
+from collections.abc import Generator
+from contextvars import ContextVar, copy_context
 from typing import Any, cast
 
 import pytest
@@ -15,6 +16,7 @@ from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain_core.runnables import RunnableBinding, RunnablePassthrough
 from langchain_core.runnables.config import (
+    ContextThreadPoolExecutor,
     RunnableConfig,
     _get_langsmith_inheritable_metadata_from_config,
     _merge_metadata_dicts,
@@ -414,3 +416,41 @@ class TestMergeMetadataDicts:
         assert merged["metadata"] == {
             "lc_versions": {"a": "1", "b": "2", "c": "3"},
         }
+
+
+class TestContextThreadPoolExecutorMap:
+    """Tests for ContextThreadPoolExecutor.map() generator/iterable support."""
+
+    def test_map_accepts_generator(self) -> None:
+        def values() -> Generator[int, None, None]:
+            yield from range(3)
+
+        with ContextThreadPoolExecutor(max_workers=2) as executor:
+            result = list(executor.map(lambda x: x * 2, values()))
+
+        assert result == [0, 2, 4]
+
+    def test_map_accepts_list(self) -> None:
+        with ContextThreadPoolExecutor(max_workers=2) as executor:
+            result = list(executor.map(lambda x: x + 1, [10, 20, 30]))
+
+        assert result == [11, 21, 31]
+
+    def test_map_accepts_iterator(self) -> None:
+        with ContextThreadPoolExecutor(max_workers=2) as executor:
+            result = list(executor.map(lambda x: x, iter([5, 6, 7])))
+
+        assert result == [5, 6, 7]
+
+    def test_map_preserves_context(self) -> None:
+        var: ContextVar[str] = ContextVar("var", default="outer")
+        var.set("outer")
+        captured = []
+
+        def read_var(_: int) -> str:
+            return var.get()
+
+        with ContextThreadPoolExecutor(max_workers=2) as executor:
+            captured = list(executor.map(read_var, range(3)))
+
+        assert all(v == "outer" for v in captured)


### PR DESCRIPTION
Fixes #39211

## Root cause

`ContextThreadPoolExecutor.map()` pre-allocates one context per item with:

```python
contexts = [copy_context() for _ in range(len(iterables[0]))]
```

This calls `len()` on the first iterable, which raises `TypeError` for generators and other unsized iterables even though `ThreadPoolExecutor.map()` accepts them.

## What changed

Eagerly consume the first iterable into a list before pre-allocating contexts, then pass that list to `super().map()` so the (now exhausted) original is not used twice:

```python
first, *rest = iterables
first_list = list(first)
contexts = [copy_context() for _ in first_list]
# ...
return super().map(_wrapped_fn, first_list, *rest, **kwargs)
```

## Test evidence

Four new tests in `TestContextThreadPoolExecutorMap`:
- `test_map_accepts_generator` — generator input now works (was `TypeError` before)
- `test_map_accepts_list` — existing list-based usage unaffected
- `test_map_accepts_iterator` — unsized `iter()` input now works
- `test_map_preserves_context` — context variables still propagate correctly

All 25 tests in `test_config.py` pass; ruff passes.

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.