### PR TITLE
fix(langchain): ShellSession incorrectly times out when command output has no trailing newline (#39363)

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -265,8 +265,24 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
-                _, _, status = data.partition(" ")
+            if source == "stdout" and marker in data:
+                prefix, _, tail = data.partition(marker)
+                if prefix:
+                    # Command output had no trailing newline; it was merged with
+                    # the marker into a single readline() result.
+                    total_lines += 1
+                    encoded_prefix = prefix.encode("utf-8", "replace")
+                    total_bytes += len(encoded_prefix)
+                    if total_lines > self._policy.max_output_lines:
+                        truncated_by_lines = True
+                    elif (
+                        self._policy.max_output_bytes is not None
+                        and total_bytes > self._policy.max_output_bytes
+                    ):
+                        truncated_by_bytes = True
+                    else:
+                        collected.append(prefix)
+                _, _, status = tail.partition(" ")
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.
                 # The stderr reader thread runs independently, so output might

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -694,3 +694,59 @@ def test_kill_process_noop_without_active_process(tmp_path: Path) -> None:
 
     # No process has been started; this must not raise.
     session._kill_process()
+
+
+def test_command_without_trailing_newline_is_not_timed_out(tmp_path: Path) -> None:
+    """Printf without a trailing newline must not cause a spurious timeout.
+
+    Root cause: when the command output lacks a trailing newline, readline() can
+    return the output and the completion marker concatenated in one chunk.
+    The old check (data.startswith(marker)) then missed the marker entirely,
+    causing the session to wait until the command timeout.
+    """
+    policy = HostExecutionPolicy(command_timeout=5.0)
+    middleware = ShellToolMiddleware(
+        workspace_root=tmp_path / "workspace", execution_policy=policy
+    )
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+
+        result = middleware._run_shell_tool(
+            resources,
+            {"command": "printf 'hello-without-newline'"},
+            tool_call_id=None,
+        )
+
+        assert "timed out" not in result.lower(), (
+            f"Command incorrectly reported as timed out; got: {result!r}"
+        )
+        assert "hello-without-newline" in result
+    finally:
+        middleware.after_agent(state, runtime)
+
+
+def test_command_output_then_newline_still_works(tmp_path: Path) -> None:
+    """Normal commands with a trailing newline must continue to work."""
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+
+        result = middleware._run_shell_tool(
+            resources,
+            {"command": "echo 'hello-with-newline'"},
+            tool_call_id=None,
+        )
+
+        assert "hello-with-newline" in result
+    finally:
+        middleware.after_agent(state, runtime)


### PR DESCRIPTION
Fixes #39363

## Root cause

`ShellSession._collect_output()` injects a unique completion marker after each command and detects it with `data.startswith(marker)`. When a command writes output without a trailing newline (e.g. `printf 'hello'`), the shell's buffered I/O can deliver the unterminated output and the marker in a single `readline()` result:

```
hello-without-newline__LC_SHELL_DONE__<uuid> 0
```

`data.startswith(marker)` is then `False`, so the session never recognises command completion, waits out the full `command_timeout`, and reports a spurious timeout with empty output.

## What changed

Changed the marker check from `data.startswith(marker)` to `marker in data`. When the marker is found but not at the start, the prefix (the unterminated output) is extracted, counted against line/byte truncation limits, and appended to `collected` before the exit-code is parsed from the tail.

## Test evidence

Two new tests:
- `test_command_without_trailing_newline_is_not_timed_out` — `printf 'hello-without-newline'` now returns the correct output without timing out
- `test_command_output_then_newline_still_works` — normal `echo` commands with a trailing newline continue to work

All 723 existing tests pass; ruff passes.

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.