### PR TITLE
fix(indexing): capture get_time() once per batch in InMemoryRecordManager.update()

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -296,12 +296,16 @@ class InMemoryRecordManager(RecordManager):
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+        current_time = self.get_time()
+        if time_at_least and time_at_least > current_time:
+            msg = "time_at_least must be in the past"
+            raise ValueError(msg)
+        update_time = (
+            max(current_time, time_at_least) if time_at_least else current_time
+        )
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
-                msg = "time_at_least must be in the past"
-                raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            self.records[key] = {"group_id": group_id, "updated_at": update_time}
 
     async def aupdate(
         self,

--- a/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
+++ b/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
@@ -277,3 +277,34 @@ async def test_adelete_keys(amanager: InMemoryRecordManager) -> None:
     # Check if the deleted keys are no longer in the database
     remaining_keys = await amanager.alist_keys()
     assert remaining_keys == ["key3"]
+
+
+def test_update_batch_uses_consistent_timestamps(
+    manager: InMemoryRecordManager,
+) -> None:
+    """Regression: all keys in one update() call must share the same timestamp.
+
+    Before the fix, get_time() was called once per key, so rapid indexing could
+    assign slightly different timestamps within a single batch.  After the fix,
+    get_time() is called once before the loop and the single value is reused.
+    """
+    tick = iter([1.0, 2.0, 3.0])
+
+    with patch.object(manager, "get_time", side_effect=lambda: next(tick)):
+        manager.update(["key1", "key2", "key3"])
+
+    timestamps = {k: manager.records[k]["updated_at"] for k in ["key1", "key2", "key3"]}
+    assert len(set(timestamps.values())) == 1, (
+        f"Expected all keys to share one timestamp, got {timestamps}"
+    )
+
+
+def test_update_time_at_least_raises_when_in_future(
+    manager: InMemoryRecordManager,
+) -> None:
+    """time_at_least greater than current time must raise ValueError."""
+    with (
+        patch.object(manager, "get_time", return_value=1000.0),
+        pytest.raises(ValueError, match="time_at_least must be in the past"),
+    ):
+        manager.update(["key1"], time_at_least=2000.0)


### PR DESCRIPTION
**Issue:** #39087

## Problem

`InMemoryRecordManager.update()` called `self.get_time()` inside the per-key loop, so every document in the same batch could receive a slightly different `updated_at` timestamp. This also meant the `time_at_least` guard ran redundantly on every iteration.

When callers later clean up stale records with `list_keys(before=index_start_dt)`, documents that happened to be stamped after `index_start_dt` due to clock drift within the loop would be silently skipped — exactly the scenario described in the issue.

## Fix

Capture `get_time()` once **before** the loop, validate `time_at_least` a single time against that value, then assign the same `update_time` to every record in the batch:

```python
current_time = self.get_time()
if time_at_least and time_at_least > current_time:
    raise ValueError("time_at_least must be in the past")
update_time = max(current_time, time_at_least) if time_at_least else current_time
for index, key in enumerate(keys):
    group_id = group_ids[index] if group_ids else None
    self.records[key] = {"group_id": group_id, "updated_at": update_time}
```

## Tests

Two new tests in `test_in_memory_record_manager.py`:

- `test_update_batch_uses_consistent_timestamps` — patches `get_time()` with a tick counter (1.0, 2.0, 3.0); asserts all three keys receive the same timestamp after a single `update()` call.
- `test_update_time_at_least_raises_when_in_future` — asserts `ValueError` is raised when `time_at_least > current_time`.

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.