### PR TITLE
fix(core): preserve tool-call id/name when streaming continuation sends empty string

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -336,9 +336,9 @@ def _accumulate(state: CompatBlock | None, delta: CompatBlock) -> CompatBlock:
                 state[key] = value
     elif btype in {"tool_call_chunk", "server_tool_call_chunk"} and dtype == btype:
         state["args"] = (state.get("args", "") or "") + (delta.get("args") or "")
-        if delta.get("id") is not None:
+        if delta.get("id") is not None and (delta["id"] or not state.get("id")):
             state["id"] = delta["id"]
-        if delta.get("name") is not None:
+        if delta.get("name") is not None and (delta["name"] or not state.get("name")):
             state["name"] = delta["name"]
     elif btype == dtype and "data" in delta:
         state["data"] = (state.get("data", "") or "") + (delta.get("data") or "")

--- a/libs/core/langchain_core/language_models/chat_model_stream.py
+++ b/libs/core/langchain_core/language_models/chat_model_stream.py
@@ -73,8 +73,11 @@ def _merge_block_delta_into_store(
     """Shallow-merge a block-delta snapshot into an indexed chunk store."""
     existing = store.get(idx, {})
     for key, value in fields.items():
-        if value is not None:
-            existing[key] = value
+        if value is None:
+            continue
+        if key in {"id", "name"} and value == "" and existing.get(key):
+            continue
+        existing[key] = value
     store[idx] = existing
 
 

--- a/libs/core/tests/unit_tests/language_models/test_chat_model_stream.py
+++ b/libs/core/tests/unit_tests/language_models/test_chat_model_stream.py
@@ -785,6 +785,45 @@ class TestChatModelStream:
         assert itc["args"] == '{"q": '
         assert "Failed to parse" in (itc["error"] or "")
 
+    def test_tool_call_empty_id_name_continuation_not_overwritten(self) -> None:
+        """Regression #39335: empty-string id/name deltas must not overwrite values."""
+        stream = ChatModelStream()
+        stream.dispatch({"event": "message-start", "role": "ai"})
+        stream.dispatch(
+            {
+                "event": "content-block-delta",
+                "index": 0,
+                "delta": {
+                    "type": "block-delta",
+                    "fields": {
+                        "type": "tool_call_chunk",
+                        "id": "call_abc",
+                        "name": "search",
+                        "args": "",
+                    },
+                },
+            }
+        )
+        stream.dispatch(
+            {
+                "event": "content-block-delta",
+                "index": 0,
+                "delta": {
+                    "type": "block-delta",
+                    "fields": {
+                        "type": "tool_call_chunk",
+                        "id": "",
+                        "name": "",
+                        "args": '{"q":"hi"}',
+                    },
+                },
+            }
+        )
+        stored = stream._tool_call_chunks[0]
+        assert stored["id"] == "call_abc", f"id overwritten: {stored['id']!r}"
+        assert stored["name"] == "search", f"name overwritten: {stored['name']!r}"
+        assert stored["args"] == '{"q":"hi"}'
+
 
 # ---------------------------------------------------------------------------
 # AsyncChatModelStream unit tests

--- a/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
+++ b/libs/core/tests/unit_tests/language_models/test_compat_bridge.py
@@ -8,6 +8,7 @@ from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 
 from langchain_core.language_models._compat_bridge import (
     CompatBlock,
+    _accumulate,
     _finalize_block,
     _isolate_usage,
     achunks_to_events,
@@ -1374,6 +1375,21 @@ def test_lifecycle_validator_invalid_tool_call_args() -> None:
     finishes: list[Any] = [e for e in events if e["event"] == "content-block-finish"]
     assert len(finishes) == 1
     assert finishes[0]["content"]["type"] == "invalid_tool_call"
+
+
+def test_accumulate_empty_id_name_not_overwritten() -> None:
+    """Regression #39335: _accumulate preserves id/name when delta sends empty str."""
+    state = _accumulate(
+        None,
+        {"type": "tool_call_chunk", "id": "call_abc", "name": "search", "args": ""},
+    )
+    final = _accumulate(
+        state,
+        {"type": "tool_call_chunk", "id": "", "name": "", "args": '{"q":"hi"}'},
+    )
+    assert final["id"] == "call_abc", f"id overwritten: {final['id']!r}"
+    assert final["name"] == "search", f"name overwritten: {final['name']!r}"
+    assert final["args"] == '{"q":"hi"}'
 
 
 def test_lifecycle_validator_empty_stream() -> None:


### PR DESCRIPTION
**Issue:** #39335

## Problem

When providers stream tool calls, continuation deltas (which carry incremental `args` only) sometimes re-emit `id` and/or `name` as `""`. The previous guard `if value is not None` treated empty string as a valid update and overwrote previously accumulated valid metadata.

This caused downstream logic to see an empty `id`/`name` on an otherwise complete tool call, producing malformed or invalid tool-call objects.

## Changes

Two accumulation paths are fixed — both must be patched because they handle different streaming shapes independently:

**`langchain_core/language_models/chat_model_stream.py` — `_merge_block_delta_into_store`**

```python
# Before
for key, value in fields.items():
    if value is not None:
        existing[key] = value

# After
for key, value in fields.items():
    if value is None:
        continue
    if key in {"id", "name"} and value == "" and existing.get(key):
        continue
    existing[key] = value
```

**`langchain_core/language_models/_compat_bridge.py` — `_accumulate` (tool_call_chunk branch)**

```python
# Before
if delta.get("id") is not None:
    state["id"] = delta["id"]
if delta.get("name") is not None:
    state["name"] = delta["name"]

# After
if delta.get("id") is not None and (delta["id"] or not state.get("id")):
    state["id"] = delta["id"]
if delta.get("name") is not None and (delta["name"] or not state.get("name")):
    state["name"] = delta["name"]
```

## Tests

Two new regression tests:
- `TestChatModelStream::test_tool_call_empty_id_name_continuation_not_overwritten` — dispatches a valid `id`/`name` delta followed by a continuation delta with `id="", name=""`, asserts original values preserved.
- `test_accumulate_empty_id_name_not_overwritten` — tests the `_accumulate` path directly with the same sequence.

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.