### PR TITLE
fix(indexing): ensure updated_at > time_at_least in InMemoryRecordManager.update()

### DIFF
--- a/libs/core/langchain_core/indexing/base.py
+++ b/libs/core/langchain_core/indexing/base.py
@@ -296,12 +296,20 @@ class InMemoryRecordManager(RecordManager):
         if group_ids and len(keys) != len(group_ids):
             msg = "Length of keys must match length of group_ids"
             raise ValueError(msg)
+        current_time = self.get_time()
+        if time_at_least and time_at_least > current_time:
+            msg = "time_at_least must be in the past"
+            raise ValueError(msg)
+        if time_at_least is not None:
+            # Guarantee updated_at > time_at_least so that
+            # list_keys(before=time_at_least) never returns records from
+            # this batch — even on clocks with 1-second resolution.
+            update_time = max(current_time, time_at_least + 1e-6)
+        else:
+            update_time = current_time
         for index, key in enumerate(keys):
             group_id = group_ids[index] if group_ids else None
-            if time_at_least and time_at_least > self.get_time():
-                msg = "time_at_least must be in the past"
-                raise ValueError(msg)
-            self.records[key] = {"group_id": group_id, "updated_at": self.get_time()}
+            self.records[key] = {"group_id": group_id, "updated_at": update_time}
 
     async def aupdate(
         self,

--- a/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
+++ b/libs/core/tests/unit_tests/indexing/test_in_memory_record_manager.py
@@ -264,6 +264,61 @@ def test_delete_keys(manager: InMemoryRecordManager) -> None:
     assert remaining_keys == ["key3"]
 
 
+def test_update_batch_uses_consistent_timestamps(
+    manager: InMemoryRecordManager,
+) -> None:
+    """Regression #39087: all keys in one update() call must share the same timestamp.
+
+    Before the fix, get_time() was called once per key so rapid batches could
+    assign slightly different updated_at values within the same call.
+    """
+    tick = iter([1.0, 2.0, 3.0])
+
+    with patch.object(manager, "get_time", side_effect=lambda: next(tick)):
+        manager.update(["key1", "key2", "key3"])
+
+    timestamps = {k: manager.records[k]["updated_at"] for k in ["key1", "key2", "key3"]}
+    assert len(set(timestamps.values())) == 1, (
+        f"Expected all keys to share one timestamp, got {timestamps}"
+    )
+
+
+def test_update_time_at_least_raises_when_in_future(
+    manager: InMemoryRecordManager,
+) -> None:
+    """time_at_least greater than current time must raise ValueError."""
+    with (
+        patch.object(manager, "get_time", return_value=1000.0),
+        pytest.raises(ValueError, match="time_at_least must be in the past"),
+    ):
+        manager.update(["key1"], time_at_least=2000.0)
+
+
+def test_update_time_at_least_yields_strictly_greater_timestamp(
+    manager: InMemoryRecordManager,
+) -> None:
+    """Regression #39106: updated_at must be > time_at_least.
+
+    On low-resolution clocks get_time() can return the same value as
+    time_at_least (e.g. on Windows with 1-second resolution).
+    list_keys(before=time_at_least) with strict < then fails to return
+    records from a previous run that have updated_at == time_at_least.
+    The fix: ensure updated_at > time_at_least so cleanup always works.
+    """
+    time_at_least = 1000.0
+    with patch.object(manager, "get_time", return_value=time_at_least):
+        manager.update(["key1"], time_at_least=time_at_least)
+
+    stored_ts = manager.records["key1"]["updated_at"]
+    assert stored_ts > time_at_least, (
+        f"updated_at {stored_ts} must be strictly greater than "
+        f"time_at_least {time_at_least}"
+    )
+    assert manager.list_keys(before=time_at_least) == [], (
+        "a freshly-indexed record must not appear in list_keys(before=time_at_least)"
+    )
+
+
 async def test_adelete_keys(amanager: InMemoryRecordManager) -> None:
     """Test deleting keys from the database."""
     # Insert records


### PR DESCRIPTION
**Issues:** #39087, #39106

## Problem

`InMemoryRecordManager.update()` had two related bugs:

**Bug 1 (#39087):** `self.get_time()` was called inside the per-key loop, so multiple documents in the same batch could receive different `updated_at` timestamps. When callers use `list_keys(before=index_start_dt)` to clean up stale records, documents stamped slightly after `index_start_dt` would silently escape cleanup.

**Bug 2 (#39106):** When `time_at_least` is provided, `updated_at` was set to `max(current_time, time_at_least)`. On low-resolution clocks (e.g. Windows with 1-second resolution), `current_time == time_at_least`, so `updated_at == time_at_least`. The cleanup query `list_keys(before=index_start_dt)` uses a strict `<` comparison — records with `updated_at == index_start_dt` (old stale records from the previous run with the same second-resolution timestamp) are excluded, causing incomplete cleanup.

## Fix

Capture `get_time()` once before the loop, then compute:

```python
current_time = self.get_time()
if time_at_least and time_at_least > current_time:
    raise ValueError("time_at_least must be in the past")
if time_at_least is not None:
    # Guarantee updated_at > time_at_least so that
    # list_keys(before=time_at_least) never returns records from
    # this batch — even on clocks with 1-second resolution.
    update_time = max(current_time, time_at_least + 1e-6)
else:
    update_time = current_time
```

This ensures:
- All records in a single `update()` call get **identical** timestamps
- `updated_at` is always **strictly greater** than `time_at_least` when provided
- `list_keys(before=index_start_dt)` correctly excludes freshly-indexed records

## Tests

Three new regression tests:
- `test_update_batch_uses_consistent_timestamps` — patches `get_time()` with a tick counter; asserts all keys in one call share one timestamp
- `test_update_time_at_least_raises_when_in_future` — confirms `ValueError` on future timestamp
- `test_update_time_at_least_yields_strictly_greater_timestamp` — freezes clock at `time_at_least`, confirms `updated_at > time_at_least` and that `list_keys(before=time_at_least)` returns empty

> **Note:** This supersedes #39504, which addressed only bug 1.

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.