### PR TITLE
fix(core): raise ValueError when tool_outputs length mismatches tool calls in tool_example_to_messages()

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -713,6 +713,12 @@ def tool_example_to_messages(
     messages.append(
         AIMessage(content="", additional_kwargs={"tool_calls": openai_tool_calls})
     )
+    if tool_outputs is not None and len(tool_outputs) != len(openai_tool_calls):
+        msg = (
+            f"Length of tool_outputs ({len(tool_outputs)}) does not match "
+            f"number of tool calls ({len(openai_tool_calls)})."
+        )
+        raise ValueError(msg)
     tool_outputs = tool_outputs or ["You have correctly called this tool."] * len(
         openai_tool_calls
     )

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1371,6 +1371,37 @@ class TestParseGoogleDocstring:
         assert "y: the y value" in args["x"]
 
 
+def test_tool_outputs_fewer_than_tool_calls_raises() -> None:
+    """Regression #39138: mismatched tool_outputs must raise, not silently truncate."""
+    with pytest.raises(ValueError, match="Length of tool_outputs"):
+        tool_example_to_messages(
+            input="Extract both values",
+            tool_calls=[FakeCall(data="a"), FakeCall(data="b")],
+            tool_outputs=["only one output"],
+        )
+
+
+def test_tool_outputs_more_than_tool_calls_raises() -> None:
+    """Regression #39138: extra tool_outputs must raise, not silently be dropped."""
+    with pytest.raises(ValueError, match="Length of tool_outputs"):
+        tool_example_to_messages(
+            input="Extract one value",
+            tool_calls=[FakeCall(data="a")],
+            tool_outputs=["output1", "output2"],
+        )
+
+
+def test_tool_outputs_none_auto_fills() -> None:
+    """Passing tool_outputs=None still auto-fills one placeholder per tool call."""
+    messages = tool_example_to_messages(
+        input="Extract both",
+        tool_calls=[FakeCall(data="a"), FakeCall(data="b")],
+        tool_outputs=None,
+    )
+    tool_messages = [m for m in messages if isinstance(m, ToolMessage)]
+    assert len(tool_messages) == 2
+
+
 def test_convert_to_openai_tool_apply_patch_passthrough() -> None:
     """Test apply_patch is passed through as an OpenAI built-in tool."""
     tool = {"type": "apply_patch"}


### PR DESCRIPTION
**Issue:** #39138

## Problem

`tool_example_to_messages()` silently drops excess `tool_outputs` (or produces fewer `ToolMessage`s than the advertised `tool_calls` list) when the caller provides an explicitly-sized `tool_outputs` list whose length differs from the number of inferred tool calls. The root cause was `zip(..., strict=False)` at line 719 of `function_calling.py`.

```python
# Before — silently truncates:
messages = tool_example_to_messages(
    "Extract both values",
    [Extraction(value="a"), Extraction(value="b")],
    tool_outputs=["only one output"],
)
print(len(messages[1].additional_kwargs["tool_calls"]))  # 2
print(len([m for m in messages if isinstance(m, ToolMessage)]))  # 1 — mismatch!
```

## Fix

Add a length guard between the `tool_outputs` normalisation and the `zip`. Only applies when the caller explicitly passes `tool_outputs` (not `None`); the auto-fill path is unchanged.

```python
if tool_outputs is not None and len(tool_outputs) != len(openai_tool_calls):
    msg = (
        f"Length of tool_outputs ({len(tool_outputs)}) does not match "
        f"number of tool calls ({len(openai_tool_calls)})."
    )
    raise ValueError(msg)
```

## Tests

Three new regression tests:
- `test_tool_outputs_fewer_than_tool_calls_raises` — fewer outputs than calls raises `ValueError`
- `test_tool_outputs_more_than_tool_calls_raises` — extra outputs also raises
- `test_tool_outputs_none_auto_fills` — passing `None` still generates one placeholder per call

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.