### PR TITLE
fix(core): fix ContextThreadPoolExecutor.map generator rejection and batch_iterate/abatch_iterate size validation

### DIFF
--- a/libs/core/langchain_core/runnables/config.py
+++ b/libs/core/langchain_core/runnables/config.py
@@ -644,16 +644,7 @@ class ContextThreadPoolExecutor(ThreadPoolExecutor):
         Returns:
             The iterator for the mapped function.
         """
-        contexts = [copy_context() for _ in range(len(iterables[0]))]  # type: ignore[arg-type]
-
-        def _wrapped_fn(*args: Any) -> T:
-            return contexts.pop().run(fn, *args)
-
-        return super().map(
-            _wrapped_fn,
-            *iterables,
-            **kwargs,
-        )
+        return super().map(fn, *iterables, **kwargs)
 
 
 @contextmanager

--- a/libs/core/langchain_core/utils/aiter.py
+++ b/libs/core/langchain_core/utils/aiter.py
@@ -333,7 +333,14 @@ async def abatch_iterate(
 
     Yields:
         The batches.
+
+    Raises:
+        ValueError: If ``size`` is not a positive integer.
     """
+    if size <= 0:
+        raise ValueError(
+            f"abatch_iterate size must be a positive integer, got {size}."
+        )
     batch: list[T] = []
     async for element in iterable:
         if len(batch) < size:
@@ -345,3 +352,4 @@ async def abatch_iterate(
 
     if batch:
         yield batch
+

--- a/libs/core/langchain_core/utils/iter.py
+++ b/libs/core/langchain_core/utils/iter.py
@@ -214,10 +214,18 @@ def batch_iterate(size: int | None, iterable: Iterable[T]) -> Iterator[list[T]]:
 
     Yields:
         The batches of the iterable.
+
+    Raises:
+        ValueError: If ``size`` is not ``None`` and is not a positive integer.
     """
+    if size is not None and size <= 0:
+        raise ValueError(
+            f"batch_iterate size must be a positive integer or None, got {size}."
+        )
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))
         if not chunk:
             return
         yield chunk
+

--- a/libs/core/tests/unit_tests/runnables/test_config.py
+++ b/libs/core/tests/unit_tests/runnables/test_config.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from contextvars import copy_context
+from contextvars import ContextVar, copy_context
 from typing import Any, cast
 
 import pytest
@@ -15,6 +15,7 @@ from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_core.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from langchain_core.runnables import RunnableBinding, RunnablePassthrough
 from langchain_core.runnables.config import (
+    ContextThreadPoolExecutor,
     RunnableConfig,
     _get_langsmith_inheritable_metadata_from_config,
     _merge_metadata_dicts,
@@ -414,3 +415,35 @@ class TestMergeMetadataDicts:
         assert merged["metadata"] == {
             "lc_versions": {"a": "1", "b": "2", "c": "3"},
         }
+
+
+class TestContextThreadPoolExecutorMap:
+    """Regression tests for ContextThreadPoolExecutor.map (fixes #39211)."""
+
+    def test_map_accepts_generator_input(self) -> None:
+        """map() must not call len() on its first iterable (was broken for generators)."""
+
+        def _gen():
+            yield from range(5)
+
+        with ContextThreadPoolExecutor(max_workers=2) as executor:
+            result = list(executor.map(lambda x: x * 2, _gen()))
+
+        assert result == [0, 2, 4, 6, 8]
+
+    def test_map_propagates_context_var(self) -> None:
+        """Context vars set before map() must be visible inside the mapped function."""
+        var: ContextVar[str] = ContextVar("_test_var", default="missing")
+        var.set("from_caller")
+
+        with ContextThreadPoolExecutor(max_workers=2) as executor:
+            values = list(executor.map(lambda _: var.get(), range(3)))
+
+        assert all(v == "from_caller" for v in values)
+
+    def test_map_multiple_iterables_shortest_wins(self) -> None:
+        """Standard shortest-iterable truncation must be preserved."""
+        with ContextThreadPoolExecutor(max_workers=2) as executor:
+            result = list(executor.map(lambda a, b: a + b, [1, 2, 3], [10, 20]))
+
+        assert result == [11, 22]

--- a/libs/core/tests/unit_tests/utils/test_aiter.py
+++ b/libs/core/tests/unit_tests/utils/test_aiter.py
@@ -29,3 +29,27 @@ async def test_abatch_iterate(
 
     output = [el async for el in iterator_]
     assert output == expected_output
+
+
+@pytest.mark.parametrize("bad_size", [0, -1, -100])
+async def test_abatch_iterate_invalid_size_raises(bad_size: int) -> None:
+    """abatch_iterate must raise ValueError for non-positive size."""
+
+    async def _gen() -> AsyncIterator[int]:
+        yield 1
+
+    with pytest.raises(ValueError, match="positive integer"):
+        async for _ in abatch_iterate(bad_size, _gen()):
+            pass
+
+
+async def test_abatch_iterate_accepts_async_generator() -> None:
+    """abatch_iterate must correctly batch a real async generator."""
+
+    async def _gen() -> AsyncIterator[int]:
+        for i in range(5):
+            yield i
+
+    result = [batch async for batch in abatch_iterate(2, _gen())]
+    assert result == [[0, 1], [2, 3], [4]]
+

--- a/libs/core/tests/unit_tests/utils/test_iter.py
+++ b/libs/core/tests/unit_tests/utils/test_iter.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+
 import pytest
 
 from langchain_core.utils.iter import batch_iterate
@@ -17,3 +19,24 @@ def test_batch_iterate(
 ) -> None:
     """Test batching function."""
     assert list(batch_iterate(input_size, input_iterable)) == expected_output
+
+
+@pytest.mark.parametrize("bad_size", [0, -1, -100])
+def test_batch_iterate_invalid_size_raises(bad_size: int) -> None:
+    """batch_iterate must raise ValueError for non-positive size."""
+    with pytest.raises(ValueError, match="positive integer"):
+        list(batch_iterate(bad_size, [1, 2, 3]))
+
+
+def test_batch_iterate_none_size_returns_single_batch() -> None:
+    """size=None should return the entire iterable as one batch."""
+    assert list(batch_iterate(None, [1, 2, 3])) == [[1, 2, 3]]
+
+
+def test_batch_iterate_accepts_generator() -> None:
+    """batch_iterate must accept unsized iterables such as generators."""
+
+    def _gen() -> Generator[int, None, None]:
+        yield from range(5)
+
+    assert list(batch_iterate(2, _gen())) == [[0, 1], [2, 3], [4]]


### PR DESCRIPTION
## Summary

Fixes two independent bugs in `langchain-core`, both in the `langchain_core` package. Combined into one PR since both touch core utility/executor code with no interdependencies.

---

### 1. `ContextThreadPoolExecutor.map` rejects generator inputs — fixes #39211

**Root cause**: The override pre-allocated contexts with `len(iterables[0])`, which raises `TypeError` for any unsized iterable (generators, lazy sequences):

```python
# before — broken for generators
contexts = [copy_context() for _ in range(len(iterables[0]))]
```

**Fix**: delegate directly to `super().map()`. The stdlib implementation calls through `self.submit()` for each item, and `ContextThreadPoolExecutor.submit()` already wraps every call with `copy_context().run(...)`. Context propagation is fully preserved — no pre-allocation needed.

```python
# after — one line, correct for all iterables
return super().map(fn, *iterables, **kwargs)
```

**Tests added** (`tests/unit_tests/runnables/test_config.py`):
- `test_map_accepts_generator_input` — generator works without `TypeError`
- `test_map_propagates_context_var` — `ContextVar` set in caller is visible in workers
- `test_map_multiple_iterables_shortest_wins` — standard shortest-iterable behavior preserved

---

### 2. `batch_iterate`/`abatch_iterate` silently discard data for `size <= 0` — fixes #39566

**Root cause**: No validation on `size`, unlike sibling functions `_batch`/`_abatch` in `indexing/api.py` (guarded in #36663).

| Call | Before | After |
|------|--------|-------|
| `batch_iterate(0, data)` | Returns `[]` silently | `ValueError` |
| `batch_iterate(-1, data)` | Confusing `islice` internal error | Clear `ValueError` |
| `abatch_iterate(0, data)` | Yields `[]` per element (all data lost, no exception) | `ValueError` |
| `abatch_iterate(-1, data)` | Same total silent data loss | `ValueError` |

Real-world impact: `batch_iterate` is used in `CacheBackedEmbeddings.embed_documents()` — `size=0` causes it to silently return `None` placeholders cast as `list[list[float]]`, violating the type contract invisibly.

**Fix**: port the guard already present in `_batch`/`_abatch`:
```python
if size <= 0:
    raise ValueError(f"... must be a positive integer, got {size}.")
```

**Tests added** (`tests/unit_tests/utils/test_iter.py`, `test_aiter.py`):
- `test_batch_iterate_invalid_size_raises` — parametrized over `[0, -1, -100]`
- `test_batch_iterate_none_size_returns_single_batch` — `None` remains valid
- `test_batch_iterate_accepts_generator` — unsized iterable still works
- `test_abatch_iterate_invalid_size_raises` — async variant
- `test_abatch_iterate_accepts_async_generator` — normal async batching still works
