### PR TITLE
fix(core): raise ValueError on non-positive batch_size in batch_iterate and abatch_iterate

### DIFF
--- a/libs/core/langchain_core/utils/aiter.py
+++ b/libs/core/langchain_core/utils/aiter.py
@@ -323,23 +323,28 @@ class aclosing(AbstractAsyncContextManager[Any]):  # noqa: N801
 
 
 async def abatch_iterate(
-    size: int, iterable: AsyncIterable[T]
+    size: int | None, iterable: AsyncIterable[T]
 ) -> AsyncIterator[list[T]]:
     """Utility batching function for async iterables.
 
     Args:
         size: The size of the batch.
+
+            If `None`, returns a single batch.
         iterable: The async iterable to batch.
 
     Yields:
         The batches.
     """
+    if size is not None and size <= 0:
+        msg = f"Batch size must be a positive integer, got {size}."
+        raise ValueError(msg)
+
     batch: list[T] = []
     async for element in iterable:
-        if len(batch) < size:
-            batch.append(element)
+        batch.append(element)
 
-        if len(batch) >= size:
+        if size is not None and len(batch) >= size:
             yield batch
             batch = []
 

--- a/libs/core/langchain_core/utils/iter.py
+++ b/libs/core/langchain_core/utils/iter.py
@@ -215,6 +215,10 @@ def batch_iterate(size: int | None, iterable: Iterable[T]) -> Iterator[list[T]]:
     Yields:
         The batches of the iterable.
     """
+    if size is not None and size <= 0:
+        msg = f"Batch size must be a positive integer, got {size}."
+        raise ValueError(msg)
+
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))

--- a/libs/core/tests/unit_tests/utils/test_aiter.py
+++ b/libs/core/tests/unit_tests/utils/test_aiter.py
@@ -12,14 +12,15 @@ from langchain_core.utils.aiter import abatch_iterate
         (3, [10, 20, 30, 40, 50], [[10, 20, 30], [40, 50]]),
         (1, [100, 200, 300], [[100], [200], [300]]),
         (4, [], []),
+        (None, [1, 2, 3], [[1, 2, 3]]),
     ],
 )
 async def test_abatch_iterate(
-    input_size: int, input_iterable: list[str], expected_output: list[list[str]]
+    input_size: int | None, input_iterable: list[int], expected_output: list[list[int]]
 ) -> None:
     """Test batching function."""
 
-    async def _to_async_iterable(iterable: list[str]) -> AsyncIterator[str]:
+    async def _to_async_iterable(iterable: list[int]) -> AsyncIterator[int]:
         for item in iterable:
             yield item
 
@@ -29,3 +30,17 @@ async def test_abatch_iterate(
 
     output = [el async for el in iterator_]
     assert output == expected_output
+
+
+@pytest.mark.parametrize("invalid_size", [0, -1, -5])
+async def test_abatch_iterate_invalid_size(invalid_size: int) -> None:
+    """Test that non-positive batch size raises ValueError."""
+
+    async def _to_async_iterable(iterable: list[int]) -> AsyncIterator[int]:
+        for item in iterable:
+            yield item
+
+    with pytest.raises(
+        ValueError, match="Batch size must be a positive integer, got"
+    ):
+        _ = [el async for el in abatch_iterate(invalid_size, _to_async_iterable([1, 2, 3]))]

--- a/libs/core/tests/unit_tests/utils/test_iter.py
+++ b/libs/core/tests/unit_tests/utils/test_iter.py
@@ -10,10 +10,20 @@ from langchain_core.utils.iter import batch_iterate
         (3, [10, 20, 30, 40, 50], [[10, 20, 30], [40, 50]]),
         (1, [100, 200, 300], [[100], [200], [300]]),
         (4, [], []),
+        (None, [1, 2, 3], [[1, 2, 3]]),
     ],
 )
 def test_batch_iterate(
-    input_size: int, input_iterable: list[str], expected_output: list[list[str]]
+    input_size: int | None, input_iterable: list[int], expected_output: list[list[int]]
 ) -> None:
     """Test batching function."""
     assert list(batch_iterate(input_size, input_iterable)) == expected_output
+
+
+@pytest.mark.parametrize("invalid_size", [0, -1, -5])
+def test_batch_iterate_invalid_size(invalid_size: int) -> None:
+    """Test that non-positive batch size raises ValueError."""
+    with pytest.raises(
+        ValueError, match="Batch size must be a positive integer, got"
+    ):
+        list(batch_iterate(invalid_size, [1, 2, 3]))


### PR DESCRIPTION
### Summary

Fixes #39566.

### Problem
Previously, `batch_iterate` and `abatch_iterate` had no validation on their `size` parameter:
- `batch_iterate(0, ...)` returned an empty iterator without raising.
- `batch_iterate(-1, ...)` raised a confusing `ValueError` from deep within `itertools.islice`.
- `abatch_iterate(0, ...)` and `abatch_iterate(-1, ...)` yielded empty lists repeatedly and silently dropped all incoming elements.

### Solution
- Added explicit validation to raise `ValueError(f"Batch size must be a positive integer, got {size}.")` when `size is not None and size <= 0` in both `batch_iterate` and `abatch_iterate`, matching the behavior of `_batch`/`_abatch` in `langchain_core.indexing.api`.
- Added comprehensive unit tests in `test_iter.py` and `test_aiter.py` for `size <= 0` and `size=None` cases.

Closes #39566
