### PR TITLE
fix(core): exclude injected arguments from validation dumps

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -720,19 +720,8 @@ class ChildTool(BaseTool):
         # re-injected during execution. `StructuredTool` overrides this to
         # inspect its wrapped `func`/`coroutine` instead.
         #
-        # Resolve annotations via `get_type_hints` (rather than reading raw
-        # `signature` annotations) so postponed annotations -- e.g. from
-        # `from __future__ import annotations` or quoted forward references --
-        # are recognized. Fall back to the raw annotation per-parameter when a
-        # hint can't be resolved.
         for method in (self._run, self._arun):
-            params = signature(method).parameters
-            hints = _get_type_hints(method, include_extras=True) or {}
-            keys = frozenset(
-                name
-                for name, param in params.items()
-                if _is_injected_arg_type(hints.get(name, param.annotation))
-            )
+            keys = _get_injected_args_keys(method)
             if keys:
                 return keys
         return _EMPTY_SET
@@ -818,10 +807,17 @@ class ChildTool(BaseTool):
         if input_args is not None:
             if isinstance(input_args, dict):
                 return tool_input
+            input_annotations = get_all_basemodel_annotations(input_args)
+            schema_injected_keys = {
+                key
+                for key, annotation in input_annotations.items()
+                if _is_injected_arg_type(annotation)
+            }
+            injected_input_keys = schema_injected_keys | self._injected_args_keys
             result: BaseModel | BaseModelV1
             if issubclass(input_args, BaseModel):
                 # Check args_schema for InjectedToolCallId
-                for k, v in get_all_basemodel_annotations(input_args).items():
+                for k, v in input_annotations.items():
                     if _is_injected_arg_type(v, injected_type=InjectedToolCallId):
                         if tool_call_id is None:
                             msg = (
@@ -834,11 +830,11 @@ class ChildTool(BaseTool):
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
                 result_v2 = input_args.model_validate(tool_input)
-                result_dict = result_v2.model_dump()
+                result_dict = result_v2.model_dump(exclude=injected_input_keys)
                 result = result_v2
             elif issubclass(input_args, BaseModelV1):
                 # Check args_schema for InjectedToolCallId
-                for k, v in get_all_basemodel_annotations(input_args).items():
+                for k, v in input_annotations.items():
                     if _is_injected_arg_type(v, injected_type=InjectedToolCallId):
                         if tool_call_id is None:
                             msg = (
@@ -851,7 +847,7 @@ class ChildTool(BaseTool):
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
                 result_v1 = input_args.parse_obj(tool_input)
-                result_dict = result_v1.dict()
+                result_dict = result_v1.dict(exclude=injected_input_keys)
                 result = result_v1
             else:
                 msg = (  # type: ignore[unreachable]
@@ -881,6 +877,10 @@ class ChildTool(BaseTool):
                     )
                     if has_default:
                         validated_input[k] = getattr(result, k)
+
+            for k in injected_input_keys:
+                if k in field_info:
+                    validated_input[k] = getattr(result, k)
 
             for k in self._injected_args_keys:
                 if k in tool_input:
@@ -1498,6 +1498,17 @@ def _get_type_hints(
         return get_type_hints(func, include_extras=include_extras)
     except Exception:
         return None
+
+
+def _get_injected_args_keys(func: Callable[..., Any]) -> frozenset[str]:
+    """Return runtime-injected parameters declared by a callable."""
+    params = signature(func).parameters
+    hints = _get_type_hints(func, include_extras=True) or {}
+    return frozenset(
+        name
+        for name, param in params.items()
+        if _is_injected_arg_type(hints.get(name, param.annotation))
+    )
 
 
 def _get_runnable_config_param(func: Callable[..., Any]) -> str | None:

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -27,8 +27,8 @@ from langchain_core.tools.base import (
     FILTERED_ARGS,
     ArgsSchema,
     BaseTool,
+    _get_injected_args_keys,
     _get_runnable_config_param,
-    _is_injected_arg_type,
     create_schema_from_function,
 )
 from langchain_core.utils.pydantic import is_basemodel_subclass
@@ -256,11 +256,7 @@ class StructuredTool(BaseTool):
         fn = self.func or self.coroutine
         if fn is None:
             return _EMPTY_SET
-        return frozenset(
-            k
-            for k, v in signature(fn).parameters.items()
-            if _is_injected_arg_type(v.annotation)
-        )
+        return _get_injected_args_keys(fn)
 
 
 def _filter_schema_args(func: Callable[..., Any]) -> list[str]:

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -7,6 +7,7 @@ import pickle
 import sys
 import textwrap
 import threading
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
@@ -23,7 +24,14 @@ from typing import (
 )
 
 import pytest
-from pydantic import BaseModel, ConfigDict, Field, RootModel, ValidationError
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    ValidationError,
+    model_serializer,
+)
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import ValidationError as ValidationErrorV1
 from typing_extensions import TypedDict, override
@@ -3493,6 +3501,191 @@ async def test_filter_injected_args_async() -> None:
     assert captured["query"] == "async test"
 
 
+def test_tool_does_not_serialize_injected_pydantic_v2_arg() -> None:
+    """Injected Pydantic v2 arguments must bypass model serialization."""
+
+    class InjectedValue(BaseModel):
+        value: str
+
+        @model_serializer
+        def fail_serialization(self) -> dict[str, str]:
+            raise AssertionError
+
+    class InputSchema(BaseModel):
+        query: str
+        injected: Annotated[InjectedValue, InjectedToolArg]
+
+    captured: dict[str, Any] = {}
+
+    @tool(args_schema=InputSchema)
+    def injected_tool(
+        query: str,
+        injected: InjectedValue,
+    ) -> str:
+        """Return the query without inspecting the injected value."""
+        captured["injected"] = injected
+        return query
+
+    assert (
+        injected_tool.invoke(
+            {"query": "test", "injected": {"value": "large runtime graph"}}
+        )
+        == "test"
+    )
+    assert captured["injected"] == InjectedValue(value="large runtime graph")
+
+
+@skip_if_no_pydantic_v1
+def test_tool_does_not_serialize_injected_pydantic_v1_arg() -> None:
+    """Injected Pydantic v1 arguments must bypass model serialization."""
+
+    class InjectedValueV1(BaseModelV1):
+        value: str
+
+        def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+            raise AssertionError
+
+    class InputSchemaV1(BaseModelV1):
+        query: str
+        injected: Annotated[InjectedValueV1, InjectedToolArg]
+
+    captured: dict[str, Any] = {}
+
+    @tool(args_schema=InputSchemaV1)
+    def injected_tool(
+        query: str,
+        injected: InjectedValueV1,
+    ) -> str:
+        """Return the query without inspecting the injected value."""
+        captured["injected"] = injected
+        return query
+
+    assert (
+        injected_tool.invoke(
+            {"query": "test", "injected": {"value": "large runtime graph"}}
+        )
+        == "test"
+    )
+    captured_injected = captured["injected"]
+    assert isinstance(captured_injected, InjectedValueV1)
+    assert captured_injected.value == "large runtime graph"
+
+
+def test_tool_does_not_serialize_callable_only_injected_pydantic_v2_arg() -> None:
+    """Callable-only injected arguments must bypass Pydantic v2 serialization."""
+
+    class InjectedValue(BaseModel):
+        value: str
+
+        @model_serializer
+        def fail_serialization(self) -> dict[str, str]:
+            raise AssertionError
+
+    class InputSchema(BaseModel, extra="allow"):
+        query: str
+
+    captured: dict[str, Any] = {}
+
+    @tool(args_schema=InputSchema)
+    def injected_tool(
+        query: str,
+        injected: Annotated[InjectedValue, InjectedToolArg],
+    ) -> str:
+        """Return the query without inspecting the injected value."""
+        captured["injected"] = injected
+        return query
+
+    injected = InjectedValue(value="large runtime graph")
+
+    assert injected_tool.invoke({"query": "test", "injected": injected}) == "test"
+    assert captured["injected"] is injected
+
+
+def test_tool_does_not_serialize_generic_directly_injected_arg() -> None:
+    """Generic directly injected arguments must bypass model serialization."""
+    ContextT = TypeVar("ContextT")
+    StateT = TypeVar("StateT")
+
+    @dataclass
+    class GenericRuntime(
+        _DirectlyInjectedToolArg,
+        Generic[ContextT, StateT],
+    ):
+        context: ContextT
+        state: StateT
+
+    captured: dict[str, Any] = {}
+
+    @tool
+    def injected_tool(
+        query: str,
+        runtime: GenericRuntime[None, dict[str, str]],
+    ) -> str:
+        """Return the query without inspecting the injected value."""
+        captured["runtime"] = runtime
+        return query
+
+    runtime = GenericRuntime(
+        context={"catalog_size": 48_283},
+        state={"query": "hexagon bolt"},
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert injected_tool.invoke({"query": "test", "runtime": runtime}) == "test"
+
+    assert captured["runtime"] is runtime
+
+
+def test_tool_preserves_injected_arg_schema_default() -> None:
+    """Schema defaults for omitted injected arguments must remain supported."""
+
+    class InputSchema(BaseModel):
+        query: str
+        injected: Annotated[str, InjectedToolArg] = "default"
+
+    @tool(args_schema=InputSchema)
+    def injected_tool(query: str, injected: str) -> str:
+        """Return the injected value."""
+        return f"{query}: {injected}"
+
+    assert injected_tool.invoke({"query": "test"}) == "test: default"
+
+
+def test_tool_preserves_callable_injected_arg_schema_default() -> None:
+    """Schema defaults remain supported for callable-only injected arguments."""
+
+    class InputSchema(BaseModel):
+        query: str
+        injected: str = "default"
+
+    @tool(args_schema=InputSchema)
+    def injected_tool(
+        query: str,
+        injected: Annotated[str, InjectedToolArg],
+    ) -> str:
+        """Return the injected value."""
+        return f"{query}: {injected}"
+
+    assert injected_tool.invoke({"query": "test"}) == "test: default"
+
+
+@skip_if_no_pydantic_v1
+def test_tool_preserves_injected_arg_pydantic_v1_schema_default() -> None:
+    """Pydantic v1 defaults for omitted injected arguments remain supported."""
+
+    class InputSchemaV1(BaseModelV1):
+        query: str
+        injected: Annotated[str, InjectedToolArg] = "default"
+
+    @tool(args_schema=InputSchemaV1)
+    def injected_tool(query: str, injected: str) -> str:
+        """Return the injected value."""
+        return f"{query}: {injected}"
+
+    assert injected_tool.invoke({"query": "test"}) == "test: default"
+
+
 @pytest.mark.skipif(not HAS_LANGGRAPH, reason="langgraph not installed")
 def test_filter_tool_runtime_directly_injected_arg() -> None:
     """Test that ToolRuntime (a _DirectlyInjectedToolArg) is filtered."""
@@ -3554,7 +3747,7 @@ class _ToolArgsSchemaNoRuntime(BaseModel):
 
 
 def _tool_func_directly_injected(
-    query: str, limit: int, runtime: _CustomRuntime
+    query: str, limit: int, runtime: "_CustomRuntime"
 ) -> str:
     """Tool with directly injected runtime not in schema.
 


### PR DESCRIPTION
Fixes #34770

---

`BaseTool._parse_input()` currently serializes injected arguments and then replaces them with their original values. This skips those fields during the Pydantic dump, avoiding traversal of large runtime objects before every tool call while preserving validation for normal arguments.

I reproduced the issue on current `master` and ran the `langchain-core` tests locally.

## Release note

`BaseTool` no longer serializes runtime-injected arguments while validating tool input.
