### PR TITLE
fix(core): validate `batch_iterate`/`abatch_iterate` size is positive

### DIFF
--- a/libs/core/langchain_core/utils/aiter.py
+++ b/libs/core/langchain_core/utils/aiter.py
@@ -333,7 +333,13 @@ async def abatch_iterate(
 
     Yields:
         The batches.
+
+    Raises:
+        ValueError: If `size` is not a positive integer.
     """
+    if size <= 0:
+        msg = f"Batch size must be a positive integer, got {size}."
+        raise ValueError(msg)
     batch: list[T] = []
     async for element in iterable:
         if len(batch) < size:

--- a/libs/core/langchain_core/utils/iter.py
+++ b/libs/core/langchain_core/utils/iter.py
@@ -214,7 +214,13 @@ def batch_iterate(size: int | None, iterable: Iterable[T]) -> Iterator[list[T]]:
 
     Yields:
         The batches of the iterable.
+
+    Raises:
+        ValueError: If `size` is not `None` and is not a positive integer.
     """
+    if size is not None and size <= 0:
+        msg = f"Batch size must be a positive integer, got {size}."
+        raise ValueError(msg)
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))

--- a/libs/core/tests/unit_tests/utils/test_aiter.py
+++ b/libs/core/tests/unit_tests/utils/test_aiter.py
@@ -29,3 +29,16 @@ async def test_abatch_iterate(
 
     output = [el async for el in iterator_]
     assert output == expected_output
+
+
+@pytest.mark.parametrize("invalid_size", [0, -1, -100])
+async def test_abatch_iterate_invalid_size_raises(invalid_size: int) -> None:
+    """abatch_iterate must raise ValueError for non-positive size."""
+
+    async def _agen() -> AsyncIterator[int]:
+        for i in [1, 2, 3]:
+            yield i
+
+    with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        async for _ in abatch_iterate(invalid_size, _agen()):
+            pass

--- a/libs/core/tests/unit_tests/utils/test_iter.py
+++ b/libs/core/tests/unit_tests/utils/test_iter.py
@@ -17,3 +17,10 @@ def test_batch_iterate(
 ) -> None:
     """Test batching function."""
     assert list(batch_iterate(input_size, input_iterable)) == expected_output
+
+
+@pytest.mark.parametrize("invalid_size", [0, -1, -100])
+def test_batch_iterate_invalid_size_raises(invalid_size: int) -> None:
+    """batch_iterate must raise ValueError for non-positive size."""
+    with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        list(batch_iterate(invalid_size, [1, 2, 3]))


### PR DESCRIPTION
Closes #39566

---

`batch_iterate` and `abatch_iterate` (the *public* exports in `langchain_core.utils`) did not validate their `size` parameter, leading to silent data loss:

- `batch_iterate(0, items)` returned an empty iterator — no error, no data.
- `batch_iterate(-1, items)` raised a low-level `ValueError` from inside `itertools.islice` with no indication the problem was an invalid `size`.
- `abatch_iterate(0, items)` and `abatch_iterate(-1, items)` were worse: the accumulation condition `len(batch) < size` was never satisfied, so every element was silently dropped and an empty batch was yielded once per input item.

The bug already exists in the sibling `_batch`/`_abatch` helpers in `langchain_core.indexing.api`, and was fixed there in #36663 (closing #36647). That fix never reached `batch_iterate`/`abatch_iterate`, the older and publicly-exported pair. This PR ports the same one-line guard to both functions:

```python
if size <= 0:
    msg = f"Batch size must be a positive integer, got {size}."
    raise ValueError(msg)
```

(`batch_iterate` also accepts `size=None` as "no limit", so the guard is `size is not None and size <= 0`.)

Both functions now raise `ValueError` immediately on invalid input rather than silently discarding data. Three parametrized cases (0, -1, -100) are added to each test file to confirm the behavior fails before the fix and passes after.

## Release note

`batch_iterate` and `abatch_iterate` now raise `ValueError` immediately when called with a non-positive `size`, rather than silently returning empty or discarding all input elements.

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.