### PR TITLE
fix(core): resolve postponed annotations in `StructuredTool._injected_args_keys`

### DIFF
--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -28,6 +28,7 @@ from langchain_core.tools.base import (
     ArgsSchema,
     BaseTool,
     _get_runnable_config_param,
+    _get_type_hints,
     _is_injected_arg_type,
     create_schema_from_function,
 )
@@ -256,10 +257,12 @@ class StructuredTool(BaseTool):
         fn = self.func or self.coroutine
         if fn is None:
             return _EMPTY_SET
+        params = signature(fn).parameters
+        hints = _get_type_hints(fn, include_extras=True) or {}
         return frozenset(
             k
-            for k, v in signature(fn).parameters.items()
-            if _is_injected_arg_type(v.annotation)
+            for k, v in params.items()
+            if _is_injected_arg_type(hints.get(k, v.annotation))
         )
 
 

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -4295,3 +4295,55 @@ def test_tool_call_schema_json_schema_cache_invalidated_on_reassignment() -> Non
     new_schema = new_cls.model_json_schema()
     assert new_schema is not old_schema
     assert new_schema["description"] == "New description for cache test."
+
+
+def test_structured_tool_injects_postponed_annotation_runtime() -> None:
+    """StructuredTool._injected_args_keys must resolve postponed annotations.
+
+    When `from __future__ import annotations` is active (or a quoted forward
+    reference is used), `signature()` returns raw string annotations that
+    `_is_injected_arg_type` cannot match.  The fix mirrors the resolution
+    already applied to ChildTool._injected_args_keys in #39202.  Closes #39568.
+    """
+
+    class EchoInput(BaseModel):
+        query: str
+
+    captured: dict[str, Any] = {}
+
+    # Quoted forward reference -> raw string annotation at `signature()` time.
+    @tool(args_schema=EchoInput)
+    def my_tool(query: str, secret: "Annotated[str, InjectedToolArg]") -> str:
+        """Echo the query."""
+        captured["secret"] = secret
+        return query
+
+    assert "secret" in my_tool._injected_args_keys
+
+    result = my_tool.invoke({"query": "hello", "secret": "topsecret"})
+    assert result == "hello"
+    assert captured["secret"] == "topsecret"
+
+
+def test_structured_tool_from_function_injects_postponed_annotation() -> None:
+    """StructuredTool.from_function also uses _injected_args_keys; same fix applies."""
+
+    class CalcInput(BaseModel):
+        a: int
+        b: int
+
+    captured: dict[str, Any] = {}
+
+    def multiply(a: int, b: int, ctx: "Annotated[str, InjectedToolArg]") -> int:
+        captured["ctx"] = ctx
+        return a * b
+
+    tool_ = StructuredTool.from_function(
+        multiply, args_schema=CalcInput, description="Multiply."
+    )
+
+    assert "ctx" in tool_._injected_args_keys
+
+    result = tool_.invoke({"a": 3, "b": 4, "ctx": "my-context"})
+    assert result == 12
+    assert captured["ctx"] == "my-context"


### PR DESCRIPTION
Closes #39568

---

`StructuredTool._injected_args_keys` determines which parameters of the wrapped function receive runtime injection (`InjectedToolArg`, `ToolRuntime`, `InjectedToolCallId`) by calling `signature(fn).parameters` and testing each parameter's raw `.annotation` with `_is_injected_arg_type`. Under `from __future__ import annotations` (PEP 563) — or any quoted forward reference — the annotation is a plain string at `signature()` time rather than the actual type, so `_is_injected_arg_type` never matches, the injected key is silently omitted from `_injected_args_keys`, and invoking the tool raises a bare `TypeError` for a missing positional argument.

The identical bug was already fixed for `ChildTool._injected_args_keys` in #39202 (resolving #34558) by switching to `_get_type_hints(fn, include_extras=True)` — which resolves string annotations before testing them. The comment added by that PR explicitly acknowledges: "StructuredTool overrides this to inspect its wrapped func/coroutine instead" — but the `StructuredTool` override itself was not updated. This PR applies the same fix there.

**Changed files:**

- `langchain_core/tools/structured.py` — import `_get_type_hints` from `tools.base`; use it with `include_extras=True` inside `StructuredTool._injected_args_keys`, with `hints.get(k, v.annotation)` as the per-param fallback (mirrors `ChildTool`).
- `tests/unit_tests/test_tools.py` — two regression tests: one for `@tool(args_schema=...)` and one for `StructuredTool.from_function`, each using a quoted forward-reference annotation for an `InjectedToolArg` parameter.

## Release note

`StructuredTool` (and tools created via `@tool`) now correctly identifies `InjectedToolArg` / `ToolRuntime` / `InjectedToolCallId` parameters that use postponed annotations (`from __future__ import annotations` or quoted forward references), rather than silently missing the injection and raising a `TypeError` at call time.

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.