### PR TITLE
fix(core): preserve non-str/non-dict items in `DictPromptTemplate` list values

### DIFF
--- a/libs/core/langchain_core/prompts/dict.py
+++ b/libs/core/langchain_core/prompts/dict.py
@@ -161,7 +161,7 @@ def _insert_input_variables(
                 warnings.warn(msg, stacklevel=2)
             formatted[k] = _insert_input_variables(v, inputs, template_format)
         elif isinstance(v, (list, tuple)):
-            formatted_v: list[str | dict[str, Any]] = []
+            formatted_v: list[Any] = []
             for x in v:
                 if isinstance(x, str):
                     formatted_v.append(formatter(x, **inputs))
@@ -169,6 +169,8 @@ def _insert_input_variables(
                     formatted_v.append(
                         _insert_input_variables(x, inputs, template_format)
                     )
+                else:
+                    formatted_v.append(x)
             formatted[k] = type(v)(formatted_v)
         else:
             formatted[k] = v

--- a/libs/core/tests/unit_tests/prompts/test_dict.py
+++ b/libs/core/tests/unit_tests/prompts/test_dict.py
@@ -116,3 +116,46 @@ def test_prompt_template_blocks_attribute_access() -> None:
         ValueError, match="Variable names cannot contain attribute access"
     ):
         PromptTemplate.from_template("{name.__class__}", template_format="f-string")
+
+
+def test_dict_prompt_template_preserves_non_str_items_in_list() -> None:
+    """Non-str/non-dict items inside lists must be preserved, not silently dropped.
+
+    Regression test for #39152: int, float, bool, None and other scalars nested
+    inside a list value were silently discarded by _insert_input_variables.
+    """
+    template = {
+        "type": "tool_use",
+        "id": "call_1",
+        "name": "search",
+        "input": {
+            "query": "{q}",
+            "top_k_scores": [1, 2, 3],
+            "flags": [True, None],
+        },
+    }
+    prompt = DictPromptTemplate(template=template, template_format="f-string")
+    result = prompt.format(q="cats")
+
+    assert result["input"]["query"] == "cats"
+    assert result["input"]["top_k_scores"] == [1, 2, 3]
+    assert result["input"]["flags"] == [True, None]
+
+
+def test_dict_prompt_template_preserves_mixed_list() -> None:
+    """Mixed-type lists must survive formatting unchanged (except str interpolation)."""
+    template = {
+        "type": "x",
+        "mixed": ["a {v}", 1, 2.5, {"k": "val"}, None, True],
+    }
+    prompt = DictPromptTemplate(template=template, template_format="f-string")
+    result = prompt.format(v="b")
+
+    assert result["mixed"] == ["a b", 1, 2.5, {"k": "val"}, None, True]
+
+
+def test_dict_prompt_template_preserves_list_with_no_variables() -> None:
+    """Items must survive even when the template has no variables at all."""
+    template = {"nums": [1, 2]}
+    prompt = DictPromptTemplate(template=template, template_format="mustache")
+    assert prompt.format() == {"nums": [1, 2]}


### PR DESCRIPTION
Closes #39152

---

`DictPromptTemplate.format()` is documented to substitute template variables and return the dict unchanged otherwise. In practice, any item inside a list-valued key that is not a `str` or `dict` was silently dropped: `int`, `float`, `bool`, `None`, and nested lists all disappeared.

**Root cause:** `_insert_input_variables` iterated list items and only appended `str` (after formatting) and `dict` (after recursing). There was no `else` branch, so every other type was swallowed.

**Fix:** Add an `else: formatted_v.append(x)` pass-through and widen `formatted_v` from `list[str | dict[str, Any]]` to `list[Any]`. Scalars that don't contain template variables don't need any processing; they should just be copied as-is.

Before:
```python
{"input": {"query": "cats", "top_k_scores": [], "flags": []}}  # data lost
```

After:
```python
{"input": {"query": "cats", "top_k_scores": [1, 2, 3], "flags": [True, None]}}
```

Three regression tests cover: a realistic tool-use content block with integer and boolean lists, a mixed-type list alongside dict and str items, and a template with no variables at all (confirming the data was destroyed even with nothing to substitute).

## Release note

`DictPromptTemplate` (and `ChatPromptTemplate` content blocks backed by it) now preserves `int`, `float`, `bool`, `None`, and other non-string/non-dict values inside list-valued template keys, rather than silently discarding them.

---

Prepared with AI assistance (Claude Code, Anthropic), reviewed for correctness before submission.