### PR TITLE
chore(langchain): fix type errors in tests

### DIFF
--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_internal_call_transformer.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_internal_call_transformer.py
@@ -1,5 +1,11 @@
 """Tests for `InternalCallTransformer` filtering middleware-internal model calls."""
 
+# `run.tool_calls`/`run.subagents` are stream projections registered dynamically by
+# `create_agent` (via langgraph-prebuilt's `ToolCallTransformer` and langchain's
+# `SubagentTransformer`), not declared on langgraph's typed `GraphRunStream`
+# (langgraph#8389). The `# type: ignore[attr-defined]` below self-remove once
+# langgraph adds a `__getattr__` fallback (strict mode's `warn_unused_ignores`).
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -97,7 +103,7 @@ def test_internal_call_transformer_not_registered_without_offending_middleware()
     assert not any(isinstance(t, InternalCallTransformer) for t in transformers)
 
     # Drain to close cleanly.
-    list(run.tool_calls)
+    list(run.tool_calls)  # type: ignore[attr-defined]
 
 
 def test_internal_call_transformer_registered_before_messages_transformer() -> None:
@@ -125,7 +131,7 @@ def test_internal_call_transformer_registered_before_messages_transformer() -> N
     )
 
     # Drain to close cleanly.
-    list(run.tool_calls)
+    list(run.tool_calls)  # type: ignore[attr-defined]
 
 
 def test_internal_call_transformer_deduped_across_middleware() -> None:
@@ -147,7 +153,7 @@ def test_internal_call_transformer_deduped_across_middleware() -> None:
     assert sum(isinstance(t, InternalCallTransformer) for t in transformers) == 1
 
     # Drain to close cleanly.
-    list(run.tool_calls)
+    list(run.tool_calls)  # type: ignore[attr-defined]
 
 
 def test_internal_call_transformer_deduped_alongside_builtins() -> None:
@@ -170,7 +176,7 @@ def test_internal_call_transformer_deduped_alongside_builtins() -> None:
     assert sum(isinstance(t, InternalCallTransformer) for t in transformers) == 1
 
     # Drain to close cleanly.
-    list(run.tool_calls)
+    list(run.tool_calls)  # type: ignore[attr-defined]
 
 
 def test_internal_call_transformer_dedup_accepts_unhashable_factories() -> None:
@@ -193,7 +199,7 @@ def test_internal_call_transformer_dedup_accepts_unhashable_factories() -> None:
     )
 
     run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
-    list(run.tool_calls)
+    list(run.tool_calls)  # type: ignore[attr-defined]
 
 
 def test_internal_model_calls_excluded_from_messages_projection_sync() -> None:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_transformers.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/core/test_transformers.py
@@ -1,5 +1,11 @@
 """Tests for middleware-registered stream transformers."""
 
+# `run.tool_calls`/`run.subagents` are stream projections registered dynamically by
+# `create_agent` (via langgraph-prebuilt's `ToolCallTransformer` and langchain's
+# `SubagentTransformer`), not declared on langgraph's typed `GraphRunStream`
+# (langgraph#8389). The `# type: ignore[attr-defined]` below self-remove once
+# langgraph adds a `__getattr__` fallback (strict mode's `warn_unused_ignores`).
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -62,7 +68,7 @@ def test_middleware_transformer_registered_on_compiled_graph() -> None:
 
     assert "middleware_marker" in run._mux.extensions
     # Drain to close the run cleanly.
-    list(run.tool_calls)
+    list(run.tool_calls)  # type: ignore[attr-defined]
 
 
 def test_middleware_and_user_transformers_compose_in_order() -> None:
@@ -91,7 +97,7 @@ def test_middleware_and_user_transformers_compose_in_order() -> None:
         "transformers must register as: built-in, then middleware, then user-supplied"
     )
 
-    list(run.tool_calls)
+    list(run.tool_calls)  # type: ignore[attr-defined]
 
 
 def test_transformers_from_multiple_middleware_preserve_middleware_order() -> None:
@@ -124,7 +130,7 @@ def test_transformers_from_multiple_middleware_preserve_middleware_order() -> No
     idx_b = next(i for i, t in enumerate(transformers) if isinstance(t, _MarkerB))
     assert idx_a < idx_b
 
-    list(run.tool_calls)
+    list(run.tool_calls)  # type: ignore[attr-defined]
 
 
 def test_middleware_without_transformers_does_not_affect_registry() -> None:
@@ -140,4 +146,4 @@ def test_middleware_without_transformers_does_not_affect_registry() -> None:
     assert any(isinstance(t, ToolCallTransformer) for t in transformers)
     assert not any(isinstance(t, _MiddlewareMarker) for t in transformers)
 
-    list(run.tool_calls)
+    list(run.tool_calls)  # type: ignore[attr-defined]

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -1,5 +1,11 @@
 """Tests for PII detection middleware."""
 
+# `run.tool_calls`/`run.subagents` are stream projections registered dynamically by
+# `create_agent` (via langgraph-prebuilt's `ToolCallTransformer` and langchain's
+# `SubagentTransformer`), not declared on langgraph's typed `GraphRunStream`
+# (langgraph#8389). The `# type: ignore[attr-defined]` below self-remove once
+# langgraph adds a `__getattr__` fallback (strict mode's `warn_unused_ignores`).
+
 import re
 from typing import Any
 
@@ -1973,7 +1979,7 @@ class TestPIIStreamTransformer:
         )
 
         # Drain to close cleanly.
-        list(run.tool_calls)
+        list(run.tool_calls)  # type: ignore[attr-defined]
 
 
 class TestPIIStreamingEndToEnd:
@@ -2113,8 +2119,6 @@ class TestPIIStreamingEndToEnd:
         surfaces: list[str] = []
         run = await agent.astream_events({"messages": [HumanMessage("hi")]}, version="v3")
         async for event in run:
-            if not isinstance(event, dict):
-                continue
             data = event.get("params", {}).get("data")
             if isinstance(data, tuple) and len(data) == 2:
                 p = data[0]
@@ -2187,8 +2191,6 @@ class TestPIIStreamingEndToEnd:
         surfaces: list[str] = []
         run = await agent.astream_events({"messages": [HumanMessage("hi")]}, version="v3")
         async for event in run:
-            if not isinstance(event, dict):
-                continue
             data = event.get("params", {}).get("data")
             if isinstance(data, tuple) and len(data) == 2:
                 p = data[0]

--- a/libs/langchain_v1/tests/unit_tests/agents/test_agent_streaming.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_agent_streaming.py
@@ -1,5 +1,11 @@
 """Unit tests for create_agent graphs streaming via `stream_events(version="v3")`."""
 
+# `run.tool_calls`/`run.subagents` are stream projections registered dynamically by
+# `create_agent` (via langgraph-prebuilt's `ToolCallTransformer` and langchain's
+# `SubagentTransformer`), not declared on langgraph's typed `GraphRunStream`
+# (langgraph#8389). The `# type: ignore[attr-defined]` below self-remove once
+# langgraph adds a `__getattr__` fallback (strict mode's `warn_unused_ignores`).
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -65,7 +71,7 @@ class TestAgentStreamV3Sync:
         run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
 
         # Drain so the run closes cleanly.
-        list(run.tool_calls)
+        list(run.tool_calls)  # type: ignore[attr-defined]
 
     def test_tool_calls_populated_without_opt_in(self) -> None:
         """`ToolCallTransformer` is registered by default on the agent streamer."""
@@ -74,7 +80,7 @@ class TestAgentStreamV3Sync:
 
         run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
 
-        collected: list[ToolCallStream] = list(run.tool_calls)
+        collected: list[ToolCallStream] = list(run.tool_calls)  # type: ignore[attr-defined]
         assert len(collected) == 1
         tc = collected[0]
         assert tc.tool_name == "echo"
@@ -89,7 +95,7 @@ class TestAgentStreamV3Sync:
         run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
 
         tool_calls: list[ToolCallStream] = []
-        for tc in run.tool_calls:
+        for tc in run.tool_calls:  # type: ignore[attr-defined]
             tool_calls.append(tc)
             assert list(tc.output_deltas) == ["one", "two"]
         assert len(tool_calls) == 1
@@ -100,7 +106,7 @@ class TestAgentStreamV3Sync:
         agent = create_agent(model, [])
 
         run = agent.stream_events({"messages": [HumanMessage("hi")]}, version="v3")
-        assert list(run.tool_calls) == []
+        assert list(run.tool_calls) == []  # type: ignore[attr-defined]
         assert run.output is not None
 
     def test_messages_projection_present(self) -> None:
@@ -116,7 +122,7 @@ class TestAgentStreamV3Sync:
         assert "messages" in run._mux.extensions
         assert hasattr(run, "messages")
         # Drain so the run closes cleanly.
-        for tc in run.tool_calls:
+        for tc in run.tool_calls:  # type: ignore[attr-defined]
             list(tc.output_deltas)
 
     def test_caller_transformers_appended_not_replaced(self) -> None:
@@ -161,7 +167,7 @@ class TestAgentStreamV3Sync:
             "ToolCallTransformer must be registered before user-supplied transformers"
         )
 
-        list(run.tool_calls)
+        list(run.tool_calls)  # type: ignore[attr-defined]
 
     def test_tool_error_sets_error_field(self) -> None:
         """Tool errors are surfaced on the `ToolCallStream.error` field.
@@ -178,7 +184,7 @@ class TestAgentStreamV3Sync:
         collected: list[ToolCallStream] = []
 
         def _drive() -> None:
-            for tc in run.tool_calls:
+            for tc in run.tool_calls:  # type: ignore[attr-defined]
                 collected.append(tc)
                 list(tc.output_deltas)
 
@@ -265,7 +271,7 @@ class TestAgentStreamV3Async:
         agent = create_agent(model, [echo])
 
         run = await agent.astream_events({"messages": [HumanMessage("hi")]}, version="v3")
-        async for tc in run.tool_calls:
+        async for tc in run.tool_calls:  # type: ignore[attr-defined]
             async for _ in tc.output_deltas:
                 pass
 
@@ -277,7 +283,7 @@ class TestAgentStreamV3Async:
         run = await agent.astream_events({"messages": [HumanMessage("hi")]}, version="v3")
 
         collected: list[ToolCallStream] = []
-        async for tc in run.tool_calls:
+        async for tc in run.tool_calls:  # type: ignore[attr-defined]
             collected.append(tc)
             deltas = [d async for d in tc.output_deltas]
             assert deltas == ["hi", "hi!"]

--- a/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/test_subagent_transformer.py
@@ -6,6 +6,12 @@ The transformer surfaces, on `run.subagents`, any nested run that carries an
 dispatches a nested `create_agent` from a tool, giving true end-to-end coverage.
 """
 
+# `run.tool_calls`/`run.subagents` are stream projections registered dynamically by
+# `create_agent` (via langgraph-prebuilt's `ToolCallTransformer` and langchain's
+# `SubagentTransformer`), not declared on langgraph's typed `GraphRunStream`
+# (langgraph#8389). The `# type: ignore[attr-defined]` below self-remove once
+# langgraph adds a `__getattr__` fallback (strict mode's `warn_unused_ignores`).
+
 from __future__ import annotations
 
 import sys
@@ -52,7 +58,7 @@ def test_subagents_surfaces_named_subagent() -> None:
     run = supervisor.stream_events({"messages": [HumanMessage("weather?")]}, version="v3")
 
     handles = []
-    for handle in run.subagents:
+    for handle in run.subagents:  # type: ignore[attr-defined]
         handles.append(handle)
         # Drain the nested run so it completes.
         for _ in handle:
@@ -101,7 +107,7 @@ async def test_subagents_surfaces_named_subagent_async() -> None:
     run = await supervisor.astream_events({"messages": [HumanMessage("weather?")]}, version="v3")
 
     handles = []
-    async for handle in run.subagents:
+    async for handle in run.subagents:  # type: ignore[attr-defined]
         handles.append(handle)
         # Drain the nested run so it completes.
         async for _ in handle:
@@ -130,7 +136,7 @@ def test_plain_tool_not_surfaced() -> None:
 
     run = supervisor.stream_events({"messages": [HumanMessage("weather?")]}, version="v3")
 
-    handles = list(run.subagents)
+    handles = list(run.subagents)  # type: ignore[attr-defined]
     # Drain the main run to completion.
     for _ in run:
         pass
@@ -166,7 +172,7 @@ def test_unnamed_inner_agent_surfaces_with_inherited_name() -> None:
     run = supervisor.stream_events({"messages": [HumanMessage("weather?")]}, version="v3")
 
     handles = []
-    for handle in run.subagents:
+    for handle in run.subagents:  # type: ignore[attr-defined]
         handles.append(handle)
         for _ in handle:
             pass
@@ -204,7 +210,7 @@ def test_same_name_nested_agent_surfaced() -> None:
     run = supervisor.stream_events({"messages": [HumanMessage("weather?")]}, version="v3")
 
     handles = []
-    for handle in run.subagents:
+    for handle in run.subagents:  # type: ignore[attr-defined]
         handles.append(handle)
         for _ in handle:
             pass

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1044,7 +1044,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -2462,7 +2462,7 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.4.2"
+version = "1.4.3"
 source = { editable = "../partners/openai" }
 dependencies = [
     { name = "langchain-core" },
@@ -2665,7 +2665,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.5"
+version = "1.2.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2675,9 +2675,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9d/7c9ebd17b95569122e2d2e641f535cf086c870d66bb8e59be33cdba856b3/langgraph-1.2.5.tar.gz", hash = "sha256:09a3bdec6fdb3228623fc78b6f69a1400d383f66348d0b04d0efb692022cc6ef", size = 712532, upload-time = "2026-06-12T20:30:58.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/0d/c8e7ee98896659e1b6555db0ab115a9ca899844744645d5d894032bab1d7/langgraph-1.2.11.tar.gz", hash = "sha256:9ecfe11e50d338b34b15cf4d8a442642de103e8ae6971320efba84e4542eb363", size = 725753, upload-time = "2026-08-11T14:00:36.945Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/03/187281cf61845c5a9c397ae6cd9cd73bb54b39435e5575a7b83c853e5b76/langgraph-1.2.5-py3-none-any.whl", hash = "sha256:9286bb5def82fc865959c14378fe473518dc097d586225f622f029637a2a4bb9", size = 246150, upload-time = "2026-06-12T20:30:57.018Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7f/c5c30e4be99ff821029c7ac872a480676bb179c9f3df85ea3f38d13f86d4/langgraph-1.2.11-py3-none-any.whl", hash = "sha256:8bab70de7b2d00b5300fb289bcf38d8b241400f3184c1e95e8ce706fb0e8686b", size = 248854, upload-time = "2026-08-11T14:00:35.494Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/langchain-ai/langgraph/pull/8389 added typing to the `stream_events` return. LangChain adds projections (e.g., `tool_calls`) that are not captured in the base type. Type ignoring to unblock while the underlying problem gets resolved.