### PR TITLE
fix(langchain): bound email PII detector regex to prevent ReDoS

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_redaction.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_redaction.py
@@ -56,7 +56,7 @@ def detect_email(content: str) -> list[PIIMatch]:
     Returns:
         A list of detected email matches.
     """
-    pattern = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
+    pattern = r"\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,255}\.[A-Za-z]{2,}\b"
     return [
         PIIMatch(
             type="email",


### PR DESCRIPTION
## What

`detect_email` in `libs/langchain_v1/langchain/agents/middleware/_redaction.py` uses an unbounded regex for the local part and domain of an email address:

```python
pattern = r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b"
```

The leading `[A-Za-z0-9._%+-]+` matches greedily at every word-boundary start position and then backtracks when the required `@` is absent. On a long run of characters from that class (with no `@`), the scan degrades to O(n^2).

## Why it matters

`PIIMiddleware` runs these detectors over content the agent does not control, including tool results (`tool-output-delta`, tool inputs) and model output content blocks. A tool that returns attacker-influenced text (for example a web fetch, a document loader, or an email/ticket integration) can include a long token such as a base64 blob, a long identifier, or a big number. Feeding that through the email detector consumes quadratic CPU time and stalls the agent, a denial of service on any agent configured with `PIIMiddleware("email", ...)`.

Measured on CPython 3.13 with an input of `("a." * n) + "!"` (no `@`):

| input length | current regex | bounded regex |
|---|---|---|
| 20k | 2.2 s | < 0.01 s |
| 40k | 8.9 s | 0.016 s |
| 80k | 35 s | 0.03 s |

The current pattern scales quadratically; the bounded pattern scales linearly.

## Fix

Bound the quantifiers to their RFC-realistic maxima so the engine cannot backtrack across an unbounded run:

```python
pattern = r"\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,255}\.[A-Za-z]{2,}\b"
```

- Local part capped at 64 characters (RFC 5321 limit).
- Domain capped at 255 characters (RFC 1035 limit).
- Also replaces the erroneous `[A-Z|a-z]` TLD class (which incorrectly allowed a literal `|`) with `[A-Za-z]`.

One line changed, no API change. Valid addresses are far below these bounds so detection is unchanged.

## Test

Existing emails still match (`john.doe@example.com`, `a_b%c+d@sub.domain.co.uk`, `x@y.io`, `JOHN@EXAMPLE.COM`).

Regression check for the ReDoS:

```python
import re, time
p = r"\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,255}\.[A-Za-z]{2,}\b"
s = ("a." * 80000) + "!"
t = time.time(); re.findall(p, s); print(time.time() - t)  # ~0.03s, was ~35s
```
