### PR TITLE
fix(core): stop reusing memoized `_serialized` for the LLM cache key

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1569,7 +1569,13 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             param_string = str(sorted(params.items()))
             # This code is not super efficient as it goes back and forth between
             # json and dict.
-            serialized_repr = self._serialized
+            # Recompute rather than reuse `self._serialized`: that property is
+            # memoized, so reusing it here would (1) freeze the cache key to
+            # whatever the model's fields were at first use, silently ignoring
+            # later attribute mutations, and (2) let the in-place cleanup below
+            # permanently strip fields from the memoized dict that callbacks
+            # also read via `self._serialized`.
+            serialized_repr = dumpd(self)
             _cleanup_llm_representation(serialized_repr, 1)
             llm_string = json.dumps(serialized_repr, sort_keys=True)
             return llm_string + "---" + param_string

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_cache.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_cache.py
@@ -307,6 +307,61 @@ def test_llm_representation_for_serializable() -> None:
     )
 
 
+def test_llm_string_reflects_field_mutated_after_first_use() -> None:
+    """`_get_llm_string` must reflect current fields, not fields at first use.
+
+    `_serialized` is a memoized (`cached_property`) view of the model. Tracing
+    callbacks (`on_chat_model_start`) access it independently of caching, so it
+    may already be memoized by the time `_get_llm_string` runs. `_get_llm_string`
+    used to read straight from that memo, so a field changed after `_serialized`
+    was first populated was invisible to the resulting cache key.
+    """
+    chat = CustomChat(cache=InMemoryCache(), messages=iter([]))
+
+    # Populate the memo first, simulating a tracing callback firing before
+    # `_get_llm_string` is ever called.
+    _ = chat._serialized
+    assert "_serialized" in chat.__dict__
+
+    before = chat._get_llm_string()
+    chat.disable_streaming = True
+    after = chat._get_llm_string()
+
+    assert before != after
+
+
+def test_get_llm_string_does_not_mutate_cached_serialized() -> None:
+    """`_get_llm_string` must not corrupt the memoized `_serialized` dict.
+
+    Tracing callbacks (`on_chat_model_start`) also read `_serialized`.
+    `_cleanup_llm_representation` deletes keys (nested `repr`, `graph`) from
+    whatever dict it's given, in place. It must operate on a fresh dict, not
+    the shared memoized one. `CustomChat`'s `messages` field is a `not_implemented`
+    iterator, so its `repr` key is a real, naturally occurring victim of that
+    in-place cleanup (there's no natural `graph` key to observe here).
+    """
+    chat = CustomChat(cache=InMemoryCache(), messages=iter([]))
+    chat._get_llm_string()
+
+    assert "repr" in chat._serialized["kwargs"]["messages"]
+
+
+def test_cache_miss_after_field_mutation() -> None:
+    """A cache lookup after mutating a field must miss.
+
+    It must not silently reuse a response generated under the model's
+    previous configuration.
+    """
+    cache = InMemoryCache()
+    chat = CustomChat(cache=cache, messages=iter(["hello", "goodbye"]))
+
+    assert chat.invoke("How are you?").content == "hello"
+
+    chat.disable_streaming = True
+
+    assert chat.invoke("How are you?").content == "goodbye"
+
+
 def test_cache_with_generation_objects() -> None:
     """Test that cache can handle Generation objects instead of ChatGeneration objects.
 


### PR DESCRIPTION
`BaseChatModel`'s LLM cache key is computed from the memoized `_serialized` property (a `cached_property` snapshot of the model's fields), which is then also mutated in place before being turned into the key string. If a chat model instance is reused after mutating a field — a common pattern in notebooks, eval harnesses, and batch jobs, e.g. sweeping `temperature`, or swapping `model` on a shared instance — the cache key stays frozen at whatever the fields were on first use. With a cache enabled, later calls can silently return responses generated under the old configuration instead of the new one, with no error or warning. The same in-place mutation also permanently strips fields from what tracing callbacks receive for that instance, since they read the same memoized dict.

This computes a fresh snapshot per cache-key calculation instead of reusing the memoized one, so the key always reflects the model's current configuration, and stops corrupting the dict tracing callbacks depend on.

**Trade-off worth noting for review:** `_get_llm_string` now re-serializes the model on every cache-key computation rather than reusing a cached copy, so repeated calls on the same cached model instance are marginally more expensive than before. A stale or corrupted cache key seemed like the worse failure mode to leave in place.

## Release note

Fixes a bug where `BaseChatModel`'s LLM cache key could go stale after mutating a model's fields (e.g. `temperature`, `model`) on a reused instance, causing silent cache hits against an outdated configuration.

---

This fix was developed with AI-assisted tooling (Claude Code), used under my direction and review before submission.