### PR TITLE
text-splitters: stop re-inserting consuming regex separators into merged chunks (keep_separator=False)

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -10,6 +10,31 @@ from typing_extensions import override
 from langchain_text_splitters.base import Language, TextSplitter
 
 
+def _regex_is_literal(pattern: str) -> bool:
+    """Return whether ``pattern`` matches only its own literal text.
+
+    When ``keep_separator=False`` the split pieces are re-joined with the
+    separator used as a *literal* join string (see ``CharacterTextSplitter``
+    and ``RecursiveCharacterTextSplitter``). That is only safe for a regex
+    that is effectively literal (``" "``, ``","``, ``"\\n\\n"``): the string
+    re-inserted is then exactly the text the pattern consumed. A consuming
+    pattern such as ``r"\\s+"`` matches variable text, so re-inserting the raw
+    pattern string would corrupt the chunk content with literal regex syntax
+    (e.g. ``"AAA\\s+BBB"``). ``#31137`` special-cased zero-width lookarounds;
+    this handles every other consuming pattern.
+
+    Args:
+        pattern: The regex separator string.
+
+    Returns:
+        True if the pattern matches its own text verbatim.
+    """
+    try:
+        return re.fullmatch(pattern, pattern) is not None
+    except re.error:
+        return False
+
+
 class CharacterTextSplitter(TextSplitter):
     """Splitting text that looks at characters."""
 
@@ -52,9 +77,15 @@ class CharacterTextSplitter(TextSplitter):
 
         # 4. Decide merge separator:
         #    - if keep_separator or lookaround -> don't re-insert
+        #    - if a consuming regex separator would corrupt the chunk when
+        #      re-inserted verbatim -> drop it (keep_separator=False semantics)
+        #      instead of embedding literal regex syntax in the output
         #    - else -> re-insert literal separator
         merge_sep = ""
-        if not (self._keep_separator or is_lookaround):
+        reinsert_corrupts = self._is_separator_regex and not _regex_is_literal(
+            self._separator
+        )
+        if not (self._keep_separator or is_lookaround or reinsert_corrupts):
             merge_sep = self._separator
 
         # 5. Merge adjacent splits and return
@@ -130,7 +161,10 @@ class RecursiveCharacterTextSplitter(TextSplitter):
 
         # Now go merging things, recursively splitting longer texts.
         good_splits = []
-        separator_ = "" if self._keep_separator else separator
+        reinsert_corrupts = self._is_separator_regex and not _regex_is_literal(
+            separator
+        )
+        separator_ = "" if (self._keep_separator or reinsert_corrupts) else separator
         for s in splits:
             if self._length_function(s) < self._chunk_size:
                 good_splits.append(s)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters_merge_regex.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters_merge_regex.py
@@ -1,0 +1,85 @@
+"""Regression tests for regex-separator merge corruption.
+
+See https://github.com/langchain-ai/langchain/issues/39569
+
+When ``is_separator_regex=True`` and ``keep_separator=False``, both
+``CharacterTextSplitter`` and ``RecursiveCharacterTextSplitter`` re-join split
+pieces using the raw regex pattern string as a *literal* merge separator. For
+any consuming pattern (e.g. ``r"\\s+"``) that string is not the text the regex
+matched, so the merged chunk is corrupted with literal regex syntax (e.g.
+``"AAA\\s+BBB"``) and is no longer a substring of the source document.
+"""
+
+from langchain_text_splitters.character import (
+    CharacterTextSplitter,
+    RecursiveCharacterTextSplitter,
+)
+
+
+def test_character_text_splitter_consuming_regex_not_reinserted_on_merge() -> None:
+    """Merged chunks must not embed the raw consuming regex pattern."""
+    splitter = CharacterTextSplitter(
+        separator=r"\s+",
+        chunk_size=15,
+        chunk_overlap=0,
+        keep_separator=False,
+        is_separator_regex=True,
+    )
+    output = splitter.split_text("AAA   BBB\tCCC\n\nDDD    EEE")
+    # keep_separator=False drops the separator; the merged chunk must never
+    # contain the literal pattern text "\s+".
+    assert output == ["AAABBBCCCDDDEEE"]
+
+
+def test_recursive_character_text_splitter_consuming_regex_not_reinserted() -> None:
+    """RecursiveCharacterTextSplitter must not embed the raw regex pattern."""
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=15,
+        chunk_overlap=0,
+        separators=[r"\s+"],
+        keep_separator=False,
+        is_separator_regex=True,
+    )
+    output = splitter.split_text("one   two\tthree\n\nfour     five")
+    assert output == ["onetwothreefour", "five"]
+
+
+def test_character_text_splitter_raw_string_literal_regex_not_corrupted() -> None:
+    """A raw-string regex for a literal (e.g. r"\\n\\n") must not leak.
+
+    ``r"\\n\\n"`` matches two real newlines but its *pattern string* is the
+    four characters ``\n\n``. Re-inserting that pattern verbatim would embed
+    literal backslashes into the output.
+    """
+    splitter = CharacterTextSplitter(
+        separator=r"\n\n",
+        chunk_size=200,
+        chunk_overlap=0,
+        keep_separator=False,
+        is_separator_regex=True,
+    )
+    assert splitter.split_text("foo\n\nbar") == ["foobar"]
+
+
+def test_character_text_splitter_literal_regex_separator_still_reinserted() -> None:
+    """A truly literal regex separator is still re-inserted on merge."""
+    splitter = CharacterTextSplitter(
+        separator="\n\n",
+        chunk_size=200,
+        chunk_overlap=0,
+        keep_separator=False,
+        is_separator_regex=True,
+    )
+    assert splitter.split_text("foo\n\nbar") == ["foo\n\nbar"]
+
+
+def test_character_text_splitter_consuming_regex_keep_separator_true() -> None:
+    """keep_separator=True must still preserve the actual matched separator."""
+    splitter = CharacterTextSplitter(
+        separator=r"\s+",
+        chunk_size=200,
+        chunk_overlap=0,
+        keep_separator=True,
+        is_separator_regex=True,
+    )
+    assert splitter.split_text("AAA   BBB") == ["AAA   BBB"]


### PR DESCRIPTION
Fixes #39569

## Summary

`CharacterTextSplitter` and `RecursiveCharacterTextSplitter` corrupt chunk content when `is_separator_regex=True` and `keep_separator=False` (the default for `CharacterTextSplitter`) and the separator is a *consuming* regex such as `\s+`, `[,;]+`, or `\n{2,}`.

When split pieces need to be merged into a chunk, both splitters re-join them using the raw regex pattern string as a literal separator. For a consuming pattern that string is not the text the regex actually matched, so the merged chunk contains literal regex syntax (e.g. `"AAA\s+BBB"`) and is not a substring of the source document. `add_start_index` then reports `-1` because the corrupted string genuinely cannot be found in the source.

#31137 already special-cased zero-width lookarounds (`(?=`, `(?<!`, `(?<=`, `(?!`) so the pattern is never re-inserted for those. This PR extends the same protection to every other consuming pattern.

## What changed

- Added module-level helper `_regex_is_literal()` in `character.py`: returns whether the regex matches only its own literal text (e.g. `" "`, `","`, `"\n\n"`). Re-inserting such a pattern verbatim is safe because the pattern string equals the text it consumes.
- `CharacterTextSplitter.split_text`: when `keep_separator=False` and the separator is a consuming (non-literal) regex, the merge separator is `""` instead of the raw pattern. Literal regex separators and lookarounds keep their previous behavior.
- `RecursiveCharacterTextSplitter._split_text`: the same handling (it previously had no lookaround or consuming-regex carve-out at all).

For `keep_separator=False` the separator is dropped, which is that option's documented meaning; the important change is that the output can no longer contain literal regex syntax.

## Before

```python
from langchain_text_splitters import CharacterTextSplitter

CharacterTextSplitter(
    chunk_size=15, separator=r"\s+", is_separator_regex=True, keep_separator=False
).split_text("AAA   BBB\tCCC\n\nDDD    EEE")
# ['AAA\\s+BBB\\s+CCC', 'DDD\\s+EEE']   <- corrupted: literal "\s+" in the output
```

## After

```python
# ['AAABBBCCCDDDEEE']
```

## Verification

- Added `test_text_splitters_merge_regex.py` with regression tests covering both `CharacterTextSplitter` and `RecursiveCharacterTextSplitter`, plus guards confirming literal regex separators are still re-inserted on merge and `keep_separator=True` still preserves separators.
- `pytest tests/unit_tests/test_text_splitters_merge_regex.py` fails on `master` (reproduces the corruption) and passes with this change.
- Existing tests covering the affected code paths (literal separators, lookaround separators, `keep_separator=True`, `from_language`) continue to pass unchanged.

## Notes on prior attempts

This is the long-standing issue previously reported in #23394, #10840 and #9843, with earlier fix attempts #37664 and #23397 that did not land. I chose the minimal "do not re-insert the pattern" direction (an extension of #31137) rather than reconstructing the exact per-occurrence matched separator text, keeping the diff small. Happy to follow up with the reconstruction approach if a maintainer prefers it.