### PR TITLE
fix(core): raise ValueError in batch_iterate and abatch_iterate for non-positive batch size

### DIFF
--- a/libs/core/langchain_core/utils/aiter.py
+++ b/libs/core/langchain_core/utils/aiter.py
@@ -333,7 +333,13 @@ async def abatch_iterate(
 
     Yields:
         The batches.
+
+    Raises:
+        ValueError: If ``size`` is not a positive integer.
     """
+    if size <= 0:
+        msg = f"Batch size must be a positive integer, got {size}."
+        raise ValueError(msg)
     batch: list[T] = []
     async for element in iterable:
         if len(batch) < size:

--- a/libs/core/langchain_core/utils/iter.py
+++ b/libs/core/langchain_core/utils/iter.py
@@ -214,7 +214,13 @@ def batch_iterate(size: int | None, iterable: Iterable[T]) -> Iterator[list[T]]:
 
     Yields:
         The batches of the iterable.
+
+    Raises:
+        ValueError: If ``size`` is not ``None`` and is not a positive integer.
     """
+    if size is not None and size <= 0:
+        msg = f"Batch size must be a positive integer, got {size}."
+        raise ValueError(msg)
     it = iter(iterable)
     while True:
         chunk = list(islice(it, size))

--- a/libs/core/tests/unit_tests/utils/test_aiter.py
+++ b/libs/core/tests/unit_tests/utils/test_aiter.py
@@ -29,3 +29,15 @@ async def test_abatch_iterate(
 
     output = [el async for el in iterator_]
     assert output == expected_output
+
+
+async def _to_async_iterable(iterable: list[str]) -> AsyncIterator[str]:
+    for item in iterable:
+        yield item
+
+
+@pytest.mark.parametrize("invalid_size", [0, -1])
+async def test_abatch_iterate_raises_on_non_positive_size(invalid_size: int) -> None:
+    with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        async for _ in abatch_iterate(invalid_size, _to_async_iterable([1, 2, 3])):
+            pass

--- a/libs/core/tests/unit_tests/utils/test_iter.py
+++ b/libs/core/tests/unit_tests/utils/test_iter.py
@@ -17,3 +17,9 @@ def test_batch_iterate(
 ) -> None:
     """Test batching function."""
     assert list(batch_iterate(input_size, input_iterable)) == expected_output
+
+
+@pytest.mark.parametrize("invalid_size", [0, -1])
+def test_batch_iterate_raises_on_non_positive_size(invalid_size: int) -> None:
+    with pytest.raises(ValueError, match="Batch size must be a positive integer"):
+        list(batch_iterate(invalid_size, [1, 2, 3]))


### PR DESCRIPTION
## Description

Fix #39566. Previously, `batch_iterate(0/negative, ...)` and `abatch_iterate(0/negative, ...)` silently dropped all data instead of raising an error.

Port the existing guard from `_batch`/`_abatch` in `langchain_core.indexing.api` to validate the `size` parameter in the publicly exported `batch_iterate` and `abatch_iterate` in `langchain_core.utils.iter`/`langchain_core.utils.aiter`.

## Changes

- **`libs/core/langchain_core/utils/iter.py`**: Add `size is not None and size <= 0` guard with `ValueError`
- **`libs/core/langchain_core/utils/aiter.py`**: Add `size <= 0` guard with `ValueError`
- **`libs/core/tests/unit_tests/utils/test_iter.py`**: Add test for size=0 and size=-1
- **`libs/core/tests/unit_tests/utils/test_aiter.py`**: Add test for size=0 and size=-1

## Verification

```
$ python3 -m pytest libs/core/tests/unit_tests/utils/test_iter.py libs/core/tests/unit_tests/utils/test_aiter.py -xvs
12 passed in 0.04s
```

6 existing tests continue to pass. 6 new tests (error cases for size=0 and size=-1 on both sync and async) also pass.