### PR TITLE
chore(core): add httpx as an explicit dep

### DIFF
--- a/libs/core/pyproject.toml
+++ b/libs/core/pyproject.toml
@@ -25,6 +25,7 @@ version = "1.5.4"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langsmith>=0.3.45,<1.0.0",
+    "httpx>=0.23.0,<1.0.0",
     "tenacity!=8.4.0,>=8.1.0,<10.0.0",
     "jsonpatch>=1.33.0,<2.0.0",
     "PyYAML>=5.3.0,<7.0.0",

--- a/libs/core/uv.lock
+++ b/libs/core/uv.lock
@@ -1043,6 +1043,7 @@ name = "langchain-core"
 version = "1.5.4"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
     { name = "langsmith" },
@@ -1090,6 +1091,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
     { name = "langchain-protocol", specifier = ">=0.0.17" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },


### PR DESCRIPTION
httpx is used explicitly in SSRF-safe HTTP transport in `_security`.