### PR TITLE
feat(openai): support openai 3.0 SDK

### DIFF
--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -33,9 +33,9 @@ test tests:
 # (3.x) transport paths are always covered, regardless of which openai version
 # uv.lock currently resolves.
 integration_test integration_tests:
-	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 	uv run --with 'openai>=2.45.0,<3.0.0' --group test --group test_integration pytest -v --tb=short $(SDK_SMOKE_TEST)
 	uv run --with 'openai>=3.0.0,<4.0.0' --group test --group test_integration pytest -v --tb=short $(SDK_SMOKE_TEST)
+	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 
 # Run VCR cassette-backed integration tests in playback-only mode (no API keys needed).
 # Catches stale cassettes caused by test input changes without re-recording.

--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -29,9 +29,9 @@ test tests:
 	TIKTOKEN_CACHE_DIR=tiktoken_cache uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 # Runs the full integration suite against the locked SDK, then smokes a single
-# live request on each supported openai major so the httpx (2.x) and httpx2
-# (3.x) transport paths are always covered, regardless of which openai version
-# uv.lock currently resolves.
+# live request on each supported openai major -- openai 2.x (backed by `httpx`)
+# and openai 3.x (backed by `httpx2`) -- so both transport paths stay covered
+# regardless of which openai version uv.lock currently resolves.
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 	uv run --with 'openai>=2.45.0,<3.0.0' --group test --group test_integration pytest -v --tb=short $(SDK_SMOKE_TEST)

--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -10,6 +10,10 @@ UV_FROZEN = true
 TEST_FILE ?= tests/unit_tests/
 PYTEST_EXTRA ?=
 
+# A single canonical live request, reused to smoke both supported openai
+# majors in `integration_test` (see below).
+SDK_SMOKE_TEST = tests/integration_tests/chat_models/test_responses_standard.py::TestOpenAIResponses::test_invoke
+
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
 # unit tests are run with the --disable-socket flag to prevent network calls
@@ -24,8 +28,14 @@ test tests:
 	fi
 	TIKTOKEN_CACHE_DIR=tiktoken_cache uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
+# Runs the full integration suite against the locked SDK, then smokes a single
+# live request on each supported openai major so the httpx (2.x) and httpx2
+# (3.x) transport paths are always covered, regardless of which openai version
+# uv.lock currently resolves.
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
+	uv run --with 'openai>=2.45.0,<3.0.0' --group test --group test_integration pytest -v --tb=short $(SDK_SMOKE_TEST)
+	uv run --with 'openai>=3.0.0,<4.0.0' --group test --group test_integration pytest -v --tb=short $(SDK_SMOKE_TEST)
 
 # Run VCR cassette-backed integration tests in playback-only mode (no API keys needed).
 # Catches stale cassettes caused by test input changes without re-recording.

--- a/libs/partners/openai/Makefile
+++ b/libs/partners/openai/Makefile
@@ -29,9 +29,9 @@ test tests:
 	TIKTOKEN_CACHE_DIR=tiktoken_cache uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 # Runs the full integration suite against the locked SDK, then smokes a single
-# live request on each supported openai major -- openai 2.x (backed by `httpx`)
-# and openai 3.x (backed by `httpx2`) -- so both transport paths stay covered
-# regardless of which openai version uv.lock currently resolves.
+# live request on each supported openai major so the httpx (2.x) and httpx2
+# (3.x) transport paths are always covered, regardless of which openai version
+# uv.lock currently resolves.
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(TEST_FILE)
 	uv run --with 'openai>=2.45.0,<3.0.0' --group test --group test_integration pytest -v --tb=short $(SDK_SMOKE_TEST)

--- a/libs/partners/openai/langchain_openai/_compat.py
+++ b/libs/partners/openai/langchain_openai/_compat.py
@@ -1,0 +1,37 @@
+"""Resolve the `httpx` library matching the installed `openai` SDK.
+
+`openai>=3` is backed by `httpx2` (an API-identical drop-in for `httpx`),
+`openai<3` by `httpx`. Transport/config objects injected into the SDK client
+must come from the same library, so this module re-exports whichever one the
+SDK uses.
+
+Import `httpx` from here **only** for objects handed to the OpenAI SDK client
+(e.g. a custom transport, `Limits`, `Proxy`, or `http_client=`). Standalone HTTP
+code should import `httpx` directly.
+
+Note: the SDK's `DefaultHttpxClient`/`DefaultAsyncHttpxClient` classes are *not*
+re-exported here — they are subclassable in both SDK versions (backed by
+`httpx2` on `openai>=3`), so subclass `openai.DefaultHttpxClient` directly. The
+`DefaultHttpx2Client` names are factory functions, not classes, and cannot be
+subclassed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import openai
+
+if TYPE_CHECKING:
+    # Type-check against `httpx`, whose API `httpx2` mirrors. This keeps mypy
+    # working in the lint environment (which installs `httpx`, not `httpx2`)
+    # while the runtime selection below picks the correct module.
+    import httpx
+elif hasattr(openai, "DefaultHttpx2Client"):
+    # openai>=3: SDK client is backed by `httpx2`.
+    import httpx2 as httpx  # type: ignore[import-not-found]
+else:
+    # openai<3: SDK client is backed by `httpx`.
+    import httpx
+
+__all__ = ["httpx"]

--- a/libs/partners/openai/langchain_openai/_compat.py
+++ b/libs/partners/openai/langchain_openai/_compat.py
@@ -1,22 +1,13 @@
 """Resolve the `httpx` library matching the installed `openai` SDK.
 
-`openai>=3` is backed by `httpx2` (Pydantic's `httpx` fork; the public API
-mirrors `httpx` closely, but the classes are *distinct types* —
-`isinstance(httpx.Client(), httpx2.Client)` is `False`), `openai<3` by `httpx`.
-
-The SDK accepts a fully built `http_client=` from either library and normalizes
-it internally. What is *not* normalized are the pieces we assemble ourselves:
-`_client_utils` builds its clients by subclassing `openai.DefaultHttpxClient`,
-whose base is `httpx2.Client` on `openai>=3`, so the `Limits`/`Proxy`/transport
-objects passed to that constructor are consumed by `httpx2` directly. Mixing
-libraries there constructs successfully and then fails on the first request with
-a bare `AssertionError` that the SDK reports as `APIConnectionError`. This
-module re-exports whichever library the installed SDK is built on so those
-objects always match.
+`openai>=3` is backed by `httpx2` (an API-identical drop-in for `httpx`),
+`openai<3` by `httpx`. Transport/config objects injected into the SDK client
+must come from the same library, so this module re-exports whichever one the
+installed SDK version defaults to.
 
 Import `httpx` from here **only** for objects handed to the OpenAI SDK client
-(e.g. a custom transport, `Limits`, or `Proxy`). Standalone HTTP code should
-import `httpx` directly.
+(e.g. a custom transport, `Limits`, `Proxy`, or `http_client=`). Standalone HTTP
+code should import `httpx` directly.
 
 Note: the SDK's `DefaultHttpxClient`/`DefaultAsyncHttpxClient` classes are *not*
 re-exported here — they are subclassable in both SDK versions (backed by
@@ -27,72 +18,25 @@ subclassed.
 
 from __future__ import annotations
 
-import logging
-import re
 from typing import TYPE_CHECKING
 
 import openai
 
-logger = logging.getLogger(__name__)
-
-# Top-level module names of the two supported HTTP libraries, most recent first.
-_HTTPX_MODULES = ("httpx2", "httpx")
-
 
 def _sdk_uses_httpx2() -> bool:
-    """Whether the installed `openai` SDK is built on `httpx2` (openai>=3).
-
-    Read off the SDK itself rather than inferred from its version string:
-    `openai.DefaultHttpxClient` subclasses the client class of whichever library
-    the SDK uses, so its MRO *is* the answer. `_client_utils` subclasses that
-    same attribute, which makes a disagreement between this result and the
-    library our transport objects must match structurally impossible.
-
-    Falls back to the version string only if the SDK stops exposing a
-    recognizable base class, warning so the guess is visible in logs rather
-    than surfacing later as an opaque `APIConnectionError`.
-    """
-    for base in getattr(getattr(openai, "DefaultHttpxClient", None), "__mro__", ()):
-        root = base.__module__.split(".", 1)[0]
-        if root in _HTTPX_MODULES:
-            return root == "httpx2"
-
-    major = _sdk_major_version()
-    if major is None:
-        logger.warning(
-            "Could not determine which httpx library the installed openai SDK "
-            "(version %r) is built on: it exposes no recognizable "
-            "DefaultHttpxClient base class and its version is unparseable. "
-            "Falling back to classic `httpx`. If requests fail with "
-            "`APIConnectionError`, pass an explicit `http_client=`.",
-            getattr(openai, "__version__", None),
-        )
+    """Whether the installed `openai` SDK defaults to `httpx2` (openai>=3)."""
+    try:
+        major = int(openai.__version__.split(".", 1)[0])
+    except (AttributeError, ValueError):
+        # Unparseable version: fall back to classic httpx (always present).
         return False
-    logger.warning(
-        "The installed openai SDK (version %r) exposes no recognizable "
-        "DefaultHttpxClient base class; falling back to its major version (%d) "
-        "to select an httpx library.",
-        getattr(openai, "__version__", None),
-        major,
-    )
     return major >= 3
 
 
-def _sdk_major_version() -> int | None:
-    """Major version of the installed `openai` SDK, or `None` if unreadable.
-
-    Tolerates tag-derived strings such as `v3.0.0`, which build tooling
-    sometimes leaves unstripped, by reading the first integer run.
-    """
-    match = re.match(r"\D*(\d+)", str(getattr(openai, "__version__", "")))
-    return int(match.group(1)) if match else None
-
-
 if TYPE_CHECKING:
-    # Type-check against `httpx`, whose API `httpx2` mirrors. The runtime
-    # branch below is not statically resolvable, and `httpx2` is absent
-    # whenever `openai<3` is installed, so annotations pin the library that is
-    # always available. Cross-library type mismatches are the trade-off.
+    # Type-check against `httpx`, whose API `httpx2` mirrors. This keeps mypy
+    # working in the lint environment (which installs `httpx`, not `httpx2`)
+    # while the runtime selection below picks the correct module.
     import httpx
 elif _sdk_uses_httpx2():
     import httpx2 as httpx  # type: ignore[import-not-found]

--- a/libs/partners/openai/langchain_openai/_compat.py
+++ b/libs/partners/openai/langchain_openai/_compat.py
@@ -1,13 +1,22 @@
 """Resolve the `httpx` library matching the installed `openai` SDK.
 
-`openai>=3` is backed by `httpx2` (an API-identical drop-in for `httpx`),
-`openai<3` by `httpx`. Transport/config objects injected into the SDK client
-must come from the same library, so this module re-exports whichever one the
-installed SDK version defaults to.
+`openai>=3` is backed by `httpx2` (Pydantic's `httpx` fork; the public API
+mirrors `httpx` closely, but the classes are *distinct types* —
+`isinstance(httpx.Client(), httpx2.Client)` is `False`), `openai<3` by `httpx`.
+
+The SDK accepts a fully built `http_client=` from either library and normalizes
+it internally. What is *not* normalized are the pieces we assemble ourselves:
+`_client_utils` builds its clients by subclassing `openai.DefaultHttpxClient`,
+whose base is `httpx2.Client` on `openai>=3`, so the `Limits`/`Proxy`/transport
+objects passed to that constructor are consumed by `httpx2` directly. Mixing
+libraries there constructs successfully and then fails on the first request with
+a bare `AssertionError` that the SDK reports as `APIConnectionError`. This
+module re-exports whichever library the installed SDK is built on so those
+objects always match.
 
 Import `httpx` from here **only** for objects handed to the OpenAI SDK client
-(e.g. a custom transport, `Limits`, `Proxy`, or `http_client=`). Standalone HTTP
-code should import `httpx` directly.
+(e.g. a custom transport, `Limits`, or `Proxy`). Standalone HTTP code should
+import `httpx` directly.
 
 Note: the SDK's `DefaultHttpxClient`/`DefaultAsyncHttpxClient` classes are *not*
 re-exported here — they are subclassable in both SDK versions (backed by
@@ -18,25 +27,72 @@ subclassed.
 
 from __future__ import annotations
 
+import logging
+import re
 from typing import TYPE_CHECKING
 
 import openai
 
+logger = logging.getLogger(__name__)
+
+# Top-level module names of the two supported HTTP libraries, most recent first.
+_HTTPX_MODULES = ("httpx2", "httpx")
+
 
 def _sdk_uses_httpx2() -> bool:
-    """Whether the installed `openai` SDK defaults to `httpx2` (openai>=3)."""
-    try:
-        major = int(openai.__version__.split(".", 1)[0])
-    except (AttributeError, ValueError):
-        # Unparseable version: fall back to classic httpx (always present).
+    """Whether the installed `openai` SDK is built on `httpx2` (openai>=3).
+
+    Read off the SDK itself rather than inferred from its version string:
+    `openai.DefaultHttpxClient` subclasses the client class of whichever library
+    the SDK uses, so its MRO *is* the answer. `_client_utils` subclasses that
+    same attribute, which makes a disagreement between this result and the
+    library our transport objects must match structurally impossible.
+
+    Falls back to the version string only if the SDK stops exposing a
+    recognizable base class, warning so the guess is visible in logs rather
+    than surfacing later as an opaque `APIConnectionError`.
+    """
+    for base in getattr(getattr(openai, "DefaultHttpxClient", None), "__mro__", ()):
+        root = base.__module__.split(".", 1)[0]
+        if root in _HTTPX_MODULES:
+            return root == "httpx2"
+
+    major = _sdk_major_version()
+    if major is None:
+        logger.warning(
+            "Could not determine which httpx library the installed openai SDK "
+            "(version %r) is built on: it exposes no recognizable "
+            "DefaultHttpxClient base class and its version is unparseable. "
+            "Falling back to classic `httpx`. If requests fail with "
+            "`APIConnectionError`, pass an explicit `http_client=`.",
+            getattr(openai, "__version__", None),
+        )
         return False
+    logger.warning(
+        "The installed openai SDK (version %r) exposes no recognizable "
+        "DefaultHttpxClient base class; falling back to its major version (%d) "
+        "to select an httpx library.",
+        getattr(openai, "__version__", None),
+        major,
+    )
     return major >= 3
 
 
+def _sdk_major_version() -> int | None:
+    """Major version of the installed `openai` SDK, or `None` if unreadable.
+
+    Tolerates tag-derived strings such as `v3.0.0`, which build tooling
+    sometimes leaves unstripped, by reading the first integer run.
+    """
+    match = re.match(r"\D*(\d+)", str(getattr(openai, "__version__", "")))
+    return int(match.group(1)) if match else None
+
+
 if TYPE_CHECKING:
-    # Type-check against `httpx`, whose API `httpx2` mirrors. This keeps mypy
-    # working in the lint environment (which installs `httpx`, not `httpx2`)
-    # while the runtime selection below picks the correct module.
+    # Type-check against `httpx`, whose API `httpx2` mirrors. The runtime
+    # branch below is not statically resolvable, and `httpx2` is absent
+    # whenever `openai<3` is installed, so annotations pin the library that is
+    # always available. Cross-library type mismatches are the trade-off.
     import httpx
 elif _sdk_uses_httpx2():
     import httpx2 as httpx  # type: ignore[import-not-found]

--- a/libs/partners/openai/langchain_openai/_compat.py
+++ b/libs/partners/openai/langchain_openai/_compat.py
@@ -18,6 +18,7 @@ subclassed.
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 import openai
@@ -25,12 +26,10 @@ import openai
 
 def _sdk_uses_httpx2() -> bool:
     """Whether the installed `openai` SDK defaults to `httpx2` (openai>=3)."""
-    try:
-        major = int(openai.__version__.split(".", 1)[0])
-    except (AttributeError, ValueError):
-        # Unparseable version: fall back to classic httpx (always present).
-        return False
-    return major >= 3
+    # First integer run, so tag-derived strings like `v3.0.0` still parse;
+    # unparseable falls back to classic httpx (always present).
+    match = re.match(r"\D*(\d+)", str(getattr(openai, "__version__", "")))
+    return match is not None and int(match.group(1)) >= 3
 
 
 if TYPE_CHECKING:

--- a/libs/partners/openai/langchain_openai/_compat.py
+++ b/libs/partners/openai/langchain_openai/_compat.py
@@ -3,7 +3,7 @@
 `openai>=3` is backed by `httpx2` (an API-identical drop-in for `httpx`),
 `openai<3` by `httpx`. Transport/config objects injected into the SDK client
 must come from the same library, so this module re-exports whichever one the
-SDK uses.
+installed SDK version defaults to.
 
 Import `httpx` from here **only** for objects handed to the OpenAI SDK client
 (e.g. a custom transport, `Limits`, `Proxy`, or `http_client=`). Standalone HTTP
@@ -22,16 +22,25 @@ from typing import TYPE_CHECKING
 
 import openai
 
+
+def _sdk_uses_httpx2() -> bool:
+    """Whether the installed `openai` SDK defaults to `httpx2` (openai>=3)."""
+    try:
+        major = int(openai.__version__.split(".", 1)[0])
+    except (AttributeError, ValueError):
+        # Unparseable version: fall back to classic httpx (always present).
+        return False
+    return major >= 3
+
+
 if TYPE_CHECKING:
     # Type-check against `httpx`, whose API `httpx2` mirrors. This keeps mypy
     # working in the lint environment (which installs `httpx`, not `httpx2`)
     # while the runtime selection below picks the correct module.
     import httpx
-elif hasattr(openai, "DefaultHttpx2Client"):
-    # openai>=3: SDK client is backed by `httpx2`.
+elif _sdk_uses_httpx2():
     import httpx2 as httpx  # type: ignore[import-not-found]
 else:
-    # openai<3: SDK client is backed by `httpx`.
     import httpx
 
 __all__ = ["httpx"]

--- a/libs/partners/openai/langchain_openai/_compat.py
+++ b/libs/partners/openai/langchain_openai/_compat.py
@@ -2,7 +2,7 @@
 
 `openai>=3` is backed by `httpx2` (an API-identical drop-in for `httpx`),
 `openai<3` by `httpx`. Transport/config objects injected into the SDK client
-must come from the same library, so this module re-exports whichever one the
+are built from the same library, so this module re-exports whichever one the
 installed SDK version defaults to.
 
 Import `httpx` from here **only** for objects handed to the OpenAI SDK client

--- a/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
@@ -22,9 +22,10 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from functools import lru_cache
 from typing import Any, TypeVar, cast
 
-import httpx
 import openai
 from pydantic import SecretStr
+
+from langchain_openai._compat import httpx
 
 logger = logging.getLogger(__name__)
 

--- a/libs/partners/openai/langchain_openai/embeddings/base.py
+++ b/libs/partners/openai/langchain_openai/embeddings/base.py
@@ -421,11 +421,12 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
             else:
                 if self.openai_proxy and not self.http_client:
                     try:
-                        import httpx
+                        from langchain_openai._compat import httpx
                     except ImportError as e:
                         msg = (
-                            "Could not import httpx python package. "
-                            "Please install it with `pip install httpx`."
+                            "Could not import the httpx package used by the "
+                            "OpenAI SDK. It is normally installed alongside "
+                            "`openai`; reinstall with `pip install openai`."
                         )
                         raise ImportError(msg) from e
                     self.http_client = httpx.Client(proxy=self.openai_proxy)
@@ -437,11 +438,12 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
         if not self.async_client:
             if self.openai_proxy and not self.http_async_client:
                 try:
-                    import httpx
+                    from langchain_openai._compat import httpx
                 except ImportError as e:
                     msg = (
-                        "Could not import httpx python package. "
-                        "Please install it with `pip install httpx`."
+                        "Could not import the httpx package used by the "
+                        "OpenAI SDK. It is normally installed alongside "
+                        "`openai`; reinstall with `pip install openai`."
                     )
                     raise ImportError(msg) from e
                 self.http_async_client = httpx.AsyncClient(proxy=self.openai_proxy)

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -24,13 +24,6 @@ version = "1.4.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.5.3,<2.0.0",
-    # `certifi` is imported at module load for the shared SSL context, so it is
-    # declared directly: it used to arrive via `httpx`, but `openai>=3` depends
-    # on `httpx2`, whose chain (httpcore2 + truststore) does not include it.
-    # Classic `httpx` is also imported directly (the SSRF-safe image fetch) and
-    # must be the *same* `httpx` that `langchain-core`'s SSRF transport uses; it
-    # is not pinned here because it reaches us transitively
-    # (langchain-core -> langsmith -> httpx).
     "certifi>=2024.6.2",
     "openai>=2.45.0,<4.0.0",
     "tiktoken>=0.7.0,<1.0.0",

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -23,8 +23,15 @@ classifiers = [
 version = "1.4.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
+    # `certifi` is imported directly at module load (the shared SSL context), so
+    # it is declared here. Classic `httpx` is also imported directly (the
+    # SSRF-safe image fetch), but it must be the *same* `httpx` that
+    # `langchain-core`'s SSRF transport uses — so it is inherited from
+    # `langchain-core` rather than pinned separately. `openai>=3` pulls in the
+    # drop-in `httpx2` distribution on its own.
+    "certifi>=2024.6.2",
     "langchain-core>=1.5.3,<2.0.0",
-    "openai>=2.45.0,<3.0.0",
+    "openai>=2.45.0,<4.0.0",
     "tiktoken>=0.7.0,<1.0.0",
 ]
 

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -23,14 +23,8 @@ classifiers = [
 version = "1.4.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    # `certifi` is imported directly at module load (the shared SSL context), so
-    # it is declared here. Classic `httpx` is also imported directly (the
-    # SSRF-safe image fetch), but it must be the *same* `httpx` that
-    # `langchain-core`'s SSRF transport uses — so it is inherited from
-    # `langchain-core` rather than pinned separately. `openai>=3` pulls in the
-    # drop-in `httpx2` distribution on its own.
-    "certifi>=2024.6.2",
     "langchain-core>=1.5.3,<2.0.0",
+    "certifi>=2024.6.2",
     "openai>=2.45.0,<4.0.0",
     "tiktoken>=0.7.0,<1.0.0",
 ]

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -24,6 +24,13 @@ version = "1.4.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.5.3,<2.0.0",
+    # `certifi` is imported at module load for the shared SSL context, so it is
+    # declared directly: it used to arrive via `httpx`, but `openai>=3` depends
+    # on `httpx2`, whose chain (httpcore2 + truststore) does not include it.
+    # Classic `httpx` is also imported directly (the SSRF-safe image fetch) and
+    # must be the *same* `httpx` that `langchain-core`'s SSRF transport uses; it
+    # is not pinned here because it reaches us transitively
+    # (langchain-core -> langsmith -> httpx).
     "certifi>=2024.6.2",
     "openai>=2.45.0,<4.0.0",
     "tiktoken>=0.7.0,<1.0.0",

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -57,7 +57,7 @@ test = [
     "pytest-retry>=1.7.0,<1.8.0",
     "pytest-socket>=0.6.0,<1.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
-    "vcrpy>=8.0.0,<9.0.0",
+    "vcrpy>=8.2.0,<9.0.0",
     "numpy>=1.26.4; python_version<'3.13'",
     "numpy>=2.1.0; python_version>='3.13'",
     "langchain>=1.0.0,<2.0.0",

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_client_utils.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_client_utils.py
@@ -456,7 +456,7 @@ def test_build_proxied_async_httpx_client_opt_out_returns_plain_client() -> None
         verify=True,
         socket_options=(),
     )
-    assert isinstance(client, httpx.AsyncClient)
+    assert isinstance(client, _client_utils.httpx.AsyncClient)
 
 
 def test_build_proxied_async_httpx_client_wraps_transport() -> None:
@@ -470,7 +470,7 @@ def test_build_proxied_async_httpx_client_wraps_transport() -> None:
         verify=True,
         socket_options=((SOL_SOCKET, SO_KEEPALIVE, 1),),
     )
-    assert isinstance(client, httpx.AsyncClient)
+    assert isinstance(client, _client_utils.httpx.AsyncClient)
 
 
 def test_build_proxied_sync_httpx_client_opt_out_returns_plain_client() -> None:
@@ -479,7 +479,7 @@ def test_build_proxied_sync_httpx_client_opt_out_returns_plain_client() -> None:
         verify=True,
         socket_options=(),
     )
-    assert isinstance(client, httpx.Client)
+    assert isinstance(client, _client_utils.httpx.Client)
 
 
 def test_build_proxied_sync_httpx_client_wraps_transport() -> None:
@@ -488,7 +488,7 @@ def test_build_proxied_sync_httpx_client_wraps_transport() -> None:
         verify=True,
         socket_options=((SOL_SOCKET, SO_KEEPALIVE, 1),),
     )
-    assert isinstance(client, httpx.Client)
+    assert isinstance(client, _client_utils.httpx.Client)
 
 
 def test_warn_if_proxy_env_shadowed_emits_once(

--- a/libs/partners/openai/tests/unit_tests/test_compat.py
+++ b/libs/partners/openai/tests/unit_tests/test_compat.py
@@ -1,7 +1,6 @@
 """Tests for the `httpx` / `httpx2` compatibility shim (`_compat`)."""
 
 import inspect
-import logging
 
 import openai
 import pytest
@@ -11,33 +10,23 @@ from langchain_openai.chat_models import _client_utils
 
 
 def test_module_httpx_matches_helper() -> None:
-    """The import branch and the helper must not diverge (same predicate).
-
-    Note this shares its predicate with the code under test, so it guards
-    against the `if`/`elif`/`else` wiring in `_compat` being edited to
-    contradict `_sdk_uses_httpx2`, not against the helper itself being wrong.
-    """
+    """The module-level `httpx` binding agrees with the version check."""
     expected = "httpx2" if _compat._sdk_uses_httpx2() else "httpx"
     assert _compat.httpx.__name__ == expected
 
 
 def test_only_httpx_is_exported() -> None:
-    """`__all__` stays minimal; the module docstring explains why.
-
-    The default client classes are deliberately left out, so nothing but the
-    resolved `httpx` module should appear here.
-    """
+    """The default client classes are intentionally not re-exported."""
     assert _compat.__all__ == ["httpx"]
-    assert not hasattr(_compat, "DefaultHttpxClient")
 
 
 def test_default_clients_are_subclassable_classes() -> None:
-    """`DefaultHttpxClient`/`DefaultAsyncHttpxClient` must stay classes.
+    """`DefaultHttpxClient`/`DefaultAsyncHttpxClient` must be classes, not factories.
 
-    The wrappers in `_client_utils` subclass them. The parallel
-    `DefaultHttpx2Client` names are factory functions and cannot be subclassed,
-    which is why they are not used — but they are absent on the `openai>=2.45.0`
-    floor, so that asymmetry is documented rather than asserted here.
+    Regression guard: on openai>=3, `DefaultHttpx2Client` is a *factory
+    function* (returns an `httpx2.Client`) and cannot be subclassed, while the
+    legacy `DefaultHttpxClient` name remains a subclassable class. The wrappers
+    below depend on subclassing the latter.
     """
     assert inspect.isclass(openai.DefaultHttpxClient)
     assert inspect.isclass(openai.DefaultAsyncHttpxClient)
@@ -61,39 +50,6 @@ def test_client_utils_transport_objects_use_shim_httpx() -> None:
     assert isinstance(_client_utils._DEFAULT_CONNECTION_LIMITS, _compat.httpx.Limits)
 
 
-def test_selection_matches_sdk_backing_library() -> None:
-    """The selection agrees with the library the SDK is demonstrably built on.
-
-    An oracle independent of `_compat`: whichever httpx client class
-    `openai.DefaultHttpxClient` inherits from is, by definition, the library our
-    transport objects have to match. Unlike a version-string check, this catches
-    a wrong selection under the SDK actually installed.
-    """
-    base = next(
-        b
-        for b in openai.DefaultHttpxClient.__mro__
-        if b.__module__.split(".", 1)[0] in ("httpx", "httpx2")
-    )
-    expected = base.__module__.split(".", 1)[0]
-    assert _compat.httpx.__name__ == expected
-    assert _compat._sdk_uses_httpx2() is (expected == "httpx2")
-
-
-def test_selection_ignores_version_string() -> None:
-    """A mangled version must not change the answer while the SDK is readable.
-
-    Regression guard for the original heuristic: build tooling that stamps
-    `__version__` from a git tag can leave a `v` prefix, which an `int()` parse
-    rejects. Selection then silently fell back to classic `httpx` even on
-    openai 3, surfacing much later as `APIConnectionError`.
-    """
-    truth = _compat._sdk_uses_httpx2()
-    for version in ("v3.0.0", "not-a-version", "", "2.0.0", "9.9.9"):
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(openai, "__version__", version)
-            assert _compat._sdk_uses_httpx2() is truth
-
-
 @pytest.mark.parametrize(
     ("version", "expected"),
     [
@@ -102,56 +58,32 @@ def test_selection_ignores_version_string() -> None:
         ("3.0.0", True),
         ("3.1.2", True),
         ("4.0.0", True),
-        # Tag-derived version strings the old `int()` parse choked on.
-        ("v3.0.0", True),
-        ("3.0.0b1", True),
-        ("3.0.0.dev1", True),
     ],
 )
-def test_version_fallback_reads_major_version(
+def test_sdk_uses_httpx2_reads_major_version(
     monkeypatch: pytest.MonkeyPatch, version: str, expected: bool
 ) -> None:
-    """With no readable base class, fall back to the openai major version."""
-    monkeypatch.setattr(openai, "DefaultHttpxClient", object, raising=False)
+    """Selection keys on the openai major version (httpx2 default landed in 3.0)."""
     monkeypatch.setattr(openai, "__version__", version)
     assert _compat._sdk_uses_httpx2() is expected
 
 
-def test_version_fallback_warns(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+def test_httpx2_factory_presence_does_not_flip_selection(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Falling back to the version string must be visible in logs.
+    """Late openai 2.x exposes a `DefaultHttpx2Client` factory but stays classic.
 
-    A silent fallback is what made the original failure so hard to trace: the
-    only symptom was a retried `APIConnectionError` naming no cause.
+    Regression guard for the case where a 2.x SDK backports the httpx2 factory:
+    the major version (2) must win, so the shim stays on classic `httpx`.
     """
-    monkeypatch.setattr(openai, "DefaultHttpxClient", object, raising=False)
-    monkeypatch.setattr(openai, "__version__", "3.0.0")
-    with caplog.at_level(logging.WARNING, logger=_compat.__name__):
-        assert _compat._sdk_uses_httpx2() is True
-    assert "no recognizable" in caplog.text
-    assert "3.0.0" in caplog.text
+    monkeypatch.setattr(openai, "__version__", "2.54.0")
+    monkeypatch.setattr(openai, "DefaultHttpx2Client", object(), raising=False)
+    assert _compat._sdk_uses_httpx2() is False
 
 
-def test_unreadable_sdk_warns_and_falls_back_to_classic(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+def test_sdk_uses_httpx2_unparseable_version_falls_back_to_classic(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Neither a base class nor a version: warn loudly, do not raise at import."""
-    monkeypatch.setattr(openai, "DefaultHttpxClient", object, raising=False)
+    """An unparseable version must not raise at import; fall back to classic."""
     monkeypatch.setattr(openai, "__version__", "not-a-version")
-    with caplog.at_level(logging.WARNING, logger=_compat.__name__):
-        assert _compat._sdk_uses_httpx2() is False
-    assert "unparseable" in caplog.text
-    assert "http_client=" in caplog.text
-
-
-@pytest.mark.parametrize(
-    ("version", "expected"),
-    [("3.0.0", 3), ("v3.0.0", 3), ("2.45.0", 2), ("10.1.0", 10), ("", None)],
-)
-def test_sdk_major_version_parsing(
-    monkeypatch: pytest.MonkeyPatch, version: str, expected: int | None
-) -> None:
-    """Leading non-digits are tolerated; an empty version reads as unknown."""
-    monkeypatch.setattr(openai, "__version__", version)
-    assert _compat._sdk_major_version() == expected
+    assert _compat._sdk_uses_httpx2() is False

--- a/libs/partners/openai/tests/unit_tests/test_compat.py
+++ b/libs/partners/openai/tests/unit_tests/test_compat.py
@@ -1,0 +1,98 @@
+"""Tests for the `httpx` / `httpx2` compatibility shim (`_compat`)."""
+
+import importlib
+import inspect
+import sys
+import types
+from collections.abc import Iterator
+
+import openai
+import pytest
+
+from langchain_openai import _compat
+from langchain_openai.chat_models import _client_utils
+
+
+def _sdk_is_httpx2() -> bool:
+    """Whether the installed openai SDK is backed by httpx2 (openai>=3)."""
+    return hasattr(openai, "DefaultHttpx2Client")
+
+
+def test_shim_httpx_matches_installed_openai() -> None:
+    """The shim resolves httpx2 iff the installed SDK is httpx2-backed."""
+    expected = "httpx2" if _sdk_is_httpx2() else "httpx"
+    assert _compat.httpx.__name__ == expected
+
+
+def test_only_httpx_is_exported() -> None:
+    """The default client classes are intentionally not re-exported."""
+    assert _compat.__all__ == ["httpx"]
+
+
+def test_default_clients_are_subclassable_classes() -> None:
+    """`DefaultHttpxClient`/`DefaultAsyncHttpxClient` must be classes, not factories.
+
+    Regression guard: on openai>=3, `DefaultHttpx2Client` is a *factory
+    function* (returns an `httpx2.Client`) and cannot be subclassed, while the
+    legacy `DefaultHttpxClient` name remains a subclassable class. The wrappers
+    below depend on subclassing the latter.
+    """
+    assert inspect.isclass(openai.DefaultHttpxClient)
+    assert inspect.isclass(openai.DefaultAsyncHttpxClient)
+
+
+def test_wrappers_subclass_openai_default_clients() -> None:
+    """The client wrappers extend the SDK's version-appropriate base classes."""
+    assert issubclass(_client_utils._SyncHttpxClientWrapper, openai.DefaultHttpxClient)
+    assert issubclass(
+        _client_utils._AsyncHttpxClientWrapper, openai.DefaultAsyncHttpxClient
+    )
+
+
+def test_client_utils_transport_objects_use_shim_httpx() -> None:
+    """Transport/config objects come from the same module the SDK client uses.
+
+    If these were built from a different httpx than the SDK's backing library,
+    an httpx transport would be handed to an httpx2 client (or vice versa).
+    """
+    assert _client_utils.httpx is _compat.httpx
+    assert isinstance(_client_utils._DEFAULT_CONNECTION_LIMITS, _compat.httpx.Limits)
+
+
+@pytest.fixture
+def isolated_compat() -> Iterator[types.ModuleType]:
+    """Yield `_compat`, then reload it to its true env-derived state.
+
+    The branch-selection tests mutate `openai`/`sys.modules` and reload
+    `_compat`; this guarantees the module is restored for later tests even if
+    an assertion fails mid-test. Requested *before* `monkeypatch` so its
+    teardown (the restoring reload) runs *after* the mutations are undone.
+    """
+    try:
+        yield _compat
+    finally:
+        importlib.reload(_compat)
+
+
+def test_selects_classic_httpx_when_sdk_lacks_httpx2_factory(
+    isolated_compat: types.ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """openai<3 shape (no `DefaultHttpx2Client`) resolves to classic `httpx`."""
+    monkeypatch.delattr(openai, "DefaultHttpx2Client", raising=False)
+    reloaded = importlib.reload(isolated_compat)
+    assert reloaded.httpx.__name__ == "httpx"
+
+
+def test_selects_httpx2_when_sdk_exposes_httpx2_factory(
+    isolated_compat: types.ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """openai>=3 shape (has `DefaultHttpx2Client`) resolves to `httpx2`.
+
+    Stubs `httpx2` in `sys.modules` so the branch is exercised even in an
+    environment where `httpx2` is not installed (i.e. CI on openai<3).
+    """
+    monkeypatch.setattr(openai, "DefaultHttpx2Client", object(), raising=False)
+    if "httpx2" not in sys.modules:
+        monkeypatch.setitem(sys.modules, "httpx2", types.ModuleType("httpx2"))
+    reloaded = importlib.reload(isolated_compat)
+    assert reloaded.httpx.__name__ == "httpx2"

--- a/libs/partners/openai/tests/unit_tests/test_compat.py
+++ b/libs/partners/openai/tests/unit_tests/test_compat.py
@@ -43,8 +43,10 @@ def test_wrappers_subclass_openai_default_clients() -> None:
 def test_client_utils_transport_objects_use_shim_httpx() -> None:
     """Transport/config objects come from the same module the SDK client uses.
 
-    If these were built from a different httpx than the SDK's backing library,
-    an httpx transport would be handed to an httpx2 client (or vice versa).
+    Handing the SDK an `httpx` object when it expects `httpx2` (or vice
+    versa) happens to work today because the two libraries are drop-in
+    equivalents. Matching them anyway keeps type annotations and `isinstance`
+    checks honest.
     """
     assert _client_utils.httpx is _compat.httpx
     assert isinstance(_client_utils._DEFAULT_CONNECTION_LIMITS, _compat.httpx.Limits)

--- a/libs/partners/openai/tests/unit_tests/test_compat.py
+++ b/libs/partners/openai/tests/unit_tests/test_compat.py
@@ -1,6 +1,7 @@
 """Tests for the `httpx` / `httpx2` compatibility shim (`_compat`)."""
 
 import inspect
+import logging
 
 import openai
 import pytest
@@ -10,23 +11,33 @@ from langchain_openai.chat_models import _client_utils
 
 
 def test_module_httpx_matches_helper() -> None:
-    """The module-level `httpx` binding agrees with the version check."""
+    """The import branch and the helper must not diverge (same predicate).
+
+    Note this shares its predicate with the code under test, so it guards
+    against the `if`/`elif`/`else` wiring in `_compat` being edited to
+    contradict `_sdk_uses_httpx2`, not against the helper itself being wrong.
+    """
     expected = "httpx2" if _compat._sdk_uses_httpx2() else "httpx"
     assert _compat.httpx.__name__ == expected
 
 
 def test_only_httpx_is_exported() -> None:
-    """The default client classes are intentionally not re-exported."""
+    """`__all__` stays minimal; the module docstring explains why.
+
+    The default client classes are deliberately left out, so nothing but the
+    resolved `httpx` module should appear here.
+    """
     assert _compat.__all__ == ["httpx"]
+    assert not hasattr(_compat, "DefaultHttpxClient")
 
 
 def test_default_clients_are_subclassable_classes() -> None:
-    """`DefaultHttpxClient`/`DefaultAsyncHttpxClient` must be classes, not factories.
+    """`DefaultHttpxClient`/`DefaultAsyncHttpxClient` must stay classes.
 
-    Regression guard: on openai>=3, `DefaultHttpx2Client` is a *factory
-    function* (returns an `httpx2.Client`) and cannot be subclassed, while the
-    legacy `DefaultHttpxClient` name remains a subclassable class. The wrappers
-    below depend on subclassing the latter.
+    The wrappers in `_client_utils` subclass them. The parallel
+    `DefaultHttpx2Client` names are factory functions and cannot be subclassed,
+    which is why they are not used — but they are absent on the `openai>=2.45.0`
+    floor, so that asymmetry is documented rather than asserted here.
     """
     assert inspect.isclass(openai.DefaultHttpxClient)
     assert inspect.isclass(openai.DefaultAsyncHttpxClient)
@@ -50,6 +61,39 @@ def test_client_utils_transport_objects_use_shim_httpx() -> None:
     assert isinstance(_client_utils._DEFAULT_CONNECTION_LIMITS, _compat.httpx.Limits)
 
 
+def test_selection_matches_sdk_backing_library() -> None:
+    """The selection agrees with the library the SDK is demonstrably built on.
+
+    An oracle independent of `_compat`: whichever httpx client class
+    `openai.DefaultHttpxClient` inherits from is, by definition, the library our
+    transport objects have to match. Unlike a version-string check, this catches
+    a wrong selection under the SDK actually installed.
+    """
+    base = next(
+        b
+        for b in openai.DefaultHttpxClient.__mro__
+        if b.__module__.split(".", 1)[0] in ("httpx", "httpx2")
+    )
+    expected = base.__module__.split(".", 1)[0]
+    assert _compat.httpx.__name__ == expected
+    assert _compat._sdk_uses_httpx2() is (expected == "httpx2")
+
+
+def test_selection_ignores_version_string() -> None:
+    """A mangled version must not change the answer while the SDK is readable.
+
+    Regression guard for the original heuristic: build tooling that stamps
+    `__version__` from a git tag can leave a `v` prefix, which an `int()` parse
+    rejects. Selection then silently fell back to classic `httpx` even on
+    openai 3, surfacing much later as `APIConnectionError`.
+    """
+    truth = _compat._sdk_uses_httpx2()
+    for version in ("v3.0.0", "not-a-version", "", "2.0.0", "9.9.9"):
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(openai, "__version__", version)
+            assert _compat._sdk_uses_httpx2() is truth
+
+
 @pytest.mark.parametrize(
     ("version", "expected"),
     [
@@ -58,32 +102,56 @@ def test_client_utils_transport_objects_use_shim_httpx() -> None:
         ("3.0.0", True),
         ("3.1.2", True),
         ("4.0.0", True),
+        # Tag-derived version strings the old `int()` parse choked on.
+        ("v3.0.0", True),
+        ("3.0.0b1", True),
+        ("3.0.0.dev1", True),
     ],
 )
-def test_sdk_uses_httpx2_reads_major_version(
+def test_version_fallback_reads_major_version(
     monkeypatch: pytest.MonkeyPatch, version: str, expected: bool
 ) -> None:
-    """Selection keys on the openai major version (httpx2 default landed in 3.0)."""
+    """With no readable base class, fall back to the openai major version."""
+    monkeypatch.setattr(openai, "DefaultHttpxClient", object, raising=False)
     monkeypatch.setattr(openai, "__version__", version)
     assert _compat._sdk_uses_httpx2() is expected
 
 
-def test_httpx2_factory_presence_does_not_flip_selection(
-    monkeypatch: pytest.MonkeyPatch,
+def test_version_fallback_warns(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Late openai 2.x exposes a `DefaultHttpx2Client` factory but stays classic.
+    """Falling back to the version string must be visible in logs.
 
-    Regression guard for the case where a 2.x SDK backports the httpx2 factory:
-    the major version (2) must win, so the shim stays on classic `httpx`.
+    A silent fallback is what made the original failure so hard to trace: the
+    only symptom was a retried `APIConnectionError` naming no cause.
     """
-    monkeypatch.setattr(openai, "__version__", "2.54.0")
-    monkeypatch.setattr(openai, "DefaultHttpx2Client", object(), raising=False)
-    assert _compat._sdk_uses_httpx2() is False
+    monkeypatch.setattr(openai, "DefaultHttpxClient", object, raising=False)
+    monkeypatch.setattr(openai, "__version__", "3.0.0")
+    with caplog.at_level(logging.WARNING, logger=_compat.__name__):
+        assert _compat._sdk_uses_httpx2() is True
+    assert "no recognizable" in caplog.text
+    assert "3.0.0" in caplog.text
 
 
-def test_sdk_uses_httpx2_unparseable_version_falls_back_to_classic(
-    monkeypatch: pytest.MonkeyPatch,
+def test_unreadable_sdk_warns_and_falls_back_to_classic(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """An unparseable version must not raise at import; fall back to classic."""
+    """Neither a base class nor a version: warn loudly, do not raise at import."""
+    monkeypatch.setattr(openai, "DefaultHttpxClient", object, raising=False)
     monkeypatch.setattr(openai, "__version__", "not-a-version")
-    assert _compat._sdk_uses_httpx2() is False
+    with caplog.at_level(logging.WARNING, logger=_compat.__name__):
+        assert _compat._sdk_uses_httpx2() is False
+    assert "unparseable" in caplog.text
+    assert "http_client=" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [("3.0.0", 3), ("v3.0.0", 3), ("2.45.0", 2), ("10.1.0", 10), ("", None)],
+)
+def test_sdk_major_version_parsing(
+    monkeypatch: pytest.MonkeyPatch, version: str, expected: int | None
+) -> None:
+    """Leading non-digits are tolerated; an empty version reads as unknown."""
+    monkeypatch.setattr(openai, "__version__", version)
+    assert _compat._sdk_major_version() == expected

--- a/libs/partners/openai/tests/unit_tests/test_compat.py
+++ b/libs/partners/openai/tests/unit_tests/test_compat.py
@@ -1,10 +1,6 @@
 """Tests for the `httpx` / `httpx2` compatibility shim (`_compat`)."""
 
-import importlib
 import inspect
-import sys
-import types
-from collections.abc import Iterator
 
 import openai
 import pytest
@@ -13,14 +9,9 @@ from langchain_openai import _compat
 from langchain_openai.chat_models import _client_utils
 
 
-def _sdk_is_httpx2() -> bool:
-    """Whether the installed openai SDK is backed by httpx2 (openai>=3)."""
-    return hasattr(openai, "DefaultHttpx2Client")
-
-
-def test_shim_httpx_matches_installed_openai() -> None:
-    """The shim resolves httpx2 iff the installed SDK is httpx2-backed."""
-    expected = "httpx2" if _sdk_is_httpx2() else "httpx"
+def test_module_httpx_matches_helper() -> None:
+    """The module-level `httpx` binding agrees with the version check."""
+    expected = "httpx2" if _compat._sdk_uses_httpx2() else "httpx"
     assert _compat.httpx.__name__ == expected
 
 
@@ -59,40 +50,40 @@ def test_client_utils_transport_objects_use_shim_httpx() -> None:
     assert isinstance(_client_utils._DEFAULT_CONNECTION_LIMITS, _compat.httpx.Limits)
 
 
-@pytest.fixture
-def isolated_compat() -> Iterator[types.ModuleType]:
-    """Yield `_compat`, then reload it to its true env-derived state.
-
-    The branch-selection tests mutate `openai`/`sys.modules` and reload
-    `_compat`; this guarantees the module is restored for later tests even if
-    an assertion fails mid-test. Requested *before* `monkeypatch` so its
-    teardown (the restoring reload) runs *after* the mutations are undone.
-    """
-    try:
-        yield _compat
-    finally:
-        importlib.reload(_compat)
-
-
-def test_selects_classic_httpx_when_sdk_lacks_httpx2_factory(
-    isolated_compat: types.ModuleType, monkeypatch: pytest.MonkeyPatch
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("2.45.0", False),
+        ("2.54.0", False),
+        ("3.0.0", True),
+        ("3.1.2", True),
+        ("4.0.0", True),
+    ],
+)
+def test_sdk_uses_httpx2_reads_major_version(
+    monkeypatch: pytest.MonkeyPatch, version: str, expected: bool
 ) -> None:
-    """openai<3 shape (no `DefaultHttpx2Client`) resolves to classic `httpx`."""
-    monkeypatch.delattr(openai, "DefaultHttpx2Client", raising=False)
-    reloaded = importlib.reload(isolated_compat)
-    assert reloaded.httpx.__name__ == "httpx"
+    """Selection keys on the openai major version (httpx2 default landed in 3.0)."""
+    monkeypatch.setattr(openai, "__version__", version)
+    assert _compat._sdk_uses_httpx2() is expected
 
 
-def test_selects_httpx2_when_sdk_exposes_httpx2_factory(
-    isolated_compat: types.ModuleType, monkeypatch: pytest.MonkeyPatch
+def test_httpx2_factory_presence_does_not_flip_selection(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """openai>=3 shape (has `DefaultHttpx2Client`) resolves to `httpx2`.
+    """Late openai 2.x exposes a `DefaultHttpx2Client` factory but stays classic.
 
-    Stubs `httpx2` in `sys.modules` so the branch is exercised even in an
-    environment where `httpx2` is not installed (i.e. CI on openai<3).
+    Regression guard for the case where a 2.x SDK backports the httpx2 factory:
+    the major version (2) must win, so the shim stays on classic `httpx`.
     """
+    monkeypatch.setattr(openai, "__version__", "2.54.0")
     monkeypatch.setattr(openai, "DefaultHttpx2Client", object(), raising=False)
-    if "httpx2" not in sys.modules:
-        monkeypatch.setitem(sys.modules, "httpx2", types.ModuleType("httpx2"))
-    reloaded = importlib.reload(isolated_compat)
-    assert reloaded.httpx.__name__ == "httpx2"
+    assert _compat._sdk_uses_httpx2() is False
+
+
+def test_sdk_uses_httpx2_unparseable_version_falls_back_to_classic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unparseable version must not raise at import; fall back to classic."""
+    monkeypatch.setattr(openai, "__version__", "not-a-version")
+    assert _compat._sdk_uses_httpx2() is False

--- a/libs/partners/openai/tests/unit_tests/test_compat.py
+++ b/libs/partners/openai/tests/unit_tests/test_compat.py
@@ -58,6 +58,10 @@ def test_client_utils_transport_objects_use_shim_httpx() -> None:
         ("3.0.0", True),
         ("3.1.2", True),
         ("4.0.0", True),
+        # Tag-derived / pre-release strings a plain `int()` parse choked on.
+        ("v3.0.0", True),
+        ("3.0.0rc1", True),
+        ("3.0.0.dev1", True),
     ],
 )
 def test_sdk_uses_httpx2_reads_major_version(

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -6,8 +6,10 @@ resolution-markers = [
     "python_full_version >= '3.13' and python_full_version < '3.15' and platform_python_implementation == 'PyPy'",
     "python_full_version >= '3.15' and platform_python_implementation != 'PyPy'",
     "python_full_version >= '3.13' and python_full_version < '3.15' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten') or (python_full_version == '3.11.*' and platform_python_implementation == 'PyPy' and sys_platform == 'emscripten')",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform == 'emscripten')",
     "python_full_version < '3.11' and platform_python_implementation == 'PyPy'",
     "python_full_version < '3.11' and platform_python_implementation != 'PyPy'",
 ]
@@ -449,6 +451,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version != '3.12.*' or sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -464,12 +479,38 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.15"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1193,8 +1234,10 @@ resolution-markers = [
     "python_full_version >= '3.13' and python_full_version < '3.15' and platform_python_implementation == 'PyPy'",
     "python_full_version >= '3.15' and platform_python_implementation != 'PyPy'",
     "python_full_version >= '3.13' and python_full_version < '3.15' and platform_python_implementation != 'PyPy'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation == 'PyPy'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation != 'PyPy'",
+    "python_full_version == '3.12.*' and platform_python_implementation == 'PyPy' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation == 'PyPy' and sys_platform != 'emscripten') or (python_full_version == '3.11.*' and platform_python_implementation == 'PyPy' and sys_platform == 'emscripten')",
+    "python_full_version == '3.12.*' and platform_python_implementation != 'PyPy' and sys_platform == 'emscripten'",
+    "(python_full_version >= '3.11' and python_full_version < '3.13' and platform_python_implementation != 'PyPy' and sys_platform != 'emscripten') or (python_full_version == '3.11.*' and platform_python_implementation != 'PyPy' and sys_platform == 'emscripten')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b5/f4/098d2270d52b41f1bd7db9fc288aaa0400cb48c2a3e2af6fa365d9720947/numpy-2.3.4.tar.gz", hash = "sha256:a7d018bfedb375a8d979ac758b120ba846a7fe764911a64465fd87b8729f4a6a", size = 20582187, upload-time = "2025-10-15T16:18:11.77Z" }
 wheels = [
@@ -1275,21 +1318,21 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.45.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "distro" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/8c/2f500e8be09d1ae98c530467962535198b02cd4550cd418bbbaedc8b2910/openai-3.0.0.tar.gz", hash = "sha256:ffd00ef1678d70957e1f1ed98d5bfcf1d661f41ea4482f22e7d0144a66435a49", size = 1123740, upload-time = "2026-08-12T01:55:50.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/0d/9850e7eddb5e66da4439ed503e78e09ad1fd0195e6df51e4236c75763581/openai-3.0.0-py3-none-any.whl", hash = "sha256:8d32ac3a6647a66910d6cb8a64f0fa5a6c823604b6e82db83d9d055c6709bd51", size = 1665775, upload-time = "2026-08-12T01:55:48.678Z" },
 ]
 
 [[package]]
@@ -2269,6 +2312,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -795,7 +795,7 @@ test = [
     { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
     { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
+    { name = "vcrpy", specifier = ">=8.2.0,<9.0.0" },
 ]
 test-integration = [
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },

--- a/libs/partners/openai/uv.lock
+++ b/libs/partners/openai/uv.lock
@@ -601,7 +601,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.14"
+version = "1.3.15"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },
@@ -630,7 +630,7 @@ requires-dist = [
     { name = "langchain-perplexity", marker = "extra == 'perplexity'" },
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
-    { name = "langgraph", specifier = ">=1.2.5,<1.3.0" },
+    { name = "langgraph", specifier = ">=1.2.11,<1.3.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
 ]
 provides-extras = ["community", "anthropic", "openai", "azure-ai", "google-vertexai", "google-genai", "fireworks", "ollama", "together", "mistralai", "huggingface", "groq", "aws", "baseten", "deepseek", "xai", "perplexity", "meta"]
@@ -666,7 +666,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.5.3"
+version = "1.5.4"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },
@@ -731,6 +731,7 @@ name = "langchain-openai"
 version = "1.4.3"
 source = { editable = "." }
 dependencies = [
+    { name = "certifi" },
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
@@ -770,8 +771,9 @@ typing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "certifi", specifier = ">=2024.6.2" },
     { name = "langchain-core", editable = "../../core" },
-    { name = "openai", specifier = ">=2.45.0,<3.0.0" },
+    { name = "openai", specifier = ">=2.45.0,<4.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
 ]
 
@@ -864,7 +866,7 @@ typing = [
 
 [[package]]
 name = "langgraph"
-version = "1.2.5"
+version = "1.2.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -874,9 +876,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9d/7c9ebd17b95569122e2d2e641f535cf086c870d66bb8e59be33cdba856b3/langgraph-1.2.5.tar.gz", hash = "sha256:09a3bdec6fdb3228623fc78b6f69a1400d383f66348d0b04d0efb692022cc6ef", size = 712532, upload-time = "2026-06-12T20:30:58.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/0d/c8e7ee98896659e1b6555db0ab115a9ca899844744645d5d894032bab1d7/langgraph-1.2.11.tar.gz", hash = "sha256:9ecfe11e50d338b34b15cf4d8a442642de103e8ae6971320efba84e4542eb363", size = 725753, upload-time = "2026-08-11T14:00:36.945Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/03/187281cf61845c5a9c397ae6cd9cd73bb54b39435e5575a7b83c853e5b76/langgraph-1.2.5-py3-none-any.whl", hash = "sha256:9286bb5def82fc865959c14378fe473518dc097d586225f622f029637a2a4bb9", size = 246150, upload-time = "2026-06-12T20:30:57.018Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7f/c5c30e4be99ff821029c7ac872a480676bb179c9f3df85ea3f38d13f86d4/langgraph-1.2.11-py3-none-any.whl", hash = "sha256:8bab70de7b2d00b5300fb289bcf38d8b241400f3184c1e95e8ce706fb0e8686b", size = 248854, upload-time = "2026-08-11T14:00:35.494Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Supports openai 3.x in langchain-openai.

The major change associated with openai 3.0 is a migration from `httpx` to [`httpx2`](https://github.com/pydantic/httpx2): https://github.com/openai/openai-python/releases/tag/v3.0.0.

Here we support `openai` 2.x and 3.x simultaneously in `langchain-openai`. `httpx` is already a dependency of `langchain-core` and the `langsmith` sdk, so all environments running a langchain package install it.

We add a _compat.py that re-exports whatever `httpx` library the openai SDK uses. For any use of httpx that feeds into the openai SDK, we import from `_compat`. `httpx` continues to be used elsewhere in `langchain-openai` (`langchain-core` exports an SSRF-safe httpx client that we use for image token counting).

Manual specification of `httpx` clients remains supported via OpenAI's [legacy escape hatch](https://github.com/openai/openai-python/blob/main/httpx2.md#temporary-escape-hatch-a-legacy-httpx-client) (langchain passes through), but support for this may be removed in a future release.