### PR TITLE
fix(fireworks): avoid repeated `service_tier` [closes #39619]

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -471,8 +471,6 @@ def _convert_chunk_to_message_chunk(
 ) -> BaseMessageChunk:
     choices = chunk.get("choices") or []
     response_metadata: dict[str, Any] = {"model_provider": "fireworks"}
-    if service_tier := chunk.get("service_tier"):
-        response_metadata["service_tier"] = service_tier
     if not choices:
         # Final chunk emitted when `stream_options.include_usage=True`:
         # `choices` is empty and the chunk carries only `usage`.
@@ -1103,6 +1101,8 @@ class ChatFireworks(BaseChatModel):
                 if finish_reason := choice.get("finish_reason"):
                     generation_info["finish_reason"] = finish_reason
                     generation_info["model_name"] = self.model_name
+                    if service_tier := chunk.get("service_tier"):
+                        generation_info["service_tier"] = service_tier
                 logprobs = choice.get("logprobs")
                 if logprobs:
                     generation_info["logprobs"] = logprobs
@@ -1214,6 +1214,8 @@ class ChatFireworks(BaseChatModel):
                 if finish_reason := choice.get("finish_reason"):
                     generation_info["finish_reason"] = finish_reason
                     generation_info["model_name"] = self.model_name
+                    if service_tier := chunk.get("service_tier"):
+                        generation_info["service_tier"] = service_tier
                 logprobs = choice.get("logprobs")
                 if logprobs:
                     generation_info["logprobs"] = logprobs

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1668,12 +1668,16 @@ class TestServiceTier:
         assert isinstance(result, AIMessage)
         assert result.response_metadata["service_tier"] == "priority"
 
-    def test_service_tier_echoed_in_stream_chunks(self) -> None:
+    def test_service_tier_echoed_once_in_stream_chunks(self) -> None:
         model = _make_model(service_tier="priority")
         model.client = MagicMock()
         chunks: list[dict[str, Any]] = [
             {
                 "choices": [{"delta": {"role": "assistant", "content": "hi"}}],
+                "service_tier": "priority",
+            },
+            {
+                "choices": [{"delta": {}, "finish_reason": "stop"}],
                 "service_tier": "priority",
             },
             {
@@ -1687,10 +1691,42 @@ class TestServiceTier:
             },
         ]
         model.client.create.return_value = iter(chunks)
-        out = list(model.stream("Hello"))
-        tagged = [c for c in out if c.response_metadata.get("service_tier")]
-        assert tagged
-        assert all(c.response_metadata["service_tier"] == "priority" for c in tagged)
+        output = list(model.stream("Hello"))
+        tagged = [c for c in output if c.response_metadata.get("service_tier")]
+        assert len(tagged) == 1
+        assert tagged[0].response_metadata["service_tier"] == "priority"
+
+        combined = output[0]
+        for chunk in output[1:]:
+            combined += chunk
+        assert combined.response_metadata["service_tier"] == "priority"
+
+    async def test_service_tier_echoed_once_in_async_stream_chunks(self) -> None:
+        model = _make_model(service_tier="priority")
+        model.async_client = MagicMock()
+        chunks: list[dict[str, Any]] = [
+            {
+                "choices": [{"delta": {"role": "assistant", "content": "hi"}}],
+                "service_tier": "priority",
+            },
+            {
+                "choices": [{"delta": {}, "finish_reason": "stop"}],
+                "service_tier": "priority",
+            },
+        ]
+
+        async def _aiter() -> Any:
+            for chunk in chunks:
+                yield chunk
+
+        async def _create(**_kwargs: Any) -> Any:
+            return _aiter()
+
+        model.async_client.create = MagicMock(side_effect=_create)
+        output = [chunk async for chunk in model.astream("Hello")]
+        tagged = [c for c in output if c.response_metadata.get("service_tier")]
+        assert len(tagged) == 1
+        assert tagged[0].response_metadata["service_tier"] == "priority"
 
     def test_service_tier_absent_when_not_in_response(self) -> None:
         model = _make_model()


### PR DESCRIPTION
Closes #39619

---

Fireworks repeats `service_tier` on each streamed response frame, which caused chunk aggregation to concatenate the value. This records it only with terminal generation metadata and covers synchronous and asynchronous streams.

## Release note
Fixed `ChatFireworks` streaming so aggregated `service_tier` response metadata is reported once instead of concatenated.

Made by [Open SWE](https://openswe.vercel.app/agents/4de4ff26-4098-0d36-9f91-f359c6160a6c)