### PR TITLE
release(anthropic): 1.5.6

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/_version.py
+++ b/libs/partners/anthropic/langchain_anthropic/_version.py
@@ -1,3 +1,3 @@
 """Version information for `langchain-anthropic`."""
 
-__version__ = "1.5.5"
+__version__ = "1.5.6"

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 
-version = "1.5.5"
+version = "1.5.6"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "anthropic>=0.120.0,<1.0.0",

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -617,7 +617,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.5.5"
+version = "1.5.6"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Bumps `langchain-anthropic` from 1.5.5 to 1.5.6, a patch release containing two fixes since the last release:

- `fix(anthropic):` normalize `tool_search_tool_result` blocks (#39621)
- `fix(anthropic):` correct model profile data for Fable 5, Sonnet 5, Opus 4.1 (#39604)