### PR TITLE
fix: Support structured output with Pydantic models in `langchain-huggingface`

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -47,9 +47,10 @@ from langchain_core.messages import (
 )
 from langchain_core.messages.tool import ToolCallChunk
 from langchain_core.messages.tool import tool_call_chunk as create_tool_call_chunk
-from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.output_parsers import JsonOutputParser, PydanticOutputParser
 from langchain_core.output_parsers.openai_tools import (
     JsonOutputKeyToolsParser,
+    PydanticToolsParser,
     make_invalid_tool_call,
     parse_tool_call,
 )
@@ -1174,12 +1175,20 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": formatted_tool,
                 },
             )
-            if is_pydantic_schema:
-                msg = "Pydantic schema is not supported for function calling"
-                raise NotImplementedError(msg)
-            output_parser: JsonOutputKeyToolsParser | JsonOutputParser = (
-                JsonOutputKeyToolsParser(key_name=tool_name, first_tool_only=True)
+            output_parser: (
+                JsonOutputKeyToolsParser
+                | PydanticToolsParser
+                | JsonOutputParser
+                | PydanticOutputParser
             )
+            if is_pydantic_schema:
+                output_parser = PydanticToolsParser(
+                    tools=[cast("type[BaseModel]", schema)], first_tool_only=True
+                )
+            else:
+                output_parser = JsonOutputKeyToolsParser(
+                    key_name=tool_name, first_tool_only=True
+                )
         elif method == "json_schema":
             if schema is None:
                 msg = (
@@ -1195,7 +1204,12 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(
+                    pydantic_object=cast("type[BaseModel]", schema)
+                )
+            else:
+                output_parser = JsonOutputParser()
         elif method == "json_mode":
             llm = self.bind(
                 response_format={"type": "json_object"},
@@ -1204,11 +1218,16 @@ class ChatHuggingFace(BaseChatModel):
                     "schema": schema,
                 },
             )
-            output_parser = JsonOutputParser()  # type: ignore[arg-type]
+            if is_pydantic_schema:
+                output_parser = PydanticOutputParser(
+                    pydantic_object=cast("type[BaseModel]", schema)
+                )
+            else:
+                output_parser = JsonOutputParser()
         else:
             msg = (
-                f"Unrecognized method argument. Expected one of 'function_calling' or "
-                f"'json_mode'. Received: '{method}'"
+                "Unrecognized method argument. Expected one of 'function_calling', "
+                f"'json_schema', or 'json_mode'. Received: '{method}'"
             )
             raise ValueError(msg)
 

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest  # type: ignore[import-not-found]
@@ -10,7 +10,9 @@ from langchain_core.messages import (
     SystemMessage,
 )
 from langchain_core.outputs import ChatResult
+from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
@@ -222,6 +224,56 @@ def test_bind_tools(chat_hugging_face: Any) -> None:
         _, kwargs = mock_super_bind.call_args
         assert kwargs["tools"] == tools
         assert kwargs["tool_choice"] == "auto"
+
+
+class StructuredAnswer(BaseModel):
+    answer: int
+
+
+def test_with_structured_output_pydantic_function_calling(
+    chat_hugging_face: Any,
+) -> None:
+    message = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "StructuredAnswer",
+                "args": {"answer": 42},
+                "id": "tool-call-id",
+            }
+        ],
+    )
+    llm = RunnableLambda(lambda _: message)
+
+    with patch.object(
+        ChatHuggingFace, "bind_tools", return_value=llm
+    ):
+        structured_model = chat_hugging_face.with_structured_output(StructuredAnswer)
+
+    result = structured_model.invoke("Return an answer")
+
+    assert isinstance(result, StructuredAnswer)
+    assert result.answer == 42
+
+
+@pytest.mark.parametrize("method", ["json_mode", "json_schema"])
+def test_with_structured_output_pydantic_json_methods(
+    chat_hugging_face: Any,
+    method: Literal["json_mode", "json_schema"],
+) -> None:
+    llm = RunnableLambda(
+        lambda _: AIMessage(content='{"answer": 42}')
+    )
+
+    with patch.object(ChatHuggingFace, "bind", return_value=llm):
+        structured_model = chat_hugging_face.with_structured_output(
+            StructuredAnswer, method=method
+        )
+
+    result = structured_model.invoke("Return an answer")
+
+    assert isinstance(result, StructuredAnswer)
+    assert result.answer == 42
 
 
 def test_property_inheritance_integration(chat_hugging_face: Any) -> None:


### PR DESCRIPTION
Closes #32197

I used an AI coding assistant to help draft this patch, then reviewed the diff and ran the test suite locally before opening this PR. Happy to make adjustments if the approach doesn't fit the project's conventions.

Tests: `cd libs/partners/huggingface && uv run pytest tests/unit_tests/test_chat_models.py`