### PR TITLE
fix(core): preserve existing entries when updating full cache

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -226,9 +226,14 @@ class InMemoryCache(BaseCache):
 
                 The value is a list of `Generation` (or subclasses).
         """
-        if self._maxsize is not None and len(self._cache) == self._maxsize:
+        key = (prompt, llm_string)
+        if (
+            self._maxsize is not None
+            and len(self._cache) == self._maxsize
+            and key not in self._cache
+        ):
             del self._cache[next(iter(self._cache))]
-        self._cache[prompt, llm_string] = return_val
+        self._cache[key] = return_val
 
     @override
     def clear(self, **kwargs: Any) -> None:

--- a/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
+++ b/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
@@ -69,6 +69,21 @@ def test_update_with_maxsize() -> None:
     assert cache.lookup(prompt3, llm_string3) == generations3
 
 
+def test_update_existing_key_at_maxsize_does_not_evict() -> None:
+    """Test updating an existing key does not evict another cached entry."""
+    cache = InMemoryCache(maxsize=2)
+    prompt1, llm_string1, generations1 = cache_item(1)
+    prompt2, llm_string2, generations2 = cache_item(2)
+
+    cache.update(prompt1, llm_string1, generations1)
+    cache.update(prompt2, llm_string2, generations2)
+    updated_generations = [Generation(text="updated")]
+    cache.update(prompt2, llm_string2, updated_generations)
+
+    assert cache.lookup(prompt1, llm_string1) == generations1
+    assert cache.lookup(prompt2, llm_string2) == updated_generations
+
+
 def test_clear(cache: InMemoryCache) -> None:
     """Test the clear method of InMemoryCache."""
     prompt, llm_string, generations = cache_item(1)


### PR DESCRIPTION
Fixes #39636

---

Updating an existing key in a full `InMemoryCache` should replace its value without evicting an unrelated entry. The eviction guard now checks whether the key is new before removing the oldest item.

Added a regression test covering an existing-key update at capacity.

## Release note

`InMemoryCache` no longer evicts an unrelated entry when updating an existing key at its configured capacity.

This contribution was prepared with AI assistance and verified locally.

Validation: `uv run --group test pytest tests/unit_tests/caches/test_in_memory_cache.py`; `uv run --group lint ruff check ...`; `uv run --group lint ruff format --check ...`.