### PR TITLE
fix(core): raise ValueError when ids length does not match texts length in add_texts

### DIFF
--- a/libs/core/langchain_core/vectorstores/base.py
+++ b/libs/core/langchain_core/vectorstores/base.py
@@ -82,6 +82,12 @@ class VectorStore(ABC):
                     f"Got {len(metadatas)} metadatas and {len(texts_)} texts."
                 )
                 raise ValueError(msg)
+            if ids is not None and len(ids) != len(texts_):
+            msg = (
+                "The number of ids must match the number of texts."
+                f"Got {len(ids)} ids and {len(texts_)} texts."
+            )
+            raise ValueError(msg)
             metadatas_ = iter(metadatas) if metadatas else cycle([{}])
             ids_: Iterator[str | None] = iter(ids) if ids else cycle([None])
             docs = [


### PR DESCRIPTION
Fixes #38203

  I noticed there are already a few PRs addressing this issue — commented on the issue for visibility.

  `VectorStore.add_texts` currently uses `zip()` to pair texts with ids, which silently truncates data when `len(ids) != len(texts)`. This PR adds an explicit length check that raises a `ValueError`, matching the same validation pattern already used for `metadatas`.