### PR TITLE
fix(huggingface): remove retired IPEX backend

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface.py
@@ -5,15 +5,6 @@ from typing import Any
 from langchain_core.embeddings import Embeddings
 from pydantic import BaseModel, ConfigDict, Field
 
-from langchain_huggingface.utils.import_utils import (
-    IMPORT_ERROR,
-    is_ipex_available,
-    is_optimum_intel_available,
-    is_optimum_intel_version,
-)
-
-_MIN_OPTIMUM_VERSION = "1.22"
-
 
 class HuggingFaceEmbeddings(BaseModel, Embeddings):
     """HuggingFace sentence_transformers embedding models.
@@ -73,26 +64,7 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
             )
             raise ImportError(msg) from exc
 
-        if self.model_kwargs.get("backend", "torch") == "ipex":
-            if not is_optimum_intel_available() or not is_ipex_available():
-                msg = f"Backend: ipex {IMPORT_ERROR.format('optimum[ipex]')}"
-                raise ImportError(msg)
-
-            if is_optimum_intel_version("<", _MIN_OPTIMUM_VERSION):
-                msg = (
-                    f"Backend: ipex requires optimum-intel>="
-                    f"{_MIN_OPTIMUM_VERSION}. You can install it with pip: "
-                    "`pip install --upgrade --upgrade-strategy eager "
-                    "`optimum[ipex]`."
-                )
-                raise ImportError(msg)
-
-            from optimum.intel import IPEXSentenceTransformer  # type: ignore[import]
-
-            model_cls = IPEXSentenceTransformer
-
-        else:
-            model_cls = sentence_transformers.SentenceTransformer
+        model_cls = sentence_transformers.SentenceTransformer
 
         self._client = model_cls(
             self.model_name, cache_folder=self.cache_folder, **self.model_kwargs

--- a/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/embeddings/huggingface.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 from langchain_core.embeddings import Embeddings
@@ -63,6 +64,15 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
                 "Please install it with `pip install sentence-transformers`."
             )
             raise ImportError(msg) from exc
+
+        if self.model_kwargs.get("backend", "torch") == "ipex":
+            msg = (
+                "`backend='ipex'` is no longer supported; the default `torch` "
+                "backend will be used instead. Intel GPU acceleration is "
+                "natively supported in PyTorch 2.5 and later."
+            )
+            warnings.warn(msg, UserWarning, stacklevel=2)
+            self.model_kwargs["backend"] = "torch"
 
         model_cls = sentence_transformers.SentenceTransformer
 

--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -14,7 +14,6 @@ from typing_extensions import Self
 from langchain_huggingface._version import __version__
 from langchain_huggingface.utils.import_utils import (
     IMPORT_ERROR,
-    is_ipex_available,
     is_openvino_available,
     is_optimum_intel_available,
     is_optimum_intel_version,
@@ -158,7 +157,7 @@ class HuggingFacePipeline(BaseLLM):
             _model_kwargs["device_map"] = device_map
         tokenizer = AutoTokenizer.from_pretrained(model_id, **_model_kwargs)
 
-        if backend in {"openvino", "ipex"}:
+        if backend == "openvino":
             if task not in VALID_TASKS:
                 msg = (
                     f"Got invalid task {task}, "
@@ -170,51 +169,26 @@ class HuggingFacePipeline(BaseLLM):
             if not is_optimum_intel_available():
                 raise ImportError(err_msg)
 
-            # TODO: upgrade _MIN_OPTIMUM_VERSION to 1.22 after release
-            min_optimum_version = (
-                "1.22"
-                if backend == "ipex" and task != "text-generation"
-                else _MIN_OPTIMUM_VERSION
-            )
-            if is_optimum_intel_version("<", min_optimum_version):
+            if is_optimum_intel_version("<", _MIN_OPTIMUM_VERSION):
                 msg = (
                     f"Backend: {backend} requires optimum-intel>="
-                    f"{min_optimum_version}. You can install it with pip: "
+                    f"{_MIN_OPTIMUM_VERSION}. You can install it with pip: "
                     "`pip install --upgrade --upgrade-strategy eager "
                     f"`optimum[{backend}]`."
                 )
                 raise ImportError(msg)
 
-            if backend == "openvino":
-                if not is_openvino_available():
-                    raise ImportError(err_msg)
+            if not is_openvino_available():
+                raise ImportError(err_msg)
 
-                from optimum.intel import (  # type: ignore[import]
-                    OVModelForCausalLM,
-                    OVModelForSeq2SeqLM,
-                )
+            from optimum.intel import (  # type: ignore[import]
+                OVModelForCausalLM,
+                OVModelForSeq2SeqLM,
+            )
 
-                model_cls = (
-                    OVModelForCausalLM
-                    if task == "text-generation"
-                    else OVModelForSeq2SeqLM
-                )
-            else:
-                if not is_ipex_available():
-                    raise ImportError(err_msg)
-
-                if task == "text-generation":
-                    from optimum.intel import (
-                        IPEXModelForCausalLM,  # type: ignore[import]
-                    )
-
-                    model_cls = IPEXModelForCausalLM
-                else:
-                    from optimum.intel import (
-                        IPEXModelForSeq2SeqLM,  # type: ignore[import]
-                    )
-
-                    model_cls = IPEXModelForSeq2SeqLM
+            model_cls = (
+                OVModelForCausalLM if task == "text-generation" else OVModelForSeq2SeqLM
+            )
 
         else:
             model_cls = (

--- a/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
+++ b/libs/partners/huggingface/langchain_huggingface/llms/huggingface_pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations  # type: ignore[import-not-found]
 
 import importlib.util
 import logging
+import warnings
 from collections.abc import Iterator, Mapping
 from typing import Any
 
@@ -156,6 +157,15 @@ class HuggingFacePipeline(BaseLLM):
 
             _model_kwargs["device_map"] = device_map
         tokenizer = AutoTokenizer.from_pretrained(model_id, **_model_kwargs)
+
+        if backend == "ipex":
+            msg = (
+                "`backend='ipex'` is no longer supported; the default "
+                "`transformers` backend will be used instead. Intel GPU acceleration "
+                "is natively supported in PyTorch 2.5 and later."
+            )
+            warnings.warn(msg, UserWarning, stacklevel=2)
+            backend = "default"
 
         if backend == "openvino":
             if task not in VALID_TASKS:

--- a/libs/partners/huggingface/langchain_huggingface/utils/import_utils.py
+++ b/libs/partners/huggingface/langchain_huggingface/utils/import_utils.py
@@ -35,9 +35,6 @@ if _optimum_intel_available:
     except importlib.metadata.PackageNotFoundError:
         _optimum_intel_available = False
 
-
-_ipex_available = importlib.util.find_spec("intel_extension_for_pytorch") is not None
-
 _openvino_available = importlib.util.find_spec("openvino") is not None
 
 
@@ -79,10 +76,6 @@ def is_optimum_available() -> bool:
 
 def is_optimum_intel_available() -> bool:
     return _optimum_intel_available
-
-
-def is_ipex_available() -> bool:
-    return _ipex_available
 
 
 def is_openvino_available() -> bool:


### PR DESCRIPTION
Fixes #36765

Intel retired Intel Extension for PyTorch (IPEX) after upstreaming most of its Intel-platform features and optimizations into PyTorch. Official releases stopped after IPEX 2.8, the project was archived on March 30, 2026, and Intel now [recommends using PyTorch directly](https://github.com/intel/intel-extension-for-pytorch#retirement-plan).

Hugging Face deprecated its IPEX integration in Optimum Intel v1.27.0 and [fully removed it in v2.0.0](https://github.com/huggingface/optimum-intel/releases/tag/v2.0.0). Consequently, the IPEX-specific classes imported by `HuggingFaceEmbeddings` and `HuggingFacePipeline` are no longer available in supported Optimum Intel releases. This removes those stale code paths and their dependency detection while retaining the default PyTorch and OpenVINO backends.

This is a breaking change for users who explicitly selected IPEX (via `backend="ipex"` for `HuggingFacePipeline`, or `model_kwargs={"backend": "ipex"}` for `HuggingFaceEmbeddings`); users should migrate to the default PyTorch backend or OpenVINO.

## Release note

Removed the retired IPEX backend from `HuggingFaceEmbeddings` and `HuggingFacePipeline`. Use PyTorch directly for upstreamed Intel optimizations or use the OpenVINO backend for optimized inference on Intel hardware.

---

Ran the following from `libs/partners/huggingface`:

- `make format`, `make lint`, and `make test` all pass.
- The IPEX removal touches both `HuggingFacePipeline` and `HuggingFaceEmbeddings`, so both were exercised end to end on the OpenVINO backend to confirm the remaining path still works. OpenVINO is an optional dependency, so it was installed into the package's environment first, and the available devices were listed before the run:

  ```bash
  uv pip install "optimum[openvino]"
  # List the devices OpenVINO can see:
  uv run python -c "import openvino as ov; print(ov.Core().available_devices)"
  # Run the script below from the package environment:
  uv run python openvino_backend_example.py
  ```

  `openvino_backend_example.py`:

  ```python
  from langchain_huggingface import HuggingFaceEmbeddings, HuggingFacePipeline

  DEVICE = "GPU.0"

  # Stage 1: HuggingFacePipeline (text generation)
  llm = HuggingFacePipeline.from_model_id(
      model_id="gpt2",
      task="text-generation",
      backend="openvino",
      model_kwargs={
          "export": True,
          "device": DEVICE,
      },
      pipeline_kwargs={"max_new_tokens": 32},
  )
  print("[pipeline]  ", llm.invoke("The capital of France is"))

  # Stage 2: HuggingFaceEmbeddings
  embeddings = HuggingFaceEmbeddings(
      model_name="sentence-transformers/all-MiniLM-L6-v2",
      model_kwargs={
          "backend": "openvino",
          "model_kwargs": {"device": DEVICE},
      },
  )
  vector = embeddings.embed_query("The capital of France is Paris.")
  print("[embeddings]", f"dim={len(vector)}", vector[:4])
  ```

  Both stages run on the OpenVINO backend: the pipeline generates text and the embeddings produce a 384-dimensional vector.

  > [pipeline]  The capital of France is home to some of the world's best hotels, bars and restaurants. Today's hotel scene, which includes the legendary Débar, is a popular destination for

  > [embeddings] dim=384 [0.10315027832984924, 0.030387870967388153, 0.029067767783999443, -0.03727174550294876]

  **The generated text from pipeline will vary between runs since `gpt2` sampling is non-deterministic.

- `backend="ipex"` is the path whose behavior this PR changes, so it was exercised end to end as well, to confirm that existing IPEX callers keep working and are told what happened. No extra dependencies are needed here — the point is that no IPEX package is installed:

  ```bash
  uv run python ipex_backend_example.py
  ```

  `ipex_backend_example.py`:

  ```python
  from langchain_huggingface import HuggingFaceEmbeddings, HuggingFacePipeline

  # Stage 1: HuggingFacePipeline (text generation)
  llm = HuggingFacePipeline.from_model_id(
      model_id="gpt2",
      task="text-generation",
      backend="ipex",
      pipeline_kwargs={"max_new_tokens": 32},
  )
  print("[pipeline]   model class:", type(llm.pipeline.model).__name__)
  print("[pipeline]  ", llm.invoke("The capital of France is"))

  # Stage 2: HuggingFaceEmbeddings
  embeddings = HuggingFaceEmbeddings(
      model_name="sentence-transformers/all-MiniLM-L6-v2",
      model_kwargs={"backend": "ipex"},
  )
  print("[embeddings] backend now:", embeddings.model_kwargs["backend"])
  vector = embeddings.embed_query("The capital of France is Paris.")
  print("[embeddings]", f"dim={len(vector)}", vector[:4])
  ```

  Both stages warn once and then succeed on the default backend. Each warning is attributed to the caller's own line rather than to a line inside `langchain-huggingface`, so users see which of their calls needs updating. `GPT2LMHeadModel` confirms the pipeline loaded a plain `transformers` class rather than an IPEX one, and `backend now: torch` confirms the retired value was replaced before it reached `sentence_transformers`, which accepts only `torch`, `onnx` and `openvino`.
