### PR TITLE
fix(langchain): handle shell command output without trailing newline in `ShellSession`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
+++ b/libs/langchain_v1/langchain/agents/middleware/shell_tool.py
@@ -265,8 +265,15 @@ class ShellSession:
             if data is None:
                 continue
 
-            if source == "stdout" and data.startswith(marker):
-                _, _, status = data.partition(" ")
+            # The marker may be glued to the tail of the command's own output
+            # when that output does not end with a newline (e.g. `printf x`),
+            # so match it anywhere in the line instead of only at the start.
+            if source == "stdout" and marker in data:
+                before, _, status = data.partition(marker)
+                if before:
+                    collected.append(before)
+                    total_lines += 1
+                    total_bytes += len(before.encode("utf-8", "replace"))
                 exit_code = self._safe_int(status.strip())
                 # Drain any remaining stderr that may have arrived concurrently.
                 # The stderr reader thread runs independently, so output might

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_shell_tool.py
@@ -115,6 +115,30 @@ def test_timeout_returns_error(tmp_path: Path) -> None:
         middleware.after_agent(state, runtime)
 
 
+def test_command_output_without_trailing_newline(tmp_path: Path) -> None:
+    """Commands whose output lacks a trailing newline must not time out.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/39363:
+    the completion marker is printed immediately after the command output, so
+    with unterminated output the marker arrives glued to the final line.
+    """
+    middleware = ShellToolMiddleware(workspace_root=tmp_path / "workspace")
+    runtime = Runtime()
+    state = _empty_state()
+    try:
+        updates = middleware.before_agent(state, runtime)
+        if updates:
+            state.update(cast("ShellToolState", updates))
+        resources = middleware._get_or_create_resources(state)
+        result = middleware._run_shell_tool(
+            resources, {"command": "printf 'hello-without-newline'"}, tool_call_id=None
+        )
+        assert "timed out" not in result.lower()
+        assert "hello-without-newline" in result
+    finally:
+        middleware.after_agent(state, runtime)
+
+
 def test_redaction_policy_applies(tmp_path: Path) -> None:
     middleware = ShellToolMiddleware(
         workspace_root=tmp_path / "workspace",


### PR DESCRIPTION
Closes #39363

---

When a shell command produces stdout without a trailing newline (e.g. `printf 'hello'`), the completion marker arrives glued to the final output line. The previous `data.startswith(marker)` check never matched, causing the session to falsely report a timeout and restart the shell.

This change detects the marker anywhere in the stdout line and preserves any preceding content as command output.

## Release note

Fixed a bug where `ShellSession` incorrectly timed out when a command's output did not end with a newline.

---

🤖 This contribution was developed with assistance from an AI coding agent.

Made with [Cursor](https://cursor.com)