### PR TITLE
core: dispatch non-inline handlers in AsyncCallbackManager.on_llm_start

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1913,21 +1913,23 @@ class AsyncCallbackManager(BaseCallbackManager):
                         **kwargs,
                     )
                 )
-            else:
-                non_inline_tasks.append(
-                    ahandle_event(
-                        non_inline_handlers,
-                        "on_llm_start",
-                        "ignore_llm",
-                        serialized,
-                        [prompt],
-                        run_id=run_id_,
-                        parent_run_id=self.parent_run_id,
-                        tags=self.tags,
-                        metadata=self.metadata,
-                        **kwargs,
-                    )
+            # Non-inline handlers must run whenever present, not only when there
+            # are no inline handlers (gh #39633). ahandle_event is a no-op for
+            # an empty list, so this is safe for inline-only managers.
+            non_inline_tasks.append(
+                ahandle_event(
+                    non_inline_handlers,
+                    "on_llm_start",
+                    "ignore_llm",
+                    serialized,
+                    [prompt],
+                    run_id=run_id_,
+                    parent_run_id=self.parent_run_id,
+                    tags=self.tags,
+                    metadata=self.metadata,
+                    **kwargs,
                 )
+            )
 
             managers.append(
                 AsyncCallbackManagerForLLMRun(

--- a/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
+++ b/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
@@ -151,6 +151,50 @@ async def test_inline_handlers_share_parent_context_multiple() -> None:
         ]
 
 
+async def test_non_inline_handlers_run_alongside_inline_handlers() -> None:
+    """Non-inline handlers must fire even when inline handlers are present.
+
+    Regression test for gh-39633: AsyncCallbackManager.on_llm_start dispatched
+    non-inline handlers only when there were zero inline handlers, silently
+    dropping them in the common mixed configuration.
+    """
+    received: list[str] = []
+
+    class H(AsyncCallbackHandler):
+        def __init__(self, name: str, *, run_inline: bool) -> None:
+            self.name = name
+            self.run_inline = run_inline
+
+        @override
+        async def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+            received.append(self.name)
+
+    # Mixed: inline + non-inline. Both must be dispatched (the bug dropped the
+    # non-inline handler here).
+    mixed = AsyncCallbackManager(
+        handlers=[H("inline", run_inline=True), H("non_inline", run_inline=False)]
+    )
+    await mixed.on_llm_start({}, ["hi"])
+    assert received == ["inline", "non_inline"]
+
+    # Inline-only stays unchanged.
+    received.clear()
+    inline_only = AsyncCallbackManager(handlers=[H("inline", run_inline=True)])
+    await inline_only.on_llm_start({}, ["hi"])
+    assert received == ["inline"]
+
+    # Non-inline-only stays unchanged.
+    received.clear()
+    non_inline_only = AsyncCallbackManager(handlers=[H("non_inline", run_inline=False)])
+    await non_inline_only.on_llm_start({}, ["hi"])
+    assert received == ["non_inline"]
+
+    # Multiple prompts still dispatch non-inline handlers for every prompt.
+    received.clear()
+    await mixed.on_llm_start({}, ["one", "two"])
+    assert received == ["inline", "inline", "non_inline", "non_inline"]
+
+
 async def test_shielded_callback_context_preservation() -> None:
     """Verify that shielded callbacks preserve context variables.
 


### PR DESCRIPTION
## Summary

`AsyncCallbackManager.on_llm_start` dispatched non-inline handlers only when there were **zero** inline handlers (the `if inline_handlers: ... else:` split). With tracing enabled — `LangChainTracer` sets `run_inline = True` — every non-inline `AsyncCallbackHandler` silently stopped receiving `on_llm_start` for completion-style LLMs while still getting `on_llm_end`, leaving per-run state handlers with an end but no start.

This mirrors the sibling `on_chat_model_start`, which classifies each handler by `run_inline` and always dispatches. Non-inline handlers are now appended unconditionally; `ahandle_event` is a no-op for an empty list, so inline-only managers are unaffected.

Fixes #39633

## Changes

- `libs/core/langchain_core/callbacks/manager.py` — remove the `if/else` split in `on_llm_start`; always dispatch `non_inline_handlers` via `ahandle_event`.
- `libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py` — regression test asserting both inline and non-inline handlers fire; verified it fails on the pre-fix code.

## Validation

- New regression test passes with the fix, fails without it.
- Full `test_async_callback_manager.py` suite (22 tests) passes.
- `make lint` clean on the touched packages.

🤖 Generated with Codebuff
