### PR TITLE
fix(xai): recompute total_tokens after adding reasoning tokens to output

### DIFF
--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -652,6 +652,11 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
             rtn.generations[0].message.usage_metadata["output_tokens"] += (  # type: ignore[attr-defined]
                 reasoning_tokens
             )
+            # Keep the documented UsageMetadata invariant
+            # total_tokens == input_tokens + output_tokens (gh #39634).
+            usage_metadata["total_tokens"] = (
+                usage_metadata["input_tokens"] + usage_metadata["output_tokens"]
+            )
 
         return rtn
 
@@ -700,6 +705,11 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
             )
         ):
             generation_chunk.message.usage_metadata["output_tokens"] += reasoning_tokens  # type: ignore[attr-defined]
+            # Keep the documented UsageMetadata invariant
+            # total_tokens == input_tokens + output_tokens (gh #39634).
+            usage_metadata["total_tokens"] = (
+                usage_metadata["input_tokens"] + usage_metadata["output_tokens"]
+            )
         return generation_chunk
 
     def with_structured_output(

--- a/libs/partners/xai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/xai/tests/unit_tests/test_chat_models.py
@@ -309,7 +309,6 @@ def test_create_chat_result_recomputes_total_tokens_for_reasoning() -> None:
                 message=ChatCompletionMessage(
                     role="assistant",
                     content="Test response",
-                    reasoning_content="Thinking...",
                 ),
             )
         ],
@@ -323,7 +322,9 @@ def test_create_chat_result_recomputes_total_tokens_for_reasoning() -> None:
 
     result = llm._create_chat_result(response)
 
-    usage_metadata = result.generations[0].message.usage_metadata
+    message = result.generations[0].message
+    assert isinstance(message, AIMessage)
+    usage_metadata = message.usage_metadata
     assert usage_metadata is not None
     assert usage_metadata["input_tokens"] == 32
     assert usage_metadata["output_tokens"] == 14  # 9 completion + 5 reasoning
@@ -359,7 +360,9 @@ def test_convert_chunk_recomputes_total_tokens_for_reasoning() -> None:
     )
     assert generation_chunk is not None
 
-    usage_metadata = generation_chunk.message.usage_metadata
+    message = generation_chunk.message
+    assert isinstance(message, AIMessageChunk)
+    usage_metadata = message.usage_metadata
     assert usage_metadata is not None
     assert usage_metadata["input_tokens"] == 32
     assert usage_metadata["output_tokens"] == 14  # 9 completion + 5 reasoning

--- a/libs/partners/xai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/xai/tests/unit_tests/test_chat_models.py
@@ -3,6 +3,7 @@ import json
 import pytest  # type: ignore[import-not-found]
 from langchain_core.messages import (
     AIMessage,
+    AIMessageChunk,
     FunctionMessage,
     HumanMessage,
     SystemMessage,
@@ -11,6 +12,13 @@ from langchain_core.messages import (
 from langchain_openai.chat_models.base import (
     _convert_dict_to_message,
     _convert_message_to_dict,
+)
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.completion_usage import (
+    CompletionTokensDetails,
+    CompletionUsage,
 )
 from pydantic import SecretStr
 
@@ -278,3 +286,82 @@ def test_metadata_versions() -> None:
     assert "langchain-core" in versions
     assert "langchain-xai" in versions
     assert "langchain-openai" in versions
+
+
+def test_create_chat_result_recomputes_total_tokens_for_reasoning() -> None:
+    """Adding reasoning tokens to output_tokens must keep total_tokens consistent.
+
+    xAI reports reasoning tokens separately from completion tokens, so ChatXAI
+    adds them into output_tokens. total_tokens must be recomputed afterwards to
+    preserve the UsageMetadata invariant total_tokens == input + output
+    (gh #39634).
+    """
+    llm = ChatXAI(model=MODEL_NAME)
+    response = ChatCompletion(
+        id="chatcmpl-1",
+        object="chat.completion",
+        created=0,
+        model=MODEL_NAME,
+        choices=[
+            Choice(
+                index=0,
+                finish_reason="stop",
+                message=ChatCompletionMessage(
+                    role="assistant",
+                    content="Test response",
+                    reasoning_content="Thinking...",
+                ),
+            )
+        ],
+        usage=CompletionUsage(
+            prompt_tokens=32,
+            completion_tokens=9,
+            total_tokens=41,
+            completion_tokens_details=CompletionTokensDetails(reasoning_tokens=5),
+        ),
+    )
+
+    result = llm._create_chat_result(response)
+
+    usage_metadata = result.generations[0].message.usage_metadata
+    assert usage_metadata is not None
+    assert usage_metadata["input_tokens"] == 32
+    assert usage_metadata["output_tokens"] == 14  # 9 completion + 5 reasoning
+    assert usage_metadata["total_tokens"] == 46  # 32 + 14, invariant holds
+    assert usage_metadata["output_token_details"]["reasoning"] == 5
+
+
+def test_convert_chunk_recomputes_total_tokens_for_reasoning() -> None:
+    """Streaming chunks must keep the total_tokens invariant as well (gh #39634)."""
+    llm = ChatXAI(model=MODEL_NAME)
+    chunk = {
+        "id": "chatcmpl-1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": MODEL_NAME,
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": "Test"},
+                "finish_reason": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 32,
+            "completion_tokens": 9,
+            "total_tokens": 41,
+            "completion_tokens_details": {"reasoning_tokens": 5},
+        },
+    }
+
+    generation_chunk = llm._convert_chunk_to_generation_chunk(
+        chunk, AIMessageChunk, None
+    )
+    assert generation_chunk is not None
+
+    usage_metadata = generation_chunk.message.usage_metadata
+    assert usage_metadata is not None
+    assert usage_metadata["input_tokens"] == 32
+    assert usage_metadata["output_tokens"] == 14  # 9 completion + 5 reasoning
+    assert usage_metadata["total_tokens"] == 46  # 32 + 14, invariant holds
+    assert usage_metadata["output_token_details"]["reasoning"] == 5


### PR DESCRIPTION
## Summary

`ChatXAI` adds xAI-reported reasoning tokens into `output_tokens` (xAI reports reasoning separately from completion tokens) but never updates `total_tokens`, so the returned `UsageMetadata` violates its documented invariant `total_tokens == input_tokens + output_tokens` on every reasoning-model call. Example from the issue: `prompt=32, completion=9, total=41, reasoning=5` → after the bump `output=14` but `total` stays `41` (32 + 14 = 46 ≠ 41).

This keeps the existing reasoning-additive behavior and recomputes `total_tokens = input_tokens + output_tokens` after the bump at both sites:
- `_create_chat_result` (non-streaming)
- `_convert_chunk_to_generation_chunk` (streaming)

Fixes #39634

## Changes

- `libs/partners/xai/langchain_xai/chat_models.py` — recompute `total_tokens` after folding reasoning tokens into `output_tokens`.
- `libs/partners/xai/tests/unit_tests/test_chat_models.py` — regression tests for both sites (non-streaming and streaming), asserting `output_tokens == 14` and `total_tokens == 46` for the issue's numbers; verified both fail on the pre-fix code.

## Validation

- New tests pass with the fix, fail without it.
- Full `tests/unit_tests/test_chat_models.py` suite: 32 passed.
- `ruff format --check` clean; `mypy` clean on `chat_models.py`; only pre-existing repo-wide CPY001 (missing copyright header, present on HEAD files too) flagged.

🤖 Generated with Codebuff
