### PR TITLE
fix(chroma): unwrap embedding in `similarity_search_by_image_with_rel…

### DIFF
--- a/libs/partners/chroma/langchain_chroma/vectorstores.py
+++ b/libs/partners/chroma/langchain_chroma/vectorstores.py
@@ -1011,7 +1011,7 @@ class Chroma(VectorStore):
         ):
             # Obtain image embedding
             # Assuming embed_image returns a single embedding
-            image_embedding = self._embedding_function.embed_image(uris=[uri])
+            image_embedding = self._embedding_function.embed_image(uris=[uri])[0]
 
             # Perform similarity search based on the obtained embedding
             return self.similarity_search_by_vector_with_relevance_scores(

--- a/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
+++ b/libs/partners/chroma/tests/unit_tests/test_vectorstores.py
@@ -1,8 +1,16 @@
+from langchain_core.documents import Document
 from langchain_core.embeddings.fake import (
     FakeEmbeddings,
 )
 
 from langchain_chroma.vectorstores import Chroma
+
+
+class FakeEmbeddingsWithImage(FakeEmbeddings):
+    """FakeEmbeddings that also implements embed_image, for image search tests."""
+
+    def embed_image(self, uris: list[str]) -> list[list[float]]:
+        return [self._get_embedding() for _ in uris]
 
 
 def test_initialization() -> None:
@@ -28,3 +36,38 @@ def test_similarity_search() -> None:
     output = docsearch.similarity_search("foo", k=1)
     docsearch.delete_collection()
     assert len(output) == 1
+
+
+def test_similarity_search_by_image() -> None:
+    """Test similarity search by image returns Documents."""
+    texts = ["foo", "bar", "baz"]
+    docsearch = Chroma.from_texts(
+        collection_name="test_collection_image",
+        texts=texts,
+        embedding=FakeEmbeddingsWithImage(size=10),
+    )
+    output = docsearch.similarity_search_by_image(uri="fake_uri.jpg", k=1)
+    docsearch.delete_collection()
+    assert len(output) == 1
+    assert all(isinstance(doc, Document) for doc in output)
+
+
+def test_similarity_search_by_image_with_relevance_score() -> None:
+    """Test similarity search by image with relevance score.
+
+    Returns scored Documents without raising on the embedding shape.
+    """
+    texts = ["foo", "bar", "baz"]
+    docsearch = Chroma.from_texts(
+        collection_name="test_collection_image_score",
+        texts=texts,
+        embedding=FakeEmbeddingsWithImage(size=10),
+    )
+    output = docsearch.similarity_search_by_image_with_relevance_score(
+        uri="fake_uri.jpg", k=1
+    )
+    docsearch.delete_collection()
+    assert len(output) == 1
+    doc, score = output[0]
+    assert isinstance(doc, Document)
+    assert isinstance(score, float)


### PR DESCRIPTION
Fixes #33851

---

`similarity_search_by_image_with_relevance_score` never got the fix that landed for the sibling method `similarity_search_by_image` in #33899. `embed_image` returns a single-item embedding list, and this method passed it straight into `similarity_search_by_vector_with_relevance_scores` without unwrapping it, producing the same nested embedding shape Chroma rejects. This unwraps it the same way #33899 did, and adds unit test coverage for both image-search methods since neither had any before.

Includes AI assistance for investigation and drafting.