### PR TITLE
fix(openai): stream `reasoning_content` incrementally with `response_format` json_object

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1650,7 +1650,9 @@ class BaseChatOpenAI(BaseChatModel):
         base_generation_info = {}
 
         try:
-            if "response_format" in payload:
+            if "response_format" in payload and _response_format_needs_parsing(
+                payload["response_format"]
+            ):
                 if self.include_response_headers:
                     warnings.warn(
                         "Cannot currently include response headers when "
@@ -1910,7 +1912,9 @@ class BaseChatOpenAI(BaseChatModel):
         base_generation_info = {}
 
         try:
-            if "response_format" in payload:
+            if "response_format" in payload and _response_format_needs_parsing(
+                payload["response_format"]
+            ):
                 if self.include_response_headers:
                     warnings.warn(
                         "Cannot currently include response headers when "
@@ -4088,6 +4092,34 @@ def _resize(width: int, height: int) -> tuple[int, int]:
             height = (height * 768) // width
             width = 768
     return width, height
+
+
+def _response_format_needs_parsing(response_format: Any) -> bool:
+    """Whether a `response_format` value requires the beta parsing/streaming helper.
+
+    OpenAI's `beta.chat.completions.stream()` buffers the entire response so it can
+    parse structured output (a Pydantic model or a JSON Schema) and expose it via
+    `get_final_completion()`. That buffering means incremental fields streamed by
+    some providers (e.g. DeepSeek's `reasoning_content`) only surface in the single
+    final chunk instead of token-by-token.
+
+    Plain JSON mode (`{"type": "json_object"}`) needs no such parsing, so it should
+    use the standard streaming path and stream incrementally like an unconstrained
+    request does.
+
+    Args:
+        response_format: The `response_format` value from the request payload.
+
+    Returns:
+        `True` if the value is a Pydantic model class or a `json_schema` dict (which
+        require the parsing helper), `False` otherwise (e.g. plain JSON mode).
+    """
+    if isinstance(response_format, type):
+        # A Pydantic model class -> structured output parsing is required.
+        return True
+    if isinstance(response_format, dict):
+        return response_format.get("type") == "json_schema"
+    return False
 
 
 def _convert_to_openai_response_format(

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -89,6 +89,7 @@ from langchain_openai.chat_models.base import (
     _model_prefers_responses_api,
     _oai_structured_outputs_parser,
     _resize,
+    _response_format_needs_parsing,
 )
 
 OPENAI_TEST_MODEL = "gpt-5.5"
@@ -537,6 +538,28 @@ def test_deepseek_stream(mock_deepseek_completion: list) -> None:
     assert usage_metadata["total_tokens"] == usage_chunk["usage"]["total_tokens"]
 
 
+def test_response_format_needs_parsing() -> None:
+    """Only Pydantic models and `json_schema` dicts need the beta parsing helper."""
+
+    class Foo(BaseModel):
+        bar: str
+
+    # Pydantic model class -> needs parsing.
+    assert _response_format_needs_parsing(Foo) is True
+    # json_schema dict -> needs parsing.
+    assert (
+        _response_format_needs_parsing(
+            {"type": "json_schema", "json_schema": {"name": "foo", "schema": {}}}
+        )
+        is True
+    )
+    # Plain JSON mode -> does NOT need parsing (should stream incrementally).
+    assert _response_format_needs_parsing({"type": "json_object"}) is False
+    # Missing/other type -> does not need parsing.
+    assert _response_format_needs_parsing({}) is False
+    assert _response_format_needs_parsing({"type": "text"}) is False
+
+
 OPENAI_STREAM_DATA = """{"id":"chatcmpl-9nhARrdUiJWEMd5plwV1Gc9NCjb9M","object":"chat.completion.chunk","created":1721631035,"model":"gpt-5.5","system_fingerprint":"fp_18cc0f1fa0","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"usage":null}
 {"id":"chatcmpl-9nhARrdUiJWEMd5plwV1Gc9NCjb9M","object":"chat.completion.chunk","created":1721631035,"model":"gpt-5.5","system_fingerprint":"fp_18cc0f1fa0","choices":[{"index":0,"delta":{"content":"我是"},"logprobs":null,"finish_reason":null}],"usage":null}
 {"id":"chatcmpl-9nhARrdUiJWEMd5plwV1Gc9NCjb9M","object":"chat.completion.chunk","created":1721631035,"model":"gpt-5.5","system_fingerprint":"fp_18cc0f1fa0","choices":[{"index":0,"delta":{"content":"助手"},"logprobs":null,"finish_reason":null}],"usage":null}
@@ -627,6 +650,73 @@ def test_openai_stream(mock_openai_completion: list) -> None:
         with patch.object(llm, "client", mock_client):
             _ = list(llm.stream("..."))
         assert "stream_options" not in call_kwargs[-1]
+
+
+def test_stream_json_object_uses_plain_streaming_path(
+    mock_openai_completion: list,
+) -> None:
+    """`response_format={"type": "json_object"}` must not use the buffering helper.
+
+    Routing plain JSON mode through `beta.chat.completions.stream()` buffers the
+    whole response, so provider-specific incremental fields (e.g. DeepSeek's
+    `reasoning_content`) only surface in a single final chunk. Plain JSON mode needs
+    no parsing, so it should use the standard streaming path and stream token by
+    token, exactly as an unconstrained request does.
+    """
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
+    mock_client = MagicMock()
+    create_calls = []
+
+    def mock_create(*args: Any, **kwargs: Any) -> MockSyncContextManager:
+        create_calls.append(kwargs)
+        return MockSyncContextManager(mock_openai_completion)
+
+    mock_client.create = mock_create
+    beta_stream = MagicMock()
+
+    bound = llm.bind(response_format={"type": "json_object"})
+    with (
+        patch.object(llm, "client", mock_client),
+        patch.object(llm.root_client.beta.chat.completions, "stream", beta_stream),
+    ):
+        chunks = list(bound.stream("hi"))
+
+    # The plain streaming path was used; the buffering helper was not.
+    assert len(create_calls) == 1
+    assert create_calls[0]["response_format"] == {"type": "json_object"}
+    beta_stream.assert_not_called()
+    # Content still streams across multiple chunks (not aggregated into one).
+    assert len([c for c in chunks if c.content]) > 1
+
+
+async def test_astream_json_object_uses_plain_streaming_path(
+    mock_openai_completion: list,
+) -> None:
+    """Async counterpart of `test_stream_json_object_uses_plain_streaming_path`."""
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
+    mock_client = AsyncMock()
+    create_calls = []
+
+    async def mock_create(*args: Any, **kwargs: Any) -> MockAsyncContextManager:
+        create_calls.append(kwargs)
+        return MockAsyncContextManager(mock_openai_completion)
+
+    mock_client.create = mock_create
+    beta_stream = MagicMock()
+
+    bound = llm.bind(response_format={"type": "json_object"})
+    with (
+        patch.object(llm, "async_client", mock_client),
+        patch.object(
+            llm.root_async_client.beta.chat.completions, "stream", beta_stream
+        ),
+    ):
+        chunks = [chunk async for chunk in bound.astream("hi")]
+
+    assert len(create_calls) == 1
+    assert create_calls[0]["response_format"] == {"type": "json_object"}
+    beta_stream.assert_not_called()
+    assert len([c for c in chunks if c.content]) > 1
 
 
 def test_openai_stream_events_v3_lifecycle(mock_openai_completion: list) -> None:


### PR DESCRIPTION
Closes #39601

---

When `ChatOpenAI`/`ChatDeepSeek` is used with `response_format={"type": "json_object"}` and streaming, provider-specific incremental fields such as DeepSeek's `reasoning_content` arrive as a **single aggregated chunk** instead of streaming token by token. Without `response_format`, the same fields stream incrementally, so applications that show a live "thinking" view lose that behavior the moment they switch to JSON mode.

**Why it happens**

`BaseChatOpenAI._stream`/`_astream` route *any* request that has `response_format` in the payload through `client.beta.chat.completions.stream()`. That beta helper is a buffering/parsing wrapper: it accumulates the whole response so it can expose a parsed result via `get_final_completion()`. As a side effect, extra provider fields that are not part of the standard OpenAI delta schema only surface in the single final chunk it emits.

The buffering is only *needed* when there is an actual schema to parse — a Pydantic model or a `{"type": "json_schema", ...}` dict. Plain JSON mode (`{"type": "json_object"}`) has no schema, so it can safely use the ordinary streaming path, exactly like an unconstrained request.

**The fix**

Introduce `_response_format_needs_parsing()` and route through the beta helper only when `response_format` is a Pydantic model class or a `json_schema` dict. Plain `{"type": "json_object"}` now falls through to the standard `client.create(...)` / `async_client.create(...)` streaming path, so incremental fields stream normally. Structured-output (`json_schema` / Pydantic) behavior is unchanged.

## Release note

Fixed a regression where `response_format={"type": "json_object"}` combined with streaming caused provider-specific incremental fields (e.g. DeepSeek's `reasoning_content`) to be aggregated into a single chunk instead of streaming token by token. JSON mode now streams incrementally, matching the behavior of unconstrained streaming requests. Structured output using a JSON Schema or Pydantic model is unaffected.

---

Added sync and async regression tests asserting that JSON mode uses the plain streaming path (never the buffering helper) and yields content across multiple chunks, plus a unit test for the new `_response_format_needs_parsing()` classifier.

This contribution was prepared with the assistance of an AI agent.
