### PR TITLE
fix(core): accept non-dict Mapping values in mustache templates

### DIFF
--- a/libs/core/langchain_core/utils/mustache.py
+++ b/libs/core/langchain_core/utils/mustache.py
@@ -394,7 +394,7 @@ def _get_key(
                 if resolved_scope in (0, False):
                     return resolved_scope
                 # Move into the scope
-                if isinstance(resolved_scope, dict):
+                if isinstance(resolved_scope, Mapping):
                     try:
                         resolved_scope = resolved_scope[child]
                     except (KeyError, TypeError):

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -1,7 +1,9 @@
 """Test functionality related to prompts."""
 
 import re
+from collections import ChainMap, UserDict
 from tempfile import NamedTemporaryFile
+from types import MappingProxyType
 from typing import Any, Literal
 from unittest import mock
 
@@ -249,6 +251,16 @@ def test_mustache_prompt_from_template(snapshot: SnapshotAssertion) -> None:
         "title": "PromptInput",
         "type": "object",
     }
+
+
+def test_mustache_prompt_with_non_dict_mapping() -> None:
+    """Test mustache templates accept non-`dict` `Mapping` values."""
+    template = "Hello {{user.name}}"
+    prompt = PromptTemplate.from_template(template, template_format="mustache")
+
+    assert prompt.format(user=ChainMap({"name": "Alice"})) == "Hello Alice"
+    assert prompt.format(user=UserDict({"name": "Alice"})) == "Hello Alice"
+    assert prompt.format(user=MappingProxyType({"name": "Alice"})) == "Hello Alice"
 
 
 def test_prompt_from_template_with_partial_variables() -> None:


### PR DESCRIPTION
Fixes #39678

---

Mustache templates document their input as a `Mapping[str, Any]`, but only plain `dict` values actually resolved. Any other `Mapping` — a `ChainMap`, `UserDict`, `MappingProxyType`, or `os.environ` — silently rendered as an empty string, so users passing a valid `Mapping` saw variables disappear with no error and no way to tell a missing key from an unsupported type.

The nested-value lookup now dispatches on the abstract `Mapping` ABC instead of the concrete `dict`, so every `Mapping` resolves through `__getitem__` exactly as the API promises. The `else` branch that rejects traversal into arbitrary objects is unchanged, so the earlier template-injection hardening still applies.

Added a unit test covering `ChainMap`, `UserDict`, and `MappingProxyType` values.

## Release note

Mustache prompt templates now resolve variables from any `Mapping` value (such as `ChainMap`, `UserDict`, or `os.environ`), not only `dict`.

---

*This contribution was prepared with AI assistance.*
