### PR TITLE
fix(anthropic): exclude sibling directories from grep search scope

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
@@ -300,7 +300,7 @@ class StateFileSearchMiddleware(AgentMiddleware):
 
         for file_path, file_data in files.items():
             if (
-                base_path != "/"
+                base_path != "/"  # noqa: PLR1714
                 and file_path != base_path
                 and not file_path.startswith(base_path + "/")
             ):

--- a/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
@@ -299,7 +299,11 @@ class StateFileSearchMiddleware(AgentMiddleware):
         results: dict[str, list[tuple[int, str]]] = {}
 
         for file_path, file_data in files.items():
-            if not file_path.startswith(base_path):
+            if (
+                base_path != "/"
+                and file_path != base_path
+                and not file_path.startswith(base_path + "/")
+            ):
                 continue
 
             # Check include filter

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_file_search.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_file_search.py
@@ -400,6 +400,38 @@ class TestFilesystemGrepSearch:
         assert "/src/main.py" in result
         assert "/tests/test.py" not in result
 
+    def test_grep_excludes_sibling_directory(self) -> None:
+        """Test grep scoped to a path excludes sibling directories sharing a prefix."""
+        middleware = StateFileSearchMiddleware()
+
+        state: AnthropicToolsState = {
+            "messages": [],
+            "text_editor_files": {
+                "/app/config.txt": {
+                    "content": ["service=web"],
+                    "created_at": "2025-01-01T00:00:00",
+                    "modified_at": "2025-01-01T00:00:00",
+                },
+                "/app-secret/creds.txt": {
+                    "content": ["password=SIBLING-LEAK"],
+                    "created_at": "2025-01-01T00:00:00",
+                    "modified_at": "2025-01-01T00:00:00",
+                },
+            },
+        }
+
+        result = middleware._handle_grep_search(
+            pattern="password|service",
+            path="/app",
+            include=None,
+            output_mode="files_with_matches",
+            state=state,
+        )
+
+        assert isinstance(result, str)
+        assert "/app/config.txt" in result
+        assert "/app-secret/creds.txt" not in result
+
     def test_grep_no_matches(self) -> None:
         """Test grep with no matching content."""
         middleware = StateFileSearchMiddleware()


### PR DESCRIPTION
Fixes #39679

---

`StateFileSearchMiddleware._handle_grep_search` scoped a search with a raw `startswith` check, so a file under a sibling directory that shares the scope prefix (for example `/app-secret/creds.txt` when scoped to `/app`) was included in the results. This disagreed with `_handle_glob_search`, which already enforces a segment boundary.

The grep lookup now uses the same segment-aware boundary: a file is in scope when the base path is `/`, when it is the base path itself, or when it lives directly under `base_path/`. Sibling directories that merely share the prefix are excluded, matching `_handle_glob_search`.

Added a unit test covering a sibling directory that shares the scope prefix.

## Release note

`grep_search` in the Anthropic file-search middleware now respects the directory boundary of its `path` argument and no longer returns files from sibling directories that merely share the path prefix.

---

*This contribution was prepared with AI assistance.*
