### PR TITLE
fix(core): serialize non-JSON values inside lc-escaped dicts

### DIFF
--- a/libs/core/langchain_core/load/_validation.py
+++ b/libs/core/langchain_core/load/_validation.py
@@ -66,6 +66,27 @@ def _is_escaped_dict(obj: dict[str, Any]) -> bool:
     return len(obj) == 1 and _LC_ESCAPED_KEY in obj
 
 
+def _serialize_escaped_contents(obj: Any) -> Any:
+    """Encode values inside an escaped dict without further LC escaping.
+
+    An escaped user dict is unwrapped as-is on deserialization, so its nested
+    dicts must not receive their own escape wrapper. They do still need to be
+    JSON-serializable, so non-JSON-native values are encoded to the
+    `not_implemented` marker.
+    """
+    if isinstance(obj, Serializable):
+        return _serialize_lc_object(obj)
+    if isinstance(obj, dict):
+        if not all(isinstance(k, (str, int, float, bool, type(None))) for k in obj):
+            return to_json_not_implemented(obj)
+        return {k: _serialize_escaped_contents(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_serialize_escaped_contents(item) for item in obj]
+    if isinstance(obj, (str, int, float, bool, type(None))):
+        return obj
+    return to_json_not_implemented(obj)
+
+
 def _serialize_value(obj: Any) -> Any:
     """Serialize a value with escaping of user dicts.
 
@@ -86,11 +107,11 @@ def _serialize_value(obj: Any) -> Any:
             # if keys are not json serializable
             return to_json_not_implemented(obj)
         # Check if dict needs escaping BEFORE recursing into values.
-        # If it needs escaping, wrap it as-is - the contents are user data that
-        # will be returned as-is during deserialization (no instantiation).
-        # This prevents re-escaping of already-escaped nested content.
+        # If it needs escaping, encode its values so the result stays
+        # JSON-serializable, but wrap them without further LC escaping — the
+        # contents are user data returned as-is during deserialization.
         if _needs_escaping(obj):
-            return _escape_dict(obj)
+            return _escape_dict(_serialize_escaped_contents(obj))
         # Safe dict (no 'lc' key) - recurse into values
         return {k: _serialize_value(v) for k, v in obj.items()}
     if isinstance(obj, (list, tuple)):

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -452,6 +452,21 @@ def test_dumps_mixed_data_structure() -> None:
     assert parsed["primitive"] == "string"
 
 
+def test_dumpd_lc_key_with_non_serializable_value() -> None:
+    """Test `dumpd()` with an `'lc'` key alongside a non-JSON-native value."""
+    import datetime
+
+    data = {"lc": "en", "indexed_at": datetime.datetime(2024, 1, 1)}
+    serialized = dumpd(data)
+
+    escaped = serialized["__lc_escaped__"]
+    assert escaped["lc"] == "en"
+    assert escaped["indexed_at"]["type"] == "not_implemented"
+
+    # The result must be JSON-serializable (this raised a `TypeError` before).
+    json.dumps(serialized)
+
+
 def test_document_normal_metadata_allowed() -> None:
     """Test that `Document` metadata without `'lc'` key works fine."""
     doc = Document(


### PR DESCRIPTION
Fixes #39677

---

`dumps()` / `dumpd()` raised a `TypeError` when a plain dict carried an `"lc"` key (a benign abbreviation such as a locale or language-code field) next to a non-JSON-native value like a `datetime`. The `"lc"` escaping treated the whole dict as user data and wrapped it without encoding its values, so the raw `datetime` reached `json.dumps` with no fallback.

The escape now encodes the contents of an escaped dict — routing non-JSON-native values through the `not_implemented` marker, exactly like any other dict — while still wrapping the result so it is unwrapped as plain data on deserialization. Nested dicts inside the escaped contents are intentionally *not* re-escaped, because the outer wrapper already covers the whole subtree.

Added a unit test covering an `"lc"`-keyed dict with a `datetime` value.

## Release note

`dumps()` and `dumpd()` no longer raise a `TypeError` for plain dicts that contain an `"lc"` key together with a non-JSON-native value (such as a `datetime`); those values are encoded with the `not_implemented` marker like any other non-serializable value.

---

*This contribution was prepared with AI assistance.*
