### PR TITLE
fix(core): honour the color argument in FileCallbackHandler.on_tool_end

### DIFF
--- a/libs/core/langchain_core/callbacks/file.py
+++ b/libs/core/langchain_core/callbacks/file.py
@@ -229,7 +229,7 @@ class FileCallbackHandler(BaseCallbackHandler):
         """
         if observation_prefix is not None:
             self._write(f"\n{observation_prefix}")
-        self._write(output)
+        self._write(output, color=color or self.color)
         if llm_prefix is not None:
             self._write(f"\n{llm_prefix}")
 

--- a/libs/core/tests/unit_tests/callbacks/test_file.py
+++ b/libs/core/tests/unit_tests/callbacks/test_file.py
@@ -1,0 +1,57 @@
+"""Tests for `FileCallbackHandler`."""
+
+import pathlib
+import re
+
+from langchain_core.agents import AgentAction
+from langchain_core.callbacks import FileCallbackHandler
+
+_ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _colored_segments(text: str) -> list[str]:
+    """Return the visible text of each segment that carries an ANSI color."""
+    return [
+        _ANSI.sub("", segment)
+        for segment in re.findall(r"\x1b\[[\d;]*m.*?\x1b\[0m", text, flags=re.DOTALL)
+    ]
+
+
+def test_on_tool_end_uses_the_color(tmp_path: pathlib.Path) -> None:
+    """Tool output is colored, both from `self.color` and from an override."""
+    log = tmp_path / "output.log"
+    with FileCallbackHandler(str(log), color="green") as handler:
+        handler.on_tool_end("DEFAULT")
+        handler.on_tool_end("OVERRIDE", color="red")
+
+    written = log.read_text()
+    assert _colored_segments(written) == ["DEFAULT", "OVERRIDE"]
+    # the override is a different color from the handler default
+    assert "\x1b[32;1m" in written
+    assert "\x1b[31;1m" in written
+
+
+def test_on_tool_end_matches_its_siblings(tmp_path: pathlib.Path) -> None:
+    """The other handlers already color their output; `on_tool_end` agrees."""
+    log = tmp_path / "output.log"
+    action = AgentAction(tool="tool", tool_input="input", log="ACTION")
+    with FileCallbackHandler(str(log), color="green") as handler:
+        handler.on_text("TEXT")
+        handler.on_agent_action(action)
+        handler.on_tool_end("TOOL")
+
+    assert _colored_segments(log.read_text()) == ["TEXT", "ACTION", "TOOL"]
+
+
+def test_on_tool_end_keeps_its_prefixes(tmp_path: pathlib.Path) -> None:
+    """The prefixes are unchanged and stay outside the colored segment."""
+    log = tmp_path / "output.log"
+    with FileCallbackHandler(str(log), color="green") as handler:
+        handler.on_tool_end(
+            "TOOL", observation_prefix="Observation:", llm_prefix="Thought:"
+        )
+
+    written = log.read_text()
+    assert "Observation:" in _ANSI.sub("", written)
+    assert "Thought:" in _ANSI.sub("", written)
+    assert _colored_segments(written) == ["TOOL"]


### PR DESCRIPTION
Anyone logging an agent run to a file with `FileCallbackHandler` gets the tool output in plain text, while every other line in the same log is colored. Passing an explicit color to `on_tool_end` does nothing either.

`on_tool_end` documents `color` as an override that falls back to `self.color`, but it wrote the output without passing a color at all, so neither the override nor the handler's own color ever reached the file. Every other write in the class already uses `color or self.color`, and `StdOutCallbackHandler.on_tool_end` does the same, so this one was out of step with both its siblings and its own docstring.

Writing to a log with `color="green"` before this change gives:

```
\x1b[32;1m\x1b[1;3mTEXT\x1b[0m\x1b[32;1m\x1b[1;3mACTION\x1b[0mTOOL
```

`TEXT` and `ACTION` are colored; `TOOL` is bare.

Tests are new because `FileCallbackHandler` had no unit tests in `core`. One of them compares `on_tool_end` against `on_text` and `on_agent_action` in the same log, which is the assertion that would have caught this.

## Release note

`FileCallbackHandler.on_tool_end` now colors tool output, using the `color` argument when given and `self.color` otherwise.

---

Disclosure: an AI agent was involved in preparing this change.
