### PR TITLE
fix(anthropic): drop `temperature`/`top_p`/`top_k` for models that reject them

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -854,6 +854,23 @@ def _reasoning_effort_levels(profile: object) -> tuple[str, ...]:
     return tuple(levels)
 
 
+_SAMPLING_PARAMS: Final[tuple[str, ...]] = ("temperature", "top_k", "top_p")
+
+
+def _supports_sampling_params(profile: object) -> bool:
+    """Return whether a model's profile permits sampling parameters.
+
+    Anthropic removed `temperature`/`top_p`/`top_k` on its newer models, which
+    reject them with a 400. The bundled profiles record that as
+    `temperature: False`. Anything else - an absent profile, a non-mapping
+    value, or a profile that predates the flag - is treated as "supported" so
+    unrecognized models keep their existing behavior.
+    """
+    if not isinstance(profile, Mapping):
+        return True
+    return profile.get("temperature") is not False
+
+
 def _is_direct_anthropic_llm_type(llm_type: object) -> bool:
     """Return whether an `_llm_type` reaches Claude via the direct Anthropic API.
 
@@ -1472,6 +1489,24 @@ class ChatAnthropic(BaseChatModel):
             **self.model_kwargs,
             **kwargs,
         }
+
+        # Newer models reject sampling parameters outright, so forwarding them
+        # turns a model upgrade into an opaque provider 400 for code that has
+        # always passed `temperature=0`. Drop them and name what was dropped.
+        # Applied after the kwargs merge so call-time overrides are covered too.
+        if not _supports_sampling_params(self.profile):
+            dropped = [key for key in _SAMPLING_PARAMS if payload.get(key) is not None]
+            for key in _SAMPLING_PARAMS:
+                payload.pop(key, None)
+            if dropped:
+                warnings.warn(
+                    f"{self.model} does not support sampling parameters. Dropped "
+                    f"{', '.join(repr(key) for key in dropped)} from the request; "
+                    "remove them to silence this warning.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
         # Captured before `self.thinking` is applied below, so a call-time
         # `thinking` kwarg counts as "explicitly set" too.
         thinking_explicitly_set = "thinking" in payload or self.thinking is not None

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -41,6 +41,7 @@ from langchain_anthropic.chat_models import (
     _is_builtin_tool,
     _merge_messages,
     _normalize_tool_call_id,
+    _supports_sampling_params,
     _thinking_in_params,
     convert_to_anthropic_tool,
 )
@@ -2503,6 +2504,109 @@ def test_cache_control_kwarg_unknown_subclass_injects_into_blocks() -> None:
     assert payload["messages"][-1]["content"] == [
         {"type": "text", "text": "hello", "cache_control": {"type": "ephemeral"}}
     ]
+
+
+def _sampling_warnings(caught: list[warnings.WarningMessage]) -> list[str]:
+    return [str(w.message) for w in caught if "sampling parameters" in str(w.message)]
+
+
+def test_sampling_params_dropped_for_unsupported_model() -> None:
+    """Sampling params are dropped for models whose profile rejects them.
+
+    Anthropic removed `temperature`/`top_p`/`top_k` on its newer models, so
+    forwarding them turns a model-string upgrade into an opaque provider 400
+    for the very common `temperature=0` configuration.
+    """
+    llm = ChatAnthropic(model="claude-opus-5", temperature=0, top_p=0.5, top_k=10)
+
+    with pytest.warns(UserWarning, match="does not support sampling parameters"):
+        payload = llm._get_request_payload([HumanMessage("hello")])
+
+    assert "temperature" not in payload
+    assert "top_p" not in payload
+    assert "top_k" not in payload
+
+
+def test_sampling_params_warning_names_only_what_was_set() -> None:
+    """The warning lists the dropped keys so the fix is obvious."""
+    llm = ChatAnthropic(model="claude-opus-5", temperature=0)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        llm._get_request_payload([HumanMessage("hello")])
+
+    assert len(_sampling_warnings(caught)) == 1
+    message = _sampling_warnings(caught)[0]
+    assert "'temperature'" in message
+    assert "'top_p'" not in message
+    assert "'top_k'" not in message
+
+
+def test_sampling_params_dropped_from_call_kwargs() -> None:
+    """Call-time overrides are gated too, not just constructor fields."""
+    llm = ChatAnthropic(model="claude-opus-5")
+
+    with pytest.warns(UserWarning, match="does not support sampling parameters"):
+        payload = llm._get_request_payload([HumanMessage("hello")], temperature=0.7)
+
+    assert "temperature" not in payload
+
+
+def test_sampling_params_kept_for_supported_model() -> None:
+    """Models that still accept sampling params are left untouched."""
+    llm = ChatAnthropic(model="claude-sonnet-4-6", temperature=0, top_p=0.5, top_k=10)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        payload = llm._get_request_payload([HumanMessage("hello")])
+
+    assert _sampling_warnings(caught) == []
+    assert payload["temperature"] == 0
+    assert payload["top_p"] == 0.5
+    assert payload["top_k"] == 10
+
+
+def test_sampling_params_kept_for_unrecognized_model() -> None:
+    """An unrecognized model has no profile, so behavior is unchanged.
+
+    Gating on a missing profile would silently strip sampling params for
+    models this package does not ship a profile for yet.
+    """
+    llm = ChatAnthropic(model="claude-not-a-real-model", temperature=0)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        payload = llm._get_request_payload([HumanMessage("hello")])
+
+    assert _sampling_warnings(caught) == []
+    assert payload["temperature"] == 0
+
+
+def test_sampling_params_unset_is_silent() -> None:
+    """No warning when the caller never set a sampling param."""
+    llm = ChatAnthropic(model="claude-opus-5")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        payload = llm._get_request_payload([HumanMessage("hello")])
+
+    assert _sampling_warnings(caught) == []
+    assert "temperature" not in payload
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected"),
+    [
+        ({"temperature": False}, False),
+        ({"temperature": True}, True),
+        ({}, True),
+        (None, True),
+        ("not-a-mapping", True),
+    ],
+)
+def test_supports_sampling_params(profile: object, expected: bool) -> None:  # noqa: FBT001
+    """Only an explicit `temperature: False` disables sampling params."""
+    assert _supports_sampling_params(profile) is expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #39688

---

Anthropic removed the sampling parameters on its newer models, so a request carrying `temperature`, `top_p`, or `top_k` now comes back as a `400` from the provider. `ChatAnthropic` forwarded them regardless.

The practical effect is that upgrading a model string breaks working code. Someone running `ChatAnthropic(model=..., temperature=0)` — the single most common configuration in the ecosystem, and the one this repo's own docstring examples teach — changes nothing but the model name and gets an opaque `` `temperature` is deprecated for this model `` error back from the API, with nothing pointing at the parameter they set months ago.

The package already knows which models are affected: the bundled profiles carry `temperature: False` for exactly the failing set (`claude-opus-5`, `claude-opus-4-8`, `claude-opus-4-7`, `claude-sonnet-5`, `claude-fable-5`). Nothing read that flag — `_get_request_payload` filtered the sampling parameters only by `is not None`.

This reads it. When the resolved profile declares `temperature: False`, `_get_request_payload` drops `temperature`, `top_k`, and `top_p` and emits a `UserWarning` naming exactly which keys were dropped, matching the warn-and-drop convention already used there for `cache_control`. The gate runs after the kwargs merge, so call-time overrides are covered as well as constructor fields.

Two choices worth a careful look:

- **Warn-and-drop rather than raising.** Raising a `ValueError` would still hard-break the `temperature=0` code above, just with a LangChain traceback instead of a provider `400`. Dropping lets a model upgrade keep working while making the change visible. The gate supports raising instead if you'd rather — happy to switch.
- **The gate keys on an explicit `temperature: False` only.** A model with no profile, a non-mapping profile, or a profile predating the flag is treated as supported and behaves exactly as it does today. That keeps unrecognized model strings from silently losing their sampling parameters, at the cost of not covering a new unsupported model until its profile ships.

Because it reads the resolved profile rather than matching on the model string, a caller-supplied `profile` override is respected too.

## Release note

`ChatAnthropic` no longer sends `temperature`, `top_p`, or `top_k` to models whose profile marks sampling parameters as unsupported (`claude-opus-4-7` and newer, `claude-sonnet-5`, `claude-fable-5`). Previously these were forwarded and rejected by the API with a `400`; they are now dropped with a `UserWarning` naming the dropped parameters, so upgrading a model string no longer breaks existing code. Models that still accept sampling parameters are unaffected.

_Drafted with AI assistance; reviewed and tested by me._
