### PR TITLE
chore(infra): cover Docker dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -117,3 +117,23 @@ updates:
           - "*"
         update-types:
           - "major"
+
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/.devcontainer/"
+      - "/libs/langchain/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## Summary

- add monthly Dependabot coverage for the maintained development-container Compose file
- add monthly Dependabot coverage for the LangChain development Dockerfile
- keep major updates separate from minor and patch updates

## Test Plan

- parsed `.github/dependabot.yml` with Ruby `YAML.safe_load_file`
- ran `git diff --check`
- verified the staged diff contains only `.github/dependabot.yml`

This contribution was prepared with AI-agent assistance.