### PR TITLE
fix(core): count only readable text in reasoning/thinking blocks for `count_tokens_approximately`

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2352,6 +2352,11 @@ def count_tokens_approximately(
                     elif block_type == "text":
                         text = block.get("text", "")
                         message_chars += len(text)
+                    # Count only the readable text in reasoning/thinking blocks,
+                    # not provider metadata (e.g. encrypted_content in extras)
+                    elif block_type in {"reasoning", "thinking"}:
+                        text = block.get("reasoning") or block.get("thinking") or ""
+                        message_chars += len(text)
                     # Conservative estimate for unknown block types
                     else:
                         message_chars += len(repr(block))

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2879,6 +2879,70 @@ def test_count_tokens_approximately_with_unknown_block_type() -> None:
     assert mixed > text_only
 
 
+def test_count_tokens_approximately_reasoning_block_excludes_extras() -> None:
+    """Reasoning blocks should count only readable text, not provider metadata.
+
+    OpenAI reasoning models (with store=False) return an encrypted copy of the
+    chain-of-thought inside ``extras.encrypted_content``.  The ciphertext is
+    much longer than the actual reasoning and is not billed by the provider, so
+    including it in the estimate inflates the count by up to 10x.
+    """
+    reasoning_text = "I should inspect the staging model."
+    ciphertext = "g" * 4000
+
+    block_with_extras = {
+        "type": "reasoning",
+        "id": "rs_abc",
+        "reasoning": reasoning_text,
+        "extras": {"content": [], "encrypted_content": ciphertext},
+    }
+    block_without_extras = {
+        "type": "reasoning",
+        "id": "rs_abc",
+        "reasoning": reasoning_text,
+    }
+
+    with_extras = count_tokens_approximately(
+        [AIMessage(content=[block_with_extras], id="ai-1")]
+    )
+    without_extras = count_tokens_approximately(
+        [AIMessage(content=[block_without_extras], id="ai-1")]
+    )
+
+    assert with_extras == without_extras
+
+
+def test_count_tokens_approximately_thinking_block_excludes_extras() -> None:
+    """Thinking blocks (Anthropic) should count only the thinking text."""
+    thinking_text = "Let me consider the options."
+    block = {
+        "type": "thinking",
+        "thinking": thinking_text,
+        "extras": {"signature": "s" * 2000},
+    }
+
+    with_extras = count_tokens_approximately([AIMessage(content=[block], id="ai-1")])
+    text_only = count_tokens_approximately(
+        [AIMessage(content=[{"type": "text", "text": thinking_text}], id="ai-1")]
+    )
+
+    assert with_extras == text_only
+
+
+def test_count_tokens_approximately_encrypted_only_reasoning_block() -> None:
+    """A reasoning block with no readable text should contribute zero chars."""
+    block = {
+        "type": "reasoning",
+        "id": "rs_abc",
+        "extras": {"encrypted_content": "g" * 4000},
+    }
+
+    count = count_tokens_approximately([AIMessage(content=[block], id="ai-1")])
+    empty = count_tokens_approximately([AIMessage(content=[], id="ai-1")])
+
+    assert count == empty
+
+
 def test_count_tokens_approximately_ai_tool_calls_skipped_for_list_content() -> None:
     """Test that tool_calls aren't double-counted for list (Anthropic-style) content."""
     tool_calls = [


### PR DESCRIPTION
Closes #39696

---

`count_tokens_approximately` has no dedicated case for `reasoning` or `thinking` content blocks, so they fall through to the catch-all `len(repr(block))`. This includes provider metadata that is not prompt text, most notably the `encrypted_content` field that OpenAI reasoning models return when `store=False`.

The ciphertext is much longer than the actual reasoning it encodes. In production conversations we observed estimates inflated by 5-10x, which causes downstream token-budget logic (trim/summarize thresholds, context-window guards) to trigger far too early.

---

The fix adds a branch for `reasoning` and `thinking` block types that counts only the readable text (`block["reasoning"]` or `block["thinking"]`), matching what `get_buffer_string` already does for the same blocks. Provider bookkeeping in `extras` (encrypted content, signatures, item IDs) is excluded.

Three new tests cover:
- Reasoning block with `extras.encrypted_content` produces the same estimate as the same block without extras
- Thinking block (Anthropic) counts only the `thinking` text
- An encrypted-only reasoning block (no readable text) contributes zero characters

## Release note

`count_tokens_approximately` no longer counts provider metadata (e.g. `encrypted_content`) in `reasoning` and `thinking` content blocks. Previously these blocks fell through to `repr()`, which inflated estimates by up to 10x for conversations with reasoning models.

---

This contribution was drafted with AI assistance under the direction of @alan-andrade.