### PR TITLE
fix(openrouter): close `httpx` clients created for attribution headers

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -66,7 +66,14 @@ from langchain_core.utils.function_calling import (
     convert_to_openai_tool,
 )
 from langchain_core.utils.pydantic import is_basemodel_subclass
-from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    SecretStr,
+    model_validator,
+)
 from typing_extensions import Self
 
 from langchain_openrouter._version import __version__
@@ -163,6 +170,19 @@ class ChatOpenRouter(BaseChatModel):
 
     client: Any = Field(default=None, exclude=True)
     """Underlying SDK client (`openrouter.OpenRouter`)."""
+
+    _http_client: Any = PrivateAttr(default=None)
+    """`httpx.Client` created for attribution headers; closed by `close()`.
+
+    Only set when `_build_client` constructs the client. A user-supplied SDK
+    `client` is never stored here and is never closed by this class.
+    """
+
+    _http_async_client: Any = PrivateAttr(default=None)
+    """`httpx.AsyncClient` created for attribution headers; closed by `aclose()`.
+
+    See `_http_client`.
+    """
 
     openrouter_api_key: SecretStr | None = Field(
         alias="api_key",
@@ -446,12 +466,14 @@ class ChatOpenRouter(BaseChatModel):
         if extra_headers:
             import httpx  # noqa: PLC0415
 
-            client_kwargs["client"] = httpx.Client(
+            self._http_client = httpx.Client(
                 headers=extra_headers, follow_redirects=True
             )
-            client_kwargs["async_client"] = httpx.AsyncClient(
+            self._http_async_client = httpx.AsyncClient(
                 headers=extra_headers, follow_redirects=True
             )
+            client_kwargs["client"] = self._http_client
+            client_kwargs["async_client"] = self._http_async_client
         if self.request_timeout is not None:
             client_kwargs["timeout_ms"] = self.request_timeout
         if self.max_retries > 0:
@@ -495,6 +517,47 @@ class ChatOpenRouter(BaseChatModel):
                 )
                 raise ImportError(msg) from e
         return self
+
+    def close(self) -> None:
+        """Close the sync httpx client created for attribution headers.
+
+        After calling, sync invocations that rely on this client may raise.
+        Async invocations remain available until `aclose()` is also called.
+        Safe to call multiple times. Does not close a user-supplied SDK
+        `client`.
+        """
+        if self._http_client is not None:
+            self._http_client.close()
+            self._http_client = None
+
+    async def aclose(self) -> None:
+        """Close the async httpx client created for attribution headers.
+
+        Releases the connector owned by the `httpx.AsyncClient` that
+        `_build_client` creates for attribution headers. Without this,
+        transient `ChatOpenRouter` instances can leak sockets and
+        ephemeral ports. Safe to call multiple times. Does not close a
+        user-supplied SDK `client`.
+        """
+        if self._http_async_client is not None:
+            await self._http_async_client.aclose()
+            self._http_async_client = None
+
+    def __enter__(self) -> Self:
+        """Enter a context manager that closes the sync HTTP client on exit."""
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        """Exit the context manager and close the sync HTTP client."""
+        self.close()
+
+    async def __aenter__(self) -> Self:
+        """Enter an async context manager that closes the async HTTP client on exit."""
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit the async context manager and close the async HTTP client."""
+        await self.aclose()
 
     def _resolve_model_profile(self) -> ModelProfile | None:
         return _get_default_model_profile(self.model_name) or None

--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -531,17 +531,16 @@ class ChatOpenRouter(BaseChatModel):
             self._http_client = None
 
     async def aclose(self) -> None:
-        """Close the async httpx client created for attribution headers.
+        """Close httpx clients created for attribution headers.
 
-        Releases the connector owned by the `httpx.AsyncClient` that
-        `_build_client` creates for attribution headers. Without this,
-        transient `ChatOpenRouter` instances can leak sockets and
-        ephemeral ports. Safe to call multiple times. Does not close a
-        user-supplied SDK `client`.
+        Closes the async client first, then the sync client, so `async with`
+        does not leave a leftover `httpx.Client`. Safe to call multiple times.
+        Does not close a user-supplied SDK `client`.
         """
         if self._http_async_client is not None:
             await self._http_async_client.aclose()
             self._http_async_client = None
+        self.close()
 
     def __enter__(self) -> Self:
         """Enter a context manager that closes the sync HTTP client on exit."""

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -718,6 +718,74 @@ class TestChatOpenRouterInstantiation:
 
 
 # ===========================================================================
+# HTTP client lifecycle tests
+# ===========================================================================
+
+
+class TestHttpClientLifecycle:
+    """Tests for closing httpx clients created for attribution headers."""
+
+    def test_constructing_model_creates_httpx_clients(self) -> None:
+        """Test that default attribution headers cause httpx clients to be created."""
+        mock_sync = MagicMock()
+        mock_async = MagicMock()
+        with (
+            patch("openrouter.OpenRouter", return_value=MagicMock()),
+            patch("httpx.Client", return_value=mock_sync) as mock_client_cls,
+            patch("httpx.AsyncClient", return_value=mock_async) as mock_async_cls,
+        ):
+            model = _make_model()
+        mock_client_cls.assert_called_once()
+        mock_async_cls.assert_called_once()
+        assert model._http_client is mock_sync
+        assert model._http_async_client is mock_async
+
+    def test_close_closes_sync_client_once(self) -> None:
+        """Test that `close()` closes the sync client once; a second call is a no-op."""
+        mock_sync = MagicMock()
+        with (
+            patch("openrouter.OpenRouter", return_value=MagicMock()),
+            patch("httpx.Client", return_value=mock_sync),
+            patch("httpx.AsyncClient", return_value=MagicMock()),
+        ):
+            model = _make_model()
+        model.close()
+        mock_sync.close.assert_called_once()
+        assert model._http_client is None
+        model.close()
+        mock_sync.close.assert_called_once()
+
+    async def test_aclose_closes_async_client_once(self) -> None:
+        """Test that `aclose()` closes the async client once."""
+        mock_async = MagicMock()
+        mock_async.aclose = AsyncMock()
+        with (
+            patch("openrouter.OpenRouter", return_value=MagicMock()),
+            patch("httpx.Client", return_value=MagicMock()),
+            patch("httpx.AsyncClient", return_value=mock_async),
+        ):
+            model = _make_model()
+        await model.aclose()
+        mock_async.aclose.assert_awaited_once()
+        assert model._http_async_client is None
+        await model.aclose()
+        mock_async.aclose.assert_awaited_once()
+
+    async def test_async_context_manager_calls_aclose(self) -> None:
+        """Test that `async with ChatOpenRouter(...)` closes the async client."""
+        mock_async = MagicMock()
+        mock_async.aclose = AsyncMock()
+        with (
+            patch("openrouter.OpenRouter", return_value=MagicMock()),
+            patch("httpx.Client", return_value=MagicMock()),
+            patch("httpx.AsyncClient", return_value=mock_async),
+        ):
+            async with _make_model():
+                pass
+        mock_async.aclose.assert_awaited_once()
+
+
+# ===========================================================================
 # Serialization tests
 # ===========================================================================
 

--- a/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/openrouter/tests/unit_tests/test_chat_models.py
@@ -756,33 +756,53 @@ class TestHttpClientLifecycle:
         mock_sync.close.assert_called_once()
 
     async def test_aclose_closes_async_client_once(self) -> None:
-        """Test that `aclose()` closes the async client once."""
+        """Test that `aclose()` closes both clients; a second call is a no-op."""
+        mock_sync = MagicMock()
         mock_async = MagicMock()
         mock_async.aclose = AsyncMock()
         with (
             patch("openrouter.OpenRouter", return_value=MagicMock()),
-            patch("httpx.Client", return_value=MagicMock()),
+            patch("httpx.Client", return_value=mock_sync),
             patch("httpx.AsyncClient", return_value=mock_async),
         ):
             model = _make_model()
         await model.aclose()
         mock_async.aclose.assert_awaited_once()
+        mock_sync.close.assert_called_once()
         assert model._http_async_client is None
+        assert model._http_client is None
         await model.aclose()
         mock_async.aclose.assert_awaited_once()
+        mock_sync.close.assert_called_once()
+
+    def test_sync_context_manager_calls_close(self) -> None:
+        """Test that `with ChatOpenRouter(...)` closes the sync client."""
+        mock_sync = MagicMock()
+        with (
+            patch("openrouter.OpenRouter", return_value=MagicMock()),
+            patch("httpx.Client", return_value=mock_sync),
+            patch("httpx.AsyncClient", return_value=MagicMock()),
+        ):
+            model = _make_model()
+        with model:
+            pass
+        mock_sync.close.assert_called_once()
 
     async def test_async_context_manager_calls_aclose(self) -> None:
-        """Test that `async with ChatOpenRouter(...)` closes the async client."""
+        """Test that `async with ChatOpenRouter(...)` closes both clients."""
+        mock_sync = MagicMock()
         mock_async = MagicMock()
         mock_async.aclose = AsyncMock()
         with (
             patch("openrouter.OpenRouter", return_value=MagicMock()),
-            patch("httpx.Client", return_value=MagicMock()),
+            patch("httpx.Client", return_value=mock_sync),
             patch("httpx.AsyncClient", return_value=mock_async),
         ):
-            async with _make_model():
-                pass
+            model = _make_model()
+        async with model:
+            pass
         mock_async.aclose.assert_awaited_once()
+        mock_sync.close.assert_called_once()
 
 
 # ===========================================================================


### PR DESCRIPTION
Fixes #38610

`ChatOpenRouter` always builds attribution headers, so it always constructs `httpx.Client` / `httpx.AsyncClient` and never closed them. Callers can now `close()` / `aclose()` or use `with` / `async with`; `aclose()` shuts down both clients so `async with` does not leave a leftover sync socket.

## Release note
`ChatOpenRouter` now exposes `close()` / `aclose()` (and context managers) so the httpx clients created for OpenRouter attribution headers can be released.

## How did you verify your code works?
- `make format && make lint` in `libs/partners/openrouter`
- `pytest tests/unit_tests/test_chat_models.py::TestHttpClientLifecycle` (5 passed)
- Full package unit tests previously passed (259)