### PR TITLE
docs(core): clarify `Runnable` pipe coercion

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -663,6 +663,12 @@ class Runnable(ABC, Generic[Input, Output]):
 
         Returns:
             A new `Runnable`.
+
+        Raises:
+            TypeError: If `other` cannot be coerced to a `Runnable`. This method does
+                not return `NotImplemented`, to avoid delegating LCEL composition to
+                unrelated reflected `|` implementations. To interoperate, implement
+                `Runnable`, make the object callable, or define `__or__` on the left.
         """
         return RunnableSequence(self, coerce_to_runnable(other))
 
@@ -706,6 +712,12 @@ class Runnable(ABC, Generic[Input, Output]):
 
         Returns:
             A new `Runnable`.
+
+        Raises:
+            TypeError: If `other` cannot be coerced to a `Runnable`. This method does
+                not return `NotImplemented`, to avoid delegating LCEL composition to
+                unrelated reflected `|` implementations. To interoperate, implement
+                `Runnable`, make the object callable, or define `__or__` on the left.
         """
         return RunnableSequence(coerce_to_runnable(other), self)
 


### PR DESCRIPTION
Resolves #39075

---

Clarifies why `Runnable.__or__` and `Runnable.__ror__` raise `TypeError` for unsupported operands instead of returning `NotImplemented`, including the supported interoperability paths. This preserves the intentionally closed LCEL coercion boundary while making the behavior explicit for maintainers and users.

No tests added because this changes docstrings only; Ruff formatting and lint checks pass.

Made by [Open SWE](https://openswe.vercel.app/agents/ef7dbe9d-fed3-94b0-eb10-1637bdbfd076)