### PR TITLE
docs: fix typos in core tools, output parser, and test data

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -1620,7 +1620,7 @@ def _is_injected_arg_type(
         injected_type = InjectedToolArg
 
     # if the type is an Annotated type, check if annotated metadata
-    # is an intance or subclass of the injected type
+    # is an instance or subclass of the injected type
     return any(
         isinstance(arg, injected_type)
         or (isinstance(arg, type) and issubclass(arg, injected_type))

--- a/libs/langchain/langchain_classic/agents/mrkl/output_parser.py
+++ b/libs/langchain/langchain_classic/agents/mrkl/output_parser.py
@@ -59,7 +59,7 @@ class MRKLOutputParser(AgentOutputParser):
             action = action_match.group(1).strip()
             action_input = action_match.group(2)
             tool_input = action_input.strip(" ")
-            # ensure if its a well formed SQL query we don't remove any trailing " chars
+            # ensure if it's a well-formed SQL query we don't remove any trailing " chars
             if tool_input.startswith("SELECT ") is False:
                 tool_input = tool_input.strip('"')
 

--- a/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
+++ b/libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py
@@ -724,7 +724,7 @@ def test_stream_reasoning_summary(
     )
     message_1 = {
         "role": "user",
-        "content": "What was the third tallest buliding in the year 2000?",
+        "content": "What was the third tallest building in the year 2000?",
     }
     response_1: BaseMessage
     if use_v2_stream:
@@ -793,7 +793,7 @@ def test_stream_encrypted_reasoning() -> None:
     )
     message_1 = {
         "role": "user",
-        "content": "What was the third tallest buliding in the year 2000?",
+        "content": "What was the third tallest building in the year 2000?",
     }
     response_1 = llm.stream_events([message_1], version="v3").output
     total_reasoning_blocks = 0


### PR DESCRIPTION
## Description

Fixed three typos found in the codebase:

1. **`intance` → `instance`** in `libs/core/langchain_core/tools/base.py` (line 1623) — comment describing type checking logic
2. **`buliding` → `building`** in `libs/partners/openai/tests/integration_tests/chat_models/test_responses_api.py` (lines 727, 796) — test prompt string  
3. **`its a` → `it's a`** and **`well formed` → `well-formed`** in `libs/langchain/langchain_classic/agents/mrkl/output_parser.py` (line 62) — code comment

## Type of change

- [x] Documentation / comments fix (no functional change)