### PR TITLE
fix(standard-tests): close quote in `bind_tools` example

### DIFF
--- a/libs/standard-tests/README.md
+++ b/libs/standard-tests/README.md
@@ -89,5 +89,5 @@ as required is optional.
 
 - `chat_model_class` (required): The class of the chat model to be tested
 - `chat_model_params`: The keyword arguments to pass to the chat model constructor
-- `chat_model_has_tool_calling`: Whether the chat model can call tools. By default, this is set to `hasattr(chat_model_class, 'bind_tools)`
+- `chat_model_has_tool_calling`: Whether the chat model can call tools. By default, this is set to `hasattr(chat_model_class, 'bind_tools')`
 - `chat_model_has_structured_output`: Whether the chat model can structured output. By default, this is set to `hasattr(chat_model_class, 'with_structured_output')`


### PR DESCRIPTION
Closes #39718

---

Corrects the malformed `hasattr` example for `chat_model_has_tool_calling` so readers can copy and evaluate it without a `SyntaxError`.

Made by [Open SWE](https://openswe.vercel.app/agents/80a92d5a-5b00-5823-9ccc-84afdee3be22)