### PR TITLE
fix(core): remove stale sync-stream `xfail` [closes #39720]

### DIFF
--- a/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable_events_v1.py
@@ -2144,11 +2144,6 @@ async def test_async_in_async_stream_lambdas() -> None:
     _assert_events_equal_allow_superset_metadata(events, EXPECTED_EVENTS)
 
 
-@pytest.mark.xfail(
-    reason="This test is failing due to missing functionality."
-    "Need to implement logic in _transform_stream_with_config that mimics the async "
-    "variant that uses tap_output_iter"
-)
 async def test_sync_in_sync_lambdas() -> None:
     """Test invoking nested runnable lambda."""
 


### PR DESCRIPTION
Closes #39720

---

The v1 sync-in-sync event-stream test remained marked as an expected failure after #21842 added synchronous iterator output tapping. Removing the stale marker makes future regressions fail normally and aligns the test with its v2 counterpart.

Made by [Open SWE](https://openswe.vercel.app/agents/adafd279-5015-5715-aeac-cebb7a73fe54)