### PR TITLE
fix(core): do not mask BaseException in agenerate callbacks

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -1824,12 +1824,12 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
                     *[
                         run_manager.on_llm_end(
                             LLMResult(
-                                generations=[res.generations],  # type: ignore[union-attr]
-                                llm_output=res.llm_output,  # type: ignore[union-attr]
+                                generations=[res.generations],
+                                llm_output=res.llm_output,
                             )
                         )
                         for run_manager, res in zip(run_managers, results, strict=False)
-                        if not isinstance(res, Exception)
+                        if not isinstance(res, BaseException)
                     ]
                 )
             raise exceptions[0]

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -1,5 +1,6 @@
 """Test base chat model."""
 
+import asyncio
 import uuid
 import warnings
 from collections.abc import AsyncIterator, Iterator
@@ -233,6 +234,39 @@ async def test_stream_error_callback() -> None:
         with pytest.raises(FakeListChatModelError):
             next(llm_stream)
         eval_response(cb_sync, i)
+
+
+async def test_agenerate_reraises_cancelled_error_with_callbacks() -> None:
+    """`agenerate` should re-raise `CancelledError`, not mask it as `AttributeError`."""
+
+    class CancellingChatModel(SimpleChatModel):
+        @property
+        @override
+        def _llm_type(self) -> str:
+            return "cancelling-chat-model"
+
+        @override
+        def _call(
+            self,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> str:
+            return "unused"
+
+        @override
+        async def _agenerate(
+            self,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> ChatResult:
+            raise asyncio.CancelledError
+
+    llm = CancellingChatModel()
+    with pytest.raises(asyncio.CancelledError):
+        await llm.agenerate(
+            [[HumanMessage(content="hello")]],
+            callbacks=[FakeAsyncCallbackHandler()],
+        )
 
 
 async def test_astream_fallback_to_ainvoke() -> None:


### PR DESCRIPTION
Fixes #38469

`agenerate` recorded failures as `BaseException` but then treated `CancelledError` as a successful `LLMResult` when running `on_llm_end`, which raised `AttributeError` and hid the original cancellation.

## Release note
`BaseChatModel.agenerate` now re-raises cancellation and other non-`Exception` failures instead of masking them as `AttributeError` when callbacks are configured.

## How did you verify your code works?
- `make format && make lint` in `libs/core`
- `test_agenerate_reraises_cancelled_error_with_callbacks` plus the chat-model unit suite