### PR TITLE
fix(openai): raise on unexpected chat completion response type

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1881,6 +1881,18 @@ class BaseChatOpenAI(BaseChatModel):
     ) -> ChatResult:
         generations = []
 
+        if not isinstance(response, dict | openai.BaseModel):
+            max_preview_length = 200
+            preview = str(response)
+            if len(preview) > max_preview_length:
+                preview = f"{preview[:max_preview_length]}..."
+            msg = (
+                f"Unexpected chat completion response type "
+                f"{type(response).__name__}. "
+                f"Expected dict or openai.BaseModel. Preview: {preview}"
+            )
+            raise ValueError(msg)
+
         response_dict = (
             response
             if isinstance(response, dict)

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -2100,6 +2100,26 @@ def test_create_chat_result_avoids_parsed_model_dump_warning() -> None:
     )
 
 
+def test_create_chat_result_raises_on_string_html_response() -> None:
+    html = (
+        "<html><head><title>302 Found</title></head><body>"
+        + ("x" * 5000)
+        + "</body></html>"
+    )
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    with pytest.raises(ValueError, match="str") as exc_info:
+        llm._create_chat_result(html)  # type: ignore[arg-type]
+    message = str(exc_info.value)
+    assert "302 Found" in message
+    assert len(message) < len(html)
+
+
+def test_create_chat_result_raises_on_non_pydantic_response() -> None:
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    with pytest.raises(ValueError, match="object"):
+        llm._create_chat_result(object())  # type: ignore[arg-type]
+
+
 @pytest.mark.skipif(
     (PYDANTIC_VERSION.major, PYDANTIC_VERSION.minor) < (2, 8),
     reason=(


### PR DESCRIPTION
Fixes #38866

`_create_chat_result` assumed every non-dict payload had `model_dump`. A string body from a redirect or proxy page raised `AttributeError`. It now raises `ValueError` with the type name and a short preview.

## Release note
`ChatOpenAI` now raises a clear `ValueError` when a chat completion response is neither a dict nor an OpenAI model object, instead of failing with `AttributeError`.

## How did you verify your code works?
- `make format && make lint` in `libs/partners/openai`
- Unit tests for a string HTML body and a non-pydantic object, plus the existing parsed-response test