### PR TITLE
fix(partners): isolate unit tests from network [closes #39727]

### DIFF
--- a/libs/partners/exa/Makefile
+++ b/libs/partners/exa/Makefile
@@ -12,14 +12,11 @@ PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE=tests/integration_tests/
 
-test:
-	uv run --group test --group test_integration pytest $(PYTEST_EXTRA) $(TEST_FILE)
+test tests:
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(PYTEST_EXTRA) $(TEST_FILE)
-
-tests:
-	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/mistralai/Makefile
+++ b/libs/partners/mistralai/Makefile
@@ -14,7 +14,7 @@ PYTEST_EXTRA ?=
 integration_test integration_tests: TEST_FILE=$(INTEGRATION_TEST_FILE)
 
 test tests:
-	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)

--- a/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_embeddings.py
@@ -1,6 +1,6 @@
 import os
 from typing import cast
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import httpx
 from pydantic import SecretStr
@@ -15,12 +15,16 @@ os.environ["MISTRAL_API_KEY"] = "foo"
 
 
 def test_mistral_init() -> None:
-    for model in [
-        MistralAIEmbeddings(model="mistral-embed", mistral_api_key="test"),  # type: ignore[call-arg]
-        MistralAIEmbeddings(model="mistral-embed", api_key="test"),  # type: ignore[arg-type]
-    ]:
-        assert model.model == "mistral-embed"
-        assert cast("SecretStr", model.mistral_api_key).get_secret_value() == "test"
+    with patch(
+        "langchain_mistralai.embeddings.Tokenizer.from_pretrained",
+        return_value=MagicMock(),
+    ):
+        for model in [
+            MistralAIEmbeddings(model="mistral-embed", mistral_api_key="test"),  # type: ignore[call-arg]
+            MistralAIEmbeddings(model="mistral-embed", api_key="test"),  # type: ignore[arg-type]
+        ]:
+            assert model.model == "mistral-embed"
+            assert cast("SecretStr", model.mistral_api_key).get_secret_value() == "test"
 
 
 def test_is_retryable_error_timeout() -> None:

--- a/libs/partners/nomic/Makefile
+++ b/libs/partners/nomic/Makefile
@@ -12,14 +12,11 @@ PYTEST_EXTRA ?=
 
 integration_test integration_tests: TEST_FILE = tests/integration_tests/
 
-test:
-	uv run --group test --group test_integration pytest $(PYTEST_EXTRA) $(TEST_FILE)
+test tests:
+	uv run --group test pytest $(PYTEST_EXTRA) --disable-socket --allow-unix-socket $(TEST_FILE)
 
 integration_test integration_tests:
 	uv run --group test --group test_integration pytest -v --tb=short -n auto --benchmark-disable $(PYTEST_EXTRA) $(TEST_FILE)
-
-tests:
-	uv run --group test pytest $(PYTEST_EXTRA) $(TEST_FILE)
 
 test_watch:
 	uv run --group test ptw --snapshot-update --now . -- -vv $(TEST_FILE)


### PR DESCRIPTION
Closes #39727

---
## Description
Partner unit-test targets now block network sockets, and Exa/Nomic no longer install integration dependencies for unit tests. The MistralAI initialization test mocks tokenizer loading so the isolated suite remains deterministic.

## Test Plan
- [x] `make test` in Exa, MistralAI, and Nomic; `make format && make lint` in MistralAI

Made by [Open SWE](https://openswe.vercel.app/agents/fd6865af-effb-565b-9a9c-082dd2de44d5)