### PR TITLE
fix(anthropic): preserve response_metadata when stream_usage=False (#39713)

### DIFF
--- a/PR_DESCRIPTION_DRAFT.md
+++ b/PR_DESCRIPTION_DRAFT.md
@@ -1,0 +1,16 @@
+## 📌 Summary
+Fixes #39713
+
+Preserves `response_metadata` fields (`model_name`, `stop_reason`, `stop_sequence`, etc.) when `stream_usage=False` in `ChatAnthropic`, while properly omitting only `usage_metadata`.
+
+---
+
+## 🔍 Root Cause Analysis
+Previously in `ChatAnthropic._make_message_chunk_from_anthropic_event`, `stream_usage` was part of the event-dispatch conditions (`if event.type == "message_start" and stream_usage:` and `elif event.type == "message_delta" and stream_usage:`). When callers set `stream_usage=False`, neither branch produced an `AIMessageChunk`, which caused callers to lose `model_name` and `stop_reason` during streaming completions.
+
+---
+
+## 🛠️ Solution
+- Decoupled `stream_usage` from event handling in `message_start` and `message_delta`.
+- Gated only the creation of `usage_metadata` (`_create_usage_metadata(event.usage) if stream_usage else None`).
+- Added unit test in `libs/partners/anthropic/tests/unit_tests/test_stream_usage_metadata.py`.

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1755,7 +1755,7 @@ class ChatAnthropic(BaseChatModel):
         message_chunk: AIMessageChunk | None = None
         # Reference: Anthropic SDK streaming implementation
         # https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/streaming/_messages.py  # noqa: E501
-        if event.type == "message_start" and stream_usage:
+        if event.type == "message_start":
             # Capture model name, but don't include usage_metadata yet
             # as it will be properly reported in message_delta with complete info
             if hasattr(event.message, "model"):
@@ -1909,8 +1909,10 @@ class ChatAnthropic(BaseChatModel):
                 message_chunk = AIMessageChunk(content=[content_block])
 
         # Process final usage metadata and completion info
-        elif event.type == "message_delta" and stream_usage:
-            usage_metadata = _create_usage_metadata(event.usage)
+        elif event.type == "message_delta":
+            usage_metadata = (
+                _create_usage_metadata(event.usage) if stream_usage else None
+            )
             response_metadata = {
                 "stop_reason": event.delta.stop_reason,
                 "stop_sequence": event.delta.stop_sequence,

--- a/libs/partners/anthropic/tests/unit_tests/test_stream_usage_metadata.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_stream_usage_metadata.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock
+from langchain_anthropic.chat_models import ChatAnthropic
+from langchain_core.messages import AIMessageChunk
+
+def test_stream_usage_false_preserves_response_metadata():
+    """Verify stream_usage=False preserves stop_reason and model_name while omitting usage_metadata (#39713)."""
+    chat = ChatAnthropic(model="claude-3-5-sonnet-20241022", api_key="mock-key")
+    
+    # Mock message_start event
+    mock_start = MagicMock()
+    mock_start.type = "message_start"
+    mock_start.message.model = "claude-3-5-sonnet-20241022"
+    
+    chunk_start, _ = chat._make_message_chunk_from_anthropic_event(
+        mock_start, stream_usage=False, coerce_content_to_string=False
+    )
+    assert chunk_start is not None
+    assert chunk_start.response_metadata.get("model_name") == "claude-3-5-sonnet-20241022"
+    assert chunk_start.usage_metadata is None
+
+    # Mock message_delta event
+    mock_delta = MagicMock()
+    mock_delta.type = "message_delta"
+    mock_delta.delta.stop_reason = "max_tokens"
+    mock_delta.delta.stop_sequence = None
+    mock_delta.delta.container = None
+    mock_delta.usage.input_tokens = 10
+    mock_delta.usage.output_tokens = 20
+
+    chunk_delta, _ = chat._make_message_chunk_from_anthropic_event(
+        mock_delta, stream_usage=False, coerce_content_to_string=False
+    )
+    assert chunk_delta is not None
+    assert chunk_delta.response_metadata.get("stop_reason") == "max_tokens"
+    assert chunk_delta.usage_metadata is None


### PR DESCRIPTION
## 📌 Summary
Fixes #39713

Preserves `response_metadata` fields (`model_name`, `stop_reason`, `stop_sequence`, etc.) when `stream_usage=False` in `ChatAnthropic`, while properly omitting only `usage_metadata`.

---

## 🔍 Root Cause Analysis
Previously in `ChatAnthropic._make_message_chunk_from_anthropic_event`, `stream_usage` was part of the event-dispatch conditions (`if event.type == "message_start" and stream_usage:` and `elif event.type == "message_delta" and stream_usage:`). When callers set `stream_usage=False`, neither branch produced an `AIMessageChunk`, which caused callers to lose `model_name` and `stop_reason` during streaming completions.

---

## 🛠️ Solution
- Decoupled `stream_usage` from event handling in `message_start` and `message_delta`.
- Gated only the creation of `usage_metadata` (`_create_usage_metadata(event.usage) if stream_usage else None`).
- Added unit test in `libs/partners/anthropic/tests/unit_tests/test_stream_usage_metadata.py`.
