### PR TITLE
feat(fireworks): add document reranking

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/__init__.py
+++ b/libs/partners/fireworks/langchain_fireworks/__init__.py
@@ -4,10 +4,12 @@ from langchain_fireworks._version import __version__
 from langchain_fireworks.chat_models import ChatFireworks
 from langchain_fireworks.embeddings import FireworksEmbeddings
 from langchain_fireworks.llms import Fireworks
+from langchain_fireworks.rerank import FireworksRerank
 
 __all__ = [
     "ChatFireworks",
     "Fireworks",
     "FireworksEmbeddings",
+    "FireworksRerank",
     "__version__",
 ]

--- a/libs/partners/fireworks/langchain_fireworks/rerank.py
+++ b/libs/partners/fireworks/langchain_fireworks/rerank.py
@@ -10,7 +10,7 @@ from typing import Any
 from langchain_core.callbacks import Callbacks
 from langchain_core.documents import BaseDocumentCompressor, Document
 from langchain_core.utils import secret_from_env
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import override
 
@@ -20,6 +20,9 @@ class FireworksRerank(BaseDocumentCompressor):
 
     client: Any = None
     """OpenAI-compatible client used to call Fireworks."""
+
+    async_client: Any = None
+    """Async OpenAI-compatible client used to call Fireworks."""
 
     top_n: int | None = 3
     """Number of documents to return."""
@@ -45,17 +48,23 @@ class FireworksRerank(BaseDocumentCompressor):
 
     @model_validator(mode="after")
     def validate_environment(self) -> FireworksRerank:
-        """Create the OpenAI-compatible client when one was not supplied."""
-        if self.client is None:
+        """Create the OpenAI-compatible clients that were not supplied."""
+        if self.client is None or self.async_client is None:
             if self.fireworks_api_key is None:
-                msg = "FIREWORKS_API_KEY is required when no client is supplied."
+                msg = (
+                    "FIREWORKS_API_KEY is required unless both client and "
+                    "async_client are supplied."
+                )
                 raise ValueError(msg)
-            api_key = self.fireworks_api_key.get_secret_value()
-            self.client = OpenAI(
-                api_key=api_key,
-                base_url=self.base_url,
-                default_headers={"User-Agent": self.user_agent},
-            )
+            client_kwargs: dict[str, Any] = {
+                "api_key": self.fireworks_api_key.get_secret_value(),
+                "base_url": self.base_url,
+                "default_headers": {"User-Agent": self.user_agent},
+            }
+            if self.client is None:
+                self.client = OpenAI(**client_kwargs)
+            if self.async_client is None:
+                self.async_client = AsyncOpenAI(**client_kwargs)
         return self
 
     def _document_to_str(
@@ -72,6 +81,43 @@ class FireworksRerank(BaseDocumentCompressor):
                 value = {key: document[key] for key in rank_fields if key in document}
             return json.dumps(value, ensure_ascii=False, default=str)
         return document
+
+    def _build_payload(
+        self,
+        documents: Sequence[str | Document | Mapping[str, Any]],
+        query: str,
+        *,
+        rank_fields: Sequence[str] | None,
+        model: str | None,
+        top_n: int | None,
+        task: str | None,
+    ) -> dict[str, Any]:
+        """Build the request body for the `/rerank` endpoint."""
+        requested_top_n = top_n if top_n is None or top_n > 0 else self.top_n
+        payload: dict[str, Any] = {
+            "model": model or self.model,
+            "query": query,
+            "documents": [
+                self._document_to_str(document, rank_fields) for document in documents
+            ],
+            "return_documents": False,
+        }
+        if requested_top_n is not None:
+            payload["top_n"] = requested_top_n
+        if task is not None:
+            payload["task"] = task
+        return payload
+
+    @staticmethod
+    def _parse_response(response: Mapping[str, Any]) -> list[dict[str, Any]]:
+        """Extract index and score pairs from a reranking response."""
+        return [
+            {
+                "index": result["index"],
+                "relevance_score": result["relevance_score"],
+            }
+            for result in response["data"]
+        ]
 
     def rerank(
         self,
@@ -99,28 +145,70 @@ class FireworksRerank(BaseDocumentCompressor):
         if not documents:
             return []
 
-        requested_top_n = top_n if top_n is None or top_n > 0 else self.top_n
-        payload: dict[str, Any] = {
-            "model": model or self.model,
-            "query": query,
-            "documents": [
-                self._document_to_str(document, rank_fields) for document in documents
-            ],
-            "return_documents": False,
-        }
-        if requested_top_n is not None:
-            payload["top_n"] = requested_top_n
-        if task is not None:
-            payload["task"] = task
-
+        payload = self._build_payload(
+            documents,
+            query,
+            rank_fields=rank_fields,
+            model=model,
+            top_n=top_n,
+            task=task,
+        )
         response = self.client.post("/rerank", cast_to=dict, body=payload)
-        return [
-            {
-                "index": result["index"],
-                "relevance_score": result["relevance_score"],
-            }
-            for result in response["data"]
-        ]
+        return self._parse_response(response)
+
+    async def arerank(
+        self,
+        documents: Sequence[str | Document | Mapping[str, Any]],
+        query: str,
+        *,
+        rank_fields: Sequence[str] | None = None,
+        model: str | None = None,
+        top_n: int | None = -1,
+        task: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Asynchronously return document indexes ordered by relevance to a query.
+
+        Args:
+            documents: Documents to rerank.
+            query: Query used for reranking.
+            rank_fields: Mapping fields to include when serializing mappings.
+            model: Model to use instead of the configured model.
+            top_n: Number of results to return. `None` returns all results.
+            task: Optional task instruction for the reranking model.
+
+        Returns:
+            Reranking results containing each document index and score.
+        """
+        if not documents:
+            return []
+
+        payload = self._build_payload(
+            documents,
+            query,
+            rank_fields=rank_fields,
+            model=model,
+            top_n=top_n,
+            task=task,
+        )
+        response = await self.async_client.post("/rerank", cast_to=dict, body=payload)
+        return self._parse_response(response)
+
+    @staticmethod
+    def _apply_results(
+        documents: Sequence[Document],
+        results: Sequence[Mapping[str, Any]],
+    ) -> list[Document]:
+        """Copy the reranked documents, recording each relevance score."""
+        compressed = []
+        for result in results:
+            document = documents[result["index"]]
+            document_copy = Document(
+                document.page_content,
+                metadata=deepcopy(document.metadata),
+            )
+            document_copy.metadata["relevance_score"] = result["relevance_score"]
+            compressed.append(document_copy)
+        return compressed
 
     @override
     def compress_documents(
@@ -130,13 +218,14 @@ class FireworksRerank(BaseDocumentCompressor):
         callbacks: Callbacks | None = None,
     ) -> Sequence[Document]:
         """Compress documents by keeping the most relevant results."""
-        compressed = []
-        for result in self.rerank(documents, query):
-            document = documents[result["index"]]
-            document_copy = Document(
-                document.page_content,
-                metadata=deepcopy(document.metadata),
-            )
-            document_copy.metadata["relevance_score"] = result["relevance_score"]
-            compressed.append(document_copy)
-        return compressed
+        return self._apply_results(documents, self.rerank(documents, query))
+
+    @override
+    async def acompress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks: Callbacks | None = None,
+    ) -> Sequence[Document]:
+        """Asynchronously compress documents by keeping the most relevant results."""
+        return self._apply_results(documents, await self.arerank(documents, query))

--- a/libs/partners/fireworks/langchain_fireworks/rerank.py
+++ b/libs/partners/fireworks/langchain_fireworks/rerank.py
@@ -47,11 +47,10 @@ class FireworksRerank(BaseDocumentCompressor):
     def validate_environment(self) -> FireworksRerank:
         """Create the OpenAI-compatible client when one was not supplied."""
         if self.client is None:
-            api_key = (
-                self.fireworks_api_key.get_secret_value()
-                if self.fireworks_api_key is not None
-                else None
-            )
+            if self.fireworks_api_key is None:
+                msg = "FIREWORKS_API_KEY is required when no client is supplied."
+                raise ValueError(msg)
+            api_key = self.fireworks_api_key.get_secret_value()
             self.client = OpenAI(
                 api_key=api_key,
                 base_url=self.base_url,

--- a/libs/partners/fireworks/langchain_fireworks/rerank.py
+++ b/libs/partners/fireworks/langchain_fireworks/rerank.py
@@ -1,0 +1,143 @@
+"""Fireworks document reranking integration."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from typing import Any
+
+from langchain_core.callbacks import Callbacks
+from langchain_core.documents import BaseDocumentCompressor, Document
+from langchain_core.utils import secret_from_env
+from openai import OpenAI
+from pydantic import ConfigDict, Field, SecretStr, model_validator
+from typing_extensions import override
+
+
+class FireworksRerank(BaseDocumentCompressor):
+    """Document compressor that uses Fireworks' reranking API."""
+
+    client: Any = None
+    """OpenAI-compatible client used to call Fireworks."""
+
+    top_n: int | None = 3
+    """Number of documents to return."""
+
+    model: str
+    """Fireworks reranking model to use."""
+
+    fireworks_api_key: SecretStr | None = Field(
+        default_factory=secret_from_env("FIREWORKS_API_KEY", default=None)
+    )
+    """Fireworks API key."""
+
+    base_url: str = "https://api.fireworks.ai/inference/v1"
+    """Base URL for the Fireworks API."""
+
+    user_agent: str = "langchain:partner"
+    """Identifier for the application making the request."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        extra="forbid",
+    )
+
+    @model_validator(mode="after")
+    def validate_environment(self) -> FireworksRerank:
+        """Create the OpenAI-compatible client when one was not supplied."""
+        if self.client is None:
+            api_key = (
+                self.fireworks_api_key.get_secret_value()
+                if self.fireworks_api_key is not None
+                else None
+            )
+            self.client = OpenAI(
+                api_key=api_key,
+                base_url=self.base_url,
+                default_headers={"User-Agent": self.user_agent},
+            )
+        return self
+
+    def _document_to_str(
+        self,
+        document: str | Document | Mapping[str, Any],
+        rank_fields: Sequence[str] | None = None,
+    ) -> str:
+        """Convert a supported document value to the string API format."""
+        if isinstance(document, Document):
+            return document.page_content
+        if isinstance(document, Mapping):
+            value: Mapping[str, Any] = document
+            if rank_fields is not None:
+                value = {key: document[key] for key in rank_fields if key in document}
+            return json.dumps(value, ensure_ascii=False, default=str)
+        return document
+
+    def rerank(
+        self,
+        documents: Sequence[str | Document | Mapping[str, Any]],
+        query: str,
+        *,
+        rank_fields: Sequence[str] | None = None,
+        model: str | None = None,
+        top_n: int | None = -1,
+        task: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return document indexes ordered by relevance to a query.
+
+        Args:
+            documents: Documents to rerank.
+            query: Query used for reranking.
+            rank_fields: Mapping fields to include when serializing mappings.
+            model: Model to use instead of the configured model.
+            top_n: Number of results to return. `None` returns all results.
+            task: Optional task instruction for the reranking model.
+
+        Returns:
+            Reranking results containing each document index and score.
+        """
+        if not documents:
+            return []
+
+        requested_top_n = top_n if top_n is None or top_n > 0 else self.top_n
+        payload: dict[str, Any] = {
+            "model": model or self.model,
+            "query": query,
+            "documents": [
+                self._document_to_str(document, rank_fields) for document in documents
+            ],
+            "return_documents": False,
+        }
+        if requested_top_n is not None:
+            payload["top_n"] = requested_top_n
+        if task is not None:
+            payload["task"] = task
+
+        response = self.client.post("/rerank", cast_to=dict, body=payload)
+        return [
+            {
+                "index": result["index"],
+                "relevance_score": result["relevance_score"],
+            }
+            for result in response["data"]
+        ]
+
+    @override
+    def compress_documents(
+        self,
+        documents: Sequence[Document],
+        query: str,
+        callbacks: Callbacks | None = None,
+    ) -> Sequence[Document]:
+        """Compress documents by keeping the most relevant results."""
+        compressed = []
+        for result in self.rerank(documents, query):
+            document = documents[result["index"]]
+            document_copy = Document(
+                document.page_content,
+                metadata=deepcopy(document.metadata),
+            )
+            document_copy.metadata["relevance_score"] = result["relevance_score"]
+            compressed.append(document_copy)
+        return compressed

--- a/libs/partners/fireworks/langchain_fireworks/rerank.py
+++ b/libs/partners/fireworks/langchain_fireworks/rerank.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import Any
 
+from langchain_core._api import beta
 from langchain_core.callbacks import Callbacks
 from langchain_core.documents import BaseDocumentCompressor, Document
 from langchain_core.utils import secret_from_env
@@ -19,6 +20,7 @@ from typing_extensions import override
 _RESPONSE_TYPE = dict[str, Any]
 
 
+@beta()
 class FireworksRerank(BaseDocumentCompressor):
     """Document compressor that uses Fireworks' reranking API."""
 

--- a/libs/partners/fireworks/langchain_fireworks/rerank.py
+++ b/libs/partners/fireworks/langchain_fireworks/rerank.py
@@ -14,6 +14,10 @@ from openai import AsyncOpenAI, OpenAI
 from pydantic import ConfigDict, Field, SecretStr, model_validator
 from typing_extensions import override
 
+# The OpenAI SDK unpacks `get_args()` on a `dict` `cast_to`, so a bare `dict`
+# raises `ValueError` while parsing the response. Keep this parameterized.
+_RESPONSE_TYPE = dict[str, Any]
+
 
 class FireworksRerank(BaseDocumentCompressor):
     """Document compressor that uses Fireworks' reranking API."""
@@ -153,7 +157,7 @@ class FireworksRerank(BaseDocumentCompressor):
             top_n=top_n,
             task=task,
         )
-        response = self.client.post("/rerank", cast_to=dict, body=payload)
+        response = self.client.post("/rerank", cast_to=_RESPONSE_TYPE, body=payload)
         return self._parse_response(response)
 
     async def arerank(
@@ -190,7 +194,9 @@ class FireworksRerank(BaseDocumentCompressor):
             top_n=top_n,
             task=task,
         )
-        response = await self.async_client.post("/rerank", cast_to=dict, body=payload)
+        response = await self.async_client.post(
+            "/rerank", cast_to=_RESPONSE_TYPE, body=payload
+        )
         return self._parse_response(response)
 
     @staticmethod

--- a/libs/partners/fireworks/tests/unit_tests/test_imports.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_imports.py
@@ -5,6 +5,7 @@ EXPECTED_ALL = [
     "ChatFireworks",
     "Fireworks",
     "FireworksEmbeddings",
+    "FireworksRerank",
 ]
 
 

--- a/libs/partners/fireworks/tests/unit_tests/test_rerank.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_rerank.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import pytest
 from langchain_core.documents import Document
 
 from langchain_fireworks import FireworksRerank
@@ -21,9 +22,45 @@ class FakeClient:
         return self.response
 
 
+class FakeAsyncClient(FakeClient):
+    async def post(  # type: ignore[override]
+        self,
+        path: str,
+        *,
+        cast_to: type[dict[str, Any]],
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        return super().post(path, cast_to=cast_to, body=body)
+
+
+def _reranker(
+    response: dict[str, Any], **kwargs: Any
+) -> tuple[FireworksRerank, FakeClient, FakeAsyncClient]:
+    client = FakeClient(response)
+    async_client = FakeAsyncClient(response)
+    reranker = FireworksRerank(client=client, async_client=async_client, **kwargs)
+    return reranker, client, async_client
+
+
+def test_missing_api_key_without_clients() -> None:
+    with pytest.raises(ValueError, match="FIREWORKS_API_KEY is required"):
+        FireworksRerank(model="reranker", fireworks_api_key=None)
+
+
+def test_missing_api_key_with_only_sync_client() -> None:
+    with pytest.raises(ValueError, match="FIREWORKS_API_KEY is required"):
+        FireworksRerank(
+            model="reranker",
+            client=FakeClient({"data": []}),
+            fireworks_api_key=None,
+        )
+
+
 def test_rerank_posts_fireworks_payload() -> None:
-    client = FakeClient({"data": [{"index": 1, "relevance_score": 0.9}]})
-    reranker = FireworksRerank(model="fireworks/qwen3-reranker-8b", client=client)
+    reranker, client, _ = _reranker(
+        {"data": [{"index": 1, "relevance_score": 0.9}]},
+        model="fireworks/qwen3-reranker-8b",
+    )
 
     result = reranker.rerank(
         [Document("first"), Document("second")],
@@ -47,9 +84,37 @@ def test_rerank_posts_fireworks_payload() -> None:
     ]
 
 
+async def test_arerank_posts_fireworks_payload() -> None:
+    reranker, client, async_client = _reranker(
+        {"data": [{"index": 1, "relevance_score": 0.9}]},
+        model="fireworks/qwen3-reranker-8b",
+    )
+
+    result = await reranker.arerank(
+        [Document("first"), Document("second")],
+        "the query",
+        top_n=1,
+    )
+
+    assert result == [{"index": 1, "relevance_score": 0.9}]
+    assert async_client.calls == [
+        {
+            "path": "/rerank",
+            "cast_to": dict,
+            "body": {
+                "model": "fireworks/qwen3-reranker-8b",
+                "query": "the query",
+                "documents": ["first", "second"],
+                "return_documents": False,
+                "top_n": 1,
+            },
+        }
+    ]
+    assert client.calls == []
+
+
 def test_rerank_serializes_mappings_and_rank_fields() -> None:
-    client = FakeClient({"data": []})
-    reranker = FireworksRerank(model="reranker", client=client)
+    reranker, client, _ = _reranker({"data": []}, model="reranker")
 
     reranker.rerank(
         [{"title": "keep", "body": "keep", "ignored": "drop"}],
@@ -66,24 +131,48 @@ def test_rerank_serializes_mappings_and_rank_fields() -> None:
     }
 
 
+async def test_arerank_serializes_mappings_and_rank_fields() -> None:
+    reranker, _, async_client = _reranker({"data": []}, model="reranker")
+
+    await reranker.arerank(
+        [{"title": "keep", "body": "keep", "ignored": "drop"}],
+        "query",
+        rank_fields=["title", "body"],
+        top_n=None,
+    )
+
+    assert async_client.calls[0]["body"] == {
+        "model": "reranker",
+        "query": "query",
+        "documents": ['{"title": "keep", "body": "keep"}'],
+        "return_documents": False,
+    }
+
+
 def test_rerank_empty_documents_does_not_call_client() -> None:
-    client = FakeClient({"data": []})
-    reranker = FireworksRerank(model="reranker", client=client)
+    reranker, client, _ = _reranker({"data": []}, model="reranker")
 
     assert reranker.rerank([], "query") == []
     assert client.calls == []
 
 
+async def test_arerank_empty_documents_does_not_call_client() -> None:
+    reranker, _, async_client = _reranker({"data": []}, model="reranker")
+
+    assert await reranker.arerank([], "query") == []
+    assert async_client.calls == []
+
+
 def test_compress_documents_preserves_metadata_and_adds_score() -> None:
-    client = FakeClient(
+    reranker, _, _ = _reranker(
         {
             "data": [
                 {"index": 1, "relevance_score": 0.8},
                 {"index": 0, "relevance_score": 0.4},
             ]
-        }
+        },
+        model="reranker",
     )
-    reranker = FireworksRerank(model="reranker", client=client)
     documents = [
         Document("first", metadata={"nested": {"value": 1}}),
         Document("second", metadata={"source": "test"}),
@@ -97,3 +186,32 @@ def test_compress_documents_preserves_metadata_and_adds_score() -> None:
         "nested": {"value": 1},
         "relevance_score": 0.4,
     }
+
+
+async def test_acompress_documents_preserves_metadata_and_adds_score() -> None:
+    reranker, client, async_client = _reranker(
+        {
+            "data": [
+                {"index": 1, "relevance_score": 0.8},
+                {"index": 0, "relevance_score": 0.4},
+            ]
+        },
+        model="reranker",
+    )
+    documents = [
+        Document("first", metadata={"nested": {"value": 1}}),
+        Document("second", metadata={"source": "test"}),
+    ]
+
+    result = await reranker.acompress_documents(documents, "query")
+
+    assert [document.page_content for document in result] == ["second", "first"]
+    assert result[0].metadata == {"source": "test", "relevance_score": 0.8}
+    assert result[1].metadata == {
+        "nested": {"value": 1},
+        "relevance_score": 0.4,
+    }
+    assert documents[1].metadata == {"source": "test"}
+    # The async path must not fall back to the sync client via `run_in_executor`.
+    assert client.calls == []
+    assert len(async_client.calls) == 1

--- a/libs/partners/fireworks/tests/unit_tests/test_rerank.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_rerank.py
@@ -72,7 +72,7 @@ def test_rerank_posts_fireworks_payload() -> None:
     assert client.calls == [
         {
             "path": "/rerank",
-            "cast_to": dict,
+            "cast_to": dict[str, Any],
             "body": {
                 "model": "fireworks/qwen3-reranker-8b",
                 "query": "the query",
@@ -100,7 +100,7 @@ async def test_arerank_posts_fireworks_payload() -> None:
     assert async_client.calls == [
         {
             "path": "/rerank",
-            "cast_to": dict,
+            "cast_to": dict[str, Any],
             "body": {
                 "model": "fireworks/qwen3-reranker-8b",
                 "query": "the query",

--- a/libs/partners/fireworks/tests/unit_tests/test_rerank.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_rerank.py
@@ -1,0 +1,99 @@
+from typing import Any
+
+from langchain_core.documents import Document
+
+from langchain_fireworks import FireworksRerank
+
+
+class FakeClient:
+    def __init__(self, response: dict[str, Any]) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def post(
+        self,
+        path: str,
+        *,
+        cast_to: type[dict[str, Any]],
+        body: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.calls.append({"path": path, "cast_to": cast_to, "body": body})
+        return self.response
+
+
+def test_rerank_posts_fireworks_payload() -> None:
+    client = FakeClient({"data": [{"index": 1, "relevance_score": 0.9}]})
+    reranker = FireworksRerank(model="fireworks/qwen3-reranker-8b", client=client)
+
+    result = reranker.rerank(
+        [Document("first"), Document("second")],
+        "the query",
+        top_n=1,
+    )
+
+    assert result == [{"index": 1, "relevance_score": 0.9}]
+    assert client.calls == [
+        {
+            "path": "/rerank",
+            "cast_to": dict,
+            "body": {
+                "model": "fireworks/qwen3-reranker-8b",
+                "query": "the query",
+                "documents": ["first", "second"],
+                "return_documents": False,
+                "top_n": 1,
+            },
+        }
+    ]
+
+
+def test_rerank_serializes_mappings_and_rank_fields() -> None:
+    client = FakeClient({"data": []})
+    reranker = FireworksRerank(model="reranker", client=client)
+
+    reranker.rerank(
+        [{"title": "keep", "body": "keep", "ignored": "drop"}],
+        "query",
+        rank_fields=["title", "body"],
+        top_n=None,
+    )
+
+    assert client.calls[0]["body"] == {
+        "model": "reranker",
+        "query": "query",
+        "documents": ['{"title": "keep", "body": "keep"}'],
+        "return_documents": False,
+    }
+
+
+def test_rerank_empty_documents_does_not_call_client() -> None:
+    client = FakeClient({"data": []})
+    reranker = FireworksRerank(model="reranker", client=client)
+
+    assert reranker.rerank([], "query") == []
+    assert client.calls == []
+
+
+def test_compress_documents_preserves_metadata_and_adds_score() -> None:
+    client = FakeClient(
+        {
+            "data": [
+                {"index": 1, "relevance_score": 0.8},
+                {"index": 0, "relevance_score": 0.4},
+            ]
+        }
+    )
+    reranker = FireworksRerank(model="reranker", client=client)
+    documents = [
+        Document("first", metadata={"nested": {"value": 1}}),
+        Document("second", metadata={"source": "test"}),
+    ]
+
+    result = reranker.compress_documents(documents, "query")
+
+    assert [document.page_content for document in result] == ["second", "first"]
+    assert result[0].metadata == {"source": "test", "relevance_score": 0.8}
+    assert result[1].metadata == {
+        "nested": {"value": 1},
+        "relevance_score": 0.4,
+    }


### PR DESCRIPTION
Fixes #39340

Add `FireworksRerank` to `langchain-fireworks`, allowing users to rerank LangChain documents with Fireworks reranking models through the standard `BaseDocumentCompressor` interface.

## Release note

Add native Fireworks document reranking support.

## Verification

- make format, lint, test passed
- Created unit test covering fireworks request payloads, document conversion, empty inputs and metadata preservation.

## Social handles

LinkedIn: https://linkedin.com/in/11adyy