### PR TITLE
fix(core): stop dropping list-content messages in list/XML parser streaming

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -74,11 +74,8 @@ class ListOutputParser(BaseTransformOutputParser[list[str]]):
         buffer = ""
         for chunk in input:
             if isinstance(chunk, BaseMessage):
-                # Extract text
-                chunk_content = chunk.content
-                if not isinstance(chunk_content, str):
-                    continue
-                buffer += chunk_content
+                # Extract text (also covers list content, e.g. content blocks)
+                buffer += chunk.text
             else:
                 # Add current chunk to buffer
                 buffer += chunk
@@ -108,11 +105,8 @@ class ListOutputParser(BaseTransformOutputParser[list[str]]):
         buffer = ""
         async for chunk in input:
             if isinstance(chunk, BaseMessage):
-                # Extract text
-                chunk_content = chunk.content
-                if not isinstance(chunk_content, str):
-                    continue
-                buffer += chunk_content
+                # Extract text (also covers list content, e.g. content blocks)
+                buffer += chunk.text
             else:
                 # Add current chunk to buffer
                 buffer += chunk

--- a/libs/core/langchain_core/output_parsers/xml.py
+++ b/libs/core/langchain_core/output_parsers/xml.py
@@ -91,12 +91,9 @@ class _StreamingParser:
             xml.etree.ElementTree.ParseError: If the XML is not well-formed.
         """
         if isinstance(chunk, BaseMessage):
-            # extract text
-            chunk_content = chunk.content
-            if not isinstance(chunk_content, str):
-                # ignore non-string messages (e.g., function calls)
-                return
-            chunk = chunk_content
+            # extract text; also covers list content (e.g. content blocks), in
+            # which non-text blocks (e.g., tool calls) contribute nothing
+            chunk = chunk.text
         # add chunk to buffer of unprocessed text
         self.buffer += chunk
         # if xml string hasn't started yet, continue to next chunk

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncIterator, Iterable
 from typing import TypeVar
 
+from langchain_core.messages import AIMessageChunk
 from langchain_core.output_parsers.list import (
     CommaSeparatedListOutputParser,
     MarkdownListOutputParser,
@@ -312,3 +313,34 @@ async def test_markdown_list_async() -> None:
         assert [
             a async for a in parser.atransform(aiter_from_iter([text]))
         ] == expectedlist
+
+
+def test_list_content_stream() -> None:
+    """Streamed messages with list content parse the same as string content."""
+    parser = CommaSeparatedListOutputParser()
+    chunks = [
+        AIMessageChunk(content=[{"type": "text", "text": "foo, ba", "index": 0}]),
+        AIMessageChunk(content=[{"type": "text", "text": "r, baz", "index": 0}]),
+        # Non-text blocks contribute no text, same as in `parse`
+        AIMessageChunk(
+            content=[{"type": "tool_call_chunk", "name": "t", "args": "", "index": 1}]
+        ),
+    ]
+    assert list(parser.transform(iter(chunks))) == [["foo"], ["bar"], ["baz"]]
+
+
+async def test_list_content_stream_async() -> None:
+    """Streamed messages with list content parse the same as string content."""
+    parser = CommaSeparatedListOutputParser()
+    chunks = [
+        AIMessageChunk(content=[{"type": "text", "text": "foo, ba", "index": 0}]),
+        AIMessageChunk(content=[{"type": "text", "text": "r, baz", "index": 0}]),
+        AIMessageChunk(
+            content=[{"type": "tool_call_chunk", "name": "t", "args": "", "index": 1}]
+        ),
+    ]
+    assert [a async for a in parser.atransform(aiter_from_iter(chunks))] == [
+        ["foo"],
+        ["bar"],
+        ["baz"],
+    ]

--- a/libs/core/tests/unit_tests/output_parsers/test_xml_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_xml_parser.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator, Iterable
 import pytest
 
 from langchain_core.exceptions import OutputParserException
+from langchain_core.messages import AIMessageChunk
 from langchain_core.output_parsers.xml import XMLOutputParser
 
 DATA = """
@@ -120,6 +121,25 @@ async def test_xml_output_parser_defused(content: str) -> None:
     """Test XMLOutputParser."""
     xml_parser = XMLOutputParser(parser="defusedxml")
     await _test_parser(xml_parser, content)
+
+
+async def test_xml_output_parser_list_content_stream() -> None:
+    """Streamed messages with list content parse the same as string content."""
+    xml_parser = XMLOutputParser(parser="xml")
+    chunks = [
+        AIMessageChunk(content=[{"type": "text", "text": "<body>Text of", "index": 0}]),
+        AIMessageChunk(content=[{"type": "text", "text": " the body.", "index": 0}]),
+        AIMessageChunk(content=[{"type": "text", "text": "</body>", "index": 0}]),
+    ]
+
+    async def _achunks() -> AsyncIterator[AIMessageChunk]:
+        for chunk in chunks:
+            yield chunk
+
+    assert list(xml_parser.transform(iter(chunks))) == [{"body": "Text of the body."}]
+    assert [a async for a in xml_parser.atransform(_achunks())] == [
+        {"body": "Text of the body."}
+    ]
 
 
 @pytest.mark.parametrize("result", ["foo></foo>", "<foo></foo", "foo></foo", "foofoo"])


### PR DESCRIPTION
Fixes #39744

## Description

`ListOutputParser._transform`/`_atransform` and the XML `_StreamingParser` skip any message whose content is not a plain string, so streaming from providers that emit content blocks (e.g. Anthropic) silently yields nothing while `invoke()` on the same message parses fine — repro in the linked issue. This replaces the skip guard with `message.text`, the same extraction the non-streaming `ChatGeneration` path uses, so streaming and invoke see identical text. String content is returned unchanged by `.text`, so the existing path is unaffected, and pure tool-call messages contribute `""`, preserving the original "ignore function calls" intent.

## Tests

Added sync+async regression tests for `CommaSeparatedListOutputParser` and `XMLOutputParser` streaming over list-content chunks, including a non-text (tool-call) block that must stay ignored. They fail on `master` (`assert [] == [['foo'], ['bar'], ['baz']]`) and pass with the fix. Full `tests/unit_tests/output_parsers/` suite: 129 passed; `runnables/test_runnable.py` + `test_graph.py`: 134 passed, 8 skipped. `ruff check`/`ruff format --check`/`mypy` clean on changed files.

Disclosure: prepared with AI assistance (Claude Code); I reviewed, ran, and verified everything myself.