### PR TITLE
fix(core): preserve tool schema and execution semantics

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -30,6 +30,7 @@ from pydantic import (
     Field,
     PrivateAttr,
     PydanticDeprecationWarning,
+    RootModel,
     SkipValidation,
     ValidationError,
     validate_arguments,
@@ -59,6 +60,7 @@ from langchain_core.utils.function_calling import (
     _parse_google_docstring,
     _py_38_safe_origin,
 )
+from langchain_core.utils.json_schema import dereference_refs
 from langchain_core.utils.pydantic import (
     TypeBaseModel,
     _create_subset_model,
@@ -354,7 +356,10 @@ def create_schema_from_function(
         if not has_kwargs and field == "kwargs":
             continue
 
-        if field == "v__duplicate_kwargs":  # Internal pydantic field
+        if field in {
+            "v__duplicate_kwargs",
+            "v__positional_only",
+        }:  # Internal pydantic fields
             continue
 
         if field not in filter_args_:
@@ -429,6 +434,51 @@ def _patch_json_schema_cache(model_cls: type) -> None:
         return cast("dict[str, Any]", result)
 
     setattr(model_cls, method_name, classmethod(_cached_json_schema))
+
+
+def _extract_model_input(
+    result: BaseModel | BaseModelV1,
+    input_args: type[BaseModel | BaseModelV1],
+) -> dict[str, Any]:
+    """Extract validated tool arguments without applying serialization settings."""
+    if isinstance(result, RootModel):
+        root = result.root
+        return root.copy() if isinstance(root, dict) else {"root": root}
+
+    field_info = get_fields(input_args)
+    provided_fields = (
+        result.model_fields_set
+        if isinstance(result, BaseModel)
+        else result.__fields_set__
+    )
+    validated_input: dict[str, Any] = {}
+    for field_name, field in field_info.items():
+        if field_name in {"v__duplicate_kwargs", "v__positional_only"}:
+            continue
+        if field_name in provided_fields:
+            validated_input[field_name] = getattr(result, field_name)
+            continue
+        if field_name in {"args", "kwargs"}:
+            continue
+        has_default = (
+            not field.is_required()
+            if hasattr(field, "is_required")
+            else not getattr(field, "required", True)
+        )
+        if has_default:
+            validated_input[field_name] = getattr(result, field_name)
+
+    if isinstance(result, BaseModel):
+        validated_input.update(result.model_extra or {})
+    else:
+        validated_input.update(
+            {
+                key: value
+                for key, value in result.__dict__.items()
+                if key not in field_info
+            }
+        )
+    return validated_input
 
 
 class BaseTool(RunnableSerializable[str | dict[str, Any] | ToolCall, Any]):
@@ -700,6 +750,15 @@ class ChildTool(BaseTool):
             return memo
 
         full_schema = self.get_input_schema()
+        if isinstance(full_schema, type) and issubclass(full_schema, RootModel):
+            root_schema = dereference_refs(model_json_schema(full_schema))
+            if root_schema.get("type") == "object":
+                root_schema.pop("$defs", None)
+                root_schema["title"] = self.name
+                if self.description:
+                    root_schema["description"] = self.description
+                self._tool_call_schema_memo = root_schema
+                return root_schema
         fields = []
         for name, type_ in get_all_basemodel_annotations(full_schema).items():
             if not _is_injected_arg_type(type_):
@@ -725,13 +784,24 @@ class ChildTool(BaseTool):
         # `from __future__ import annotations` or quoted forward references --
         # are recognized. Fall back to the raw annotation per-parameter when a
         # hint can't be resolved.
+        return self._get_injected_args_keys(None)
+
+    @functools.cached_property
+    def _injected_tool_call_id_keys(self) -> frozenset[str]:
+        return self._get_injected_args_keys(InjectedToolCallId)
+
+    def _get_injected_args_keys(
+        self, injected_type: type[InjectedToolArg] | None
+    ) -> frozenset[str]:
         for method in (self._run, self._arun):
             params = signature(method).parameters
             hints = _get_type_hints(method, include_extras=True) or {}
             keys = frozenset(
                 name
                 for name, param in params.items()
-                if _is_injected_arg_type(hints.get(name, param.annotation))
+                if _is_injected_arg_type(
+                    hints.get(name, param.annotation), injected_type=injected_type
+                )
             )
             if keys:
                 return keys
@@ -834,8 +904,6 @@ class ChildTool(BaseTool):
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
                 result_v2 = input_args.model_validate(tool_input)
-                result_dict = result_v2.model_dump()
-                provided_fields = result_v2.model_fields_set
                 result = result_v2
             elif issubclass(input_args, BaseModelV1):
                 # Check args_schema for InjectedToolCallId
@@ -852,8 +920,6 @@ class ChildTool(BaseTool):
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
                 result_v1 = input_args.parse_obj(tool_input)
-                result_dict = result_v1.dict()
-                provided_fields = result_v1.__fields_set__
                 result = result_v1
             else:
                 msg = (  # type: ignore[unreachable]
@@ -861,37 +927,12 @@ class ChildTool(BaseTool):
                 )
                 raise NotImplementedError(msg)
 
-            # Include fields from tool_input, fields provided through Pydantic aliases,
-            # plus fields with explicit defaults. This applies Pydantic defaults (like
-            # Field(default=1)) while excluding synthetic "args"/"kwargs" fields that
-            # Pydantic creates for *args/**kwargs.
-            field_info = get_fields(input_args)
-            validated_input = {}
-            for k in result_dict:
-                if k in tool_input:
-                    # Field was provided in input - include it (validated)
-                    validated_input[k] = getattr(result, k)
-                elif k in provided_fields:
-                    # Field was provided through a Pydantic alias - include it.
-                    validated_input[k] = getattr(result, k)
-                elif k in field_info and k not in {"args", "kwargs"}:
-                    # Check if field has an explicit default defined in the schema.
-                    # Exclude "args"/"kwargs" as these are synthetic fields for variadic
-                    # parameters that should not be passed as keyword arguments.
-                    fi = field_info[k]
-                    # Pydantic v2 uses is_required() method, v1 uses required attribute
-                    has_default = (
-                        not fi.is_required()
-                        if hasattr(fi, "is_required")
-                        else not getattr(fi, "required", True)
-                    )
-                    if has_default:
-                        validated_input[k] = getattr(result, k)
+            validated_input = _extract_model_input(result, input_args)
 
             for k in self._injected_args_keys:
                 if k in tool_input:
                     validated_input[k] = tool_input[k]
-                elif k == "tool_call_id":
+                elif k in self._injected_tool_call_id_keys:
                     if tool_call_id is None:
                         msg = (
                             "When tool includes an InjectedToolCallId "
@@ -1129,7 +1170,7 @@ class ChildTool(BaseTool):
         except (Exception, KeyboardInterrupt) as e:
             error_to_raise = e
 
-        if error_to_raise:
+        if error_to_raise is not None:
             run_manager.on_tool_error(error_to_raise, tool_call_id=tool_call_id)
             raise error_to_raise
         output = _format_output(content, artifact, tool_call_id, self.name, status)
@@ -1259,7 +1300,7 @@ class ChildTool(BaseTool):
         except (Exception, KeyboardInterrupt) as e:
             error_to_raise = e
 
-        if error_to_raise:
+        if error_to_raise is not None:
             await run_manager.on_tool_error(error_to_raise, tool_call_id=tool_call_id)
             raise error_to_raise
 
@@ -1654,6 +1695,11 @@ def get_all_basemodel_annotations(
                 continue
             field_name = alias_map.get(name, name)
             annotations[field_name] = param.annotation
+        for field_name, field in fields.items():
+            if field_name not in annotations:
+                field_annotation = field.annotation
+                if field_annotation is not None:
+                    annotations[field_name] = field_annotation
         orig_bases = getattr(cls, "__orig_bases__", ())
     # cls has subscript: cls = FooBar[int]
     else:

--- a/libs/core/langchain_core/tools/structured.py
+++ b/libs/core/langchain_core/tools/structured.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import functools
 import textwrap
 from collections.abc import Awaitable, Callable
 from inspect import signature
@@ -27,7 +26,9 @@ from langchain_core.tools.base import (
     FILTERED_ARGS,
     ArgsSchema,
     BaseTool,
+    InjectedToolArg,
     _get_runnable_config_param,
+    _get_type_hints,
     _is_injected_arg_type,
     create_schema_from_function,
 )
@@ -94,7 +95,8 @@ class StructuredTool(BaseTool):
                 kwargs["callbacks"] = run_manager.get_child()
             if config_param := _get_runnable_config_param(self.func):
                 kwargs[config_param] = config
-            return self.func(*args, **kwargs)
+            call_args, call_kwargs = _prepare_function_call(self.func, args, kwargs)
+            return self.func(*call_args, **call_kwargs)
         msg = "StructuredTool does not support sync invocation."
         raise NotImplementedError(msg)
 
@@ -121,7 +123,10 @@ class StructuredTool(BaseTool):
                 kwargs["callbacks"] = run_manager.get_child()
             if config_param := _get_runnable_config_param(self.coroutine):
                 kwargs[config_param] = config
-            return await self.coroutine(*args, **kwargs)
+            call_args, call_kwargs = _prepare_function_call(
+                self.coroutine, args, kwargs
+            )
+            return await self.coroutine(*call_args, **call_kwargs)
 
         # If self.coroutine is None, then this will delegate to the default
         # implementation which is expected to delegate to _run on a separate thread.
@@ -251,16 +256,65 @@ class StructuredTool(BaseTool):
             **kwargs,
         )
 
-    @functools.cached_property
-    def _injected_args_keys(self) -> frozenset[str]:
+    @override
+    def _get_injected_args_keys(
+        self, injected_type: type[InjectedToolArg] | None
+    ) -> frozenset[str]:
         fn = self.func or self.coroutine
         if fn is None:
             return _EMPTY_SET
+        params = signature(fn).parameters
+        hints = _get_type_hints(fn, include_extras=True) or {}
         return frozenset(
-            k
-            for k, v in signature(fn).parameters.items()
-            if _is_injected_arg_type(v.annotation)
+            name
+            for name, param in params.items()
+            if _is_injected_arg_type(
+                hints.get(name, param.annotation), injected_type=injected_type
+            )
         )
+
+
+def _prepare_function_call(
+    func: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    """Convert structured arguments for positional-only and variadic callables."""
+    if args:
+        return args, kwargs
+
+    parameters = tuple(signature(func).parameters.values())
+    var_positional = next(
+        (
+            parameter
+            for parameter in parameters
+            if parameter.kind == parameter.VAR_POSITIONAL
+        ),
+        None,
+    )
+    expand_varargs = (
+        var_positional is not None and kwargs.get(var_positional.name) is not None
+    )
+    positional_args: list[Any] = []
+    call_kwargs = kwargs.copy()
+
+    for parameter in parameters:
+        if parameter.kind == parameter.POSITIONAL_ONLY:
+            if parameter.name in call_kwargs:
+                positional_args.append(call_kwargs.pop(parameter.name))
+        elif parameter.kind == parameter.POSITIONAL_OR_KEYWORD and expand_varargs:
+            if parameter.name in call_kwargs:
+                positional_args.append(call_kwargs.pop(parameter.name))
+            elif parameter.default is not parameter.empty:
+                positional_args.append(parameter.default)
+        elif parameter.kind == parameter.VAR_POSITIONAL:
+            positional_args.extend(call_kwargs.pop(parameter.name, None) or ())
+        elif parameter.kind == parameter.VAR_KEYWORD:
+            extra_kwargs = call_kwargs.pop(parameter.name, None)
+            if extra_kwargs:
+                call_kwargs.update(extra_kwargs)
+
+    return tuple(positional_args), call_kwargs
 
 
 def _filter_schema_args(func: Callable[..., Any]) -> list[str]:

--- a/libs/core/langchain_core/utils/pydantic.py
+++ b/libs/core/langchain_core/utils/pydantic.py
@@ -6,6 +6,7 @@ import inspect
 import textwrap
 import warnings
 from contextlib import nullcontext
+from copy import copy
 from functools import lru_cache, wraps
 from types import GenericAlias
 from typing import (
@@ -243,15 +244,8 @@ def _create_subset_model_v2(
     fields = {}
     for field_name in field_names:
         field = model.model_fields[field_name]
-        description = descriptions_.get(field_name, field.description)
-        field_kwargs: dict[str, Any] = {"description": description}
-        if field.default_factory is not None:
-            field_kwargs["default_factory"] = field.default_factory
-        else:
-            field_kwargs["default"] = field.default
-        field_info = FieldInfoV2(**field_kwargs)
-        if field.metadata:
-            field_info.metadata = field.metadata
+        field_info = copy(field)
+        field_info.description = descriptions_.get(field_name, field.description)
         fields[field_name] = (field.annotation, field_info)
 
     rtn = cast(

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -821,6 +821,54 @@ def test_create_tool_keyword_args() -> None:
     assert test_tool.description == "test_description"
 
 
+def test_structured_tool_positional_only_args() -> None:
+    """Structured tools bind positional-only parameters from dictionary inputs."""
+
+    @tool
+    def add(x: int, /, y: int) -> int:
+        """Add two values."""
+        return x + y
+
+    properties = _get_tool_call_json_schema(add)["properties"]
+    assert properties.keys() == {"x", "y"}
+    assert "v__positional_only" not in properties
+    assert add.invoke({"x": 1, "y": 2}) == 3
+
+
+def test_structured_tool_var_positional_args() -> None:
+    """Structured tools expand validated variadic positional parameters."""
+
+    @tool
+    def join(prefix: str, *values: int) -> str:
+        """Join a prefix and integer values."""
+        return f"{prefix}:{','.join(str(value) for value in values)}"
+
+    assert join.invoke({"prefix": "n", "values": [1, 2]}) == "n:1,2"
+
+
+def test_structured_tool_var_keyword_args() -> None:
+    """Structured tools expand validated variadic keyword parameters."""
+
+    @tool
+    def join(prefix: str, **values: int) -> str:
+        """Join a prefix and named integer values."""
+        rendered = ",".join(f"{key}={value}" for key, value in values.items())
+        return f"{prefix}:{rendered}"
+
+    assert join.invoke({"prefix": "n", "values": {"a": 1, "b": 2}}) == "n:a=1,b=2"
+
+
+async def test_async_structured_tool_var_positional_args() -> None:
+    """Async structured tools expand validated variadic parameters."""
+
+    @tool
+    async def join(prefix: str, *values: int) -> str:
+        """Join a prefix and integer values."""
+        return f"{prefix}:{','.join(str(value) for value in values)}"
+
+    assert await join.ainvoke({"prefix": "n", "values": [1, 2]}) == "n:1,2"
+
+
 async def test_create_async_tool() -> None:
     """Test that async tools are allowed."""
 
@@ -851,6 +899,11 @@ class _FakeExceptionTool(BaseTool):
 
     async def _arun(self) -> str:
         raise self.exception
+
+
+class _FalseyError(RuntimeError):
+    def __bool__(self) -> bool:
+        return False
 
 
 def test_exception_handling_bool() -> None:
@@ -950,6 +1003,12 @@ def test_exception_handling_non_tool_exception() -> None:
         tool_.run({})
 
 
+def test_falsey_exception_is_raised() -> None:
+    tool_ = _FakeExceptionTool(exception=_FalseyError("some error"))
+    with pytest.raises(_FalseyError, match="some error"):
+        tool_.run({})
+
+
 async def test_async_exception_handling_bool() -> None:
     tool_ = _FakeExceptionTool(handle_tool_error=True)
     expected = "Tool execution error"
@@ -1024,6 +1083,12 @@ async def test_async_exception_handling_callable_message_content_blocks_sequence
 async def test_async_exception_handling_non_tool_exception() -> None:
     tool_ = _FakeExceptionTool(exception=ValueError("some error"))
     with pytest.raises(ValueError, match="some error"):
+        await tool_.arun({})
+
+
+async def test_async_falsey_exception_is_raised() -> None:
+    tool_ = _FakeExceptionTool(exception=_FalseyError("some error"))
+    with pytest.raises(_FalseyError, match="some error"):
         await tool_.arun({})
 
 
@@ -2863,6 +2928,30 @@ def test_tool_injected_tool_call_id_with_custom_schema() -> None:
     assert result == ToolMessage("42", tool_call_id="direct_id")
 
 
+def test_tool_injected_tool_call_id_with_custom_parameter_name() -> None:
+    """The annotation, rather than the parameter name, controls ID injection."""
+
+    class InputSchema(BaseModel):
+        x: int
+
+    @tool(args_schema=InputSchema)
+    def injected_tool(
+        x: int, call_id: Annotated[str, InjectedToolCallId]
+    ) -> ToolMessage:
+        """Return a message with the injected call ID."""
+        return ToolMessage(str(x), tool_call_id=call_id)
+
+    result = injected_tool.invoke(
+        {
+            "type": "tool_call",
+            "args": {"x": 42},
+            "name": "injected_tool",
+            "id": "test_call_id",
+        }
+    )
+    assert result == ToolMessage("42", tool_call_id="test_call_id")
+
+
 def test_tool_injected_arg_with_custom_schema() -> None:
     """Ensure InjectedToolArg works with custom args schema."""
 
@@ -3622,6 +3711,19 @@ def _tool_func_directly_injected(
     return f"Query: {query}, Limit: {limit}"
 
 
+def _tool_func_postponed_directly_injected(
+    query: str, limit: int, runtime: "_CustomRuntime"
+) -> str:
+    """Tool with a postponed directly injected runtime annotation.
+
+    Args:
+        query: The search query.
+        limit: Max results.
+        runtime: Custom runtime (directly injected, not in schema).
+    """
+    return f"Query: {query}, Limit: {limit}"
+
+
 def _tool_func_annotated_injected(
     query: str, limit: int, runtime: Annotated[Any, InjectedToolArg()]
 ) -> str:
@@ -3649,6 +3751,12 @@ def _tool_func_annotated_injected(
             {"foo": "bar"},
             "annotated injected (Annotated[Any, InjectedToolArg()])",
             id="annotated_injected",
+        ),
+        pytest.param(
+            _tool_func_postponed_directly_injected,
+            _CustomRuntime(data={"foo": "bar"}),
+            "postponed directly injected annotation",
+            id="postponed_directly_injected",
         ),
     ],
 )
@@ -4045,6 +4153,75 @@ def test_tool_args_schema_required_field_validation_alias() -> None:
         return canonical
 
     assert aliased_tool.invoke({"alias": "value"}) == "value"
+
+
+def test_tool_call_schema_preserves_pydantic_aliases() -> None:
+    """Tool schemas preserve aliases used to validate model-generated arguments."""
+
+    class Args(BaseModel):
+        model_config = ConfigDict(serialize_by_alias=True)
+
+        canonical: str = Field(alias="external", description="An aliased value.")
+
+    @tool(args_schema=Args)
+    def aliased_tool(canonical: str) -> str:
+        """Return the canonical argument."""
+        return canonical
+
+    properties = _get_tool_call_json_schema(aliased_tool)["properties"]
+    assert properties.keys() == {"external"}
+    assert aliased_tool.invoke({"external": "value"}) == "value"
+
+
+def test_tool_call_schema_preserves_validation_alias() -> None:
+    """A validation-only alias remains visible in the model-facing schema."""
+
+    class Args(BaseModel):
+        canonical: str = Field(validation_alias="external")
+
+    @tool(args_schema=Args)
+    def aliased_tool(canonical: str) -> str:
+        """Return the canonical argument."""
+        return canonical
+
+    properties = _get_tool_call_json_schema(aliased_tool)["properties"]
+    assert properties.keys() == {"external"}
+    assert aliased_tool.invoke({"external": "value"}) == "value"
+
+
+def test_tool_args_schema_excluded_field_reaches_tool() -> None:
+    """Serialization exclusions do not remove validated execution arguments."""
+
+    class Args(BaseModel):
+        visible: str
+        hidden: str = Field(exclude=True)
+
+    @tool(args_schema=Args)
+    def joined_tool(visible: str, hidden: str) -> str:
+        """Join visible and hidden arguments."""
+        return f"{visible}:{hidden}"
+
+    assert joined_tool.invoke({"visible": "a", "hidden": "b"}) == "a:b"
+
+
+def test_tool_args_schema_root_model_dict() -> None:
+    """Dictionary root models expose and pass through their fields directly."""
+
+    class RootArgsDict(TypedDict):
+        x: int
+        y: int
+
+    class RootArgs(RootModel[RootArgsDict]):
+        pass
+
+    @tool(args_schema=RootArgs)
+    def add_tool(x: int, y: int) -> int:
+        """Add two values."""
+        return x + y
+
+    properties = _get_tool_call_json_schema(add_tool)["properties"]
+    assert properties.keys() == {"x", "y"}
+    assert add_tool.invoke({"x": 1, "y": 2}) == 3
 
 
 def test_tool_args_schema_default_values() -> None:


### PR DESCRIPTION
Fixes #39738

---

Tool authors can provide valid Pydantic schemas and Python signatures that currently produce model-facing schemas different from runtime validation, lose runtime-only arguments, or fail during execution. This makes otherwise valid tool calls fail, and in one edge case silently swallows a raised exception.

This change preserves Pydantic field metadata in subset schemas, extracts validated values without applying serialization rules, handles object `RootModel` schemas, resolves postponed injected annotations, injects tool call IDs based on annotation rather than parameter name, binds positional and variadic callables correctly, and checks pending exceptions by identity.

Regression coverage includes aliases, validation aliases, excluded fields, root-model dictionaries, positional-only arguments, `*args`, `**kwargs`, postponed injection, custom call-ID names, and falsey exceptions.

Reviewers may want to pay particular attention to the `FieldInfo` copy and variadic argument-binding behavior, since these preserve metadata and Python call semantics without changing public signatures.

## Release note

Fixed LangChain tools to preserve Pydantic schema semantics and correctly execute aliased, root-model, injected, positional-only, and variadic arguments. Tool execution now also propagates falsey exception instances instead of silently returning `None`.

AI-agent involvement: This contribution was implemented and tested with assistance from an AI coding agent.