### PR TITLE
fix(core): accept non-dict `Mapping` inputs in prompt templates

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -159,7 +159,7 @@ class BasePromptTemplate(
         )
 
     def _validate_input(self, inner_input: Any) -> builtins.dict[str, Any]:
-        if not isinstance(inner_input, dict):
+        if not isinstance(inner_input, Mapping):
             if len(self.input_variables) == 1:
                 var_name = self.input_variables[0]
                 inner_input_ = {var_name: inner_input}
@@ -175,7 +175,7 @@ class BasePromptTemplate(
                     )
                 )
         else:
-            inner_input_ = inner_input
+            inner_input_ = dict(inner_input)
         missing = set(self.input_variables).difference(inner_input_)
         if missing:
             msg = (

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -263,6 +263,56 @@ def test_mustache_prompt_with_non_dict_mapping() -> None:
     assert prompt.format(user=MappingProxyType({"name": "Alice"})) == "Hello Alice"
 
 
+@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
+def test_prompt_invoke_with_non_dict_mapping(mapping_cls: type) -> None:
+    """Test `invoke` accepts non-`dict` `Mapping` inputs.
+
+    Regression test: the input check only accepted `dict`, so a `Mapping` that is not
+    a `dict` subclass was treated as a single positional value for
+    single-variable templates.
+    """
+    prompt = PromptTemplate.from_template("Hello {name}")
+
+    result = prompt.invoke(mapping_cls({"name": "Alice"}))
+
+    assert result.to_string() == "Hello Alice"
+
+
+@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
+def test_prompt_invoke_multivariable_with_non_dict_mapping(mapping_cls: type) -> None:
+    """Test multi-variable templates accept non-`dict` `Mapping` inputs.
+
+    Regression test: these raised `TypeError` reporting that a mapping type was
+    expected, even though the input was a `Mapping`.
+    """
+    prompt = PromptTemplate.from_template("{greeting} {name}")
+
+    result = prompt.invoke(mapping_cls({"greeting": "Hello", "name": "Alice"}))
+
+    assert result.to_string() == "Hello Alice"
+
+
+async def test_prompt_ainvoke_with_non_dict_mapping() -> None:
+    """Test `ainvoke` also accepts non-`dict` `Mapping` inputs."""
+    prompt = PromptTemplate.from_template("{greeting} {name}")
+
+    result = await prompt.ainvoke(ChainMap({"greeting": "Hello", "name": "Alice"}))
+
+    assert result.to_string() == "Hello Alice"
+
+
+def test_prompt_invoke_does_not_mutate_mapping_input() -> None:
+    """Test that validating the input does not mutate the caller's mapping."""
+    prompt = PromptTemplate.from_template("Hello {name}")
+    original = {"name": "Alice"}
+    chain_map = ChainMap(original)
+
+    prompt.invoke(chain_map)
+
+    assert original == {"name": "Alice"}
+    assert dict(chain_map) == {"name": "Alice"}
+
+
 def test_prompt_from_template_with_partial_variables() -> None:
     """Test prompts can be constructed from a template with partial variables."""
     # given


### PR DESCRIPTION
Fixes #39743

---

Prompt templates accept any `Mapping` through `.format(**payload)` but reject non-`dict` mappings such as `ChainMap` and `UserDict` through `.invoke(payload)`, and silently render the mapping's repr instead of the value through `.format`. Users storing prompt variables in a `ChainMap` get a wrong prompt with no error.

## Release note

`PromptTemplate.invoke()` now accepts any `Mapping` (e.g. `ChainMap`, `UserDict`, `MappingProxyType`), matching what `.format()` already accepted, and `.format()` no longer renders the mapping's repr for non-`dict` mappings.
