### PR TITLE
fix(core): dispatch on_llm_start to non-inline handlers when inline handlers exist

### DIFF
--- a/libs/core/langchain_core/callbacks/manager.py
+++ b/libs/core/langchain_core/callbacks/manager.py
@@ -1885,10 +1885,6 @@ class AsyncCallbackManager(BaseCallbackManager):
         """
         inline_tasks = []
         non_inline_tasks = []
-        inline_handlers = [handler for handler in self.handlers if handler.run_inline]
-        non_inline_handlers = [
-            handler for handler in self.handlers if not handler.run_inline
-        ]
         managers = []
 
         for prompt in prompts:
@@ -1898,36 +1894,23 @@ class AsyncCallbackManager(BaseCallbackManager):
             else:
                 run_id_ = uuid7()
 
-            if inline_handlers:
-                inline_tasks.append(
-                    ahandle_event(
-                        inline_handlers,
-                        "on_llm_start",
-                        "ignore_llm",
-                        serialized,
-                        [prompt],
-                        run_id=run_id_,
-                        parent_run_id=self.parent_run_id,
-                        tags=self.tags,
-                        metadata=self.metadata,
-                        **kwargs,
-                    )
+            for handler in self.handlers:
+                task = ahandle_event(
+                    [handler],
+                    "on_llm_start",
+                    "ignore_llm",
+                    serialized,
+                    [prompt],
+                    run_id=run_id_,
+                    parent_run_id=self.parent_run_id,
+                    tags=self.tags,
+                    metadata=self.metadata,
+                    **kwargs,
                 )
-            else:
-                non_inline_tasks.append(
-                    ahandle_event(
-                        non_inline_handlers,
-                        "on_llm_start",
-                        "ignore_llm",
-                        serialized,
-                        [prompt],
-                        run_id=run_id_,
-                        parent_run_id=self.parent_run_id,
-                        tags=self.tags,
-                        metadata=self.metadata,
-                        **kwargs,
-                    )
-                )
+                if handler.run_inline:
+                    inline_tasks.append(task)
+                else:
+                    non_inline_tasks.append(task)
 
             managers.append(
                 AsyncCallbackManagerForLLMRun(

--- a/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
+++ b/libs/core/tests/unit_tests/callbacks/test_async_callback_manager.py
@@ -151,6 +151,30 @@ async def test_inline_handlers_share_parent_context_multiple() -> None:
         ]
 
 
+async def test_on_llm_start_dispatches_to_inline_and_non_inline_handlers() -> None:
+    """Non-inline handlers must receive `on_llm_start` when inline handlers exist."""
+    received: list[str] = []
+
+    class RecordingHandler(AsyncCallbackHandler):
+        def __init__(self, name: str, *, run_inline: bool) -> None:
+            self.name = name
+            self.run_inline = run_inline
+
+        @override
+        async def on_llm_start(self, *args: Any, **kwargs: Any) -> None:
+            received.append(self.name)
+
+    manager = AsyncCallbackManager(
+        handlers=[
+            RecordingHandler("inline", run_inline=True),
+            RecordingHandler("non_inline", run_inline=False),
+        ]
+    )
+    await manager.on_llm_start({}, ["hi"])
+
+    assert received == ["inline", "non_inline"]
+
+
 async def test_shielded_callback_context_preservation() -> None:
     """Verify that shielded callbacks preserve context variables.
 


### PR DESCRIPTION
Closes #39633

---

`AsyncCallbackManager.on_llm_start` used an if/else that routed the event to non-inline handlers only when *no* inline handlers were registered. Any user mixing inline (e.g. streaming/tracing) and background handlers on a callback manager silently lost `on_llm_start` events to the background handlers. `on_chat_model_start` already dispatches per-handler, so this aligns `on_llm_start` with that behavior: each handler receives the event in the inline or non-inline task list based on its own `run_inline` flag.

## Release note

Fix `on_llm_start` callback dispatch so all handlers are notified when both inline and non-inline handlers are registered.

---

🤖 This contribution was developed with assistance from an AI coding agent.
