### PR TITLE
fix(core): make `convert_to_openai_function` handle callables and non-dict mappings

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -9,6 +9,7 @@ import logging
 import types
 import typing
 import uuid
+from collections.abc import Mapping
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -29,14 +30,13 @@ from pydantic.v1 import Field as Field_v1
 from pydantic.v1 import create_model as create_model_v1
 from typing_extensions import TypedDict, is_typeddict
 
-import langchain_core
 from langchain_core._api import beta
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.utils.json_schema import dereference_refs
 from langchain_core.utils.pydantic import is_basemodel_subclass
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable
 
     from langchain_core.tools import BaseTool
 
@@ -225,8 +225,13 @@ def _convert_python_function_to_openai_function(
     Returns:
         The OpenAI function description.
     """
+    # Import locally: `langchain_core.tools` is only bound as an attribute of
+    # `langchain_core` once something imports it, so reaching it through the parent
+    # package raises `AttributeError` in a process that has not.
+    from langchain_core.tools.base import create_schema_from_function  # noqa: PLC0415
+
     func_name = _get_python_function_name(function)
-    model = langchain_core.tools.base.create_schema_from_function(
+    model = create_schema_from_function(
         func_name,
         function,
         filter_args=(),
@@ -336,9 +341,11 @@ def _format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
     Returns:
         The function description.
     """
-    is_simple_oai_tool = (
-        isinstance(tool, langchain_core.tools.simple.Tool) and not tool.args_schema
-    )
+    # Import locally to prevent circular import, and because `langchain_core.tools`
+    # is not guaranteed to be bound on the parent package.
+    from langchain_core.tools.simple import Tool  # noqa: PLC0415
+
+    is_simple_oai_tool = isinstance(tool, Tool) and not tool.args_schema
     if tool.tool_call_schema and not is_simple_oai_tool:
         if isinstance(tool.tool_call_schema, dict):
             return _convert_json_schema_to_openai_function(
@@ -402,6 +409,17 @@ def convert_to_openai_function(
         `description` and `parameters` keys are now optional. Only `name` is
         required and guaranteed to be part of the output.
     """
+    # Import locally to prevent circular import. `langchain_core.tools` is also only
+    # bound as an attribute of `langchain_core` once something imports it, so reaching
+    # it through the parent package raises `AttributeError` in a process that has not.
+    from langchain_core.tools import BaseTool  # noqa: PLC0415
+
+    # Normalize any non-`dict` mapping (e.g. `ChainMap`, `MappingProxyType`) so the
+    # format checks below, which rely on `dict` behavior, apply to every `Mapping`.
+    # Done before the `strict` copy so mapping inputs are protected from mutation too.
+    if isinstance(function, Mapping) and not isinstance(function, dict):
+        function = dict(function)
+
     if strict and isinstance(function, dict):
         function = copy.deepcopy(function)
 
@@ -447,7 +465,7 @@ def convert_to_openai_function(
             "dict[str, Any]",
             _convert_typed_dict_to_openai_function(cast("type", function)),
         )
-    elif isinstance(function, langchain_core.tools.base.BaseTool):
+    elif isinstance(function, BaseTool):
         oai_function = cast("dict[str, Any]", _format_tool_to_openai_function(function))
     elif callable(function):
         oai_function = cast(
@@ -549,6 +567,10 @@ def convert_to_openai_tool(
     # Import locally to prevent circular import
     from langchain_core.tools import Tool  # noqa: PLC0415
 
+    # Normalize any non-`dict` mapping so the checks below apply to every `Mapping`,
+    # and so a passthrough return honors the declared `dict[str, Any]` return type.
+    if isinstance(tool, Mapping) and not isinstance(tool, dict):
+        tool = dict(tool)
     if isinstance(tool, dict):
         if tool.get("type") in _WellKnownOpenAITools:
             return tool

--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -9,7 +9,6 @@ import logging
 import types
 import typing
 import uuid
-from collections.abc import Mapping
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -36,7 +35,7 @@ from langchain_core.utils.json_schema import dereference_refs
 from langchain_core.utils.pydantic import is_basemodel_subclass
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Mapping
 
     from langchain_core.tools import BaseTool
 
@@ -225,9 +224,7 @@ def _convert_python_function_to_openai_function(
     Returns:
         The OpenAI function description.
     """
-    # Import locally: `langchain_core.tools` is only bound as an attribute of
-    # `langchain_core` once something imports it, so reaching it through the parent
-    # package raises `AttributeError` in a process that has not.
+    # Import locally to prevent circular import
     from langchain_core.tools.base import create_schema_from_function  # noqa: PLC0415
 
     func_name = _get_python_function_name(function)
@@ -341,9 +338,8 @@ def _format_tool_to_openai_function(tool: BaseTool) -> FunctionDescription:
     Returns:
         The function description.
     """
-    # Import locally to prevent circular import, and because `langchain_core.tools`
-    # is not guaranteed to be bound on the parent package.
-    from langchain_core.tools.simple import Tool  # noqa: PLC0415
+    # Import locally to prevent circular import
+    from langchain_core.tools import Tool  # noqa: PLC0415
 
     is_simple_oai_tool = isinstance(tool, Tool) and not tool.args_schema
     if tool.tool_call_schema and not is_simple_oai_tool:
@@ -409,16 +405,8 @@ def convert_to_openai_function(
         `description` and `parameters` keys are now optional. Only `name` is
         required and guaranteed to be part of the output.
     """
-    # Import locally to prevent circular import. `langchain_core.tools` is also only
-    # bound as an attribute of `langchain_core` once something imports it, so reaching
-    # it through the parent package raises `AttributeError` in a process that has not.
+    # Import locally to prevent circular import
     from langchain_core.tools import BaseTool  # noqa: PLC0415
-
-    # Normalize any non-`dict` mapping (e.g. `ChainMap`, `MappingProxyType`) so the
-    # format checks below, which rely on `dict` behavior, apply to every `Mapping`.
-    # Done before the `strict` copy so mapping inputs are protected from mutation too.
-    if isinstance(function, Mapping) and not isinstance(function, dict):
-        function = dict(function)
 
     if strict and isinstance(function, dict):
         function = copy.deepcopy(function)
@@ -567,10 +555,6 @@ def convert_to_openai_tool(
     # Import locally to prevent circular import
     from langchain_core.tools import Tool  # noqa: PLC0415
 
-    # Normalize any non-`dict` mapping so the checks below apply to every `Mapping`,
-    # and so a passthrough return honors the declared `dict[str, Any]` return type.
-    if isinstance(tool, Mapping) and not isinstance(tool, dict):
-        tool = dict(tool)
     if isinstance(tool, dict):
         if tool.get("type") in _WellKnownOpenAITools:
             return tool

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1,7 +1,5 @@
 import typing
-from collections import ChainMap, UserDict
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
-from types import MappingProxyType
 from typing import Annotated as ExtensionsAnnotated
 from typing import (
     Any,
@@ -1478,97 +1476,6 @@ def test_convert_to_openai_tool_computer_passthrough() -> None:
     }
     result = convert_to_openai_tool(computer_tool)
     assert result == computer_tool
-
-
-@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
-@pytest.mark.parametrize(
-    ("payload", "expected_name"),
-    [
-        pytest.param(
-            {"name": "f", "description": "d", "parameters": {"type": "object"}},
-            "f",
-            id="openai-format",
-        ),
-        pytest.param(
-            {"name": "f", "description": "d", "input_schema": {"type": "object"}},
-            "f",
-            id="anthropic-format",
-        ),
-        pytest.param(
-            {
-                "toolSpec": {
-                    "name": "f",
-                    "description": "d",
-                    "inputSchema": {"json": {"type": "object"}},
-                }
-            },
-            "f",
-            id="bedrock-converse-format",
-        ),
-        pytest.param(
-            {"title": "f", "description": "d", "properties": {}},
-            "f",
-            id="json-schema-with-title",
-        ),
-    ],
-)
-def test_convert_to_openai_function_accepts_non_dict_mapping(
-    mapping_cls: type, payload: dict[str, Any], expected_name: str
-) -> None:
-    """Test `convert_to_openai_function` accepts any `Mapping`, not only `dict`.
-
-    Regression test: the annotation accepts `Mapping[str, Any]`, but every format check
-    used `isinstance(function, dict)`, so a `Mapping` that is not a `dict` subclass fell
-    through to the unsupported-input branch.
-    """
-    result = convert_to_openai_function(mapping_cls(payload))
-
-    assert result["name"] == expected_name
-
-
-@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
-def test_convert_to_openai_tool_accepts_non_dict_mapping(mapping_cls: type) -> None:
-    """Test `convert_to_openai_tool` accepts any `Mapping`, not only `dict`."""
-    payload = {"name": "f", "description": "d", "parameters": {"type": "object"}}
-
-    result = convert_to_openai_tool(mapping_cls(payload))
-
-    assert result == {
-        "type": "function",
-        "function": {
-            "name": "f",
-            "description": "d",
-            "parameters": {"type": "object"},
-        },
-    }
-
-
-@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
-def test_convert_to_openai_tool_mapping_passthrough_returns_dict(
-    mapping_cls: type,
-) -> None:
-    """Test a well-known tool passed as a `Mapping` is returned as a `dict`.
-
-    The declared return type is `dict[str, Any]`, so the passthrough branch must not
-    hand back the original mapping.
-    """
-    payload = {"type": "web_search_preview"}
-
-    result = convert_to_openai_tool(mapping_cls(payload))
-
-    assert isinstance(result, dict)
-    assert result == payload
-
-
-@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
-def test_convert_to_openai_function_mapping_without_name_still_raises(
-    mapping_cls: type,
-) -> None:
-    """Test unsupported mappings keep raising, with the JSON-schema specific message."""
-    payload = {"type": "object", "properties": {}}
-
-    with pytest.raises(ValueError, match="top-level 'title' key"):
-        convert_to_openai_function(mapping_cls(payload))
 
 
 def test_convert_to_openai_function_without_tools_module_imported(

--- a/libs/core/tests/unit_tests/utils/test_function_calling.py
+++ b/libs/core/tests/unit_tests/utils/test_function_calling.py
@@ -1,5 +1,7 @@
 import typing
+from collections import ChainMap, UserDict
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from types import MappingProxyType
 from typing import Annotated as ExtensionsAnnotated
 from typing import (
     Any,
@@ -25,6 +27,7 @@ from packaging.version import parse
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.errors import PydanticInvalidForJsonSchema
 
+import langchain_core
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import BaseTool, StructuredTool, Tool, tool
@@ -1475,3 +1478,120 @@ def test_convert_to_openai_tool_computer_passthrough() -> None:
     }
     result = convert_to_openai_tool(computer_tool)
     assert result == computer_tool
+
+
+@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
+@pytest.mark.parametrize(
+    ("payload", "expected_name"),
+    [
+        pytest.param(
+            {"name": "f", "description": "d", "parameters": {"type": "object"}},
+            "f",
+            id="openai-format",
+        ),
+        pytest.param(
+            {"name": "f", "description": "d", "input_schema": {"type": "object"}},
+            "f",
+            id="anthropic-format",
+        ),
+        pytest.param(
+            {
+                "toolSpec": {
+                    "name": "f",
+                    "description": "d",
+                    "inputSchema": {"json": {"type": "object"}},
+                }
+            },
+            "f",
+            id="bedrock-converse-format",
+        ),
+        pytest.param(
+            {"title": "f", "description": "d", "properties": {}},
+            "f",
+            id="json-schema-with-title",
+        ),
+    ],
+)
+def test_convert_to_openai_function_accepts_non_dict_mapping(
+    mapping_cls: type, payload: dict[str, Any], expected_name: str
+) -> None:
+    """Test `convert_to_openai_function` accepts any `Mapping`, not only `dict`.
+
+    Regression test: the annotation accepts `Mapping[str, Any]`, but every format check
+    used `isinstance(function, dict)`, so a `Mapping` that is not a `dict` subclass fell
+    through to the unsupported-input branch.
+    """
+    result = convert_to_openai_function(mapping_cls(payload))
+
+    assert result["name"] == expected_name
+
+
+@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
+def test_convert_to_openai_tool_accepts_non_dict_mapping(mapping_cls: type) -> None:
+    """Test `convert_to_openai_tool` accepts any `Mapping`, not only `dict`."""
+    payload = {"name": "f", "description": "d", "parameters": {"type": "object"}}
+
+    result = convert_to_openai_tool(mapping_cls(payload))
+
+    assert result == {
+        "type": "function",
+        "function": {
+            "name": "f",
+            "description": "d",
+            "parameters": {"type": "object"},
+        },
+    }
+
+
+@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
+def test_convert_to_openai_tool_mapping_passthrough_returns_dict(
+    mapping_cls: type,
+) -> None:
+    """Test a well-known tool passed as a `Mapping` is returned as a `dict`.
+
+    The declared return type is `dict[str, Any]`, so the passthrough branch must not
+    hand back the original mapping.
+    """
+    payload = {"type": "web_search_preview"}
+
+    result = convert_to_openai_tool(mapping_cls(payload))
+
+    assert isinstance(result, dict)
+    assert result == payload
+
+
+@pytest.mark.parametrize("mapping_cls", [ChainMap, UserDict, MappingProxyType])
+def test_convert_to_openai_function_mapping_without_name_still_raises(
+    mapping_cls: type,
+) -> None:
+    """Test unsupported mappings keep raising, with the JSON-schema specific message."""
+    payload = {"type": "object", "properties": {}}
+
+    with pytest.raises(ValueError, match="top-level 'title' key"):
+        convert_to_openai_function(mapping_cls(payload))
+
+
+def test_convert_to_openai_function_without_tools_module_imported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test conversion works when `langchain_core.tools` is not bound on the package.
+
+    Regression test: the `BaseTool` check reached the class through
+    `langchain_core.tools.base`, which is only an attribute of `langchain_core` once
+    something imports that submodule. Called from a process that had not, conversion
+    raised `AttributeError: module 'langchain_core' has no attribute 'tools'` instead of
+    converting the callable.
+    """
+    monkeypatch.delattr(langchain_core, "tools", raising=False)
+
+    def my_func(x: int) -> int:
+        """Return the input.
+
+        Args:
+            x: A number.
+        """
+        return x
+
+    result = convert_to_openai_function(my_func)
+
+    assert result["name"] == "my_func"


### PR DESCRIPTION
Fixes #39749

---

Anyone converting a plain Python function to a tool schema with
`convert_to_openai_function` hits `AttributeError: module 'langchain_core' has no attribute
'tools'` in a process that has not already imported `langchain_core.tools`. The `BaseTool`
check reaches the class through the parent package, and importing a package does not bind
its submodules, so the check itself raises before it can run. It stayed hidden because
`convert_to_openai_tool` opens with a local `from langchain_core.tools import Tool`, whose
side effect binds the submodule — so only direct calls to `convert_to_openai_function`
crash. This uses a local import instead, matching the existing pattern in the same module,
and does the same for the two other lines that relied on that side effect.

The same function also rejects mappings its own signature promises. Both helpers annotate
their first argument as `Mapping[str, Any]`, but every format check dispatches on
`isinstance(function, dict)`, so a `ChainMap`, `UserDict` or `MappingProxyType` falls
through to `ValueError: Unsupported function` — accepted by a type checker, failing only at
runtime. A non-`dict` mapping is now normalised once at the entry point, which leaves the
existing format detection untouched, and happens before the `strict` deep copy so mapping
inputs get the same protection from mutation. This also fixes the well-known-tool
passthrough in `convert_to_openai_tool`, which returned the caller's mapping even though
the declared return type is `dict[str, Any]`.

## Release note

`convert_to_openai_function` no longer raises `AttributeError` when converting a callable
in a process that has not imported `langchain_core.tools`, and both
`convert_to_openai_function` and `convert_to_openai_tool` now accept any `Mapping`, as
their type hints already indicated.

_Disclosure: I used an AI assistant while investigating and preparing this change. I
reproduced the behaviour, reviewed the change, and ran the checks locally myself._
