### PR TITLE
fix(core): allow deserializing `RunnablePick`

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -548,6 +548,12 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "passthrough",
         "RunnableAssign",
     ),
+    ("langchain", "schema", "runnable", "RunnablePick"): (
+        "langchain_core",
+        "runnables",
+        "passthrough",
+        "RunnablePick",
+    ),
     ("langchain", "schema", "runnable", "RunnableRetry"): (
         "langchain_core",
         "runnables",
@@ -962,6 +968,12 @@ OLD_CORE_NAMESPACES_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "runnables",
         "passthrough",
         "RunnableAssign",
+    ),
+    ("langchain_core", "runnables", "passthrough", "RunnablePick"): (
+        "langchain_core",
+        "runnables",
+        "passthrough",
+        "RunnablePick",
     ),
     ("langchain_core", "runnables", "retry", "RunnableRetry"): (
         "langchain_core",

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -23,6 +23,7 @@ from langchain_core.prompts import (
     HumanMessagePromptTemplate,
     PromptTemplate,
 )
+from langchain_core.runnables import RunnablePassthrough, RunnablePick
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain_core.tracers import log_stream
 from langchain_core.utils import from_env
@@ -1233,3 +1234,27 @@ class TestInternalCallSitesUseMessages:
             'allowed_objects="messages"' in source
             or "allowed_objects='messages'" in source
         )
+
+
+def test_runnable_pick_roundtrips() -> None:
+    """Test `RunnablePick` can be loaded back after being dumped.
+
+    Regression test: `RunnablePick` reports `is_lc_serializable()` and dumps fine,
+    but was missing from the deserialization mapping, so `load` rejected it while
+    its siblings in the same module round-tripped.
+    """
+    original = RunnablePick(keys=["a"])
+
+    revived = load(dumpd(original))
+
+    assert isinstance(revived, RunnablePick)
+    assert revived.keys == ["a"]
+
+
+def test_chain_using_pick_roundtrips() -> None:
+    """Test a chain built with the public `.pick()` helper survives a round trip."""
+    chain = RunnablePassthrough().pick(["a"])
+
+    revived = load(dumpd(chain))
+
+    assert revived.invoke({"a": 1, "b": 2}) == {"a": 1}


### PR DESCRIPTION
Fixes #39752

---

A chain built with the public `Runnable.pick()` helper can be serialized but not read back:
`dumpd` and `dumps` both succeed, then `load` raises `ValueError: Deserialization of
('langchain', 'schema', 'runnable', 'RunnablePick') is not allowed`. Because the write and the
read usually happen in different processes, the failure surfaces well away from the code that
produced the payload.

`RunnablePick` reports `is_lc_serializable() is True` but has no entry in the deserialization
mapping, while `RunnablePassthrough` and `RunnableAssign` — declared in the same module — each
have one for the legacy `langchain.schema.runnable` path and one for the current
`langchain_core.runnables.passthrough` path. This adds the two matching entries, so a class
that declares itself serializable can also be loaded.

## Release note

Chains using `Runnable.pick()` can now be deserialized with `load`/`loads`. Previously they
serialized successfully but failed to load, since `RunnablePick` was missing from the
deserialization mapping.

_Disclosure: I used an AI assistant while investigating and preparing this change. I found it
by round-tripping every `langchain_core` class that reports `is_lc_serializable()`, reproduced
the failure, and ran the checks locally myself._
