### PR TITLE
feat(langchain): support custom token_counter in ContextEditingMiddleware

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/context_editing.py
+++ b/libs/langchain_v1/langchain/agents/middleware/context_editing.py
@@ -196,12 +196,14 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
 
     edits: list[ContextEdit]
     token_count_method: Literal["approximate", "model"]
+    token_counter: TokenCounter | None
 
     def __init__(
         self,
         *,
         edits: Iterable[ContextEdit] | None = None,
         token_count_method: Literal["approximate", "model"] = "approximate",  # noqa: S107
+        token_counter: TokenCounter | None = None,
     ) -> None:
         """Initialize an instance of context editing middleware.
 
@@ -212,10 +214,38 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
             token_count_method: Whether to use approximate token counting
                 (faster, less accurate) or exact counting implemented by the
                 chat model (potentially slower, more accurate).
+
+                Ignored when `token_counter` is provided.
+            token_counter: Optional custom function counting tokens for a
+                sequence of messages. Takes precedence over
+                `token_count_method` when provided, mirroring
+                `SummarizationMiddleware`. Useful when the built-in
+                approximation is inaccurate for a workload (e.g. CJK-heavy
+                conversations) or when a provider-specific tokenizer should
+                be used without implementing
+                `get_num_tokens_from_messages`.
         """
         super().__init__()
         self.edits = list(edits or (ClearToolUsesEdit(),))
         self.token_count_method = token_count_method
+        self.token_counter = token_counter
+
+    def _resolve_token_counter(self, request: ModelRequest[ContextT]) -> TokenCounter:
+        """Select the token counter used to evaluate edit triggers."""
+        if self.token_counter is not None:
+            return self.token_counter
+
+        if self.token_count_method == "approximate":  # noqa: S105
+            return count_tokens_approximately
+
+        system_msg = [request.system_message] if request.system_message else []
+
+        def count_tokens(messages: Sequence[BaseMessage]) -> int:
+            return request.model.get_num_tokens_from_messages(
+                system_msg + list(messages), request.tools
+            )
+
+        return count_tokens
 
     def wrap_model_call(
         self,
@@ -235,18 +265,7 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
         if not request.messages:
             return handler(request)
 
-        if self.token_count_method == "approximate":  # noqa: S105
-
-            def count_tokens(messages: Sequence[BaseMessage]) -> int:
-                return count_tokens_approximately(messages)
-
-        else:
-            system_msg = [request.system_message] if request.system_message else []
-
-            def count_tokens(messages: Sequence[BaseMessage]) -> int:
-                return request.model.get_num_tokens_from_messages(
-                    system_msg + list(messages), request.tools
-                )
+        count_tokens = self._resolve_token_counter(request)
 
         edited_messages = deepcopy(list(request.messages))
         for edit in self.edits:
@@ -272,18 +291,7 @@ class ContextEditingMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, 
         if not request.messages:
             return await handler(request)
 
-        if self.token_count_method == "approximate":  # noqa: S105
-
-            def count_tokens(messages: Sequence[BaseMessage]) -> int:
-                return count_tokens_approximately(messages)
-
-        else:
-            system_msg = [request.system_message] if request.system_message else []
-
-            def count_tokens(messages: Sequence[BaseMessage]) -> int:
-                return request.model.get_num_tokens_from_messages(
-                    system_msg + list(messages), request.tools
-                )
+        count_tokens = self._resolve_token_counter(request)
 
         edited_messages = deepcopy(list(request.messages))
         for edit in self.edits:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_context_editing.py
@@ -468,3 +468,113 @@ async def test_exclude_tools_prevents_clearing_async() -> None:
 
     assert isinstance(calc_tool, ToolMessage)
     assert calc_tool.content == "[cleared]"
+
+
+def test_custom_token_counter_forces_clearing() -> None:
+    """A custom token counter is used to evaluate edit triggers."""
+    tool_call_id = "call-custom"
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[{"id": tool_call_id, "name": "search", "args": {}}],
+    )
+    # Tiny output: approximate counting would stay far below the trigger.
+    tool_message = ToolMessage(content="12345", tool_call_id=tool_call_id)
+
+    _state, request = _make_state_and_request([ai_message, tool_message])
+
+    counted_batches: list[int] = []
+
+    def fake_counter(messages: Sequence[BaseMessage]) -> int:
+        counted_batches.append(len(messages))
+        return 1_000
+
+    middleware = ContextEditingMiddleware(
+        edits=[ClearToolUsesEdit(trigger=50, keep=0, placeholder="[cleared]")],
+        token_counter=fake_counter,
+    )
+
+    modified_request = None
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        nonlocal modified_request
+        modified_request = req
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    middleware.wrap_model_call(request, mock_handler)
+
+    assert counted_batches, "custom token counter was not called"
+    assert modified_request is not None
+    cleared_tool = modified_request.messages[1]
+    assert isinstance(cleared_tool, ToolMessage)
+    assert cleared_tool.content == "[cleared]"
+
+
+def test_custom_token_counter_takes_precedence_over_method() -> None:
+    """When provided, the custom counter overrides `token_count_method`."""
+    tool_call_id = "call-custom-low"
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[{"id": tool_call_id, "name": "search", "args": {}}],
+    )
+    # Large output: approximate counting would exceed the trigger and clear.
+    tool_message = ToolMessage(content="x" * 200, tool_call_id=tool_call_id)
+
+    _state, request = _make_state_and_request([ai_message, tool_message])
+
+    middleware = ContextEditingMiddleware(
+        edits=[ClearToolUsesEdit(trigger=50, keep=0, placeholder="[cleared]")],
+        token_count_method="approximate",  # noqa: S106
+        token_counter=lambda _messages: 10,
+    )
+
+    modified_request = None
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        nonlocal modified_request
+        modified_request = req
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    middleware.wrap_model_call(request, mock_handler)
+
+    assert modified_request is not None
+    untouched_tool = modified_request.messages[1]
+    assert isinstance(untouched_tool, ToolMessage)
+    assert untouched_tool.content == "x" * 200
+
+
+async def test_custom_token_counter_forces_clearing_async() -> None:
+    """Async version: a custom token counter is used to evaluate edit triggers."""
+    tool_call_id = "call-custom"
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[{"id": tool_call_id, "name": "search", "args": {}}],
+    )
+    tool_message = ToolMessage(content="12345", tool_call_id=tool_call_id)
+
+    _state, request = _make_state_and_request([ai_message, tool_message])
+
+    counted_batches: list[int] = []
+
+    def fake_counter(messages: Sequence[BaseMessage]) -> int:
+        counted_batches.append(len(messages))
+        return 1_000
+
+    middleware = ContextEditingMiddleware(
+        edits=[ClearToolUsesEdit(trigger=50, keep=0, placeholder="[cleared]")],
+        token_counter=fake_counter,
+    )
+
+    modified_request = None
+
+    async def mock_handler(req: ModelRequest) -> ModelResponse:
+        nonlocal modified_request
+        modified_request = req
+        return ModelResponse(result=[AIMessage(content="mock response")])
+
+    await middleware.awrap_model_call(request, mock_handler)
+
+    assert counted_batches, "custom token counter was not called"
+    assert modified_request is not None
+    cleared_tool = modified_request.messages[1]
+    assert isinstance(cleared_tool, ToolMessage)
+    assert cleared_tool.content == "[cleared]"


### PR DESCRIPTION
## Description

`ContextEditingMiddleware` hardcodes its token counter inside `wrap_model_call` / `awrap_model_call`: `token_count_method` only allows `"approximate"` (which calls `count_tokens_approximately` with its defaults) or `"model"`. There is no way to inject a custom counter, even though:

- the module already defines a public `TokenCounter` type alias, and `ContextEdit.apply()` already receives `count_tokens` as a parameter — the extension point exists everywhere except the middleware's public API;
- the sibling `SummarizationMiddleware` already accepts `token_counter: TokenCounter = count_tokens_approximately`, so this change simply brings the two middlewares to API parity.

**Why this matters:** `count_tokens_approximately` assumes ~4 chars/token, which fits English prose but systematically underestimates CJK-heavy workloads by 2–3x (we measured 1.4–2.1 chars/token against provider-reported `usage_metadata` on Chinese financial filings and HTML tables). With the estimate reading 2–3x low, `ClearToolUsesEdit.trigger` fires far later than configured, silently defeating the purpose of threshold-based context management. The `"model"` counting mode is not a general fallback: many OpenAI-compatible providers do not implement `get_num_tokens_from_messages`.

## Changes

- Add optional `token_counter: TokenCounter | None = None` to `ContextEditingMiddleware.__init__`; when provided it takes precedence over `token_count_method` (mirroring `SummarizationMiddleware`).
- Deduplicate the counter-selection logic shared by the sync/async paths into a private `_resolve_token_counter()` helper.
- Unit tests covering: a custom counter drives trigger evaluation (sync and async), and it takes precedence over `token_count_method`.

Example:

```python
from functools import partial
from langchain_core.messages.utils import count_tokens_approximately

middleware = ContextEditingMiddleware(
    edits=[ClearToolUsesEdit(trigger=120_000, keep=12)],
    token_counter=partial(count_tokens_approximately, chars_per_token=2.0),
)
```

Backwards compatible: no behavior change unless the new argument is passed. No new dependencies.

## Issue

Fixes #39757
