### PR TITLE
fix(core): filter injected args before validation in strict args_schema

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -830,6 +830,24 @@ class ChildTool(BaseTool):
             if isinstance(input_args, dict):
                 return tool_input
             result: BaseModel | BaseModelV1
+            field_info = get_fields(input_args)
+            # Keys that may legitimately appear in the payload but are not model
+            # arguments: filtered args (e.g. `run_manager`) and injected args.
+            # Strict (`extra="forbid"`) schemas reject them, so they are
+            # stripped before validation unless the schema declares them as a
+            # field (e.g. the `Annotated[..., SkipJsonSchema()]` workaround).
+            # Injected values are re-merged into the validated input below.
+            injected_keys = (
+                set(FILTERED_ARGS)
+                | self._injected_args_keys
+                | {
+                    name
+                    for name, field_type in get_all_basemodel_annotations(
+                        input_args
+                    ).items()
+                    if _is_injected_arg_type(field_type)
+                }
+            )
             if issubclass(input_args, BaseModel):
                 # Check args_schema for InjectedToolCallId
                 for k, v in get_all_basemodel_annotations(input_args).items():
@@ -844,7 +862,12 @@ class ChildTool(BaseTool):
                             )
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
-                result_v2 = input_args.model_validate(tool_input)
+                validate_input = {
+                    k: v
+                    for k, v in tool_input.items()
+                    if k in field_info or k not in injected_keys
+                }
+                result_v2 = input_args.model_validate(validate_input)
                 result_dict = result_v2.model_dump()
                 provided_fields = result_v2.model_fields_set
                 result = result_v2
@@ -862,7 +885,12 @@ class ChildTool(BaseTool):
                             )
                             raise ValueError(msg)
                         tool_input[k] = tool_call_id
-                result_v1 = input_args.parse_obj(tool_input)
+                validate_input = {
+                    k: v
+                    for k, v in tool_input.items()
+                    if k in field_info or k not in injected_keys
+                }
+                result_v1 = input_args.parse_obj(validate_input)
                 result_dict = result_v1.dict()
                 provided_fields = result_v1.__fields_set__
                 result = result_v1
@@ -876,7 +904,6 @@ class ChildTool(BaseTool):
             # plus fields with explicit defaults. This applies Pydantic defaults (like
             # Field(default=1)) while excluding synthetic "args"/"kwargs" fields that
             # Pydantic creates for *args/**kwargs.
-            field_info = get_fields(input_args)
             validated_input = {}
             for k in result_dict:
                 if k in tool_input:

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3718,6 +3718,91 @@ def test_filter_injected_args_not_in_schema(
     assert "runtime" not in captured
 
 
+def test_injected_arg_not_in_strict_args_schema() -> None:
+    """Injected args must survive validation with strict args schemas.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/34246:
+    a `StructuredTool` whose `args_schema` uses `extra="forbid"` raised
+    `ValidationError` (`extra_forbidden`) when an injected argument not
+    declared in the schema was present in the invoke payload, because the
+    full payload was validated before injected args were stripped.
+    """
+
+    class StrictArgsSchema(BaseModel):
+        """Schema with `extra="forbid"` and no injected field."""
+
+        query: str
+        limit: int
+
+        model_config = ConfigDict(extra="forbid")
+
+    def tool_func(query: str, limit: int, runtime: _CustomRuntime) -> Any:
+        """Echo the input, receiving a directly injected runtime.
+
+        Args:
+            query: The query.
+            limit: Max results.
+            runtime: Custom runtime (directly injected, not in schema).
+
+        Returns:
+            The echoed input including the injected runtime.
+        """
+        return {"query": query, "limit": limit, "runtime": runtime}
+
+    tool_ = StructuredTool.from_function(
+        func=tool_func,
+        name="strict_echo_tool",
+        description="Echoes input with an injected runtime not in schema",
+        args_schema=StrictArgsSchema,
+    )
+
+    runtime = _CustomRuntime(data={"foo": "bar"})
+    result = tool_.invoke({"query": "test", "limit": 5, "runtime": runtime})
+
+    assert result == {"query": "test", "limit": 5, "runtime": runtime}
+
+
+def test_declared_injected_arg_in_strict_args_schema() -> None:
+    """Declared injected args must still validate under strict schemas.
+
+    Guards the #34246 workaround: when the `args_schema` itself declares the
+    injected argument as a field, the value must validate as a normal field
+    rather than being stripped before validation.
+    """
+
+    class DeclaredArgsSchema(BaseModel):
+        """Schema with `extra="forbid"` that declares the injected field."""
+
+        query: str
+        runtime: Any
+
+        model_config = ConfigDict(extra="forbid")
+
+    def tool_func(query: str, runtime: _CustomRuntime) -> Any:
+        """Echo the input, receiving a declared injected runtime.
+
+        Args:
+            query: The query.
+            runtime: Custom runtime (declared in schema, injected).
+
+        Returns:
+            The echoed input including the injected runtime.
+        """
+        return {"query": query, "runtime": runtime}
+
+    tool_ = StructuredTool.from_function(
+        func=tool_func,
+        name="declared_echo_tool",
+        description="Echoes input with the injected runtime declared in schema",
+        args_schema=DeclaredArgsSchema,
+    )
+
+    runtime = _CustomRuntime(data={"foo": "bar"})
+    result = tool_.invoke({"query": "test", "runtime": runtime})
+
+    assert result == {"query": "test", "runtime": runtime}
+
+
 def test_base_tool_subclass_injects_directly_injected_runtime() -> None:
     """Directly injected args on a `BaseTool` subclass `_run` must be injected.
 


### PR DESCRIPTION
Closes #34246

---

A `StructuredTool` with a strict `args_schema` (`extra="forbid"`) raised `ValidationError: Extra inputs are not permitted` whenever an injected argument (e.g. `ToolRuntime`) was present in the invoke payload. `_parse_input` validated the full payload before injected keys were dealt with, and the earlier fix for #31688 re-adds injected args only *after* validation — which does not help when validation itself rejects them.

`_parse_input` now strips injected and filtered keys (filtered args such as `run_manager`, signature-injected args, and schema fields annotated with an injected type) from the payload before `model_validate`, unless the schema declares the key as a field. That keeps the documented workaround of declaring the injected arg in the schema working, and the existing post-validation loop still re-merges the injected values, so behavior for non-strict schemas is unchanged.

## Release note

Injected tool arguments (e.g. `ToolRuntime`) no longer break validation for tools whose `args_schema` uses `extra="forbid"`.

---

🤖 This contribution was developed with assistance from an AI coding agent.
