### PR TITLE
fix(core): ensure langchain_core.tools is loaded before attribute access (gh-39749)

### DIFF
--- a/libs/core/langchain_core/utils/function_calling.py
+++ b/libs/core/langchain_core/utils/function_calling.py
@@ -30,6 +30,7 @@ from pydantic.v1 import create_model as create_model_v1
 from typing_extensions import TypedDict, is_typeddict
 
 import langchain_core
+import langchain_core.tools  # noqa: F401  # ensure submodule is loaded before attribute access
 from langchain_core._api import beta
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
 from langchain_core.utils.json_schema import dereference_refs


### PR DESCRIPTION
Hi @hinthornw @nikitakaraivanov, @eyurtsev — friendly heads-up that this PR is ready for review. Issue: #39749 — convert_to_openai_function() raises AttributeError unless langchain_core.tools was imported. Fix: added import langchain_core.tools after import langchain_core in function_calling.py. One line, zero behavior changes. Ready for review/merge.