### PR TITLE
fix(core): support all Mapping types as prompt template inputs (#39743)

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -158,8 +158,8 @@ class BasePromptTemplate(
             field_definitions={**required_input_variables, **optional_input_variables},
         )
 
-    def _validate_input(self, inner_input: Any) -> builtins.dict[str, Any]:
-        if not isinstance(inner_input, dict):
+    def _validate_input(self, inner_input: Any) -> Mapping[str, Any]:
+        if not isinstance(inner_input, Mapping):
             if len(self.input_variables) == 1:
                 var_name = self.input_variables[0]
                 inner_input_ = {var_name: inner_input}
@@ -195,13 +195,13 @@ class BasePromptTemplate(
         return inner_input_
 
     def _format_prompt_with_error_handling(
-        self, inner_input: builtins.dict[str, Any]
+        self, inner_input: Mapping[str, Any]
     ) -> PromptValue:
         inner_input_ = self._validate_input(inner_input)
         return self.format_prompt(**inner_input_)
 
     async def _aformat_prompt_with_error_handling(
-        self, inner_input: builtins.dict[str, Any]
+        self, inner_input: Mapping[str, Any]
     ) -> PromptValue:
         inner_input_ = self._validate_input(inner_input)
         return await self.aformat_prompt(**inner_input_)

--- a/libs/core/tests/unit_tests/prompts/test_prompt.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt.py
@@ -744,3 +744,17 @@ def test_prompt_template_add(
         variable="template",
         another_variable="other_template",
     )
+
+
+@pytest.mark.parametrize("cls", [dict, ChainMap, UserDict, MappingProxyType])
+def test_prompt_template_invoke_with_mapping_types(cls: Any) -> None:
+    """Regression test for issue #39743: Prompt templates must support all Mapping types."""
+    single = PromptTemplate.from_template("Hello {name}")
+    multi = PromptTemplate.from_template("{greeting} {name}")
+
+    assert single.invoke(cls({"name": "Alice"})).to_string() == "Hello Alice"
+    assert (
+        multi.invoke(cls({"greeting": "Hello", "name": "Alice"})).to_string()
+        == "Hello Alice"
+    )
+


### PR DESCRIPTION
## Description
Fixes #39743

In `langchain_core/prompts/base.py`, `BasePromptTemplate._validate_input` previously checked `isinstance(inner_input, dict)` to determine if the input passed to `invoke` / `ainvoke` is a mapping.

Standard-library mappings that are not `dict` subclasses (such as `ChainMap`, `UserDict`, `MappingProxyType`, or custom `collections.abc.Mapping` implementations) therefore took the wrong branch:
- Single-variable templates treated the mapping as a scalar value and stringified it via `str()` (e.g. producing `'Hello ChainMap({\'name\': \'Alice\'})'` instead of `'Hello Alice'`).
- Multi-variable templates raised a `TypeError: Expected mapping type as input to PromptTemplate`.

### Solution:
- Updated `_validate_input`, `_format_prompt_with_error_handling`, and `_aformat_prompt_with_error_handling` to check `isinstance(inner_input, Mapping)` (from `collections.abc`).
- Added unit tests in `libs/core/tests/unit_tests/prompts/test_prompt.py` verifying `dict`, `ChainMap`, `UserDict`, and `MappingProxyType` execution across single and multi-variable templates.
