### PR TITLE
fix(langchain): accept non-list config sequences in `batch_as_completed`

### DIFF
--- a/libs/langchain_v1/langchain/chat_models/base.py
+++ b/libs/langchain_v1/langchain/chat_models/base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import importlib
 import warnings
+from collections.abc import Sequence
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -39,7 +40,7 @@ def _init_langsmith(cls: type[BaseChatModel], **kwargs: Any) -> BaseChatModel:
 
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable, Iterator, Sequence
+    from collections.abc import AsyncIterator, Callable, Iterator
     from types import ModuleType
 
     from langchain_core.runnables.schema import StreamEvent
@@ -872,7 +873,7 @@ class _ConfigurableModel(Runnable[LanguageModelInput, Any]):
         config = config or None
         # If <= 1 config use the underlying models batch implementation.
         if config is None or isinstance(config, dict) or len(config) <= 1:
-            if isinstance(config, list):
+            if isinstance(config, Sequence):
                 config = config[0]
             yield from self._model(cast("RunnableConfig", config)).batch_as_completed(  # type: ignore[call-overload]
                 inputs,
@@ -901,7 +902,7 @@ class _ConfigurableModel(Runnable[LanguageModelInput, Any]):
         config = config or None
         # If <= 1 config use the underlying models batch implementation.
         if config is None or isinstance(config, dict) or len(config) <= 1:
-            if isinstance(config, list):
+            if isinstance(config, Sequence):
                 config = config[0]
             async for x in self._model(
                 cast("RunnableConfig", config),

--- a/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
+++ b/libs/langchain_v1/tests/unit_tests/chat_models/test_chat_models.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 from langchain_core.language_models.fake_chat_models import FakeChatModel
+from langchain_core.messages import AIMessage
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig, RunnableSequence
 from pydantic import SecretStr
@@ -427,3 +428,39 @@ def test_configurable_with_default() -> None:
     prompt = ChatPromptTemplate.from_messages([("system", "foo")])
     chain = prompt | model_with_config
     assert isinstance(chain, RunnableSequence)
+
+
+def test_configurable_batch_as_completed_single_tuple_config() -> None:
+    """Test `batch_as_completed` with a singleton tuple config."""
+    model = init_chat_model()
+    config: tuple[RunnableConfig] = ({"tags": ["test"]},)
+
+    with mock.patch(
+        "langchain.chat_models.base._init_chat_model_helper",
+        return_value=FakeChatModel(),
+    ):
+        results = list(model.batch_as_completed(["hello"], config=config))
+
+    assert len(results) == 1
+    index, response = results[0]
+    assert index == 0
+    assert isinstance(response, AIMessage)
+    assert response.content == "fake response"
+
+
+async def test_configurable_abatch_as_completed_single_tuple_config() -> None:
+    """Test `abatch_as_completed` with a singleton tuple config."""
+    model = init_chat_model()
+    config: tuple[RunnableConfig] = ({"tags": ["test"]},)
+
+    with mock.patch(
+        "langchain.chat_models.base._init_chat_model_helper",
+        return_value=FakeChatModel(),
+    ):
+        results = [item async for item in model.abatch_as_completed(["hello"], config=config)]
+
+    assert len(results) == 1
+    index, response = results[0]
+    assert index == 0
+    assert isinstance(response, AIMessage)
+    assert response.content == "fake response"


### PR DESCRIPTION
Fixes #39765



`init_chat_model()` returns a configurable model whose `batch_as_completed` and
`abatch_as_completed` declare `Sequence[RunnableConfig]`, matching the base `Runnable`. A tuple
holding one config satisfies that annotation but raised
`AttributeError: 'tuple' object has no attribute 'items'` from inside `langchain_core`, because the
single-config branch unwrapped the sequence only when it was a concrete `list`. The traceback pointed
away from the caller's own code, and a `cast` on the following line kept the type checker quiet about
it.

The check now accepts any `Sequence`, so a tuple is unwrapped exactly as a list already was. This
mirrors `get_config_list` in `langchain_core.runnables.config`, which dispatches on the same ABC for
this input. `batch` and `abatch` keep their `list` check on purpose: they declare
`list[RunnableConfig]`, so a tuple is outside their contract and widening them would change a
different promise. Only the singleton case was affected, since two or more configs already delegate
to `super()`.

Added a unit test for each of `batch_as_completed` and `abatch_as_completed` passing a singleton
tuple config; both fail on an unmodified tree.

## Release note

Fixed an `AttributeError` when passing a single-element tuple of configs to `batch_as_completed` or
`abatch_as_completed` on a model returned by `init_chat_model()`.