### PR TITLE
fix(core): retry batches when the exception is falsey

### DIFF
--- a/libs/core/langchain_core/runnables/retry.py
+++ b/libs/core/langchain_core/runnables/retry.py
@@ -259,16 +259,19 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     )
                     # Register the results of the inputs that have succeeded, mapping
                     # back to their original indices.
-                    first_exception = None
+                    first_exception: Exception | None = None
                     for offset, r in enumerate(result):
                         if isinstance(r, Exception):
-                            if not first_exception:
+                            # Compare against `None`: an exception overriding
+                            # `__bool__`/`__len__` is falsey, and a truthiness check
+                            # would skip the retry entirely.
+                            if first_exception is None:
                                 first_exception = r
                             continue
                         orig_idx = remaining_indices[offset]
                         results_map[orig_idx] = r
                     # If any exception occurred, raise it, to retry the failed ones
-                    if first_exception:
+                    if first_exception is not None:
                         raise first_exception
                 if (
                     attempt.retry_state.outcome
@@ -334,16 +337,19 @@ class RunnableRetry(RunnableBindingBase[Input, Output]):  # type: ignore[no-rede
                     )
                     # Register the results of the inputs that have succeeded, mapping
                     # back to their original indices.
-                    first_exception = None
+                    first_exception: Exception | None = None
                     for offset, r in enumerate(result):
                         if isinstance(r, Exception):
-                            if not first_exception:
+                            # Compare against `None`: an exception overriding
+                            # `__bool__`/`__len__` is falsey, and a truthiness check
+                            # would skip the retry entirely.
+                            if first_exception is None:
                                 first_exception = r
                             continue
                         orig_idx = remaining_indices[offset]
                         results_map[orig_idx] = r
                     # If any exception occurred, raise it, to retry the failed ones
-                    if first_exception:
+                    if first_exception is not None:
                         raise first_exception
                 if (
                     attempt.retry_state.outcome

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -4039,6 +4039,56 @@ def test_retry_batch_preserves_order() -> None:
     assert results == [0, 1, 2]
 
 
+class _FalseyError(RuntimeError):
+    """Exception whose truth value is `False`."""
+
+    def __bool__(self) -> bool:
+        return False
+
+
+def test_retry_batch_retries_falsey_exception() -> None:
+    """Test batch retries an exception that evaluates to `False`.
+
+    Regression test: the retry loop recorded the first failure with a truthiness check,
+    so an exception overriding `__bool__` was never raised to `tenacity` and the batch
+    silently completed after a single attempt instead of retrying.
+    """
+    attempts = 0
+
+    def always_fail(_x: int) -> int:
+        nonlocal attempts
+        attempts += 1
+        msg = "boom"
+        raise _FalseyError(msg)
+
+    runnable = RunnableLambda(always_fail).with_retry(
+        stop_after_attempt=3, wait_exponential_jitter=False
+    )
+
+    runnable.batch([0], return_exceptions=True)
+
+    assert attempts == 3
+
+
+async def test_async_retry_batch_retries_falsey_exception() -> None:
+    """Test abatch shares the fixed retry behaviour for falsey exceptions."""
+    attempts = 0
+
+    def always_fail(_x: int) -> int:
+        nonlocal attempts
+        attempts += 1
+        msg = "boom"
+        raise _FalseyError(msg)
+
+    runnable = RunnableLambda(always_fail).with_retry(
+        stop_after_attempt=3, wait_exponential_jitter=False
+    )
+
+    await runnable.abatch([0], return_exceptions=True)
+
+    assert attempts == 3
+
+
 async def test_async_retry_batch_preserves_order() -> None:
     """Async variant of order preservation regression test."""
     first_fail: set[int] = {1}


### PR DESCRIPTION
**Description:** `RunnableRetry._batch`/`_abatch` decide whether an attempt failed by testing the
collected exception for truthiness rather than comparing against `None`. An exception that
overrides `__bool__` (or inherits `__len__`-based truthiness) is therefore never re-raised to
`tenacity`, so the attempt counts as a success and no retry happens — silently.

`stop_after_attempt=3`, one input, measured on `upstream/master` (`3478c28ef`):

| exception raised by the callable | invocations before | invocations after |
| --- | --- | --- |
| `RuntimeError` (ordinary) | 3 | 3 |
| falsey exception (`__bool__` → `False`) | **1** | 3 |

`abatch` shows the same 3 vs 1 split and gets the identical fix.

**Issue:** #39780

**Change:** two call sites (`_batch` at `retry.py:262-272`, `_abatch` at `337-347`) switch from
`if not first_exception:` / `if first_exception:` to `is None` / `is not None`, plus an explicit
`Exception | None` annotation and a comment recording why the comparison must be explicit.

Deliberately *not* changed: `isinstance(r, Exception)` is left as-is. I verified that plain
`Runnable.batch(return_exceptions=True)` propagates a non-`Exception` `BaseException` rather than
collecting it, so widening that check would be dead code here and would overlap #38469.

**Tests:** two regression tests (`test_retry_batch_retries_falsey_exception`,
`test_async_retry_batch_retries_falsey_exception`) assert the underlying callable is invoked 3
times. Reverting the fix fails exactly these two and no others; the four pre-existing retry tests
keep passing.

**Verification** against `upstream/master` (`3478c28ef`):

- `ruff check`, `ruff format --check`, `mypy`, `scripts/lint_imports.sh` — clean
- `langchain-core` unit suite: **2249 passed** (baseline `master` 2247; +2 are the new tests). The
  one failure I see, `test_ssrf_protection.py::test_discord_webhook`, is a DNS artifact of my own
  network and reproduces on unmodified `master`.
- Downstream `langchain` (v1) unit suite: **1098 passed**, unchanged from `master`.
- Single package touched; `uv.lock` and `pyproject.toml` untouched.

_Disclosure: AI-assisted implementation. Every number above is from runs I executed locally against
the commit named._
