### PR TITLE
fix(core): deserialize `ImagePromptValue`

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -460,6 +460,11 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "prompt_values",
         "StringPromptValue",
     ),
+    ("langchain", "schema", "prompt", "ImagePromptValue"): (
+        "langchain_core",
+        "prompt_values",
+        "ImagePromptValue",
+    ),
     ("langchain", "prompts", "chat", "BaseStringMessagePromptTemplate"): (
         "langchain_core",
         "prompts",
@@ -887,6 +892,11 @@ OLD_CORE_NAMESPACES_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "langchain_core",
         "prompt_values",
         "StringPromptValue",
+    ),
+    ("langchain_core", "prompt_values", "ImagePromptValue"): (
+        "langchain_core",
+        "prompt_values",
+        "ImagePromptValue",
     ),
     ("langchain_core", "prompts", "chat", "BaseStringMessagePromptTemplate"): (
         "langchain_core",

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -23,6 +23,7 @@ from langchain_core.prompts import (
     HumanMessagePromptTemplate,
     PromptTemplate,
 )
+from langchain_core.prompts.image import ImagePromptTemplate
 from langchain_core.runnables import RunnablePassthrough, RunnablePick
 from langchain_core.runnables.history import RunnableWithMessageHistory
 from langchain_core.tracers import log_stream
@@ -1249,6 +1250,20 @@ def test_runnable_pick_roundtrips() -> None:
 
     assert isinstance(revived, RunnablePick)
     assert revived.keys == ["a"]
+
+
+def test_image_prompt_value_roundtrips() -> None:
+    """Test ImagePromptValue can be loaded back after being dumped."""
+    template = ImagePromptTemplate(
+        template={"url": "https://example.com/{name}.png"},
+        input_variables=["name"],
+    )
+    original = template.format_prompt(name="cat")
+
+    revived = load(dumpd(original))
+
+    assert type(revived) is type(original)
+    assert revived == original
 
 
 def test_chain_using_pick_roundtrips() -> None:


### PR DESCRIPTION
Fixes #39783

---

Image prompt users can now deserialize `ImagePromptValue` objects produced by `ImagePromptTemplate.format_prompt()` with the default core allowlist. The mapping now mirrors the other prompt value classes that already round-trip through serialization.

## Release note

`ImagePromptValue` now round-trips through `dumps()` and `loads()` with the default core deserialization allowlist.

Verified locally:

- `uv run --group test pytest tests/unit_tests/load/test_serializable.py -q`
- `uv run --group lint ruff check langchain_core/load/mapping.py tests/unit_tests/load/test_serializable.py`
- `uv run --group lint ruff format --check langchain_core/load/mapping.py tests/unit_tests/load/test_serializable.py`

Disclosure: AI-assisted contribution; implementation and tests were verified locally.