### PR TITLE
feat(langchain): bridge MCP elicitation to LangGraph interrupts

### DIFF
--- a/libs/langchain_v1/langchain/mcp/__init__.py
+++ b/libs/langchain_v1/langchain/mcp/__init__.py
@@ -30,9 +30,11 @@ except ImportError as e:  # pragma: no cover
     )
     raise ModuleNotFoundError(msg) from e
 
+from langchain.mcp._elicitation import MCPElicitation
 from langchain.mcp.tools import convert_mcp_tool, load_mcp_tools
 
 __all__ = [
+    "MCPElicitation",
     "convert_mcp_tool",
     "load_mcp_tools",
 ]

--- a/libs/langchain_v1/langchain/mcp/_elicitation.py
+++ b/libs/langchain_v1/langchain/mcp/_elicitation.py
@@ -23,7 +23,6 @@ from typing_extensions import NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from fastmcp import Client
-    from fastmcp.client.transports import ClientTransport
     from mcp.types import CallToolResult, InputResponses
 
 _VALID_ACTIONS = ("accept", "decline", "cancel")
@@ -45,7 +44,7 @@ class MCPElicitation(TypedDict):
 
 
 async def call_tool_with_elicitation(
-    client: Client[ClientTransport],
+    client: Client[Any],
     name: str,
     arguments: dict[str, Any],
 ) -> CallToolResult:

--- a/libs/langchain_v1/langchain/mcp/_elicitation.py
+++ b/libs/langchain_v1/langchain/mcp/_elicitation.py
@@ -1,0 +1,113 @@
+"""Bridge MCP elicitation to LangGraph interrupts (2026-07-28 input-required flow).
+
+On the modern MCP protocol there is no server->client back-channel, so elicitation is
+delivered as an `InputRequiredResult` (SEP-2322): a tool call returns a request for input,
+the client answers it, and the call is retried with the answer. We drive that loop here
+and surface each elicitation as a LangGraph `interrupt()`, so the human answers by resuming
+the graph.
+
+Only servers speaking the modern input-required mechanism trigger this path: older servers
+never return an `InputRequiredResult`, so a plain call runs unchanged. The side-effectful
+part of a guard-pattern tool runs exactly once; only the (side-effect-free) input check
+re-runs on resume, per the guard-pattern contract.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from langchain_core.tools import ToolException
+from langgraph.types import interrupt
+from mcp.types import ElicitRequest, ElicitResult, InputRequiredResult
+from typing_extensions import NotRequired, TypedDict
+
+if TYPE_CHECKING:
+    from fastmcp import Client
+    from fastmcp.client.transports import ClientTransport
+    from mcp.types import CallToolResult, InputResponses
+
+_VALID_ACTIONS = ("accept", "decline", "cancel")
+
+
+class MCPElicitation(TypedDict):
+    """Value surfaced by `interrupt()` when an MCP server elicits input.
+
+    Resume the graph with `Command(resume={"action": ..., "content": ...})`, where `action`
+    is one of `"accept"`, `"decline"`, or `"cancel"`, and `content` (on accept) matches
+    `response_schema`.
+    """
+
+    type: Literal["mcp_elicitation"]
+    message: str
+    mode: str
+    response_schema: dict[str, Any]
+    url: NotRequired[str]
+
+
+async def call_tool_with_elicitation(
+    client: Client[ClientTransport],
+    name: str,
+    arguments: dict[str, Any],
+) -> CallToolResult:
+    """Call an MCP tool, bridging any modern-spec elicitation to `interrupt()`.
+
+    Args:
+        client: Connected FastMCP client.
+        name: Tool name.
+        arguments: Tool arguments.
+
+    Returns:
+        The terminal tool result once all elicitation rounds are answered.
+
+    Raises:
+        ToolException: If the server requests unsupported (non-elicitation) input.
+    """
+    session = client.session
+    result = await session.call_tool(name, arguments, allow_input_required=True)
+
+    while isinstance(result, InputRequiredResult):
+        responses: InputResponses = {}
+        for key, request in (result.input_requests or {}).items():
+            if not isinstance(request, ElicitRequest):
+                msg = (
+                    f"MCP tool {name!r} requested unsupported input "
+                    f"{type(request).__name__!r}; only elicitation is supported."
+                )
+                raise ToolException(msg)
+            responses[key] = _resolve_elicitation(request)
+
+        result = await session.call_tool(
+            name,
+            arguments,
+            input_responses=responses,
+            request_state=result.request_state,
+            allow_input_required=True,
+        )
+
+    return result
+
+
+def _resolve_elicitation(request: ElicitRequest) -> ElicitResult:
+    """Surface one elicitation request as an interrupt and map the resume to a result."""
+    params = request.params
+    payload: MCPElicitation = {
+        "type": "mcp_elicitation",
+        "mode": getattr(params, "mode", "form"),
+        "message": params.message,
+        "response_schema": getattr(params, "requested_schema", {}),
+    }
+    url = getattr(params, "url", None)
+    if url is not None:
+        payload["url"] = str(url)
+
+    answer = interrupt(payload)
+    if not isinstance(answer, dict) or answer.get("action") not in _VALID_ACTIONS:
+        msg = (
+            f"Invalid elicitation response {answer!r}; resume with "
+            f'{{"action": one of {_VALID_ACTIONS}, "content": ...}}.'
+        )
+        raise ToolException(msg)
+
+    action = answer["action"]
+    content = answer.get("content") if action == "accept" else None
+    return ElicitResult(action=action, content=content)

--- a/libs/langchain_v1/langchain/mcp/tools.py
+++ b/libs/langchain_v1/langchain/mcp/tools.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from fastmcp import Client
-    from fastmcp.client.transports import ClientTransport
     from langchain_core.tools import BaseTool
     from mcp.types import ContentBlock as MCPContentBlock
     from mcp.types import Tool as MCPTool
@@ -51,7 +50,7 @@ class _ToolResult(Protocol):
 
 
 async def load_mcp_tools(
-    client: Client[ClientTransport],
+    client: Client[Any],
     *,
     elicitation: ElicitationMode | None = None,
 ) -> list[BaseTool]:
@@ -79,7 +78,7 @@ async def load_mcp_tools(
 
 def convert_mcp_tool(
     tool: MCPTool,
-    client: Client[ClientTransport],
+    client: Client[Any],
     *,
     elicitation: ElicitationMode | None = None,
 ) -> BaseTool:

--- a/libs/langchain_v1/langchain/mcp/tools.py
+++ b/libs/langchain_v1/langchain/mcp/tools.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 from langchain_core.messages.content import (
     ContentBlock,
@@ -20,19 +20,41 @@ from mcp.types import (
     TextResourceContents,
 )
 
+from langchain.mcp._elicitation import call_tool_with_elicitation
+
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from fastmcp import Client
-    from fastmcp.client.client import CallToolResult
     from fastmcp.client.transports import ClientTransport
     from langchain_core.tools import BaseTool
     from mcp.types import ContentBlock as MCPContentBlock
     from mcp.types import Tool as MCPTool
 
+#: How to handle server elicitation. `"interrupt"` bridges modern-spec elicitation to a
+#: LangGraph `interrupt()`; `None` (default) leaves it unhandled.
+ElicitationMode = Literal["interrupt"]
+
 # Result artifact carrying the server's structured (JSON) output, when provided.
 _STRUCTURED_CONTENT_KEY = "structured_content"
 
 
-async def load_mcp_tools(client: Client[ClientTransport]) -> list[BaseTool]:
+class _ToolResult(Protocol):
+    """Structural view shared by the FastMCP and MCP `CallToolResult` types."""
+
+    @property
+    def content(self) -> Sequence[Any]: ...
+    @property
+    def structured_content(self) -> dict[str, Any] | None: ...
+    @property
+    def is_error(self) -> bool: ...
+
+
+async def load_mcp_tools(
+    client: Client[ClientTransport],
+    *,
+    elicitation: ElicitationMode | None = None,
+) -> list[BaseTool]:
     """Load the tools exposed by an MCP server as LangChain tools.
 
     Connection, transport, multi-server configuration, authentication, and protocol
@@ -43,20 +65,30 @@ async def load_mcp_tools(client: Client[ClientTransport]) -> list[BaseTool]:
         client: A FastMCP [`Client`][fastmcp.Client]. Enter it as an async context
             manager (`async with client: ...`) to reuse a single connection across tool
             calls; otherwise FastMCP connects per call as needed.
+        elicitation: If `"interrupt"`, modern-spec server elicitation is surfaced as a
+            LangGraph `interrupt()` (resume with the user's answer). Requires the tool to
+            run inside a graph/agent. Only servers speaking the 2026-07-28 input-required
+            mechanism trigger it; older servers are unaffected.
 
     Returns:
         The server's tools as LangChain tools.
     """
     tools = await client.list_tools()
-    return [convert_mcp_tool(tool, client) for tool in tools]
+    return [convert_mcp_tool(tool, client, elicitation=elicitation) for tool in tools]
 
 
-def convert_mcp_tool(tool: MCPTool, client: Client[ClientTransport]) -> BaseTool:
+def convert_mcp_tool(
+    tool: MCPTool,
+    client: Client[ClientTransport],
+    *,
+    elicitation: ElicitationMode | None = None,
+) -> BaseTool:
     """Convert a single MCP tool definition into a LangChain tool.
 
     Args:
         tool: The MCP tool definition to convert.
         client: FastMCP client used to invoke the tool.
+        elicitation: See [`load_mcp_tools`][langchain.mcp.load_mcp_tools].
 
     Returns:
         A [`StructuredTool`][langchain_core.tools.StructuredTool] wrapping the MCP tool.
@@ -64,7 +96,11 @@ def convert_mcp_tool(tool: MCPTool, client: Client[ClientTransport]) -> BaseTool
     tool_name = tool.name
 
     async def call_tool(**arguments: Any) -> tuple[list[ContentBlock], dict[str, Any] | None]:
-        result = await client.call_tool(tool_name, arguments, raise_on_error=False)
+        result: _ToolResult
+        if elicitation == "interrupt":
+            result = await call_tool_with_elicitation(client, tool_name, arguments)
+        else:
+            result = await client.call_tool(tool_name, arguments, raise_on_error=False)
         return _convert_call_result(result)
 
     return StructuredTool(
@@ -88,12 +124,12 @@ def _tool_metadata(tool: MCPTool) -> dict[str, Any] | None:
 
 
 def _convert_call_result(
-    result: CallToolResult,
+    result: _ToolResult,
 ) -> tuple[list[ContentBlock], dict[str, Any] | None]:
     """Convert an MCP tool-call result into LangChain content and an artifact.
 
     Args:
-        result: The result returned by the FastMCP client.
+        result: The result returned by the FastMCP client (or raw MCP session).
 
     Returns:
         A `(content, artifact)` tuple. `content` is a list of content blocks; `artifact`

--- a/libs/langchain_v1/tests/unit_tests/mcp/test_elicitation.py
+++ b/libs/langchain_v1/tests/unit_tests/mcp/test_elicitation.py
@@ -1,0 +1,85 @@
+"""Unit tests for the MCP elicitation -> interrupt bridge."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.tools import ToolException
+from mcp.types import (
+    CallToolResult,
+    ElicitRequest,
+    ElicitRequestFormParams,
+    InputRequiredResult,
+    TextContent,
+)
+
+from langchain.mcp import _elicitation
+
+_SCHEMA = {"type": "object", "properties": {"date": {"type": "string"}}, "required": ["date"]}
+
+
+class _Session:
+    """Stub MCP session: asks for input once, then returns a terminal result."""
+
+    def __init__(self) -> None:
+        self.rounds = 0
+
+    async def call_tool(
+        self,
+        name: str,  # noqa: ARG002
+        arguments: dict[str, Any],  # noqa: ARG002
+        *,
+        allow_input_required: bool = False,  # noqa: ARG002
+        input_responses: dict[str, Any] | None = None,
+        request_state: str | None = None,  # noqa: ARG002
+    ) -> InputRequiredResult | CallToolResult:
+        if input_responses is None:
+            self.rounds += 1
+            return InputRequiredResult(
+                result_type="input_required",
+                request_state="s1",
+                input_requests={
+                    "date": ElicitRequest(
+                        method="elicitation/create",
+                        params=ElicitRequestFormParams(
+                            mode="form", message="What date?", requested_schema=_SCHEMA
+                        ),
+                    )
+                },
+            )
+        assert input_responses["date"].action == "accept"
+        return CallToolResult(content=[TextContent(type="text", text="booked")], is_error=False)
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.session = _Session()
+
+
+async def test_elicitation_bridges_to_interrupt(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[Any] = []
+
+    def fake_interrupt(payload: Any) -> dict[str, Any]:
+        seen.append(payload)
+        return {"action": "accept", "content": {"date": "2026-12-24"}}
+
+    monkeypatch.setattr(_elicitation, "interrupt", fake_interrupt)
+
+    client: Any = _Client()
+    result = await _elicitation.call_tool_with_elicitation(client, "book", {})
+
+    block = result.content[0]
+    assert isinstance(block, TextContent)
+    assert block.text == "booked"
+    # The interrupt payload surfaces the elicitation for a UI / resume handler.
+    assert seen[0]["type"] == "mcp_elicitation"
+    assert seen[0]["message"] == "What date?"
+    assert seen[0]["response_schema"] == _SCHEMA
+
+
+async def test_invalid_resume_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(_elicitation, "interrupt", lambda _payload: {"action": "maybe"})
+    client: Any = _Client()
+    with pytest.raises(ToolException, match="Invalid elicitation response"):
+        await _elicitation.call_tool_with_elicitation(client, "book", {})


### PR DESCRIPTION
Stacked on #39764.

Adds opt-in elicitation support to `langchain.mcp`. When an MCP server needs input mid-tool-call, this surfaces it as a LangGraph `interrupt()` so the human answers by resuming the graph:

```python
tools = await load_mcp_tools(client, elicitation="interrupt")
# server asks for input -> agent pauses with an interrupt -> resume with the answer:
agent.invoke(Command(resume={"action": "accept", "content": {"date": "2026-12-24"}}))
```

### How it works

On the modern MCP protocol (2026-07-28) there's no server->client back-channel; elicitation is delivered as an `InputRequiredResult`. We drive that loop ourselves and call `interrupt()` on the graph node's own stack, so the pause/resume works cleanly. Only servers speaking that mechanism trigger it — older servers never return an `InputRequiredResult`, so plain calls are unchanged (hence "opt-in and modern-only" fall out naturally).

The exported `MCPElicitation` type describes the `interrupt()` payload (`message`, `response_schema`, `mode`) so UIs / resume handlers can type against it.

### Notes for reviewers

- The side-effectful part of a guard-pattern tool runs exactly once; only the side-effect-free input check re-runs on graph replay, which the guard pattern requires to be safe.
- Verified end-to-end (server emits input-required -> `interrupt()` -> resume -> final result) in addition to the unit tests here.

Built with the help of an AI agent.