### PR TITLE
fix(core): allow deserializing `ImagePromptValue`, and enforce the serialization contracts

### DIFF
--- a/libs/core/langchain_core/load/mapping.py
+++ b/libs/core/langchain_core/load/mapping.py
@@ -460,6 +460,11 @@ SERIALIZABLE_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "prompt_values",
         "StringPromptValue",
     ),
+    ("langchain", "schema", "prompt", "ImagePromptValue"): (
+        "langchain_core",
+        "prompt_values",
+        "ImagePromptValue",
+    ),
     ("langchain", "prompts", "chat", "BaseStringMessagePromptTemplate"): (
         "langchain_core",
         "prompts",
@@ -882,6 +887,11 @@ OLD_CORE_NAMESPACES_MAPPING: dict[tuple[str, ...], tuple[str, ...]] = {
         "prompts",
         "string",
         "StringPromptTemplate",
+    ),
+    ("langchain_core", "prompt_values", "ImagePromptValue"): (
+        "langchain_core",
+        "prompt_values",
+        "ImagePromptValue",
     ),
     ("langchain_core", "prompt_values", "StringPromptValue"): (
         "langchain_core",

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -1,6 +1,9 @@
+import importlib
 import inspect
 import json
+import pkgutil
 import warnings
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -8,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
+import langchain_core
 from langchain_core._api import LangChainDeprecationWarning
 from langchain_core._api.deprecation import LangChainPendingDeprecationWarning
 from langchain_core.documents import Document
@@ -1275,3 +1279,72 @@ def test_chain_using_pick_roundtrips() -> None:
     revived = load(dumpd(chain))
 
     assert revived.invoke({"a": 1, "b": 2}) == {"a": 1}
+
+
+def _iter_declared_serializable_classes() -> Iterator[tuple[str, type]]:
+    """Yield every `langchain_core` class that reports `is_lc_serializable()`.
+
+    Generic aliases (`Foo[str]`), nested classes and private classes are skipped: the
+    first two are artefacts of walking module namespaces rather than distinct classes,
+    and private ones are not part of the serialization contract users rely on.
+    """
+    seen: dict[tuple[str, str], type] = {}
+    for module_info in pkgutil.walk_packages(
+        langchain_core.__path__, "langchain_core."
+    ):
+        if "sys_info" in module_info.name:
+            continue
+        try:
+            module = importlib.import_module(module_info.name)
+        except Exception:  # optional deps may be absent
+            continue
+        for obj in vars(module).values():
+            if not inspect.isclass(obj):
+                continue
+            try:
+                if not issubclass(obj, Serializable) or obj is Serializable:
+                    continue
+                if not obj.is_lc_serializable():
+                    continue
+            except Exception:  # abstract/partially built classes
+                continue
+            qualname = obj.__qualname__
+            if "[" in qualname or "." in qualname or qualname.startswith("_"):
+                continue
+            seen.setdefault((obj.__module__, qualname), obj)
+    for (module_name, qualname), cls in sorted(seen.items()):
+        yield f"{module_name}.{qualname}", cls
+
+
+def test_declared_serializable_classes_are_loadable() -> None:
+    """Test every class claiming to be serializable can also be deserialized.
+
+    `is_lc_serializable()` returning `True` is a promise that a `dumps`/`loads` round
+    trip works. `dumps` writes an id of `get_lc_namespace() + [class name]`, and `load`
+    only accepts ids present in the allowlist derived from the serialization mappings.
+    A class can therefore declare itself serializable, dump successfully, and still be
+    rejected on the way back in if nobody added it to `load/mapping.py`.
+
+    That is not hypothetical: `RunnablePick` (#39752) and `ImagePromptValue` (#39783)
+    were both in exactly that state. This test turns the whole family into a build
+    failure instead of a runtime surprise, so a new serializable class cannot be added
+    without registering it.
+    """
+    allowed_paths = _get_default_allowed_class_paths("core")
+
+    def dumped_id(cls: type) -> tuple[str, ...]:
+        """The id `dumps` writes for this class."""
+        return (*tuple(cls.get_lc_namespace()), cls.__qualname__)
+
+    unregistered = [
+        (name, dumped_id(cls))
+        for name, cls in _iter_declared_serializable_classes()
+        if dumped_id(cls) not in allowed_paths
+    ]
+
+    assert not unregistered, (
+        "These classes report `is_lc_serializable()` but the id `dumps` writes for "
+        "them is not accepted by `load`. Add the id to "
+        "`langchain_core/load/mapping.py`:\n"
+        + "\n".join(f"  {name}: {lc_id}" for name, lc_id in unregistered)
+    )

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -18,6 +18,7 @@ from langchain_core.load.load import (
 from langchain_core.load.serializable import _is_field_useful, _try_neq_default
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration, Generation
+from langchain_core.prompt_values import ImagePromptValue
 from langchain_core.prompts import (
     ChatPromptTemplate,
     HumanMessagePromptTemplate,
@@ -1249,6 +1250,22 @@ def test_runnable_pick_roundtrips() -> None:
 
     assert isinstance(revived, RunnablePick)
     assert revived.keys == ["a"]
+
+
+def test_image_prompt_value_roundtrips() -> None:
+    """Test `ImagePromptValue` can be loaded back after being dumped.
+
+    Regression test: `ImagePromptValue` reports `is_lc_serializable()` and dumps fine,
+    but was missing from the deserialization mapping, so `load` rejected it while its
+    siblings in the same module (`StringPromptValue`, `ChatPromptValue`,
+    `ChatPromptValueConcrete`) all round-tripped.
+    """
+    original = ImagePromptValue(image_url={"url": "https://example.com/cat.png"})
+
+    revived = load(dumpd(original))
+
+    assert isinstance(revived, ImagePromptValue)
+    assert revived.image_url == {"url": "https://example.com/cat.png"}
 
 
 def test_chain_using_pick_roundtrips() -> None:

--- a/libs/core/tests/unit_tests/load/test_serializable.py
+++ b/libs/core/tests/unit_tests/load/test_serializable.py
@@ -20,7 +20,7 @@ from langchain_core.load.load import (
     _get_default_allowed_class_paths,
 )
 from langchain_core.load.serializable import _is_field_useful, _try_neq_default
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, AIMessageChunk
 from langchain_core.outputs import ChatGeneration, Generation
 from langchain_core.prompt_values import ImagePromptValue
 from langchain_core.prompts import (
@@ -1348,3 +1348,54 @@ def test_declared_serializable_classes_are_loadable() -> None:
         "`langchain_core/load/mapping.py`:\n"
         + "\n".join(f"  {name}: {lc_id}" for name, lc_id in unregistered)
     )
+
+
+@pytest.mark.parametrize(
+    "instance",
+    [
+        AIMessage("hi"),
+        AIMessage(
+            "",
+            tool_calls=[
+                {"name": "f", "args": {"x": 1}, "id": "1", "type": "tool_call"}
+            ],
+        ),
+        AIMessageChunk("hi"),
+        PromptTemplate.from_template("{a}"),
+        ChatPromptTemplate.from_messages([("human", "{a}")]),
+    ],
+    ids=[
+        "AIMessage",
+        "AIMessage-with-tool-calls",
+        "AIMessageChunk",
+        "PromptTemplate",
+        "ChatPromptTemplate",
+    ],
+)
+def test_lc_attributes_are_constructor_arguments(instance: Serializable) -> None:
+    """Test `lc_attributes` only names arguments the constructor accepts.
+
+    `Serializable.lc_attributes` documents itself as "attributes that should be included
+    in the serialized kwargs" and states "These attributes must be accepted by the
+    constructor". `to_json` merges them into the serialized `kwargs`, which `load` then
+    passes to the constructor — so a key that is not a real field (renamed, misspelled,
+    or drifted away in a subclass) breaks the round trip.
+
+    Nothing enforced that contract, so this checks the declared keys against the model's
+    fields (including aliases) and confirms the round trip still works.
+    """
+    model_fields = type(instance).model_fields
+    accepted = set(model_fields)
+    accepted.update(
+        field.alias for field in model_fields.values() if field.alias is not None
+    )
+
+    declared = set(instance.lc_attributes)
+
+    assert declared <= accepted, (
+        f"{type(instance).__name__}.lc_attributes declares "
+        f"{sorted(declared - accepted)}, which the constructor does not accept"
+    )
+
+    revived = load(dumpd(instance))
+    assert type(revived) is type(instance)


### PR DESCRIPTION
Fixes #39783

---

`ImagePromptValue` reports `is_lc_serializable() == True` and `dumps()` succeeds, but it is absent from the deserialization allowlist, so `loads()` rejects the id that `dumps()` itself wrote. Its three siblings in the same module are all registered.

Also adds two tests that check the contract across every class rather than this one instance, so the next omission fails in CI instead of being found by hand — the same defect had already shipped once as `RunnablePick` (#39752).

## Release note

`ImagePromptValue` can now be deserialized with `loads()`/`load()`, matching the other prompt value types.
