### PR TITLE
fix(langchain): drop foreign provider built-in tools on model fallback

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -11,11 +11,16 @@ are valid and preserve prompt caching, so they are left intact.
 The knowledge of the `cache_control` marker is duplicated here (rather than owned
 solely by the Anthropic partner package) because an outer caching middleware
 never re-runs during fallback and therefore cannot clean up after itself.
+
+Provider built-in tools (OpenAI's `{"type": "web_search"}`, Anthropic's server
+tools, Gemini's `{"google_search": {}}`) are provider-scoped in the same way, and
+are dropped from fallback attempts that target a different provider.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.tools import BaseTool
@@ -276,6 +281,124 @@ def _supports_anthropic_cache_control(model: BaseChatModel) -> bool:
     return isinstance(llm_type, str) and llm_type in _ANTHROPIC_LLM_TYPES
 
 
+# Provider built-in tools are passed as dicts and are only accepted by the provider
+# that defines them: OpenAI Responses built-ins are bare `{"type": ...}` entries,
+# Anthropic server tools carry a dated `type` (`web_search_20250305`), and Gemini
+# built-ins are single-key payloads (`{"google_search": {}}`). Plain function-tool
+# dicts match none of those shapes and are never touched.
+_OPENAI_BUILTIN_TOOL_TYPES: frozenset[str] = frozenset(
+    {
+        "code_interpreter",
+        "computer_use_preview",
+        "file_search",
+        "image_generation",
+        "mcp",
+        "web_search",
+        "web_search_preview",
+    }
+)
+_ANTHROPIC_BUILTIN_TOOL_TYPE = re.compile(r"_\d{8}$")
+_GOOGLE_BUILTIN_TOOL_KEYS: frozenset[str] = frozenset(
+    {
+        "code_execution",
+        "enterprise_web_search",
+        "google_search",
+        "google_search_retrieval",
+        "url_context",
+    }
+)
+
+# Substring matched against `_llm_type`, ordered so `anthropic-chat-vertexai`
+# resolves to Anthropic rather than Google.
+_LLM_TYPE_PROVIDERS: tuple[tuple[str, str], ...] = (
+    ("anthropic", "anthropic"),
+    ("openai", "openai"),
+    ("google", "google"),
+    ("gemini", "google"),
+    ("vertex", "google"),
+)
+
+
+def _model_provider(model: BaseChatModel) -> str | None:
+    """Return the provider whose built-in tools `model` accepts, if recognized."""
+    llm_type = getattr(model, "_llm_type", None)
+    if not isinstance(llm_type, str):
+        return None
+    return next(
+        (provider for marker, provider in _LLM_TYPE_PROVIDERS if marker in llm_type),
+        None,
+    )
+
+
+def _builtin_tool_provider(tool: dict[str, Any]) -> str | None:
+    """Return the provider that defines this built-in tool, or `None` for plain tools."""
+    tool_type = tool.get("type")
+    if isinstance(tool_type, str):
+        if tool_type in _OPENAI_BUILTIN_TOOL_TYPES:
+            return "openai"
+        if _ANTHROPIC_BUILTIN_TOOL_TYPE.search(tool_type):
+            return "anthropic"
+        return None
+    if len(tool) == 1 and not _GOOGLE_BUILTIN_TOOL_KEYS.isdisjoint(tool):
+        return "google"
+    return None
+
+
+def _is_foreign_builtin_tool(tool: BaseTool | dict[str, Any], provider: str | None) -> bool:
+    if not isinstance(tool, dict):
+        return False
+    owner = _builtin_tool_provider(tool)
+    return owner is not None and owner != provider
+
+
+def _without_foreign_builtin_tools(
+    request: ModelRequest[ContextT], fallback_model: BaseChatModel
+) -> ModelRequest[ContextT]:
+    """Drop built-in tools the fallback model's provider does not define.
+
+    An unrecognized fallback provider drops them too: a built-in tool only exists
+    on its own provider's API, so losing the capability on a retry beats failing
+    the retry outright on an unknown tool type.
+    """
+    provider = _model_provider(fallback_model)
+    tools = [tool for tool in request.tools if not _is_foreign_builtin_tool(tool, provider)]
+    if len(tools) == len(request.tools):
+        return request
+
+    logger.warning(
+        "Dropped %d provider built-in tool(s) not supported by the fallback model",
+        len(request.tools) - len(tools),
+    )
+    return request.override(tools=tools)
+
+
+def _prepare_request_for_fallback(
+    request: ModelRequest[ContextT], fallback_model: BaseChatModel
+) -> ModelRequest[ContextT]:
+    """Strip everything the fallback model cannot accept from `request`."""
+    prepared = (
+        request
+        if _supports_anthropic_cache_control(fallback_model)
+        else _sanitize_request_for_fallback(request)
+    )
+    return _without_foreign_builtin_tools(prepared, fallback_model)
+
+
+def _log_fallback_attempt(exception: Exception, fallback_model: BaseChatModel) -> None:
+    """Report a fallback attempt without logging request content (may hold PII)."""
+    logger.warning(
+        "Model call failed with %s; retrying with fallback model %s",
+        type(exception).__name__,
+        _model_label(fallback_model),
+    )
+    logger.debug("Model call failure preceding fallback", exc_info=exception)
+
+
+def _model_label(model: BaseChatModel) -> str:
+    name = getattr(model, "model_name", None) or getattr(model, "model", None)
+    return name if isinstance(name, str) and name else type(model).__name__
+
+
 class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, ResponseT]):
     """Automatic fallback to alternative models on errors.
 
@@ -350,16 +473,12 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         except Exception as e:
             last_exception = e
 
-        # Try fallback models — sanitize cache markers only when the fallback
-        # model cannot accept them (i.e. is not an Anthropic-compatible model).
-        # The request is derived outside the try so a sanitizer or `_llm_type`
-        # bug surfaces directly instead of being masked as a model failure.
+        # Try fallback models — the request is prepared outside the try so a
+        # sanitizer or `_llm_type` bug surfaces directly instead of being masked
+        # as a model failure.
         for fallback_model in self.models:
-            fallback_request = (
-                request
-                if _supports_anthropic_cache_control(fallback_model)
-                else _sanitize_request_for_fallback(request)
-            )
+            fallback_request = _prepare_request_for_fallback(request, fallback_model)
+            _log_fallback_attempt(last_exception, fallback_model)
             try:
                 return handler(fallback_request.override(model=fallback_model))
             except GraphBubbleUp:
@@ -396,16 +515,12 @@ class ModelFallbackMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, R
         except Exception as e:
             last_exception = e
 
-        # Try fallback models — sanitize cache markers only when the fallback
-        # model cannot accept them (i.e. is not an Anthropic-compatible model).
-        # The request is derived outside the try so a sanitizer or `_llm_type`
-        # bug surfaces directly instead of being masked as a model failure.
+        # Try fallback models — the request is prepared outside the try so a
+        # sanitizer or `_llm_type` bug surfaces directly instead of being masked
+        # as a model failure.
         for fallback_model in self.models:
-            fallback_request = (
-                request
-                if _supports_anthropic_cache_control(fallback_model)
-                else _sanitize_request_for_fallback(request)
-            )
+            fallback_request = _prepare_request_for_fallback(request, fallback_model)
+            _log_fallback_attempt(last_exception, fallback_model)
             try:
                 return await handler(fallback_request.override(model=fallback_model))
             except GraphBubbleUp:

--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -24,6 +24,7 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import _WellKnownOpenAITools
 from langgraph.errors import GraphBubbleUp
 
 from langchain.agents.middleware.types import (
@@ -288,21 +289,13 @@ def _supports_anthropic_cache_control(model: BaseChatModel) -> bool:
 # payloads (`{"google_search": {}}`) in either snake or camel case. Plain function
 # tools — `{"type": "function", ...}`, OpenAI's `namespace` grouping, Gemini's
 # `functionDeclarations` — match none of these shapes and are never dropped.
-_OPENAI_BUILTIN_TOOL_TYPES: frozenset[str] = frozenset(
-    {
-        "apply_patch",
-        "code_interpreter",
-        "computer_use_preview",
-        "file_search",
-        "image_generation",
-        "local_shell",
-        "mcp",
-        "shell",
-        "tool_search",
-        "web_search",
-        "web_search_preview",
-    }
-)
+# Sourced from core's own allowlist so the two cannot drift, minus the two entries
+# that carry client tools rather than a provider capability (`function` wraps a
+# function schema, `namespace` groups them) — dropping those would delete real tools.
+# `local_shell` and `shell` are Responses tools that core does not list.
+_OPENAI_BUILTIN_TOOL_TYPES: frozenset[str] = (
+    frozenset(_WellKnownOpenAITools) - {"function", "namespace"}
+) | {"local_shell", "shell"}
 _ANTHROPIC_BUILTIN_TOOL_TYPES: frozenset[str] = frozenset(
     {
         "mcp_toolset",

--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -286,9 +286,9 @@ def _supports_anthropic_cache_control(model: BaseChatModel) -> bool:
 # that defines them. OpenAI Responses built-ins are `{"type": <name>}` entries, with
 # dated variants (`web_search_preview_2025_03_11`); Anthropic tools carry a dated
 # `type` (`web_search_20250305`) plus a few undated ones; Gemini built-ins are keyed
-# payloads (`{"google_search": {}}`) in either snake or camel case. Plain function
-# tools — `{"type": "function", ...}`, OpenAI's `namespace` grouping, Gemini's
-# `functionDeclarations` — match none of these shapes and are never dropped.
+# payloads (`{"google_search": {}}`) in either snake or camel case. Provider-neutral
+# function tools — `BaseTool`, `{"type": "function", ...}`, OpenAI's `namespace`
+# grouping — match none of these shapes and are never dropped.
 # Sourced from core's own allowlist so the two cannot drift, minus the two entries
 # that carry client tools rather than a provider capability (`function` wraps a
 # function schema, `namespace` groups them) — dropping those would delete real tools.
@@ -304,15 +304,21 @@ _ANTHROPIC_BUILTIN_TOOL_TYPES: frozenset[str] = frozenset(
     }
 )
 _ANTHROPIC_DATED_BUILTIN_TOOL_TYPE = re.compile(r"_\d{8}$")
-_GOOGLE_BUILTIN_TOOL_KEYS: frozenset[str] = frozenset(
+# Every field of the Gemini `Tool` payload, `functionDeclarations` included: a Gemini
+# tool object is Gemini-shaped in all of its parts, so no other provider can read one
+# even when it carries function declarations.
+_GOOGLE_TOOL_KEYS: frozenset[str] = frozenset(
     {
         "codeexecution",
         "computeruse",
         "enterprisewebsearch",
         "filesearch",
+        "functiondeclarations",
         "googlemaps",
         "googlesearch",
         "googlesearchretrieval",
+        "mcpservers",
+        "retrieval",
         "urlcontext",
     }
 )
@@ -357,9 +363,7 @@ def _builtin_tool_provider(tool: dict[str, Any]) -> str | None:
         ):
             return "openai"
         return None
-    # A payload mixing built-ins with `functionDeclarations` keeps its function tools
-    # rather than being dropped whole, so every key must be a built-in to qualify.
-    if tool and all(_normalized_key(key) in _GOOGLE_BUILTIN_TOOL_KEYS for key in tool):
+    if tool and all(_normalized_key(key) in _GOOGLE_TOOL_KEYS for key in tool):
         return "google"
     return None
 

--- a/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
+++ b/libs/langchain_v1/langchain/agents/middleware/model_fallback.py
@@ -282,29 +282,45 @@ def _supports_anthropic_cache_control(model: BaseChatModel) -> bool:
 
 
 # Provider built-in tools are passed as dicts and are only accepted by the provider
-# that defines them: OpenAI Responses built-ins are bare `{"type": ...}` entries,
-# Anthropic server tools carry a dated `type` (`web_search_20250305`), and Gemini
-# built-ins are single-key payloads (`{"google_search": {}}`). Plain function-tool
-# dicts match none of those shapes and are never touched.
+# that defines them. OpenAI Responses built-ins are `{"type": <name>}` entries, with
+# dated variants (`web_search_preview_2025_03_11`); Anthropic tools carry a dated
+# `type` (`web_search_20250305`) plus a few undated ones; Gemini built-ins are keyed
+# payloads (`{"google_search": {}}`) in either snake or camel case. Plain function
+# tools — `{"type": "function", ...}`, OpenAI's `namespace` grouping, Gemini's
+# `functionDeclarations` — match none of these shapes and are never dropped.
 _OPENAI_BUILTIN_TOOL_TYPES: frozenset[str] = frozenset(
     {
+        "apply_patch",
         "code_interpreter",
         "computer_use_preview",
         "file_search",
         "image_generation",
+        "local_shell",
         "mcp",
+        "shell",
+        "tool_search",
         "web_search",
         "web_search_preview",
     }
 )
-_ANTHROPIC_BUILTIN_TOOL_TYPE = re.compile(r"_\d{8}$")
+_ANTHROPIC_BUILTIN_TOOL_TYPES: frozenset[str] = frozenset(
+    {
+        "mcp_toolset",
+        "tool_search_tool_bm25",
+        "tool_search_tool_regex",
+    }
+)
+_ANTHROPIC_DATED_BUILTIN_TOOL_TYPE = re.compile(r"_\d{8}$")
 _GOOGLE_BUILTIN_TOOL_KEYS: frozenset[str] = frozenset(
     {
-        "code_execution",
-        "enterprise_web_search",
-        "google_search",
-        "google_search_retrieval",
-        "url_context",
+        "codeexecution",
+        "computeruse",
+        "enterprisewebsearch",
+        "filesearch",
+        "googlemaps",
+        "googlesearch",
+        "googlesearchretrieval",
+        "urlcontext",
     }
 )
 
@@ -331,17 +347,33 @@ def _model_provider(model: BaseChatModel) -> str | None:
 
 
 def _builtin_tool_provider(tool: dict[str, Any]) -> str | None:
-    """Return the provider that defines this built-in tool, or `None` for plain tools."""
+    """Return the provider that defines this built-in tool, or `None` for plain tools.
+
+    Anthropic is matched before OpenAI: `tool_search_tool_bm25_20251119` would also
+    match the `tool_search` prefix, and `web_search_20250305` the `web_search` one.
+    """
     tool_type = tool.get("type")
     if isinstance(tool_type, str):
-        if tool_type in _OPENAI_BUILTIN_TOOL_TYPES:
-            return "openai"
-        if _ANTHROPIC_BUILTIN_TOOL_TYPE.search(tool_type):
+        if tool_type in _ANTHROPIC_BUILTIN_TOOL_TYPES or _ANTHROPIC_DATED_BUILTIN_TOOL_TYPE.search(
+            tool_type
+        ):
             return "anthropic"
+        if any(
+            tool_type == name or tool_type.startswith(f"{name}_")
+            for name in _OPENAI_BUILTIN_TOOL_TYPES
+        ):
+            return "openai"
         return None
-    if len(tool) == 1 and not _GOOGLE_BUILTIN_TOOL_KEYS.isdisjoint(tool):
+    # A payload mixing built-ins with `functionDeclarations` keeps its function tools
+    # rather than being dropped whole, so every key must be a built-in to qualify.
+    if tool and all(_normalized_key(key) in _GOOGLE_BUILTIN_TOOL_KEYS for key in tool):
         return "google"
     return None
+
+
+def _normalized_key(key: str) -> str:
+    """Fold a Gemini tool key so snake and camel spellings compare equal."""
+    return key.replace("_", "").lower()
 
 
 def _is_foreign_builtin_tool(tool: BaseTool | dict[str, Any], provider: str | None) -> bool:

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -1176,11 +1176,15 @@ def test_model_provider_resolves_from_llm_type() -> None:
         ({"google_search": {}}, "google"),
         ({"googleSearch": {}, "urlContext": {}}, "google"),
         ({"enterprise_web_search": {}}, "google"),
-        # Plain tool payloads, including a Gemini tool that also declares functions.
+        ({"mcpServers": []}, "google"),
+        ({"retrieval": {}}, "google"),
+        # A Gemini payload is Gemini-shaped throughout, function declarations included.
+        ({"googleSearch": {}, "functionDeclarations": []}, "google"),
+        ({"functionDeclarations": []}, "google"),
+        # Provider-neutral tool payloads.
         ({"type": "function", "function": {"name": "lookup", "parameters": {}}}, None),
         ({"type": "namespace", "name": "group", "tools": []}, None),
         ({"name": "lookup", "description": "", "parameters": {}}, None),
-        ({"googleSearch": {}, "functionDeclarations": []}, None),
     ],
 )
 def test_builtin_tool_provider_classifies_payloads(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import warnings
 from typing import TYPE_CHECKING, Any, cast
 
@@ -18,6 +19,8 @@ from langchain.agents.factory import create_agent
 from langchain.agents.middleware import model_fallback as model_fallback_module
 from langchain.agents.middleware.model_fallback import (
     ModelFallbackMiddleware,
+    _builtin_tool_provider,
+    _model_provider,
     _sanitize_request_for_fallback,
     _supports_anthropic_cache_control,
 )
@@ -1110,3 +1113,151 @@ async def test_fallback_sanitizer_error_is_not_masked_async(
 
     with pytest.raises(RuntimeError, match="sanitizer boom"):
         await middleware.awrap_model_call(request, mock_handler)
+
+
+class _FakeOpenAIModel(GenericFakeChatModel):
+    """Fake model that reports `openai-chat` as its `_llm_type`."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "openai-chat"
+
+
+class _FakeGoogleModel(GenericFakeChatModel):
+    """Fake model that reports `chat-google-generative-ai` as its `_llm_type`."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "chat-google-generative-ai"
+
+
+@tool
+def _plain_tool(query: str) -> str:
+    """Regular function tool that must survive every fallback attempt."""
+    return query
+
+
+def test_model_provider_resolves_from_llm_type() -> None:
+    """Provider detection is `_llm_type`-based, with Anthropic winning over Vertex."""
+    assert _model_provider(_FakeOpenAIModel(messages=iter([]))) == "openai"
+    assert _model_provider(_FakeAnthropicModel(messages=iter([]))) == "anthropic"
+    assert _model_provider(_FakeVertexAnthropicModel(messages=iter([]))) == "anthropic"
+    assert _model_provider(_FakeGoogleModel(messages=iter([]))) == "google"
+    assert _model_provider(GenericFakeChatModel(messages=iter([]))) is None
+    assert _model_provider(_FakeNonStringLlmTypeModel(messages=iter([]))) is None
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"type": "web_search"}, "openai"),
+        ({"type": "code_interpreter", "container": {"type": "auto"}}, "openai"),
+        ({"type": "web_search_20250305", "name": "web_search"}, "anthropic"),
+        ({"type": "bash_20250124", "name": "bash"}, "anthropic"),
+        ({"google_search": {}}, "google"),
+        ({"type": "function", "function": {"name": "lookup", "parameters": {}}}, None),
+        ({"name": "lookup", "description": "", "parameters": {}}, None),
+    ],
+)
+def test_builtin_tool_provider_classifies_payloads(
+    payload: dict[str, Any], expected: str | None
+) -> None:
+    """Only provider built-in shapes are classified; plain function dicts are not."""
+    assert _builtin_tool_provider(payload) == expected
+
+
+def _builtin_tool_request(primary_model: BaseChatModel) -> ModelRequest:
+    return _make_request().override(
+        model=primary_model,
+        tools=[_plain_tool, {"type": "web_search"}],
+    )
+
+
+def test_fallback_drops_builtin_tools_the_provider_does_not_define() -> None:
+    """An OpenAI built-in tool is dropped for a Claude fallback, plain tools kept."""
+    primary_model = _FakeOpenAIModel(messages=iter([AIMessage(content="primary")]))
+    openai_fallback = _FakeOpenAIModel(messages=iter([AIMessage(content="openai fallback")]))
+    anthropic_fallback = _FakeAnthropicModel(
+        messages=iter([AIMessage(content="anthropic fallback")])
+    )
+    middleware = ModelFallbackMiddleware(openai_fallback, anthropic_fallback)
+    request = _builtin_tool_request(primary_model)
+    attempts: list[ModelRequest] = []
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        attempts.append(req)
+        if req.model is anthropic_fallback:
+            return ModelResponse(result=[AIMessage(content="anthropic fallback")])
+        msg = "model failed"
+        raise ValueError(msg)
+
+    middleware.wrap_model_call(request, mock_handler)
+
+    # Same-provider fallback keeps the built-in tool; cross-provider drops it.
+    assert attempts[1].tools == [_plain_tool, {"type": "web_search"}]
+    assert attempts[2].tools == [_plain_tool]
+
+
+async def test_fallback_drops_builtin_tools_the_provider_does_not_define_async() -> None:
+    """Async: cross-provider fallback drops the built-in tool."""
+    primary_model = _FakeOpenAIModel(messages=iter([AIMessage(content="primary")]))
+    anthropic_fallback = _FakeAnthropicModel(
+        messages=iter([AIMessage(content="anthropic fallback")])
+    )
+    middleware = ModelFallbackMiddleware(anthropic_fallback)
+    request = _builtin_tool_request(primary_model)
+    attempts: list[ModelRequest] = []
+
+    async def mock_handler(req: ModelRequest) -> ModelResponse:
+        attempts.append(req)
+        if req.model is anthropic_fallback:
+            return ModelResponse(result=[AIMessage(content="anthropic fallback")])
+        msg = "model failed"
+        raise ValueError(msg)
+
+    await middleware.awrap_model_call(request, mock_handler)
+
+    assert attempts[1].tools == [_plain_tool]
+
+
+def test_fallback_drops_builtin_tools_for_unrecognized_provider() -> None:
+    """A fallback whose provider cannot be identified loses provider built-ins."""
+    primary_model = _FakeOpenAIModel(messages=iter([AIMessage(content="primary")]))
+    unknown_fallback = GenericFakeChatModel(messages=iter([AIMessage(content="fallback")]))
+    middleware = ModelFallbackMiddleware(unknown_fallback)
+    request = _builtin_tool_request(primary_model)
+    attempts: list[ModelRequest] = []
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        attempts.append(req)
+        if req.model is unknown_fallback:
+            return ModelResponse(result=[AIMessage(content="fallback")])
+        msg = "model failed"
+        raise ValueError(msg)
+
+    middleware.wrap_model_call(request, mock_handler)
+
+    assert attempts[1].tools == [_plain_tool]
+
+
+def test_fallback_attempt_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """Every fallback attempt warns, naming the failure type and the fallback model."""
+    primary_model = _FakeOpenAIModel(messages=iter([AIMessage(content="primary")]))
+    fallback_model = _FakeAnthropicModel(messages=iter([AIMessage(content="fallback")]))
+    middleware = ModelFallbackMiddleware(fallback_model)
+    request = _make_request().override(model=primary_model)
+
+    def mock_handler(req: ModelRequest) -> ModelResponse:
+        if req.model is primary_model:
+            msg = "primary boom"
+            raise ValueError(msg)
+        return ModelResponse(result=[AIMessage(content="fallback")])
+
+    with caplog.at_level(logging.WARNING, logger=model_fallback_module.__name__):
+        middleware.wrap_model_call(request, mock_handler)
+
+    assert any(
+        "Model call failed with ValueError" in record.message
+        and "retrying with fallback model" in record.message
+        for record in caplog.records
+    )

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -1151,12 +1151,25 @@ def test_model_provider_resolves_from_llm_type() -> None:
     ("payload", "expected"),
     [
         ({"type": "web_search"}, "openai"),
+        ({"type": "web_search_preview_2025_03_11"}, "openai"),
         ({"type": "code_interpreter", "container": {"type": "auto"}}, "openai"),
+        ({"type": "apply_patch"}, "openai"),
+        ({"type": "local_shell"}, "openai"),
+        ({"type": "tool_search"}, "openai"),
         ({"type": "web_search_20250305", "name": "web_search"}, "anthropic"),
         ({"type": "bash_20250124", "name": "bash"}, "anthropic"),
+        # Undated Anthropic types, and a dated one that also matches an OpenAI prefix.
+        ({"type": "mcp_toolset", "mcp_servers": []}, "anthropic"),
+        ({"type": "tool_search_tool_bm25"}, "anthropic"),
+        ({"type": "tool_search_tool_bm25_20251119"}, "anthropic"),
         ({"google_search": {}}, "google"),
+        ({"googleSearch": {}, "urlContext": {}}, "google"),
+        ({"enterprise_web_search": {}}, "google"),
+        # Plain tool payloads, including a Gemini tool that also declares functions.
         ({"type": "function", "function": {"name": "lookup", "parameters": {}}}, None),
+        ({"type": "namespace", "name": "group", "tools": []}, None),
         ({"name": "lookup", "description": "", "parameters": {}}, None),
+        ({"googleSearch": {}, "functionDeclarations": []}, None),
     ],
 )
 def test_builtin_tool_provider_classifies_payloads(

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_model_fallback.py
@@ -12,12 +12,14 @@ from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.tools import BaseTool, tool
+from langchain_core.utils.function_calling import _WellKnownOpenAITools
 from langgraph.errors import GraphInterrupt
 from typing_extensions import override
 
 from langchain.agents.factory import create_agent
 from langchain.agents.middleware import model_fallback as model_fallback_module
 from langchain.agents.middleware.model_fallback import (
+    _OPENAI_BUILTIN_TOOL_TYPES,
     ModelFallbackMiddleware,
     _builtin_tool_provider,
     _model_provider,
@@ -1137,6 +1139,14 @@ def _plain_tool(query: str) -> str:
     return query
 
 
+def test_openai_builtin_types_track_core_allowlist() -> None:
+    """Core's allowlist is the source of truth, minus its client-tool containers."""
+    assert set(_WellKnownOpenAITools) - {"function", "namespace"} <= _OPENAI_BUILTIN_TOOL_TYPES
+    # Both carry client tools, so classifying them as provider built-ins would drop
+    # real function tools on fallback.
+    assert not {"function", "namespace"} & _OPENAI_BUILTIN_TOOL_TYPES
+
+
 def test_model_provider_resolves_from_llm_type() -> None:
     """Provider detection is `_llm_type`-based, with Anthropic winning over Vertex."""
     assert _model_provider(_FakeOpenAIModel(messages=iter([]))) == "openai"
@@ -1155,6 +1165,7 @@ def test_model_provider_resolves_from_llm_type() -> None:
         ({"type": "code_interpreter", "container": {"type": "auto"}}, "openai"),
         ({"type": "apply_patch"}, "openai"),
         ({"type": "local_shell"}, "openai"),
+        ({"type": "computer"}, "openai"),
         ({"type": "tool_search"}, "openai"),
         ({"type": "web_search_20250305", "name": "web_search"}, "anthropic"),
         ({"type": "bash_20250124", "name": "bash"}, "anthropic"),

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1044,7 +1044,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -2120,7 +2120,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.5.5"
+version = "1.6.0"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2260,9 +2260,10 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.5.4"
+version = "1.6.0"
 source = { editable = "../core" }
 dependencies = [
+    { name = "httpx" },
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
     { name = "langsmith" },
@@ -2276,6 +2277,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
     { name = "langchain-protocol", specifier = ">=0.0.17" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
@@ -2462,9 +2464,10 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.4.3"
+version = "1.6.0"
 source = { editable = "../partners/openai" }
 dependencies = [
+    { name = "certifi" },
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
@@ -2472,8 +2475,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "certifi", specifier = ">=2024.6.2" },
     { name = "langchain-core", editable = "../core" },
-    { name = "openai", specifier = ">=2.45.0,<3.0.0" },
+    { name = "openai", specifier = ">=2.45.0,<4.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
 ]
 
@@ -2495,7 +2499,7 @@ test = [
     { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
     { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
+    { name = "vcrpy", specifier = ">=8.2.0,<9.0.0" },
 ]
 test-integration = [
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1044,7 +1044,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -2120,7 +2120,7 @@ typing = [
 
 [[package]]
 name = "langchain-anthropic"
-version = "1.6.0"
+version = "1.5.5"
 source = { editable = "../partners/anthropic" }
 dependencies = [
     { name = "anthropic" },
@@ -2260,10 +2260,9 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.6.0"
+version = "1.5.4"
 source = { editable = "../core" }
 dependencies = [
-    { name = "httpx" },
     { name = "jsonpatch" },
     { name = "langchain-protocol" },
     { name = "langsmith" },
@@ -2277,7 +2276,6 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.23.0,<1.0.0" },
     { name = "jsonpatch", specifier = ">=1.33.0,<2.0.0" },
     { name = "langchain-protocol", specifier = ">=0.0.17" },
     { name = "langsmith", specifier = ">=0.3.45,<1.0.0" },
@@ -2464,10 +2462,9 @@ wheels = [
 
 [[package]]
 name = "langchain-openai"
-version = "1.6.0"
+version = "1.4.3"
 source = { editable = "../partners/openai" }
 dependencies = [
-    { name = "certifi" },
     { name = "langchain-core" },
     { name = "openai" },
     { name = "tiktoken" },
@@ -2475,9 +2472,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "certifi", specifier = ">=2024.6.2" },
     { name = "langchain-core", editable = "../core" },
-    { name = "openai", specifier = ">=2.45.0,<4.0.0" },
+    { name = "openai", specifier = ">=2.45.0,<3.0.0" },
     { name = "tiktoken", specifier = ">=0.7.0,<1.0.0" },
 ]
 
@@ -2499,7 +2495,7 @@ test = [
     { name = "pytest-watcher", specifier = ">=0.3.4,<1.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
     { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
-    { name = "vcrpy", specifier = ">=8.2.0,<9.0.0" },
+    { name = "vcrpy", specifier = ">=8.0.0,<9.0.0" },
 ]
 test-integration = [
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },


### PR DESCRIPTION
`ModelFallbackMiddleware` already owns cross-provider request cleanup — it strips Anthropic `cache_control` markers before a non-Anthropic fallback attempt. Provider built-in tools were not covered: an agent bound to OpenAI's `{"type": "web_search"}` that falls back to Claude re-sent that tool dict verbatim, so the fallback attempt failed on an unknown tool type instead of recovering. Same for Anthropic server tools (`web_search_20250305`) falling back to OpenAI, and Gemini's `{"google_search": {}}` either way.

Fallback attempts now drop built-in tools the fallback model's provider does not define, keyed off `_llm_type`. Plain function tools (`BaseTool`, `{"type": "function", ...}`, bare name/parameters dicts) match none of the built-in shapes and always pass through. An unrecognized fallback provider drops built-ins too: losing a provider capability on a retry beats failing the retry outright.

Also adds a `logger.warning` on every fallback attempt, naming the failure type and the fallback model — previously a silent model swap, with only a `debug` line when cache markers were stripped. The exception message itself stays at `debug` level (`exc_info`) since provider errors can echo prompt content.

## Release note

`ModelFallbackMiddleware` now drops provider built-in tools that the fallback model's provider does not support, so a cross-provider fallback no longer fails on an unknown tool type, and logs a warning whenever it falls back to another model.
