### PR TITLE
fix(core): exclude the pydantic v2 root field from the parallel input schema

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -4044,13 +4044,21 @@ class RunnableParallel(RunnableSerializable[Input, dict[str, Any]]):
                     return step_input_schema
 
             # This is correct, but pydantic typings/mypy don't think so.
+            #
+            # `root`/`__root__` are the synthetic field names Pydantic uses for a
+            # root model, which is how a step that accepts any single value (e.g.
+            # `RunnablePassthrough`, an unannotated `RunnableLambda`) reports its
+            # input schema. They are not keys the caller is expected to supply, so
+            # merging them in would require callers to pass `{"root": ...}` while
+            # `invoke` actually takes the bare value. `__root__` is the Pydantic v1
+            # spelling and was already excluded; `root` is the v2 spelling.
             return create_model_v2(
                 self.get_name("Input"),
                 field_definitions={
                     k: _get_schema_field_definition(v)
                     for step in self.steps__.values()
                     for k, v in get_fields(step.get_input_schema(config)).items()
-                    if k != "__root__"
+                    if k not in {"__root__", "root"}
                 },
             )
 

--- a/libs/core/tests/unit_tests/runnables/test_runnable.py
+++ b/libs/core/tests/unit_tests/runnables/test_runnable.py
@@ -5893,6 +5893,44 @@ def test_runnable_parallel_preserves_required_v1_input_fields() -> None:
 
 
 @skip_if_no_pydantic_v1
+def test_runnable_parallel_input_schema_accepts_what_invoke_accepts() -> None:
+    """Test the parallel input schema validates the inputs `invoke` actually takes.
+
+    Regression test: a step that accepts any single value (`RunnablePassthrough`, an
+    unannotated `RunnableLambda`) reports its input schema as a Pydantic root model,
+    whose synthetic field is named `root` in v2. Merging that name into the parallel
+    schema made it demand `{"root": ...}`, so no input could satisfy both the declared
+    schema and `invoke`. The v1 spelling `__root__` was already excluded.
+    """
+    parallel = RunnableParallel(a=RunnablePassthrough(), b=RunnableLambda(lambda x: x))
+    schema = parallel.get_input_schema()
+
+    assert "root" not in schema.model_fields
+
+    # Whatever `invoke` accepts, the schema must accept too.
+    for value in ({"k": 1}, {"nested": {"x": 1}}):
+        parallel.invoke(value)
+        schema.model_validate(value)
+
+
+def test_runnable_parallel_input_schema_keeps_real_step_fields() -> None:
+    """Test excluding the root field does not drop genuine step fields.
+
+    Mixing a root-model step with a step that declares real fields must keep the real
+    fields; only the synthetic root name is dropped.
+    """
+    parallel = RunnableParallel(
+        passthrough=RunnablePassthrough(),
+        prompt=PromptTemplate.from_template("{question}"),
+    )
+    schema = parallel.get_input_schema()
+
+    assert "root" not in schema.model_fields
+    assert "question" in schema.model_fields
+
+    schema.model_validate({"question": "hi"})
+
+
 def test_runnable_parallel_uses_base_schema_for_v1_root_model() -> None:
     class InputModel(BaseModelV1):
         __root__: dict[str, int]


### PR DESCRIPTION
Fixes #39792

---

`RunnableParallel.get_input_schema()` advertises `root` as a required field when a step accepts a single unannotated value, but `invoke` takes the bare value and would reject `{"root": ...}`. The Pydantic v1 spelling `__root__` was already excluded; this adds the v2 spelling.

## Release note

`RunnableParallel` input schemas no longer include the synthetic `root` field, so generated JSON schemas and tool argument specs match what `invoke` actually accepts.

---

**Note on this PR's contents.** GitHub does not record pushes to a closed PR, so this PR captures only
the first of the branch's two commits. The missing one is
`test(core): cover compositions built on a parallel` (`fa99e0514`), which checks the fix through `|`
composition rather than only on a directly constructed `RunnableParallel` — implicit dict-to-parallel
coercion goes through a different construction path and is how most callers reach this.

Complete branch: `gaoanze888/langchain@gaoanze888/core/parallel-input-schema-root`. Verified against
`upstream/master` (`9bdaf437b`): the commit in this PR gives `2253 passed` vs a `2251` baseline; the
full branch gives `2254`. `ruff`, `ruff format --check` and `mypy` clean on both. I'm not opening a
replacement PR for the missing commit — one change occupying two PR numbers is what I did with
#39784/#39787 and it isn't worth a second maintainer-facing item.
