### PR TITLE
fix(mistralai): classify timeout and connection errors as model errors

### DIFF
--- a/libs/partners/mistralai/langchain_mistralai/chat_models.py
+++ b/libs/partners/mistralai/langchain_mistralai/chat_models.py
@@ -13,6 +13,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    NoReturn,
     cast,
 )
 
@@ -26,10 +27,12 @@ from langchain_core.callbacks import (
 from langchain_core.exceptions import (
     ModelAPIError,
     ModelAuthenticationError,
+    ModelConnectionError,
     ModelInvalidRequestError,
     ModelNotFoundError,
     ModelPermissionDeniedError,
     ModelRateLimitError,
+    ModelTimeoutError,
 )
 from langchain_core.language_models import (
     LanguageModelInput,
@@ -251,6 +254,14 @@ class MistralAIAPIError(httpx.HTTPStatusError, ModelAPIError):
     """Mistral AI server error classified as a LangChain model error."""
 
 
+class MistralAITimeoutError(httpx.TimeoutException, ModelTimeoutError):
+    """Mistral AI timeout classified as a LangChain model error."""
+
+
+class MistralAIConnectionError(httpx.ConnectError, ModelConnectionError):
+    """Mistral AI connection failure classified as a LangChain model error."""
+
+
 _STATUS_ERROR_TYPES: dict[int, type[httpx.HTTPStatusError]] = {
     400: MistralAIInvalidRequestError,
     401: MistralAIAuthenticationError,
@@ -339,11 +350,41 @@ async def acompletion_with_retry(
                 llm.async_client, "POST", "/chat/completions", json=kwargs
             )
             return _aiter_sse(event_source)
-        response = await llm.async_client.post(url="/chat/completions", json=kwargs)
+        try:
+            response = await llm.async_client.post(url="/chat/completions", json=kwargs)
+        except httpx.HTTPError as e:
+            _raise_classified_transport_error(e)
         await _araise_on_error(response)
         return response.json()
 
     return await _completion_with_retry(**kwargs)
+
+
+def _raise_classified_transport_error(e: httpx.HTTPError) -> NoReturn:
+    """Re-raise a transport-level `httpx` error as its LangChain equivalent.
+
+    Timeouts and connection failures never produce an HTTP response, so they do not
+    pass through `_raise_on_error` and would otherwise reach callers as plain `httpx`
+    exceptions. The other integrations classify these (`OpenAITimeoutError`,
+    `AnthropicTimeoutError`, `FireworksTimeoutError`), and `ModelError` documents that
+    "the same condition maps to the same exception type regardless of provider".
+
+    Args:
+        e: The transport-level error raised by `httpx`.
+
+    Raises:
+        MistralAITimeoutError: If the request timed out.
+        MistralAIConnectionError: If the endpoint could not be reached.
+    """
+    # `ConnectTimeout` subclasses both `TimeoutException` and `ConnectError`;
+    # check the timeout branch first so it keeps its more specific meaning.
+    if isinstance(e, httpx.TimeoutException):
+        raise MistralAITimeoutError(str(e), request=e.request) from e
+    if isinstance(e, httpx.ConnectError):
+        raise MistralAIConnectionError(str(e), request=e.request) from e
+    # Anything else keeps its original type. `raise e` rather than a bare `raise`
+    # so the helper also behaves correctly when called outside an `except` block.
+    raise e
 
 
 def _convert_chunk_to_message_chunk(
@@ -743,7 +784,10 @@ class ChatMistralAI(BaseChatModel):
                             yield event.json()
 
                 return iter_sse()
-            response = self.client.post(url="/chat/completions", json=kwargs)
+            try:
+                response = self.client.post(url="/chat/completions", json=kwargs)
+            except httpx.HTTPError as e:
+                _raise_classified_transport_error(e)
             _raise_on_error(response)
             return response.json()
 

--- a/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/mistralai/tests/unit_tests/test_chat_models.py
@@ -2,7 +2,7 @@
 
 import os
 from collections.abc import AsyncGenerator, Generator
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -11,11 +11,13 @@ from langchain_core.callbacks.base import BaseCallbackHandler
 from langchain_core.exceptions import (
     ModelAPIError,
     ModelAuthenticationError,
+    ModelConnectionError,
     ModelError,
     ModelInvalidRequestError,
     ModelNotFoundError,
     ModelPermissionDeniedError,
     ModelRateLimitError,
+    ModelTimeoutError,
 )
 from langchain_core.messages import (
     AIMessage,
@@ -43,9 +45,12 @@ from langchain_mistralai.chat_models import (  # type: ignore[import]
     _convert_tool_call_id_to_mistral_compatible,
     _format_message_content,
     _is_valid_mistral_tool_call_id,
+    _raise_classified_transport_error,
     _raise_on_error,
     _sanitize_chat_completions_content,
 )
+
+_REQUEST = httpx.Request("POST", "https://api.mistral.ai/v1/chat/completions")
 
 os.environ["MISTRAL_API_KEY"] = "foo"
 
@@ -1149,6 +1154,86 @@ async def test_error_classification_async() -> None:
         await _araise_on_error(_error_response(429))
 
     assert isinstance(exc_info.value, ModelRateLimitError)
+
+
+@pytest.mark.parametrize(
+    ("httpx_error", "model_error_type"),
+    [
+        (
+            httpx.ConnectTimeout("timed out", request=_REQUEST),
+            ModelTimeoutError,
+        ),
+        (
+            httpx.ReadTimeout("read timed out", request=_REQUEST),
+            ModelTimeoutError,
+        ),
+        (
+            httpx.ConnectError("cannot connect", request=_REQUEST),
+            ModelConnectionError,
+        ),
+    ],
+    ids=["connect-timeout", "read-timeout", "connect-error"],
+)
+def test_transport_error_classification(
+    httpx_error: httpx.HTTPError,
+    model_error_type: type[ModelError],
+) -> None:
+    """Test transport failures are classified like the other integrations.
+
+    Timeouts and connection failures never produce an HTTP response, so they do not
+    reach `_raise_on_error` and previously surfaced as plain `httpx` exceptions —
+    unlike `langchain-openai`, `langchain-anthropic` and `langchain-fireworks`, which
+    map them to the LangChain types. `ModelError` documents that the same condition
+    maps to the same exception type regardless of provider.
+    """
+    with pytest.raises(model_error_type) as exc_info:
+        _raise_classified_transport_error(httpx_error)
+
+    # Still catchable as the original httpx type, so existing handlers keep working.
+    assert isinstance(exc_info.value, type(httpx_error).__mro__[1])
+    assert exc_info.value.is_retryable is True
+    assert exc_info.value.__cause__ is httpx_error
+
+
+@pytest.mark.parametrize(
+    ("httpx_error", "model_error_type"),
+    [
+        (httpx.ConnectTimeout("timed out", request=_REQUEST), ModelTimeoutError),
+        (httpx.ConnectError("cannot connect", request=_REQUEST), ModelConnectionError),
+    ],
+    ids=["timeout", "connection"],
+)
+def test_invoke_classifies_transport_errors(
+    httpx_error: httpx.HTTPError,
+    model_error_type: type[ModelError],
+) -> None:
+    """Test the classification is wired into the request path, not just the helper.
+
+    Asserting on the helper alone would still pass if the `try`/`except` around the
+    `post` call were removed, so this drives `invoke` with a client that fails at the
+    transport layer.
+    """
+
+    class FailingClient:
+        def post(self, **_kwargs: Any) -> NoReturn:
+            raise httpx_error
+
+    model = ChatMistralAI(model="mistral-small", api_key="k", max_retries=0)  # type: ignore[call-arg]
+    model.client = FailingClient()  # type: ignore[assignment]
+
+    with pytest.raises(model_error_type):
+        model.invoke("hi")
+
+
+def test_unclassified_transport_error_is_reraised() -> None:
+    """Test transport errors outside the taxonomy keep their original type."""
+    original = httpx.TooManyRedirects("too many", request=_REQUEST)
+
+    with pytest.raises(httpx.TooManyRedirects) as exc_info:
+        _raise_classified_transport_error(original)
+
+    assert exc_info.value is original
+    assert not isinstance(exc_info.value, ModelError)
 
 
 def test_unclassified_status_stays_a_plain_status_error() -> None:


### PR DESCRIPTION
Fixes #39794

---

Timeouts and connection failures from `ChatMistralAI` reach callers as raw `httpx` exceptions, while the OpenAI, Anthropic, and Fireworks integrations classify the same conditions as `ModelTimeoutError`/`ModelConnectionError`. `ModelError` documents that the same condition should map to the same exception type regardless of provider.

## Release note

`ChatMistralAI` now raises `MistralAITimeoutError` and `MistralAIConnectionError` (subclasses of both the `httpx` exception and the corresponding `langchain-core` `ModelError`) for transport failures, so provider-agnostic error handling works with Mistral.
