### PR TITLE
fix(core): stop treating a v0 block id as an extra

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/langchain_v0.py
+++ b/libs/core/langchain_core/messages/block_translators/langchain_v0.py
@@ -65,7 +65,13 @@ def _convert_legacy_v0_content_block_to_v1(
         Returns:
             A dictionary of extra keys not part of the known v0 format.
         """
-        return {k: v for k, v in block_dict.items() if k not in known_keys}
+        # `id` is never an extra: it is either passed explicitly to the factory
+        # (which would collide with `**extras`) or, for `source_type="id"`, it is
+        # the file reference itself and already listed in that branch's
+        # `known_keys`. Excluding it here keeps every caller correct.
+        return {
+            k: v for k, v in block_dict.items() if k not in known_keys and k != "id"
+        }
 
     # Check if this is actually a v0 format block
     block_type = block.get("type")

--- a/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
@@ -1,3 +1,5 @@
+import pytest
+
 from langchain_core.messages import HumanMessage
 from langchain_core.messages import content as types
 from langchain_core.messages.block_translators.langchain_v0 import (
@@ -111,3 +113,66 @@ def test_convert_with_extras_on_v0_block() -> None:
     }
 
     assert _convert_legacy_v0_content_block_to_v1(block) == expected_output
+
+
+@pytest.mark.parametrize(
+    ("block_type", "source"),
+    [
+        ("image", {"source_type": "url", "url": "https://example.com/x.png"}),
+        (
+            "image",
+            {"source_type": "base64", "data": "aGk=", "mime_type": "image/png"},
+        ),
+        ("audio", {"source_type": "url", "url": "https://example.com/x.mp3"}),
+        (
+            "audio",
+            {"source_type": "base64", "data": "aGk=", "mime_type": "audio/mp3"},
+        ),
+        ("file", {"source_type": "url", "url": "https://example.com/x.pdf"}),
+        (
+            "file",
+            {"source_type": "base64", "data": "aGk=", "mime_type": "application/pdf"},
+        ),
+    ],
+    ids=[
+        "image-url",
+        "image-base64",
+        "audio-url",
+        "audio-base64",
+        "file-url",
+        "file-base64",
+    ],
+)
+def test_block_id_is_not_treated_as_an_extra(
+    block_type: str, source: dict[str, str]
+) -> None:
+    """Test a v0 block carrying `id` converts instead of raising.
+
+    Regression test: `_extract_v0_extras` filtered by each branch's `known_keys`, and
+    the `url`/`base64` branches did not list `id`. It therefore stayed in `extras`,
+    and expanding `**extras` alongside the explicit `id=block["id"]` argument raised
+    `TypeError: got multiple values for keyword argument 'id'`. The `source_type="id"`
+    branches were unaffected because their `known_keys` included it.
+    """
+    block = {"type": block_type, "id": "block-1", **source}
+
+    converted = _convert_legacy_v0_content_block_to_v1(block)
+
+    assert converted["id"] == "block-1"
+    assert "id" not in converted.get("extras", {})
+
+
+def test_block_id_does_not_shadow_real_extras() -> None:
+    """Test excluding `id` from extras leaves genuine extra keys intact."""
+    block = {
+        "type": "image",
+        "source_type": "url",
+        "url": "https://example.com/x.png",
+        "id": "block-1",
+        "alt_text": "kept",
+    }
+
+    converted = _convert_legacy_v0_content_block_to_v1(block)
+
+    assert converted["id"] == "block-1"
+    assert converted["extras"] == {"alt_text": "kept"}


### PR DESCRIPTION
Fixes #39797

---

Converting a v0 content block that carries an `id` raises `TypeError`, because the id is passed through as an unexpected keyword argument instead of being recognized as a known field.

## Release note

Converting v0 content blocks that carry an `id` no longer raises `TypeError`.
