### PR TITLE
fix(perplexity): include type='message' on Responses input items (#39775)

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -237,7 +237,9 @@ def _translate_responses_input(message_dicts: list[dict[str, Any]]) -> list[Any]
             # as `function_call` items.
             text = _content_to_text(message.get("content"))
             if text:
-                translated.append({"role": "assistant", "content": text})
+                translated.append(
+                    {"type": "message", "role": "assistant", "content": text}
+                )
             for tool_call in message["tool_calls"]:
                 function = tool_call.get("function", {})
                 call_id = tool_call.get("id")
@@ -274,6 +276,8 @@ def _translate_responses_input(message_dicts: list[dict[str, Any]]) -> list[Any]
                     "output": output,
                 }
             )
+        elif role in {"assistant", "system", "user", "developer"}:
+            translated.append({**message, "type": "message"})
         else:
             translated.append(message)
     return translated

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models.py
@@ -493,7 +493,7 @@ def test_translate_responses_input_tool_roundtrip() -> None:
         {"role": "tool", "content": "18C cloudy", "tool_call_id": "call_1"},
     ]
     translated = _translate_responses_input(message_dicts)
-    assert translated[0] == {"role": "user", "content": "hi"}
+    assert translated[0] == {"type": "message", "role": "user", "content": "hi"}
     # Empty/None assistant content is dropped; only the function_call item remains.
     assert translated[1] == {
         "type": "function_call",
@@ -525,9 +525,56 @@ def test_translate_responses_input_keeps_assistant_text_with_tool_calls() -> Non
             }
         ]
     )
-    assert translated[0] == {"role": "assistant", "content": "Let me check."}
+    assert translated[0] == {
+        "type": "message",
+        "role": "assistant",
+        "content": "Let me check.",
+    }
     assert translated[1]["type"] == "function_call"
     assert translated[1]["call_id"] == "call_1"
+
+
+def test_to_responses_payload_marks_message_items_with_type() -> None:
+    """Message items use the SDK's `message` union variant."""
+    llm = ChatPerplexity(model="openai/gpt-5", api_key="test")
+    payload = llm._to_responses_payload(
+        [
+            {"role": "system", "content": "Be concise."},
+            {"role": "user", "content": "What is the weather?"},
+            {"role": "assistant", "content": "It is sunny."},
+            {
+                "role": "assistant",
+                "content": "Let me check.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "get_weather", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "content": "18C cloudy", "tool_call_id": "call_1"},
+        ],
+        {},
+    )
+
+    assert payload["input"] == [
+        {"type": "message", "role": "system", "content": "Be concise."},
+        {"type": "message", "role": "user", "content": "What is the weather?"},
+        {"type": "message", "role": "assistant", "content": "It is sunny."},
+        {"type": "message", "role": "assistant", "content": "Let me check."},
+        {
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "get_weather",
+            "arguments": "{}",
+        },
+        {
+            "type": "function_call_output",
+            "call_id": "call_1",
+            "output": "18C cloudy",
+        },
+    ]
 
 
 def test_to_responses_payload_flattens_tools_and_translates_messages() -> None:

--- a/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_chat_models_responses.py
@@ -600,7 +600,7 @@ def test_to_responses_payload_renames_and_drops_keys() -> None:
         },
     )
 
-    assert payload["input"] == [{"role": "user", "content": "hi"}]
+    assert payload["input"] == [{"type": "message", "role": "user", "content": "hi"}]
     assert payload["model"] == "sonar-pro"
     assert payload["max_output_tokens"] == 128
     assert "max_tokens" not in payload


### PR DESCRIPTION
## Bugfix

Fixes [#39775](https://github.com/langchain-ai/langchain/issues/39775) — `ChatPerplexity(use_responses_api=True).invoke()` raises `pydantic.ValidationError` on every call because the response payload's message items are missing the discriminating `type="message"` field Perplexity's SDK requires.

## Root cause

`_translate_responses_input` in `langchain_perplexity.chat_models` produced message dictionaries without a `type` field. Perplexity's `ResponsesRequestInput.input` is a pydantic discriminated union (`InputMessageInput | FunctionCallInputInput | FunctionCallOutputInputInput`), and **each** variant requires an explicit `type` so the validator can pick the right schema. Plain chat-message items (`{"role": "assistant", "content": "..."}`) need `type: "message"`; tool-call and tool-output items were already correct.

This affects every `.invoke()` / `.stream()` / agent call routed through the Responses API. The bug follows users through the Sonar Chat Completions deprecation (2026-09-27). The recommended migration target (`ChatPerplexity(use_responses_api=True)`) is the migration target, and it was unusable.

## Fix

Tag every plain message item with `type: "message"` in both translation paths:

1. The assistant-with-tool-calls branch (which also emits an assistant text item).
2. The catch-all `else` branch that translates unaugmented role messages (`assistant`, `system`, `user`, `developer`).

Carries `type: "message"` forward as a keyword so existing tool/tool-call emission paths are untouched.

## Tests

`tests/unit_tests/test_chat_models.py`:
- Update `test_translate_responses_input_tool_roundtrip` to expect `type: "message"` on the `user` message.
- Update `test_translate_responses_input_keeps_assistant_text_with_tool_calls` to expect `type: "message"` on the assistant message.
- Add `test_to_responses_payload_marks_message_items_with_type` covering `system`, `user`, plain `assistant`, and `assistant + tool_calls` end-to-end through `_to_responses_payload`.

`tests/unit_tests/test_chat_models_responses.py`:
- Update existing assertion in `test_to_responses_payload_renames_and_drops_keys` to expect `type: "message"`.

## Diff

`+55 / -4` across 3 files (matches the patch originally drafted in #39774).

## Attribution

This re-applies the patch originally authored by [@andrewmadson-pplx](https://github.com/andrewmadson-pplx) in [#39774](https://github.com/langchain-ai/langchain/pull/39774). That PR was drafted with the right code, but had an empty body with no `Fixes #39775` keyword, so langchain-bot could not auto-merge / auto-close the issue. Re-opening the fix here with the proper auto-link so the patch can land.

The reporter on #39775 explicitly wrote: *"A fix is drafted in closed PR #39774 with a regression test covering all union variants. make test passes 153 tests, make lint_diff passes ruff, format, and mypy. Happy to re-open once assigned to this issue."* Re-submitting here so the patch lands.

I am the submitter but **the fix, tests, and review-ready state are @andrewmadson-pplx's work**.
