### PR TITLE
docs(standard-tests): fix grammar typo in README

### DIFF
--- a/libs/standard-tests/README.md
+++ b/libs/standard-tests/README.md
@@ -90,4 +90,4 @@ as required is optional.
 - `chat_model_class` (required): The class of the chat model to be tested
 - `chat_model_params`: The keyword arguments to pass to the chat model constructor
 - `chat_model_has_tool_calling`: Whether the chat model can call tools. By default, this is set to `hasattr(chat_model_class, 'bind_tools')`
-- `chat_model_has_structured_output`: Whether the chat model can structured output. By default, this is set to `hasattr(chat_model_class, 'with_structured_output')`
+- `chat_model_has_structured_output`: Whether the chat model can produce structured output. By default, this is set to `hasattr(chat_model_class, 'with_structured_output')`


### PR DESCRIPTION
- Fix a grammar typo in `libs/standard-tests/README.md` (line 93).
- Changed "can structured output" to "can produce structured output" to make the sentence grammatically correct.

Fixes #39771