### PR TITLE
fix(anthropic): filter invalid tool calls from v1 content

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/_compat.py
+++ b/libs/partners/anthropic/langchain_anthropic/_compat.py
@@ -140,6 +140,9 @@ def _convert_from_v1_to_anthropic(
                 }
             )
 
+        elif block["type"] == "invalid_tool_call":
+            continue
+
         elif block["type"] == "reasoning" and model_provider == "anthropic":
             new_block = {}
             if "reasoning" in block:

--- a/libs/partners/anthropic/tests/unit_tests/test_compat.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_compat.py
@@ -1,0 +1,37 @@
+"""Tests for Anthropic content compatibility helpers."""
+
+from langchain_core.messages import content as types
+
+from langchain_anthropic._compat import _convert_from_v1_to_anthropic
+
+
+def test_convert_from_v1_filters_invalid_tool_calls() -> None:
+    """Test that invalid tool calls are not sent to Anthropic."""
+    content: list[types.ContentBlock] = [
+        {"type": "text", "text": "Let me check."},
+        {
+            "type": "invalid_tool_call",
+            "id": "toolu_invalid",
+            "name": "get_weather",
+            "args": '{"city":',
+            "error": "Invalid JSON",
+        },
+        {
+            "type": "tool_call",
+            "id": "toolu_valid",
+            "name": "get_weather",
+            "args": {"city": "San Francisco"},
+        },
+    ]
+
+    result = _convert_from_v1_to_anthropic(content, [], "anthropic")
+
+    assert result == [
+        {"type": "text", "text": "Let me check."},
+        {
+            "type": "tool_use",
+            "id": "toolu_valid",
+            "name": "get_weather",
+            "input": {"city": "San Francisco"},
+        },
+    ]


### PR DESCRIPTION
Anthropic rejects LangChain's `invalid_tool_call` content block when a partial streamed tool call is replayed. Filter that unsupported block during v1-to-Anthropic conversion while retaining `AIMessage.invalid_tool_calls` for diagnostics.

This narrow conversion fix is sufficient because the attribute is not otherwise serialized into Anthropic content. Covered by a focused unit test that preserves adjacent text and valid tool calls.

Made by [Open SWE](https://openswe.vercel.app/agents/ab6cedee-55aa-58fc-9143-bd044dabbe17)