### PR TITLE
fix(fireworks): filter invalid tool calls from v1 content

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/_compat.py
+++ b/libs/partners/fireworks/langchain_fireworks/_compat.py
@@ -15,7 +15,7 @@ def _convert_from_v1_to_chat_completions(message: AIMessage) -> AIMessage:
                 if block_type == "text":
                     # Strip annotations
                     new_content.append({"type": "text", "text": block["text"]})
-                elif block_type in ("reasoning", "tool_call"):
+                elif block_type in ("reasoning", "tool_call", "invalid_tool_call"):
                     pass
                 else:
                     new_content.append(block)

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -172,6 +172,44 @@ def test_sanitize_chat_completions_content_passthrough_string() -> None:
     assert _sanitize_chat_completions_content("hello") == "hello"
 
 
+def test_convert_v1_message_filters_invalid_tool_call_content() -> None:
+    """Invalid tool calls remain diagnostic metadata, not content blocks."""
+    message = AIMessage(
+        content=[
+            {"type": "text", "text": "Let me check."},
+            {
+                "type": "invalid_tool_call",
+                "id": "call_invalid",
+                "name": "get_weather",
+                "args": '{"city":',
+                "error": "Invalid JSON",
+            },
+        ],
+        invalid_tool_calls=[
+            {
+                "type": "invalid_tool_call",
+                "id": "call_invalid",
+                "name": "get_weather",
+                "args": '{"city":',
+                "error": "Invalid JSON",
+            }
+        ],
+        response_metadata={"output_version": "v1"},
+    )
+
+    assert _convert_message_to_dict(message) == {
+        "role": "assistant",
+        "content": "Let me check.",
+        "tool_calls": [
+            {
+                "type": "function",
+                "id": "call_invalid",
+                "function": {"name": "get_weather", "arguments": '{"city":'},
+            }
+        ],
+    }
+
+
 def test_sanitize_chat_completions_content_passthrough_non_text_block() -> None:
     blocks = [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]
     assert _sanitize_chat_completions_content(blocks) == blocks


### PR DESCRIPTION
Fireworks rejects LangChain's `invalid_tool_call` content block when malformed or partial tool-call history is replayed. Filter that unsupported block during v1-to-Chat-Completions conversion while retaining `AIMessage.invalid_tool_calls` for the existing diagnostic `tool_calls` serialization.

Covered by a focused request-serialization regression test that also verifies adjacent text is preserved.

Made by [Open SWE](https://openswe.vercel.app/agents/ab6cedee-55aa-58fc-9143-bd044dabbe17)