### PR TITLE
fix(openrouter): fix ChatOpenRouter timeout unit conversion

### DIFF
--- a/libs/partners/openrouter/langchain_openrouter/chat_models.py
+++ b/libs/partners/openrouter/langchain_openrouter/chat_models.py
@@ -220,8 +220,8 @@ class ChatOpenRouter(BaseChatModel):
     See https://openrouter.ai/docs/app-attribution for recognized categories.
     """
 
-    request_timeout: int | None = Field(default=None, alias="timeout")
-    """Timeout for requests in milliseconds. Maps to SDK `timeout_ms`."""
+    request_timeout: float | None = Field(default=None, alias="timeout")
+    """Timeout for requests in seconds. Converted to milliseconds for SDK `timeout_ms`."""
 
     max_retries: int = 2
     """Maximum number of retries.
@@ -453,7 +453,7 @@ class ChatOpenRouter(BaseChatModel):
                 headers=extra_headers, follow_redirects=True
             )
         if self.request_timeout is not None:
-            client_kwargs["timeout_ms"] = self.request_timeout
+            client_kwargs["timeout_ms"] = int(self.request_timeout * 1000)
         if self.max_retries > 0:
             client_kwargs["retry_config"] = RetryConfig(
                 strategy="backoff",


### PR DESCRIPTION
Fixes #39812

`ChatOpenRouter` was incorrectly typed to take `timeout` in milliseconds and forwarded the value verbatim to the OpenRouter SDK. This violates the
LangChain `BaseChatModel` standard (used by `ChatOpenAI`, etc.) where `timeout` is always expected to be in seconds.

This PR:
- Changes `request_timeout` type to `float | None` to accept LangChain standard seconds (including fractional seconds).
- Multiplies by 1000 before passing to the SDK `timeout_ms`.
- Updates the existing unit test to a parametrized case covering both whole-second and fractional-second values.
- Updates the `test_standard.ambr` snapshot to reflect the new float type.

---
Test coverage for fractional-second timeout values and the snapshot
update were adapted from @jackjin1997's fork (jackjin1997@76b6e7e20).
Thanks for the help getting this over the line.