### PR TITLE
fix(text-splitters): recognize custom header patterns when merging nested headers

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -85,6 +85,25 @@ class MarkdownHeaderTextSplitter:
                 return True
         return False
 
+    def _is_header_line(self, line: str) -> bool:
+        """Check if a line is a tracked header, standard or custom.
+
+        Args:
+            line: The line to check
+
+        Returns:
+            `True` if the line matches any tracked standard or custom header
+        """
+        for sep, _ in self.headers_to_split_on:
+            if line.startswith(sep) and (
+                # Header with no text OR header is followed by space
+                len(line) == len(sep) or line[len(sep)] == " "
+            ):
+                return True
+            if self._is_custom_header(line, sep):
+                return True
+        return False
+
     def aggregate_lines_to_chunks(self, lines: list[LineType]) -> list[Document]:
         """Combine lines with common metadata into chunks.
 
@@ -110,7 +129,9 @@ class MarkdownHeaderTextSplitter:
                 and aggregated_chunks[-1]["metadata"] != line["metadata"]
                 # may be issues if other metadata is present
                 and len(aggregated_chunks[-1]["metadata"]) < len(line["metadata"])
-                and aggregated_chunks[-1]["content"].split("\n")[-1][0] == "#"
+                and self._is_header_line(
+                    aggregated_chunks[-1]["content"].split("\n")[-1]
+                )
                 and not self.strip_headers
             ):
                 # If the last line in the aggregated list

--- a/libs/text-splitters/langchain_text_splitters/markdown.py
+++ b/libs/text-splitters/langchain_text_splitters/markdown.py
@@ -54,6 +54,22 @@ class MarkdownHeaderTextSplitter:
         # Custom header patterns with their levels
         self.custom_header_patterns = custom_header_patterns or {}
 
+    def _is_standard_header(self, line: str, sep: str) -> bool:
+        """Check if a line is a standard `#`-style header for a separator.
+
+        Args:
+            line: The line to check
+            sep: The separator pattern to match
+
+        Returns:
+            `True` if the line is a standard header for `sep`
+        """
+        return line.startswith(sep) and (
+            # Header with no text OR header is followed by space
+            # Both are valid conditions that sep is being used a header
+            len(line) == len(sep) or line[len(sep)] == " "
+        )
+
     def _is_custom_header(self, line: str, sep: str) -> bool:
         """Check if line matches a custom header pattern.
 
@@ -95,12 +111,7 @@ class MarkdownHeaderTextSplitter:
             `True` if the line matches any tracked standard or custom header
         """
         for sep, _ in self.headers_to_split_on:
-            if line.startswith(sep) and (
-                # Header with no text OR header is followed by space
-                len(line) == len(sep) or line[len(sep)] == " "
-            ):
-                return True
-            if self._is_custom_header(line, sep):
+            if self._is_standard_header(line, sep) or self._is_custom_header(line, sep):
                 return True
         return False
 
@@ -204,11 +215,7 @@ class MarkdownHeaderTextSplitter:
 
             # Check each line against each of the header types (e.g., #, ##)
             for sep, name in self.headers_to_split_on:
-                is_standard_header = stripped_line.startswith(sep) and (
-                    # Header with no text OR header is followed by space
-                    # Both are valid conditions that sep is being used a header
-                    len(stripped_line) == len(sep) or stripped_line[len(sep)] == " "
-                )
+                is_standard_header = self._is_standard_header(stripped_line, sep)
                 is_custom_header = self._is_custom_header(stripped_line, sep)
 
                 # Check if line matches either standard or custom header pattern

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1948,6 +1948,42 @@ def test_md_header_text_splitter_custom_headers_strip_unchanged() -> None:
     assert output == expected_output
 
 
+def test_md_header_text_splitter_hash_prefixed_body_line() -> None:
+    """Test a body line starting with `#` does not merge its chunk into the next.
+
+    The old check read any line starting with `#` as a header, so a chunk
+    ending in a body line such as `#hashtag` was merged into the next chunk and
+    the body line picked up that chunk's metadata. `_is_header_line` requires a
+    real header. No custom patterns are involved here: this is the default
+    `#`-only path.
+    """
+    markdown_document = "# H1\n#hashtag\n## H2\nbody\n"
+
+    headers_to_split_on = [
+        ("#", "Header 1"),
+        ("##", "Header 2"),
+    ]
+
+    markdown_splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=headers_to_split_on,
+        strip_headers=False,
+    )
+    output = markdown_splitter.split_text(markdown_document)
+
+    expected_output = [
+        Document(
+            page_content="# H1\n#hashtag",
+            metadata={"Header 1": "H1"},
+        ),
+        Document(
+            page_content="## H2\nbody",
+            metadata={"Header 1": "H1", "Header 2": "H2"},
+        ),
+    ]
+
+    assert output == expected_output
+
+
 EXPERIMENTAL_MARKDOWN_DOCUMENT = (
     "# My Header 1\n"
     "Content for header 1\n"

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1848,6 +1848,42 @@ Content under custom header 2.
     assert output == expected_output
 
 
+def test_md_header_text_splitter_preserve_headers_custom() -> None:
+    """Test custom headers merge like standard headers when preserving headers.
+
+    The nested-header merge branch in `aggregate_lines_to_chunks` used a
+    hardcoded `line[0] == "#"` check, so custom patterns such as `**Header**`
+    were never merged and the parent header was emitted as a header-only chunk.
+    """
+    markdown_document = "**H1**\n***H2***\nbody\n"
+
+    headers_to_split_on = [
+        ("**", "Header 1"),
+        ("***", "Header 2"),
+    ]
+
+    custom_header_patterns = {
+        "**": 1,
+        "***": 2,
+    }
+
+    markdown_splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=headers_to_split_on,
+        custom_header_patterns=custom_header_patterns,
+        strip_headers=False,
+    )
+    output = markdown_splitter.split_text(markdown_document)
+
+    expected_output = [
+        Document(
+            page_content="**H1**  \n***H2***\nbody",
+            metadata={"Header 1": "H1", "Header 2": "H2"},
+        ),
+    ]
+
+    assert output == expected_output
+
+
 EXPERIMENTAL_MARKDOWN_DOCUMENT = (
     "# My Header 1\n"
     "Content for header 1\n"

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1984,6 +1984,47 @@ def test_md_header_text_splitter_hash_prefixed_body_line() -> None:
     assert output == expected_output
 
 
+def test_md_header_text_splitter_custom_headers_nested_siblings() -> None:
+    """Test a header-only custom parent merges into its child, siblings do not.
+
+    The empty `**H1**` is absorbed by the first `***H2***`, matching how `#`
+    headers behave. `***H2b***` is at the same level as `***H2***`, so it stays
+    a separate chunk: the merge only ever pulls a shallower header into a
+    deeper one. Without the fix this splits into three chunks, one per header.
+    """
+    markdown_document = "**H1**\n***H2***\n***H2b***\nbody\n"
+
+    headers_to_split_on = [
+        ("**", "Header 1"),
+        ("***", "Header 2"),
+    ]
+
+    custom_header_patterns = {
+        "**": 1,
+        "***": 2,
+    }
+
+    markdown_splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=headers_to_split_on,
+        custom_header_patterns=custom_header_patterns,
+        strip_headers=False,
+    )
+    output = markdown_splitter.split_text(markdown_document)
+
+    expected_output = [
+        Document(
+            page_content="**H1**  \n***H2***",
+            metadata={"Header 1": "H1", "Header 2": "H2"},
+        ),
+        Document(
+            page_content="***H2b***\nbody",
+            metadata={"Header 1": "H1", "Header 2": "H2b"},
+        ),
+    ]
+
+    assert output == expected_output
+
+
 EXPERIMENTAL_MARKDOWN_DOCUMENT = (
     "# My Header 1\n"
     "Content for header 1\n"

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1884,6 +1884,70 @@ def test_md_header_text_splitter_preserve_headers_custom() -> None:
     assert output == expected_output
 
 
+def test_md_header_text_splitter_preserve_headers_mixed() -> None:
+    """Test a custom parent header merges with a standard child header.
+
+    The parent must be a custom header here: a `#` parent would satisfy the old
+    `line[0] == "#"` check and pass even without the fix.
+    """
+    markdown_document = "**Custom H1**\n## H2\nContent.\n"
+
+    headers_to_split_on = [
+        ("**", "Custom Header"),
+        ("##", "Header 2"),
+    ]
+
+    custom_header_patterns = {
+        "**": 1,
+    }
+
+    markdown_splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=headers_to_split_on,
+        custom_header_patterns=custom_header_patterns,
+        strip_headers=False,
+    )
+    output = markdown_splitter.split_text(markdown_document)
+
+    expected_output = [
+        Document(
+            page_content="**Custom H1**  \n## H2\nContent.",
+            metadata={"Custom Header": "Custom H1", "Header 2": "H2"},
+        ),
+    ]
+
+    assert output == expected_output
+
+
+def test_md_header_text_splitter_custom_headers_strip_unchanged() -> None:
+    """Test that stripping headers is unaffected by the aggregation fix."""
+    markdown_document = "**H1**\n***H2***\nbody\n"
+
+    headers_to_split_on = [
+        ("**", "Header 1"),
+        ("***", "Header 2"),
+    ]
+
+    custom_header_patterns = {
+        "**": 1,
+        "***": 2,
+    }
+
+    markdown_splitter = MarkdownHeaderTextSplitter(
+        headers_to_split_on=headers_to_split_on,
+        custom_header_patterns=custom_header_patterns,
+    )
+    output = markdown_splitter.split_text(markdown_document)
+
+    expected_output = [
+        Document(
+            page_content="body",
+            metadata={"Header 1": "H1", "Header 2": "H2"},
+        ),
+    ]
+
+    assert output == expected_output
+
+
 EXPERIMENTAL_MARKDOWN_DOCUMENT = (
     "# My Header 1\n"
     "Content for header 1\n"


### PR DESCRIPTION
Fixes #38702

---

Re-opened from a user-account fork, replacing #39672. Same commits, nothing
changed.

`MarkdownHeaderTextSplitter` supports custom header formats through
`custom_header_patterns`. With `strip_headers=False`, a parent custom header was
emitted as its own header-only chunk instead of merging with its nested child,
while the same structure written with `#` merged into one chunk.

The cause is in `aggregate_lines_to_chunks`: the test for whether the previous
chunk ends in a header was hardcoded to `line[0] == "#"`, which no custom
pattern can satisfy. `_is_header_line` now checks the line against the tracked
standard prefixes and the existing `_is_custom_header` regex. The parsing path
already tracked custom headers correctly.

This also changes the default `#`-only path, intentionally. The old check was
true for any line starting with `#`, including body text such as `#hashtag` that
the parser does not treat as a header, so such a chunk merged into its child and
the body line came out carrying the child's metadata. A differential run over 20
documents x `strip_headers` x `return_each_line` (80 configurations) shows three
that change: the custom-header fix, and two shapes of this second case.

`_is_standard_header` is extracted because the standard-prefix condition
otherwise lives in both `_is_header_line` and `split_text`. Same 80
configurations, no difference.

Four of the five regression tests fail on the pre-fix file; the
`strip_headers=True` one passes either way and guards that path. The sibling
one covers a gap the others miss: loosening the metadata-depth comparison in
`aggregate_lines_to_chunks` from `<` to `<=` leaves the rest of the suite green
while swallowing a section into its sibling's chunk. `make format`, `make lint`
and `make test` pass in `libs/text-splitters` (154 passed, 10 skipped).

## Release note

`MarkdownHeaderTextSplitter` with `strip_headers=False` now merges nested
headers defined through `custom_header_patterns` into a single chunk, matching
standard `#` headers. A chunk whose last line starts with `#` but is not a
header (such as `#hashtag`) is no longer merged into the following chunk, so
that line keeps its own header's metadata.

---

Contributed on behalf of [Goatshave](https://github.com/Goatshave). Prepared
with AI assistance (Claude Code, Anthropic), reviewed for correctness before
submission.
