### PR TITLE
feat(langchain): Add SkillValidator to validate SKILL.md frontmatter and directory structure  #39808

### DIFF
--- a/libs/langchain_v1/langchain/skills/__init__.py
+++ b/libs/langchain_v1/langchain/skills/__init__.py
@@ -1,0 +1,13 @@
+"""Utilities for working with agent skill packs (directories containing `SKILL.md` files)."""
+
+from langchain.skills.validator import (
+    SkillValidationReport,
+    validate_skill_directory,
+    validate_skill_file,
+)
+
+__all__ = [
+    "SkillValidationReport",
+    "validate_skill_directory",
+    "validate_skill_file",
+]

--- a/libs/langchain_v1/langchain/skills/validator.py
+++ b/libs/langchain_v1/langchain/skills/validator.py
@@ -1,0 +1,223 @@
+"""Validation for `SKILL.md` frontmatter and skill directory structure.
+
+A malformed `SKILL.md` is often skipped silently or fails at agent runtime with
+little indication of what went wrong. `validate_skill_file` and
+`validate_skill_directory` catch these issues ahead of time (e.g. in CI) by
+checking that a skill's YAML frontmatter is well-formed and complete, and that
+a directory of skill packs follows the expected `<skill-name>/SKILL.md` layout.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from os import PathLike
+
+# Anthropic's skill naming convention: lowercase letters, digits, and single hyphens.
+_NAME_PATTERN = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+_MAX_NAME_LENGTH = 64
+_MAX_DESCRIPTION_LENGTH = 1024
+_FRONTMATTER_DELIMITER = "---"
+
+
+@dataclass
+class SkillValidationReport:
+    """Result of validating a single `SKILL.md` file.
+
+    Attributes:
+        path: Path to the validated `SKILL.md` file (or skill directory, if the
+            file itself could not be found).
+        errors: Problems that make the skill invalid.
+        warnings: Problems that don't invalidate the skill but should be
+            addressed (e.g. an overly long description).
+    """
+
+    path: Path
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        """Whether the skill has no validation errors.
+
+        A report can be valid while still having warnings.
+        """
+        return not self.errors
+
+
+def _split_frontmatter(text: str) -> tuple[str, str] | None:
+    """Split `SKILL.md` content into raw YAML frontmatter and body text.
+
+    Args:
+        text: Raw content of the `SKILL.md` file.
+
+    Returns:
+        A tuple of `(raw_frontmatter, body)`, or `None` if the file doesn't
+        start with a `---` delimited frontmatter block.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != _FRONTMATTER_DELIMITER:
+        return None
+
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == _FRONTMATTER_DELIMITER:
+            raw_frontmatter = "\n".join(lines[1:index])
+            body = "\n".join(lines[index + 1 :])
+            return raw_frontmatter, body
+
+    return None
+
+
+def _parse_frontmatter(text: str) -> dict[str, Any]:
+    """Parse the YAML frontmatter out of `SKILL.md` content.
+
+    Args:
+        text: Raw content of the `SKILL.md` file.
+
+    Returns:
+        The parsed frontmatter mapping.
+
+    Raises:
+        ValueError: If the frontmatter block is missing or isn't valid YAML.
+        TypeError: If the frontmatter doesn't parse to a mapping.
+    """
+    split = _split_frontmatter(text)
+    if split is None:
+        msg = "Missing YAML frontmatter: file must start with a '---' delimited block."
+        raise ValueError(msg)
+
+    raw_frontmatter, _body = split
+    try:
+        frontmatter = yaml.safe_load(raw_frontmatter)
+    except yaml.YAMLError as e:
+        msg = f"Invalid YAML frontmatter: {e}"
+        raise ValueError(msg) from e
+
+    if not isinstance(frontmatter, dict):
+        msg = "Frontmatter must be a YAML mapping of key-value pairs."
+        raise TypeError(msg)
+
+    return frontmatter
+
+
+def validate_skill_file(path: str | PathLike[str]) -> SkillValidationReport:
+    """Validate a single `SKILL.md` file's frontmatter and contents.
+
+    Checks that the file exists, has valid YAML frontmatter delimited by `---`
+    markers, and that the frontmatter declares a well-formed `name` (lowercase
+    alphanumeric characters and hyphens, at most 64 characters) and a
+    non-empty `description` (warning, not erroring, past 1024 characters).
+
+    Args:
+        path: Path to the `SKILL.md` file to validate.
+
+    Returns:
+        A `SkillValidationReport` describing any errors or warnings found.
+    """
+    path = Path(path)
+    report = SkillValidationReport(path=path)
+
+    if not path.is_file():
+        report.errors.append(f"File not found: {path}")
+        return report
+
+    text = path.read_text(encoding="utf-8")
+    try:
+        frontmatter = _parse_frontmatter(text)
+    except (ValueError, TypeError) as e:
+        report.errors.append(str(e))
+        return report
+
+    name = frontmatter.get("name")
+    if not name:
+        report.errors.append("Frontmatter is missing required field 'name'.")
+    elif not isinstance(name, str):
+        report.errors.append("Frontmatter field 'name' must be a string.")
+    else:
+        if len(name) > _MAX_NAME_LENGTH:
+            report.errors.append(
+                f"Frontmatter field 'name' must be at most {_MAX_NAME_LENGTH} "
+                f"characters (got {len(name)})."
+            )
+        if not _NAME_PATTERN.match(name):
+            report.errors.append(
+                "Frontmatter field 'name' must contain only lowercase "
+                "alphanumeric characters separated by single hyphens "
+                "(e.g. 'code-review')."
+            )
+
+    description = frontmatter.get("description")
+    if not description:
+        report.errors.append("Frontmatter is missing required field 'description'.")
+    elif not isinstance(description, str):
+        report.errors.append("Frontmatter field 'description' must be a string.")
+    elif len(description) > _MAX_DESCRIPTION_LENGTH:
+        report.warnings.append(
+            f"Frontmatter field 'description' exceeds the recommended "
+            f"{_MAX_DESCRIPTION_LENGTH} character limit (got {len(description)})."
+        )
+
+    return report
+
+
+def validate_skill_directory(path: str | PathLike[str]) -> list[SkillValidationReport]:
+    """Validate every skill in a directory of skill packs.
+
+    Each immediate subdirectory of `path` is expected to contain a `SKILL.md`
+    file, following the `<skill-name>/SKILL.md` layout convention (e.g.
+    `skills/code-review/SKILL.md`). A subdirectory whose frontmatter `name`
+    doesn't match its directory name produces a warning, since agents that
+    key off the directory name would silently load the wrong skill identity.
+
+    Args:
+        path: Path to the directory containing skill subdirectories.
+
+    Returns:
+        A list of `SkillValidationReport`, one per skill subdirectory found.
+        A missing directory or one with no subdirectories produces a single
+        report with an error and no other checks performed.
+    """
+    root = Path(path)
+
+    if not root.is_dir():
+        return [SkillValidationReport(path=root, errors=[f"Directory not found: {root}"])]
+
+    skill_dirs = sorted((p for p in root.iterdir() if p.is_dir()), key=lambda p: p.name)
+    if not skill_dirs:
+        return [SkillValidationReport(path=root, errors=[f"No skill directories found in: {root}"])]
+
+    reports = []
+    for skill_dir in skill_dirs:
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.is_file():
+            reports.append(
+                SkillValidationReport(
+                    path=skill_dir,
+                    errors=[f"Missing SKILL.md file in skill directory: {skill_dir}"],
+                )
+            )
+            continue
+
+        report = validate_skill_file(skill_file)
+
+        try:
+            frontmatter = _parse_frontmatter(skill_file.read_text(encoding="utf-8"))
+        except (ValueError, TypeError):
+            pass
+        else:
+            name = frontmatter.get("name")
+            if isinstance(name, str) and name != skill_dir.name:
+                report.warnings.append(
+                    f"Frontmatter name '{name}' does not match its directory "
+                    f"name '{skill_dir.name}'."
+                )
+
+        reports.append(report)
+
+    return reports

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -82,6 +82,7 @@ lint = [
 typing = [
     "mypy>=2.1.0,<2.2.0",
     "types-toml>=0.10.8.20240310,<1.0.0.0",
+    "types-pyyaml>=6.0.12.2,<7.0.0.0",
 ]
 
 test_integration = [

--- a/libs/langchain_v1/tests/unit_tests/skills/test_validator.py
+++ b/libs/langchain_v1/tests/unit_tests/skills/test_validator.py
@@ -1,0 +1,203 @@
+"""Unit tests for `langchain.skills.validator`."""
+
+from pathlib import Path
+
+import pytest
+
+from langchain.skills.validator import (
+    SkillValidationReport,
+    validate_skill_directory,
+    validate_skill_file,
+)
+
+
+def _write_skill(path: Path, content: str) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_valid_skill_file(tmp_path: Path) -> None:
+    skill_file = _write_skill(
+        tmp_path / "SKILL.md",
+        "---\nname: code-review\ndescription: Reviews pull requests for bugs.\n---\nBody text.\n",
+    )
+
+    report = validate_skill_file(skill_file)
+
+    assert report.is_valid
+    assert report.errors == []
+    assert report.warnings == []
+
+
+def test_missing_file() -> None:
+    report = validate_skill_file("/nonexistent/SKILL.md")
+
+    assert not report.is_valid
+    assert len(report.errors) == 1
+    assert "File not found" in report.errors[0]
+
+
+def test_missing_frontmatter_delimiter(tmp_path: Path) -> None:
+    skill_file = _write_skill(tmp_path / "SKILL.md", "name: code-review\ndescription: A skill.\n")
+
+    report = validate_skill_file(skill_file)
+
+    assert not report.is_valid
+    assert any("frontmatter" in error.lower() for error in report.errors)
+
+
+def test_invalid_yaml_syntax(tmp_path: Path) -> None:
+    skill_file = _write_skill(
+        tmp_path / "SKILL.md",
+        "---\nname: code-review\n  bad_indent: [unterminated\n---\nBody.\n",
+    )
+
+    report = validate_skill_file(skill_file)
+
+    assert not report.is_valid
+    assert any("Invalid YAML" in error for error in report.errors)
+
+
+def test_frontmatter_not_a_mapping(tmp_path: Path) -> None:
+    skill_file = _write_skill(tmp_path / "SKILL.md", "---\n- just\n- a\n- list\n---\nBody.\n")
+
+    report = validate_skill_file(skill_file)
+
+    assert not report.is_valid
+    assert any("mapping" in error.lower() for error in report.errors)
+
+
+def test_missing_required_fields(tmp_path: Path) -> None:
+    skill_file = _write_skill(tmp_path / "SKILL.md", "---\nfoo: bar\n---\nBody.\n")
+
+    report = validate_skill_file(skill_file)
+
+    assert not report.is_valid
+    assert any("'name'" in error for error in report.errors)
+    assert any("'description'" in error for error in report.errors)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["Code-Review", "code_review", "code review", "-code-review", "code-review-", "code--review"],
+)
+def test_invalid_name_format(tmp_path: Path, name: str) -> None:
+    skill_file = _write_skill(
+        tmp_path / "SKILL.md",
+        f"---\nname: {name}\ndescription: A skill.\n---\nBody.\n",
+    )
+
+    report = validate_skill_file(skill_file)
+
+    assert not report.is_valid
+    assert any("lowercase" in error.lower() for error in report.errors)
+
+
+def test_name_too_long(tmp_path: Path) -> None:
+    long_name = "a" * 65
+    skill_file = _write_skill(
+        tmp_path / "SKILL.md",
+        f"---\nname: {long_name}\ndescription: A skill.\n---\nBody.\n",
+    )
+
+    report = validate_skill_file(skill_file)
+
+    assert not report.is_valid
+    assert any("at most 64" in error for error in report.errors)
+
+
+def test_description_too_long_is_a_warning_not_an_error(tmp_path: Path) -> None:
+    long_description = "a" * 1025
+    skill_file = _write_skill(
+        tmp_path / "SKILL.md",
+        f"---\nname: code-review\ndescription: {long_description}\n---\nBody.\n",
+    )
+
+    report = validate_skill_file(skill_file)
+
+    assert report.is_valid
+    assert len(report.warnings) == 1
+    assert "1024" in report.warnings[0]
+
+
+def test_validate_skill_directory_happy_path(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "code-review"
+    skill_dir.mkdir()
+    _write_skill(
+        skill_dir / "SKILL.md",
+        "---\nname: code-review\ndescription: Reviews pull requests.\n---\nBody.\n",
+    )
+
+    reports = validate_skill_directory(tmp_path)
+
+    assert len(reports) == 1
+    assert reports[0].is_valid
+    assert reports[0].path == skill_dir / "SKILL.md"
+
+
+def test_validate_skill_directory_missing_skill_md(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "code-review"
+    skill_dir.mkdir()
+
+    reports = validate_skill_directory(tmp_path)
+
+    assert len(reports) == 1
+    assert not reports[0].is_valid
+    assert "Missing SKILL.md" in reports[0].errors[0]
+
+
+def test_validate_skill_directory_name_mismatch_warns(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "code-review"
+    skill_dir.mkdir()
+    _write_skill(
+        skill_dir / "SKILL.md",
+        "---\nname: something-else\ndescription: Reviews pull requests.\n---\nBody.\n",
+    )
+
+    reports = validate_skill_directory(tmp_path)
+
+    assert len(reports) == 1
+    assert reports[0].is_valid
+    assert any("does not match" in warning for warning in reports[0].warnings)
+
+
+def test_validate_skill_directory_missing_root(tmp_path: Path) -> None:
+    reports = validate_skill_directory(tmp_path / "does-not-exist")
+
+    assert len(reports) == 1
+    assert not reports[0].is_valid
+    assert "Directory not found" in reports[0].errors[0]
+
+
+def test_validate_skill_directory_empty(tmp_path: Path) -> None:
+    reports = validate_skill_directory(tmp_path)
+
+    assert len(reports) == 1
+    assert not reports[0].is_valid
+    assert "No skill directories found" in reports[0].errors[0]
+
+
+def test_validate_skill_directory_multiple_skills(tmp_path: Path) -> None:
+    good_dir = tmp_path / "code-review"
+    good_dir.mkdir()
+    _write_skill(
+        good_dir / "SKILL.md",
+        "---\nname: code-review\ndescription: Reviews pull requests.\n---\nBody.\n",
+    )
+
+    bad_dir = tmp_path / "broken-skill"
+    bad_dir.mkdir()
+    _write_skill(bad_dir / "SKILL.md", "no frontmatter here\n")
+
+    reports = validate_skill_directory(tmp_path)
+
+    assert len(reports) == 2
+    reports_by_name = {report.path.parent.name: report for report in reports}
+    assert reports_by_name["code-review"].is_valid
+    assert not reports_by_name["broken-skill"].is_valid
+
+
+def test_skill_validation_report_is_valid_with_only_warnings() -> None:
+    report = SkillValidationReport(path=Path("SKILL.md"), warnings=["a warning"])
+
+    assert report.is_valid

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1473,6 +1473,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ed/6bfa4109fcb23a58819600392564fea69cdc6551ffd5e69ccf1d52a40cbc/greenlet-3.2.4-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:8c68325b0d0acf8d91dde4e6f930967dd52a5302cd4062932a6b2e7c2969f47c", size = 271061, upload-time = "2025-08-07T13:17:15.373Z" },
     { url = "https://files.pythonhosted.org/packages/2a/fc/102ec1a2fc015b3a7652abab7acf3541d58c04d3d17a8d3d6a44adae1eb1/greenlet-3.2.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:94385f101946790ae13da500603491f04a76b6e4c059dab271b3ce2e283b2590", size = 629475, upload-time = "2025-08-07T13:42:54.009Z" },
     { url = "https://files.pythonhosted.org/packages/c5/26/80383131d55a4ac0fb08d71660fd77e7660b9db6bdb4e8884f46d9f2cc04/greenlet-3.2.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c", size = 640802, upload-time = "2025-08-07T13:45:25.52Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/7c/e7833dbcd8f376f3326bd728c845d31dcde4c84268d3921afcae77d90d08/greenlet-3.2.4-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c8c9e331e58180d0d83c5b7999255721b725913ff6bc6cf39fa2a45841a4fd4b", size = 636703, upload-time = "2025-08-07T13:53:12.622Z" },
     { url = "https://files.pythonhosted.org/packages/e9/49/547b93b7c0428ede7b3f309bc965986874759f7d89e4e04aeddbc9699acb/greenlet-3.2.4-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58b97143c9cc7b86fc458f215bd0932f1757ce649e05b640fea2e79b54cedb31", size = 635417, upload-time = "2025-08-07T13:18:25.189Z" },
     { url = "https://files.pythonhosted.org/packages/7f/91/ae2eb6b7979e2f9b035a9f612cf70f1bf54aad4e1d125129bef1eae96f19/greenlet-3.2.4-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c2ca18a03a8cfb5b25bc1cbe20f3d9a4c80d8c3b13ba3df49ac3961af0b1018d", size = 584358, upload-time = "2025-08-07T13:18:23.708Z" },
     { url = "https://files.pythonhosted.org/packages/f7/85/433de0c9c0252b22b16d413c9407e6cb3b41df7389afc366ca204dbc1393/greenlet-3.2.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9fe0a28a7b952a21e2c062cd5756d34354117796c6d9215a87f55e38d15402c5", size = 1113550, upload-time = "2025-08-07T13:42:37.467Z" },
@@ -1483,6 +1484,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -1493,6 +1495,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1503,6 +1506,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1513,6 +1517,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -2060,6 +2065,7 @@ test-integration = [
 ]
 typing = [
     { name = "mypy" },
+    { name = "types-pyyaml" },
     { name = "types-toml" },
 ]
 
@@ -2115,6 +2121,7 @@ test-integration = [
 ]
 typing = [
     { name = "mypy", specifier = ">=2.1.0,<2.2.0" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.2,<7.0.0.0" },
     { name = "types-toml", specifier = ">=0.10.8.20240310,<1.0.0.0" },
 ]
 
@@ -5002,6 +5009,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/7d/b1e0399aa5e27071f0042784681d28417f3e526c61f62c8e3635ee5ad334/typer-0.9.4.tar.gz", hash = "sha256:f714c2d90afae3a7929fcd72a3abb08df305e1ff61719381384211c4070af57f", size = 276061, upload-time = "2024-03-23T17:07:55.568Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/39/82c9d3e10979851847361d922a373bdfef4091020da7f893acfaf07c0225/typer-0.9.4-py3-none-any.whl", hash = "sha256:aa6c4a4e2329d868b80ecbaf16f807f2b54e192209d7ac9dd42691d63f7a54eb", size = 45973, upload-time = "2024-03-23T17:07:53.985Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260815"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/72/b56089aeee6c496d969bac42376bedb6e3eeab4682e1018fa3137122f94b/types_pyyaml-6.0.12.20260815.tar.gz", hash = "sha256:28764110c9cf35846e733da32d8d734df7473c5dde9ef67c3b7332ec0e819858", size = 18545, upload-time = "2026-08-15T02:41:51.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/52/eefeba09be4ef2a1eb989eb92934561e8e502a6ee3c32654996e4be7e399/types_pyyaml-6.0.12.20260815-py3-none-any.whl", hash = "sha256:6f332212b7e191f3afd5016a713c510b6340593b7ebec573c7d5d20aa5386d3b", size = 21148, upload-time = "2026-08-15T02:41:50.555Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Relates to #39808

---

Teams maintaining skill packs for agents often hit malformed `SKILL.md` files — an uppercase name, a missing `description`, bad YAML indentation — that get skipped silently or fail only at agent runtime, with little indication of what went wrong. This adds a validator that catches those issues ahead of time (e.g. wired into CI) with a clear list of errors and warnings.

`langchain.skills.validator` exposes:

- `validate_skill_file(path)` — validates a single `SKILL.md` file's YAML frontmatter: required `name` and `description` fields, `name` format (lowercase alphanumeric with hyphens, max 64 characters), and a soft warning when `description` exceeds 1024 characters.
- `validate_skill_directory(path)` — validates every skill in a directory of skill packs (the `<skill-name>/SKILL.md` layout), additionally warning when a skill's frontmatter `name` doesn't match its directory name.

Both return a `SkillValidationReport` with `is_valid`, `errors`, and `warnings`.

## Release note

Added `langchain.skills.validator` with `validate_skill_file` and `validate_skill_directory` for validating `SKILL.md` frontmatter and skill directory structure ahead of agent runtime.

## How this was verified

Added unit tests in `tests/unit_tests/skills/test_validator.py` covering valid skills, missing files, missing/invalid frontmatter, invalid YAML, name format and length violations, the description length warning, and directory-level checks (missing `SKILL.md`, name/directory mismatch, empty/missing directories). `make format`, `make lint`, and `make test` pass for the `langchain` package.

---

*This PR was prepared with AI assistance (Claude).*
