### PR TITLE
fix(core): escape brackets in mermaid nodes and normalize search paths

### DIFF
--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -144,6 +144,7 @@ def draw_mermaid(
                 + "\n".join(f"{k} = {value}" for k, value in node.metadata.items())
                 + "</em></small>"
             )
+        label = label.replace("[", "(").replace("]", ")")
         node_label = format_dict.get(key, format_dict[default_class_label]).format(
             _to_safe_id(key), label
         )

--- a/libs/core/tests/unit_tests/runnables/test_graph.py
+++ b/libs/core/tests/unit_tests/runnables/test_graph.py
@@ -719,3 +719,28 @@ def test_graph_mermaid_special_chars(snapshot: SnapshotAssertion) -> None:
         ],
     )
     assert graph.draw_mermaid() == snapshot(name="mermaid")
+
+
+def test_graph_mermaid_brackets_in_node_name() -> None:
+    """Test that square brackets in node names are sanitized in mermaid output."""
+    graph = Graph(
+        nodes={
+            "__start__": Node(
+                id="__start__", name="__start__", data=BaseModel, metadata=None
+            ),
+            "node[0]": Node(
+                id="node[0]", name="node[0]", data=BaseModel, metadata=None
+            ),
+            "__end__": Node(
+                id="__end__", name="__end__", data=BaseModel, metadata=None
+            ),
+        },
+        edges=[
+            Edge(source="__start__", target="node[0]", data=None, conditional=False),
+            Edge(source="node[0]", target="__end__", data=None, conditional=False),
+        ],
+    )
+    mermaid_str = graph.draw_mermaid()
+    assert "node(0)" in mermaid_str
+    assert "node[0]" not in mermaid_str
+    assert r"node\5b0\5d" in mermaid_str

--- a/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
+++ b/libs/partners/anthropic/langchain_anthropic/middleware/file_search.py
@@ -220,7 +220,12 @@ class StateFileSearchMiddleware(AgentMiddleware):
                 Returns `'No files found'` if no matches.
         """
         # Normalize base path
-        base_path = path if path.startswith("/") else "/" + path
+        normalized_path = path.rstrip("/")
+        base_path = (
+            normalized_path
+            if normalized_path.startswith("/")
+            else "/" + normalized_path
+        )
 
         # Get files from state
         files = cast("dict[str, Any]", state.get(self.state_key, {}))
@@ -283,7 +288,12 @@ class StateFileSearchMiddleware(AgentMiddleware):
                 Returns `'No matches found'` if no results.
         """
         # Normalize base path
-        base_path = path if path.startswith("/") else "/" + path
+        normalized_path = path.rstrip("/")
+        base_path = (
+            normalized_path
+            if normalized_path.startswith("/")
+            else "/" + normalized_path
+        )
 
         # Compile regex pattern (for validation)
         try:

--- a/libs/partners/anthropic/tests/unit_tests/middleware/test_file_search.py
+++ b/libs/partners/anthropic/tests/unit_tests/middleware/test_file_search.py
@@ -121,6 +121,34 @@ class TestGlobSearch:
         assert "/src/main.py" in result
         assert "/tests/test.py" not in result
 
+    def test_glob_with_trailing_slash_path(self) -> None:
+        """Test glob with base path ending in trailing slash."""
+        middleware = StateFileSearchMiddleware()
+
+        state: AnthropicToolsState = {
+            "messages": [],
+            "text_editor_files": {
+                "/src/main.py": {
+                    "content": [],
+                    "created_at": "2025-01-01T00:00:00",
+                    "modified_at": "2025-01-01T00:00:00",
+                },
+                "/tests/test.py": {
+                    "content": [],
+                    "created_at": "2025-01-01T00:00:00",
+                    "modified_at": "2025-01-01T00:00:00",
+                },
+            },
+        }
+
+        result = middleware._handle_glob_search(
+            pattern="**/*.py", path="/src/", state=state
+        )
+
+        assert isinstance(result, str)
+        assert "/src/main.py" in result
+        assert "/tests/test.py" not in result
+
     def test_glob_no_matches(self) -> None:
         """Test glob with no matching files."""
         middleware = StateFileSearchMiddleware()
@@ -391,6 +419,38 @@ class TestFilesystemGrepSearch:
         result = middleware._handle_grep_search(
             pattern="import",
             path="/src",
+            include=None,
+            output_mode="files_with_matches",
+            state=state,
+        )
+
+        assert isinstance(result, str)
+        assert "/src/main.py" in result
+        assert "/tests/test.py" not in result
+
+    def test_grep_with_trailing_slash_path(self) -> None:
+        """Test grep with base path ending in trailing slash."""
+        middleware = StateFileSearchMiddleware()
+
+        state: AnthropicToolsState = {
+            "messages": [],
+            "text_editor_files": {
+                "/src/main.py": {
+                    "content": ["import foo"],
+                    "created_at": "2025-01-01T00:00:00",
+                    "modified_at": "2025-01-01T00:00:00",
+                },
+                "/tests/test.py": {
+                    "content": ["import foo"],
+                    "created_at": "2025-01-01T00:00:00",
+                    "modified_at": "2025-01-01T00:00:00",
+                },
+            },
+        }
+
+        result = middleware._handle_grep_search(
+            pattern="import",
+            path="/src/",
             include=None,
             output_mode="files_with_matches",
             state=state,


### PR DESCRIPTION
Fixes #39816, Fixes #39820

### Summary
1. Escapes bracket characters in mermaid node names to prevent 400 Bad Request responses when rendering diagrams with `draw_mermaid_png()` (#39816).
2. Normalizes input paths in `StateFileSearchMiddleware` to support trailing slashes in `grep_search` and `glob_search` (#39820).

### Verification
- Unit tests pass cleanly.