### PR TITLE
fix(core): Populate gateway metadata on error

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -87,7 +87,10 @@ from langchain_core.tracers._streaming import (
     _StreamingCallbackHandler,
     _V2StreamingCallbackHandler,
 )
-from langchain_core.utils._gateway import GATEWAY_METADATA_RESPONSE_KEY
+from langchain_core.utils._gateway import (
+    GATEWAY_METADATA_RESPONSE_KEY,
+    _parse_gateway_metadata,
+)
 from langchain_core.utils.function_calling import (
     convert_to_json_schema,
     convert_to_openai_tool,
@@ -127,8 +130,17 @@ def _generate_response_from_error(error: BaseException) -> list[ChatGeneration]:
             metadata["status_code"] = response.status_code
         if hasattr(error, "request_id"):
             metadata["request_id"] = error.request_id
+        gateway_metadata = _parse_gateway_metadata(getattr(response, "headers", None))
+        generation_info = (
+            {GATEWAY_METADATA_RESPONSE_KEY: gateway_metadata}
+            if gateway_metadata is not None
+            else None
+        )
         generations = [
-            ChatGeneration(message=AIMessage(content="", response_metadata=metadata))
+            ChatGeneration(
+                message=AIMessage(content="", response_metadata=metadata),
+                generation_info=generation_info,
+            )
         ]
     else:
         generations = []

--- a/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
+++ b/libs/core/tests/unit_tests/language_models/chat_models/test_base.py
@@ -54,6 +54,7 @@ from langchain_core.tracers.context import collect_runs
 from langchain_core.tracers.event_stream import _AstreamEventsCallbackHandler
 from langchain_core.tracers.langchain import LangChainTracer
 from langchain_core.tracers.schemas import Run
+from langchain_core.utils._gateway import GATEWAY_METADATA_RESPONSE_KEY
 from langchain_core.version import VERSION
 from tests.unit_tests.fake.callbacks import (
     BaseFakeCallbackHandler,
@@ -1728,6 +1729,22 @@ def test_generate_response_from_error_with_valid_json() -> None:
     }
     assert metadata["headers"] == {"content-type": "application/json"}
     assert metadata["status_code"] == 400
+
+
+def test_generate_response_from_error_includes_gateway_metadata() -> None:
+    """Test gateway response headers are exposed for error tracing."""
+    response = MockResponse(
+        headers={
+            "X-LangSmith-Gateway-Metadata": '{"provider": "openai"}',
+        }
+    )
+    error = MockAPIError("API Error", response=response)
+
+    generations = _generate_response_from_error(error)
+
+    assert generations[0].generation_info == {
+        GATEWAY_METADATA_RESPONSE_KEY: {"provider": "openai"}
+    }
 
 
 def test_generate_response_from_error_handles_streaming_response_failure() -> None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -737,7 +737,7 @@ async def test_openai_ainvoke(mock_async_client: AsyncMock) -> None:
 
 
 class _GatewayMetadataTracer(BaseTracer):
-    """Captures gateway metadata promoted onto completed LLM runs."""
+    """Captures gateway metadata promoted onto completed or errored LLM runs."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -746,10 +746,16 @@ class _GatewayMetadataTracer(BaseTracer):
     def _persist_run(self, run: Run) -> None:
         """No-op; runs are inspected as they complete."""
 
-    def _on_llm_end(self, run: Run) -> None:
+    def _capture_gateway_metadata(self, run: Run) -> None:
         metadata = run.extra.get("metadata", {})
         if "ls_gateway_info" in metadata:
             self.gateway_metadata = metadata["ls_gateway_info"]
+
+    def _on_llm_end(self, run: Run) -> None:
+        self._capture_gateway_metadata(run)
+
+    def _on_llm_error(self, run: Run) -> None:
+        self._capture_gateway_metadata(run)
 
 
 _GATEWAY_METADATA_HEADERS = httpx2.Headers(
@@ -816,6 +822,35 @@ def test_openai_invoke_surfaces_gateway_metadata(
     assert tracer.gateway_metadata == {"provider": "openai"}
     # ...but is kept off the user-facing message `response_metadata`.
     assert GATEWAY_METADATA_RESPONSE_KEY not in res.response_metadata
+
+
+@pytest.mark.parametrize("use_responses_api", [False, True])
+def test_openai_error_surfaces_gateway_metadata(*, use_responses_api: bool) -> None:
+    """Gateway metadata reaches the tracer when a request errors."""
+    llm = ChatOpenAI(use_responses_api=use_responses_api)
+    request = httpx2.Request("POST", "https://gateway.smith.langchain.com/openai/v1")
+    response = httpx2.Response(
+        429,
+        headers=_GATEWAY_METADATA_HEADERS,
+        request=request,
+    )
+    sdk_error = openai.RateLimitError("rate limited", response=response, body=None)
+    mock_client = MagicMock()
+    if use_responses_api:
+        mock_client.responses.with_raw_response.create.side_effect = sdk_error
+        client_attr = "root_client"
+    else:
+        mock_client.with_raw_response.create.side_effect = sdk_error
+        client_attr = "client"
+
+    tracer = _GatewayMetadataTracer()
+    with (
+        patch.object(llm, client_attr, mock_client),
+        pytest.raises(ModelRateLimitError),
+    ):
+        llm.invoke("bar", config={"callbacks": [tracer]})
+
+    assert tracer.gateway_metadata == {"provider": "openai"}
 
 
 @pytest.mark.parametrize("use_responses_api", [False, True])


### PR DESCRIPTION
@eyurtsev did this for successful requests, we should also populate trace metadata on errors