### PR TITLE
docs(perplexity): update `ChatPerplexity` docstring examples for Agent API

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -681,17 +681,32 @@ class ChatPerplexity(BaseChatModel):
         Responses-only field (`previous_response_id`, `instructions`, `input`,
         `include`) is supplied.
 
+        The Agent API uses its own model catalog (see
+        https://docs.perplexity.ai/docs/agent-api/models). Select routing by
+        passing either an explicit `model=` such as `"openai/gpt-5.6-sol"`, or a
+        Perplexity `preset` (`"fast"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`,
+        or `"wide-research"`) through
+        `model_kwargs`. Perplexity's built-in tools and Agent-API-only fields
+        also go through `model_kwargs`:
+
         ```python
         from langchain_perplexity import ChatPerplexity
 
-        model = ChatPerplexity(model="sonar-pro", use_responses_api=True)
-        model.invoke("What is the capital of France?")
+        model = ChatPerplexity(
+            use_responses_api=True,
+            model_kwargs={
+                "preset": "medium",
+                "tools": [{"type": "web_search"}],
+            },
+        )
+        model.invoke("What did Perplexity announce most recently?")
         ```
 
-        Auto-detection example:
+        Auto-detection example (routes to the Agent API because a built-in
+        `web_search` tool is present):
 
         ```python
-        model = ChatPerplexity(model="sonar-pro")
+        model = ChatPerplexity(model="openai/gpt-5.6-sol")
         model.invoke(
             "Find recent news about AI.",
             tools=[{"type": "web_search"}],


### PR DESCRIPTION
Replace legacy sonar/sonar-pro examples in the ChatPerplexity docstring with the Agent API pattern that 1.4.1 supports:

- use_responses_api=True with model_kwargs.preset + built-in web_search tool
- explicit Agent API model IDs such as openai/gpt-5.6-sol
- pointer to the six current presets (fast, low, medium, high, xhigh, wide-research) and to the Agent API models catalog

The rendered library docstring is what users see from IDEs and help(ChatPerplexity), so this keeps it in sync with what 1.4.1 actually routes to.

Fixes #39775