### PR TITLE
fix(core): exclude 'id' from extras in _extract_v0_extras

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/langchain_v0.py
+++ b/libs/core/langchain_core/messages/block_translators/langchain_v0.py
@@ -65,7 +65,9 @@ def _convert_legacy_v0_content_block_to_v1(
         Returns:
             A dictionary of extra keys not part of the known v0 format.
         """
-        return {k: v for k, v in block_dict.items() if k not in known_keys}
+        return {
+            k: v for k, v in block_dict.items() if k not in known_keys and k != "id"
+        }
 
     # Check if this is actually a v0 format block
     block_type = block.get("type")

--- a/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_langchain_v0.py
@@ -111,3 +111,189 @@ def test_convert_with_extras_on_v0_block() -> None:
     }
 
     assert _convert_legacy_v0_content_block_to_v1(block) == expected_output
+
+
+def test_v0_block_with_id_does_not_raise_type_error() -> None:
+    """Regression test for https://github.com/langchain-ai/langchain/issues/39797.
+
+    A v0 image block that also carries a block `id` should not raise `TypeError`
+    when converted via `HumanMessage.content_blocks`.
+    """
+    message = HumanMessage(
+        content=[
+            {
+                "type": "image",
+                "source_type": "url",
+                "url": "https://example.com/x.png",
+                "id": "block-1",
+            }
+        ]
+    )
+    blocks = message.content_blocks
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "image"
+    assert blocks[0].get("id") == "block-1"
+    assert blocks[0].get("url") == "https://example.com/x.png"
+
+
+def test_v0_image_base64_with_id() -> None:
+    """image/base64 v0 block with id should convert cleanly."""
+    message = HumanMessage(
+        content=[
+            {
+                "type": "image",
+                "source_type": "base64",
+                "data": "<base64 data>",
+                "mime_type": "image/png",
+                "id": "block-2",
+            }
+        ]
+    )
+    blocks = message.content_blocks
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "image"
+    assert blocks[0].get("id") == "block-2"
+    assert blocks[0].get("base64") == "<base64 data>"
+    assert blocks[0].get("mime_type") == "image/png"
+
+
+def test_v0_audio_url_with_id() -> None:
+    """audio/url v0 block with id should convert cleanly."""
+    message = HumanMessage(
+        content=[
+            {
+                "type": "audio",
+                "source_type": "url",
+                "url": "https://example.com/audio.mp3",
+                "id": "audio-1",
+            }
+        ]
+    )
+    blocks = message.content_blocks
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "audio"
+    assert blocks[0].get("id") == "audio-1"
+    assert blocks[0].get("url") == "https://example.com/audio.mp3"
+
+
+def test_v0_audio_base64_with_id() -> None:
+    """audio/base64 v0 block with id should convert cleanly."""
+    message = HumanMessage(
+        content=[
+            {
+                "type": "audio",
+                "source_type": "base64",
+                "data": "<base64 data>",
+                "mime_type": "audio/mpeg",
+                "id": "audio-2",
+            }
+        ]
+    )
+    blocks = message.content_blocks
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "audio"
+    assert blocks[0].get("id") == "audio-2"
+
+
+def test_v0_file_url_with_id() -> None:
+    """file/url v0 block with id should convert cleanly."""
+    message = HumanMessage(
+        content=[
+            {
+                "type": "file",
+                "source_type": "url",
+                "url": "https://example.com/doc.pdf",
+                "id": "file-1",
+            }
+        ]
+    )
+    blocks = message.content_blocks
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "file"
+    assert blocks[0].get("id") == "file-1"
+    assert blocks[0].get("url") == "https://example.com/doc.pdf"
+
+
+def test_v0_file_base64_with_id() -> None:
+    """file/base64 v0 block with id should convert cleanly."""
+    message = HumanMessage(
+        content=[
+            {
+                "type": "file",
+                "source_type": "base64",
+                "data": "<base64 data>",
+                "mime_type": "application/pdf",
+                "id": "file-2",
+            }
+        ]
+    )
+    blocks = message.content_blocks
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "file"
+    assert blocks[0].get("id") == "file-2"
+
+
+def test_v0_image_id_source_still_maps_to_file_id() -> None:
+    """source_type='id' (file reference) must still map id to file_id, not block id."""
+    message = HumanMessage(
+        content=[
+            {
+                "type": "image",
+                "source_type": "id",
+                "id": "file-ref-123",
+            }
+        ]
+    )
+    blocks = message.content_blocks
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "image"
+    assert blocks[0].get("file_id") == "file-ref-123"
+
+
+def test_v0_audio_id_source_still_maps_to_file_id() -> None:
+    message = HumanMessage(
+        content=[
+            {
+                "type": "audio",
+                "source_type": "id",
+                "id": "file-ref-456",
+            }
+        ]
+    )
+    blocks = message.content_blocks
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "audio"
+    assert blocks[0].get("file_id") == "file-ref-456"
+
+
+def test_v0_file_id_source_still_maps_to_file_id() -> None:
+    message = HumanMessage(
+        content=[
+            {
+                "type": "file",
+                "source_type": "id",
+                "id": "file-ref-789",
+            }
+        ]
+    )
+    blocks = message.content_blocks
+    assert len(blocks) == 1
+    assert blocks[0]["type"] == "file"
+    assert blocks[0].get("file_id") == "file-ref-789"
+
+
+def test_v0_block_with_id_preserves_extras() -> None:
+    """Genuine extras (non-id unknown keys) must still survive when id is present."""
+    block = {
+        "type": "image",
+        "source_type": "url",
+        "url": "https://example.com/x.png",
+        "id": "block-1",
+        "alt_text": "An example image",
+        "caption": "Example caption",
+    }
+    result = _convert_legacy_v0_content_block_to_v1(block)
+    assert result["type"] == "image"
+    assert result["id"] == "block-1"
+    assert result.get("extras", {}).get("alt_text") == "An example image"
+    assert result.get("extras", {}).get("caption") == "Example caption"


### PR DESCRIPTION
Fixes #39797

A v0 content block that carries a block `id` (alongside a `url` or
`base64` `source_type`) raised `TypeError` from
`HumanMessage.content_blocks` because the explicit `id=` kwarg collided
with `id` inside the splatted `**extras` returned by
`_extract_v0_extras`.

Excluding `id` once inside the helper keeps all ten call sites consistent.
`id` is never a genuine extra: it is either passed explicitly to the
factory, or (for `source_type="id"`) the file reference itself, which
those branches already list in `known_keys`. `source_type="id"`
behaviour is unchanged.

Regression tests added for all six failing combinations
(image/audio/file × url/base64, each with `id`), plus the three
`source_type="id"` paths and extras-with-id preservation. `ruff check`,
`ruff format --check`, and the langchain-core test suite for the touched
file pass.