### PR TITLE
fix(core): replace backslash escapes in _to_safe_id with Mermaid-valid IDs

### DIFF
--- a/libs/core/langchain_core/runnables/graph_mermaid.py
+++ b/libs/core/langchain_core/runnables/graph_mermaid.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import hashlib
 import random
 import re
 import string
@@ -256,14 +257,17 @@ def _to_safe_id(label: str) -> str:
     """Convert a string into a Mermaid-compatible node id.
 
     Keep [a-zA-Z0-9_-] characters unchanged.
-    Map every other character -> backslash + lowercase hex codepoint.
+    Replace all other characters with underscores, then append a short
+    deterministic hash suffix to guarantee uniqueness even when different
+    labels would otherwise sanitize to the same string.
 
-    Result is guaranteed to be unique and Mermaid-compatible,
-    so nodes with special characters always render correctly.
+    Result is always valid Mermaid syntax (no backslashes), so nodes
+    with special characters like brackets render correctly.
     """
     allowed = string.ascii_letters + string.digits + "_-"
-    out = [ch if ch in allowed else "\\" + format(ord(ch), "x") for ch in label]
-    return "".join(out)
+    sanitized = "".join(ch if ch in allowed else "_" for ch in label)
+    suffix = hashlib.sha256(label.encode()).hexdigest()[:6]
+    return f"{sanitized}_{suffix}"
 
 
 def _generate_mermaid_graph_styles(node_colors: NodeStyles) -> str:

--- a/libs/core/tests/unit_tests/runnables/test_graph.py
+++ b/libs/core/tests/unit_tests/runnables/test_graph.py
@@ -525,11 +525,27 @@ def test_runnable_get_graph_with_invalid_output_type() -> None:
 
 
 def test_graph_mermaid_to_safe_id() -> None:
-    """Test that node labels are correctly preprocessed for draw_mermaid."""
-    assert _to_safe_id("foo") == "foo"
-    assert _to_safe_id("foo-bar") == "foo-bar"
-    assert _to_safe_id("foo_1") == "foo_1"
-    assert _to_safe_id("#foo*&!") == "\\23foo\\2a\\26\\21"
+    """Test that _to_safe_id produces Mermaid-valid, unique IDs."""
+    import hashlib as _hl
+    allowed = string.ascii_letters + string.digits + "_-"
+
+    # Basic: alphanumeric preserved, unique suffix appended
+    result_foo = _to_safe_id("foo")
+    result_bar = _to_safe_id("bar")
+    assert result_foo != result_bar, "Different inputs must produce different IDs"
+    assert result_foo.startswith("foo_"), "Alphanumeric prefix preserved"
+
+    # All characters in result must be Mermaid-valid (no backslashes)
+    for r in [result_foo, result_bar]:
+        assert "\\" not in r, f"Backslash found in Mermaid ID: {r}"
+        assert all(c in allowed for c in r), f"Invalid chars in Mermaid ID: {r}"
+
+    # Bracket regression test for #39816
+    bracket_result = _to_safe_id("PIIMiddleware[email].before_model")
+    assert "\\" not in bracket_result, "Backslash in bracket ID"
+    assert all(c in allowed for c in bracket_result), "Invalid chars in bracket ID"
+    assert "PIIMiddleware" in bracket_result, "Original prefix should appear"
+
 
 
 def test_graph_mermaid_duplicate_nodes(snapshot: SnapshotAssertion) -> None:


### PR DESCRIPTION
## Summary

Fixes #39816

`_to_safe_id()` in `graph_mermaid.py` maps disallowed characters to backslash + hex codepoint (e.g., `[` -> `\5b`). Backslashes are **not valid in Mermaid node IDs**, causing the Mermaid.ink API to reject the graph with a 400 error.

This affects any node with `[`, `]`, `.`, or other special characters in its name.

## What changed

- **`libs/core/langchain_core/runnables/graph_mermaid.py`**: Replaced backslash-escape logic with underscore substitution + 6-char SHA-256 hash suffix. Result is always `[A-Za-z0-9_-]+`, which Mermaid parses correctly.
- **`libs/core/tests/unit_tests/runnables/test_graph.py`**: Updated `test_graph_mermaid_to_safe_id` to verify no backslashes, valid character set, uniqueness, and bracket regression.

## Testing

- Updated unit test verifies no backslashes, valid chars, uniqueness, and bracket handling
- Snapshot tests will need regeneration with `--snapshot-update` (expected since IDs change format).

## Related

- Fixes #39816
- Regression from #32857