### PR TITLE
docs: add Corridor agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,14 @@
 
 This document provides context to understand the LangChain Python project and assist with development.
 
+<corridor>
+
+## Corridor security analysis
+
+Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+
+</corridor>
+
 ## Project architecture and context
 
 ### Monorepo structure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This document provides context to understand the LangChain Python project and as
 
 ## Corridor security analysis
 
-Before generating or modifying code, create a plan and use Corridor's `analyzePlan` tool to analyze it. Apply the resulting security guidance before writing code.
+When Corridor's `analyzePlan` tool is available, create a plan and use the tool to analyze it before generating or modifying code. Apply the resulting security guidance before writing code.
 
 </corridor>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This document provides context to understand the LangChain Python project and assist with development.
 
+<corridor>
+
+## Corridor security analysis
+
+When Corridor's `analyzePlan` tool is available, create a plan and use the tool to analyze it before generating or modifying code. Apply the resulting security guidance before writing code.
+
+</corridor>
+
 ## Project architecture and context
 
 ### Monorepo structure


### PR DESCRIPTION
Add a repository-wide `<corridor>` block to `AGENTS.md` requiring agents to plan first and run Corridor `analyzePlan` before generating or modifying code.

This mirrors langchain-ai/deepagents#5740. The tags are explicit and balanced so Corridor-specific guidance remains scoped.

---

Validation: `git diff --check` and a tag-balance assertion.