### PR TITLE
fix(huggingface): pass bound tools through the local pipeline chat template (#29033)

### DIFF
--- a/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
+++ b/libs/partners/huggingface/langchain_huggingface/chat_models/huggingface.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import re
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from operator import itemgetter
@@ -320,6 +321,41 @@ def _is_huggingface_endpoint(llm: Any) -> bool:
 
 def _is_huggingface_pipeline(llm: Any) -> bool:
     return isinstance(llm, HuggingFacePipeline)
+
+
+def _template_supports_tools(tokenizer: Any) -> bool:
+    """Check whether a tokenizer's chat template accepts a ``tools`` variable."""
+    template = getattr(tokenizer, "chat_template", None)
+    if isinstance(template, Mapping):
+        template = "\n".join(str(t) for t in template.values())
+    elif not isinstance(template, str):
+        return False
+    try:
+        from jinja2 import Environment  # type: ignore[import-not-found]
+        from jinja2.meta import (  # type: ignore[import-not-found]
+            find_undeclared_variables,
+        )
+
+        variables = find_undeclared_variables(Environment().parse(template))
+        return "tools" in variables
+    except ImportError:
+        # transformers normally ships Jinja; fall back to a source check.
+        return re.search(r"\btools\b", template) is not None
+
+
+_TOOLS_PROMPT_HEADER = (
+    "In this environment you have access to a set of tools you can use to "
+    "answer the user's question.\n\n"
+    'You can invoke functions by writing a JSON object with the keys "name" '
+    'and "arguments" inside <tool_call> </tool_call> XML tags as part of '
+    "your reply.\n\nAvailable tools:\n"
+)
+
+
+def _format_tools_for_system_message(tools: Sequence[Any]) -> str:
+    """Render tool schemas into a plain-text block for the system message."""
+    schemas = "\n".join(json.dumps(tool, ensure_ascii=False) for tool in tools)
+    return f"{_TOOLS_PROMPT_HEADER}{schemas}\n\n"
 
 
 class ChatHuggingFace(BaseChatModel):
@@ -754,7 +790,7 @@ class ChatHuggingFace(BaseChatModel):
             }
             answer = self.llm.client.chat_completion(messages=message_dicts, **params)
             return self._create_chat_result(answer)
-        llm_input = self._to_chat_prompt(messages)
+        llm_input = self._to_chat_prompt(messages, tools=kwargs.get("tools"))
 
         if should_stream:
             stream_iter = self.llm._stream(
@@ -799,7 +835,7 @@ class ChatHuggingFace(BaseChatModel):
         if _is_huggingface_pipeline(self.llm):
             msg = "async generation is not supported with HuggingFacePipeline"
             raise NotImplementedError(msg)
-        llm_input = self._to_chat_prompt(messages)
+        llm_input = self._to_chat_prompt(messages, tools=kwargs.get("tools"))
         llm_result = await self.llm._agenerate(
             prompts=[llm_input], stop=stop, run_manager=run_manager, **kwargs
         )
@@ -882,7 +918,7 @@ class ChatHuggingFace(BaseChatModel):
                     )
                 yield generation_chunk
         else:
-            llm_input = self._to_chat_prompt(messages)
+            llm_input = self._to_chat_prompt(messages, tools=kwargs.get("tools"))
             stream_iter = self.llm._stream(
                 llm_input, stop=stop, run_manager=run_manager, **kwargs
             )
@@ -952,8 +988,15 @@ class ChatHuggingFace(BaseChatModel):
     def _to_chat_prompt(
         self,
         messages: list[BaseMessage],
+        tools: Sequence[Any] | None = None,
     ) -> str:
-        """Convert a list of messages into a prompt format expected by wrapped LLM."""
+        """Convert a list of messages into a prompt format expected by wrapped LLM.
+
+        When tools are bound and the tokenizer's chat template supports a
+        ``tools`` variable, they are passed to ``apply_chat_template``
+        natively. Otherwise they are injected into the first system message
+        (or a new one) as a fallback so local models still see the schemas.
+        """
         if not messages:
             msg = "At least one HumanMessage must be provided!"
             raise ValueError(msg)
@@ -964,8 +1007,38 @@ class ChatHuggingFace(BaseChatModel):
 
         messages_dicts = [self._to_chatml_format(m) for m in messages]
 
+        if not tools:
+            return self.tokenizer.apply_chat_template(
+                messages_dicts, tokenize=False, add_generation_prompt=True
+            )
+
+        if _template_supports_tools(self.tokenizer):
+            return self.tokenizer.apply_chat_template(
+                messages_dicts,
+                tokenize=False,
+                add_generation_prompt=True,
+                tools=list(tools),
+            )
+
+        flattened_tools = [
+            tool.get("function", tool) if isinstance(tool, Mapping) else tool
+            for tool in tools
+        ]
+        tool_block = _format_tools_for_system_message(flattened_tools)
+        injected = False
+        rendered_messages = []
+        for message_dict in messages_dicts:
+            if not injected and message_dict["role"] == "system":
+                message_dict = {
+                    **message_dict,
+                    "content": f"{tool_block}{message_dict['content']}",
+                }
+                injected = True
+            rendered_messages.append(message_dict)
+        if not injected:
+            rendered_messages.insert(0, {"role": "system", "content": tool_block})
         return self.tokenizer.apply_chat_template(
-            messages_dicts, tokenize=False, add_generation_prompt=True
+            rendered_messages, tokenize=False, add_generation_prompt=True
         )
 
     def _to_chatml_format(self, message: BaseMessage) -> dict:

--- a/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/huggingface/tests/unit_tests/test_chat_models.py
@@ -9,14 +9,15 @@ from langchain_core.messages import (
     HumanMessage,
     SystemMessage,
 )
-from langchain_core.outputs import ChatResult
+from langchain_core.outputs import ChatResult, Generation, LLMResult
 from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
 
 from langchain_huggingface.chat_models import (  # type: ignore[import]
     ChatHuggingFace,
     _convert_dict_to_message,
 )
-from langchain_huggingface.llms import HuggingFaceEndpoint
+from langchain_huggingface.llms import HuggingFaceEndpoint, HuggingFacePipeline
 
 
 @pytest.fixture
@@ -222,6 +223,129 @@ def test_bind_tools(chat_hugging_face: Any) -> None:
         _, kwargs = mock_super_bind.call_args
         assert kwargs["tools"] == tools
         assert kwargs["tool_choice"] == "auto"
+
+
+class GetWeather(BaseModel):
+    """Get the current weather in a given location."""
+
+    location: str = Field(..., description="The city name")
+
+
+class _StubTokenizer:
+    def __init__(self, chat_template: str | None) -> None:
+        self.chat_template = chat_template
+        self.calls: list[dict[str, Any]] = []
+
+    def apply_chat_template(
+        self, messages: list[dict[str, Any]], **kwargs: Any
+    ) -> str:
+        self.calls.append({"messages": messages, **kwargs})
+        return "rendered prompt"
+
+
+def _pipeline_chat_with_tokenizer(stub_tokenizer: Any) -> ChatHuggingFace:
+    pipeline_llm = Mock(spec=HuggingFacePipeline)
+    with patch(
+        "langchain_huggingface.chat_models.huggingface.ChatHuggingFace."
+        "_resolve_model_id"
+    ):
+        return ChatHuggingFace(llm=pipeline_llm, tokenizer=stub_tokenizer)
+
+
+def test_to_chat_prompt_passes_tools_when_template_supports_them() -> None:
+    stub = _StubTokenizer(
+        "{%- for tool in tools %}{{ tool|tojson }}{%- endfor %}"
+    )
+    chat = _pipeline_chat_with_tokenizer(stub)
+    bound_tools = list(chat.bind_tools([GetWeather]).kwargs["tools"])
+    messages = [
+        SystemMessage(content="You are helpful."),
+        HumanMessage(content="What is the weather in Paris?"),
+    ]
+
+    prompt = chat._to_chat_prompt(messages, tools=bound_tools)
+
+    assert prompt == "rendered prompt"
+    assert len(stub.calls) == 1
+    assert stub.calls[0]["tools"] == bound_tools
+    assert stub.calls[0]["messages"] == [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is the weather in Paris?"},
+    ]
+
+
+def test_to_chat_prompt_injects_tool_block_into_system_message() -> None:
+    stub = _StubTokenizer(
+        "{{ messages[0]['content'] }}{% for m in messages %}{% endfor %}"
+    )
+    chat = _pipeline_chat_with_tokenizer(stub)
+    bound_tools = list(chat.bind_tools([GetWeather]).kwargs["tools"])
+    messages = [
+        SystemMessage(content="You are helpful."),
+        HumanMessage(content="What is the weather in Paris?"),
+    ]
+
+    prompt = chat._to_chat_prompt(messages, tools=bound_tools)
+
+    assert prompt == "rendered prompt"
+    call_messages = stub.calls[0]["messages"]
+    assert len(call_messages) == 2
+    system_content = call_messages[0]["content"]
+    assert system_content.startswith("In this environment you have access")
+    assert '"name": "GetWeather"' in system_content
+    assert '"location"' in system_content
+    assert system_content.endswith("You are helpful.")
+    assert "tools" not in stub.calls[0]
+
+
+def test_to_chat_prompt_prepends_tool_block_without_system_message() -> None:
+    stub = _StubTokenizer("plain template without tools support")
+    chat = _pipeline_chat_with_tokenizer(stub)
+    bound_tools = list(chat.bind_tools([GetWeather]).kwargs["tools"])
+    messages = [HumanMessage(content="What is the weather in Paris?")]
+
+    chat._to_chat_prompt(messages, tools=bound_tools)
+
+    call_messages = stub.calls[0]["messages"]
+    assert len(call_messages) == 2
+    assert call_messages[0]["role"] == "system"
+    assert '"name": "GetWeather"' in call_messages[0]["content"]
+    assert call_messages[1] == {
+        "role": "user",
+        "content": "What is the weather in Paris?",
+    }
+
+
+def test_to_chat_prompt_no_tools_keeps_original_template_call(
+    chat_hugging_face: Any,
+) -> None:
+    stub = _StubTokenizer("any template")
+    chat_hugging_face.tokenizer = stub
+    messages = [HumanMessage(content="Hi")]
+
+    chat_hugging_face._to_chat_prompt(messages)
+
+    assert stub.calls == [
+        {
+            "messages": [{"role": "user", "content": "Hi"}],
+            "tokenize": False,
+            "add_generation_prompt": True,
+        }
+    ]
+
+
+def test_bound_tools_reach_local_pipeline_prompt() -> None:
+    stub = _StubTokenizer("{% for tool in tools %}{{ tool|tojson }}{% endfor %}")
+    chat = _pipeline_chat_with_tokenizer(stub)
+    chat.llm._generate.return_value = LLMResult(
+        generations=[[Generation(text="calling GetWeather")]], llm_output={}
+    )
+    bound = chat.bind_tools([GetWeather])
+
+    result = bound.invoke([HumanMessage(content="Weather in Paris?")])
+
+    assert result.content == "calling GetWeather"
+    assert stub.calls[-1]["tools"] == list(bound.kwargs["tools"])
 
 
 def test_property_inheritance_integration(chat_hugging_face: Any) -> None:


### PR DESCRIPTION
Closes #29033

ChatHuggingFace with a local HuggingFacePipeline dropped bound tools: the local branch renders prompts via _to_chat_prompt, which never forwarded tools to tokenizer.apply_chat_template (endpoint branches pass kwargs straight through).

- Capability detection via Jinja find_undeclared_variables on the chat template (str + dict multi-template aware); when supported, formatted OpenAI-style tools are passed natively as tools=
- Fallback: tool schemas injected into the first system message (prepended if absent)
- No-tools invocations keep byte-identical template kwargs; public API unchanged

## Release note
Fixed ChatHuggingFace ignoring bind_tools when running against a local HuggingFacePipeline; tools now reach the chat template natively where supported, with a system-prompt fallback otherwise.

Tests use stubbed tokenizers only - no model downloads.