### PR TITLE
fix(core): XMLOutputParser drops child elements on mixed text content

### DIFF
--- a/libs/core/langchain_core/output_parsers/xml.py
+++ b/libs/core/langchain_core/output_parsers/xml.py
@@ -269,11 +269,15 @@ class XMLOutputParser(BaseTransformOutputParser[dict[str, Any]]):
 
     def _root_to_dict(self, root: ET.Element) -> dict[str, str | list[Any]]:
         """Converts xml tree to python dictionary."""
-        if root.text and bool(re.search(r"\S", root.text)):
-            # If root text contains any non-whitespace character it
-            # returns {root.tag: root.text}
+        if len(root) == 0 and root.text and bool(re.search(r"\S", root.text)):
+            # Leaf element (no children) with non-whitespace text: return the
+            # text directly, e.g. {root.tag: root.text}.
             return {root.tag: root.text}
         root_tag: list[Any] = []
+        if root.text and bool(re.search(r"\S", root.text)):
+            # Root has both text and child elements (mixed content). Preserve
+            # the text instead of silently dropping the children below.
+            root_tag.append({"_text": root.text})
         for child in root:
             if len(child) == 0:
                 root_tag.append({child.tag: child.text})

--- a/libs/core/tests/unit_tests/output_parsers/test_xml_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_xml_parser.py
@@ -147,6 +147,31 @@ MALICIOUS_XML = """<?xml version="1.0"?>
 <lolz>&lol9;</lolz>"""
 
 
+MIXED_CONTENT = "<result>Summary<detail>info</detail></result>"
+
+MIXED_CONTENT_EXPECTED = {
+    "result": [
+        {"_text": "Summary"},
+        {"detail": "info"},
+    ],
+}
+
+
+@pytest.mark.parametrize("parser_impl", ["xml", "defusedxml"])
+def test_xml_output_parser_mixed_content(parser_impl: str) -> None:
+    """Regression test for #36744.
+
+    An element that has both non-whitespace text *and* child elements
+    (mixed content) must not silently drop the child elements -- only the
+    element's own text used to short-circuit `_root_to_dict` and discard
+    everything else.
+    """
+    if parser_impl == "defusedxml" and importlib.util.find_spec("defusedxml") is None:
+        pytest.skip("defusedxml is not installed")
+    xml_parser = XMLOutputParser(parser=parser_impl)
+    assert xml_parser.parse(MIXED_CONTENT) == MIXED_CONTENT_EXPECTED
+
+
 async def tests_billion_laughs_attack() -> None:
     # Testing with standard XML parser since it's safe to use in
     # newer versions of Python


### PR DESCRIPTION
Fixes #36744

## Bug

`XMLOutputParser._root_to_dict` short-circuits on any element that has non-whitespace text, returning `{tag: text}` without ever looking at child elements:

```python
if root.text and bool(re.search(r"\S", root.text)):
    return {root.tag: root.text}
```

This silently discards structured sub-tags whenever an element has *mixed content* — text plus children. For example, an LLM asked to emit `<response>The answer is 42.<reasoning>...</reasoning></response>` (a text preamble followed by structured sub-tags) loses the `<reasoning>` content entirely, with no error raised:

```python
>>> XMLOutputParser().parse("<result>Summary<detail>info</detail></result>")
{'result': 'Summary'}   # <detail>info</detail> silently gone
```

## Fix

Gate the leaf-node shortcut on having no children (`len(root) == 0`), so it only fires for genuine leaf-with-text nodes — preserving the existing `{"body": "text"}` behavior exactly. When a node has both text and children, the text is kept as a `{"_text": ...}` entry ahead of the children instead of being used to discard them:

```diff
-if root.text and bool(re.search(r"\S", root.text)):
+if len(root) == 0 and root.text and bool(re.search(r"\S", root.text)):
     return {root.tag: root.text}
 root_tag: list[Any] = []
+if root.text and bool(re.search(r"\S", root.text)):
+    root_tag.append({"_text": root.text})
 for child in root:
     ...
```

## Testing

Added `test_xml_output_parser_mixed_content` (parametrized over the `xml`/`defusedxml` parsers), asserting `<result>Summary<detail>info</detail></result>` parses to `{"result": [{"_text": "Summary"}, {"detail": "info"}]}`.

- Reverting the fix: both parametrized cases fail with `AssertionError: {'result': 'Summary'} == {'result': [...]}` — reproduces the exact bug.
- With the fix: full `tests/unit_tests/output_parsers/` suite passes (132 tests), no regressions — including existing tests for root-only text, nested structures, streaming, and the billion-laughs XXE guard.

Ran `ruff check`, `ruff format --check`, and `mypy` (whole `langchain_core` package, 181 files) — all clean.