### PR TITLE
fix(openai): ensure stream=False when streaming is disabled for tool calling

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1833,7 +1833,7 @@ class BaseChatOpenAI(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         self._ensure_sync_client_available()
-        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        payload = self._get_request_payload(messages, stop=stop, stream=False, **kwargs)
         generation_info = None
         raw_response = None
         try:
@@ -2129,7 +2129,7 @@ class BaseChatOpenAI(BaseChatModel):
         run_manager: AsyncCallbackManagerForLLMRun | None = None,
         **kwargs: Any,
     ) -> ChatResult:
-        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        payload = self._get_request_payload(messages, stop=stop, stream=False, **kwargs)
         generation_info = {}
         raw_response = None
         try:


### PR DESCRIPTION
Fixes #35436

### Summary
This PR fixes a crash in `ChatOpenAI` when `disable_streaming="tool_calling"` is used with `streaming=True`.

### Root Cause
When `disable_streaming="tool_calling"` is active and tools are passed, `BaseChatModel._should_stream` returns `False`. This causes `astream` to fall back to `ainvoke` -> `_agenerate`. 
However, `ChatOpenAI._agenerate` (and `_generate`) was inheriting the default `stream=True` from the model's parameters, causing the OpenAI client to return an `AsyncStream` instead of a `ChatCompletion`. The SDK then crashed when trying to call `model_dump()` on the `AsyncStream`.

### Changes
- Explicitly pass `stream=False` to `_get_request_payload` in both `_generate` and `_agenerate` to ensure the OpenAI client returns a standard completion object when streaming is disabled at the model level.
