### PR TITLE
fix(agents): sync additional_kwargs during HITL edits to ensure state…

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
+++ b/libs/langchain_v1/langchain/agents/middleware/human_in_the_loop.py
@@ -327,7 +327,7 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
             return (
                 ToolCall(
                     type="tool_call",
-                    name=edited_action["name"],
+                    name=edited_action.get("name") or tool_call["name"],
                     args=edited_action["args"],
                     id=tool_call["id"],
                 ),
@@ -482,6 +482,30 @@ class HumanInTheLoopMiddleware(AgentMiddleware[StateT, ContextT, ResponseT]):
 
         # Update the AI message to only include approved tool calls
         last_ai_msg.tool_calls = revised_tool_calls
+
+        # If any tool calls were edited, we need to sync additional_kwargs if they exist
+        # to avoid confusing the LLM with conflicting information in the history.
+        if (
+            "tool_calls" in last_ai_msg.additional_kwargs
+            and isinstance(last_ai_msg.additional_kwargs["tool_calls"], list)
+        ):
+            new_raw_tool_calls = []
+            revised_by_id = {tc["id"]: tc for tc in revised_tool_calls}
+            
+            for raw_tc in last_ai_msg.additional_kwargs["tool_calls"]:
+                tc_id = raw_tc.get("id")
+                if tc_id in revised_by_id:
+                    revised = revised_by_id[tc_id]
+                    # Update the raw tool call with edited args
+                    import json
+                    new_raw_tc = raw_tc.copy()
+                    if "function" in new_raw_tc:
+                        new_raw_tc["function"] = new_raw_tc["function"].copy()
+                        new_raw_tc["function"]["arguments"] = json.dumps(revised["args"])
+                        new_raw_tc["function"]["name"] = revised["name"]
+                    new_raw_tool_calls.append(new_raw_tc)
+            
+            last_ai_msg.additional_kwargs["tool_calls"] = new_raw_tool_calls
 
         return {"messages": [last_ai_msg, *artificial_tool_messages]}
 

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop_sync.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop_sync.py
@@ -1,0 +1,120 @@
+from typing import Any
+from unittest.mock import patch
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.runtime import Runtime
+
+from langchain.agents.middleware.human_in_the_loop import Action, HumanInTheLoopMiddleware
+from langchain.agents.middleware.types import AgentState
+
+
+def test_human_in_the_loop_middleware_syncs_additional_kwargs() -> None:
+    """Test that HITL middleware syncs additional_kwargs during edits."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={"test_tool": {"allowed_decisions": ["approve", "edit", "reject"]}}
+    )
+
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[{"name": "test_tool", "args": {"input": "original"}, "id": "1"}],
+        additional_kwargs={
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "function": {
+                        "arguments": '{"input": "original"}',
+                        "name": "test_tool",
+                    },
+                    "type": "function",
+                }
+            ]
+        },
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hello"), ai_message])
+
+    def mock_edit(_: Any) -> dict[str, Any]:
+        return {
+            "decisions": [
+                {
+                    "type": "edit",
+                    "edited_action": Action(
+                        name="test_tool",
+                        args={"input": "edited"},
+                    ),
+                }
+            ]
+        }
+
+    with patch("langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=mock_edit):
+        result = middleware.after_model(state, Runtime())
+        assert result is not None
+        assert "messages" in result
+        updated_ai_message = result["messages"][0]
+        
+        # Verify tool_calls is updated
+        assert updated_ai_message.tool_calls[0]["args"] == {"input": "edited"}
+        
+        # Verify additional_kwargs is synced
+        raw_tool_calls = updated_ai_message.additional_kwargs["tool_calls"]
+        assert len(raw_tool_calls) == 1
+        assert raw_tool_calls[0]["function"]["arguments"] == '{"input": "edited"}'
+        assert raw_tool_calls[0]["function"]["name"] == "test_tool"
+
+
+def test_human_in_the_loop_middleware_syncs_additional_kwargs_with_name_change() -> None:
+    """Test that HITL middleware syncs additional_kwargs during name edits."""
+    middleware = HumanInTheLoopMiddleware(
+        interrupt_on={"test_tool": {"allowed_decisions": ["approve", "edit", "reject"]}}
+    )
+
+    ai_message = AIMessage(
+        content="",
+        tool_calls=[{"name": "test_tool", "args": {"input": "original"}, "id": "1"}],
+        additional_kwargs={
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "function": {
+                        "arguments": '{"input": "original"}',
+                        "name": "test_tool",
+                    },
+                    "type": "function",
+                }
+            ]
+        },
+    )
+    state = AgentState[Any](messages=[HumanMessage(content="Hello"), ai_message])
+
+    def mock_edit(_: Any) -> dict[str, Any]:
+        return {
+            "decisions": [
+                {
+                    "type": "edit",
+                    "edited_action": Action(
+                        name="new_tool",
+                        args={"input": "edited"},
+                    ),
+                }
+            ]
+        }
+
+    with patch("langchain.agents.middleware.human_in_the_loop.interrupt", side_effect=mock_edit):
+        result = middleware.after_model(state, Runtime())
+        assert result is not None
+        assert "messages" in result
+        updated_ai_message = result["messages"][0]
+        
+        # Verify tool_calls is updated
+        assert updated_ai_message.tool_calls[0]["name"] == "new_tool"
+        assert updated_ai_message.tool_calls[0]["args"] == {"input": "edited"}
+        
+        # Verify additional_kwargs is synced
+        raw_tool_calls = updated_ai_message.additional_kwargs["tool_calls"]
+        assert len(raw_tool_calls) == 1
+        assert raw_tool_calls[0]["function"]["arguments"] == '{"input": "edited"}'
+        assert raw_tool_calls[0]["function"]["name"] == "new_tool"
+
+if __name__ == "__main__":
+    test_human_in_the_loop_middleware_syncs_additional_kwargs()
+    test_human_in_the_loop_middleware_syncs_additional_kwargs_with_name_change()
+    print("All tests passed!")


### PR DESCRIPTION
Fixes #33787

This PR ensures that when a tool call is edited via `HumanInTheLoopMiddleware`, the `additional_kwargs["tool_calls"]` field in the `AIMessage` is also synchronized. 

Without this sync, many models (like OpenAI) that rely on the raw tool call data in `additional_kwargs` would see the original arguments instead of the edited ones, leading to incorrect state re-evaluation and infinite retry loops.

### Changes:
- Updated `HumanInTheLoopMiddleware.after_model` to sync `additional_kwargs` when edits occur.
- Added comprehensive unit tests in `libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_human_in_the_loop_sync.py`.