### PR TITLE
fix(openai): preserve streamed refusals and refusals in dict responses

### DIFF
--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -231,6 +231,8 @@ def _convert_dict_to_message(_dict: Mapping[str, Any]) -> BaseMessage:
         # Also OpenAI returns None for tool invocations
         content = _dict.get("content", "") or ""
         additional_kwargs: dict = {}
+        if refusal := _dict.get("refusal"):
+            additional_kwargs["refusal"] = refusal
         if function_call := _dict.get("function_call"):
             additional_kwargs["function_call"] = dict(function_call)
         tool_calls = []
@@ -489,6 +491,8 @@ def _convert_delta_to_message_chunk(
     role = cast(str, _dict.get("role"))
     content = cast(str, _dict.get("content") or "")
     additional_kwargs: dict = {}
+    if refusal := _dict.get("refusal"):
+        additional_kwargs["refusal"] = refusal
     if _dict.get("function_call"):
         function_call = dict(_dict["function_call"])
         if "name" in function_call and function_call["name"] is None:


### PR DESCRIPTION
Fixes #39747

This PR ensures that `refusal` fields from OpenAI responses are preserved in both non-streaming (`_convert_dict_to_message`) and streaming (`_convert_delta_to_message_chunk`) paths.

Currently, `ChatOpenAI` only preserves `function_call`, `tool_calls`, and `audio` in `additional_kwargs`. When a model refuses a request (e.g., due to safety filters or structured output constraints), the `refusal` field is returned by the API but dropped by LangChain's conversion logic. This leads to a `ValueError` during structured output parsing instead of the expected `OpenAIRefusalError`.

**Changes:**
- Added `refusal` preservation in `_convert_dict_to_message`.
- Added `refusal` preservation in `_convert_delta_to_message_chunk`.
- Verified with a reproduction script that `additional_kwargs["refusal"]` is now correctly populated in streaming mode.

This fix aligns the dictionary/streaming conversion paths with the typed-response behavior already present in `_create_chat_result`.