### PR TITLE
fix(langchain): support IPv6 address detection in `detect_ip`

### DIFF
--- a/libs/langchain_v1/langchain/agents/middleware/_redaction.py
+++ b/libs/langchain_v1/langchain/agents/middleware/_redaction.py
@@ -106,8 +106,10 @@ def detect_ip(content: str) -> list[PIIMatch]:
     """
     matches: list[PIIMatch] = []
     ipv4_pattern = r"\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b"
+    ipv6_pattern = r"(?<!\w)(?:[0-9a-fA-F]*:[0-9a-fA-F.:]*){2,}(?!\w)"
+    pattern = re.compile(f"(?:{ipv6_pattern}|{ipv4_pattern})")
 
-    for match in re.finditer(ipv4_pattern, content):
+    for match in pattern.finditer(content):
         ip_candidate = match.group()
         try:
             ipaddress.ip_address(ip_candidate)

--- a/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
+++ b/libs/langchain_v1/tests/unit_tests/agents/middleware/implementations/test_pii.py
@@ -148,6 +148,34 @@ class TestIPDetection:
         assert matches[0]["type"] == "ip"
         assert matches[0]["value"] == "192.168.1.1"
 
+    def test_detect_valid_ipv6(self) -> None:
+        content = "Server IP: 2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["type"] == "ip"
+        assert matches[0]["value"] == "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+
+    def test_detect_compressed_ipv6(self) -> None:
+        content = "Connect to fe80::1 or ::1"
+        matches = detect_ip(content)
+
+        assert len(matches) == 2
+        assert matches[0]["value"] == "fe80::1"
+        assert matches[1]["value"] == "::1"
+
+    def test_detect_ipv4_mapped_ipv6(self) -> None:
+        content = "Address ::ffff:192.168.1.1"
+        matches = detect_ip(content)
+
+        assert len(matches) == 1
+        assert matches[0]["value"] == "::ffff:192.168.1.1"
+
+    def test_scope_resolution_operator_not_detected(self) -> None:
+        content = "C++: std::collections, Rust: std::vector"
+        matches = detect_ip(content)
+        assert len(matches) == 0
+
     def test_detect_multiple_ips(self) -> None:
         content = "Connect to 10.0.0.1 or 8.8.8.8"
         matches = detect_ip(content)
@@ -330,6 +358,17 @@ class TestMaskStrategy:
         content = result["messages"][0].content
         assert "*.*.*.100" in content
         assert "192.168.1.100" not in content
+
+    def test_mask_ipv6(self) -> None:
+        middleware = PIIMiddleware("ip", strategy="mask")
+        state = AgentState[Any](messages=[HumanMessage("IP: 2001:db8::1")])
+
+        result = middleware.before_model(state, Runtime())
+
+        assert result is not None
+        content = result["messages"][0].content
+        assert "****" in content
+        assert "2001:db8::1" not in content
 
 
 class TestHashStrategy:


### PR DESCRIPTION
Update `detect_ip` to detect IPv6 address candidates via lookaround boundary pattern and validate them using `ipaddress.ip_address()`.

Fixes #39842

---

Users of `PIIMiddleware` configured with the `ip` strategy will now have IPv6 addresses correctly detected and sanitized alongside IPv4 addresses. Previously, only IPv4 addresses were scanned, which allowed IPv6 addresses to leak to downstream components; this is resolved by extracting IPv6 candidates using a lookaround boundary regex and validating them with Python's standard `ipaddress` library.

## Release note
- fix(langchain): support IPv6 address detection in `PIIMiddleware`

## Verification
- Added automated unit tests in `test_pii.py` covering valid, compressed, and IPv4-mapped IPv6 address detection, as well as masking verification.
- Ran tests successfully using `python -m uv run pytest tests/unit_tests/agents/middleware/implementations/test_pii.py`.

---

*This contribution was prepared with the assistance of Antigravity, an agentic AI coding assistant.*