### PR TITLE
fix(core): do not mask astream errors during cleanup

### DIFF
--- a/libs/core/langchain_core/runnables/base.py
+++ b/libs/core/langchain_core/runnables/base.py
@@ -2642,6 +2642,9 @@ class Runnable(ABC, Generic[Input, Output]):
             run_id=config.pop("run_id", None),
             defers_inputs=defers_inputs,
         )
+        # Assigned inside the try; init here so a setup failure cannot
+        # NameError in `finally` and hide the original exception.
+        iterator_: AsyncIterator[Output] | None = None
         try:
             child_config = patch_config(config, callbacks=run_manager.get_child())
             if accepts_config(transformer):
@@ -4353,18 +4356,26 @@ class RunnableParallel(RunnableSerializable[Input, dict[str, Any]]):
         # Yield chunks from each as they become available,
         # and start the next iteration of the generator that yielded it.
         # When all generators are exhausted, stop.
-        while tasks:
-            completed_tasks, _ = await asyncio.wait(
-                tasks, return_when=asyncio.FIRST_COMPLETED
-            )
-            for task in completed_tasks:
-                (step_name, generator) = tasks.pop(task)
-                try:
-                    yield AddableDict({step_name: task.result()})
-                    new_task = asyncio.create_task(get_next_chunk(generator))
-                    tasks[new_task] = (step_name, generator)
-                except StopAsyncIteration:
-                    pass
+        try:
+            while tasks:
+                completed_tasks, _ = await asyncio.wait(
+                    tasks, return_when=asyncio.FIRST_COMPLETED
+                )
+                for task in completed_tasks:
+                    (step_name, generator) = tasks.pop(task)
+                    try:
+                        yield AddableDict({step_name: task.result()})
+                        new_task = asyncio.create_task(get_next_chunk(generator))
+                        tasks[new_task] = (step_name, generator)
+                    except StopAsyncIteration:
+                        pass
+        finally:
+            leftover = list(tasks)
+            for task in leftover:
+                if not task.done():
+                    task.cancel()
+            if leftover:
+                await asyncio.gather(*leftover, return_exceptions=True)
 
     @override
     async def atransform(

--- a/libs/core/tests/unit_tests/runnables/test_sequence_astream_errors.py
+++ b/libs/core/tests/unit_tests/runnables/test_sequence_astream_errors.py
@@ -1,0 +1,154 @@
+"""Exception propagation out of `RunnableSequence.astream`.
+
+#38074 reported a silent EOF when a sequence step raised inside `astream`.
+Current `master` already re-raises. These tests lock that contract and cover
+the two cleanup holes on the same async stream error path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import AbstractContextManager
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from langchain_core.callbacks import BaseCallbackHandler
+from langchain_core.runnables import RunnableGenerator, RunnableLambda, RunnableParallel
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from langchain_core.runnables.base import Runnable
+
+
+class BoomError(Exception):
+    """Sentinel raised by the fixtures in this module."""
+
+
+class ErrorRecorder(BaseCallbackHandler):
+    """Collects `on_chain_error` payloads."""
+
+    def __init__(self) -> None:
+        self.errors: list[BaseException] = []
+
+    def on_chain_error(self, error: BaseException, **_kwargs: Any) -> None:
+        self.errors.append(error)
+
+
+def _boom(_: object) -> object:
+    msg = "step"
+    raise BoomError(msg)
+
+
+async def _agen_mid(inputs: AsyncIterator[str]) -> AsyncIterator[str]:
+    async for _x in inputs:
+        yield "pre"
+        msg = "mid-stream"
+        raise BoomError(msg)
+
+
+async def _drain(chain: Runnable[Any, Any], value: object = "hi") -> list[Any]:
+    return [chunk async for chunk in chain.astream(value)]
+
+
+@pytest.mark.parametrize(
+    "chain",
+    [
+        RunnableLambda(lambda x: x) | RunnableLambda(_boom),
+        RunnableLambda(_boom) | RunnableLambda(lambda x: x),
+        RunnableLambda(lambda x: x)
+        | RunnableLambda(_boom)
+        | RunnableLambda(lambda x: x),
+    ],
+    ids=["last-step", "first-step", "middle-step"],
+)
+async def test_sequence_astream_raises_when_a_step_raises(
+    chain: Runnable[Any, Any],
+) -> None:
+    """A raising step must come out of `async for`, not end the stream."""
+    with pytest.raises(BoomError, match="step"):
+        await _drain(chain)
+
+
+async def test_sequence_astream_raises_after_a_streamed_chunk() -> None:
+    """Chunks yielded before the error stay visible; the error still surfaces."""
+    chain: Runnable[str, str] = RunnableLambda(lambda x: x) | RunnableGenerator(
+        _agen_mid
+    )
+    chunks: list[str] = []
+
+    async def _consume() -> None:
+        async for chunk in chain.astream("hi"):
+            chunks.append(chunk)  # noqa: PERF401
+
+    with pytest.raises(BoomError, match="mid-stream"):
+        await _consume()
+    assert chunks == ["pre"]
+
+
+async def test_sequence_stream_and_ainvoke_raise_the_same_error() -> None:
+    """`stream` and `ainvoke` already raised; keep them aligned with `astream`."""
+    chain: Runnable[str, object] = RunnableLambda(lambda x: x) | RunnableLambda(_boom)
+    with pytest.raises(BoomError, match="step"):
+        list(chain.stream("hi"))
+    with pytest.raises(BoomError, match="step"):
+        await chain.ainvoke("hi")
+
+
+async def test_sequence_astream_records_on_chain_error() -> None:
+    """The run should be marked failed, not closed as a successful empty stream."""
+    handler = ErrorRecorder()
+    chain: Runnable[str, object] = RunnableLambda(lambda x: x) | RunnableLambda(_boom)
+    with pytest.raises(BoomError, match="step"):
+        await _drain(chain.with_config(callbacks=[handler]))
+    assert any(isinstance(err, BoomError) for err in handler.errors)
+
+
+async def test_parallel_astream_raises_without_orphaning_sibling_tasks() -> None:
+    """A raising parallel branch must not leave `StopAsyncIteration` unretrieved."""
+    leaked: list[BaseException] = []
+    loop = asyncio.get_running_loop()
+    previous = loop.get_exception_handler()
+
+    def _handler(_loop: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        if (exc := context.get("exception")) is not None:
+            leaked.append(exc)
+
+    loop.set_exception_handler(_handler)
+    try:
+        chain = RunnableParallel(
+            ok=RunnableLambda(lambda x: x),
+            bad=RunnableLambda(_boom),
+        )
+        with pytest.raises(BoomError, match="step"):
+            await _drain(chain)
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous)
+
+    assert leaked == []
+
+
+async def test_astream_setup_error_is_not_hidden_by_aclose(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If stream setup fails, `finally` must not replace it with `NameError`."""
+
+    class _BoomContext(AbstractContextManager[None]):
+        def __enter__(self) -> None:
+            msg = "setup failed"
+            raise RuntimeError(msg)
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+    monkeypatch.setattr(
+        "langchain_core.runnables.base.set_config_context",
+        lambda *_args: _BoomContext(),
+    )
+    chain: Runnable[str, object] = RunnableLambda(lambda x: x) | RunnableLambda(
+        lambda x: x
+    )
+    with pytest.raises(RuntimeError, match="setup failed"):
+        await _drain(chain)


### PR DESCRIPTION
Fixes #38074

---

`RunnableSequence.astream` already re-raises a mid-chain exception on current `master`. The report has no runnable chain, and I could not get a silent EOF on first step, middle step, last step, a generator that errors after a chunk, fallbacks, retries, branch, listeners, or parallel.

This PR locks that contract and closes two cleanup holes on the same async stream error path.

`_atransform_stream_with_config` only assigned `iterator_` after `set_config_context` succeeded. A setup failure then hit `NameError` in the `aclose()` `finally` and hid the original exception. `iterator_` now starts as `None`.

`RunnableParallel._atransform` left sibling tasks sitting when one branch raised. That produced `Task exception was never retrieved` for the other branch's `StopAsyncIteration`. Leftover tasks are now cancelled and gathered.

## Release note

`RunnableSequence.astream` still surfaces a failing step to the caller. A setup failure in the async stream helper no longer becomes `NameError`, and a failing `RunnableParallel` branch no longer leaves sibling tasks unretrieved.

An AI coding agent helped write this contribution.