### PR TITLE
fix(core): avoid mutating Bedrock Converse message content

### DIFF
--- a/libs/core/langchain_core/messages/block_translators/bedrock_converse.py
+++ b/libs/core/langchain_core/messages/block_translators/bedrock_converse.py
@@ -159,13 +159,19 @@ def _convert_to_v1_from_converse(message: AIMessage) -> list[types.ContentBlock]
         # Converse outputs multiple chunks containing response metadata
         return []
 
-    if isinstance(message.content, str):
-        message.content = [{"type": "text", "text": message.content}]
+    content = (
+        [{"type": "text", "text": message.content}]
+        if isinstance(message.content, str)
+        else message.content
+    )
 
     def _iter_blocks() -> Iterator[types.ContentBlock]:
-        for block in message.content:
-            if not isinstance(block, dict):
+        for raw_block in content:
+            if not isinstance(raw_block, dict):
                 continue
+            # Translating content must not mutate the message. In particular, the
+            # non-standard block path removes an ``index`` key while normalizing it.
+            block = raw_block.copy()
             block_type = block.get("type")
 
             if block_type == "text":

--- a/libs/core/tests/unit_tests/messages/block_translators/test_bedrock_converse.py
+++ b/libs/core/tests/unit_tests/messages/block_translators/test_bedrock_converse.py
@@ -3,8 +3,7 @@ from langchain_core.messages import content as types
 
 
 def test_convert_to_v1_from_bedrock_converse() -> None:
-    message = AIMessage(
-        [
+    content = [
             {
                 "type": "reasoning_content",
                 "reasoning_content": {"text": "foo", "signature": "foo_signature"},
@@ -53,7 +52,9 @@ def test_convert_to_v1_from_bedrock_converse() -> None:
                 ],
             },
             {"type": "something_else", "foo": "bar"},
-        ],
+        ]
+    message = AIMessage(
+        content,
         response_metadata={"model_provider": "bedrock_converse"},
     )
     expected_content: list[types.ContentBlock] = [
@@ -122,7 +123,7 @@ def test_convert_to_v1_from_bedrock_converse() -> None:
     assert message.content_blocks == expected_content
 
     # Check no mutation
-    assert message.content != expected_content
+    assert message.content == content
 
 
 def test_convert_to_v1_from_converse_chunk() -> None:


### PR DESCRIPTION
Closes #39821

---

`AIMessage.content_blocks` could mutate the original Bedrock Converse message content while translating provider blocks. Copy raw block dictionaries before removing translation-only fields, and add a regression assertion that the input content remains unchanged.

Validation:
- `python3 -m compileall -q libs/core/langchain_core libs/core/tests/unit_tests/messages/block_translators`
- `git diff --check`
- The targeted test could not run locally because `uv` is not installed and `langchain_core` is not available in the system interpreter.

AI-agent involvement: used for code navigation and drafting; I reviewed the changes and validation results.