### PR TITLE
Add Perl separators and preserve cache entries on update

### DIFF
--- a/libs/core/langchain_core/caches.py
+++ b/libs/core/langchain_core/caches.py
@@ -226,9 +226,10 @@ class InMemoryCache(BaseCache):
 
                 The value is a list of `Generation` (or subclasses).
         """
-        if self._maxsize is not None and len(self._cache) == self._maxsize:
+        key = (prompt, llm_string)
+        if self._maxsize is not None and len(self._cache) == self._maxsize and key not in self._cache:
             del self._cache[next(iter(self._cache))]
-        self._cache[prompt, llm_string] = return_val
+        self._cache[key] = return_val
 
     @override
     def clear(self, **kwargs: Any) -> None:

--- a/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
+++ b/libs/core/tests/unit_tests/caches/test_in_memory_cache.py
@@ -69,6 +69,19 @@ def test_update_with_maxsize() -> None:
     assert cache.lookup(prompt3, llm_string3) == generations3
 
 
+def test_update_existing_key_does_not_evict_at_maxsize() -> None:
+    cache = InMemoryCache(maxsize=2)
+    prompt1, llm_string1, generations1 = cache_item(1)
+    prompt2, llm_string2, generations2 = cache_item(2)
+    cache.update(prompt1, llm_string1, generations1)
+    cache.update(prompt2, llm_string2, generations2)
+
+    cache.update(prompt2, llm_string2, [Generation(text="updated")])
+
+    assert cache.lookup(prompt1, llm_string1) == generations1
+    assert cache.lookup(prompt2, llm_string2) == [Generation(text="updated")]
+
+
 def test_clear(cache: InMemoryCache) -> None:
     """Test the clear method of InMemoryCache."""
     prompt, llm_string, generations = cache_item(1)

--- a/libs/text-splitters/langchain_text_splitters/character.py
+++ b/libs/text-splitters/langchain_text_splitters/character.py
@@ -472,6 +472,25 @@ class RecursiveCharacterTextSplitter(TextSplitter):
                 " ",
                 "",
             ]
+        if language == Language.PERL:
+            return [
+                "\npackage ",
+                "\nsub ",
+                "\nuse ",
+                "\nrequire ",
+                "\ndo ",
+                "\neval ",
+                "\nif ",
+                "\nunless ",
+                "\nwhile ",
+                "\nuntil ",
+                "\nfor ",
+                "\nforeach ",
+                "\n\n",
+                "\n",
+                " ",
+                "",
+            ]
         if language == Language.SCALA:
             return [
                 # Split along class definitions

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -1289,6 +1289,13 @@ fn main() {
     assert chunks == ["fn main() {", 'println!("Hello', ",", 'World!");', "}"]
 
 
+def test_perl_code_splitter() -> None:
+    splitter = RecursiveCharacterTextSplitter.from_language(
+        Language.PERL, chunk_size=CHUNK_SIZE, chunk_overlap=0
+    )
+    assert splitter.split_text("package Demo;\nsub greet {\n    return 1;\n}")
+
+
 def test_r_code_splitter() -> None:
     splitter = RecursiveCharacterTextSplitter.from_language(
         Language.R, chunk_size=CHUNK_SIZE, chunk_overlap=0


### PR DESCRIPTION
Closes #36750\n\nSummary:\n- Add Perl-aware separators to RecursiveCharacterTextSplitter.\n- Avoid evicting an existing cache entry when updating its value at capacity.\n- Add focused regressions.\n\nTests:\n- Python syntax compilation passed.\n- Targeted pytest could not start because the blockbuster dependency is unavailable.