### PR TITLE
fix(core): await aformat for DictPromptTemplate in async message path

### DIFF
--- a/libs/core/langchain_core/prompts/chat.py
+++ b/libs/core/langchain_core/prompts/chat.py
@@ -641,7 +641,7 @@ class _StringImageMessagePromptTemplate(BaseMessagePromptTemplate):
                 formatted_image = await prompt.aformat(**inputs)
                 content.append({"type": "image_url", "image_url": formatted_image})
             elif isinstance(prompt, DictPromptTemplate):
-                formatted_dict = prompt.format(**inputs)
+                formatted_dict = await prompt.aformat(**inputs)
                 content.append(formatted_dict)
         return self._msg_class(
             content=content, additional_kwargs=self.additional_kwargs

--- a/libs/core/tests/unit_tests/prompts/test_chat.py
+++ b/libs/core/tests/unit_tests/prompts/test_chat.py
@@ -2004,3 +2004,41 @@ def test_mustache_template_attribute_access_vulnerability() -> None:
     )
     result_dict = prompt_dict.invoke({"person": {"name": "Alice"}})
     assert result_dict.messages[0].content == "Alice"  # type: ignore[attr-defined]
+
+
+async def test_aformat_uses_dict_prompt_aformat() -> None:
+    """DictPromptTemplate.aformat should be awaited, not bypassed by sync format.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/39835
+    """
+    from unittest.mock import patch
+
+    from langchain_core.prompts.dict import DictPromptTemplate
+
+    calls: list[str] = []
+
+    real_format = DictPromptTemplate.format
+    real_aformat = DictPromptTemplate.aformat
+
+    def traced_format(self: DictPromptTemplate, **kwargs: Any) -> dict:
+        calls.append("format")
+        return real_format(self, **kwargs)
+
+    async def traced_aformat(self: DictPromptTemplate, **kwargs: Any) -> dict:
+        calls.append("aformat")
+        return await real_aformat(self, **kwargs)
+
+    dpt = DictPromptTemplate(
+        template={"type": "text", "text": "{foo}"}, template_format="f-string"
+    )
+    prompt = HumanMessagePromptTemplate(prompt=[dpt])
+
+    with (
+        patch.object(DictPromptTemplate, "format", traced_format),
+        patch.object(DictPromptTemplate, "aformat", traced_aformat),
+    ):
+        result = await prompt.aformat_messages(foo="bar")
+
+    # aformat must be the entry point; it delegates to sync format internally
+    assert "aformat" in calls
+    assert result[0].content == [{"type": "text", "text": "bar"}]


### PR DESCRIPTION
Fixes #39835

## Summary

`_StringImageMessagePromptTemplate.aformat_messages` called the sync `prompt.format()` on `DictPromptTemplate` entries, while the sibling `StringPromptTemplate` and `ImagePromptTemplate` branches correctly awaited their async formatters. This meant `DictPromptTemplate.aformat` was never invoked through this path.

## Fix

One line in `libs/core/langchain_core/prompts/chat.py`:

```diff
             elif isinstance(prompt, DictPromptTemplate):
-                formatted_dict = prompt.format(**inputs)
+                formatted_dict = await prompt.aformat(**inputs)
                 content.append(formatted_dict)
```

## Test

Added `test_aformat_uses_dict_prompt_aformat` regression test: patches both `DictPromptTemplate.format` and `.aformat` to record calls, then asserts `"aformat"` is used as the entry point when `aformat_messages` runs.

**On the old code**: test fails (`calls == ['format']`, aformat never entered).
**On the fixed code**: test passes; all 73 tests in `test_chat.py` + `test_dict.py` pass (6 skipped, 1 xfailed).