### PR TITLE
fix(core): allow any Mapping type in prompt validation

### DIFF
--- a/libs/core/langchain_core/prompts/base.py
+++ b/libs/core/langchain_core/prompts/base.py
@@ -159,7 +159,7 @@ class BasePromptTemplate(
         )
 
     def _validate_input(self, inner_input: Any) -> builtins.dict[str, Any]:
-        if not isinstance(inner_input, dict):
+        if not isinstance(inner_input, Mapping):
             if len(self.input_variables) == 1:
                 var_name = self.input_variables[0]
                 inner_input_ = {var_name: inner_input}
@@ -175,7 +175,11 @@ class BasePromptTemplate(
                     )
                 )
         else:
-            inner_input_ = inner_input
+            inner_input_ = (
+                inner_input
+                if isinstance(inner_input, dict)
+                else dict(inner_input.items())
+            )
         missing = set(self.input_variables).difference(inner_input_)
         if missing:
             msg = (

--- a/libs/core/tests/unit_tests/prompts/test_prompt_regression_39743.py
+++ b/libs/core/tests/unit_tests/prompts/test_prompt_regression_39743.py
@@ -1,0 +1,32 @@
+from collections import ChainMap, UserDict
+from types import MappingProxyType
+
+from langchain_core.prompts import PromptTemplate
+
+def test_prompt_validation_with_various_mappings() -> None:
+    """Test that _validate_input handles various Mapping types correctly."""
+    template = "Hello {name}! Today is {day}."
+    prompt = PromptTemplate.from_template(template)
+    
+    # Test cases with multi-variable input that were previously failing
+    test_cases = [
+        ("UserDict", UserDict({"name": "World", "day": "Monday"})),
+        ("ChainMap", ChainMap({"name": "World", "day": "Monday"})),
+        ("MappingProxyType", MappingProxyType({"name": "World", "day": "Monday"})),
+    ]
+    
+    for label, input_data in test_cases:
+        # Should not raise TypeError
+        validated = prompt._validate_input(input_data)
+        assert isinstance(validated, dict), f"Failed for {label}: expected dict output"
+        assert validated == {"name": "World", "day": "Monday"}, f"Failed for {label}: incorrect content"
+
+def test_prompt_invoke_with_various_mappings() -> None:
+    """Test that invoke handles various Mapping types correctly."""
+    template = "Hello {name}! Today is {day}."
+    prompt = PromptTemplate.from_template(template)
+    
+    input_data = ChainMap({"name": "World", "day": "Monday"})
+    # Should not raise TypeError
+    result = prompt.invoke(input_data)
+    assert result.to_string() == "Hello World! Today is Monday."


### PR DESCRIPTION
Fixes #39743

### Summary
This PR updates `BasePromptTemplate._validate_input` to accept any `Mapping` type (e.g., `ChainMap`, `UserDict`, `MappingProxyType`) instead of strictly requiring a `dict`. This ensures consistency with other parts of the codebase and prevents `TypeError` when valid mapping objects are passed to `invoke` or `format`.

### Changes
- Changed `isinstance(inner_input, dict)` to `isinstance(inner_input, Mapping)` in `_validate_input`.
- Added a conversion to `dict` for non-dict mappings to maintain downstream compatibility.
- Added a native regression test covering various mapping types.

### Validation
- Verified with a reproduction script that was previously failing for `ChainMap`, `UserDict`, and `MappingProxyType`.
- All core prompt unit tests passed.