### PR TITLE
fix(anthropic): keep non-usage response metadata when `stream_usage` is false

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -1822,6 +1822,8 @@ class ChatAnthropic(BaseChatModel):
         Args:
             event: Raw streaming event from Anthropic SDK
             stream_usage: Whether to include usage metadata in the output chunks.
+                Non-usage response metadata (`model_name`, `stop_reason`,
+                `stop_sequence`) is included regardless.
             coerce_content_to_string: Whether to convert structured content to plain
                 text strings.
 
@@ -1845,7 +1847,7 @@ class ChatAnthropic(BaseChatModel):
         message_chunk: AIMessageChunk | None = None
         # Reference: Anthropic SDK streaming implementation
         # https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/streaming/_messages.py  # noqa: E501
-        if event.type == "message_start" and stream_usage:
+        if event.type == "message_start":
             # Capture model name, but don't include usage_metadata yet
             # as it will be properly reported in message_delta with complete info
             if hasattr(event.message, "model"):
@@ -1999,8 +2001,7 @@ class ChatAnthropic(BaseChatModel):
                 message_chunk = AIMessageChunk(content=[content_block])
 
         # Process final usage metadata and completion info
-        elif event.type == "message_delta" and stream_usage:
-            usage_metadata = _create_usage_metadata(event.usage)
+        elif event.type == "message_delta":
             response_metadata = {
                 "stop_reason": event.delta.stop_reason,
                 "stop_sequence": event.delta.stop_sequence,
@@ -2014,6 +2015,9 @@ class ChatAnthropic(BaseChatModel):
                 container := getattr(message_delta, "container", None)
             ):
                 response_metadata["container"] = container.model_dump(mode="json")
+            usage_metadata = (
+                _create_usage_metadata(event.usage) if stream_usage else None
+            )
             message_chunk = AIMessageChunk(
                 content="" if coerce_content_to_string else [],
                 usage_metadata=usage_metadata,

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import os
 import warnings
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable
 from types import SimpleNamespace
 from typing import Any, Literal, cast
 from unittest.mock import MagicMock, patch
@@ -2683,6 +2683,120 @@ def test_streaming_cache_token_reporting() -> None:
     assert delta_chunk.usage_metadata["input_tokens"] == 135
     assert delta_chunk.usage_metadata["output_tokens"] == 50
     assert delta_chunk.usage_metadata["total_tokens"] == 185
+
+
+def _stream_events() -> list[Any]:
+    """Build a realistic raw event stream ending with final usage info."""
+    from anthropic.types import (
+        Message,
+        RawMessageDeltaEvent,
+        RawMessageStartEvent,
+        TextBlock,
+        Usage,
+    )
+    from anthropic.types.raw_message_delta_event import Delta as RawMessageDelta
+    from anthropic.types.raw_message_delta_event import (
+        MessageDeltaUsage as RawMessageDeltaUsage,
+    )
+
+    return [
+        RawMessageStartEvent(
+            message=Message(
+                id="msg_01",
+                type="message",
+                role="assistant",
+                model=MODEL_NAME,
+                content=[TextBlock(type="text", text="Paris")],
+                stop_reason=None,
+                stop_sequence=None,
+                usage=Usage(input_tokens=12, output_tokens=1),
+            ),
+            type="message_start",
+        ),
+        RawMessageDeltaEvent(
+            delta=RawMessageDelta(stop_reason="max_tokens", stop_sequence=None),
+            type="message_delta",
+            usage=RawMessageDeltaUsage(
+                output_tokens=50,
+                input_tokens=10,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            ),
+        ),
+    ]
+
+
+async def _collect_stream(llm: ChatAnthropic) -> AIMessageChunk | None:
+    """Stream 'hi' through `llm` with a stubbed transport and sum the chunks."""
+    events = _stream_events()
+
+    async def event_iter() -> AsyncIterator[Any]:
+        for event in events:
+            yield event
+
+    async def mock_acreate(_payload: Any) -> Any:
+        return event_iter()
+
+    with patch.object(llm, "_acreate", mock_acreate):
+        full: AIMessageChunk | None = None
+        async for chunk in llm.astream("hi"):
+            full = chunk if full is None else full + chunk
+    return full
+
+
+def test_stream_usage_false_keeps_stop_reason_and_model_name() -> None:
+    """Non-usage response metadata survives `stream_usage=False`.
+
+    `stream_usage=False` means "don't report token counts", not "strip
+    everything": `model_name`, `stop_reason`, and `stop_sequence` must still
+    reach `response_metadata`,     matching the non-streaming path (#39713).
+    """
+    llm = ChatAnthropic(model=MODEL_NAME)  # type: ignore[call-arg]
+    events = iter(_stream_events())
+
+    start_chunk, _ = llm._make_message_chunk_from_anthropic_event(
+        next(events),
+        stream_usage=False,
+        coerce_content_to_string=True,
+        block_start_event=None,
+    )
+    assert start_chunk is not None
+    assert start_chunk.response_metadata["model_name"] == MODEL_NAME
+
+    delta_chunk, _ = llm._make_message_chunk_from_anthropic_event(
+        next(events),
+        stream_usage=False,
+        coerce_content_to_string=True,
+        block_start_event=None,
+    )
+    assert delta_chunk is not None
+    assert delta_chunk.response_metadata["stop_reason"] == "max_tokens"
+    assert delta_chunk.response_metadata["stop_sequence"] is None
+    assert delta_chunk.usage_metadata is None
+
+
+async def test_stream_usage_false_astream_metadata_matches_non_streaming() -> None:
+    """Aggregated astream chunks keep non-usage metadata when usage is off."""
+    llm = ChatAnthropic(model=MODEL_NAME, stream_usage=False)  # type: ignore[call-arg]
+
+    full = await _collect_stream(llm)
+
+    assert full is not None
+    assert full.response_metadata["model_name"] == MODEL_NAME
+    assert full.response_metadata["stop_reason"] == "max_tokens"
+    assert full.usage_metadata is None
+
+
+async def test_stream_usage_true_astream_still_reports_usage() -> None:
+    """Default (`stream_usage=True`) behavior is unchanged by the fix above."""
+    llm = ChatAnthropic(model=MODEL_NAME, stream_usage=True)  # type: ignore[call-arg]
+
+    full = await _collect_stream(llm)
+
+    assert full is not None
+    assert full.response_metadata["stop_reason"] == "max_tokens"
+    assert full.usage_metadata is not None
+    assert full.usage_metadata["output_tokens"] == 50
 
 
 def _aggregate_anthropic_events(


### PR DESCRIPTION
Closes #39713

---

## Why

`ChatAnthropic(stream_usage=False)` currently skips `message_start` and `message_delta` streaming events entirely. That drops more than token counts from `response_metadata`: `model_name`, `stop_reason`, and `stop_sequence` all disappear, and code-execution `container` info is lost too. The non-streaming path always returns these, so streaming with usage off behaves differently than `invoke` for the same call.

A user turning off `stream_usage` is saying "don't report token counts," not "hide why the model stopped." Anyone relying on `stop_reason` — e.g. detecting `max_tokens` truncation — gets silently broken behavior when they disable usage reporting.

This mirrors the fix merged for the same defect class in `langchain-openrouter` (#39338).

## What changed

- `message_start` chunks now carry `model_name` regardless of `stream_usage`.
- `message_delta` chunks now carry `stop_reason` / `stop_sequence` / `context_management` / `container` regardless of `stream_usage`; only `usage_metadata` remains gated by the flag.
- Regression tests cover the direct handler path and full async streaming with `stream_usage=False` (metadata present, usage absent), plus a guard that default `stream_usage=True` output is unchanged. The regression tests fail on unfixed master.

## Release note

Fixed: streaming with `stream_usage=False` no longer drops `model_name`, `stop_reason`, and related non-usage response metadata from chat model chunks; only usage metadata is suppressed.

---

🤖 AI-assisted contribution: implemented with an AI coding agent (Sisyphus), human-reviewed.
