### PR TITLE
fix(ollama): forward invalid_tool_calls to the model

### DIFF
--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -61,6 +61,7 @@ from langchain_core.messages import (
     BaseMessage,
     ChatMessage,
     HumanMessage,
+    InvalidToolCall,
     SystemMessage,
     ToolCall,
     ToolMessage,
@@ -227,8 +228,15 @@ def _get_tool_calls_from_response(
     return tool_calls
 
 
-def _lc_tool_call_to_openai_tool_call(tool_call_: ToolCall) -> dict:
-    """Convert a LangChain tool call to an OpenAI tool call format."""
+def _lc_tool_call_to_openai_tool_call(tool_call_: ToolCall | InvalidToolCall) -> dict:
+    """Convert a LangChain tool call to an OpenAI tool call format.
+
+    Accepts both `ToolCall` and `InvalidToolCall` so that invalid tool calls
+    can be forwarded to the model (e.g. so it can see and correct a
+    malformed call it previously emitted). Both TypedDicts share the `id`,
+    `name`, and `args` keys used here; `args` is a raw string for an
+    `InvalidToolCall`, and is passed through unchanged either way.
+    """
     return {
         "type": "function",
         "id": tool_call_["id"],
@@ -1005,12 +1013,16 @@ class ChatOllama(BaseChatModel):
                 role = "user"
             elif isinstance(message, AIMessage):
                 role = "assistant"
+                all_tool_calls = [
+                    *message.tool_calls,
+                    *message.invalid_tool_calls,
+                ]
                 tool_calls = (
                     [
                         _lc_tool_call_to_openai_tool_call(tool_call)
-                        for tool_call in message.tool_calls
+                        for tool_call in all_tool_calls
                     ]
-                    if message.tool_calls
+                    if all_tool_calls
                     else None
                 )
             elif isinstance(message, SystemMessage):

--- a/libs/partners/ollama/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/ollama/tests/unit_tests/test_chat_models.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from langchain_core.exceptions import OutputParserException
 from langchain_core.messages import AIMessage, BaseMessage, ChatMessage, HumanMessage
+from langchain_core.messages.tool import InvalidToolCall, ToolCall
 from langchain_tests.unit_tests import ChatModelUnitTests
 
 from langchain_ollama.chat_models import (
@@ -1173,3 +1174,102 @@ def test_multimodal_message_content_has_no_leading_newline() -> None:
     ollama_messages = model._convert_messages_to_ollama_messages([message])
 
     assert ollama_messages[0]["content"] == "Extract all text from this image."
+
+
+def test_invalid_tool_calls_are_forwarded_with_valid_tool_calls() -> None:
+    """`AIMessage.invalid_tool_calls` should be forwarded alongside `tool_calls`.
+
+    Without this, a model never sees its own malformed tool call and can't
+    self-correct in a repair/retry loop.
+    """
+    with patch("langchain_ollama.chat_models.Client"):
+        llm = ChatOllama(model="test-model")
+
+    valid_call: ToolCall = {
+        "name": "get_weather",
+        "args": {"location": "SF"},
+        "id": "call_valid",
+        "type": "tool_call",
+    }
+    invalid_call: InvalidToolCall = {
+        "name": "get_weather",
+        "args": "{location: SF",  # malformed JSON string
+        "id": "call_invalid",
+        "error": "Malformed args.",
+        "type": "invalid_tool_call",
+    }
+    message = AIMessage(
+        content="",
+        tool_calls=[valid_call],
+        invalid_tool_calls=[invalid_call],
+    )
+
+    ollama_messages = llm._convert_messages_to_ollama_messages([message])
+
+    tool_calls = ollama_messages[0]["tool_calls"]
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+    assert tool_calls[0]["id"] == "call_valid"
+    assert tool_calls[0]["function"]["arguments"] == {"location": "SF"}
+    assert tool_calls[1]["id"] == "call_invalid"
+    assert tool_calls[1]["function"]["arguments"] == "{location: SF"
+
+
+def test_only_valid_tool_calls_unaffected() -> None:
+    """Regression: an `AIMessage` with only valid tool calls behaves as before."""
+    with patch("langchain_ollama.chat_models.Client"):
+        llm = ChatOllama(model="test-model")
+
+    valid_call: ToolCall = {
+        "name": "get_weather",
+        "args": {"location": "NYC"},
+        "id": "call_1",
+        "type": "tool_call",
+    }
+    message = AIMessage(content="", tool_calls=[valid_call])
+
+    ollama_messages = llm._convert_messages_to_ollama_messages([message])
+
+    tool_calls = ollama_messages[0]["tool_calls"]
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["id"] == "call_1"
+
+
+def test_no_tool_calls_yields_none() -> None:
+    """Regression: an `AIMessage` with neither kind of tool call has no key.
+
+    The `tool_calls` key is only set on the outgoing dict when truthy, so an
+    `AIMessage` with no tool calls at all should omit the key entirely (not
+    set it to `None` or `[]`).
+    """
+    with patch("langchain_ollama.chat_models.Client"):
+        llm = ChatOllama(model="test-model")
+
+    message = AIMessage(content="Hello")
+
+    ollama_messages = llm._convert_messages_to_ollama_messages([message])
+
+    assert "tool_calls" not in ollama_messages[0]
+
+
+def test_invalid_tool_call_with_malformed_args_does_not_raise() -> None:
+    """An invalid tool call with a raw malformed-string `args` should not raise."""
+    with patch("langchain_ollama.chat_models.Client"):
+        llm = ChatOllama(model="test-model")
+
+    invalid_call: InvalidToolCall = {
+        "name": "get_weather",
+        "args": "not even close to json {{{",
+        "id": "call_bad",
+        "error": "Malformed args.",
+        "type": "invalid_tool_call",
+    }
+    message = AIMessage(content="", invalid_tool_calls=[invalid_call])
+
+    ollama_messages = llm._convert_messages_to_ollama_messages([message])
+
+    tool_calls = ollama_messages[0]["tool_calls"]
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
+    assert tool_calls[0]["function"]["arguments"] == "not even close to json {{{"


### PR DESCRIPTION
Fixes #39871

`_convert_messages_to_ollama_messages` only reads `message.tool_calls` when building an assistant message; `message.invalid_tool_calls` is never referenced in the file. Five other partner integrations that do this same conversion forward both: groq, mistralai, openrouter, anthropic, huggingface. ollama is the only one of the six that drops invalid tool calls.

groq's version, which I used as the reference for the correct behavior:

```python
if message.tool_calls or message.invalid_tool_calls:
    message_dict["tool_calls"] = [
        _lc_tool_call_to_groq_tool_call(tc) for tc in message.tool_calls
    ] + [
        _lc_invalid_tool_call_to_groq_tool_call(tc) for tc in message.invalid_tool_calls
    ]
```

Forwarding invalid tool calls matters because it's how the model finds out it made a mistake. If an AIMessage in history has one valid and one invalid tool call — from another provider, from an agent's repair/retry loop, or built by hand after catching a bad call — and that history gets replayed through `ChatOllama.invoke/ainvoke/stream/astream`, the invalid call currently disappears with no error or warning. The model never sees that it emitted a malformed call, so any self-correction loop built on top of that history silently breaks.

## Fix

Concatenate `message.tool_calls` and `message.invalid_tool_calls` (valid first, matching the sibling integrations' ordering) before converting. `_lc_tool_call_to_openai_tool_call` only reads `id`, `name`, and `args`, which both `ToolCall` and `InvalidToolCall` have, so no separate conversion helper is needed like groq has — I widened the parameter type to `ToolCall | InvalidToolCall` instead. `args` on an `InvalidToolCall` is a raw string rather than a dict; it's passed through unchanged either way, same as it already was for valid calls.

## Release note

`ChatOllama` now forwards `AIMessage.invalid_tool_calls` (not just `tool_calls`) when converting messages, so the model can see and correct malformed tool calls from prior turns instead of silently losing them.

## Testing

Added to `libs/partners/ollama/tests/unit_tests/test_chat_models.py`:
- one valid + one invalid tool call on an `AIMessage` yields both in the converted payload, valid first
- regression: only-valid tool calls behave exactly as before
- regression: an `AIMessage` with neither kind of tool call still omits the `tool_calls` key entirely (that's what the current code does, not `None` or `[]`)
- an invalid call whose `args` is a raw malformed string survives without raising

Confirmed the new tests fail against the unfixed code (reverted the fix locally, reran, got the same 2 failures, restored it).

Ran from `libs/partners/ollama`:
- `make format` / `ruff format --diff` — clean
- `make lint` / `ruff check` — clean
- `uv run --all-groups ty check langchain_ollama` — clean
- `uv run --group test pytest --disable-socket --allow-unix-socket tests/unit_tests/` — 100 passed, 2 skipped (58 passed, 2 skipped in `test_chat_models.py` specifically, up from the 54 passed/2 skipped baseline)

Did not run integration tests (`tests/integration_tests/`) — they require a live Ollama server, which isn't wired into this environment, matching the project's own CI setup.