### PR TITLE
fix: relax middleware state type inference when state_schema is explicit

### DIFF
--- a/libs/langchain_v1/langchain/agents/factory.py
+++ b/libs/langchain_v1/langchain/agents/factory.py
@@ -767,6 +767,79 @@ def _chain_async_tool_call_wrappers(
     return result
 
 
+# Explicit `state_schema` overrides middleware state inference.
+# Heterogeneous middleware lists (e.g., AgentMiddleware[RichState, ...] mixed with
+# AgentMiddleware[AgentState, ...]) collapse to the common base type and fail type
+# checking. When `state_schema` is explicit, the middleware's state type is not
+# used for inference; the explicit schema carries the union of the middleware
+# channels, matching runtime behavior (which already merges correctly).
+@overload
+def create_agent(
+    model: str | BaseChatModel,
+    tools: Sequence[BaseTool | Callable[..., Any] | dict[str, Any]] | None = None,
+    *,
+    system_prompt: str | SystemMessage | None = None,
+    middleware: Sequence[AgentMiddleware[Any, ContextT]] = (),
+    response_format: None = None,
+    state_schema: type[AgentState[ResponseT]],
+    context_schema: type[ContextT] | None = None,
+    checkpointer: Checkpointer | None = None,
+    store: BaseStore | None = None,
+    interrupt_before: list[str] | None = None,
+    interrupt_after: list[str] | None = None,
+    debug: bool = False,
+    name: str | None = None,
+    cache: BaseCache[Any] | None = None,
+    transformers: Sequence[TransformerFactory] | None = None,
+) -> CompiledStateGraph[AgentState[ResponseT], ContextT, InputAgentState, OutputAgentState[ResponseT]]: ...
+
+
+# Same heterogeneous-middleware relaxation for explicit `state_schema` combined with a
+# raw-dict `response_format`.
+@overload
+def create_agent(
+    model: str | BaseChatModel,
+    tools: Sequence[BaseTool | Callable[..., Any] | dict[str, Any]] | None = None,
+    *,
+    system_prompt: str | SystemMessage | None = None,
+    middleware: Sequence[AgentMiddleware[Any, ContextT]] = (),
+    response_format: dict[str, Any],
+    state_schema: type[AgentState[ResponseT]],
+    context_schema: type[ContextT] | None = None,
+    checkpointer: Checkpointer | None = None,
+    store: BaseStore | None = None,
+    interrupt_before: list[str] | None = None,
+    interrupt_after: list[str] | None = None,
+    debug: bool = False,
+    name: str | None = None,
+    cache: BaseCache[Any] | None = None,
+    transformers: Sequence[TransformerFactory] | None = None,
+) -> CompiledStateGraph[AgentState[ResponseT], ContextT, InputAgentState, OutputAgentState[ResponseT]]: ...
+
+
+# Same heterogeneous-middleware relaxation for explicit `state_schema` combined with a
+# schema-typed `response_format`.
+@overload
+def create_agent(
+    model: str | BaseChatModel,
+    tools: Sequence[BaseTool | Callable[..., Any] | dict[str, Any]] | None = None,
+    *,
+    system_prompt: str | SystemMessage | None = None,
+    middleware: Sequence[AgentMiddleware[Any, ContextT]] = (),
+    response_format: ResponseFormat[ResponseT] | type[ResponseT],
+    state_schema: type[AgentState[ResponseT]],
+    context_schema: type[ContextT] | None = None,
+    checkpointer: Checkpointer | None = None,
+    store: BaseStore | None = None,
+    interrupt_before: list[str] | None = None,
+    interrupt_after: list[str] | None = None,
+    debug: bool = False,
+    name: str | None = None,
+    cache: BaseCache[Any] | None = None,
+    transformers: Sequence[TransformerFactory] | None = None,
+) -> CompiledStateGraph[AgentState[ResponseT], ContextT, InputAgentState, OutputAgentState[ResponseT]]: ...
+
+
 # No `response_format`: there is no structured output, so `ResponseT` resolves to `Any`.
 @overload
 def create_agent(


### PR DESCRIPTION
This PR adds three new `@overload` signatures for `create_agent` that handle heterogeneous middleware lists when `state_schema` is explicitly provided.

**Problem**: `create_agent` infers the `middleware` collection's state type independently of the explicit `state_schema` argument. A heterogeneous `middleware=[...]` list (e.g., `AgentMiddleware[RichState, ...]` mixed with `AgentMiddleware[AgentState, ...]`) collapses to `AgentMiddleware[AgentState, ...]`, so any middleware declaring a richer required state schema fails static type checking — even though runtime graph construction merges every middleware's `state_schema` with the explicit graph schema correctly.

**Fix**: When `state_schema` is explicit, the middleware parameter uses `AgentMiddleware[Any, ContextT]` instead of `AgentMiddleware[StateT_co, ContextT]`, so the middleware list's element types do not constrain the inference. The explicit `state_schema` is the single source of truth for the state type, matching runtime behavior.

Three new overloads cover:
1. `response_format=None` (no structured output) + explicit `state_schema`
2. `response_format=dict[str, Any]` (raw dict output) + explicit `state_schema`
3. `response_format=ResponseFormat[ResponseT] | type[ResponseT]` (typed schema) + explicit `state_schema`

Fixes #39882