### PR TITLE
fix(text-splitters): stop `HTMLSectionSplitter` from leaking the `#TITLE#` sentinel and raising on missing `Title`

### DIFF
--- a/libs/text-splitters/langchain_text_splitters/html.py
+++ b/libs/text-splitters/langchain_text_splitters/html.py
@@ -367,6 +367,11 @@ class HTMLHeaderTextSplitter:
                 yield doc
 
 
+# Internal sentinel used to mark sections that appear before the first
+# configured header. Never expose it in returned document metadata.
+_TITLE_SENTINEL = "#TITLE#"
+
+
 class HTMLSectionSplitter:
     """Splitting HTML files based on specified tag and font sizes.
 
@@ -440,12 +445,15 @@ class HTMLSectionSplitter:
         metadatas_ = metadatas or [{}] * len(texts)
         documents = []
         for i, text in enumerate(texts):
-            for chunk in self.split_text(text):
+            for chunk in self._split_text_with_sentinel(text):
                 metadata = copy.deepcopy(metadatas_[i])
 
-                for key in chunk.metadata:
-                    if chunk.metadata[key] == "#TITLE#":
-                        chunk.metadata[key] = metadata["Title"]
+                for key in list(chunk.metadata):
+                    if chunk.metadata[key] == _TITLE_SENTINEL:
+                        if "Title" in metadata:
+                            chunk.metadata[key] = metadata["Title"]
+                        else:
+                            del chunk.metadata[key]
                 metadata = {**metadata, **chunk.metadata}
                 new_doc = Document(page_content=chunk.page_content, metadata=metadata)
                 documents.append(new_doc)
@@ -488,7 +496,7 @@ class HTMLSectionSplitter:
 
         for i, header in enumerate(headers):
             if i == 0:
-                current_header = "#TITLE#"
+                current_header = _TITLE_SENTINEL
                 current_header_tag = "h1"
                 section_content: list[str] = []
             else:
@@ -547,6 +555,14 @@ class HTMLSectionSplitter:
         result = transform(tree)
         return str(result)
 
+    def _split_text_with_sentinel(self, text: str) -> list[Document]:
+        """Split HTML text, keeping the internal title sentinel in metadata.
+
+        Pre-header sections carry the sentinel so that `create_documents`
+        can replace it with the parent document's `Title` when one exists.
+        """
+        return self._split_text_from_file_with_sentinel(StringIO(text))
+
     def split_text_from_file(self, file: StringIO) -> list[Document]:
         """Split HTML content from a file into a list of `Document` objects.
 
@@ -556,6 +572,20 @@ class HTMLSectionSplitter:
         Returns:
             A list of split `Document` objects.
         """
+        docs = self._split_text_from_file_with_sentinel(file)
+        return [
+            Document(
+                page_content=doc.page_content,
+                metadata={
+                    key: value
+                    for key, value in doc.metadata.items()
+                    if value != _TITLE_SENTINEL
+                },
+            )
+            for doc in docs
+        ]
+
+    def _split_text_from_file_with_sentinel(self, file: StringIO) -> list[Document]:
         file_content = file.getvalue()
         file_content = self.convert_possible_tags_to_header(file_content)
         sections = self.split_html_by_headers(file_content)

--- a/libs/text-splitters/tests/unit_tests/test_text_splitters.py
+++ b/libs/text-splitters/tests/unit_tests/test_text_splitters.py
@@ -3280,6 +3280,69 @@ def test_happy_path_splitting_based_on_header_with_whitespace_chars() -> None:
     assert docs[2].metadata["Header 2"] == "Baz"
 
 
+_PRE_HEADER_HTML = """<!DOCTYPE html>
+    <html>
+    <body>
+        <p>Intro before header.</p>
+        <h1>Header</h1>
+        <p>Body.</p>
+    </body>
+    </html>"""
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
+def test_section_splitter_does_not_leak_title_sentinel() -> None:
+    """Pre-header content must not expose the internal title sentinel (#38142)."""
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    docs = sec_splitter.split_text(_PRE_HEADER_HTML)
+
+    assert len(docs) == 2
+    assert docs[0].page_content == "Intro before header."
+    assert docs[0].metadata == {}
+    assert docs[1].metadata == {"Header 1": "Header"}
+    assert all("#TITLE#" not in doc.metadata.values() for doc in docs)
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
+def test_create_documents_without_title_key_does_not_raise() -> None:
+    """Missing parent `Title` must not raise `KeyError` (#38142)."""
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    docs = sec_splitter.create_documents(
+        [_PRE_HEADER_HTML], metadatas=[{"source": "example"}]
+    )
+
+    assert len(docs) == 2
+    assert docs[0].metadata == {"source": "example"}
+    assert docs[1].metadata == {"source": "example", "Header 1": "Header"}
+
+
+@pytest.mark.requires("bs4")
+@pytest.mark.requires("lxml")
+def test_create_documents_with_title_key_replaces_sentinel() -> None:
+    """Parent `Title` still fills the pre-header chunk's configured key."""
+    sec_splitter = HTMLSectionSplitter(headers_to_split_on=[("h1", "Header 1")])
+
+    docs = sec_splitter.create_documents(
+        [_PRE_HEADER_HTML], metadatas=[{"source": "example", "Title": "My Doc"}]
+    )
+
+    assert len(docs) == 2
+    assert docs[0].metadata == {
+        "source": "example",
+        "Title": "My Doc",
+        "Header 1": "My Doc",
+    }
+    assert docs[1].metadata == {
+        "source": "example",
+        "Title": "My Doc",
+        "Header 1": "Header",
+    }
+
+
 @pytest.mark.requires("bs4")
 @pytest.mark.requires("lxml")
 def test_happy_path_splitting_with_duplicate_header_tag() -> None:


### PR DESCRIPTION
Closes #38142

---

## Why

`HTMLSectionSplitter` uses `#TITLE#` internally to mark content that appears before the first configured header. Two problems fall out of that sentinel:

1. It leaks into public `Document.metadata` — anyone calling `split_text()` gets `{'Header 1': '#TITLE#'}` on pre-header chunks.
2. `create_documents()` replaces the sentinel with `metadata["Title"]` unconditionally, so splitting parent documents whose metadata only carries `source` (or anything without a title) crashes with `KeyError: 'Title'`.

## What changed

- The sentinel now flows only through an internal raw path. `create_documents()` still consumes it, so a parent `Title` continues to fill the pre-header chunk's configured header key exactly as before.
- Public `split_text()` / `split_text_from_file()` output strips sentinel-valued keys: pre-header chunks return clean metadata.
- A missing parent `Title` no longer raises; the key is simply omitted.
- Three regression tests cover leak, missing-`Title`, and `Title`-present behavior. The first two fail on current master.

## Release note

Fixed: `HTMLSectionSplitter` no longer exposes its internal `#TITLE#` marker in document metadata and no longer raises `KeyError` when input documents lack a `Title` metadata key.

---

🤖 AI-assisted contribution: implemented with an AI coding agent (Sisyphus), human-reviewed.
