### PR TITLE
feat(langchain)!: upgrade `langchain.mcp` to the MCP SDK 2.x

### DIFF
--- a/libs/langchain_v1/langchain/mcp/callbacks.py
+++ b/libs/langchain_v1/langchain/mcp/callbacks.py
@@ -3,10 +3,10 @@
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
+from mcp.client.session import ClientRequestContext as MCPRequestContext
 from mcp.client.session import ElicitationFnT as MCPElicitationFnT
 from mcp.client.session import LoggingFnT as MCPLoggingFnT
-from mcp.shared.context import RequestContext as MCPRequestContext
-from mcp.shared.session import ProgressFnT as MCPProgressFnT
+from mcp.client.session import ProgressFnT as MCPProgressFnT
 from mcp.types import (
     ElicitRequestParams as MCPElicitRequestParams,
 )
@@ -51,7 +51,7 @@ class LoggingMessageCallback(Protocol):
 
 @runtime_checkable
 class ProgressCallback(Protocol):
-    """Light wrapper around the mcp.shared.session.ProgressFnT.
+    """Light wrapper around the mcp.client.session.ProgressFnT.
 
     Injects callback context as the last argument.
     """

--- a/libs/langchain_v1/langchain/mcp/client.py
+++ b/libs/langchain_v1/langchain/mcp/client.py
@@ -26,7 +26,6 @@ from langchain.mcp.sessions import (
     SSEConnection,
     StdioConnection,
     StreamableHttpConnection,
-    WebsocketConnection,
     create_session,
 )
 from langchain.mcp.tools import load_mcp_tools
@@ -284,5 +283,4 @@ __all__ = [
     "SSEConnection",
     "StdioConnection",
     "StreamableHttpConnection",
-    "WebsocketConnection",
 ]

--- a/libs/langchain_v1/langchain/mcp/resources.py
+++ b/libs/langchain_v1/langchain/mcp/resources.py
@@ -30,7 +30,7 @@ def convert_mcp_resource_to_langchain_blob(resource_uri: str, contents: Resource
         msg = f"Unsupported content type for URI {resource_uri}"
         raise TypeError(msg)
 
-    return Blob.from_data(data=data, mime_type=contents.mimeType, metadata={"uri": resource_uri})
+    return Blob.from_data(data=data, mime_type=contents.mime_type, metadata={"uri": resource_uri})
 
 
 async def get_mcp_resource(session: ClientSession, uri: str) -> list[Blob]:

--- a/libs/langchain_v1/langchain/mcp/sessions.py
+++ b/libs/langchain_v1/langchain/mcp/sessions.py
@@ -1,7 +1,7 @@
 """Session management for different MCP transport types.
 
 This module provides connection configurations and session management for various
-MCP transport types including stdio, SSE, WebSocket, and streamable HTTP.
+MCP transport types including stdio, SSE, and streamable HTTP.
 """
 
 from __future__ import annotations
@@ -10,17 +10,17 @@ from contextlib import asynccontextmanager
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
+import httpx2
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import create_mcp_http_client
 from typing_extensions import NotRequired, TypedDict
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
     from pathlib import Path
-
-    import httpx
 
     from langchain.mcp.callbacks import _MCPCallbacks
 
@@ -37,15 +37,15 @@ DEFAULT_STREAMABLE_HTTP_SSE_READ_TIMEOUT = timedelta(seconds=60 * 5)
 
 
 class McpHttpClientFactory(Protocol):
-    """Protocol for creating httpx.AsyncClient instances for MCP connections."""
+    """Protocol for creating httpx2.AsyncClient instances for MCP connections."""
 
     def __call__(
         self,
         headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
-    ) -> httpx.AsyncClient:
-        """Create an httpx.AsyncClient instance.
+        timeout: httpx2.Timeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient:
+        """Create an httpx2.AsyncClient instance.
 
         Args:
             headers: HTTP headers to include in requests.
@@ -53,7 +53,7 @@ class McpHttpClientFactory(Protocol):
             auth: Authentication configuration.
 
         Returns:
-            Configured httpx.AsyncClient instance.
+            Configured httpx2.AsyncClient instance.
         """
         ...
 
@@ -134,9 +134,9 @@ class SSEConnection(TypedDict):
     """Additional keyword arguments to pass to the ClientSession."""
 
     httpx_client_factory: NotRequired[McpHttpClientFactory | None]
-    """Custom factory for httpx.AsyncClient (optional)."""
+    """Custom factory for httpx2.AsyncClient (optional)."""
 
-    auth: NotRequired[httpx.Auth]
+    auth: NotRequired[httpx2.Auth]
     """Optional authentication for the HTTP client."""
 
 
@@ -165,25 +165,13 @@ class StreamableHttpConnection(TypedDict):
     """Additional keyword arguments to pass to the ClientSession."""
 
     httpx_client_factory: NotRequired[McpHttpClientFactory | None]
-    """Custom factory for httpx.AsyncClient (optional)."""
+    """Custom factory for httpx2.AsyncClient (optional)."""
 
-    auth: NotRequired[httpx.Auth]
+    auth: NotRequired[httpx2.Auth]
     """Optional authentication for the HTTP client."""
 
 
-class WebsocketConnection(TypedDict):
-    """Configuration for WebSocket transport connections to MCP servers."""
-
-    transport: Literal["websocket"]
-
-    url: str
-    """The URL of the Websocket endpoint to connect to."""
-
-    session_kwargs: NotRequired[dict[str, Any] | None]
-    """Additional keyword arguments to pass to the ClientSession"""
-
-
-Connection = StdioConnection | SSEConnection | StreamableHttpConnection | WebsocketConnection
+Connection = StdioConnection | SSEConnection | StreamableHttpConnection
 
 
 @asynccontextmanager
@@ -239,7 +227,7 @@ async def _create_sse_session(
     sse_read_timeout: float = DEFAULT_SSE_READ_TIMEOUT,
     session_kwargs: dict[str, Any] | None = None,
     httpx_client_factory: McpHttpClientFactory | None = None,
-    auth: httpx.Auth | None = None,
+    auth: httpx2.Auth | None = None,
 ) -> AsyncIterator[ClientSession]:
     """Create a new session to an MCP server using SSE.
 
@@ -249,7 +237,7 @@ async def _create_sse_session(
         timeout: HTTP timeout.
         sse_read_timeout: SSE read timeout.
         session_kwargs: Additional keyword arguments to pass to the ClientSession.
-        httpx_client_factory: Custom factory for httpx.AsyncClient (optional).
+        httpx_client_factory: Custom factory for httpx2.AsyncClient (optional).
         auth: Authentication for the HTTP client.
 
     Yields:
@@ -280,7 +268,7 @@ async def _create_streamable_http_session(
     terminate_on_close: bool = True,
     session_kwargs: dict[str, Any] | None = None,
     httpx_client_factory: McpHttpClientFactory | None = None,
-    auth: httpx.Auth | None = None,
+    auth: httpx2.Auth | None = None,
 ) -> AsyncIterator[ClientSession]:
     """Create a new session to an MCP server using Streamable HTTP.
 
@@ -292,62 +280,28 @@ async def _create_streamable_http_session(
             disconnecting.
         terminate_on_close: Whether to terminate the session on close.
         session_kwargs: Additional keyword arguments to pass to the ClientSession.
-        httpx_client_factory: Custom factory for httpx.AsyncClient (optional).
+        httpx_client_factory: Custom factory for httpx2.AsyncClient (optional).
         auth: Authentication for the HTTP client.
 
     Yields:
         An initialized ClientSession.
     """
-    # Create and store the connection
-    kwargs = {}
-    if httpx_client_factory is not None:
-        kwargs["httpx_client_factory"] = httpx_client_factory
+    # `streamable_http_client` no longer takes the HTTP options directly; they belong to
+    # the client it is handed, which `httpx_client_factory` may supply instead.
+    factory = httpx_client_factory or create_mcp_http_client
+    http_client = factory(
+        headers=headers,
+        timeout=httpx2.Timeout(timeout.total_seconds(), read=sse_read_timeout.total_seconds()),
+        auth=auth,
+    )
 
     async with (
-        streamablehttp_client(
+        http_client,
+        streamable_http_client(
             url,
-            headers,
-            timeout,
-            sse_read_timeout,
-            terminate_on_close,
-            auth=auth,
-            **kwargs,
-        ) as (read, write, _),
-        ClientSession(read, write, **(session_kwargs or {})) as session,
-    ):
-        yield session
-
-
-@asynccontextmanager
-async def _create_websocket_session(
-    *,
-    url: str,
-    session_kwargs: dict[str, Any] | None = None,
-) -> AsyncIterator[ClientSession]:
-    """Create a new session to an MCP server using Websockets.
-
-    Args:
-        url: URL of the Websocket endpoint.
-        session_kwargs: Additional keyword arguments to pass to the ClientSession.
-
-    Yields:
-        An initialized ClientSession.
-
-    Raises:
-        ImportError: If websockets package is not installed.
-    """
-    try:
-        from mcp.client.websocket import websocket_client  # noqa: PLC0415
-    except ImportError:
-        msg = (
-            "Could not import websocket_client. "
-            "To use Websocket connections, please install the required dependency: "
-            "'pip install mcp[ws]' or 'pip install websockets'"
-        )
-        raise ImportError(msg) from None
-
-    async with (
-        websocket_client(url) as (read, write),
+            http_client=http_client,
+            terminate_on_close=terminate_on_close,
+        ) as (read, write),
         ClientSession(read, write, **(session_kwargs or {})) as session,
     ):
         yield session
@@ -374,7 +328,7 @@ async def create_session(
         msg = (
             "Configuration error: Missing 'transport' key in server configuration. "
             "Each server must include 'transport' with one of: "
-            "'stdio', 'sse', 'websocket', 'http'. "
+            "'stdio', 'sse', 'http'. "
             "Please refer to the langchain-mcp-adapters documentation for more details."
         )
         raise ValueError(msg)
@@ -410,15 +364,6 @@ async def create_session(
             raise ValueError(msg)
         async with _create_stdio_session(**params) as session:
             yield session
-    elif transport == "websocket":
-        if "url" not in params:
-            msg = "'url' parameter is required for Websocket connection"
-            raise ValueError(msg)
-        async with _create_websocket_session(**params) as session:
-            yield session
     else:
-        msg = (
-            f"Unsupported transport: {transport}. "
-            f"Must be one of: 'stdio', 'sse', 'websocket', 'http'"
-        )
+        msg = f"Unsupported transport: {transport}. Must be one of: 'stdio', 'sse', 'http'"
         raise ValueError(msg)

--- a/libs/langchain_v1/langchain/mcp/tools.py
+++ b/libs/langchain_v1/langchain/mcp/tools.py
@@ -5,7 +5,7 @@ tools, handle tool execution, and manage tool conversion between the two formats
 """
 
 from collections.abc import Awaitable, Callable
-from typing import Annotated, Any, TypedDict, get_args
+from typing import Annotated, Any, TypedDict
 
 from langchain_core.messages import ToolMessage
 from langchain_core.messages.content import (
@@ -22,22 +22,19 @@ from langchain_core.tools import (
     StructuredTool,
     ToolException,
 )
-from langchain_core.tools.base import get_all_basemodel_annotations
 from mcp import ClientSession
-from mcp.server.fastmcp.tools import Tool as FastMCPTool
-from mcp.server.fastmcp.utilities.func_metadata import ArgModelBase, FuncMetadata
 from mcp.types import (
     AudioContent,
     BlobResourceContents,
     ContentBlock,
     EmbeddedResource,
     ImageContent,
+    PaginatedRequestParams,
     ResourceLink,
     TextContent,
     TextResourceContents,
 )
 from mcp.types import Tool as MCPTool
-from pydantic import BaseModel, create_model
 
 from langchain.mcp.callbacks import CallbackContext, Callbacks, _MCPCallbacks
 from langchain.mcp.interceptors import (
@@ -101,17 +98,17 @@ def _convert_mcp_content_to_lc_block(
         return create_text_block(text=content.text)
 
     if isinstance(content, ImageContent):
-        return create_image_block(base64=content.data, mime_type=content.mimeType)
+        return create_image_block(base64=content.data, mime_type=content.mime_type)
 
     if isinstance(content, AudioContent):
         msg = (
             "AudioContent conversion to LangChain content blocks is not yet "
-            f"supported. Received audio with mime type: {content.mimeType}"
+            f"supported. Received audio with mime type: {content.mime_type}"
         )
         raise NotImplementedError(msg)
 
     if isinstance(content, ResourceLink):
-        mime_type = content.mimeType or None
+        mime_type = content.mime_type or None
         if mime_type and mime_type.startswith("image/"):
             return create_image_block(url=str(content.uri), mime_type=mime_type)
         return create_file_block(url=str(content.uri), mime_type=mime_type)
@@ -121,7 +118,7 @@ def _convert_mcp_content_to_lc_block(
         if isinstance(resource, TextResourceContents):
             return create_text_block(text=resource.text)
         if isinstance(resource, BlobResourceContents):
-            mime_type = resource.mimeType or None
+            mime_type = resource.mime_type or None
             if mime_type and mime_type.startswith("image/"):
                 return create_image_block(base64=resource.blob, mime_type=mime_type)
             return create_file_block(base64=resource.blob, mime_type=mime_type)
@@ -176,7 +173,7 @@ def _convert_call_tool_result(
         _convert_mcp_content_to_lc_block(content) for content in call_tool_result.content
     ]
 
-    if call_tool_result.isError:
+    if call_tool_result.is_error:
         # Join text from all blocks
         error_parts = []
         for item in tool_content:
@@ -189,8 +186,8 @@ def _convert_call_tool_result(
 
     # Extract structured content and wrap in MCPToolArtifact
     artifact: MCPToolArtifact | None = None
-    if call_tool_result.structuredContent is not None:
-        artifact = MCPToolArtifact(structured_content=call_tool_result.structuredContent)
+    if call_tool_result.structured_content is not None:
+        artifact = MCPToolArtifact(structured_content=call_tool_result.structured_content)
 
     return tool_content, artifact
 
@@ -252,17 +249,18 @@ async def _list_all_tools(session: ClientSession) -> list[MCPTool]:
             msg = "Reached max of 1000 iterations while listing tools."
             raise RuntimeError(msg)
 
-        list_tools_page_result = await session.list_tools(cursor=current_cursor)
+        page_params = PaginatedRequestParams(cursor=current_cursor) if current_cursor else None
+        list_tools_page_result = await session.list_tools(params=page_params)
 
         if list_tools_page_result.tools:
             all_tools.extend(list_tools_page_result.tools)
 
         # Pagination spec: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/pagination
         # compatible with None or ""
-        if not list_tools_page_result.nextCursor:
+        if not list_tools_page_result.next_cursor:
             break
 
-        current_cursor = list_tools_page_result.nextCursor
+        current_cursor = list_tools_page_result.next_cursor
     return all_tools
 
 
@@ -411,7 +409,9 @@ def convert_mcp_tool_to_langchain_tool(
         return _convert_call_tool_result(call_tool_result)
 
     meta = getattr(tool, "meta", None)
-    base = tool.annotations.model_dump() if tool.annotations is not None else {}
+    # Dump by alias so these stay the specification's names (`readOnlyHint`), which
+    # mcp 2.x renamed to snake_case on the model itself.
+    base = tool.annotations.model_dump(by_alias=True) if tool.annotations is not None else {}
     meta = {"_meta": meta} if meta is not None else {}
     metadata = {**base, **meta} or None
 
@@ -423,7 +423,7 @@ def convert_mcp_tool_to_langchain_tool(
     return StructuredTool(
         name=lc_tool_name,
         description=tool.description or "",
-        args_schema=tool.inputSchema,
+        args_schema=tool.input_schema,
         coroutine=call_tool,
         response_format="content_and_artifact",
         metadata=metadata,
@@ -490,76 +490,3 @@ async def load_mcp_tools(
         )
         for tool in tools
     ]
-
-
-def _get_injected_args(tool: BaseTool) -> list[str]:
-    """Extract field names with InjectedToolArg annotation from tool schema.
-
-    Args:
-        tool: LangChain tool to inspect.
-
-    Returns:
-        List of field names marked as injected arguments.
-    """
-
-    def _is_injected_arg_type(type_: type) -> bool:
-        """Check if type annotation contains InjectedToolArg."""
-        return any(
-            isinstance(arg, InjectedToolArg)
-            or (isinstance(arg, type) and issubclass(arg, InjectedToolArg))
-            for arg in get_args(type_)[1:]
-        )
-
-    return [
-        field
-        for field, field_info in get_all_basemodel_annotations(tool.args_schema).items()
-        if _is_injected_arg_type(field_info)
-    ]
-
-
-def to_fastmcp(tool: BaseTool) -> FastMCPTool:
-    """Convert LangChain tool to FastMCP tool.
-
-    Args:
-        tool: LangChain tool to convert.
-
-    Returns:
-        FastMCP tool equivalent.
-
-    Raises:
-        TypeError: If args_schema is not BaseModel subclass.
-        NotImplementedError: If tool has injected arguments.
-    """
-    if not issubclass(tool.args_schema, BaseModel):
-        msg = (
-            "Tool args_schema must be a subclass of pydantic.BaseModel. "
-            "Tools with dict args schema are not supported."
-        )
-        raise TypeError(msg)
-
-    parameters = tool.tool_call_schema.model_json_schema()
-    field_definitions = {
-        field: (field_info.annotation, field_info)
-        for field, field_info in tool.tool_call_schema.model_fields.items()
-    }
-    arg_model = create_model(f"{tool.name}Arguments", **field_definitions, __base__=ArgModelBase)
-    fn_metadata = FuncMetadata(arg_model=arg_model)
-
-    # We'll use an Any type for the function return type.
-    # We're providing the parameters separately
-    async def fn(**arguments: dict[str, Any]) -> Any:
-        return await tool.ainvoke(arguments)
-
-    injected_args = _get_injected_args(tool)
-    if len(injected_args) > 0:
-        msg = "LangChain tools with injected arguments are not supported"
-        raise NotImplementedError(msg)
-
-    return FastMCPTool(
-        fn=fn,
-        name=tool.name,
-        description=tool.description,
-        parameters=parameters,
-        fn_metadata=fn_metadata,
-        is_async=True,
-    )

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -49,7 +49,7 @@ deepseek = ["langchain-deepseek"]
 xai = ["langchain-xai"]
 perplexity = ["langchain-perplexity"]
 meta = ["langchain-meta"]
-mcp = ["mcp>=1.9.2,<2.0.0", "typing-extensions>=4.14.0"]
+mcp = ["mcp>=2.0.0,<3.0.0", "typing-extensions>=4.14.0"]
 
 [project.urls]
 Homepage = "https://docs.langchain.com/"
@@ -76,11 +76,9 @@ test = [
     "blockbuster>=1.5.26,<1.6.0",
     "langchain-tests>=1.1.9,<2.0.0",
     "langchain-openai",
-    "mcp>=1.9.2,<2.0.0",
+    "mcp>=2.0.0,<3.0.0",
     "dirty-equals>=0.9.0",
-    "starlette>=0.27.0",
     "uvicorn>=0.30.0",
-    "websockets>=13.0",
 ]
 lint = [
     "ruff>=0.15.0,<0.17.0",

--- a/libs/langchain_v1/tests/integration_tests/mcp/conftest.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/conftest.py
@@ -1,58 +1,10 @@
-import multiprocessing
-import socket
-import time
-from collections.abc import Generator
-
 import pytest
 import pytest_socket
-
-from tests.integration_tests.mcp.utils import run_server
-
-
-@pytest.fixture
-def websocket_server_port() -> int:
-    with socket.socket() as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-    raise ValueError("Free port not found!")
-
-
-@pytest.fixture
-def websocket_server(websocket_server_port: int) -> Generator[None, None, None]:
-    proc = multiprocessing.Process(
-        target=run_server,
-        kwargs={"server_port": websocket_server_port},
-        daemon=True,
-    )
-    proc.start()
-
-    # Wait for server to be running
-    max_attempts = 20
-    attempt = 0
-
-    while attempt < max_attempts:
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.connect(("127.0.0.1", websocket_server_port))
-                break
-        except ConnectionRefusedError:
-            time.sleep(0.1)
-            attempt += 1
-    else:
-        raise RuntimeError(f"Server failed to start after {max_attempts} attempts")
-
-    yield
-
-    # Signal the server to stop
-    proc.kill()
-    proc.join(timeout=2)
-    if proc.is_alive():
-        raise RuntimeError("Server process is still alive after attempting to terminate it")
 
 
 @pytest.fixture
 def socket_enabled():
-    """Temporarily enable socket connections for websocket tests."""
+    """Temporarily enable socket connections to the local test servers."""
     try:
         pytest_socket.enable_socket()
         previous_state = pytest_socket.socket_allow_hosts()

--- a/libs/langchain_v1/tests/integration_tests/mcp/servers/math_server.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/servers/math_server.py
@@ -1,6 +1,6 @@
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("Math")
+mcp = MCPServer("Math")
 
 
 @mcp.tool()

--- a/libs/langchain_v1/tests/integration_tests/mcp/servers/time_server.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/servers/time_server.py
@@ -1,6 +1,6 @@
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("time")
+mcp = MCPServer("time")
 
 
 @mcp.tool()

--- a/libs/langchain_v1/tests/integration_tests/mcp/servers/weather_server.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/servers/weather_server.py
@@ -1,6 +1,6 @@
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
-mcp = FastMCP("Weather")
+mcp = MCPServer("Weather")
 
 
 @mcp.tool()

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_callbacks.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_callbacks.py
@@ -2,8 +2,7 @@
 
 import asyncio
 
-from mcp.server import FastMCP
-from mcp.server.fastmcp import Context
+from mcp.server.mcpserver import Context, MCPServer
 from mcp.server.session import ServerSession
 from mcp.types import LoggingMessageNotificationParams
 
@@ -57,7 +56,7 @@ async def test_to_mcp_format_with_callbacks() -> None:
 
 def _create_callback_server():
     """Create a server with a tool for testing callbacks."""
-    server = FastMCP(port=8186)
+    server = MCPServer()
 
     @server.tool()
     async def execute_task(task: str, ctx: Context[ServerSession, None]) -> str:

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_client.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_client.py
@@ -12,14 +12,13 @@ from tests.integration_tests.mcp.utils import IsLangChainID
 
 async def test_multi_server_mcp_client(
     socket_enabled,
-    websocket_server,
-    websocket_server_port: int,
 ):
     """Test that MultiServerMCPClient can connect to multiple servers and load tools."""
     # Get the absolute path to the server scripts
     current_dir = Path(__file__).parent
     math_server_path = os.path.join(current_dir, "servers/math_server.py")
     weather_server_path = os.path.join(current_dir, "servers/weather_server.py")
+    time_server_path = os.path.join(current_dir, "servers/time_server.py")
 
     client = MultiServerMCPClient(
         {
@@ -34,8 +33,9 @@ async def test_multi_server_mcp_client(
                 "transport": "stdio",
             },
             "time": {
-                "url": f"ws://127.0.0.1:{websocket_server_port}/ws",
-                "transport": "websocket",
+                "command": "python3",
+                "args": [time_server_path],
+                "transport": "stdio",
             },
         },
     )
@@ -92,13 +92,12 @@ async def test_multi_server_mcp_client(
 
 async def test_multi_server_connect_methods(
     socket_enabled,
-    websocket_server,
-    websocket_server_port: int,
 ):
     """Test the different connect methods for MultiServerMCPClient."""
     # Get the absolute path to the server scripts
     current_dir = Path(__file__).parent
     math_server_path = os.path.join(current_dir, "servers/math_server.py")
+    time_server_path = os.path.join(current_dir, "servers/time_server.py")
 
     # Initialize client without initial connections
     client = MultiServerMCPClient(
@@ -109,8 +108,9 @@ async def test_multi_server_connect_methods(
                 "transport": "stdio",
             },
             "time": {
-                "url": f"ws://127.0.0.1:{websocket_server_port}/ws",
-                "transport": "websocket",
+                "command": "python3",
+                "args": [time_server_path],
+                "transport": "stdio",
             },
         },
     )

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_elicitation.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_elicitation.py
@@ -1,7 +1,7 @@
 """Tests for MCP elicitation callback support."""
 
-from mcp.server.fastmcp import Context, FastMCP
-from mcp.shared.context import RequestContext
+from mcp.client.session import ClientRequestContext as RequestContext
+from mcp.server.mcpserver import Context, MCPServer
 from mcp.types import ElicitRequestParams, ElicitResult
 from pydantic import BaseModel
 
@@ -15,7 +15,7 @@ def _create_elicitation_server():
         email: str
         age: int
 
-    server = FastMCP(port=8184)
+    server = MCPServer()
 
     # Track how many times code before elicit runs (should be exactly once)
     server._pre_elicit_call_count = 0

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_interceptors.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_interceptors.py
@@ -2,7 +2,7 @@
 
 import pytest
 from langchain_core.messages import ToolMessage
-from mcp.server import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.types import (
     CallToolResult,
     TextContent,
@@ -17,7 +17,7 @@ from tests.integration_tests.mcp.utils import IsLangChainID, run_streamable_http
 
 def _create_math_server(port: int = 8200):
     """Create a math server with add and multiply tools."""
-    server = FastMCP(port=port)
+    server = MCPServer()
 
     @server.tool()
     def add(a: int, b: int) -> int:
@@ -116,7 +116,7 @@ class TestInterceptorModifiesResponse:
 
             return CallToolResult(
                 content=modified_content,
-                isError=result.isError,
+                isError=result.is_error,
             )
 
         with run_streamable_http(_create_math_server, 8203):

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_tools.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_tools.py
@@ -1,17 +1,16 @@
 import typing
 from collections.abc import Callable, Sequence
-from typing import Annotated, Any
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-import httpx
+import httpx2
 import pytest
-from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.language_models import LanguageModelInput
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import Runnable
-from langchain_core.tools import BaseTool, InjectedToolArg, ToolException, tool
-from mcp.server import FastMCP
+from langchain_core.tools import BaseTool, ToolException
+from mcp.server.mcpserver import MCPServer
 from mcp.types import (
     AudioContent,
     BlobResourceContents,
@@ -24,7 +23,6 @@ from mcp.types import (
     ToolAnnotations,
 )
 from mcp.types import Tool as MCPTool
-from pydantic import BaseModel
 
 from langchain.mcp.client import MultiServerMCPClient
 from langchain.mcp.interceptors import MCPToolCallRequest, MCPToolCallResult
@@ -33,7 +31,6 @@ from langchain.mcp.tools import (
     _convert_call_tool_result,
     convert_mcp_tool_to_langchain_tool,
     load_mcp_tools,
-    to_fastmcp,
 )
 from tests.integration_tests.mcp.utils import IsLangChainID, run_streamable_http
 
@@ -464,7 +461,7 @@ async def test_load_mcp_tools():
             inputSchema=tool_input_schema,
         ),
     ]
-    session.list_tools.return_value = MagicMock(tools=mcp_tools, nextCursor=None)
+    session.list_tools.return_value = MagicMock(tools=mcp_tools, next_cursor=None)
 
     # Mock call_tool to return different results for different tools
     async def mock_call_tool(tool_name, arguments, progress_callback=None):
@@ -519,7 +516,7 @@ async def test_load_mcp_tools():
 
 
 def _create_annotations_server():
-    server = FastMCP(port=8181)
+    server = MCPServer()
 
     @server.tool(
         annotations=ToolAnnotations(title="Get Time", readOnlyHint=True, idempotentHint=False),
@@ -577,92 +574,8 @@ async def test_load_mcp_tools_with_annotations(socket_enabled) -> None:
         }
 
 
-# Tests for to_fastmcp functionality
-
-
-@tool
-def add(a: int, b: int) -> int:
-    """Add two numbers"""
-    return a + b
-
-
-class AddInput(BaseModel):
-    """Add two numbers"""
-
-    a: int
-    b: int
-
-
-@tool("add", args_schema=AddInput)
-def add_with_schema(a: int, b: int) -> int:
-    return a + b
-
-
-@tool("add")
-def add_with_injection(a: int, b: int, injected_arg: Annotated[str, InjectedToolArg()]) -> int:
-    """Add two numbers"""
-    return a + b
-
-
-class AddTool(BaseTool):
-    name: str = "add"
-    description: str = "Add two numbers"
-    args_schema: type[BaseModel] | None = AddInput
-
-    def _run(self, a: int, b: int, run_manager: CallbackManagerForToolRun | None = None) -> int:
-        """Use the tool."""
-        return a + b
-
-    async def _arun(
-        self,
-        a: int,
-        b: int,
-        run_manager: CallbackManagerForToolRun | None = None,
-    ) -> int:
-        """Use the tool."""
-        return self._run(a, b, run_manager=run_manager)
-
-
-@pytest.mark.parametrize(
-    "tool_instance",
-    [add, add_with_schema, AddTool()],
-    ids=["tool", "tool_with_schema", "tool_class"],
-)
-async def test_convert_langchain_tool_to_fastmcp_tool(tool_instance):
-    fastmcp_tool = to_fastmcp(tool_instance)
-    assert fastmcp_tool.name == "add"
-    assert fastmcp_tool.description == "Add two numbers"
-    assert fastmcp_tool.parameters == {
-        "description": "Add two numbers",
-        "properties": {
-            "a": {"title": "A", "type": "integer"},
-            "b": {"title": "B", "type": "integer"},
-        },
-        "required": ["a", "b"],
-        "title": "add",
-        "type": "object",
-    }
-    assert fastmcp_tool.fn_metadata.arg_model.model_json_schema() == {
-        "properties": {
-            "a": {"title": "A", "type": "integer"},
-            "b": {"title": "B", "type": "integer"},
-        },
-        "required": ["a", "b"],
-        "title": "addArguments",
-        "type": "object",
-    }
-
-    arguments = {"a": 1, "b": 2}
-    assert await fastmcp_tool.run(arguments=arguments) == 3
-
-
-def test_convert_langchain_tool_to_fastmcp_tool_with_injection():
-    with pytest.raises(NotImplementedError):
-        to_fastmcp(add_with_injection)
-
-
 def _create_status_server():
-    server = FastMCP(port=8182)
+    server = MCPServer()
 
     @server.tool()
     def get_status() -> str:
@@ -681,16 +594,16 @@ async def test_load_mcp_tools_with_custom_httpx_client_factory(socket_enabled) -
     # Custom httpx client factory
     def custom_httpx_client_factory(
         headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
-    ) -> httpx.AsyncClient:
-        """Custom factory for creating httpx.AsyncClient with specific configuration."""
-        return httpx.AsyncClient(
+        timeout: httpx2.Timeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient:
+        """Custom factory for creating httpx2.AsyncClient with specific configuration."""
+        return httpx2.AsyncClient(
             headers=headers,
-            timeout=timeout or httpx.Timeout(30.0),
+            timeout=timeout or httpx2.Timeout(30.0),
             auth=auth,
             # Custom configuration
-            limits=httpx.Limits(max_keepalive_connections=5, max_connections=10),
+            limits=httpx2.Limits(max_keepalive_connections=5, max_connections=10),
         )
 
     with run_streamable_http(_create_status_server, 8182):
@@ -718,7 +631,7 @@ async def test_load_mcp_tools_with_custom_httpx_client_factory(socket_enabled) -
 
 
 def _create_info_server():
-    server = FastMCP(port=8183)
+    server = MCPServer()
 
     @server.tool()
     def get_info() -> str:
@@ -736,16 +649,16 @@ async def test_load_mcp_tools_with_custom_httpx_client_factory_sse(
     # Custom httpx client factory
     def custom_httpx_client_factory(
         headers: dict[str, str] | None = None,
-        timeout: httpx.Timeout | None = None,
-        auth: httpx.Auth | None = None,
-    ) -> httpx.AsyncClient:
-        """Custom factory for creating httpx.AsyncClient with specific configuration."""
-        return httpx.AsyncClient(
+        timeout: httpx2.Timeout | None = None,
+        auth: httpx2.Auth | None = None,
+    ) -> httpx2.AsyncClient:
+        """Custom factory for creating httpx2.AsyncClient with specific configuration."""
+        return httpx2.AsyncClient(
             headers=headers,
-            timeout=timeout or httpx.Timeout(30.0),
+            timeout=timeout or httpx2.Timeout(30.0),
             auth=auth,
             # Custom configuration for SSE
-            limits=httpx.Limits(max_keepalive_connections=3, max_connections=5),
+            limits=httpx2.Limits(max_keepalive_connections=3, max_connections=5),
         )
 
     with run_streamable_http(_create_info_server, 8183):
@@ -839,7 +752,7 @@ async def test_convert_mcp_tool_metadata_variants():
 
 
 def _create_increment_server():
-    server = FastMCP(port=8183)
+    server = MCPServer()
 
     @server.tool()
     def increment(value: int) -> str:
@@ -978,7 +891,7 @@ async def test_mcp_tools_with_agent_and_command_interceptor(socket_enabled) -> N
 
 def _create_weather_search_server():
     """Create a weather server with a search tool."""
-    server = FastMCP(port=8185)
+    server = MCPServer()
 
     @server.tool()
     def search(query: str) -> str:
@@ -990,7 +903,7 @@ def _create_weather_search_server():
 
 def _create_flights_search_server():
     """Create a flights server with a search tool."""
-    server = FastMCP(port=8186)
+    server = MCPServer()
 
     @server.tool()
     def search(destination: str) -> str:

--- a/libs/langchain_v1/tests/integration_tests/mcp/utils.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/utils.py
@@ -6,42 +6,13 @@ from collections.abc import Generator
 
 import uvicorn
 from dirty_equals import IsStr
-from mcp.server.websocket import websocket_server
-from starlette.applications import Starlette
-from starlette.routing import WebSocketRoute
-
-from tests.integration_tests.mcp.servers.time_server import mcp as time_mcp
 
 # Helper for matching auto-generated LangChain content block IDs
 IsLangChainID = IsStr(regex=r"lc_.*")
 
 
-def make_server_app() -> Starlette:
-    server = time_mcp._mcp_server
-
-    async def handle_ws(websocket):
-        async with websocket_server(websocket.scope, websocket.receive, websocket.send) as streams:
-            await server.run(streams[0], streams[1], server.create_initialization_options())
-
-    app = Starlette(routes=[WebSocketRoute("/ws", endpoint=handle_ws)])
-
-    return app
-
-
-def run_server(server_port: int) -> None:
-    app = make_server_app()
-    server = uvicorn.Server(
-        config=uvicorn.Config(app=app, host="127.0.0.1", port=server_port, log_level="error"),
-    )
-    server.run()
-
-    # Give server time to start
-    while not server.started:
-        time.sleep(0.5)
-
-
 def run_streamable_http_server(server_factory, server_port: int) -> None:
-    """Run a FastMCP server in a separate process exposing a streamable HTTP."""
+    """Run a server in a separate process exposing a streamable HTTP."""
     server = server_factory()
     app = server.streamable_http_app()
     uvicorn_server = uvicorn.Server(

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1722,6 +1722,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1761,6 +1774,32 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
 name = "huggingface-hub"
 version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1790,11 +1829,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.15"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -2091,11 +2130,9 @@ test = [
     { name = "pytest-socket" },
     { name = "pytest-watcher" },
     { name = "pytest-xdist" },
-    { name = "starlette" },
     { name = "syrupy" },
     { name = "toml" },
     { name = "uvicorn" },
-    { name = "websockets" },
 ]
 test-integration = [
     { name = "langchain-text-splitters" },
@@ -2131,7 +2168,7 @@ requires-dist = [
     { name = "langchain-together", marker = "extra == 'together'" },
     { name = "langchain-xai", marker = "extra == 'xai'" },
     { name = "langgraph", specifier = ">=1.2.11,<1.3.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.9.2,<2.0.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic", specifier = ">=2.7.4,<3.0.0" },
     { name = "typing-extensions", marker = "extra == 'mcp'", specifier = ">=4.14.0" },
 ]
@@ -2144,7 +2181,7 @@ test = [
     { name = "dirty-equals", specifier = ">=0.9.0" },
     { name = "langchain-openai", editable = "../partners/openai" },
     { name = "langchain-tests", editable = "../standard-tests" },
-    { name = "mcp", specifier = ">=1.9.2,<2.0.0" },
+    { name = "mcp", specifier = ">=2.0.0,<3.0.0" },
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.3.0,<2.0.0" },
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6.0.0" },
@@ -2153,11 +2190,9 @@ test = [
     { name = "pytest-socket", specifier = ">=0.6.0,<1.0.0" },
     { name = "pytest-watcher", specifier = ">=0.2.6,<1.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
-    { name = "starlette", specifier = ">=0.27.0" },
     { name = "syrupy", specifier = ">=5.0.0,<6.0.0" },
     { name = "toml", specifier = ">=0.10.2,<1.0.0" },
     { name = "uvicorn", specifier = ">=0.30.0" },
-    { name = "websockets", specifier = ">=13.0" },
 ]
 test-integration = [
     { name = "langchain-text-splitters", editable = "../text-splitters" },
@@ -3013,15 +3048,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.29.1"
+version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -3031,9 +3066,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/48/0bb26fdfe7ac16875f534a101ce2405eae192bdef37e7451f2f4507c13ec/mcp-1.29.1.tar.gz", hash = "sha256:1967ba4c315f7a375146209949f45950d18b0efd2f913d7cf3400bc723ee5f04", size = 646823, upload-time = "2026-08-24T18:30:41.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/3b/3acf4897b934ceeb8d22df7309a435a76c34f94be936b36eee8bb57b29a3/mcp-2.1.0.tar.gz", hash = "sha256:b4407b2890238248795d03e8c17d02d311c600ca9272d023ab12dbfa6ad21c70", size = 3983282, upload-time = "2026-08-24T19:04:32.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/04/d6b4fb82eefe9e81807aabca1ac98f460ae0883974b83a997aaa20c52545/mcp-1.29.1-py3-none-any.whl", hash = "sha256:b6310eeb59153300c4ab8b9aec4c52f4819a2d6a8e429eb43d908bed7c783648", size = 224653, upload-time = "2026-08-24T18:30:39.573Z" },
+    { url = "https://files.pythonhosted.org/packages/88/67/b2160b6cf138872860d2552cca2894dbe4d29da7f1c6fae0c21d22782838/mcp-2.1.0-py3-none-any.whl", hash = "sha256:b8acaed6ca4b9376801377463e44246395749363b1c34467ec6243a50be5ed28", size = 357320, upload-time = "2026-08-24T19:04:29.909Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/97/5b1c2e40d6121172c97638a0f1d6240526f5aeebdc9ebea11ddcf2139249/mcp_types-2.1.0.tar.gz", hash = "sha256:16f91064ce33d7ee7a75a7e198a437172215180c16d4bbcfa0e61488ede92c54", size = 66679, upload-time = "2026-08-24T19:04:34.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/99/f9041368b5af773de32af6192ff0627a71368c240123e57262439ae5b594/mcp_types-2.1.0-py3-none-any.whl", hash = "sha256:6a65bfb7d057ceaf2418781ee61b3041e1f4b5418199297f8939a4b4ed334c3a", size = 69654, upload-time = "2026-08-24T19:04:31.327Z" },
 ]
 
 [[package]]
@@ -5403,6 +5451,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #39887 — review that first, merge this after.

#39887 pinned `mcp<2.0.0` because the ported code doesn't import against 2.x. This lifts that pin to `mcp>=2.0.0,<3.0.0`.

**Removed** (the SDK no longer provides them):
- The websocket transport — `mcp.client.websocket` is gone, and websocket was never in the MCP spec. Use streamable HTTP instead.
- `to_fastmcp` — the bundled FastMCP server it depended on is no longer shipped.

**Renamed** by the upgrade: `streamablehttp_client` → `streamable_http_client` (which now takes HTTP options via the client it's handed), model fields to snake_case (`inputSchema` → `input_schema`), `list_tools(cursor=)` → `list_tools(params=)`, and `RequestContext`/`ProgressFnT` moved to `mcp.client.session`.

Worth knowing:
- **Progress and logging are not removed.** Both still exist in 2.x — only their import locations moved.
- **Tool annotation keys are preserved.** 2.x renamed those fields to snake_case, which would have silently changed `tool.metadata["annotations"]["readOnlyHint"]` for everyone. They're now dumped by alias so the keys stay as the spec names.
- **`httpx` → `httpx2` is a real break.** The SDK switched to `httpx2`, a separate package, so `auth` and `httpx_client_factory` must now be `httpx2` objects. Both packages can be installed at once, making this easy to hit at runtime.

## Release note

`langchain.mcp` now requires `mcp>=2.0.0`. The websocket transport and `to_fastmcp` are removed. Callers passing `auth` or `httpx_client_factory` must supply `httpx2` objects rather than `httpx` ones.

---

*Prepared with AI-agent assistance (Claude Code).*