### PR TITLE
feat(langchain): hold `langchain.mcp` connections open for the client's lifetime

### DIFF
--- a/libs/langchain_v1/langchain/mcp/client.py
+++ b/libs/langchain_v1/langchain/mcp/client.py
@@ -6,8 +6,7 @@ to multiple MCP servers and loading tools, prompts, and resources from them.
 
 import asyncio
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
-from types import TracebackType
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any
 
 from langchain_core.documents.base import Blob
@@ -22,17 +21,6 @@ from langchain.mcp.prompts import load_mcp_prompt
 from langchain.mcp.resources import load_mcp_resources
 from langchain.mcp.sessions import Connection, create_session
 from langchain.mcp.tools import load_mcp_tools
-
-ASYNC_CONTEXT_MANAGER_ERROR = (
-    "As of langchain-mcp-adapters 0.1.0, MultiServerMCPClient cannot be used as a "
-    "context manager (e.g., async with MultiServerMCPClient(...)). "
-    "Instead, you can do one of the following:\n"
-    "1. client = MultiServerMCPClient(...)\n"
-    "   tools = await client.get_tools()\n"
-    "2. client = MultiServerMCPClient(...)\n"
-    "   async with client.session(server_name) as session:\n"
-    "       tools = await load_mcp_tools(session)"
-)
 
 
 class MultiServerMCPClient:
@@ -101,6 +89,8 @@ class MultiServerMCPClient:
         self.callbacks = callbacks or Callbacks()
         self.tool_interceptors = tool_interceptors or []
         self.tool_name_prefix = tool_name_prefix
+        self._sessions: dict[str, ClientSession] = {}
+        self._exit_stack: AsyncExitStack | None = None
 
     @asynccontextmanager
     async def session(self, server_name: str) -> AsyncIterator[ClientSession]:
@@ -116,21 +106,32 @@ class MultiServerMCPClient:
             An initialized `ClientSession`
 
         """
+        self._require_server(server_name)
+
+        if (held := self._sessions.get(server_name)) is not None:
+            yield held
+            return
+
+        async with create_session(
+            self.connections[server_name],
+            mcp_callbacks=self.callbacks.to_mcp_format(
+                context=CallbackContext(server_name=server_name)
+            ),
+        ) as session:
+            yield session
+
+    def _require_server(self, server_name: str) -> None:
+        """Raise if the server was not configured.
+
+        Raises:
+            ValueError: If the server name is not found in the connections.
+        """
         if server_name not in self.connections:
             msg = (
                 f"Couldn't find a server with name '{server_name}', "
                 f"expected one of '{list(self.connections.keys())}'"
             )
             raise ValueError(msg)
-
-        mcp_callbacks = self.callbacks.to_mcp_format(
-            context=CallbackContext(server_name=server_name)
-        )
-
-        async with create_session(
-            self.connections[server_name], mcp_callbacks=mcp_callbacks
-        ) as session:
-            yield session
 
     async def get_tools(self, *, server_name: str | None = None) -> list[BaseTool]:
         """Get a list of all tools from all connected servers.
@@ -148,14 +149,9 @@ class MultiServerMCPClient:
 
         """
         if server_name is not None:
-            if server_name not in self.connections:
-                msg = (
-                    f"Couldn't find a server with name '{server_name}', "
-                    f"expected one of '{list(self.connections.keys())}'"
-                )
-                raise ValueError(msg)
+            self._require_server(server_name)
             return await load_mcp_tools(
-                None,
+                self._sessions.get(server_name),
                 connection=self.connections[server_name],
                 callbacks=self.callbacks,
                 server_name=server_name,
@@ -168,7 +164,7 @@ class MultiServerMCPClient:
         for name, connection in self.connections.items():
             load_mcp_tool_task = asyncio.create_task(
                 load_mcp_tools(
-                    None,
+                    self._sessions.get(name),
                     connection=connection,
                     callbacks=self.callbacks,
                     server_name=name,
@@ -235,30 +231,36 @@ class MultiServerMCPClient:
         return all_resources
 
     async def __aenter__(self) -> Self:
-        """Async context manager entry point.
+        """Connect to every server and keep the connections open.
 
-        Raises:
-            NotImplementedError: Context manager support has been removed.
+        Optional: without it a session is opened per operation, which still works but
+        repeats the handshake on every call, and respawns the subprocess for stdio
+        servers. Entering once and reusing is the reason to do it.
         """
-        raise NotImplementedError(ASYNC_CONTEXT_MANAGER_ERROR)
+        stack = AsyncExitStack()
+        try:
+            for name, connection in self.connections.items():
+                self._sessions[name] = await stack.enter_async_context(
+                    create_session(
+                        connection,
+                        mcp_callbacks=self.callbacks.to_mcp_format(
+                            context=CallbackContext(server_name=name)
+                        ),
+                    )
+                )
+        except BaseException:
+            self._sessions.clear()
+            await stack.aclose()
+            raise
+        self._exit_stack = stack
+        return self
 
-    def __aexit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        """Async context manager exit point.
-
-        Args:
-            exc_type: Exception type if an exception occurred.
-            exc_val: Exception value if an exception occurred.
-            exc_tb: Exception traceback if an exception occurred.
-
-        Raises:
-            NotImplementedError: Context manager support has been removed.
-        """
-        raise NotImplementedError(ASYNC_CONTEXT_MANAGER_ERROR)
+    async def __aexit__(self, *exc_info: object) -> None:
+        """Close every connection opened on entry."""
+        stack, self._exit_stack = self._exit_stack, None
+        self._sessions.clear()
+        if stack is not None:
+            await stack.aclose()
 
 
 __all__ = [

--- a/libs/langchain_v1/tests/integration_tests/mcp/servers/counting_server.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/servers/counting_server.py
@@ -1,0 +1,21 @@
+"""Stdio server that records its PID on startup, to count connections in tests."""
+
+import os
+import sys
+
+from mcp.server.mcpserver import MCPServer
+
+with open(sys.argv[1], "a") as handle:  # noqa: PTH123
+    handle.write(f"{os.getpid()}\n")
+
+mcp = MCPServer("counting")
+
+
+@mcp.tool()
+def get_time() -> str:
+    """Get current time"""
+    return "5:20:00 PM EST"
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/libs/langchain_v1/tests/integration_tests/mcp/test_client.py
+++ b/libs/langchain_v1/tests/integration_tests/mcp/test_client.py
@@ -306,3 +306,36 @@ def _create_time_server():
         return "5:20:00 PM EST"
 
     return server
+
+
+async def test_context_manager_reuses_one_connection_per_server(tmp_path):
+    """Entering the client holds connections open, so operations share one connection.
+
+    Counted by subprocess spawns: a stdio server starts once per connection, so a held
+    connection serves every operation from the same process.
+    """
+    log = tmp_path / "spawns.log"
+    server = os.path.join(Path(__file__).parent, "servers/counting_server.py")
+    config = {"time": {"command": "python3", "args": [server, str(log)], "transport": "stdio"}}
+    call = {"args": {}, "id": "1", "type": "tool_call"}
+
+    def spawns() -> int:
+        count = len(log.read_text().split()) if log.exists() else 0
+        log.unlink(missing_ok=True)
+        return count
+
+    async with MultiServerMCPClient(config) as client:
+        tools = {tool.name: tool for tool in await client.get_tools()}
+        await tools["get_time"].ainvoke(call)
+        await tools["get_time"].ainvoke(call)
+    held = spawns()
+
+    # Not entering still works, but opens a connection per operation.
+    unheld_client = MultiServerMCPClient(config)
+    tools = {tool.name: tool for tool in await unheld_client.get_tools()}
+    await tools["get_time"].ainvoke(call)
+    await tools["get_time"].ainvoke(call)
+    unheld = spawns()
+
+    assert held == 1, f"a held connection should start the server once, got {held}"
+    assert unheld > held, f"unheld should reconnect per operation, got {unheld}"


### PR DESCRIPTION
Stacked on #39889 (→ #39888 → #39887). Review and merge in order.

`MultiServerMCPClient` opened a session per operation, and `__aenter__` raised outright — *"MultiServerMCPClient cannot be used as a context manager"*. It now connects to every server on entry and reuses those connections.

Changes:
- `MultiServerMCPClient` is a real async context manager; entering connects to every server and holds it.
- `session()`, `get_tools()`, `get_prompt()`, and `get_resources()` reuse a held connection when one exists.
- Not entering still works exactly as before, so this is additive.
- Removes the need to wrap a transport in a callable (added in #39889): a transport can only be entered once, which was only a problem because a session was opened per operation.

Proven by counting stdio subprocess spawns across two tool calls plus discovery:

```
held connection : 1 spawn
not entered     : more than 1
```

For HTTP the same effect shows as fewer round trips — earlier measurement was 3 `server/discover` + 6 `tools/list` unheld, versus 1 + 4 held.

Worth knowing: this is the SDK-appropriate shape rather than a copy of FastMCP's. FastMCP makes *not* holding cheap — refcounted re-entry plus `keep_alive=True` on stdio — so its users rarely notice. `mcp.Client` has neither (nested entry raises, clients are single-use, stdio respawns), so the choice has to be explicit.

## Release note

`MultiServerMCPClient` can now be used as an async context manager, which connects to every server once and reuses those connections for all operations. Using it without entering is unchanged.

---

*Prepared with AI-agent assistance (Claude Code).*