### PR TITLE
release(langchain): 1.3.17

### DIFF
--- a/libs/langchain_v1/langchain/__init__.py
+++ b/libs/langchain_v1/langchain/__init__.py
@@ -1,3 +1,3 @@
 """Main entrypoint into LangChain."""
 
-__version__ = "1.3.16"
+__version__ = "1.3.17"

--- a/libs/langchain_v1/pyproject.toml
+++ b/libs/langchain_v1/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 
-version = "1.3.16"
+version = "1.3.17"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "langchain-core>=1.6.0,<2.0.0",

--- a/libs/langchain_v1/uv.lock
+++ b/libs/langchain_v1/uv.lock
@@ -1816,7 +1816,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.16"
+version = "1.3.17"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-core" },


### PR DESCRIPTION
Patch release of the `langchain` package (langchain_v1): `1.3.16` → `1.3.17`.

Bumps `version` in `pyproject.toml`, `__version__` in `langchain/__init__.py`, and the corresponding entry in `uv.lock`.

---

*Prepared with the assistance of an AI agent.*
