### PR TITLE
core(output_parsers): support '+' bullet markers in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list_parser.py
@@ -136,10 +136,16 @@ def test_markdown_list() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items with plus bullets:\n+ apple\n     + banana\n+ cherry"
+
+    text5 = "Mixed bullets:\n- apple\n* banana\n+ cherry"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["apple", "banana", "cherry"]),
+        (text5, ["apple", "banana", "cherry"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert parser.parse(text) == expected
@@ -282,10 +288,16 @@ async def test_markdown_list_async() -> None:
 
     text3 = "No items in the list."
 
+    text4 = "Items with plus bullets:\n+ apple\n+ banana\n+ cherry"
+
+    text5 = "Mixed bullets:\n- apple\n* banana\n+ cherry"
+
     for text, expected in [
         (text1, ["foo", "bar", "baz"]),
         (text2, ["apple", "banana", "cherry"]),
         (text3, []),
+        (text4, ["apple", "banana", "cherry"]),
+        (text5, ["apple", "banana", "cherry"]),
     ]:
         expectedlist = [[a] for a in expected]
         assert await parser.aparse(text) == expected


### PR DESCRIPTION
Fixes #39900

### Summary
CommonMark defines `-`, `+`, and `*` as valid bullet list markers. Previously, `MarkdownListOutputParser` only supported `-` and `*`, silently ignoring `+` bullet list items.

This PR updates the regex pattern in `MarkdownListOutputParser` to match `[-*+]` markers and adds unit tests covering `+` bullets and mixed bullet markers.