### PR TITLE
fix(fireworks): propagate reasoning_content in streaming and outbound

### DIFF
--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -370,6 +370,8 @@ def _convert_message_to_dict(message: BaseMessage) -> dict:
             # If function call only, content is None not empty string
             if message_dict["content"] == "":
                 message_dict["content"] = None
+        if reasoning_content := message.additional_kwargs.get("reasoning_content"):
+            message_dict["reasoning_content"] = reasoning_content
         if message.tool_calls or message.invalid_tool_calls:
             message_dict["tool_calls"] = [
                 _lc_tool_call_to_fireworks_tool_call(tc) for tc in message.tool_calls
@@ -506,6 +508,8 @@ def _convert_chunk_to_message_chunk(
     content = cast(str, _dict.get("content") or "")
     additional_kwargs: dict = {}
     tool_call_chunks: list[ToolCallChunk] = []
+    if reasoning_content := _dict.get("reasoning_content"):
+        additional_kwargs["reasoning_content"] = reasoning_content
     if _dict.get("function_call"):
         function_call = dict(_dict["function_call"])
         if "name" in function_call and function_call["name"] is None:

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -134,6 +134,136 @@ def test_convert_dict_to_message_without_reasoning_content() -> None:
     assert "reasoning_content" not in message.additional_kwargs
 
 
+def test_convert_chunk_to_message_chunk_with_reasoning_content() -> None:
+    """Test reasoning_content is captured from streaming deltas.
+
+    Regression test for the streaming converter dropping reasoning_content
+    that the non-streaming converter (_convert_dict_to_message) already
+    captures.  Thinking models on Fireworks (Kimi, Qwen, DeepSeek, GLM)
+    emit ``reasoning_content`` alongside ``content`` in each SSE delta.
+    """
+    chunk = {
+        "choices": [
+            {
+                "delta": {
+                    "role": "assistant",
+                    "content": "",
+                    "reasoning_content": "Thinking step 1...",
+                },
+                "index": 0,
+            }
+        ],
+    }
+
+    message = _convert_chunk_to_message_chunk(chunk, AIMessageChunk)
+
+    assert isinstance(message, AIMessageChunk)
+    assert "reasoning_content" in message.additional_kwargs
+    assert message.additional_kwargs["reasoning_content"] == "Thinking step 1..."
+
+
+def test_convert_chunk_to_message_chunk_reasoning_accumulates() -> None:
+    """Test that reasoning_content from multiple streaming chunks is captured."""
+    chunks = [
+        {
+            "choices": [
+                {"delta": {"role": "assistant", "reasoning_content": "Step 1. "}, "index": 0}
+            ],
+        },
+        {
+            "choices": [
+                {"delta": {"reasoning_content": "Step 2. "}, "index": 0}
+            ],
+        },
+        {
+            "choices": [
+                {"delta": {"reasoning_content": "Step 3.", "content": "42"}, "index": 0}
+            ],
+        },
+    ]
+
+    reasoning_parts: list[str] = []
+    content_parts: list[str] = []
+    for chunk in chunks:
+        msg = _convert_chunk_to_message_chunk(chunk, AIMessageChunk)
+        rc = msg.additional_kwargs.get("reasoning_content")
+        if rc:
+            reasoning_parts.append(rc)
+        if msg.content:
+            content_parts.append(msg.content)
+
+    assert "".join(reasoning_parts) == "Step 1. Step 2. Step 3."
+    assert "".join(content_parts) == "42"
+
+
+def test_convert_chunk_to_message_chunk_without_reasoning_content() -> None:
+    """Test that chunks without reasoning_content work correctly."""
+    chunk = {
+        "choices": [
+            {"delta": {"role": "assistant", "content": "Hello"}, "index": 0}
+        ],
+    }
+
+    message = _convert_chunk_to_message_chunk(chunk, AIMessageChunk)
+
+    assert isinstance(message, AIMessageChunk)
+    assert "reasoning_content" not in message.additional_kwargs
+    assert message.content == "Hello"
+
+
+def test_convert_message_to_dict_forwards_reasoning_content() -> None:
+    """Test reasoning_content is forwarded in outbound message conversion.
+
+    When an AIMessage carrying reasoning_content in additional_kwargs is
+    sent back to the Fireworks API (multi-turn conversations), the outbound
+    converter must preserve it so the model retains its chain-of-thought.
+    """
+    message = AIMessage(
+        content="The answer is 42.",
+        additional_kwargs={"reasoning_content": "I reasoned about this."},
+    )
+
+    result = _convert_message_to_dict(message)
+
+    assert result["role"] == "assistant"
+    assert result["content"] == "The answer is 42."
+    assert result["reasoning_content"] == "I reasoned about this."
+
+
+def test_convert_message_to_dict_without_reasoning_content() -> None:
+    """Test that outbound conversion doesn't add reasoning_content when absent."""
+    message = AIMessage(content="The answer is 42.")
+
+    result = _convert_message_to_dict(message)
+
+    assert "reasoning_content" not in result
+
+
+def test_convert_message_to_dict_reasoning_with_tool_calls() -> None:
+    """Test reasoning_content coexists with tool_calls in outbound conversion."""
+    message = AIMessage(
+        content="",
+        additional_kwargs={
+            "reasoning_content": "I need to call a tool.",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "SF"}'},
+                }
+            ],
+        },
+        tool_calls=[
+            {"name": "get_weather", "args": {"city": "SF"}, "id": "call_1", "type": "tool_call"}
+        ],
+    )
+
+    result = _convert_message_to_dict(message)
+
+    assert result["reasoning_content"] == "I need to call a tool."
+    assert "tool_calls" in result
+
+
 def test_metadata_versions() -> None:
     """Test that metadata reports the correct version info."""
     os.environ.setdefault("FIREWORKS_API_KEY", "fake-key")


### PR DESCRIPTION
Fixes #34342

## Summary

`reasoning_content` from Fireworks thinking models (Kimi, Qwen, DeepSeek, GLM) is captured correctly in non-streaming responses (`_convert_dict_to_message`, line 153), but silently dropped in two other code paths that #34343 did not address:

1. **Streaming inbound** — `_convert_chunk_to_message_chunk` builds `additional_kwargs` from `function_call` and `tool_calls` but never checks for `reasoning_content` in the SSE delta. Streaming callers never see reasoning traces.
2. **Outbound (multi-turn)** — `_convert_message_to_dict` forwards `function_call` and `tool_calls` from `additional_kwargs` but not `reasoning_content`. When prior assistant messages are sent back to the API, the model loses its chain-of-thought, which can cause hallucinations in long conversations (reported in #34342).

### Fix

Two-line additions to `chat_models.py`, both mirroring existing patterns:

- `_convert_chunk_to_message_chunk`: extract `reasoning_content` from `delta` into `additional_kwargs` (same pattern as `_convert_dict_to_message`)
- `_convert_message_to_dict`: forward `reasoning_content` from `additional_kwargs` to the outbound dict (same pattern as `function_call` forwarding)

### Context

- #34342 reported this; #34343 fixed only non-streaming inbound and was merged
- #35359 attempted to fix streaming + outbound but was closed without merge (bundled unrelated `LLMToolSelectorMiddleware` changes and was never split per reviewer request)
- Same class of bug was fixed for DeepSeek in #37390 (outbound reasoning_content forwarding)

This PR is scoped to only the two converter functions, with no changes outside `langchain-fireworks`.

## Test plan

- [x] 6 new unit tests: streaming inbound, accumulation across chunks, absence, outbound forwarding, absence, coexistence with tool_calls
- [x] Full unit test suite passes (137 passed, 0 failures)
- [x] Verified against live Fireworks serverless models (`kimi-k3`, `qwen3p8-max`, `deepseek-v4-pro`) — `reasoning_content` now appears in `AIMessageChunk.additional_kwargs` for both streaming and non-streaming