### PR TITLE
fix(core): count image tokens from image dimensions

### DIFF
--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -14,6 +14,7 @@ import inspect
 import json
 import logging
 import math
+import struct
 from collections.abc import Callable, Iterable, Sequence
 from functools import partial, wraps
 from typing import (
@@ -2241,13 +2242,232 @@ def _convert_to_openai_tool_calls(tool_calls: list[ToolCall]) -> list[dict[str, 
     ]
 
 
+_IMAGE_BASE_TOKENS = 85
+"""Base token cost of an image, also used when dimensions cannot be determined."""
+
+_IMAGE_TILE_TOKENS = 170
+_IMAGE_TILE_SIZE = 512
+_IMAGE_MAX_EDGE = 2048
+_IMAGE_MIN_EDGE = 768
+
+# PNG and WebP dimensions sit in the first few bytes, so only a tiny prefix is decoded
+# rather than a whole payload just to measure it.
+_IMAGE_HEADER_BYTES = 64
+
+# JPEG frame headers follow any metadata segments, which can be large, so the window
+# widens only if a smaller one came up short. Payloads whose frame header lies beyond
+# the largest window fall back to the fixed cost.
+_JPEG_SCAN_WINDOWS = (4_096, 131_072)
+
+# Real payloads reach the frame header in well under ten segments, so a low cap keeps
+# malformed input from being scanned at length.
+_JPEG_MAX_SEGMENTS = 64
+
+_PNG_HEADER_SIZE = 24
+_WEBP_HEADER_SIZE = 30
+_WEBP_VP8L_HEADER_SIZE = 25
+
+_JPEG_FILL_BYTE = 0xFF
+_JPEG_EOI_MARKER = 0xD9
+_JPEG_MIN_SEGMENT_LENGTH = 2
+
+# SOF0-SOF15, excluding DHT (0xC4), JPG (0xC8) and DAC (0xCC), which are not frames.
+_JPEG_SOF_MARKERS = frozenset(range(0xC0, 0xD0)) - {0xC4, 0xC8, 0xCC}
+
+# SOI, TEM and the restart markers carry no length field.
+_JPEG_STANDALONE_MARKERS = frozenset({0x01, 0xD8}) | frozenset(range(0xD0, 0xD8))
+
+
+def _decode_image_header(data: str, max_bytes: int) -> bytes:
+    """Decode a bounded prefix of a base64 payload.
+
+    Args:
+        data: Base64 encoded image data.
+        max_bytes: Approximate maximum number of bytes to decode.
+
+    Returns:
+        The decoded prefix, or empty bytes if it could not be decoded.
+    """
+    prefix = data[: (max_bytes // 3 + 1) * 4]
+    prefix = prefix[: len(prefix) - len(prefix) % 4]
+    try:
+        return base64.b64decode(prefix)
+    except (ValueError, TypeError):
+        return b""
+
+
+def _image_size_from_header(data: bytes) -> tuple[int, int] | None:
+    """Read image dimensions from a file header.
+
+    Args:
+        data: The leading bytes of an image file.
+
+    Returns:
+        A `(width, height)` tuple, or `None` if the format is not recognized.
+    """
+    if (
+        data[:8] == b"\x89PNG\r\n\x1a\n"
+        and data[12:16] == b"IHDR"
+        and len(data) >= _PNG_HEADER_SIZE
+    ):
+        width, height = struct.unpack(">II", data[16:24])
+        return width, height
+
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        fourcc = data[12:16]
+        if fourcc == b"VP8X" and len(data) >= _WEBP_HEADER_SIZE:
+            width = int.from_bytes(data[24:27], "little") + 1
+            height = int.from_bytes(data[27:30], "little") + 1
+            return width, height
+        if (
+            fourcc == b"VP8 "
+            and data[23:26] == b"\x9d\x01\x2a"
+            and len(data) >= _WEBP_HEADER_SIZE
+        ):
+            width, height = struct.unpack("<HH", data[26:30])
+            return width & 0x3FFF, height & 0x3FFF
+        if fourcc == b"VP8L" and len(data) >= _WEBP_VP8L_HEADER_SIZE:
+            bits = int.from_bytes(data[21:25], "little")
+            return (bits & 0x3FFF) + 1, ((bits >> 14) & 0x3FFF) + 1
+        return None
+
+    if data[:2] == b"\xff\xd8":
+        index = 2
+        for _ in range(_JPEG_MAX_SEGMENTS):
+            if index + 9 > len(data):
+                return None
+            if data[index] != _JPEG_FILL_BYTE:
+                # Segments start with a fill byte, so anything else is malformed
+                return None
+            marker = data[index + 1]
+            if marker == _JPEG_FILL_BYTE:
+                index += 1
+                continue
+            if marker in _JPEG_STANDALONE_MARKERS:
+                index += 2
+                continue
+            if marker == _JPEG_EOI_MARKER:
+                return None
+            if marker in _JPEG_SOF_MARKERS:
+                height, width = struct.unpack(">HH", data[index + 5 : index + 9])
+                return width, height
+            segment_length = int.from_bytes(data[index + 2 : index + 4], "big")
+            if segment_length < _JPEG_MIN_SEGMENT_LENGTH:
+                return None
+            index += segment_length + _JPEG_MIN_SEGMENT_LENGTH
+
+    return None
+
+
+def _image_size_from_base64(data: str) -> tuple[int, int] | None:
+    """Read image dimensions from a base64 payload.
+
+    Args:
+        data: Base64 encoded image data.
+
+    Returns:
+        A `(width, height)` tuple, or `None` if the dimensions cannot be read.
+    """
+    header = _decode_image_header(data, _IMAGE_HEADER_BYTES)
+    if header[:2] != b"\xff\xd8":
+        return _image_size_from_header(header)
+
+    for window in _JPEG_SCAN_WINDOWS:
+        header = _decode_image_header(data, window)
+        size = _image_size_from_header(header)
+        if size is not None:
+            return size
+        if len(header) < window:
+            # The whole payload has been scanned already
+            break
+
+    return None
+
+
+def _estimate_image_tokens(width: int, height: int) -> int:
+    """Estimate the token cost of an image from its dimensions.
+
+    Args:
+        width: Image width in pixels.
+        height: Image height in pixels.
+
+    Returns:
+        Approximate number of tokens the image will occupy.
+    """
+    if width <= 0 or height <= 0:
+        return _IMAGE_BASE_TOKENS
+
+    longest = max(width, height)
+    if longest > _IMAGE_MAX_EDGE:
+        scale = _IMAGE_MAX_EDGE / longest
+        width, height = round(width * scale), round(height * scale)
+
+    shortest = min(width, height)
+    if shortest > _IMAGE_MIN_EDGE:
+        scale = _IMAGE_MIN_EDGE / shortest
+        width, height = round(width * scale), round(height * scale)
+
+    tiles = math.ceil(width / _IMAGE_TILE_SIZE) * math.ceil(height / _IMAGE_TILE_SIZE)
+    return _IMAGE_TILE_TOKENS * tiles + _IMAGE_BASE_TOKENS
+
+
+def _image_base64(block: dict[str, Any]) -> str:
+    """Extract the base64 payload from an image content block.
+
+    Args:
+        block: A content block dictionary.
+
+    Returns:
+        The base64 payload, or an empty string if the block carries none.
+    """
+    data = block.get("base64")
+    if isinstance(data, str) and data:
+        return data
+
+    url = block.get("url")
+    if isinstance(url, str) and url.startswith("data:"):
+        return url.partition(",")[2]
+
+    image_url = block.get("image_url")
+    if isinstance(image_url, dict):
+        url = image_url.get("url")
+        if isinstance(url, str) and url.startswith("data:"):
+            return url.partition(",")[2]
+    elif isinstance(image_url, str) and image_url.startswith("data:"):
+        return image_url.partition(",")[2]
+
+    return ""
+
+
+def _count_image_tokens(block: dict[str, Any], tokens_per_image: int | None) -> int:
+    """Count the tokens contributed by a single image block.
+
+    Args:
+        block: An `image` or `image_url` content block.
+        tokens_per_image: Caller-supplied fixed cost, which takes precedence when set.
+
+    Returns:
+        Approximate number of tokens for the block.
+    """
+    if tokens_per_image is not None:
+        return tokens_per_image
+
+    data = _image_base64(block)
+    if data:
+        size = _image_size_from_base64(data)
+        if size is not None:
+            return _estimate_image_tokens(*size)
+
+    return _IMAGE_BASE_TOKENS
+
+
 def count_tokens_approximately(
     messages: Iterable[MessageLikeRepresentation],
     *,
     chars_per_token: float = 4.0,
     extra_tokens_per_message: float = 3.0,
     count_name: bool = True,
-    tokens_per_image: int = 85,
+    tokens_per_image: int | None = None,
     use_usage_metadata_scaling: bool = False,
     tools: list[BaseTool | dict[str, Any]] | None = None,
 ) -> int:
@@ -2257,8 +2477,9 @@ def count_tokens_approximately(
 
     - For AI messages, the token count also includes stringified tool calls.
     - For tool messages, the token count also includes the tool call ID.
-    - For multimodal messages with images, applies a fixed token penalty per image
-        instead of counting base64-encoded characters.
+    - For multimodal messages with images, estimates the token cost from the image
+        dimensions where they can be read from the payload, instead of counting
+        base64-encoded characters.
     - If tools are provided, the token count also includes stringified tool schemas.
 
     Args:
@@ -2272,8 +2493,10 @@ def count_tokens_approximately(
             You can also specify `float` values for more fine-grained control.
             [See more here](https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb).
         count_name: Whether to include message names in the count.
-        tokens_per_image: Fixed token cost per image (default: 85, aligned with
-            OpenAI's low-resolution image token cost).
+        tokens_per_image: Fixed token cost per image. When set, it is applied to
+            every image and no dimensions are read. When `None` (default), the
+            cost is estimated from the image's dimensions, falling back to 85 if
+            they cannot be determined.
         use_usage_metadata_scaling: If True, and all AI messages have consistent
             `response_metadata['model_provider']`, scale the approximate token count
             using the **most recent** AI message that has
@@ -2291,9 +2514,10 @@ def count_tokens_approximately(
         This is a simple approximation that may not match the exact token count used by
         specific models. For accurate counts, use model-specific tokenizers.
 
-        For multimodal messages containing images, a fixed token penalty is applied
-        per image instead of counting base64-encoded characters, which provides a
-        more realistic approximation.
+        For multimodal messages containing images, the cost is estimated from the
+        image dimensions read out of the payload header rather than from the length
+        of its base64 encoding. Images whose dimensions cannot be read, such as
+        URL-only blocks and `file_id` references, fall back to a fixed penalty.
 
     !!! version-added "Added in `langchain-core` 0.3.46"
     """
@@ -2347,7 +2571,7 @@ def count_tokens_approximately(
 
                     # Apply fixed penalty for image blocks
                     if block_type in {"image", "image_url"}:
-                        token_count += tokens_per_image
+                        token_count += _count_image_tokens(block, tokens_per_image)
                     # Count text blocks normally
                     elif block_type == "text":
                         text = block.get("text", "")

--- a/libs/core/langchain_core/messages/utils.py
+++ b/libs/core/langchain_core/messages/utils.py
@@ -2245,6 +2245,9 @@ def _convert_to_openai_tool_calls(tool_calls: list[ToolCall]) -> list[dict[str, 
 _IMAGE_BASE_TOKENS = 85
 """Base token cost of an image, also used when dimensions cannot be determined."""
 
+# Providers charge a flat rate for low-detail images, so dimensions are irrelevant.
+_IMAGE_DETAIL_LOW = "low"
+
 _IMAGE_TILE_TOKENS = 170
 _IMAGE_TILE_SIZE = 512
 _IMAGE_MAX_EDGE = 2048
@@ -2439,6 +2442,23 @@ def _image_base64(block: dict[str, Any]) -> str:
     return ""
 
 
+def _image_detail(block: dict[str, Any]) -> str:
+    """Extract the detail control from an image content block.
+
+    Args:
+        block: A content block dictionary.
+
+    Returns:
+        The lowercased `detail` value, or an empty string if the block sets none.
+    """
+    detail = block.get("detail")
+    if not isinstance(detail, str):
+        image_url = block.get("image_url")
+        detail = image_url.get("detail") if isinstance(image_url, dict) else None
+
+    return detail.lower() if isinstance(detail, str) else ""
+
+
 def _count_image_tokens(block: dict[str, Any], tokens_per_image: int | None) -> int:
     """Count the tokens contributed by a single image block.
 
@@ -2451,6 +2471,9 @@ def _count_image_tokens(block: dict[str, Any], tokens_per_image: int | None) -> 
     """
     if tokens_per_image is not None:
         return tokens_per_image
+
+    if _image_detail(block) == _IMAGE_DETAIL_LOW:
+        return _IMAGE_BASE_TOKENS
 
     data = _image_base64(block)
     if data:
@@ -2479,7 +2502,7 @@ def count_tokens_approximately(
     - For tool messages, the token count also includes the tool call ID.
     - For multimodal messages with images, estimates the token cost from the image
         dimensions where they can be read from the payload, instead of counting
-        base64-encoded characters.
+        base64-encoded characters. Images marked as low detail are fixed-cost.
     - If tools are provided, the token count also includes stringified tool schemas.
 
     Args:
@@ -2496,7 +2519,7 @@ def count_tokens_approximately(
         tokens_per_image: Fixed token cost per image. When set, it is applied to
             every image and no dimensions are read. When `None` (default), the
             cost is estimated from the image's dimensions, falling back to 85 if
-            they cannot be determined.
+            they cannot be determined or if the image is marked as low detail.
         use_usage_metadata_scaling: If True, and all AI messages have consistent
             `response_metadata['model_provider']`, scale the approximate token count
             using the **most recent** AI message that has

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -3020,6 +3020,49 @@ def test_count_tokens_approximately_image_block_shapes() -> None:
     assert counts.pop() > 700
 
 
+def test_count_tokens_approximately_low_detail_image_is_fixed_cost() -> None:
+    """Low-detail images are charged a flat rate, so dimensions must be ignored."""
+    encoded = base64.b64encode(_png_bytes(1920, 1080)).decode()
+    data_url = f"data:image/png;base64,{encoded}"
+
+    high_detail = count_tokens_approximately(
+        [HumanMessage(content=[{"type": "image_url", "image_url": {"url": data_url}}])]
+    )
+    assert high_detail > 1000
+
+    # Both the raw Chat Completions shape and the normalized block carry `detail`
+    nested = HumanMessage(
+        content=[{"type": "image_url", "image_url": {"url": data_url, "detail": "low"}}]
+    )
+    top_level = HumanMessage(
+        content=[
+            {
+                "type": "image",
+                "base64": encoded,
+                "mime_type": "image/png",
+                "detail": "low",
+            }
+        ]
+    )
+
+    for message in (nested, top_level):
+        assert count_tokens_approximately([message]) < 100
+
+
+def test_count_tokens_approximately_high_and_auto_detail_use_dimensions() -> None:
+    """Only low detail is fixed-cost; other values still estimate from dimensions."""
+    encoded = base64.b64encode(_png_bytes(1920, 1080)).decode()
+    data_url = f"data:image/png;base64,{encoded}"
+
+    for detail in ("high", "auto", "HIGH"):
+        message = HumanMessage(
+            content=[
+                {"type": "image_url", "image_url": {"url": data_url, "detail": detail}}
+            ]
+        )
+        assert count_tokens_approximately([message]) > 1000
+
+
 def test_count_tokens_approximately_image_without_dimensions() -> None:
     """Images with no readable dimensions should fall back to the fixed penalty."""
     remote = HumanMessage(

--- a/libs/core/tests/unit_tests/messages/test_utils.py
+++ b/libs/core/tests/unit_tests/messages/test_utils.py
@@ -2,6 +2,8 @@ import base64
 import json
 import math
 import re
+import struct
+import zlib
 from collections.abc import Callable, Sequence
 from typing import Any, TypedDict
 
@@ -2859,6 +2861,201 @@ def test_count_tokens_approximately_with_image_only_message() -> None:
     # Default tokens_per_image is 85 and extra_tokens_per_message is 3,
     # so we expect something in the ~90-110 range.
     assert 80 < token_count < 120
+
+
+def _png_bytes(width: int, height: int) -> bytes:
+    """Build a minimal valid PNG with the given dimensions."""
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        body = tag + data
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body))
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    scanlines = b"".join(b"\x00" + b"\x80" * (width * 3) for _ in range(height))
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", ihdr)
+        + chunk(b"IDAT", zlib.compress(scanlines))
+        + chunk(b"IEND", b"")
+    )
+
+
+def _jpeg_bytes(width: int, height: int, metadata_size: int = 0) -> bytes:
+    """Build a JPEG header, optionally padded with a metadata segment."""
+    app0 = b""
+    if metadata_size:
+        app0 = (
+            b"\xff\xe0" + struct.pack(">H", metadata_size + 2) + b"\x00" * metadata_size
+        )
+    sof0 = b"\xff\xc0" + struct.pack(">HBHHB", 17, 8, height, width, 3) + b"\x00" * 9
+    return b"\xff\xd8" + app0 + sof0 + b"\xff\xd9"
+
+
+def _webp_bytes(width: int, height: int) -> bytes:
+    """Build a WebP VP8X header with the given dimensions."""
+    payload = (
+        b"VP8X"
+        + struct.pack("<I", 10)
+        + b"\x00" * 4
+        + (width - 1).to_bytes(3, "little")
+        + (height - 1).to_bytes(3, "little")
+    )
+    return b"RIFF" + struct.pack("<I", len(payload) + 4) + b"WEBP" + payload
+
+
+def _image_message(data: bytes, mime_type: str = "image/png") -> HumanMessage:
+    """Wrap raw image bytes in a message with a single image block."""
+    encoded = base64.b64encode(data).decode()
+    return HumanMessage(
+        content=[
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime_type};base64,{encoded}"},
+            }
+        ]
+    )
+
+
+def test_count_tokens_approximately_image_scales_with_resolution() -> None:
+    """Larger images should cost more tokens than smaller ones."""
+    small = count_tokens_approximately([_image_message(_png_bytes(256, 256))])
+    medium = count_tokens_approximately([_image_message(_png_bytes(1024, 1024))])
+    large = count_tokens_approximately([_image_message(_png_bytes(1920, 1080))])
+
+    assert small < medium < large
+
+
+def test_count_tokens_approximately_image_dimension_estimates() -> None:
+    """Known dimensions should produce their expected tile-based estimate."""
+    # 4 extra tokens per message: 3 extra_tokens_per_message + 1 for the "human" role
+    overhead = 4
+    assert (
+        count_tokens_approximately([_image_message(_png_bytes(1024, 1024))])
+        == 765 + overhead
+    )
+    assert (
+        count_tokens_approximately([_image_message(_png_bytes(1920, 1080))])
+        == 1105 + overhead
+    )
+    # Downscaled to fit within the maximum edge, so it matches 1920x1080
+    assert (
+        count_tokens_approximately([_image_message(_png_bytes(2560, 1440))])
+        == 1105 + overhead
+    )
+
+
+def test_count_tokens_approximately_image_formats() -> None:
+    """Dimensions should be read from PNG, JPEG and WebP payloads alike."""
+    expected = count_tokens_approximately([_image_message(_png_bytes(1024, 1024))])
+
+    jpeg = count_tokens_approximately(
+        [_image_message(_jpeg_bytes(1024, 1024), "image/jpeg")]
+    )
+    webp = count_tokens_approximately(
+        [_image_message(_webp_bytes(1024, 1024), "image/webp")]
+    )
+
+    assert jpeg == expected
+    assert webp == expected
+
+
+def test_count_tokens_approximately_jpeg_with_metadata() -> None:
+    """A JPEG frame header behind a large metadata segment should still be found."""
+    expected = count_tokens_approximately(
+        [_image_message(_jpeg_bytes(1920, 1080), "image/jpeg")]
+    )
+    padded = count_tokens_approximately(
+        [_image_message(_jpeg_bytes(1920, 1080, metadata_size=40000), "image/jpeg")]
+    )
+
+    assert padded == expected
+
+
+def test_count_tokens_approximately_jpeg_does_not_rescan_malformed_data() -> None:
+    """A frame header behind a stray byte should be treated as malformed.
+
+    Scanning forward a byte at a time to resynchronize would let a payload of
+    meaningless bytes drive the segment walk, so the walk gives up instead.
+    """
+    header = _jpeg_bytes(1920, 1080)
+    # Insert a byte where the next segment marker is expected
+    corrupted = header[:2] + b"\x00" + header[2:]
+
+    intact = count_tokens_approximately([_image_message(header, "image/jpeg")])
+    assert intact > 1000
+
+    count = count_tokens_approximately([_image_message(corrupted, "image/jpeg")])
+    assert count < 100
+
+
+def test_count_tokens_approximately_jpeg_filler_payload_falls_back() -> None:
+    """Long runs of filler bytes should fall back rather than being scanned."""
+    payloads = [
+        b"\xff\xd8" + b"\xff" * 200_000,
+        b"\xff\xd8" + b"\x00" * 200_000,
+        b"\xff\xd8" + b"\xff\xe0\x00\x02" * 40_000,
+    ]
+
+    for payload in payloads:
+        count = count_tokens_approximately([_image_message(payload, "image/jpeg")])
+        assert count < 100
+
+
+def test_count_tokens_approximately_image_block_shapes() -> None:
+    """All base64 image block shapes should be measured the same way."""
+    encoded = base64.b64encode(_png_bytes(1024, 1024)).decode()
+    data_url = f"data:image/png;base64,{encoded}"
+    blocks: list[dict[str, Any]] = [
+        {"type": "image_url", "image_url": {"url": data_url}},
+        {"type": "image_url", "image_url": data_url},
+        {"type": "image", "base64": encoded, "mime_type": "image/png"},
+        {"type": "image", "url": data_url},
+    ]
+
+    counts = {
+        count_tokens_approximately([HumanMessage(content=[block])]) for block in blocks
+    }
+
+    assert len(counts) == 1
+    assert counts.pop() > 700
+
+
+def test_count_tokens_approximately_image_without_dimensions() -> None:
+    """Images with no readable dimensions should fall back to the fixed penalty."""
+    remote = HumanMessage(
+        content=[{"type": "image", "url": "https://example.com/image.png"}]
+    )
+    file_id = HumanMessage(content=[{"type": "image", "file_id": "file-abc123"}])
+    unparseable = _image_message(b"not really an image")
+
+    for message in (remote, file_id, unparseable):
+        assert 80 < count_tokens_approximately([message]) < 100
+
+
+def test_count_tokens_approximately_explicit_tokens_per_image_wins() -> None:
+    """An explicit tokens_per_image should suppress dimension-based estimation."""
+    message = _image_message(_png_bytes(1920, 1080))
+
+    assert count_tokens_approximately([message]) > 1000
+    assert count_tokens_approximately([message], tokens_per_image=85) < 100
+    # Zero is a valid override and must not be treated as unset
+    assert count_tokens_approximately([message], tokens_per_image=0) < 10
+
+
+def test_count_tokens_approximately_malformed_image_does_not_raise() -> None:
+    """Truncated or malformed payloads should fall back instead of raising."""
+    malformed = [
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR",
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x08",
+        b"RIFF____WEBP" + b"VP8 " + b"____" + b"___" + b"\x9d\x01\x2a",
+        b"RIFF____WEBP" + b"VP8X" + b"____",
+        b"\xff\xd8",
+        b"",
+    ]
+
+    for payload in malformed:
+        count = count_tokens_approximately([_image_message(payload)])
+        assert count > 0
 
 
 def test_count_tokens_approximately_with_unknown_block_type() -> None:


### PR DESCRIPTION
Fixes #39858

---

Anyone counting tokens on screenshot-heavy messages currently gets 85 back whether the image is 1024x1024 or 4K, so `trim_messages` under-budgets by 8x-52x and the call then fails provider-side on context length. This reads the dimensions out of the payload header and estimates from those, keeping the old fixed cost as the fallback when there are no dimensions to read.

Header parsing covers PNG, JPEG and WebP using only the standard library. Only 64 bytes are decoded unless the payload is a JPEG, whose frame header can sit behind metadata segments; that widens to 4 KB and then 128 KB, stopping as soon as the header is found.

## Release note

`count_tokens_approximately` now estimates image tokens from the image's dimensions rather than charging a flat 85 per image. Passing `tokens_per_image` explicitly keeps the previous fixed-cost behaviour.

## Testing

`make format` and `make test` pass from `libs/core` (2263 passed, 2 skipped). `make lint` reports one unused `type: ignore` in `tests/unit_tests/test_tools.py`, which this PR does not touch; it fires because `--all-groups` installs langgraph locally, making that import succeed.

Dimensions were checked against real PNG, JPEG, lossy WebP and lossless WebP files from 1x1 up to 4096x2160, and against JPEGs carrying up to 60 KB of metadata. Truncated and malformed payloads fall back instead of raising.

Because this is the first time the counter reads the payload at all, I also checked hostile input. The segment walk gives up on a stray byte rather than resynchronizing, and is capped at 64 segments, so a 200 KB run of filler bytes costs 0.17 ms and falls back. Steady-state cost is 0.002 ms per call for a 2560x1440 PNG and 0.009 ms for the equivalent JPEG. The four existing image tests pass unchanged.

## Social handles

Twitter: @saibertruckk
LinkedIn: https://linkedin.com/in/saikrishna-devendiran
