### PR TITLE
fix(perplexity): extract cache token details from input_tokens_details

### DIFF
--- a/libs/partners/perplexity/langchain_perplexity/chat_models.py
+++ b/libs/partners/perplexity/langchain_perplexity/chat_models.py
@@ -38,6 +38,7 @@ from langchain_core.messages import (
     ToolMessageChunk,
 )
 from langchain_core.messages.ai import (
+    InputTokenDetails,
     OutputTokenDetails,
     UsageMetadata,
     subtract_usage,
@@ -95,6 +96,15 @@ def _create_usage_metadata(token_usage: dict) -> UsageMetadata:
     output_tokens = token_usage.get("completion_tokens", 0)
     total_tokens = token_usage.get("total_tokens", input_tokens + output_tokens)
 
+    # Build input_token_details for cache token accounting
+    input_token_details: InputTokenDetails = {}
+    details = token_usage.get("input_tokens_details") or {}
+    if isinstance(details, dict):
+        if (cache_read := details.get("cache_read_input_tokens")) is not None:
+            input_token_details["cache_read"] = cache_read
+        if (cache_creation := details.get("cache_creation_input_tokens")) is not None:
+            input_token_details["cache_creation"] = cache_creation
+
     # Build output_token_details for Perplexity-specific fields
     output_token_details: OutputTokenDetails = {}
     if (reasoning := token_usage.get("reasoning_tokens")) is not None:
@@ -102,12 +112,15 @@ def _create_usage_metadata(token_usage: dict) -> UsageMetadata:
     if (citation_tokens := token_usage.get("citation_tokens")) is not None:
         output_token_details["citation_tokens"] = citation_tokens  # type: ignore[typeddict-unknown-key]
 
-    return UsageMetadata(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        total_tokens=total_tokens,
-        output_token_details=output_token_details,
-    )
+    kwargs: dict[str, Any] = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+        "output_token_details": output_token_details,
+    }
+    if input_token_details:
+        kwargs["input_token_details"] = input_token_details
+    return UsageMetadata(**kwargs)
 
 
 _RESPONSES_ONLY_ARGS = frozenset(
@@ -354,11 +367,26 @@ def _convert_responses_usage(usage: Any) -> UsageMetadata | None:
     total_tokens = _get_attr(usage, "total_tokens", None)
     if total_tokens is None:
         total_tokens = input_tokens + output_tokens
-    return UsageMetadata(
-        input_tokens=input_tokens,
-        output_tokens=output_tokens,
-        total_tokens=total_tokens,
-    )
+
+    # Extract cache token details from input_tokens_details sub-object
+    input_token_details: InputTokenDetails = {}
+    details = _get_attr(usage, "input_tokens_details", None)
+    if details is not None:
+        cache_read = _get_attr(details, "cache_read_input_tokens", None)
+        if cache_read is not None:
+            input_token_details["cache_read"] = cache_read
+        cache_creation = _get_attr(details, "cache_creation_input_tokens", None)
+        if cache_creation is not None:
+            input_token_details["cache_creation"] = cache_creation
+
+    kwargs: dict[str, Any] = {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+    if input_token_details:
+        kwargs["input_token_details"] = input_token_details
+    return UsageMetadata(**kwargs)
 
 
 def _extract_responses_text(response: Any) -> str:

--- a/libs/partners/perplexity/tests/unit_tests/test_cache_tokens.py
+++ b/libs/partners/perplexity/tests/unit_tests/test_cache_tokens.py
@@ -1,0 +1,24 @@
+"""Tests for cache token extraction in Perplexity usage metadata."""
+
+from langchain_perplexity.chat_models import _create_usage_metadata
+
+
+def test_create_usage_metadata_extracts_cache_tokens():
+    token_usage = {
+        "prompt_tokens": 1000,
+        "completion_tokens": 50,
+        "total_tokens": 1050,
+        "input_tokens_details": {
+            "cache_read_input_tokens": 800,
+            "cache_creation_input_tokens": 150,
+        },
+    }
+    result = _create_usage_metadata(token_usage)
+    assert result["input_token_details"]["cache_read"] == 800
+    assert result["input_token_details"]["cache_creation"] == 150
+
+
+def test_create_usage_metadata_without_cache_details():
+    token_usage = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    result = _create_usage_metadata(token_usage)
+    assert "input_token_details" not in result


### PR DESCRIPTION
## Description

Fixes #39897

Perplexity's API reports `cache_read_input_tokens` and `cache_creation_input_tokens` inside `input_tokens_details` for both the Chat Completions and Responses APIs. Neither integration path populated `UsageMetadata.input_token_details`, so the cache breakdown was silently dropped — downstream cost dashboards built on `input_token_details` saw no cache activity even when 80%+ of input tokens were cache hits.

- `_create_usage_metadata`: extracts `cache_read` / `cache_creation` from `input_tokens_details` into `InputTokenDetails`.
- `_convert_responses_usage`: reads the same fields via attribute access from the Responses usage object.

Prompts without cache details are unaffected (no `input_token_details` key emitted).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- New tests in `tests/unit_tests/test_cache_tokens.py`: cache tokens present → both keys populated; absent → no `input_token_details` key.
- Full perplexity partner suite: **155 passed, 1 skipped**.
- ruff check + format clean on both changed files.
