### PR TITLE
fix(core): include + as a valid Markdown list marker in MarkdownListOutputParser

### DIFF
--- a/libs/core/langchain_core/output_parsers/list.py
+++ b/libs/core/langchain_core/output_parsers/list.py
@@ -221,7 +221,7 @@ class NumberedListOutputParser(ListOutputParser):
 class MarkdownListOutputParser(ListOutputParser):
     """Parse a Markdown list."""
 
-    pattern: str = r"^\s*[-*]\s([^\n]+)$"
+    pattern: str = r"^\s*[-*+]\s([^\n]+)$"
     """The pattern to match a Markdown list item."""
 
     @override

--- a/libs/core/tests/unit_tests/output_parsers/test_list.py
+++ b/libs/core/tests/unit_tests/output_parsers/test_list.py
@@ -1,0 +1,14 @@
+
+
+def test_markdown_list_parser_plus_bullet() -> None:
+    """Markdown `+` bullets must be parsed alongside `-` and `*`."""
+    parser = MarkdownListOutputParser()
+    result = parser.parse("+ foo\n+ bar\n- baz")
+    assert result == ["foo", "bar", "baz"]
+
+
+def test_markdown_list_parser_plus_bullet() -> None:
+    """Markdown `+` bullets must be parsed alongside `-` and `*`."""
+    parser = MarkdownListOutputParser()
+    result = parser.parse("+ foo\n+ bar\n- baz")
+    assert result == ["foo", "bar", "baz"]


### PR DESCRIPTION
## Description

Fixes #39900

Markdown supports `-`, `*`, and `+` as list bullet markers. `MarkdownListOutputParser`'s regex only matched `[-*]`, so LLM outputs using `+` bullets were silently parsed as an empty list.

The fix adds `+` to the character class: `[-*+]`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- New test: `test_markdown_list_parser_plus_bullet` verifies that `+ foo\n+ bar\n- baz` parses to `["foo", "bar", "baz"]`.
- All existing list parser tests pass unchanged.
