### PR TITLE
fix(core): default to empty properties in `BaseTool.args`

### DIFF
--- a/libs/core/langchain_core/tools/base.py
+++ b/libs/core/langchain_core/tools/base.py
@@ -619,7 +619,10 @@ class ChildTool(BaseTool):
                 json_schema = input_schema
             else:
                 json_schema = model_json_schema(input_schema)
-        return cast("dict[str, Any]", json_schema["properties"])
+        # `properties` is optional in JSON Schema, and a schema that takes no
+        # arguments may omit it entirely. Pydantic always emits the key, so this
+        # only matters for dict schemas authored outside LangChain.
+        return cast("dict[str, Any]", json_schema.get("properties", {}))
 
     _tool_call_schema_memo: ArgsSchema | None = PrivateAttr(default=None)
     """Memoized `tool_call_schema` result.

--- a/libs/core/tests/unit_tests/test_tools.py
+++ b/libs/core/tests/unit_tests/test_tools.py
@@ -3694,6 +3694,29 @@ def test_tool_invoke_does_not_mutate_inputs() -> None:
     }
 
 
+@pytest.mark.parametrize("schema", [{}, {"type": "object"}])
+def test_tool_args_dict_schema_without_properties(schema: dict[str, Any]) -> None:
+    """`args` defaults to `{}` when a dict schema omits `properties`.
+
+    `properties` is optional in JSON Schema, and a tool that takes no arguments
+    may leave it out. Schemas authored outside LangChain do this in practice --
+    an MCP server's advertised `inputSchema`, or an OpenAPI import. Pydantic
+    always emits the key, so this only arises on the dict `args_schema` path.
+    """
+
+    def no_op() -> str:
+        return "good"
+
+    tool = StructuredTool(
+        name="sample_tool",
+        description="",
+        args_schema=schema,
+        func=no_op,
+    )
+
+    assert tool.args == {}
+
+
 def test_tool_args_schema_with_annotated_type() -> None:
     @tool
     def test_tool(


### PR DESCRIPTION
`BaseTool.args` raised `KeyError: 'properties'` for tool schemas that are valid JSON Schema but omit the key.

`properties` is optional in JSON Schema — `{}` and `{"type": "object"}` are both valid object schemas — but `args` looked it up unconditionally. Pydantic always emits the key (even for a model with no fields), so this only affected dict `args_schema` values authored outside LangChain: an MCP server's advertised `inputSchema` for a tool that takes no arguments, or an imported OpenAPI schema.

Now `args` returns `{}` for those schemas instead of raising.

Notes for review:

- The tool was otherwise fully functional — `invoke`, `tool_call_schema`, and `convert_to_openai_tool` all already worked on these schemas. Only the `args` property raised, so the change is narrow.
- This does not alter what is sent to model providers. Serialization already passes the schema through untouched.
- Strictly more permissive: an input that used to raise now returns a value. Nothing that previously succeeded changes.

## Release note

Fixed `BaseTool.args` raising `KeyError: 'properties'` when `args_schema` was given as a JSON Schema dict that omits `properties`, such as `{"type": "object"}` for a tool that takes no arguments.

---

*Written with the help of an AI agent.*
