### PR TITLE
fix(anthropic): auto-append `advisor-tool-2026-03-01` beta header for `advisor_20260301` tool

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -161,6 +161,7 @@ _TOOL_TYPE_TO_BETA: dict[str, str] = {
     "computer_20251124": "computer-use-2025-11-24",
     "tool_search_tool_regex_20251119": "advanced-tool-use-2025-11-20",
     "tool_search_tool_bm25_20251119": "advanced-tool-use-2025-11-20",
+    "advisor_20260301": "advisor-tool-2026-03-01",
 }
 """Mapping of tool type to required beta header.
 

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3226,6 +3226,7 @@ def test_advisor_is_builtin_tool() -> None:
         **bound.kwargs,  # type: ignore[attr-defined]
     )
     assert advisor_tool in payload["tools"]
+    assert "advisor-tool-2026-03-01" in payload["betas"]
 
 
 def test_tool_search_beta_headers() -> None:


### PR DESCRIPTION
Fixes #39895

---

In #38686, `advisor_` was added to `_BUILTIN_TOOL_PREFIXES` to allow native pass-through during `bind_tools()`. However, `advisor_20260301` was omitted from `_TOOL_TYPE_TO_BETA`.

This adds `"advisor_20260301": "advisor-tool-2026-03-01"` to `_TOOL_TYPE_TO_BETA` so `ChatAnthropic` auto-appends the required beta header when binding the native advisor tool, and extends `test_advisor_is_builtin_tool` to verify the header in the request payload.

## Release note

`ChatAnthropic.bind_tools()` now automatically injects the `anthropic-beta: advisor-tool-2026-03-01` header when binding the `advisor_20260301` native tool.